### PR TITLE
Allow custom properties in Iceberg REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -526,6 +526,9 @@ following properties:
 * - `iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl`
   - [Duration](prop-type-duration) for which case-insensitive namespace, table, 
     and view names are cached. Defaults to `1m`.
+* - `iceberg.rest-catalog.additional-properties`
+  - Headers that should be passed over to the REST catalog.
+    Should be provided as a list of strings in the `header=value` format.
   :::
 
 The following example shows a minimal catalog configuration using an Iceberg

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -69,6 +69,7 @@ public class TrinoIcebergRestCatalogFactory
     private final boolean caseInsensitiveNameMatching;
     private final Cache<Namespace, Namespace> remoteNamespaceMappingCache;
     private final Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache;
+    private final Map<String, String> additionalProperties;
 
     @GuardedBy("this")
     private RESTSessionCatalog icebergCatalog;
@@ -110,6 +111,7 @@ public class TrinoIcebergRestCatalogFactory
                 .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
                 .build();
+        this.additionalProperties = ImmutableMap.copyOf(restConfig.getAdditionalProperties());
     }
 
     @Override
@@ -131,6 +133,7 @@ public class TrinoIcebergRestCatalogFactory
             if (vendedCredentialsEnabled) {
                 properties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
             }
+            properties.putAll(additionalProperties);
 
             RESTSessionCatalog icebergCatalogInstance = new RESTSessionCatalog(
                     config -> HTTPClient.builder(config)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -18,6 +18,7 @@ import io.airlift.units.Duration;
 import org.apache.iceberg.CatalogProperties;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -43,7 +44,8 @@ public class TestIcebergRestCatalogConfig
                 .setViewEndpointsEnabled(true)
                 .setSigV4Enabled(false)
                 .setCaseInsensitiveNameMatching(false)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setAdditionalProperties(List.of()));
     }
 
     @Test
@@ -62,6 +64,7 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.sigv4-enabled", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl", "3m")
+                .put("iceberg.rest-catalog.additional-properties", "Authorization: Trust Me, Cache-Control: no-cache")
                 .buildOrThrow();
 
         IcebergRestCatalogConfig expected = new IcebergRestCatalogConfig()
@@ -76,7 +79,8 @@ public class TestIcebergRestCatalogConfig
                 .setViewEndpointsEnabled(false)
                 .setSigV4Enabled(true)
                 .setCaseInsensitiveNameMatching(true)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES))
+                .setAdditionalProperties(List.of("Authorization: Trust Me", "Cache-Control: no-cache"));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Closes #24236

This allows custom properties to be passed through to the Iceberg REST Catalog. This 

The idea is that certain implementations of the Iceberg REST Catalog will expect certain headers being sent. Rather than trying to enumerate all of them across an ever-growing number of implementations, we should allow users to pass in these custom headers.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This adds a new config value + passes it through with the rest of the properties.

#24236 has more discussion around this.



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
() Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Adds support for passing custom properties to the Iceberg REST Catalog using `iceberg.rest-catalog.additional-properties`.
```
