### PR TITLE
[OPA] Add additional context file to Trino OPA plugin

### DIFF
--- a/docs/src/main/sphinx/security/opa-access-control.md
+++ b/docs/src/main/sphinx/security/opa-access-control.md
@@ -65,6 +65,10 @@ The following table lists the configuration properties for the OPA access contro
   - Optional HTTP client configurations for the connection from Trino to OPA,
     for example `opa.http-client.http-proxy` for configuring the HTTP proxy.
     Find more details in [](/admin/properties-http-client).
+* - `opa.context-file`
+  - Optional properties file, containing user defined properties
+    (e.g. tenant namespace, tier or cluster) to be included in
+    the OPA query context.
 :::
 
 ### Logging

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -802,11 +802,11 @@ public sealed class OpaAccessControl
 
     OpaQueryContext buildQueryContext(Identity trinoIdentity)
     {
-        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(trinoIdentity), pluginContext, Optional.empty());
+        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(trinoIdentity), pluginContext, opaHighLevelClient.getAdditionalContext(), Optional.empty());
     }
 
     OpaQueryContext buildQueryContext(SystemSecurityContext securityContext)
     {
-        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(securityContext.getIdentity()), pluginContext, Optional.of(securityContext.getQueryId()));
+        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(securityContext.getIdentity()), pluginContext, opaHighLevelClient.getAdditionalContext(), Optional.of(securityContext.getQueryId()));
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -15,9 +15,11 @@ package io.trino.plugin.opa;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.validation.FileExists;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Optional;
 
 public class OpaConfig
@@ -31,6 +33,7 @@ public class OpaConfig
     private Optional<URI> opaRowFiltersUri = Optional.empty();
     private Optional<URI> opaColumnMaskingUri = Optional.empty();
     private Optional<URI> opaBatchColumnMaskingUri = Optional.empty();
+    private Optional<Path> additionalContextFile = Optional.empty();
 
     @NotNull
     public URI getOpaUri()
@@ -138,6 +141,19 @@ public class OpaConfig
     public OpaConfig setOpaBatchColumnMaskingUri(URI opaBatchColumnMaskingUri)
     {
         this.opaBatchColumnMaskingUri = Optional.ofNullable(opaBatchColumnMaskingUri);
+        return this;
+    }
+
+    public Optional<@FileExists Path> getAdditionalContextFile()
+    {
+        return additionalContextFile;
+    }
+
+    @Config("opa.context-file")
+    @ConfigDescription("Optional properties file, containing user defined properties (e.g. tenant namespace, tier or cluster) to be included in the OPA query context")
+    public OpaConfig setAdditionalContextFile(Path additionalContextFile)
+    {
+        this.additionalContextFile = Optional.ofNullable(additionalContextFile);
         return this;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/OpaQueryContext.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/OpaQueryContext.java
@@ -13,18 +13,21 @@
  */
 package io.trino.plugin.opa.schema;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.spi.QueryId;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record OpaQueryContext(TrinoIdentity identity, OpaPluginContext softwareStack, Optional<QueryId> queryId)
+public record OpaQueryContext(TrinoIdentity identity, OpaPluginContext softwareStack, Map<String, String> properties, Optional<QueryId> queryId)
 {
     public OpaQueryContext
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(softwareStack, "softwareStack is null");
+        properties = ImmutableMap.copyOf(properties);
         requireNonNull(queryId, "queryId is null");
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestConstants.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestConstants.java
@@ -23,6 +23,8 @@ import io.trino.spi.security.SystemAccessControlFactory;
 import io.trino.spi.security.SystemSecurityContext;
 
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 
 public final class TestConstants
@@ -58,6 +60,7 @@ public final class TestConstants
     public static final URI OPA_SERVER_BATCH_URI = URI.create("http://my-batch-uri/");
     public static final URI OPA_ROW_FILTERING_URI = URI.create("http://my-row-filtering-uri/");
     public static final URI OPA_COLUMN_MASKING_URI = URI.create("http://my-column-masking-uri/");
+    public static final Path OPA_ADDITIONAL_CONTEXT_FILE = Paths.get("src/test/resources/additional-context.properties");
     public static final Identity TEST_IDENTITY = Identity.forUser("source-user").withGroups(ImmutableSet.of("some-group")).build();
     public static final QueryId TEST_QUERY_ID = QueryId.valueOf("abcde");
     public static final SystemSecurityContext TEST_SECURITY_CONTEXT = new SystemSecurityContext(TEST_IDENTITY, new QueryIdGenerator().createNextQueryId(), Instant.now());

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestHelpers.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestHelpers.java
@@ -92,6 +92,7 @@ public final class TestHelpers
         config.getOpaRowFiltersUri().ifPresent(rowFiltersUri -> configBuilder.put("opa.policy.row-filters-uri", rowFiltersUri.toString()));
         config.getOpaColumnMaskingUri().ifPresent(columnMaskingUri -> configBuilder.put("opa.policy.column-masking-uri", columnMaskingUri.toString()));
         config.getOpaBatchColumnMaskingUri().ifPresent(batchColumnMaskingUri -> configBuilder.put("opa.policy.batch-column-masking-uri", batchColumnMaskingUri.toString()));
+        config.getAdditionalContextFile().ifPresent(additionalContextFile -> configBuilder.put("opa.context-file", additionalContextFile.toString()));
         return configBuilder.buildOrThrow();
     }
 

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControlAdditionalContextSystem.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControlAdditionalContextSystem.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.opa;
+
+import io.trino.plugin.blackhole.BlackHolePlugin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@Testcontainers
+@TestInstance(PER_CLASS)
+final class TestOpaAccessControlAdditionalContextSystem
+{
+    private static final String OPA_ALLOW_POLICY_NAME = "allow";
+    private static final String OPA_BATCH_ALLOW_POLICY_NAME = "batchAllow";
+    private static final Path OPA_ADDITIONAL_CONTEXT_FILE = Paths.get("src/test/resources/additional-context.properties");
+    @Container
+    private static final OpaContainer OPA_CONTAINER = new OpaContainer();
+
+    @Test
+    void testAllowsQueryAndFilters()
+            throws Exception
+    {
+        QueryRunnerHelper runner = setupTrinoWithOpa(new OpaConfig()
+                .setAdditionalContextFile(OPA_ADDITIONAL_CONTEXT_FILE)
+                .setOpaUri(OPA_CONTAINER.getOpaUriForPolicyPath(OPA_ALLOW_POLICY_NAME)));
+
+        OPA_CONTAINER.submitPolicy(
+                """
+                package trino
+                import future.keywords.if
+                import future.keywords.in
+
+                default allow = false
+                allow if is_admin
+                allow {
+                  is_bob
+                  is_some_namespace
+                  is_some_cluster
+                  can_be_accessed_by_bob
+                }
+
+                is_admin {
+                  input.context.identity.user == "admin"
+                }
+                is_bob {
+                  input.context.identity.user == "bob"
+                }
+                is_some_namespace {
+                  input.context.properties.namespace == "some-namespace"
+                }
+                is_some_cluster {
+                  input.context.properties.cluster == "some-cluster"
+                }
+                can_be_accessed_by_bob {
+                  input.action.operation in ["ImpersonateUser", "ExecuteQuery"]
+                }
+                can_be_accessed_by_bob {
+                  input.action.operation in ["FilterCatalogs", "AccessCatalog"]
+                  input.action.resource.catalog.name == "catalog_one"
+                }
+                """);
+        Set<String> catalogsForBob = runner.querySetOfStrings("bob", "SHOW CATALOGS");
+        assertThat(catalogsForBob).containsExactlyInAnyOrder("catalog_one");
+        Set<String> catalogsForAdmin = runner.querySetOfStrings("admin", "SHOW CATALOGS");
+        assertThat(catalogsForAdmin).containsExactlyInAnyOrder("catalog_one", "catalog_two", "system");
+        runner.teardown();
+    }
+
+    @Test
+    void testShouldDenyQueryIfDirected()
+            throws Exception
+    {
+        QueryRunnerHelper runner = setupTrinoWithOpa(new OpaConfig()
+                .setAdditionalContextFile(OPA_ADDITIONAL_CONTEXT_FILE)
+                .setOpaUri(OPA_CONTAINER.getOpaUriForPolicyPath(OPA_ALLOW_POLICY_NAME)));
+
+        OPA_CONTAINER.submitPolicy(
+                """
+                package trino
+                import future.keywords.in
+                default allow = false
+
+                allow {
+                  input.context.identity.user == "admin"
+                }
+
+                allow {
+                  input.context.identity.user == "someone"
+                  input.context.properties.namespace == "diff-namespace"
+                }
+                """);
+        assertThatThrownBy(() -> runner.querySetOfStrings("someone", "SHOW CATALOGS"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Access Denied");
+        // smoke test: we can still query if we are the right user
+        runner.querySetOfStrings("admin", "SHOW CATALOGS");
+        runner.teardown();
+    }
+
+    @Test
+    void testFilterOutItemsBatch()
+            throws Exception
+    {
+        QueryRunnerHelper runner = setupTrinoWithOpa(new OpaConfig()
+                .setAdditionalContextFile(OPA_ADDITIONAL_CONTEXT_FILE)
+                .setOpaUri(OPA_CONTAINER.getOpaUriForPolicyPath(OPA_ALLOW_POLICY_NAME))
+                .setOpaBatchUri(OPA_CONTAINER.getOpaUriForPolicyPath(OPA_BATCH_ALLOW_POLICY_NAME)));
+
+        OPA_CONTAINER.submitPolicy(
+                """
+                package trino
+                import future.keywords.if
+                import future.keywords.in
+                default allow = false
+
+                allow if is_admin
+
+                allow {
+                  is_bob
+                  input.action.operation in ["AccessCatalog", "ExecuteQuery", "ImpersonateUser", "ShowSchemas", "SelectFromColumns"]
+                }
+
+                batchAllow[i] {
+                  some i
+                  input.action.filterResources[i]
+                  is_admin
+                }
+
+                batchAllow[i] {
+                  some i
+                  is_bob
+                  is_some_namespace
+                  is_some_cluster
+                  input.action.operation == "FilterCatalogs"
+                  input.action.filterResources[i].catalog.name == "catalog_one"
+                }
+
+                is_bob {
+                  input.context.identity.user == "bob"
+                }
+
+                is_admin {
+                  input.context.identity.user == "admin"
+                }
+
+                is_some_namespace {
+                  input.context.properties.namespace == "some-namespace"
+                }
+                is_some_cluster {
+                  input.context.properties.cluster == "some-cluster"
+                }
+                """);
+        Set<String> catalogsForBob = runner.querySetOfStrings("bob", "SHOW CATALOGS");
+        assertThat(catalogsForBob).containsExactlyInAnyOrder("catalog_one");
+        Set<String> catalogsForAdmin = runner.querySetOfStrings("admin", "SHOW CATALOGS");
+        assertThat(catalogsForAdmin).containsExactlyInAnyOrder("catalog_one", "catalog_two", "system");
+        runner.teardown();
+    }
+
+    private static QueryRunnerHelper setupTrinoWithOpa(OpaConfig opaConfig)
+    {
+        QueryRunnerHelper runner = QueryRunnerHelper.withOpaConfig(opaConfig);
+        runner.getBaseQueryRunner().installPlugin(new BlackHolePlugin());
+        runner.getBaseQueryRunner().createCatalog("catalog_one", "blackhole");
+        runner.getBaseQueryRunner().createCatalog("catalog_two", "blackhole");
+        return runner;
+    }
+}

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -36,7 +37,8 @@ final class TestOpaConfig
                 .setOpaBatchColumnMaskingUri(null)
                 .setLogRequests(false)
                 .setLogResponses(false)
-                .setAllowPermissionManagementOperations(false));
+                .setAllowPermissionManagementOperations(false)
+                .setAdditionalContextFile(null));
     }
 
     @Test
@@ -51,6 +53,7 @@ final class TestOpaConfig
                 .put("opa.log-requests", "true")
                 .put("opa.log-responses", "true")
                 .put("opa.allow-permission-management-operations", "true")
+                .put("opa.context-file", "src/test/resources/additional-context.properties")
                 .buildOrThrow();
 
         OpaConfig expected = new OpaConfig()
@@ -61,7 +64,8 @@ final class TestOpaConfig
                 .setOpaBatchColumnMaskingUri(URI.create("https://opa-column-masking.example.com"))
                 .setLogRequests(true)
                 .setLogResponses(true)
-                .setAllowPermissionManagementOperations(true);
+                .setAllowPermissionManagementOperations(true)
+                .setAdditionalContextFile(Paths.get("src/test/resources/additional-context.properties"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-opa/src/test/resources/additional-context.properties
+++ b/plugin/trino-opa/src/test/resources/additional-context.properties
@@ -1,0 +1,2 @@
+namespace=some-namespace
+cluster=some-cluster


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
Add optional configuration property to Trino OPA plugin, specifying a path to a JSON containing tenant-specified context (i.e. namespace, cluster, environment, tier) as key-value pairs



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/issues/25880



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
