### PR TITLE
Add user info and query_id fields to OpenLineage facets

### DIFF
--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
@@ -168,6 +168,8 @@ public class OpenLineageListener
 
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
 
+        properties.put("query_id", queryMetadata.getQueryId());
+
         queryMetadata.getPlan().ifPresent(
                 queryPlan -> properties.put("query_plan", queryPlan));
 

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
@@ -63,6 +63,20 @@ final class TestOpenLineageListener
                 .extracting(Job::getNamespace)
                 .isEqualTo("trino://testhost");
 
+        Map<String, Object> trinoQueryMetadata =
+                result
+                .getRun()
+                .getFacets()
+                .getAdditionalProperties()
+                .get("trino_metadata")
+                .getAdditionalProperties();
+
+        assertThat(trinoQueryMetadata)
+                .containsOnly(
+                        entry("query_id", "queryId"),
+                        entry("transaction_id", "transactionId"),
+                        entry("query_plan", "queryPlan"));
+
         Map<String, Object> trinoQueryContext =
                 result
                 .getRun()
@@ -114,6 +128,20 @@ final class TestOpenLineageListener
                 .extracting(RunEvent::getJob)
                 .extracting(Job::getNamespace)
                 .isEqualTo("trino://testhost:8080");
+
+        Map<String, Object> trinoQueryMetadata =
+                result
+                .getRun()
+                .getFacets()
+                .getAdditionalProperties()
+                .get("trino_metadata")
+                .getAdditionalProperties();
+
+        assertThat(trinoQueryMetadata)
+                .containsOnly(
+                        entry("query_id", "queryId"),
+                        entry("transaction_id", "transactionId"),
+                        entry("query_plan", "queryPlan"));
 
         Map<String, Object> trinoQueryContext =
                 result

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
@@ -81,18 +81,18 @@ public class TrinoEventData
 
         queryMetadata = new QueryMetadata(
                 "queryId",
-                Optional.empty(),
-                Optional.empty(),
+                Optional.of("transactionId"),
+                Optional.empty(), // encoding
                 "create table b.c as select * from y.z",
                 Optional.of("updateType"),
                 Optional.of("preparedQuery"),
                 "COMPLETED",
-                List.of(),
-                List.of(),
+                List.of(), // tables
+                List.of(), // routines
                 URI.create("http://localhost"),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty());
+                Optional.of("queryPlan"),
+                Optional.empty(), // jsonPlan
+                Optional.empty()); // payload
 
         queryStatistics = new QueryStatistics(
                 ofSeconds(1),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Previously OpenLineage events included `trino_query_context` and `trino_metadata` facets with very limited information:
```json
{
  "trino_query_context": {
    "_producer": "https://github.com/trinodb/trino/plugin/trino-openlineage",
    "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
    "server_address": "10.220.2.3",
    "environment": "docker",
    "query_type": "SELECT"
  },
  "trino_metadata": {
    "_producer": "https://github.com/trinodb/trino/plugin/trino-openlineage",
    "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
    "query_plan": "...",
    "transaction_id": "c715f1f6-ba48-4150-ae1b-91b0ac68739d"
  }
}
```

Now this facet is extended with more fields from `QueryContext` and `QueryMetadata` classes, allowing to track specific user, client and queryId:
```json
{
  "trino_query_context": {
    "_producer": "https://github.com/trinodb/trino/plugin/trino-openlineage",
    "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
    "server_address": "10.220.2.3",
    "environment": "docker",
    "query_type": "SELECT",
    "user": "user123",
    "original_user": "user123",
    "principal": "user123",
    "source": "trino-python-client",
    "client_info": "Abritrary client information",
    "remote_client_address": "127.0.0.1",
    "user_agent": "Some-User-Agent",
    "trace_token": "abc-123"
  },
  "trino_metadata": {
    "_producer": "https://github.com/trinodb/trino/plugin/trino-openlineage",
    "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
    "query_id": "20250626_083857_00007_6nggr",
    "query_plan": "...",
    "transaction_id": "c715f1f6-ba48-4150-ae1b-91b0ac68739d"
  }
}
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Closes: #26074

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## OpenLineage
* Add user identifying fields to OpenLineage `trino_query_context` facet. ({issue}`26074`)
* Add `query_id` field to OpenLineage `trino_metadata` facet. ({issue}`26074`)
```
