### PR TITLE
Partition spooled pages while encoding data to segments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/SpoolingPagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpoolingPagePartitioner.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Page;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.execution.buffer.PageSplitterUtil.splitPage;
+import static java.lang.Math.clamp;
+
+public class SpoolingPagePartitioner
+{
+    static final double LOWER_BOUND = 0.05; // 5% of the target size
+    static final double UPPER_BOUND = 0.1; // 10% of the target size
+
+    private SpoolingPagePartitioner() {}
+
+    public static List<List<Page>> partition(List<Page> pages, long targetSize)
+    {
+        Deque<Page> queue = new ArrayDeque<>(pages);
+        List<Page> currentPartition = new ArrayList<>();
+        ImmutableList.Builder<List<Page>> partitions = ImmutableList.builder();
+
+        while (!queue.isEmpty()) {
+            Page currentPage = queue.removeFirst();
+
+            long remainingSize = targetSize - size(currentPartition);
+            verify(remainingSize >= 0, "Current partition size %s is larger than target size %s", size(currentPartition), targetSize);
+
+            if (currentPage.getSizeInBytes() < remainingSize) {
+                currentPartition.add(currentPage);
+
+                if (withinThreshold(size(currentPartition), targetSize)) {
+                    partitions.add(ImmutableList.copyOf(currentPartition));
+                    currentPartition.clear();
+                }
+
+                continue;
+            }
+
+            List<Page> currentPartitioned = new ArrayList<>(takeFromHead(currentPage, remainingSize, targetSize));
+            currentPartition.add(currentPartitioned.removeFirst());
+
+            // Add the remaining split pages back to the queue in the original order
+            currentPartitioned.reversed().forEach(queue::addFirst);
+
+            if (withinThreshold(size(currentPartition), targetSize)) {
+                partitions.add(ImmutableList.copyOf(currentPartition));
+                currentPartition.clear();
+            }
+        }
+
+        // If there are any remaining pages in the current partition, add them as a final partition
+        if (!currentPartition.isEmpty()) {
+            partitions.add(ImmutableList.copyOf(currentPartition));
+        }
+
+        return partitions.build();
+    }
+
+    private static boolean withinThreshold(long page, long targetSize)
+    {
+        return page >= targetSize * (1 - LOWER_BOUND) && page <= targetSize * (1 + UPPER_BOUND);
+    }
+
+    private static List<Page> takeFromHead(Page page, long targetHeadSize, long tailSplitSize)
+    {
+        verify(page.getSizeInBytes() >= targetHeadSize, "Page size %s must be greater than head size %s", page.getSizeInBytes(), targetHeadSize);
+        ImmutableList.Builder<Page> builder = ImmutableList.builder();
+
+        int positions = positionsWithBytes(page, targetHeadSize);
+        builder.add(page.getRegion(0, positions));
+
+        if (positions == page.getPositionCount()) {
+            return builder.build();
+        }
+        builder.addAll(splitPage(page.getRegion(positions, page.getPositionCount() - positions), tailSplitSize));
+        return builder.build();
+    }
+
+    private static long averageSizePerPosition(Page page)
+    {
+        return clamp(page.getSizeInBytes() / (long) page.getPositionCount(), 1, Integer.MAX_VALUE);
+    }
+
+    private static int positionsWithBytes(Page page, long bytes)
+    {
+        long positions = bytes / averageSizePerPosition(page);
+        return clamp(positions, 1, page.getPositionCount());
+    }
+
+    private static long size(List<Page> pages)
+    {
+        return pages.stream().mapToLong(Page::getSizeInBytes).sum();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledMetadataBlock.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpooledMetadataBlock.java
@@ -16,7 +16,6 @@ package io.trino.server.protocol.spooling;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.client.spooling.DataAttributes;
-import io.trino.spi.Page;
 import io.trino.spi.spool.SpooledLocation;
 import io.trino.spi.spool.SpooledLocation.CoordinatorLocation;
 import io.trino.spi.spool.SpooledLocation.DirectLocation;
@@ -31,11 +30,6 @@ import static java.util.Objects.requireNonNull;
 public sealed interface SpooledMetadataBlock
 {
     DataAttributes attributes();
-
-    default Page serialize()
-    {
-        return SpooledMetadataBlockSerde.serialize(this);
-    }
 
     static SpooledMetadataBlock forInlineData(DataAttributes attributes, byte[] data)
     {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -4252,8 +4252,8 @@ public class LocalExecutionPlanner
 
     private static Page validateSpooledLayoutProcessor(Page page)
     {
+        verify(page.getPositionCount() > 0, "Expected at least one position in spooled metadata block");
         verify(page.getChannelCount() == 1, "Expected a single output channel when spooling");
-        verify(page.getPositionCount() == 1, "Expected a single output position when spooling");
         verify(page.getBlock(0) instanceof RowBlock, "Expected a RowBlock for spooling metadata");
         return page;
     }

--- a/core/trino-main/src/test/java/io/trino/operator/TestSpoolingPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestSpoolingPagePartitioner.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Page;
+import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.ToLongFunction;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.SequencePageBuilder.createSequencePage;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestSpoolingPagePartitioner
+{
+    @Test
+    void testPartitionPagesWithMaxSize()
+    {
+        testPartitionPages(100, 750);
+        testPartitionPages(512, 158);
+        testPartitionPages(1_000, 82);
+        testPartitionPages(2_000, 41);
+        testPartitionPages(3_000, 28);
+        testPartitionPages(5_000, 17);
+        testPartitionPages(10_000, 9);
+        testPartitionPages(25_000, 4);
+        testPartitionPages(40_000, 3);
+        testPartitionPages(81_000, 1);
+    }
+
+    void testPartitionPages(int maxPartitionSize, int expectedPartitions)
+    {
+        List<Type> types = ImmutableList.of(BIGINT, BIGINT, BIGINT);
+        List<Page> pages = ImmutableList.<Page>builder()
+                .add(createSequencePage(types, 500, 0, 0, 0))
+                .add(createSequencePage(types, 500, 500, 500, 500))
+                .add(createSequencePage(types, 2000, 1000, 1000, 1000))
+                .build();
+
+        List<List<Page>> partitions = SpoolingPagePartitioner.partition(pages, maxPartitionSize);
+
+        // Partitioning does not change size in bytes
+        assertThat(size(partitions))
+                .isEqualTo(reduce(pages, Page::getSizeInBytes))
+                .isEqualTo(81000);
+
+        // Partitioning does not change position count
+        assertThat(positions(partitions))
+                .isEqualTo(reduce(pages, Page::getPositionCount))
+                .isEqualTo(3000);
+
+        assertPartitionSizes(partitions, maxPartitionSize, expectedPartitions);
+    }
+
+    private void assertPartitionSizes(List<List<Page>> partitions, long maxPartitionSize, int expectedPartitions)
+    {
+        assertThat(partitions).hasSize(expectedPartitions);
+
+        // Last partition can be smaller than maxPartitionSize
+        for (int i = 0; i < partitions.size() - 1; i++) {
+            List<Page> partition = partitions.get(i);
+            long partitionSize = reduce(partition, Page::getSizeInBytes);
+            assertThat(partitionSize)
+                    .isBetween(
+                            (long) (maxPartitionSize * (1 - SpoolingPagePartitioner.LOWER_BOUND)),
+                            (long) (maxPartitionSize * (1 + SpoolingPagePartitioner.UPPER_BOUND)));
+        }
+
+        List<Page> pages = flatten(partitions);
+
+        // Verify that the partitioned pages contain the expected values in expected order
+        long currentPosition = 0;
+        for (Page page : pages) {
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                    assertThat(BIGINT.getObjectValue(page.getBlock(channel), position)).isEqualTo(currentPosition);
+                }
+                currentPosition++;
+            }
+        }
+    }
+
+    private static long size(List<List<Page>> partitions)
+    {
+        return calculate(partitions, Page::getSizeInBytes);
+    }
+
+    private static long positions(List<List<Page>> partitions)
+    {
+        return calculate(partitions, Page::getPositionCount);
+    }
+
+    private static long calculate(List<List<Page>> partitions, ToLongFunction<Page> pageFunction)
+    {
+        return partitions.stream()
+                .mapToLong(pages -> reduce(pages, pageFunction))
+                .sum();
+    }
+
+    private static long reduce(List<Page> pages, ToLongFunction<Page> pageFunction)
+    {
+        return pages.stream().mapToLong(pageFunction).sum();
+    }
+
+    private static List<Page> flatten(List<List<Page>> partitions)
+    {
+        return partitions.stream()
+                .flatMap(List::stream)
+                .collect(toImmutableList());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpooledMetadataBlockSerde.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpooledMetadataBlockSerde.java
@@ -27,7 +27,9 @@ import java.util.Optional;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.client.spooling.DataAttribute.ROWS_COUNT;
 import static io.trino.client.spooling.DataAttribute.SEGMENT_SIZE;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static io.trino.server.protocol.spooling.SpooledMetadataBlockSerde.deserialize;
+import static io.trino.server.protocol.spooling.SpooledMetadataBlockSerde.serialize;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TestSpooledMetadataBlockSerde
 {
@@ -47,13 +49,13 @@ class TestSpooledMetadataBlockSerde
     public void verifySerializationRoundTrip(Slice identifier, Optional<URI> directUri, Map<String, List<String>> headers)
     {
         SpooledMetadataBlock metadata = new SpooledMetadataBlock.Spooled(createDataAttributes(10, 1200), identifier, directUri, headers);
-        assertThat(metadata).isEqualTo(SpooledMetadataBlockSerde.deserialize(metadata.serialize()));
+        assertThat(List.of(metadata)).isEqualTo(deserialize(serialize(metadata)));
     }
 
     private void verifySerializationRoundTripWithNonEmptyPage(Slice identifier, Optional<URI> directUri, Map<String, List<String>> headers)
     {
         SpooledMetadataBlock metadata = new SpooledMetadataBlock.Spooled(createDataAttributes(10, 1100), identifier, directUri, headers);
-        assertThat(metadata).isEqualTo(SpooledMetadataBlockSerde.deserialize(metadata.serialize()));
+        assertThat(List.of(metadata)).isEqualTo(deserialize(serialize(metadata)));
     }
 
     private static DataAttributes createDataAttributes(long rows, int segmentSize)


### PR DESCRIPTION
This prevents dictionary blocks to expand to a single huge segment that most clients won't be able to read due to its size.

This now partitions these kind of pages to smaller ones and allows the operator to output multiple spooled/inlined pages in a single getOutput call.

Fixes https://github.com/trinodb/trino/issues/25999

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## Client protocol
* Partition large pages to avoid OOM while serializing data in the spooling protocol. ({issue}`25999`)
```
