### PR TITLE
Make queued and buffered rows configurable in cli

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -300,6 +300,12 @@ public class ClientOptions
     @Option(names = "--decimal-data-size", description = "Show data size and rate in base 10 rather than base 2")
     public boolean decimalDataSize;
 
+    @Option(names = "--max-buffered-rows", paramLabel = "<maxBufferedRows>", description = "Maximum number of rows to buffer in memory before writing to output (default: ${DEFAULT-VALUE})")
+    public int maxBufferedRows = 10_000;
+
+    @Option(names = "--max-queued-rows", paramLabel = "<maxQueuedRows>", description = "Maximum number of rows to queue before blocking the query (default: ${DEFAULT-VALUE})")
+    public int maxQueuedRows = 50_000;
+
     public enum OutputFormat
     {
         AUTO,

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -177,7 +177,9 @@ public class Console
         try (QueryRunner queryRunner = new QueryRunner(
                 uri,
                 session,
-                clientOptions.debug)) {
+                clientOptions.debug,
+                clientOptions.maxQueuedRows,
+                clientOptions.maxBufferedRows)) {
             if (hasQuery) {
                 return executeCommand(
                         queryRunner,

--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -36,8 +36,10 @@ public class QueryRunner
     private final boolean debug;
     private final OkHttpClient httpClient;
     private final OkHttpClient segmentHttpClient;
+    private final int maxQueuedRows;
+    private final int maxBufferedRows;
 
-    public QueryRunner(TrinoUri uri, ClientSession session, boolean debug)
+    public QueryRunner(TrinoUri uri, ClientSession session, boolean debug, int maxQueuedRows, int maxBufferedRows)
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
         this.httpClient = HttpClientFactory.toHttpClientBuilder(uri, USER_AGENT).build();
@@ -45,6 +47,8 @@ public class QueryRunner
                 .unauthenticatedClientBuilder(uri, USER_AGENT)
                 .build();
         this.debug = debug;
+        this.maxQueuedRows = maxQueuedRows;
+        this.maxBufferedRows = maxBufferedRows;
     }
 
     public ClientSession getSession()
@@ -64,7 +68,7 @@ public class QueryRunner
 
     public Query startQuery(String query)
     {
-        return new Query(startInternalQuery(session.get(), query), debug);
+        return new Query(startInternalQuery(session.get(), query), debug, maxQueuedRows, maxBufferedRows);
     }
 
     public StatementClient startInternalQuery(String query)

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -383,6 +383,8 @@ public class TestClientOptions
             case "editingMode":
             case "disableAutoSuggestion":
             case "decimalDataSize":
+            case "maxBufferedRows":
+            case "maxQueuedRows":
                 return true;
         }
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -156,7 +156,9 @@ public class TestQueryRunner
         return new QueryRunner(
                 uri,
                 clientSession,
-                false);
+                false,
+                1000,
+                500);
     }
 
     static PrintStream nullPrintStream()


### PR DESCRIPTION
This prevents OOM exception when retrieving huge results

Relates to https://github.com/trinodb/trino/pull/26013

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI
* Allow configuring `--max-buffered-rows` and `--max-queued-rows` in the CLI ({issue}`issuenumber`)
```
