### PR TITLE
Update PostgreSQL driver to 42.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2298,7 +2298,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.7.6</version>
+                <version>42.7.7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

Relates to https://nvd.nist.gov/vuln/detail/CVE-2025-49146

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
