### PR TITLE
Fix block positions lookups in spatial join

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
@@ -153,7 +153,7 @@ public class PagesRTreeIndex
             return EMPTY_ADDRESSES;
         }
 
-        int probePartition = probePartitionChannel.map(channel -> INTEGER.getInt(probe.getBlock(channel), probePosition)).orElse(-1);
+        int probePartition = probePartitionChannel.map(channel -> INTEGER.getInt(probe.getBlock(channel), position)).orElse(-1);
 
         Slice slice = probeGeometryBlock.getSlice(probePosition);
         OGCGeometry probeGeometry = deserialize(slice);

--- a/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
@@ -111,14 +111,15 @@ public class PagesSpatialIndexSupplier
             int blockIndex = decodeSliceIndex(pageAddress);
             Block chennelBlock = channels.get(geometryChannel).get(blockIndex);
             VariableWidthBlock block = (VariableWidthBlock) chennelBlock.getUnderlyingValueBlock();
-            int blockPosition = chennelBlock.getUnderlyingValuePosition(decodePosition(pageAddress));
+            int blockPosition = decodePosition(pageAddress);
+            int valueBlockPosition = chennelBlock.getUnderlyingValuePosition(blockPosition);
 
             // TODO Consider pushing is-null and is-empty checks into a filter below the join
-            if (block.isNull(blockPosition)) {
+            if (block.isNull(valueBlockPosition)) {
                 continue;
             }
 
-            Slice slice = block.getSlice(blockPosition);
+            Slice slice = block.getSlice(valueBlockPosition);
             OGCGeometry ogcGeometry = deserialize(slice);
             verifyNotNull(ogcGeometry);
             if (ogcGeometry.isEmpty()) {


### PR DESCRIPTION
## Description
Previous code was using underlying value position of one channel on another channel's block. 
This can give incorrect results when one of channels uses an RLE or Dictionary block.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Seems to be broken since https://github.com/trinodb/trino/commit/de3c1600a38040a6efdec774b0ad519b748c663c


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix incorrect results with spatial joins. ({issue}`26021`)
```
