### PR TITLE
Remove redundant parameter from BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -318,11 +318,11 @@ public class BigQueryClient
         }
     }
 
-    public TableInfo getCachedTable(Duration viewExpiration, TableInfo remoteTableId, List<BigQueryColumnHandle> requiredColumns, Optional<String> filter)
+    public TableInfo getCachedTable(TableInfo remoteTableId, List<BigQueryColumnHandle> requiredColumns, Optional<String> filter)
     {
         String query = selectSql(remoteTableId.getTableId(), requiredColumns, filter, OptionalLong.empty());
         log.debug("query is %s", query);
-        return materializationCache.getCachedTable(this, query, viewExpiration, remoteTableId);
+        return materializationCache.getCachedTable(this, query, remoteTableId);
     }
 
     /**

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -15,7 +15,6 @@ package io.trino.plugin.bigquery;
 
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
-import io.airlift.units.Duration;
 import io.trino.spi.NodeManager;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -34,9 +33,9 @@ public class BigQuerySplitManager
 
     private final BigQueryClientFactory bigQueryClientFactory;
     private final BigQueryReadClientFactory bigQueryReadClientFactory;
+    private final ViewMaterializationCache viewMaterializationCache;
     private final boolean viewEnabled;
     private final boolean arrowSerializationEnabled;
-    private final Duration viewExpiration;
     private final NodeManager nodeManager;
     private final int maxReadRowsRetries;
 
@@ -45,13 +44,14 @@ public class BigQuerySplitManager
             BigQueryConfig config,
             BigQueryClientFactory bigQueryClientFactory,
             BigQueryReadClientFactory bigQueryReadClientFactory,
+            ViewMaterializationCache viewMaterializationCache,
             NodeManager nodeManager)
     {
         this.bigQueryClientFactory = requireNonNull(bigQueryClientFactory, "bigQueryClientFactory cannot be null");
         this.bigQueryReadClientFactory = requireNonNull(bigQueryReadClientFactory, "bigQueryReadClientFactory cannot be null");
+        this.viewMaterializationCache = requireNonNull(viewMaterializationCache, "viewMaterializationCache is null");
         this.viewEnabled = config.isViewsEnabled();
         this.arrowSerializationEnabled = config.isArrowSerializationEnabled();
-        this.viewExpiration = config.getViewExpireDuration();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager cannot be null");
         this.maxReadRowsRetries = config.getMaxReadRowsRetries();
     }
@@ -70,9 +70,9 @@ public class BigQuerySplitManager
                 (BigQueryTableHandle) table,
                 bigQueryClientFactory,
                 bigQueryReadClientFactory,
+                viewMaterializationCache,
                 viewEnabled,
                 arrowSerializationEnabled,
-                viewExpiration,
                 nodeManager,
                 maxReadRowsRetries);
     }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -25,7 +25,6 @@ import com.google.cloud.bigquery.storage.v1.ReadSession;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
-import io.airlift.units.Duration;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
@@ -57,7 +56,6 @@ public class ReadSessionCreator
     private final BigQueryReadClientFactory bigQueryReadClientFactory;
     private final boolean viewEnabled;
     private final boolean arrowSerializationEnabled;
-    private final Duration viewExpiration;
     private final int maxCreateReadSessionRetries;
     private final Optional<Integer> maxParallelism;
 
@@ -66,7 +64,6 @@ public class ReadSessionCreator
             BigQueryReadClientFactory bigQueryReadClientFactory,
             boolean viewEnabled,
             boolean arrowSerializationEnabled,
-            Duration viewExpiration,
             int maxCreateReadSessionRetries,
             Optional<Integer> maxParallelism)
     {
@@ -74,7 +71,6 @@ public class ReadSessionCreator
         this.bigQueryReadClientFactory = bigQueryReadClientFactory;
         this.viewEnabled = viewEnabled;
         this.arrowSerializationEnabled = arrowSerializationEnabled;
-        this.viewExpiration = viewExpiration;
         this.maxCreateReadSessionRetries = maxCreateReadSessionRetries;
         this.maxParallelism = maxParallelism;
     }
@@ -159,7 +155,7 @@ public class ReadSessionCreator
                         BigQueryConfig.VIEWS_ENABLED));
             }
             // get it from the view
-            return client.getCachedTable(viewExpiration, remoteTable, requiredColumns, filter);
+            return client.getCachedTable(remoteTable, requiredColumns, filter);
         }
         // Storage API doesn't support reading other table types (materialized views, non-biglake external tables)
         throw new TrinoException(NOT_SUPPORTED, format("Table type '%s' of table '%s.%s' is not supported",


### PR DESCRIPTION
## Description

We can set the config value in ViewMaterializationCache instead of passing from BigQuerySplitManager.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
