### PR TITLE
Add Grafana Trino Monitoring and Starburst Scheduler guides

### DIFF
--- a/docs/src/main/sphinx/overview/Grafana-Trino-Monitoring.md
+++ b/docs/src/main/sphinx/overview/Grafana-Trino-Monitoring.md
@@ -1,0 +1,203 @@
+```markdown
+# Grafana Monitoring with Trino
+
+
+## Overview
+
+Starburst is a powerful distributed SQL engine that allows teams to query data across multiple sources. However, when it comes to monitoring Starburst clusters, there are some limitations:
+
+- The Starburst web UI gives basic cluster health
+- The Starburst API exposes some system metrics
+- But full metrics (CPU, JVM, memory, total queries, slow queries, etc.) require additional integration
+
+We manage **50+ Starburst clusters** running across multiple environments (OpenShift, Kubernetes, Linux). Manually going into the Starburst UI or CLI to run queries and check metrics was becoming too complex.
+
+That’s why we came up with a solution using:
+
+- Grafana dashboards
+- Grafana Trino Plugin
+- Prometheus + JMX Exporter → full Starburst metrics export
+
+## Why Native Starburst Metrics Are Limited
+
+Out of the box, Starburst exposes basic system metrics:
+
+- Active queries
+- Running nodes
+- Query latency
+- Query errors
+
+But for deeper monitoring, you need:
+
+- JVM metrics (CPU usage, memory, GC, threads)
+- Detailed query metrics (count, latency, slow queries)
+- Resource usage per cluster
+- Cluster-wide trends over time
+- Alerting on custom thresholds
+
+Starburst does not expose all of these metrics directly in the UI or API. This is why we need an additional metrics pipeline.
+
+## Solution Architecture
+
+To fully monitor Starburst, we built this architecture:
+
+```
+
++---------------------+    JMX Exporter    +---------------+
+\| Starburst Cluster 1 |  --> Port 8081 -->  | Prometheus    |
++---------------------+                   +---------------+
+
++---------------------+    JMX Exporter    +---------------+
+\| Starburst Cluster N |  --> Port 8081 -->  | Prometheus    |
++---------------------+                   +---------------+
+
+```
+            Prometheus --> Grafana --> Dashboards / Alerts
+            + Grafana Trino Plugin --> SQL-based dashboards
+```
+
+````
+
+### Components:
+
+- **JMX Exporter** → exposes Starburst JVM + query metrics to Prometheus
+- **Prometheus** → scrapes all Starburst clusters at regular intervals
+- **Grafana** → visualizes metrics
+- **Grafana Trino Plugin** → allows you to run SQL queries on Starburst directly and show results in Grafana panels
+
+## Why Use Grafana Trino Plugin?
+
+The Grafana Trino Plugin is extremely useful for Starburst monitoring because:
+
+- It connects Grafana directly to Starburst as a SQL data source
+- You can run Starburst SQL queries in Grafana panels
+- You can refresh results dynamically
+- You can build dashboards with panels per cluster
+- It scales to multiple clusters easily
+
+**Without** this plugin, you would need to:
+
+- Manually log into each Starburst UI
+- Run the same query multiple times
+- Manually copy/paste results  
+→ Very slow and not scalable.
+
+**With** Grafana Trino Plugin:
+
+- Configure each cluster as a Trino data source in Grafana
+- Write SQL queries once
+- Save dashboards
+- Refresh all clusters with one click
+- Add alerts and trends → no manual work
+
+## Grafana Trino Plugin - Overview
+
+The Trino datasource plugin allows you to query and visualize Trino (and Starburst) data inside Grafana.
+
+### Installation
+
+Run Grafana with the plugin using Docker:
+
+```bash
+docker run -d -p 3000:3000 \
+  -v "$(pwd):/var/lib/grafana/plugins/trino" \
+  -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=trino-datasource" \
+  --name=grafana \
+  grafana/grafana-oss
+````
+
+### Features
+
+* Authentication: HTTP Basic, TLS client, OAuth, JWT
+* Raw SQL editor — run any query
+* Works with Starburst OSS, Galaxy, and Enterprise
+* Macros supported → useful for time series panels
+
+### Macros Supported
+
+* `$timeFrom($column)` — lower boundary of time range
+* `$timeTo($column)` — upper boundary of time range
+* `$timeGroup($column, $interval)` — group by time
+* `$dateFilter($column)` — date range filter
+* `$timeFilter($column)` — timestamp range filter
+* `$unixEpochFilter($column)` — unix timestamp range
+
+### Example Query Using Macros
+
+```sql
+SELECT
+  atimestamp AS time,
+  metric_value AS value
+FROM starburst_metrics_table
+WHERE $__timeFilter(atimestamp) AND cluster_name IN($cluster)
+ORDER BY atimestamp ASC
+```
+
+## How To Set It Up
+
+### 1. Enable JMX Exporter in Starburst
+
+Configure JMX agent in your Starburst deployment:
+
+```bash
+start.args=-javaagent:/opt/starburst/jmx_prometheus_javaagent.jar=8081:/opt/starburst/jmx_exporter_config.yaml
+```
+
+### 2. Configure Prometheus
+
+Add all your Starburst clusters:
+
+```yaml
+- job_name: 'starburst'
+  static_configs:
+    - targets: ['starburst-cluster-1:8081', 'starburst-cluster-2:8081']
+```
+
+### 3. Install Grafana Trino Plugin
+
+* Add Trino Plugin in Grafana → Data Sources
+* Provide Starburst cluster URL + credentials
+* Test connection
+
+### 4. Build Dashboards
+
+* Create a panel → select Trino Plugin data source
+* Write your Starburst SQL query:
+
+```sql
+SELECT state, count(*) FROM system.runtime.queries GROUP BY state
+```
+
+* Save panel → use macros for time filters
+* Build dashboards with multiple panel per cluster
+
+## Benefits
+
+* Monitor multiple Starburst clusters from one Grafana dashboard
+* Run Starburst SQL queries as panels → live refresh
+* Combine Prometheus metrics + SQL panels
+* Full CPU, JVM, memory, query stats
+* Add Slack / PagerDuty alerts for Starburst anomalies
+
+## Limitations and Tips
+
+* Starburst native metrics are limited → configure JMX Exporter carefully
+* Grafana Trino Plugin is best for SQL panels → use Prometheus panels for JVM metrics
+* Test scrape intervals carefully → avoid overloading clusters
+* Use macros to make dashboards dynamic and reusable across clusters
+
+## Conclusion
+
+If you want full Starburst monitoring, this is the best architecture:
+
+* Enable JMX Exporter → Prometheus → Grafana
+* Use Grafana Trino Plugin → SQL dashboards → live queries
+* Monitor multiple clusters from one place
+* Add alerts, trends, historical analysis
+* Share dashboards with teams
+
+## Final Architecture Summary
+
+```
+Starburst --> JMX Exporter --> Prometheus --> Grafana Panels + Trino Plugin SQL Queries --> Slack / Alerts / Visual Dashboards
+```

--- a/docs/src/main/sphinx/overview/Starburst-Scheduler.md
+++ b/docs/src/main/sphinx/overview/Starburst-Scheduler.md
@@ -1,0 +1,204 @@
+
+---
+
+```markdown
+# Starburst Scheduler: Python Pip Package to Automate Starburst.io SQL Queries
+
+
+## Meta Description
+
+Starburst Scheduler is an open-source Python package that enables you to run and schedule SQL queries on Starburst Trino OSS and Starburst Enterprise. Automate Starburst queries, monitor cluster health, and integrate with Slack and Mattermost — all from a simple CLI tool. Ideal for DevOps, data engineering, and CI/CD pipelines.
+
+
+## Introduction
+
+In today’s data-driven organizations, query automation and monitoring are critical for maintaining healthy data platforms and delivering reliable insights.
+
+**Common questions:**
+
+- How do I automate important queries to monitor our Starburst clusters?
+- How do I run scheduled reports and send alerts to Slack or Mattermost?
+
+While tools like Apache Airflow exist, I wanted something much lighter and faster — something that could run from the command line or within CI/CD pipelines.
+
+That’s why I built **Starburst Scheduler** — an open-source Python package that enables anyone to run and schedule Starburst queries with just a few commands.
+
+In this article, I’ll walk you through:
+
+- What is Starburst
+- Why I built this tool
+- How Starburst Scheduler works
+- How you can use it
+- Planned enhancements
+- How you can contribute
+
+## What is Starburst?
+
+Starburst is a modern distributed query engine built on top of Trino.
+
+It allows users to run high-performance SQL queries across multiple data sources, including:
+
+- Data lakes (S3, ADLS)
+- Hive
+- Delta Lake
+- PostgreSQL
+- MySQL
+- Oracle
+- Kafka
+- And more
+
+It powers interactive analytics and data mesh architectures in modern enterprises.
+
+### Starburst Galaxy vs Starburst Enterprise vs OSS
+
+- **Starburst Galaxy** → fully managed SaaS offering — ideal for cloud-native deployments.
+- **Starburst Enterprise** → self-managed version — deployable on Kubernetes, OpenShift, or on-premises.
+- **OSS (Open Source Trino)** → provides the core engine but lacks the enterprise features, support, and integrations.
+
+## The Need for Automation
+
+In production data platforms, teams often need to:
+
+- Monitor cluster health via scheduled queries
+- Run daily reports and publish results
+- Detect data anomalies and trigger alerts
+- Integrate query result with team communication tools (Slack, Mattermost)
+
+While Starburst provides an excellent UI, it does not natively offer lightweight scheduling.
+
+Apache Airflow is an option, but requires significant setup.  
+Cron jobs are too basic and hard to manage at scale.
+
+That’s why I built this simple CLI tool.
+
+## What is Starburst Scheduler?
+
+Starburst Scheduler is an open-source Python package that allows you to:
+
+- Run Starburst queries from the command line
+- Schedule Starburst queries to run at regular intervals (seconds, minutes, hours, days)
+- (Coming soon) Send results to Slack, Mattermost, email
+
+It is ideal for:
+
+- DevOps engineers monitoring Starburst clusters
+- Data engineers automating reports
+- Platform engineers adding checks to CI/CD pipelines
+
+It requires no additional servers or orchestration systems.
+
+## How It Works
+
+Starburst Scheduler is built using:
+
+- `pystarburst` — the official Python client for Starburst
+- `schedule` — a lightweight job scheduling library
+- `click` — for building powerful command-line interfaces
+
+### Architecture
+
+```
+
++----------------------+     +------------------+
+\| CLI (Click)          | --> | StarburstConnector|
+\|                      |     +------------------+
+\| run-query            | --> Connect --> Run query
+\| schedule-query       | --> Connect --> Schedule query
++----------------------+                |
+v
++--------------------+
+\| QueryScheduler     |
+\| (schedule library) |
++--------------------+
+
+````
+
+## Features
+
+- Run SQL queries directly from the CLI
+- Schedule queries at regular intervals (seconds, minutes, hours, days)
+- Compatible with both Starburst Galaxy and Starburst Enterprise
+- Works well in CI/CD pipelines (GitHub Actions, Jenkins, etc.)
+- Lightweight — no servers required
+- (Coming soon) Slack/Mattermost integration — automated alerts
+- MIT Licensed — fully open-source
+
+## Installation
+
+```bash
+pip install starburst_scheduler
+````
+
+## Usage
+
+### Run a Single Query
+
+```bash
+starburst-scheduler run-query --host <host> --port <port> --user <user> --password <password> --catalog sample --schema burstbank --query "SELECT * FROM system.runtime.nodes"
+```
+
+### Schedule a Query
+
+```bash
+starburst-scheduler schedule-query --host <host> --port <port> --user <user> --password <password> --catalog sample --schema burstbank --query "SELECT * FROM system.runtime.nodes" --frequency 60 --time-unit seconds
+```
+
+## Planned Enhancements
+
+### Slack & Mattermost integration
+
+Automatically post query results to team chat when queries run.
+Example: monitor active queries, cluster status, send alerts.
+
+### CSV/JSON output
+
+Option to save query results to CSV or JSON for downstream use in data pipelines.
+
+### Advanced scheduling
+
+Support for cron expressions, weekly/monthly jobs.
+
+### Email notifications
+
+Option to send query results via email.
+
+### Error alerting
+
+Notify users when query runs fail.
+
+## Example Use Cases
+
+### Cluster Health Monitoring
+
+Run this query every 5 minutes:
+
+```sql
+SELECT * FROM system.runtime.nodes
+```
+
+Send the results to Slack to monitor Starburst node status.
+
+### Daily Report Automation
+
+Schedule a complex query to run daily at 6 AM, save the results as CSV, and email them to the BI team.
+
+## How to Contribute
+
+GitHub: [https://github.com/karranikhilreddy99/starburst\_scheduler](https://github.com/karranikhilreddy99/starburst_scheduler)
+
+* Issues and PRs welcome
+* If you like the project, please star it on GitHub
+
+## Conclusion
+
+Starburst Scheduler fills an important gap:
+
+* It allows you to automate Starburst queries without setting up heavy orchestration tools
+* It is ideal for DevOps, data engineering, and CI/CD pipelines
+* It is fully open-source and easy to extend
+
+In the future, I plan to add Slack/Mattermost integrations, advanced scheduling, and more.
+
+If you use Starburst and want a lightweight scheduling tool — give **Starburst Scheduler** a try.
+
+GitHub: [https://github.com/karranikhilreddy99/starburst\_scheduler](https://github.com/karranikhilreddy99/starburst_scheduler)


### PR DESCRIPTION
## Summary

This PR adds two new documentation guides under `overview/`:

✅ Grafana Monitoring Guide → `grafana-monitoring.md`  
✅ Starburst Scheduler Guide → `starburst-scheduler.md`

---

### Grafana Monitoring Guide

A practical guide for monitoring Starburst clusters using:

- Grafana dashboards
- Grafana Trino Plugin
- Prometheus + JMX Exporter

Based on real-world experience managing 50+ Starburst clusters.

---

### Starburst Scheduler Guide

Introduction to **Starburst Scheduler** — an open-source Python package to automate Starburst queries:

- Run and schedule queries via CLI
- Integrate with Slack / Mattermost
- Monitor cluster health and automate reporting
- Lightweight alternative to heavy orchestration tools

GitHub: [https://github.com/karranikhilreddy99/starburst_scheduler](https://github.com/karranikhilreddy99/starburst_scheduler)

---

I have signed the Individual CLA.  
Looking forward to feedback — thank you!

Best regards,  
Nikhil Reddy Karra