### PR TITLE
Handle NullPointerException in StatementAnalyzer createMergeAnalysis

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -323,6 +323,7 @@ import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_IN_DISTINCT;
 import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_WINDOW;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.INVALID_CATALOG_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_CHECK_CONSTRAINT;
@@ -3767,7 +3768,18 @@ class StatementAnalyzer
             List<ColumnHandle> redistributionColumnHandles = redistributionColumnHandlesBuilder.build();
 
             List<Integer> insertPartitioningArgumentIndexes = partitioningColumnNames.stream()
-                    .map(fieldIndexes::get)
+                    .map(partitioningColumnName -> {
+                        Integer value = fieldIndexes.get(partitioningColumnName);
+                        // This shouldn't happen, as the connector should only return partitioning columns that are present in the
+                        // table schema, but validation is performed here to avoid NPEs in case of a bug in the connector
+                        if (value == null) {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, format(
+                                    "Unable to determine field index for partitioning column '%s' (available columns: [%s])",
+                                    partitioningColumnName,
+                                    fieldIndexes.keySet().stream().map(key -> format("'%s'", key)).collect(Collectors.joining(", "))));
+                        }
+                        return value;
+                    })
                     .collect(toImmutableList());
 
             Set<ColumnHandle> nonNullableColumnHandles = metadata.getTableMetadata(session, handle).columns().stream()

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestMetadataMismatch.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestMetadataMismatch.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.connector.ConnectorTableLayout;
+import io.trino.spi.security.Identity;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Optional;
+
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_SCHEMA;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestMetadataMismatch
+{
+    private static final String LOCAL_CATALOG = "local";
+    private static final String MOCK_CATALOG = "mock";
+    private static final String USER = "user";
+
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog(LOCAL_CATALOG)
+            .setSchema(TINY_SCHEMA_NAME)
+            .setIdentity(Identity.forUser(USER).build())
+            .build();
+
+    private final QueryAssertions assertions;
+
+    public TestMetadataMismatch()
+    {
+        QueryRunner runner = new StandaloneQueryRunner(SESSION);
+
+        runner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withGetColumns(_ -> TPCH_NATION_SCHEMA)
+                .withGetInsertLayout((_, _) ->
+                        Optional.of(new ConnectorTableLayout(ImmutableList.of("year"))))  // nonexistent column in TPCH_NATION_SCHEMA
+                .build()));
+        runner.createCatalog(MOCK_CATALOG, "mock", ImmutableMap.of());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testGetInsertLayoutMismatchAgainstColumns()
+    {
+        assertThat(assertions.query("DELETE FROM mock.tiny.nation WHERE nationkey < 3"))
+                .failure()
+                .hasErrorCode(GENERIC_INTERNAL_ERROR)
+                // use regex to match the error message to accommodate any ordering of the columns being printed
+                .hasMessageMatching("Unable to determine field index for partitioning column 'year' \\(available columns: \\[('(nationkey|regionkey|name|comment)', ){3}'(nationkey|regionkey|name|comment)']\\)");
+    }
+}


### PR DESCRIPTION
## Description

In `StatementAnalyzer#createMergeAnalysis`, in cases where the connector returns a partitioning column (from the insert layout) that doesn't exist in the table's schema, currently you will get a `GENERIC_INTERNAL_ERROR` with an empty message -- very confusing for users! The `failureType` is `NullPointerException` with a stack trace like this:
```
    at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:889)
    at com.google.common.collect.ImmutableList$Builder.add(ImmutableList.java:813)
    at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
    at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.createMergeAnalysis(StatementAnalyzer.java:3503)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitDelete(StatementAnalyzer.java:825)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitDelete(StatementAnalyzer.java:483)
    at io.trino.sql.tree.Delete.accept(Delete.java:61)
    at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:500)
    at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:462)
    at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:79)
    at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:71)
    at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:258)
    at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:196)
    at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:818)
    at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:143)
    at io.trino.$gen.Trino_406_223_10____20250611_200512_2.call(Unknown Source)
    at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
    at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
    at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.base/java.lang.Thread.run(Thread.java:840)
```

The connector shouldn't do this, but the `StatementAnalyzer` shouldn't throw such an opaque message even in such cases.

After this change, it now throws a `TrinoException` with a corresponding message like:
```
Unable to determine field index for partitioning column 'year' (available columns: ['nationkey', 'regionkey', 'name', 'comment'])
```

(This is a re-submission of https://github.com/trinodb/trino/pull/25775; I am taking up the PR with @artem-sokolov 's consent)

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: