### PR TITLE
Optional access control for inbuilt functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -123,6 +123,8 @@ public class FeaturesConfig
 
     private boolean faultTolerantExecutionExchangeEncryptionEnabled = true;
 
+    private boolean functionAccessControlEnabled;
+
     public enum DataIntegrityVerification
     {
         NONE,
@@ -522,5 +524,18 @@ public class FeaturesConfig
     public void applyFaultTolerantExecutionDefaults()
     {
         exchangeCompressionCodec = LZ4;
+    }
+
+    @Config("function-access-control-enabled")
+    @ConfigDescription("Enable access control on all functions")
+    public FeaturesConfig setFunctionAccessControlEnabled(boolean enabled)
+    {
+        this.functionAccessControlEnabled = enabled;
+        return this;
+    }
+
+    public boolean isFunctionAccessControlEnabled()
+    {
+        return functionAccessControlEnabled;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -70,18 +70,21 @@ public class FunctionResolver
     private final LanguageFunctionManager languageFunctionManager;
     private final WarningCollector warningCollector;
     private final FunctionBinder functionBinder;
+    private final boolean functionAccessControlEnabled;
 
     public FunctionResolver(
             Metadata metadata,
             TypeManager typeManager,
             LanguageFunctionManager languageFunctionManager,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean functionAccessControlEnabled)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.languageFunctionManager = requireNonNull(languageFunctionManager, "languageFunctionManager is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         this.functionBinder = new FunctionBinder(metadata, typeManager);
+        this.functionAccessControlEnabled = functionAccessControlEnabled;
     }
 
     /**
@@ -290,9 +293,9 @@ public class FunctionResolver
         return names.build();
     }
 
-    private static boolean canExecuteFunction(Session session, AccessControl accessControl, CatalogSchemaFunctionName functionName)
+    private boolean canExecuteFunction(Session session, AccessControl accessControl, CatalogSchemaFunctionName functionName)
     {
-        if (isInlineFunction(functionName) || isBuiltinFunctionName(functionName)) {
+        if (!functionAccessControlEnabled && (isInlineFunction(functionName) || isBuiltinFunctionName(functionName))) {
             return true;
         }
         return accessControl.canExecuteFunction(

--- a/core/trino-main/src/main/java/io/trino/sql/PlannerContext.java
+++ b/core/trino-main/src/main/java/io/trino/sql/PlannerContext.java
@@ -15,6 +15,7 @@ package io.trino.sql;
 
 import com.google.inject.Inject;
 import io.opentelemetry.api.trace.Tracer;
+import io.trino.FeaturesConfig;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.FunctionResolver;
@@ -44,6 +45,7 @@ public class PlannerContext
     private final FunctionManager functionManager;
     private final LanguageFunctionManager languageFunctionManager;
     private final Tracer tracer;
+    private final boolean functionAccessControlEnabled;
 
     @Inject
     public PlannerContext(Metadata metadata,
@@ -52,7 +54,8 @@ public class PlannerContext
             TypeManager typeManager,
             FunctionManager functionManager,
             LanguageFunctionManager languageFunctionManager,
-            Tracer tracer)
+            Tracer tracer,
+            FeaturesConfig featuresConfig)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
@@ -61,6 +64,7 @@ public class PlannerContext
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.languageFunctionManager = requireNonNull(languageFunctionManager, "languageFunctionManager is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
+        this.functionAccessControlEnabled = requireNonNull(featuresConfig, "featuresConfig is null").isFunctionAccessControlEnabled();
     }
 
     public Metadata getMetadata()
@@ -95,7 +99,7 @@ public class PlannerContext
 
     public FunctionResolver getFunctionResolver(WarningCollector warningCollector)
     {
-        return new FunctionResolver(metadata, typeManager, languageFunctionManager, warningCollector);
+        return new FunctionResolver(metadata, typeManager, languageFunctionManager, warningCollector, functionAccessControlEnabled);
     }
 
     public LanguageFunctionManager getLanguageFunctionManager()

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -429,7 +429,7 @@ public class PlanTester
                 new JsonValueFunction(functionManager, metadata, typeManager),
                 new JsonQueryFunction(functionManager, metadata, typeManager)));
 
-        this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager, languageFunctionManager, tracer);
+        this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager, languageFunctionManager, tracer, new FeaturesConfig().setFunctionAccessControlEnabled(true));
         this.pageFunctionCompiler = new PageFunctionCompiler(functionManager, 0);
         this.filterCompiler = new ColumnarFilterCompiler(functionManager, 0);
         this.expressionCompiler = new ExpressionCompiler(new CursorProcessorCompiler(functionManager), pageFunctionCompiler, filterCompiler);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -66,7 +66,8 @@ public class TestFeaturesConfig
                 .setHideInaccessibleColumns(false)
                 .setForceSpillingJoin(false)
                 .setColumnarFilterEvaluationEnabled(true)
-                .setFaultTolerantExecutionExchangeEncryptionEnabled(true));
+                .setFaultTolerantExecutionExchangeEncryptionEnabled(true)
+                .setFunctionAccessControlEnabled(false));
     }
 
     @Test
@@ -101,6 +102,7 @@ public class TestFeaturesConfig
                 .put("force-spilling-join-operator", "true")
                 .put("experimental.columnar-filter-evaluation.enabled", "false")
                 .put("fault-tolerant-execution-exchange-encryption-enabled", "false")
+                .put("function-access-control-enabled", "true")
                 .buildOrThrow();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -131,7 +133,8 @@ public class TestFeaturesConfig
                 .setHideInaccessibleColumns(true)
                 .setForceSpillingJoin(true)
                 .setColumnarFilterEvaluationEnabled(false)
-                .setFaultTolerantExecutionExchangeEncryptionEnabled(false);
+                .setFaultTolerantExecutionExchangeEncryptionEnabled(false)
+                .setFunctionAccessControlEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -160,7 +160,8 @@ public final class TestingPlannerContext
                     typeManager,
                     functionManager,
                     languageFunctionManager,
-                    noopTracer());
+                    noopTracer(),
+                    new FeaturesConfig().setFunctionAccessControlEnabled(true));
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
This is a PR to add a flag that allows users to have to option to enable access control for inbuilt functions.
Currently all inbuilt functions are treated as safe and we are not able to restrict access to specific function as per rbac policy.
This can be problematic as users might wish to have some control over what they wish to restrict over different environments.

By default the inbuilt functions will still not be blocked, this will add a configuration "function-access-control-enabled" which can be marked true in config.properties for users to enable access control over all functions



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fixes : #19912  #24435 #23278 
```