### PR TITLE
 Avoid relying on org.apache.parquet.format.RowGroup.getFile_offset

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -195,28 +195,24 @@ public final class PredicateUtils
     {
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : parquetMetadata.getBlocks(splitStart, splitLength)) {
-            long blockStart = block.getStartingPos();
-            boolean splitContainsBlock = splitStart <= blockStart && blockStart < splitStart + splitLength;
-            if (splitContainsBlock) {
-                for (int i = 0; i < parquetTupleDomains.size(); i++) {
-                    TupleDomain<ColumnDescriptor> parquetTupleDomain = parquetTupleDomains.get(i);
-                    TupleDomainParquetPredicate parquetPredicate = parquetPredicates.get(i);
-                    Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
-                    Optional<BloomFilterStore> bloomFilterStore = getBloomFilterStore(dataSource, block, parquetTupleDomain, options);
-                    PrunedBlockMetadata columnsMetadata = createPrunedColumnsMetadata(block, dataSource.getId(), descriptorsByPath);
-                    if (predicateMatches(
-                            parquetPredicate,
-                            columnsMetadata,
-                            dataSource,
-                            descriptorsByPath,
-                            parquetTupleDomain,
-                            columnIndex,
-                            bloomFilterStore,
-                            timeZone,
-                            domainCompactionThreshold)) {
-                        rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, block.fileRowCountOffset(), columnIndex));
-                        break;
-                    }
+            for (int i = 0; i < parquetTupleDomains.size(); i++) {
+                TupleDomain<ColumnDescriptor> parquetTupleDomain = parquetTupleDomains.get(i);
+                TupleDomainParquetPredicate parquetPredicate = parquetPredicates.get(i);
+                Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
+                Optional<BloomFilterStore> bloomFilterStore = getBloomFilterStore(dataSource, block, parquetTupleDomain, options);
+                PrunedBlockMetadata columnsMetadata = createPrunedColumnsMetadata(block, dataSource.getId(), descriptorsByPath);
+                if (predicateMatches(
+                        parquetPredicate,
+                        columnsMetadata,
+                        dataSource,
+                        descriptorsByPath,
+                        parquetTupleDomain,
+                        columnIndex,
+                        bloomFilterStore,
+                        timeZone,
+                        domainCompactionThreshold)) {
+                    rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, block.fileRowCountOffset(), columnIndex));
+                    break;
                 }
             }
         }


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Certain parquet writers like pyarrow can set this offset incorrectly.
That can lead to the parquet reader not idenitfying the row groups
within a split correctly. This code is changed to rely on first page
offset in ColumnChunk instead.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/26058
Related to https://github.com/trinodb/trino/pull/24618

Newer versions of pyarrow (tested parquet-cpp-arrow version 20.0.0) don't have this problem, the file showing this problem is using `parquet-cpp-arrow version 5.0.0`

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg, Hive, Hudi, Delta Lake
* Fix incorrect results when reading from parquet files produced by old versions of pyarrow. ({issue}`26058`)
```
