### PR TITLE
Replace Joda-Time DateTime with java.time.Instant

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/QuerySystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/QuerySystemTable.java
@@ -35,8 +35,8 @@ import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.type.ArrayType;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -157,12 +157,11 @@ public class QuerySystemTable
         return duration.toMillis();
     }
 
-    private static Long toTimestampWithTimeZoneMillis(DateTime dateTime)
+    private static Long toTimestampWithTimeZoneMillis(Instant instant)
     {
-        if (dateTime == null) {
+        if (instant == null) {
             return null;
         }
-        // dateTime.getZone() is the server zone, should be of no interest to the user
-        return packDateTimeWithZone(dateTime.getMillis(), UTC_KEY);
+        return packDateTimeWithZone(instant.toEpochMilli(), UTC_KEY);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/TaskSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TaskSystemTable.java
@@ -30,7 +30,8 @@ import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
-import org.joda.time.DateTime;
+
+import java.time.Instant;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.connector.SystemTable.Distribution.ALL_NODES;
@@ -162,12 +163,11 @@ public class TaskSystemTable
         return dataSize.toBytes();
     }
 
-    private static Long toTimestampWithTimeZoneMillis(DateTime dateTime)
+    private static Long toTimestampWithTimeZoneMillis(Instant instant)
     {
-        if (dateTime == null) {
+        if (instant == null) {
             return null;
         }
-        // dateTime.getZone() is the server zone, should be of no interest to the user
-        return packDateTimeWithZone(dateTime.getMillis(), UTC_KEY);
+        return packDateTimeWithZone(instant.toEpochMilli(), UTC_KEY);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/TransactionsSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TransactionsSystemTable.java
@@ -31,8 +31,8 @@ import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarcharType;
 import io.trino.transaction.TransactionInfo;
 import io.trino.transaction.TransactionManager;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -116,9 +116,8 @@ public class TransactionsSystemTable
         return builder.build();
     }
 
-    private static Long toTimestampWithTimeZoneMillis(DateTime dateTime)
+    private static Long toTimestampWithTimeZoneMillis(Instant instant)
     {
-        // dateTime.getZone() is the server zone, should be of no interest to the user
-        return packDateTimeWithZone(dateTime.getMillis(), UTC_KEY);
+        return packDateTimeWithZone(instant.toEpochMilli(), UTC_KEY);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
@@ -31,9 +31,9 @@ import io.trino.server.BasicQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
 import io.trino.spi.resourcegroups.ResourceGroupId;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.concurrent.Executor;
@@ -163,19 +163,19 @@ public class FailedDispatchQuery
     public void recordHeartbeat() {}
 
     @Override
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
         return basicQueryInfo.getQueryStats().getEndTime();
     }
 
     @Override
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return basicQueryInfo.getQueryStats().getCreateTime();
     }
 
     @Override
-    public Optional<DateTime> getExecutionStartTime()
+    public Optional<Instant> getExecutionStartTime()
     {
         return getEndTime();
     }
@@ -187,7 +187,7 @@ public class FailedDispatchQuery
     }
 
     @Override
-    public Optional<DateTime> getEndTime()
+    public Optional<Instant> getEndTime()
     {
         return Optional.ofNullable(basicQueryInfo.getQueryStats().getEndTime());
     }
@@ -263,7 +263,7 @@ public class FailedDispatchQuery
 
     private static QueryStats immediateFailureQueryStats()
     {
-        DateTime now = DateTime.now();
+        Instant now = Instant.now();
         return new QueryStats(
                 now,
                 now,

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -31,8 +31,8 @@ import io.trino.server.BasicQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -171,7 +171,7 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
         return stateMachine.getLastHeartbeat();
     }
@@ -213,13 +213,13 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return stateMachine.getCreateTime();
     }
 
     @Override
-    public Optional<DateTime> getExecutionStartTime()
+    public Optional<Instant> getExecutionStartTime()
     {
         return stateMachine.getExecutionStartTime();
     }
@@ -231,7 +231,7 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public Optional<DateTime> getEndTime()
+    public Optional<Instant> getEndTime()
     {
         return stateMachine.getEndTime();
     }

--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -79,9 +79,10 @@ import io.trino.sql.planner.planprinter.CounterBasedAnonymizer;
 import io.trino.sql.planner.planprinter.NoOpAnonymizer;
 import io.trino.sql.planner.planprinter.ValuePrinter;
 import io.trino.transaction.TransactionId;
-import org.joda.time.DateTime;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -101,15 +102,15 @@ import static io.trino.execution.StageInfo.getAllStages;
 import static io.trino.sql.planner.planprinter.PlanPrinter.jsonDistributedPlan;
 import static io.trino.sql.planner.planprinter.PlanPrinter.textDistributedPlan;
 import static io.trino.util.MoreMath.firstNonNaN;
-import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
-import static java.time.Duration.ofMillis;
-import static java.time.Instant.ofEpochMilli;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Objects.requireNonNull;
 
 public class QueryMonitor
 {
     private static final Logger log = Logger.get(QueryMonitor.class);
+    private static final ZoneId ZONE_ID = ZoneId.systemDefault();
 
     private final JsonCodec<StageInfo> stageInfoCodec;
     private final JsonCodec<OperatorStats> operatorStatsCodec;
@@ -156,7 +157,7 @@ public class QueryMonitor
     {
         eventListenerManager.queryCreated(
                 new QueryCreatedEvent(
-                        queryInfo.getQueryStats().getCreateTime().toDate().toInstant(),
+                        queryInfo.getQueryStats().getCreateTime(),
                         createQueryContext(
                                 queryInfo.getSession(),
                                 queryInfo.getResourceGroupId(),
@@ -196,10 +197,10 @@ public class QueryMonitor
                         Optional.empty(),
                         Optional::empty),
                 new QueryStatistics(
-                        ofMillis(0),
-                        ofMillis(0),
-                        ofMillis(0),
-                        ofMillis(queryInfo.getQueryStats().getQueuedTime().toMillis()),
+                        Duration.ZERO,
+                        Duration.ZERO,
+                        Duration.ZERO,
+                        queryInfo.getQueryStats().getQueuedTime().toJavaTime(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
@@ -250,9 +251,9 @@ public class QueryMonitor
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
                 createQueryFailureInfo(failure, Optional.empty()),
                 ImmutableList.of(),
-                ofEpochMilli(queryInfo.getQueryStats().getCreateTime().getMillis()),
-                ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis()),
-                ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis())));
+                queryInfo.getQueryStats().getCreateTime(),
+                queryInfo.getQueryStats().getEndTime(),
+                queryInfo.getQueryStats().getEndTime()));
 
         logQueryTimeline(queryInfo);
     }
@@ -276,9 +277,9 @@ public class QueryMonitor
                         getQueryIOMetadata(queryInfo),
                         createQueryFailureInfo(queryInfo.getFailureInfo(), queryInfo.getOutputStage()),
                         queryInfo.getWarnings(),
-                        ofEpochMilli(queryStats.getCreateTime().getMillis()),
-                        ofEpochMilli(queryStats.getExecutionStartTime().getMillis()),
-                        ofEpochMilli(queryStats.getEndTime() != null ? queryStats.getEndTime().getMillis() : 0));
+                        queryStats.getCreateTime(),
+                        queryStats.getExecutionStartTime(),
+                        queryStats.getEndTime() != null ? queryStats.getEndTime() : Instant.ofEpochMilli(0));
                 memo.put(requiresAnonymizedPlan, queryCompletedEvent);
             }
             return queryCompletedEvent;
@@ -314,23 +315,23 @@ public class QueryMonitor
 
         QueryStats queryStats = queryInfo.getQueryStats();
         return new QueryStatistics(
-                ofMillis(queryStats.getTotalCpuTime().toMillis()),
-                ofMillis(queryStats.getFailedCpuTime().toMillis()),
-                ofMillis(queryStats.getElapsedTime().toMillis()),
-                ofMillis(queryStats.getQueuedTime().toMillis()),
-                Optional.of(ofMillis(queryStats.getTotalScheduledTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getFailedScheduledTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getResourceWaitingTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getAnalysisTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getPlanningTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getPlanningCpuTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getStartingTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getExecutionTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getInputBlockedTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getFailedInputBlockedTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getOutputBlockedTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getFailedOutputBlockedTime().toMillis())),
-                Optional.of(ofMillis(queryStats.getPhysicalInputReadTime().toMillis())),
+                queryStats.getTotalCpuTime().toJavaTime(),
+                queryStats.getFailedCpuTime().toJavaTime(),
+                queryStats.getElapsedTime().toJavaTime(),
+                queryStats.getQueuedTime().toJavaTime(),
+                Optional.of(queryStats.getTotalScheduledTime().toJavaTime()),
+                Optional.of(queryStats.getFailedScheduledTime().toJavaTime()),
+                Optional.of(queryStats.getResourceWaitingTime().toJavaTime()),
+                Optional.of(queryStats.getAnalysisTime().toJavaTime()),
+                Optional.of(queryStats.getPlanningTime().toJavaTime()),
+                Optional.of(queryStats.getPlanningCpuTime().toJavaTime()),
+                Optional.of(queryStats.getStartingTime().toJavaTime()),
+                Optional.of(queryStats.getExecutionTime().toJavaTime()),
+                Optional.of(queryStats.getInputBlockedTime().toJavaTime()),
+                Optional.of(queryStats.getFailedInputBlockedTime().toJavaTime()),
+                Optional.of(queryStats.getOutputBlockedTime().toJavaTime()),
+                Optional.of(queryStats.getFailedOutputBlockedTime().toJavaTime()),
+                Optional.of(queryStats.getPhysicalInputReadTime().toJavaTime()),
                 queryStats.getPeakUserMemoryReservation().toBytes(),
                 queryStats.getPeakTaskUserMemory().toBytes(),
                 queryStats.getPeakTaskTotalMemory().toBytes(),
@@ -598,8 +599,8 @@ public class QueryMonitor
     {
         try {
             QueryStats queryStats = queryInfo.getQueryStats();
-            DateTime queryStartTime = queryStats.getCreateTime();
-            DateTime queryEndTime = queryStats.getEndTime();
+            Instant queryStartTime = queryStats.getCreateTime().truncatedTo(MILLIS);
+            Instant queryEndTime = queryStats.getEndTime().truncatedTo(MILLIS);
 
             // query didn't finish cleanly
             if (queryStartTime == null || queryEndTime == null) {
@@ -613,8 +614,8 @@ public class QueryMonitor
             long waiting = queryStats.getResourceWaitingTime().toMillis();
 
             List<StageInfo> stages = getAllStages(queryInfo.getOutputStage());
-            long firstTaskStartTime = queryEndTime.getMillis();
-            long lastTaskEndTime = queryStartTime.getMillis() + planning;
+            Instant firstTaskStartTime = queryEndTime;
+            Instant lastTaskEndTime = queryStartTime.plusMillis(planning);
             for (StageInfo stage : stages) {
                 // only consider leaf stages
                 if (!stage.getSubStages().isEmpty()) {
@@ -624,22 +625,22 @@ public class QueryMonitor
                 for (TaskInfo taskInfo : stage.getTasks()) {
                     TaskStats taskStats = taskInfo.stats();
 
-                    DateTime firstStartTime = taskStats.getFirstStartTime();
+                    Instant firstStartTime = taskStats.getFirstStartTime();
                     if (firstStartTime != null) {
-                        firstTaskStartTime = Math.min(firstStartTime.getMillis(), firstTaskStartTime);
+                        firstTaskStartTime = min(firstStartTime, firstTaskStartTime);
                     }
 
-                    DateTime endTime = taskStats.getEndTime();
+                    Instant endTime = taskStats.getEndTime();
                     if (endTime != null) {
-                        lastTaskEndTime = max(endTime.getMillis(), lastTaskEndTime);
+                        lastTaskEndTime = max(endTime, lastTaskEndTime);
                     }
                 }
             }
 
-            long elapsed = max(queryEndTime.getMillis() - queryStartTime.getMillis(), 0);
-            long scheduling = max(firstTaskStartTime - queryStartTime.getMillis() - planning, 0);
-            long running = max(lastTaskEndTime - firstTaskStartTime, 0);
-            long finishing = max(queryEndTime.getMillis() - lastTaskEndTime, 0);
+            long elapsed = Math.max(queryEndTime.toEpochMilli() - queryStartTime.toEpochMilli(), 0);
+            long scheduling = Math.max(firstTaskStartTime.toEpochMilli() - queryStartTime.toEpochMilli() - planning, 0);
+            long running = Math.max(lastTaskEndTime.toEpochMilli() - firstTaskStartTime.toEpochMilli(), 0);
+            long finishing = Math.max(queryEndTime.toEpochMilli() - lastTaskEndTime.toEpochMilli(), 0);
 
             logQueryTimeline(
                     queryInfo.getQueryId(),
@@ -662,15 +663,15 @@ public class QueryMonitor
 
     private static void logQueryTimeline(BasicQueryInfo queryInfo)
     {
-        DateTime queryStartTime = queryInfo.getQueryStats().getCreateTime();
-        DateTime queryEndTime = queryInfo.getQueryStats().getEndTime();
+        Instant queryStartTime = queryInfo.getQueryStats().getCreateTime().truncatedTo(MILLIS);
+        Instant queryEndTime = queryInfo.getQueryStats().getEndTime().truncatedTo(MILLIS);
 
         // query didn't finish cleanly
         if (queryStartTime == null || queryEndTime == null) {
             return;
         }
 
-        long elapsed = max(queryEndTime.getMillis() - queryStartTime.getMillis(), 0);
+        long elapsed = Math.max(queryEndTime.toEpochMilli() - queryStartTime.toEpochMilli(), 0);
 
         logQueryTimeline(
                 queryInfo.getQueryId(),
@@ -698,8 +699,8 @@ public class QueryMonitor
             long schedulingMillis,
             long runningMillis,
             long finishingMillis,
-            DateTime queryStartTime,
-            DateTime queryEndTime)
+            Instant queryStartTime,
+            Instant queryEndTime)
     {
         log.info("TIMELINE: Query %s :: %s%s :: elapsed %sms :: planning %sms :: waiting %sms :: scheduling %sms :: running %sms :: finishing %sms :: begin %s :: end %s%s",
                 queryId,
@@ -711,8 +712,8 @@ public class QueryMonitor
                 schedulingMillis,
                 runningMillis,
                 finishingMillis,
-                queryStartTime,
-                queryEndTime,
+                queryStartTime.atZone(ZONE_ID).format(ISO_OFFSET_DATE_TIME),
+                queryEndTime.atZone(ZONE_ID).format(ISO_OFFSET_DATE_TIME),
                 encoding.map(id -> " :: " + id).orElse(""));
     }
 
@@ -844,15 +845,15 @@ public class QueryMonitor
 
     private StageTaskStatistics computeStageTaskStatistics(QueryInfo queryInfo, StageInfo stageInfo)
     {
-        long queryCreateTimeMillis = queryInfo.getQueryStats().getCreateTime().getMillis();
-        LongSymmetricDistribution createTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.of(taskInfo.stats().getCreateTime().getMillis() - queryCreateTimeMillis));
-        LongSymmetricDistribution firstStartTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getFirstStartTime()).map(value -> value.getMillis() - queryCreateTimeMillis));
-        LongSymmetricDistribution lastStartTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getLastStartTime()).map(value -> value.getMillis() - queryCreateTimeMillis));
-        LongSymmetricDistribution terminatingStartTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getTerminatingStartTime()).map(value -> value.getMillis() - queryCreateTimeMillis));
-        LongSymmetricDistribution lastEndTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getLastEndTime()).map(value -> value.getMillis() - queryCreateTimeMillis));
-        LongSymmetricDistribution endTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getEndTime()).map(value -> value.getMillis() - queryCreateTimeMillis));
+        long queryCreateTimeMillis = queryInfo.getQueryStats().getCreateTime().toEpochMilli();
+        LongSymmetricDistribution createTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.of(taskInfo.stats().getCreateTime().toEpochMilli() - queryCreateTimeMillis));
+        LongSymmetricDistribution firstStartTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getFirstStartTime()).map(value -> value.toEpochMilli() - queryCreateTimeMillis));
+        LongSymmetricDistribution lastStartTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getLastStartTime()).map(value -> value.toEpochMilli() - queryCreateTimeMillis));
+        LongSymmetricDistribution terminatingStartTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getTerminatingStartTime()).map(value -> value.toEpochMilli() - queryCreateTimeMillis));
+        LongSymmetricDistribution lastEndTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getLastEndTime()).map(value -> value.toEpochMilli() - queryCreateTimeMillis));
+        LongSymmetricDistribution endTimeMillisDistribution = getTasksSymmetricDistribution(stageInfo, taskInfo -> Optional.ofNullable(taskInfo.stats().getEndTime()).map(value -> value.toEpochMilli() - queryCreateTimeMillis));
 
-        Optional<Long> queryExecutionTime = Optional.ofNullable(queryInfo.getQueryStats().getEndTime()).map(value -> value.getMillis() - queryCreateTimeMillis);
+        Optional<Long> queryExecutionTime = Optional.ofNullable(queryInfo.getQueryStats().getEndTime()).map(value -> value.toEpochMilli() - queryCreateTimeMillis);
         DoubleSymmetricDistribution createTimeScaledDistribution;
         DoubleSymmetricDistribution firstStartTimeScaledDistribution;
         DoubleSymmetricDistribution lastStartTimeScaledDistribution;
@@ -1021,5 +1022,15 @@ public class QueryMonitor
         {
             return fragmentId + ":" + nodeId;
         }
+    }
+
+    private static Instant min(Instant a, Instant b)
+    {
+        return a.isBefore(b) ? a : b;
+    }
+
+    private static Instant max(Instant a, Instant b)
+    {
+        return a.isAfter(b) ? a : b;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/event/SplitMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/SplitMonitor.java
@@ -82,9 +82,9 @@ public class SplitMonitor
                             taskId.getStageId().toString(),
                             taskId.toString(),
                             catalogName.map(CatalogName::toString),
-                            driverStats.getCreateTime().toDate().toInstant(),
-                            Optional.ofNullable(driverStats.getStartTime()).map(startTime -> startTime.toDate().toInstant()),
-                            Optional.ofNullable(driverStats.getEndTime()).map(endTime -> endTime.toDate().toInstant()),
+                            driverStats.getCreateTime(),
+                            Optional.ofNullable(driverStats.getStartTime()),
+                            Optional.ofNullable(driverStats.getEndTime()),
                             new SplitStatistics(
                                     ofMillis(driverStats.getTotalCpuTime().toMillis()),
                                     elapsedTime,

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -32,8 +32,8 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Statement;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -102,25 +102,25 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return stateMachine.getCreateTime();
     }
 
     @Override
-    public Optional<DateTime> getExecutionStartTime()
+    public Optional<Instant> getExecutionStartTime()
     {
         return stateMachine.getExecutionStartTime();
     }
 
     @Override
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
         return stateMachine.getLastHeartbeat();
     }
 
     @Override
-    public Optional<DateTime> getEndTime()
+    public Optional<Instant> getEndTime()
     {
         return stateMachine.getEndTime();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -63,9 +63,9 @@ import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionInfo;
 import io.trino.transaction.TransactionManager;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1343,12 +1343,12 @@ public class QueryStateMachine
         queryStateTimer.endAnalysis();
     }
 
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return queryStateTimer.getCreateTime();
     }
 
-    public Optional<DateTime> getExecutionStartTime()
+    public Optional<Instant> getExecutionStartTime()
     {
         return queryStateTimer.getExecutionStartTime();
     }
@@ -1360,12 +1360,12 @@ public class QueryStateMachine
                 .map(_ -> queryStateTimer.getPlanningTime());
     }
 
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
         return queryStateTimer.getLastHeartbeat();
     }
 
-    public Optional<DateTime> getEndTime()
+    public Optional<Instant> getEndTime()
     {
         return queryStateTimer.getEndTime();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateTimer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateTimer.java
@@ -15,10 +15,10 @@ package io.trino.execution;
 
 import com.google.common.base.Ticker;
 import io.airlift.units.Duration;
-import org.joda.time.DateTime;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -33,7 +33,7 @@ class QueryStateTimer
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
     private final Ticker ticker;
 
-    private final DateTime createTime = DateTime.now();
+    private final Instant createTime = Instant.now();
 
     private final long createNanos;
     private final AtomicReference<Long> beginResourceWaitingNanos = new AtomicReference<>();
@@ -190,19 +190,19 @@ class QueryStateTimer
     // Stats
     //
 
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }
 
-    public Optional<DateTime> getExecutionStartTime()
+    public Optional<Instant> getExecutionStartTime()
     {
-        return toDateTime(beginPlanningNanos);
+        return toInstant(beginPlanningNanos);
     }
 
-    public Optional<DateTime> getPlanningStartTime()
+    public Optional<Instant> getPlanningStartTime()
     {
-        return toDateTime(beginPlanningNanos);
+        return toInstant(beginPlanningNanos);
     }
 
     public Duration getElapsedTime()
@@ -259,9 +259,9 @@ class QueryStateTimer
         return getDuration(executionTime, beginPlanningNanos);
     }
 
-    public Optional<DateTime> getEndTime()
+    public Optional<Instant> getEndTime()
     {
-        return toDateTime(endNanos);
+        return toInstant(endNanos);
     }
 
     public Duration getAnalysisTime()
@@ -269,9 +269,9 @@ class QueryStateTimer
         return getDuration(analysisTime, beginAnalysisNanos);
     }
 
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
-        return toDateTime(lastHeartbeatNanos.get());
+        return toInstant(lastHeartbeatNanos.get());
     }
 
     //
@@ -310,19 +310,18 @@ class QueryStateTimer
         return new Duration(0, MILLISECONDS);
     }
 
-    private Optional<DateTime> toDateTime(AtomicReference<Long> instantNanos)
+    private Optional<Instant> toInstant(AtomicReference<Long> instantNanos)
     {
         Long nanos = instantNanos.get();
         if (nanos == null) {
             return Optional.empty();
         }
-        return Optional.of(toDateTime(nanos));
+        return Optional.of(toInstant(nanos));
     }
 
-    private DateTime toDateTime(long instantNanos)
+    private Instant toInstant(long instantNanos)
     {
-        long millisSinceCreate = NANOSECONDS.toMillis(instantNanos - createNanos);
-        return new DateTime(createTime.getMillis() + millisSinceCreate);
+        return createTime.plusMillis(NANOSECONDS.toMillis(instantNanos - createNanos));
     }
 
     private static long currentThreadCpuTime()

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
@@ -25,8 +25,8 @@ import io.trino.operator.TableWriterOperator;
 import io.trino.spi.eventlistener.QueryPlanOptimizerStatistics;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.OptionalDouble;
 import java.util.Set;
@@ -39,11 +39,11 @@ import static java.util.Objects.requireNonNull;
 
 public class QueryStats
 {
-    private final DateTime createTime;
+    private final Instant createTime;
 
-    private final DateTime executionStartTime;
-    private final DateTime lastHeartbeat;
-    private final DateTime endTime;
+    private final Instant executionStartTime;
+    private final Instant lastHeartbeat;
+    private final Instant endTime;
 
     private final Duration elapsedTime;
     private final Duration queuedTime;
@@ -137,10 +137,10 @@ public class QueryStats
 
     @JsonCreator
     public QueryStats(
-            @JsonProperty("createTime") DateTime createTime,
-            @JsonProperty("executionStartTime") DateTime executionStartTime,
-            @JsonProperty("lastHeartbeat") DateTime lastHeartbeat,
-            @JsonProperty("endTime") DateTime endTime,
+            @JsonProperty("createTime") Instant createTime,
+            @JsonProperty("executionStartTime") Instant executionStartTime,
+            @JsonProperty("lastHeartbeat") Instant lastHeartbeat,
+            @JsonProperty("endTime") Instant endTime,
 
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("queuedTime") Duration queuedTime,
@@ -348,26 +348,26 @@ public class QueryStats
     }
 
     @JsonProperty
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }
 
     @JsonProperty
-    public DateTime getExecutionStartTime()
+    public Instant getExecutionStartTime()
     {
         return executionStartTime;
     }
 
     @JsonProperty
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
         return lastHeartbeat;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getEndTime()
+    public Instant getEndTime()
     {
         return endTime;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -77,8 +77,8 @@ import io.trino.sql.planner.plan.OutputNode;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.Statement;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -336,13 +336,13 @@ public class SqlQueryExecution
     }
 
     @Override
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return stateMachine.getCreateTime();
     }
 
     @Override
-    public Optional<DateTime> getExecutionStartTime()
+    public Optional<Instant> getExecutionStartTime()
     {
         return stateMachine.getExecutionStartTime();
     }
@@ -354,13 +354,13 @@ public class SqlQueryExecution
     }
 
     @Override
-    public DateTime getLastHeartbeat()
+    public Instant getLastHeartbeat()
     {
         return stateMachine.getLastHeartbeat();
     }
 
     @Override
-    public Optional<DateTime> getEndTime()
+    public Optional<Instant> getEndTime()
     {
         return stateMachine.getEndTime();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -48,9 +48,9 @@ import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.tracing.TrinoAttributes;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,7 +97,7 @@ public class SqlTask
     private final SqlTaskExecutionFactory sqlTaskExecutionFactory;
     private final Executor taskNotificationExecutor;
 
-    private final AtomicReference<DateTime> lastHeartbeat = new AtomicReference<>(DateTime.now());
+    private final AtomicReference<Instant> lastHeartbeat = new AtomicReference<>(Instant.now());
     private final AtomicLong taskStatusVersion = new AtomicLong(TaskStatus.STARTING_VERSION);
     private final FutureStateChange<?> taskStatusVersionChange = new FutureStateChange<>();
     // Must be synchronized when updating the current task holder reference, but not when only reading the current reference value
@@ -247,7 +247,7 @@ public class SqlTask
         return taskStateMachine.getState();
     }
 
-    public DateTime getTaskCreatedTime()
+    public Instant getTaskCreatedTime()
     {
         return taskStateMachine.getCreatedTime();
     }
@@ -264,7 +264,7 @@ public class SqlTask
 
     public void recordHeartbeat()
     {
-        lastHeartbeat.set(DateTime.now());
+        lastHeartbeat.set(Instant.now());
     }
 
     public TaskInfo getTaskInfo()
@@ -426,7 +426,7 @@ public class SqlTask
             return taskExecution.getTaskContext().getTaskStats();
         }
         // if the task completed without creation, set end time
-        DateTime endTime = taskStateMachine.getState().isDone() ? DateTime.now() : null;
+        Instant endTime = taskStateMachine.getState().isDone() ? Instant.now() : null;
         return new TaskStats(taskStateMachine.getCreatedTime(), endTime);
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -37,8 +37,8 @@ import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.tracing.TrinoAttributes;
 import io.trino.util.Failures;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -90,7 +90,7 @@ public class StageStateMachine
     private final Span stageSpan;
     private final AtomicReference<ExecutionFailureInfo> failureCause = new AtomicReference<>();
 
-    private final AtomicReference<DateTime> schedulingComplete = new AtomicReference<>();
+    private final AtomicReference<Instant> schedulingComplete = new AtomicReference<>();
     private final Map<PlanNodeId, Distribution> getSplitDistribution = new ConcurrentHashMap<>();
     private final Map<PlanNodeId, Metrics> splitSourceMetrics = new ConcurrentHashMap<>();
 
@@ -171,7 +171,7 @@ public class StageStateMachine
 
     public boolean transitionToRunning()
     {
-        schedulingComplete.compareAndSet(null, DateTime.now());
+        schedulingComplete.compareAndSet(null, Instant.now());
         return stageState.setIf(RUNNING, currentState -> currentState != RUNNING && !currentState.isDone());
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -27,8 +27,8 @@ import io.trino.operator.OperatorStats;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,7 +47,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @Immutable
 public class StageStats
 {
-    private final DateTime schedulingComplete;
+    private final Instant schedulingComplete;
 
     private final Map<PlanNodeId, DistributionSnapshot> getSplitDistribution;
     private final Map<PlanNodeId, Metrics> splitSourceMetrics;
@@ -126,7 +126,7 @@ public class StageStats
 
     @JsonCreator
     public StageStats(
-            @JsonProperty("schedulingComplete") DateTime schedulingComplete,
+            @JsonProperty("schedulingComplete") Instant schedulingComplete,
 
             @JsonProperty("getSplitDistribution") Map<PlanNodeId, DistributionSnapshot> getSplitDistribution,
             @JsonProperty("splitSourceMetrics") Map<PlanNodeId, Metrics> splitSourceMetrics,
@@ -300,7 +300,7 @@ public class StageStats
     }
 
     @JsonProperty
-    public DateTime getSchedulingComplete()
+    public Instant getSchedulingComplete()
     {
         return schedulingComplete;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
@@ -19,9 +19,9 @@ import io.trino.execution.buffer.OutputBufferInfo;
 import io.trino.execution.buffer.PipelinedBufferInfo;
 import io.trino.operator.TaskStats;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 public record TaskInfo(
         TaskStatus taskStatus,
-        DateTime lastHeartbeat,
+        Instant lastHeartbeat,
         OutputBufferInfo outputBuffers,
         Set<PlanNodeId> noMoreSplits,
         TaskStats stats,
@@ -82,7 +82,7 @@ public record TaskInfo(
     {
         return new TaskInfo(
                 initialTaskStatus(taskId, location, nodeId, speculative),
-                DateTime.now(),
+                Instant.now(),
                 new OutputBufferInfo(
                         "UNINITIALIZED",
                         OPEN,

--- a/core/trino-main/src/main/java/io/trino/execution/TaskStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskStateMachine.java
@@ -20,8 +20,8 @@ import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.log.Logger;
 import io.trino.execution.StateMachine.StateChangeListener;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,7 +50,7 @@ public class TaskStateMachine
 {
     private static final Logger log = Logger.get(TaskStateMachine.class);
 
-    private final DateTime createdTime = DateTime.now();
+    private final Instant createdTime = Instant.now();
 
     private final TaskId taskId;
     private final Executor executor;
@@ -70,7 +70,7 @@ public class TaskStateMachine
         taskState.addStateChangeListener(newState -> log.debug("Task %s is %s", taskId, newState));
     }
 
-    public DateTime getCreatedTime()
+    public Instant getCreatedTime()
     {
         return createdTime;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -25,8 +25,8 @@ import io.trino.memory.QueryContextVisitor;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.operator.OperationTimer.OperationTiming;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -59,7 +59,7 @@ public class DriverContext
 
     private final AtomicBoolean finished = new AtomicBoolean();
 
-    private final DateTime createdTime = DateTime.now();
+    private final Instant createdTime = Instant.now();
     private final long createNanos = System.nanoTime();
 
     private final AtomicLong startNanos = new AtomicLong();
@@ -70,8 +70,8 @@ public class DriverContext
     private final AtomicReference<BlockedMonitor> blockedMonitor = new AtomicReference<>();
     private final AtomicLong blockedWallNanos = new AtomicLong();
 
-    private final AtomicReference<DateTime> executionStartTime = new AtomicReference<>();
-    private final AtomicReference<DateTime> executionEndTime = new AtomicReference<>();
+    private final AtomicReference<Instant> executionStartTime = new AtomicReference<>();
+    private final AtomicReference<Instant> executionEndTime = new AtomicReference<>();
     private final AtomicReference<Optional<Duration>> blockedTimeout = new AtomicReference<>(Optional.empty());
 
     private final MemoryTrackingContext driverMemoryContext;
@@ -153,7 +153,7 @@ public class DriverContext
     {
         // Must update startNanos first so that the value is valid once executionStartTime is not null
         if (executionStartTime.get() == null && startNanos.compareAndSet(0, System.nanoTime())) {
-            executionStartTime.set(DateTime.now());
+            executionStartTime.set(Instant.now());
             pipelineContext.start();
         }
     }
@@ -185,7 +185,7 @@ public class DriverContext
         }
         // Must update endNanos first, so that the value is valid after executionEndTime is not null
         endNanos.set(System.nanoTime());
-        executionEndTime.set(DateTime.now());
+        executionEndTime.set(Instant.now());
 
         pipelineContext.driverFinished(this);
     }
@@ -326,11 +326,11 @@ public class DriverContext
         }
 
         // startNanos is always valid once executionStartTime is not null
-        DateTime executionStartTime = this.executionStartTime.get();
+        Instant executionStartTime = this.executionStartTime.get();
         Duration queuedTime = new Duration(nanosBetween(createNanos, executionStartTime == null ? System.nanoTime() : startNanos.get()), NANOSECONDS);
 
         // endNanos is always valid once executionStartTime is not null
-        DateTime executionEndTime = this.executionEndTime.get();
+        Instant executionEndTime = this.executionEndTime.get();
         Duration elapsedTime = new Duration(nanosBetween(createNanos, executionEndTime == null ? System.nanoTime() : endNanos.get()), NANOSECONDS);
 
         List<OperatorStats> operators = getOperatorStats();

--- a/core/trino-main/src/main/java/io/trino/operator/DriverStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverStats.java
@@ -21,8 +21,8 @@ import com.google.errorprone.annotations.Immutable;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -33,9 +33,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @Immutable
 public class DriverStats
 {
-    private final DateTime createTime;
-    private final DateTime startTime;
-    private final DateTime endTime;
+    private final Instant createTime;
+    private final Instant startTime;
+    private final Instant endTime;
 
     private final Duration queuedTime;
     private final Duration elapsedTime;
@@ -78,7 +78,7 @@ public class DriverStats
 
     public DriverStats()
     {
-        this.createTime = DateTime.now();
+        this.createTime = Instant.now();
         this.startTime = null;
         this.endTime = null;
         this.queuedTime = new Duration(0, MILLISECONDS);
@@ -123,9 +123,9 @@ public class DriverStats
 
     @JsonCreator
     public DriverStats(
-            @JsonProperty("createTime") DateTime createTime,
-            @JsonProperty("startTime") DateTime startTime,
-            @JsonProperty("endTime") DateTime endTime,
+            @JsonProperty("createTime") Instant createTime,
+            @JsonProperty("startTime") Instant startTime,
+            @JsonProperty("endTime") Instant endTime,
             @JsonProperty("queuedTime") Duration queuedTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
 
@@ -214,21 +214,21 @@ public class DriverStats
     }
 
     @JsonProperty
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getStartTime()
+    public Instant getStartTime()
     {
         return startTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getEndTime()
+    public Instant getEndTime()
     {
         return endTime;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
@@ -41,13 +41,13 @@ import io.trino.server.remotetask.Backoff;
 import io.trino.spi.TrinoException;
 import io.trino.spi.TrinoTransportException;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -135,7 +135,7 @@ public final class HttpPageBufferClient
     @GuardedBy("this")
     private HttpResponseFuture<?> future;
     @GuardedBy("this")
-    private DateTime lastUpdate = DateTime.now();
+    private Instant lastUpdate = Instant.now();
     @GuardedBy("this")
     private long token;
     @GuardedBy("this")
@@ -291,7 +291,7 @@ public final class HttpPageBufferClient
 
             this.future = null;
 
-            lastUpdate = DateTime.now();
+            lastUpdate = Instant.now();
         }
 
         if (future != null && !future.isDone()) {
@@ -326,7 +326,7 @@ public final class HttpPageBufferClient
             }
         }, delayNanos, NANOSECONDS);
 
-        lastUpdate = DateTime.now();
+        lastUpdate = Instant.now();
         requestsScheduled.incrementAndGet();
     }
 
@@ -349,7 +349,7 @@ public final class HttpPageBufferClient
             sendGetResults();
         }
 
-        lastUpdate = DateTime.now();
+        lastUpdate = Instant.now();
     }
 
     private synchronized void sendGetResults()
@@ -465,7 +465,7 @@ public final class HttpPageBufferClient
                     if (future == resultFuture) {
                         future = null;
                     }
-                    lastUpdate = DateTime.now();
+                    lastUpdate = Instant.now();
                 }
                 clientCallback.requestComplete(HttpPageBufferClient.this);
             }
@@ -542,7 +542,7 @@ public final class HttpPageBufferClient
                     if (future == resultFuture) {
                         future = null;
                     }
-                    lastUpdate = DateTime.now();
+                    lastUpdate = Instant.now();
                 }
                 requestsCompleted.incrementAndGet();
                 clientCallback.clientFinished(HttpPageBufferClient.this);
@@ -590,7 +590,7 @@ public final class HttpPageBufferClient
             if (future == expectedFuture) {
                 future = null;
             }
-            lastUpdate = DateTime.now();
+            lastUpdate = Instant.now();
         }
         clientCallback.requestComplete(HttpPageBufferClient.this);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/PageBufferClientStatus.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageBufferClientStatus.java
@@ -15,9 +15,9 @@ package io.trino.operator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
@@ -28,7 +28,7 @@ public class PageBufferClientStatus
 {
     private final URI uri;
     private final String state;
-    private final DateTime lastUpdate;
+    private final Instant lastUpdate;
     private final long rowsReceived;
     private final int pagesReceived;
     // use optional to keep the output size down, since this renders for every destination
@@ -43,7 +43,7 @@ public class PageBufferClientStatus
     @JsonCreator
     public PageBufferClientStatus(@JsonProperty("uri") URI uri,
             @JsonProperty("state") String state,
-            @JsonProperty("lastUpdate") DateTime lastUpdate,
+            @JsonProperty("lastUpdate") Instant lastUpdate,
             @JsonProperty("rowsReceived") long rowsReceived,
             @JsonProperty("pagesReceived") int pagesReceived,
             @JsonProperty("rowsRejected") OptionalLong rowsRejected,
@@ -81,7 +81,7 @@ public class PageBufferClientStatus
     }
 
     @JsonProperty
-    public DateTime getLastUpdate()
+    public Instant getLastUpdate()
     {
         return lastUpdate;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
@@ -29,8 +29,8 @@ import io.trino.memory.QueryContextVisitor;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.spi.metrics.Metrics;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
@@ -70,9 +70,9 @@ public class PipelineContext
     private final AtomicInteger completedDrivers = new AtomicInteger();
     private final AtomicLong completedSplitsWeight = new AtomicLong();
 
-    private final AtomicReference<DateTime> executionStartTime = new AtomicReference<>();
-    private final AtomicReference<DateTime> lastExecutionStartTime = new AtomicReference<>();
-    private final AtomicReference<DateTime> lastExecutionEndTime = new AtomicReference<>();
+    private final AtomicReference<Instant> executionStartTime = new AtomicReference<>();
+    private final AtomicReference<Instant> lastExecutionStartTime = new AtomicReference<>();
+    private final AtomicReference<Instant> lastExecutionEndTime = new AtomicReference<>();
 
     private final CounterStat spilledDataSize = new CounterStat();
 
@@ -201,7 +201,7 @@ public class PipelineContext
         }
 
         // always update last execution end time
-        lastExecutionEndTime.set(DateTime.now());
+        lastExecutionEndTime.set(Instant.now());
 
         DriverStats driverStats = driverContext.getDriverStats();
 
@@ -252,7 +252,7 @@ public class PipelineContext
 
     public void start()
     {
-        DateTime now = DateTime.now();
+        Instant now = Instant.now();
         executionStartTime.compareAndSet(null, now);
         // always update last execution start time
         lastExecutionStartTime.set(now);
@@ -383,7 +383,7 @@ public class PipelineContext
     {
         // check for end state to avoid callback ordering problems
         if (taskContext.getState().isDone()) {
-            DateTime now = DateTime.now();
+            Instant now = Instant.now();
             executionStartTime.compareAndSet(null, now);
             lastExecutionStartTime.compareAndSet(null, now);
             lastExecutionEndTime.compareAndSet(null, now);

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
@@ -22,8 +22,8 @@ import io.airlift.stats.Distribution.DistributionSnapshot;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -36,9 +36,9 @@ public class PipelineStats
 {
     private final int pipelineId;
 
-    private final DateTime firstStartTime;
-    private final DateTime lastStartTime;
-    private final DateTime lastEndTime;
+    private final Instant firstStartTime;
+    private final Instant lastStartTime;
+    private final Instant lastEndTime;
 
     private final boolean inputPipeline;
     private final boolean outputPipeline;
@@ -96,9 +96,9 @@ public class PipelineStats
     public PipelineStats(
             @JsonProperty("pipelineId") int pipelineId,
 
-            @JsonProperty("firstStartTime") DateTime firstStartTime,
-            @JsonProperty("lastStartTime") DateTime lastStartTime,
-            @JsonProperty("lastEndTime") DateTime lastEndTime,
+            @JsonProperty("firstStartTime") Instant firstStartTime,
+            @JsonProperty("lastStartTime") Instant lastStartTime,
+            @JsonProperty("lastEndTime") Instant lastEndTime,
 
             @JsonProperty("inputPipeline") boolean inputPipeline,
             @JsonProperty("outputPipeline") boolean outputPipeline,
@@ -233,21 +233,21 @@ public class PipelineStats
 
     @Nullable
     @JsonProperty
-    public DateTime getFirstStartTime()
+    public Instant getFirstStartTime()
     {
         return firstStartTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getLastStartTime()
+    public Instant getLastStartTime()
     {
         return lastStartTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getLastEndTime()
+    public Instant getLastEndTime()
     {
         return lastEndTime;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -20,8 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import jakarta.annotation.Nullable;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,12 +33,12 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TaskStats
 {
-    private final DateTime createTime;
-    private final DateTime firstStartTime;
-    private final DateTime lastStartTime;
-    private final DateTime terminatingStartTime;
-    private final DateTime lastEndTime;
-    private final DateTime endTime;
+    private final Instant createTime;
+    private final Instant firstStartTime;
+    private final Instant lastStartTime;
+    private final Instant terminatingStartTime;
+    private final Instant lastEndTime;
+    private final Instant endTime;
 
     private final Duration elapsedTime;
     private final Duration queuedTime;
@@ -95,7 +95,7 @@ public class TaskStats
 
     private final List<PipelineStats> pipelines;
 
-    public TaskStats(DateTime createTime, DateTime endTime)
+    public TaskStats(Instant createTime, Instant endTime)
     {
         this(createTime,
                 null,
@@ -147,12 +147,12 @@ public class TaskStats
 
     @JsonCreator
     public TaskStats(
-            @JsonProperty("createTime") DateTime createTime,
-            @JsonProperty("firstStartTime") DateTime firstStartTime,
-            @JsonProperty("lastStartTime") DateTime lastStartTime,
-            @JsonProperty("terminatingStartTime") DateTime terminatingStartTime,
-            @JsonProperty("lastEndTime") DateTime lastEndTime,
-            @JsonProperty("endTime") DateTime endTime,
+            @JsonProperty("createTime") Instant createTime,
+            @JsonProperty("firstStartTime") Instant firstStartTime,
+            @JsonProperty("lastStartTime") Instant lastStartTime,
+            @JsonProperty("terminatingStartTime") Instant terminatingStartTime,
+            @JsonProperty("lastEndTime") Instant lastEndTime,
+            @JsonProperty("endTime") Instant endTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("queuedTime") Duration queuedTime,
 
@@ -289,42 +289,42 @@ public class TaskStats
     }
 
     @JsonProperty
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getFirstStartTime()
+    public Instant getFirstStartTime()
     {
         return firstStartTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getLastStartTime()
+    public Instant getLastStartTime()
     {
         return lastStartTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getTerminatingStartTime()
+    public Instant getTerminatingStartTime()
     {
         return terminatingStartTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getLastEndTime()
+    public Instant getLastEndTime()
     {
         return lastEndTime;
     }
 
     @Nullable
     @JsonProperty
-    public DateTime getEndTime()
+    public Instant getEndTime()
     {
         return endTime;
     }

--- a/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
@@ -21,8 +21,8 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.execution.QueryStats;
 import io.trino.operator.BlockedReason;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.OptionalDouble;
 import java.util.Set;
 
@@ -37,8 +37,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @Immutable
 public class BasicQueryStats
 {
-    private final DateTime createTime;
-    private final DateTime endTime;
+    private final Instant createTime;
+    private final Instant endTime;
 
     private final Duration queuedTime;
     private final Duration elapsedTime;
@@ -81,8 +81,8 @@ public class BasicQueryStats
 
     @JsonCreator
     public BasicQueryStats(
-            @JsonProperty("createTime") DateTime createTime,
-            @JsonProperty("endTime") DateTime endTime,
+            @JsonProperty("createTime") Instant createTime,
+            @JsonProperty("endTime") Instant endTime,
             @JsonProperty("queuedTime") Duration queuedTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("executionTime") Duration executionTime,
@@ -208,7 +208,7 @@ public class BasicQueryStats
 
     public static BasicQueryStats immediateFailureQueryStats()
     {
-        DateTime now = DateTime.now();
+        Instant now = Instant.now();
         return new BasicQueryStats(
                 now,
                 now,
@@ -248,13 +248,13 @@ public class BasicQueryStats
     }
 
     @JsonProperty
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }
 
     @JsonProperty
-    public DateTime getEndTime()
+    public Instant getEndTime()
     {
         return endTime;
     }

--- a/core/trino-main/src/main/java/io/trino/server/QueryStateInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryStateInfo.java
@@ -19,8 +19,8 @@ import com.google.common.collect.ImmutableList;
 import io.trino.execution.QueryState;
 import io.trino.spi.QueryId;
 import io.trino.spi.resourcegroups.ResourceGroupId;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,7 +34,7 @@ public class QueryStateInfo
     private final QueryId queryId;
     private final Optional<ResourceGroupId> resourceGroupId;
     private final String query;
-    private final DateTime createTime;
+    private final Instant createTime;
     private final String user;
     private final Optional<String> source;
     private final Optional<String> clientInfo;
@@ -49,7 +49,7 @@ public class QueryStateInfo
             @JsonProperty("queryState") QueryState queryState,
             @JsonProperty("resourceGroupId") Optional<ResourceGroupId> resourceGroupId,
             @JsonProperty("query") String query,
-            @JsonProperty("createTime") DateTime createTime,
+            @JsonProperty("createTime") Instant createTime,
             @JsonProperty("user") String user,
             @JsonProperty("source") Optional<String> source,
             @JsonProperty("clientInfo") Optional<String> clientInfo,
@@ -169,7 +169,7 @@ public class QueryStateInfo
     }
 
     @JsonProperty
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -19,7 +19,6 @@ import com.google.errorprone.annotations.FormatMethod;
 import com.sun.management.UnixOperatingSystemMXBean;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.joda.time.DateTime;
 
 import java.lang.Runtime.Version;
 import java.lang.management.GarbageCollectorMXBean;
@@ -27,6 +26,7 @@ import java.lang.management.ManagementFactory;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Year;
 import java.util.List;
 import java.util.Locale;
 import java.util.OptionalLong;
@@ -173,8 +173,8 @@ final class TrinoSystemRequirements
      */
     private static void verifySystemTimeIsReasonable()
     {
-        int currentYear = DateTime.now().year().get();
-        if (currentYear < 2024) {
+        Year currentYear = Year.now();
+        if (currentYear.isBefore(Year.of(2025))) {
             failRequirement("Trino requires the system time to be current (found year %s)", currentYear);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -73,9 +73,9 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.tracing.TrinoAttributes;
 import jakarta.ws.rs.ServiceUnavailableException;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -320,7 +320,7 @@ public final class HttpRemoteTask
                                 .collect(toImmutableList()));
             }
 
-            TaskInfo initialTask = createInitialTask(taskId, location, nodeId, this.speculative.get(), pipelinedBufferStates, new TaskStats(DateTime.now(), null));
+            TaskInfo initialTask = createInitialTask(taskId, location, nodeId, this.speculative.get(), pipelinedBufferStates, new TaskStats(Instant.now(), null));
 
             this.dynamicFiltersFetcher = new DynamicFiltersFetcher(
                     this::fatalUnacknowledgedFailure,

--- a/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
@@ -31,8 +31,8 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.transaction.IsolationLevel;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -335,7 +335,7 @@ public class InMemoryTransactionManager
     @ThreadSafe
     private static class TransactionMetadata
     {
-        private final DateTime createTime = DateTime.now();
+        private final Instant createTime = Instant.now();
         private final CatalogManager catalogManager;
         private final TransactionId transactionId;
         private final IsolationLevel isolationLevel;

--- a/core/trino-main/src/main/java/io/trino/transaction/TransactionInfo.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/TransactionInfo.java
@@ -18,8 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.transaction.IsolationLevel;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -32,7 +32,7 @@ public class TransactionInfo
     private final IsolationLevel isolationLevel;
     private final boolean readOnly;
     private final boolean autoCommitContext;
-    private final DateTime createTime;
+    private final Instant createTime;
     private final Duration idleTime;
     private final List<String> catalogNames;
     private final Optional<String> writtenCatalogName;
@@ -43,7 +43,7 @@ public class TransactionInfo
             IsolationLevel isolationLevel,
             boolean readOnly,
             boolean autoCommitContext,
-            DateTime createTime,
+            Instant createTime,
             Duration idleTime,
             List<String> catalogNames,
             Optional<String> writtenCatalogName,
@@ -80,7 +80,7 @@ public class TransactionInfo
         return autoCommitContext;
     }
 
-    public DateTime getCreateTime()
+    public Instant getCreateTime()
     {
         return createTime;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -26,9 +26,9 @@ import io.trino.server.BasicQueryInfo;
 import io.trino.server.BasicQueryStats;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -120,8 +120,8 @@ public class MockManagedQueryExecution
                 Optional.empty(),
                 Optional.empty(),
                 new BasicQueryStats(
-                        new DateTime(1),
-                        new DateTime(2),
+                        Instant.ofEpochMilli(1),
+                        Instant.ofEpochMilli(2),
                         new Duration(3, NANOSECONDS),
                         new Duration(4, NANOSECONDS),
                         new Duration(5, NANOSECONDS),
@@ -173,10 +173,10 @@ public class MockManagedQueryExecution
                 "SELECT 1",
                 Optional.empty(),
                 new QueryStats(
-                        new DateTime(1),
-                        new DateTime(2),
-                        new DateTime(3),
-                        new DateTime(4),
+                        Instant.ofEpochMilli(1),
+                        Instant.ofEpochMilli(2),
+                        Instant.ofEpochMilli(3),
+                        Instant.ofEpochMilli(4),
                         new Duration(6, NANOSECONDS),
                         new Duration(5, NANOSECONDS),
                         new Duration(31, NANOSECONDS),

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -57,9 +57,9 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.TestingMetadata.TestingColumnHandle;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -260,7 +260,7 @@ public class MockRemoteTaskFactory
         {
             return new TaskInfo(
                     getTaskStatus(),
-                    DateTime.now(),
+                    Instant.now(),
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
                     taskContext.getTaskStats(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
@@ -51,10 +51,10 @@ import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.transaction.TransactionId;
 import io.trino.type.TypeSignatureDeserializer;
 import io.trino.type.TypeSignatureKeyDeserializer;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -270,7 +270,7 @@ public class TestQueryInfo
     private static StageStats createStageStats(int value)
     {
         return new StageStats(
-                new DateTime(value),
+                Instant.ofEpochMilli(value),
                 ImmutableMap.of(new PlanNodeId(Integer.toString(value)), new Distribution.DistributionSnapshot(value, value, value, value, value, value, value, value, value, value, value, value, value, value)),
                 ImmutableMap.of(new PlanNodeId(Integer.toString(value)), new Metrics(ImmutableMap.of("abc", new LongCount(value)))),
                 value,

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
@@ -25,9 +25,9 @@ import io.trino.spi.eventlistener.QueryPlanOptimizerStatistics;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -37,7 +37,6 @@ import static io.trino.server.DynamicFilterService.DynamicFiltersStats;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class TestQueryStats
 {
@@ -182,10 +181,10 @@ public class TestQueryStats
                     0));
 
     public static final QueryStats EXPECTED = new QueryStats(
-            new DateTime(1),
-            new DateTime(2),
-            new DateTime(3),
-            new DateTime(4),
+            Instant.ofEpochMilli(1),
+            Instant.ofEpochMilli(2),
+            Instant.ofEpochMilli(3),
+            Instant.ofEpochMilli(4),
             new Duration(6, NANOSECONDS),
             new Duration(5, NANOSECONDS),
             new Duration(31, NANOSECONDS),
@@ -296,10 +295,10 @@ public class TestQueryStats
 
     public static void assertExpectedQueryStats(QueryStats actual)
     {
-        assertThat(actual.getCreateTime()).isEqualTo(new DateTime(1, UTC));
-        assertThat(actual.getExecutionStartTime()).isEqualTo(new DateTime(2, UTC));
-        assertThat(actual.getLastHeartbeat()).isEqualTo(new DateTime(3, UTC));
-        assertThat(actual.getEndTime()).isEqualTo(new DateTime(4, UTC));
+        assertThat(actual.getCreateTime()).isEqualTo(Instant.ofEpochMilli(1));
+        assertThat(actual.getExecutionStartTime()).isEqualTo(Instant.ofEpochMilli(2));
+        assertThat(actual.getLastHeartbeat()).isEqualTo(Instant.ofEpochMilli(3));
+        assertThat(actual.getEndTime()).isEqualTo(Instant.ofEpochMilli(4));
 
         assertThat(actual.getElapsedTime()).isEqualTo(new Duration(6, NANOSECONDS));
         assertThat(actual.getQueuedTime()).isEqualTo(new Duration(5, NANOSECONDS));

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStateMachine.java
@@ -35,7 +35,6 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.ValuesNode;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -44,6 +43,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.io.IOException;
 import java.net.URI;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -274,7 +274,7 @@ public class TestStageStateMachine
 
     private static TaskStats taskStats(List<PipelineContext> pipelineContexts, int baseValue)
     {
-        return new TaskStats(DateTime.now(),
+        return new TaskStats(Instant.now(),
                 null,
                 null,
                 null,

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
@@ -27,9 +27,9 @@ import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestStageStats
 {
     private static final StageStats EXPECTED = new StageStats(
-            new DateTime(0),
+            Instant.EPOCH,
 
             ImmutableMap.of(new PlanNodeId("1"), getTestDistribution(1)),
             ImmutableMap.of(new PlanNodeId("2"), new Metrics(ImmutableMap.of("metric", new LongCount(2)))),
@@ -134,7 +134,7 @@ public class TestStageStats
 
     private static void assertExpectedStageStats(StageStats actual)
     {
-        assertThat(actual.getSchedulingComplete().getMillis()).isEqualTo(0);
+        assertThat(actual.getSchedulingComplete().toEpochMilli()).isEqualTo(0);
 
         assertThat(actual.getGetSplitDistribution().get(new PlanNodeId("1")).getCount()).isEqualTo(1.0);
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -40,9 +40,9 @@ import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.PlanNodeId;
-import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,7 +142,7 @@ public class TestingRemoteTaskFactory
         {
             return new TaskInfo(
                     getTaskStatus(),
-                    DateTime.now(),
+                    Instant.now(),
                     new OutputBufferInfo(
                             "TESTING",
                             BufferState.FINISHED,
@@ -157,7 +157,7 @@ public class TestingRemoteTaskFactory
                             Optional.empty(),
                             Optional.empty()),
                     ImmutableSet.copyOf(noMoreSplits),
-                    new TaskStats(DateTime.now(), null),
+                    new TaskStats(Instant.now(), null),
                     Optional.empty(),
                     false);
         }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutorSimulation.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutorSimulation.java
@@ -27,9 +27,9 @@ import io.trino.execution.executor.timesharing.SplitGenerators.L4LeafSplitGenera
 import io.trino.execution.executor.timesharing.SplitGenerators.QuantaExceedingSplitGenerator;
 import io.trino.execution.executor.timesharing.SplitGenerators.SimpleLeafSplitGenerator;
 import io.trino.execution.executor.timesharing.SplitGenerators.SlowLeafSplitGenerator;
-import org.joda.time.DateTime;
 
 import java.io.Closeable;
+import java.time.Instant;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
@@ -114,7 +114,7 @@ public class TimeSharingTaskExecutorSimulation
         SECONDS.sleep(5);
 
         System.out.println();
-        System.out.println("Simulation finished at " + DateTime.now() + ". Runtime: " + nanosSince(start));
+        System.out.println("Simulation finished at " + Instant.now() + ". Runtime: " + nanosSince(start));
         System.out.println();
 
         printSummaryStats(controller, taskExecutor);

--- a/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestLeastWastedEffortTaskLowMemoryKiller.java
@@ -29,10 +29,10 @@ import io.trino.execution.buffer.OutputBufferInfo;
 import io.trino.execution.buffer.OutputBufferStatus;
 import io.trino.operator.TaskStats;
 import io.trino.plugin.base.metrics.TDigestHistogram;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -271,7 +271,7 @@ public class TestLeastWastedEffortTaskLowMemoryKiller
                         0,
                         1,
                         1),
-                DateTime.now(),
+                Instant.now(),
                 new OutputBufferInfo(
                         "TESTING",
                         BufferState.FINISHED,
@@ -286,7 +286,7 @@ public class TestLeastWastedEffortTaskLowMemoryKiller
                         Optional.empty(),
                         Optional.empty()),
                 ImmutableSet.of(),
-                new TaskStats(DateTime.now(),
+                new TaskStats(Instant.now(),
                         null,
                         null,
                         null,

--- a/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesTaskLowMemoryKiller.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestTotalReservationOnBlockedNodesTaskLowMemoryKiller.java
@@ -29,10 +29,10 @@ import io.trino.execution.buffer.OutputBufferInfo;
 import io.trino.execution.buffer.OutputBufferStatus;
 import io.trino.operator.TaskStats;
 import io.trino.plugin.base.metrics.TDigestHistogram;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -246,7 +246,7 @@ public class TestTotalReservationOnBlockedNodesTaskLowMemoryKiller
                         0,
                         1,
                         1),
-                DateTime.now(),
+                Instant.now(),
                 new OutputBufferInfo(
                         "TESTING",
                         BufferState.FINISHED,
@@ -261,7 +261,7 @@ public class TestTotalReservationOnBlockedNodesTaskLowMemoryKiller
                         Optional.empty(),
                         Optional.empty()),
                 ImmutableSet.of(),
-                new TaskStats(DateTime.now(),
+                new TaskStats(Instant.now(),
                         null,
                         null,
                         null,

--- a/core/trino-main/src/test/java/io/trino/operator/TestDriverStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDriverStats.java
@@ -18,20 +18,20 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
 
 import static io.trino.operator.TestOperatorStats.assertExpectedOperatorStats;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class TestDriverStats
 {
     public static final DriverStats EXPECTED = new DriverStats(
-            new DateTime(1),
-            new DateTime(2),
-            new DateTime(3),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2),
+            Instant.ofEpochSecond(3),
 
             new Duration(4, NANOSECONDS),
             new Duration(5, NANOSECONDS),
@@ -85,9 +85,9 @@ public class TestDriverStats
 
     public static void assertExpectedDriverStats(DriverStats actual)
     {
-        assertThat(actual.getCreateTime()).isEqualTo(new DateTime(1, UTC));
-        assertThat(actual.getStartTime()).isEqualTo(new DateTime(2, UTC));
-        assertThat(actual.getEndTime()).isEqualTo(new DateTime(3, UTC));
+        assertThat(actual.getCreateTime()).isEqualTo(Instant.ofEpochSecond(1));
+        assertThat(actual.getStartTime()).isEqualTo(Instant.ofEpochSecond(2));
+        assertThat(actual.getEndTime()).isEqualTo(Instant.ofEpochSecond(3));
         assertThat(actual.getQueuedTime()).isEqualTo(new Duration(4, NANOSECONDS));
         assertThat(actual.getElapsedTime()).isEqualTo(new Duration(5, NANOSECONDS));
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestPipelineStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestPipelineStats.java
@@ -20,23 +20,23 @@ import io.airlift.stats.Distribution;
 import io.airlift.stats.Distribution.DistributionSnapshot;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
 
 import static io.trino.operator.TestDriverStats.assertExpectedDriverStats;
 import static io.trino.operator.TestOperatorStats.assertExpectedOperatorStats;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class TestPipelineStats
 {
     public static final PipelineStats EXPECTED = new PipelineStats(
             0,
 
-            new DateTime(100),
-            new DateTime(101),
-            new DateTime(102),
+            Instant.ofEpochMilli(100),
+            Instant.ofEpochMilli(101),
+            Instant.ofEpochMilli(102),
 
             true,
             false,
@@ -103,9 +103,9 @@ public class TestPipelineStats
 
     public static void assertExpectedPipelineStats(PipelineStats actual)
     {
-        assertThat(actual.getFirstStartTime()).isEqualTo(new DateTime(100, UTC));
-        assertThat(actual.getLastStartTime()).isEqualTo(new DateTime(101, UTC));
-        assertThat(actual.getLastEndTime()).isEqualTo(new DateTime(102, UTC));
+        assertThat(actual.getFirstStartTime()).isEqualTo(Instant.ofEpochMilli(100));
+        assertThat(actual.getLastStartTime()).isEqualTo(Instant.ofEpochMilli(101));
+        assertThat(actual.getLastEndTime()).isEqualTo(Instant.ofEpochMilli(102));
         assertThat(actual.isInputPipeline()).isEqualTo(true);
         assertThat(actual.isOutputPipeline()).isEqualTo(false);
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTaskStats.java
@@ -18,25 +18,24 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import static io.trino.operator.TestPipelineStats.assertExpectedPipelineStats;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class TestTaskStats
 {
     public static final TaskStats EXPECTED = new TaskStats(
-            new DateTime(1),
-            new DateTime(2),
-            new DateTime(100),
-            new DateTime(102),
-            new DateTime(101),
-            new DateTime(3),
+            Instant.ofEpochMilli(1),
+            Instant.ofEpochMilli(2),
+            Instant.ofEpochMilli(100),
+            Instant.ofEpochMilli(102),
+            Instant.ofEpochMilli(101),
+            Instant.ofEpochMilli(3),
             new Duration(4, NANOSECONDS),
             new Duration(5, NANOSECONDS),
 
@@ -103,12 +102,12 @@ public class TestTaskStats
 
     public static void assertExpectedTaskStats(TaskStats actual)
     {
-        assertThat(actual.getCreateTime()).isEqualTo(new DateTime(1, UTC));
-        assertThat(actual.getFirstStartTime()).isEqualTo(new DateTime(2, UTC));
-        assertThat(actual.getLastStartTime()).isEqualTo(new DateTime(100, UTC));
-        assertThat(actual.getTerminatingStartTime()).isEqualTo(new DateTime(102, UTC));
-        assertThat(actual.getLastEndTime()).isEqualTo(new DateTime(101, UTC));
-        assertThat(actual.getEndTime()).isEqualTo(new DateTime(3, UTC));
+        assertThat(actual.getCreateTime()).isEqualTo(Instant.ofEpochMilli(1));
+        assertThat(actual.getFirstStartTime()).isEqualTo(Instant.ofEpochMilli(2));
+        assertThat(actual.getLastStartTime()).isEqualTo(Instant.ofEpochMilli(100));
+        assertThat(actual.getTerminatingStartTime()).isEqualTo(Instant.ofEpochMilli(102));
+        assertThat(actual.getLastEndTime()).isEqualTo(Instant.ofEpochMilli(101));
+        assertThat(actual.getEndTime()).isEqualTo(Instant.ofEpochMilli(3));
         assertThat(actual.getElapsedTime()).isEqualTo(new Duration(4, NANOSECONDS));
         assertThat(actual.getQueuedTime()).isEqualTo(new Duration(5, NANOSECONDS));
 

--- a/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
@@ -27,10 +27,10 @@ import io.trino.spi.QueryId;
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import io.trino.spi.resourcegroups.QueryType;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
@@ -56,10 +56,10 @@ public class TestBasicQueryInfo
                         "SELECT 4",
                         Optional.empty(),
                         new QueryStats(
-                                DateTime.parse("1991-09-06T05:00-05:30"),
-                                DateTime.parse("1991-09-06T05:01-05:30"),
-                                DateTime.parse("1991-09-06T05:02-05:30"),
-                                DateTime.parse("1991-09-06T06:00-05:30"),
+                                Instant.parse("2025-05-11T13:32:17.751968Z"),
+                                Instant.parse("2025-05-11T13:32:17.751968Z"),
+                                Instant.parse("2025-05-11T13:32:17.751968Z"),
+                                Instant.parse("2025-05-11T13:32:17.751968Z"),
                                 new Duration(8, MINUTES),
                                 new Duration(7, MINUTES),
                                 new Duration(35, MINUTES),
@@ -175,8 +175,8 @@ public class TestBasicQueryInfo
         assertThat(basicInfo.getQuery()).isEqualTo("SELECT 4");
         assertThat(basicInfo.getQueryType().get()).isEqualTo(QueryType.SELECT);
 
-        assertThat(basicInfo.getQueryStats().getCreateTime()).isEqualTo(DateTime.parse("1991-09-06T05:00-05:30"));
-        assertThat(basicInfo.getQueryStats().getEndTime()).isEqualTo(DateTime.parse("1991-09-06T06:00-05:30"));
+        assertThat(basicInfo.getQueryStats().getCreateTime()).isEqualTo(Instant.parse("2025-05-11T13:32:17.751968Z"));
+        assertThat(basicInfo.getQueryStats().getEndTime()).isEqualTo(Instant.parse("2025-05-11T13:32:17.751968Z"));
         assertThat(basicInfo.getQueryStats().getElapsedTime()).isEqualTo(new Duration(8, MINUTES));
         assertThat(basicInfo.getQueryStats().getExecutionTime()).isEqualTo(new Duration(44, MINUTES));
 

--- a/core/trino-main/src/test/java/io/trino/server/TestNodeStateManager.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestNodeStateManager.java
@@ -23,12 +23,12 @@ import io.trino.execution.TaskInfo;
 import io.trino.execution.TaskState;
 import io.trino.metadata.NodeState;
 import io.trino.operator.TaskStats;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -159,7 +159,7 @@ class TestNodeStateManager
                 "1",
                 false,
                 Optional.empty(),
-                new TaskStats(DateTime.now(), null));
+                new TaskStats(Instant.now(), null));
         taskInfos.add(task);
         tasks.set(taskInfos);
 
@@ -193,7 +193,7 @@ class TestNodeStateManager
                 "1",
                 false,
                 Optional.empty(),
-                new TaskStats(DateTime.now(), null));
+                new TaskStats(Instant.now(), null));
         taskInfos.add(task);
         tasks.set(taskInfos);
 
@@ -238,7 +238,7 @@ class TestNodeStateManager
                 "1",
                 false,
                 Optional.empty(),
-                new TaskStats(DateTime.now(), null));
+                new TaskStats(Instant.now(), null));
         taskInfos.add(task);
         tasks.set(taskInfos);
 

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
@@ -26,10 +26,10 @@ import io.trino.execution.resourcegroups.InternalResourceGroup;
 import io.trino.operator.RetryPolicy;
 import io.trino.spi.QueryId;
 import io.trino.spi.resourcegroups.QueryType;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -108,10 +108,10 @@ public class TestQueryStateInfo
                 query,
                 Optional.empty(),
                 new QueryStats(
-                        DateTime.parse("1991-09-06T05:00-05:30"),
-                        DateTime.parse("1991-09-06T05:01-05:30"),
-                        DateTime.parse("1991-09-06T05:02-05:30"),
-                        DateTime.parse("1991-09-06T06:00-05:30"),
+                        Instant.parse("2025-05-11T13:32:17.751968Z"),
+                        Instant.parse("2025-05-11T13:32:17.751968Z"),
+                        Instant.parse("2025-05-11T13:32:17.751968Z"),
+                        Instant.parse("2025-05-11T13:32:17.751968Z"),
                         new Duration(10, SECONDS),
                         new Duration(8, MINUTES),
                         new Duration(7, MINUTES),

--- a/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
+++ b/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
@@ -23,8 +23,8 @@ import io.trino.metadata.CatalogMetadata;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.transaction.IsolationLevel;
-import org.joda.time.DateTime;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +56,7 @@ public class TestingTransactionManager
                 IsolationLevel.READ_UNCOMMITTED,
                 false, //read only
                 false, // auto commit
-                DateTime.now(), // created
+                Instant.now(), // created
                 Duration.succinctNanos(0), // idle
                 ImmutableList.of(), // catalogs
                 Optional.empty(),  // write catalog

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -913,15 +913,17 @@ public class TestEventListenerBasic
         assertThat(1L).isEqualTo(queryCompletedEvent.getStatistics().getOutputRows());
 
         // Ensure the proper conversion in QueryMonitor#createQueryStatistics
+        // We are comparing java.time.Duration here because its toMillis()
+        // rounds differently than the airlift's Duration.
         QueryStatistics statistics = queryCompletedEvent.getStatistics();
         assertThat(statistics.getCpuTime().toMillis()).isEqualTo(queryStats.getTotalCpuTime().toMillis());
-        assertThat(statistics.getWallTime().toMillis()).isEqualTo(queryStats.getElapsedTime().toMillis());
-        assertThat(statistics.getQueuedTime().toMillis()).isEqualTo(queryStats.getQueuedTime().toMillis());
-        assertThat(statistics.getScheduledTime().get().toMillis()).isEqualTo(queryStats.getTotalScheduledTime().toMillis());
-        assertThat(statistics.getResourceWaitingTime().get().toMillis()).isEqualTo(queryStats.getResourceWaitingTime().toMillis());
-        assertThat(statistics.getAnalysisTime().get().toMillis()).isEqualTo(queryStats.getAnalysisTime().toMillis());
-        assertThat(statistics.getPlanningTime().get().toMillis()).isEqualTo(queryStats.getPlanningTime().toMillis());
-        assertThat(statistics.getExecutionTime().get().toMillis()).isEqualTo(queryStats.getExecutionTime().toMillis());
+        assertThat(statistics.getWallTime()).isEqualTo(queryStats.getElapsedTime().toJavaTime());
+        assertThat(statistics.getQueuedTime()).isEqualTo(queryStats.getQueuedTime().toJavaTime());
+        assertThat(statistics.getScheduledTime().get()).isEqualTo(queryStats.getTotalScheduledTime().toJavaTime());
+        assertThat(statistics.getResourceWaitingTime().get()).isEqualTo(queryStats.getResourceWaitingTime().toJavaTime());
+        assertThat(statistics.getAnalysisTime().get()).isEqualTo(queryStats.getAnalysisTime().toJavaTime());
+        assertThat(statistics.getPlanningTime().get()).isEqualTo(queryStats.getPlanningTime().toJavaTime());
+        assertThat(statistics.getExecutionTime().get()).isEqualTo(queryStats.getExecutionTime().toJavaTime());
         assertThat(statistics.getPeakUserMemoryBytes()).isEqualTo(queryStats.getPeakUserMemoryReservation().toBytes());
         assertThat(statistics.getPeakTaskUserMemory()).isEqualTo(queryStats.getPeakTaskUserMemory().toBytes());
         assertThat(statistics.getPeakTaskTotalMemory()).isEqualTo(queryStats.getPeakTaskTotalMemory().toBytes());

--- a/testing/trino-tests/src/test/java/io/trino/memory/TestClusterMemoryLeakDetector.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestClusterMemoryLeakDetector.java
@@ -24,10 +24,10 @@ import io.trino.server.BasicQueryInfo;
 import io.trino.server.BasicQueryStats;
 import io.trino.spi.QueryId;
 import io.trino.spi.resourcegroups.ResourceGroupId;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
@@ -79,8 +79,8 @@ public class TestClusterMemoryLeakDetector
                 Optional.empty(),
                 Optional.empty(),
                 new BasicQueryStats(
-                        DateTime.parse("1991-09-06T05:00-05:30"),
-                        DateTime.parse("1991-09-06T05:01-05:30"),
+                        Instant.parse("2025-05-11T13:32:17.751968Z"),
+                        Instant.parse("2025-05-11T13:32:17.751968Z"),
                         new Duration(8, MINUTES),
                         new Duration(7, MINUTES),
                         new Duration(34, MINUTES),


### PR DESCRIPTION
Switched from Joda-Time DateTime to java.time.Instant for measuring timings. This aligns with how the values
are already being used—primarily for durations rather than calendar-based datetimes. Using Instant is more
semantically appropriate and consistent with the rest of the codebase. Additionally, Instant is a @valuebased class,
allowing potential performance optimizations in newer Java versions.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
