### PR TITLE
Set Databricks JDBC socket timeout to 120 seconds

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/singlenode-delta-lake-databricks/tempto-configuration.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/singlenode-delta-lake-databricks/tempto-configuration.yaml
@@ -8,7 +8,7 @@ databases:
     prepare_statement:
       - USE ${databases.delta.schema}
     table_manager_type: jdbc
-    jdbc_url: ${DATABRICKS_JDBC_URL};EnableArrow=0
+    jdbc_url: ${DATABRICKS_JDBC_URL};EnableArrow=0;SocketTimeout=120
     jdbc_user: ${DATABRICKS_LOGIN}
     jdbc_password: ${DATABRICKS_TOKEN}
 


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
