### PR TITLE
Improve internal communication authentication

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
+++ b/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
@@ -22,6 +22,7 @@ import static io.trino.client.ProtocolHeaders.Headers.REQUEST_CLIENT_CAPABILITIE
 import static io.trino.client.ProtocolHeaders.Headers.REQUEST_CLIENT_INFO;
 import static io.trino.client.ProtocolHeaders.Headers.REQUEST_CLIENT_TAGS;
 import static io.trino.client.ProtocolHeaders.Headers.REQUEST_EXTRA_CREDENTIAL;
+import static io.trino.client.ProtocolHeaders.Headers.REQUEST_INTERNAL_AUTH;
 import static io.trino.client.ProtocolHeaders.Headers.REQUEST_LANGUAGE;
 import static io.trino.client.ProtocolHeaders.Headers.REQUEST_ORIGINAL_ROLES;
 import static io.trino.client.ProtocolHeaders.Headers.REQUEST_ORIGINAL_USER;
@@ -80,6 +81,7 @@ public final class ProtocolHeaders
         REQUEST_RESOURCE_ESTIMATE("Resource-Estimate"),
         REQUEST_EXTRA_CREDENTIAL("Extra-Credential"),
         REQUEST_QUERY_DATA_ENCODING("Query-Data-Encoding"),
+        REQUEST_INTERNAL_AUTH("Internal-Auth"),
         RESPONSE_SET_CATALOG("Set-Catalog"),
         RESPONSE_SET_SCHEMA("Set-Schema"),
         RESPONSE_SET_PATH("Set-Path"),
@@ -129,6 +131,7 @@ public final class ProtocolHeaders
     private final String requestResourceEstimate;
     private final String requestExtraCredential;
     private final String requestQueryDataEncoding;
+    private final String requestInternalAuthorization;
     private final String responseSetCatalog;
     private final String responseSetSchema;
     private final String responseSetPath;
@@ -178,6 +181,7 @@ public final class ProtocolHeaders
         requestResourceEstimate = REQUEST_RESOURCE_ESTIMATE.withProtocolName(name);
         requestExtraCredential = REQUEST_EXTRA_CREDENTIAL.withProtocolName(name);
         requestQueryDataEncoding = REQUEST_QUERY_DATA_ENCODING.withProtocolName(name);
+        requestInternalAuthorization = REQUEST_INTERNAL_AUTH.withProtocolName(name);
         responseSetCatalog = RESPONSE_SET_CATALOG.withProtocolName(name);
         responseSetSchema = RESPONSE_SET_SCHEMA.withProtocolName(name);
         responseSetPath = RESPONSE_SET_PATH.withProtocolName(name);
@@ -307,6 +311,11 @@ public final class ProtocolHeaders
     public String requestQueryDataEncoding()
     {
         return requestQueryDataEncoding;
+    }
+
+    public String requestInternalAuthorization()
+    {
+        return requestInternalAuthorization;
     }
 
     public String responseSetCatalog()

--- a/core/trino-main/src/main/java/io/trino/server/InternalAuthorization.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalAuthorization.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import jakarta.ws.rs.BadRequestException;
+
+import javax.crypto.Mac;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Base64.getEncoder;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public record InternalAuthorization(String signature, String method, String uriPath, String nodeId, long ttl)
+{
+    private static final Splitter SPLITTER = Splitter.on(";").limit(3);
+    private static final Joiner JOINER = Joiner.on(";");
+
+    public InternalAuthorization
+    {
+        requireNonNull(signature, "signature is null");
+        requireNonNull(method, "method is null");
+        requireNonNull(method, "uriPath is null");
+        requireNonNull(nodeId, "nodeId is null");
+        checkArgument(ttl > 0, "ttl should be greater than zero");
+    }
+
+    public boolean isValid(Mac mac)
+    {
+        return signature.equals(calculateSignature(mac, method(), uriPath(), nodeId(), ttl()));
+    }
+
+    public static InternalAuthorization signRequest(Mac mac, String method, String uriPath, String nodeId, long ttl)
+    {
+        return new InternalAuthorization(calculateSignature(mac, method, uriPath, nodeId, ttl), method, uriPath, nodeId, ttl);
+    }
+
+    public String toHeader()
+    {
+        return JOINER.join(nodeId, Long.toString(ttl), signature);
+    }
+
+    public static InternalAuthorization fromHeader(String header, String method, String uriPath)
+    {
+        List<String> parts = SPLITTER.splitToList(header);
+        if (parts.size() != 3) {
+            throw new BadRequestException("Invalid signature header format");
+        }
+
+        return new InternalAuthorization(
+                parts.getLast(),
+                method,
+                uriPath,
+                parts.getFirst(),
+                Long.parseLong(parts.get(1)));
+    }
+
+    private static byte normalizeMethod(String method)
+    {
+        return switch (method.toUpperCase(ENGLISH)) {
+            case "GET" -> 0x01;
+            case "POST" -> 0x02;
+            case "PUT" -> 0x03;
+            case "DELETE" -> 0x04;
+            case "HEAD" -> 0x05;
+            case "OPTIONS" -> 0x06;
+            case "PATCH" -> 0x07;
+            default -> 0x00;
+        };
+    }
+
+    private static String calculateSignature(Mac mac, String method, String uriPath, String nodeId, long ttl)
+    {
+        Slice slice = Slices.allocate(nodeId.length() + uriPath.length() + 9);
+        // Sum of strings length + byte + long
+        try (SliceOutput output = slice.getOutput()) {
+            output.appendBytes(nodeId.getBytes(UTF_8));
+            output.appendBytes(uriPath.getBytes(UTF_8));
+            output.appendByte(normalizeMethod(method));
+            output.appendLong(ttl);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return getEncoder().encodeToString(mac.doFinal(slice.byteArray()));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
@@ -18,10 +18,15 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.validation.FileExists;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDuration;
+import io.airlift.units.MinDuration;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
         "internal-communication.kerberos.enabled",
@@ -38,6 +43,7 @@ public class InternalCommunicationConfig
     private String trustStorePath;
     private String trustStorePassword;
     private boolean httpServerHttpsEnabled;
+    private Duration maxRequestAge = new Duration(3, MINUTES);
 
     @NotNull
     public Optional<String> getSharedSecret()
@@ -50,6 +56,21 @@ public class InternalCommunicationConfig
     public InternalCommunicationConfig setSharedSecret(String sharedSecret)
     {
         this.sharedSecret = sharedSecret;
+        return this;
+    }
+
+    @MinDuration("30s")
+    @MaxDuration("15m")
+    public Duration getMaxRequestAge()
+    {
+        return maxRequestAge;
+    }
+
+    @Config("internal-communication.max-request-age")
+    @ConfigDescription("Maximum age of internal requests to be considered valid")
+    public InternalCommunicationConfig setMaxRequestAge(Duration maxRequestAge)
+    {
+        this.maxRequestAge = maxRequestAge;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
+++ b/core/trino-main/src/main/java/io/trino/server/ThrowableMapper.java
@@ -19,6 +19,7 @@ import io.airlift.jaxrs.JsonParsingException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.ServiceUnavailableException;
@@ -31,6 +32,7 @@ import org.eclipse.jetty.io.EofException;
 import java.util.concurrent.TimeoutException;
 
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
 public class ThrowableMapper
@@ -63,6 +65,10 @@ public class ThrowableMapper
         return switch (throwable) {
             case ForbiddenException forbiddenException -> plainTextError(Response.Status.FORBIDDEN)
                     .entity("Error 403 Forbidden: " + forbiddenException.getMessage())
+                    .build();
+            case NotAuthorizedException unauthorizedException -> plainTextError(Response.Status.UNAUTHORIZED)
+                    .entity("Error 401 Unauthorized: " + unauthorizedException.getMessage())
+                    .header(WWW_AUTHENTICATE, unauthorizedException.getChallenges().getFirst())
                     .build();
             case ServiceUnavailableException serviceUnavailableException -> plainTextError(Response.Status.SERVICE_UNAVAILABLE)
                     .entity("Error 503 Service Unavailable: " + serviceUnavailableException.getMessage())

--- a/core/trino-main/src/main/java/io/trino/server/security/AuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/AuthenticationFilter.java
@@ -61,8 +61,7 @@ public class AuthenticationFilter
     @Override
     public void filter(ContainerRequestContext request)
     {
-        if (InternalAuthenticationManager.isInternalRequest(request)) {
-            internalAuthenticationManager.handleInternalRequest(request);
+        if (internalAuthenticationManager.handleInternalRequest(request)) {
             return;
         }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/ResourceSecurityDynamicFeature.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/ResourceSecurityDynamicFeature.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.core.FeatureContext;
 
 import java.util.Optional;
 
+import static io.trino.server.InternalAuthenticationManager.unauthorizedException;
 import static io.trino.server.ServletSecurityUtils.authenticatedIdentity;
 import static io.trino.server.ServletSecurityUtils.setAuthenticatedIdentity;
 import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
@@ -188,12 +189,11 @@ public class ResourceSecurityDynamicFeature
         @Override
         public void filter(ContainerRequestContext request)
         {
-            if (InternalAuthenticationManager.isInternalRequest(request)) {
-                internalAuthenticationManager.handleInternalRequest(request);
+            if (internalAuthenticationManager.handleInternalRequest(request)) {
                 return;
             }
 
-            throw new ForbiddenException("Internal only resource");
+            throw unauthorizedException(request, "missing signature");
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
@@ -14,6 +14,7 @@
 package io.trino.server;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -24,6 +25,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestInternalCommunicationConfig
 {
@@ -32,6 +35,7 @@ public class TestInternalCommunicationConfig
     {
         assertRecordedDefaults(recordDefaults(InternalCommunicationConfig.class)
                 .setSharedSecret(null)
+                .setMaxRequestAge(new Duration(3, MINUTES))
                 .setHttp2Enabled(true)
                 .setHttpsRequired(false)
                 .setKeyStorePath(null)
@@ -51,6 +55,7 @@ public class TestInternalCommunicationConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("internal-communication.shared-secret", "secret")
                 .put("internal-communication.http2.enabled", "false")
+                .put("internal-communication.max-request-age", "40s")
                 .put("internal-communication.https.required", "true")
                 .put("internal-communication.https.keystore.path", keystoreFile.toString())
                 .put("internal-communication.https.keystore.key", "key-key")
@@ -61,6 +66,7 @@ public class TestInternalCommunicationConfig
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
                 .setSharedSecret("secret")
+                .setMaxRequestAge(new Duration(40, SECONDS))
                 .setHttp2Enabled(false)
                 .setHttpsRequired(true)
                 .setKeyStorePath(keystoreFile.toString())


### PR DESCRIPTION
By generating and validating request signatures rather then creating and parsing JWT tokens.

This makes it harder to spoof request even if internal signature is captured, as it allows only to call a given URI with a given timestamp validity. This was not the case for JWT token.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
