### PR TITLE
[OPA] Add additional context file to Trino OPA plugin

### DIFF
--- a/plugin/trino-opa/pom.xml
+++ b/plugin/trino-opa/pom.xml
@@ -15,6 +15,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -94,11 +104,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>runtime</scope>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -802,11 +802,16 @@ public sealed class OpaAccessControl
 
     OpaQueryContext buildQueryContext(Identity trinoIdentity)
     {
-        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(trinoIdentity), pluginContext);
+        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(trinoIdentity), pluginContext, opaHighLevelClient.getAdditionalContext());
     }
 
     OpaQueryContext buildQueryContext(SystemSecurityContext securityContext)
     {
-        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(securityContext.getIdentity()), pluginContext);
+        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(securityContext.getIdentity()), pluginContext, opaHighLevelClient.getAdditionalContext());
+    }
+
+    protected OpaHighLevelClient getOpaHighLevelClient()
+    {
+        return this.opaHighLevelClient;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -15,8 +15,10 @@ package io.trino.plugin.opa;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.validation.FileExists;
 import jakarta.validation.constraints.NotNull;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Optional;
 
@@ -31,6 +33,7 @@ public class OpaConfig
     private Optional<URI> opaRowFiltersUri = Optional.empty();
     private Optional<URI> opaColumnMaskingUri = Optional.empty();
     private Optional<URI> opaBatchColumnMaskingUri = Optional.empty();
+    private Optional<File> additionalContextFile = Optional.empty();
 
     @NotNull
     public URI getOpaUri()
@@ -138,6 +141,19 @@ public class OpaConfig
     public OpaConfig setOpaBatchColumnMaskingUri(URI opaBatchColumnMaskingUri)
     {
         this.opaBatchColumnMaskingUri = Optional.ofNullable(opaBatchColumnMaskingUri);
+        return this;
+    }
+
+    public Optional<@FileExists File> getAdditionalContextFile()
+    {
+        return additionalContextFile;
+    }
+
+    @Config("opa.additional-context-file")
+    @ConfigDescription("file in JSON format containing additional tenant-specified context properties")
+    public OpaConfig setAdditionalContextFile(File additionalContextFile)
+    {
+        this.additionalContextFile = Optional.ofNullable(additionalContextFile);
         return this;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/OpaAdditionalContext.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/OpaAdditionalContext.java
@@ -13,14 +13,16 @@
  */
 package io.trino.plugin.opa.schema;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 import static java.util.Objects.requireNonNull;
 
-public record OpaQueryContext(TrinoIdentity identity, OpaPluginContext softwareStack, OpaAdditionalContext additionalContext)
+public record OpaAdditionalContext(Map<String, String> properties)
 {
-    public OpaQueryContext
+    public OpaAdditionalContext
     {
-        requireNonNull(identity, "identity is null");
-        requireNonNull(softwareStack, "softwareStack is null");
-        requireNonNull(additionalContext, "additionalContext is null");
+        properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestConstants.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestConstants.java
@@ -22,6 +22,7 @@ import io.trino.spi.security.Identity;
 import io.trino.spi.security.SystemAccessControlFactory;
 import io.trino.spi.security.SystemSecurityContext;
 
+import java.io.File;
 import java.net.URI;
 import java.time.Instant;
 
@@ -58,6 +59,7 @@ public final class TestConstants
     public static final URI OPA_SERVER_BATCH_URI = URI.create("http://my-batch-uri/");
     public static final URI OPA_ROW_FILTERING_URI = URI.create("http://my-row-filtering-uri/");
     public static final URI OPA_COLUMN_MASKING_URI = URI.create("http://my-column-masking-uri/");
+    public static final File OPA_ADDITIONAL_CONTEXT_FILE = new File("src/test/resources/additional-context.json");
     public static final Identity TEST_IDENTITY = Identity.forUser("source-user").withGroups(ImmutableSet.of("some-group")).build();
     public static final QueryId TEST_QUERY_ID = QueryId.valueOf("abcde");
     public static final SystemSecurityContext TEST_SECURITY_CONTEXT = new SystemSecurityContext(TEST_IDENTITY, new QueryIdGenerator().createNextQueryId(), Instant.now());

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestHelpers.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestHelpers.java
@@ -92,6 +92,7 @@ public final class TestHelpers
         config.getOpaRowFiltersUri().ifPresent(rowFiltersUri -> configBuilder.put("opa.policy.row-filters-uri", rowFiltersUri.toString()));
         config.getOpaColumnMaskingUri().ifPresent(columnMaskingUri -> configBuilder.put("opa.policy.column-masking-uri", columnMaskingUri.toString()));
         config.getOpaBatchColumnMaskingUri().ifPresent(batchColumnMaskingUri -> configBuilder.put("opa.policy.batch-column-masking-uri", batchColumnMaskingUri.toString()));
+        config.getAdditionalContextFile().ifPresent(additionalContextFile -> configBuilder.put("opa.additional-context-file", additionalContextFile.getPath()));
         return configBuilder.buildOrThrow();
     }
 

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.opa;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Map;
 
@@ -36,7 +37,8 @@ public class TestOpaConfig
                 .setOpaBatchColumnMaskingUri(null)
                 .setLogRequests(false)
                 .setLogResponses(false)
-                .setAllowPermissionManagementOperations(false));
+                .setAllowPermissionManagementOperations(false)
+                .setAdditionalContextFile(null));
     }
 
     @Test
@@ -51,6 +53,7 @@ public class TestOpaConfig
                 .put("opa.log-requests", "true")
                 .put("opa.log-responses", "true")
                 .put("opa.allow-permission-management-operations", "true")
+                .put("opa.additional-context-file", "src/test/resources/additional-context.json")
                 .buildOrThrow();
 
         OpaConfig expected = new OpaConfig()
@@ -61,7 +64,8 @@ public class TestOpaConfig
                 .setOpaBatchColumnMaskingUri(URI.create("https://opa-column-masking.example.com"))
                 .setLogRequests(true)
                 .setLogResponses(true)
-                .setAllowPermissionManagementOperations(true);
+                .setAllowPermissionManagementOperations(true)
+                .setAdditionalContextFile(new File("src/test/resources/additional-context.json"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-opa/src/test/resources/additional-context.json
+++ b/plugin/trino-opa/src/test/resources/additional-context.json
@@ -1,0 +1,3 @@
+{
+    "namespace" : "some-namespace"
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add optional configuration property, specifying a path to a JSON containing tenant-specified context (i.e. namespace, environment, tier) as key-value pairs


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/issues/25880


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Add additional context file to Trino OPA plugin ({issue}`25880`)
```
