### PR TITLE
Improve HashBuilderOperator unspill parallelism

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
@@ -411,7 +411,8 @@ public class HashBuilderOperator
         spiller = Optional.of(singleStreamSpillerFactory.create(
                 index.getTypes(),
                 operatorContext.getSpillContext().newLocalSpillContext(),
-                operatorContext.newLocalUserMemoryContext(HashBuilderOperator.class.getSimpleName())));
+                operatorContext.newLocalUserMemoryContext(HashBuilderOperator.class.getSimpleName()),
+                true));
         long spillStartNanos = System.nanoTime();
         ListenableFuture<DataSize> spillFuture = getSpiller().spill(index.getPages());
         addSuccessCallback(spillFuture, dataSize -> {

--- a/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpiller.java
@@ -16,6 +16,7 @@ package io.trino.spiller;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -33,6 +34,7 @@ import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.SpillContext;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
+import jakarta.annotation.Nullable;
 
 import javax.crypto.SecretKey;
 
@@ -42,6 +44,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -62,8 +65,14 @@ public class FileSingleStreamSpiller
 {
     @VisibleForTesting
     static final int BUFFER_SIZE = 4 * 1024;
+    static final int DEFAULT_SEGMENT_SIZE = 64 * 1024 * 1024; // 64 MB
 
-    private final FileHolder targetFile;
+    private final int segmentSize;
+
+    private final List<FileHolder> targetFiles;
+    private volatile long currentSegmentBytes;
+    private volatile int currentFileIndex;
+
     private final Closer closer = Closer.create();
     private final PagesSerdeFactory serdeFactory;
     private volatile Optional<SecretKey> encryptionKey;
@@ -84,11 +93,35 @@ public class FileSingleStreamSpiller
             PagesSerdeFactory serdeFactory,
             Optional<SecretKey> encryptionKey,
             ListeningExecutorService executor,
-            Path spillPath,
+            List<Path> spillPaths,
             SpillerStats spillerStats,
             SpillContext spillContext,
             LocalMemoryContext memoryContext,
             Runnable fileSystemErrorHandler)
+    {
+        this(
+                serdeFactory,
+                encryptionKey,
+                executor,
+                spillPaths,
+                spillerStats,
+                spillContext,
+                memoryContext,
+                fileSystemErrorHandler,
+                DEFAULT_SEGMENT_SIZE);
+    }
+
+    @VisibleForTesting
+    public FileSingleStreamSpiller(
+            PagesSerdeFactory serdeFactory,
+            Optional<SecretKey> encryptionKey,
+            ListeningExecutorService executor,
+            List<Path> spillPaths,
+            SpillerStats spillerStats,
+            SpillContext spillContext,
+            LocalMemoryContext memoryContext,
+            Runnable fileSystemErrorHandler,
+            int segmentSize)
     {
         this.serdeFactory = requireNonNull(serdeFactory, "serdeFactory is null");
         this.encryptionKey = requireNonNull(encryptionKey, "encryptionKey is null");
@@ -109,8 +142,15 @@ public class FileSingleStreamSpiller
         // middle of execution when close() is called (note that this applies to both readPages() and writePages() methods).
         this.memoryContext.setBytes(BUFFER_SIZE);
         this.fileSystemErrorHandler = requireNonNull(fileSystemErrorHandler, "filesystemErrorHandler is null");
+        this.segmentSize = segmentSize;
+        requireNonNull(spillPaths, "spillPaths is null");
+        checkState(!spillPaths.isEmpty(), "spillPaths is empty");
         try {
-            this.targetFile = closer.register(new FileHolder(Files.createTempFile(spillPath, SPILL_FILE_PREFIX, SPILL_FILE_SUFFIX)));
+            ImmutableList.Builder<FileHolder> builder = ImmutableList.builder();
+            for (Path path : spillPaths) {
+                builder.add(closer.register(new FileHolder(Files.createTempFile(path, SPILL_FILE_PREFIX, SPILL_FILE_SUFFIX))));
+            }
+            this.targetFiles = builder.build();
         }
         catch (IOException e) {
             this.fileSystemErrorHandler.run();
@@ -137,61 +177,176 @@ public class FileSingleStreamSpiller
     public Iterator<Page> getSpilledPages()
     {
         checkNoSpillInProgress();
-        return readPages();
-    }
-
-    @Override
-    public ListenableFuture<List<Page>> getAllSpilledPages()
-    {
-        return executor.submit(() -> ImmutableList.copyOf(getSpilledPages()));
-    }
-
-    private DataSize writePages(Iterator<Page> pageIterator)
-    {
-        checkState(writable.get(), "Spilling no longer allowed. The spiller has been made non-writable on first read for subsequent reads to be consistent");
-
-        Optional<SecretKey> encryptionKey = this.encryptionKey;
-        checkState(encrypted == encryptionKey.isPresent(), "encryptionKey has been discarded");
-        PageSerializer serializer = serdeFactory.createSerializer(encryptionKey);
-        long spilledPagesBytes = 0;
-        try (SliceOutput output = new OutputStreamSliceOutput(targetFile.newOutputStream(APPEND), BUFFER_SIZE)) {
-            while (pageIterator.hasNext()) {
-                Page page = pageIterator.next();
-                long pageSizeInBytes = page.getSizeInBytes();
-                spilledPagesBytes += pageSizeInBytes;
-                spilledPagesInMemorySize.addAndGet(pageSizeInBytes);
-                Slice serializedPage = serializer.serialize(page);
-                long pageSize = serializedPage.length();
-                localSpillContext.updateBytes(pageSize);
-                spillerStats.addToTotalSpilledBytes(pageSize);
-                output.writeBytes(serializedPage);
-            }
-        }
-        catch (UncheckedIOException | IOException e) {
-            fileSystemErrorHandler.run();
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to spill pages", e);
-        }
-        return DataSize.ofBytes(spilledPagesBytes);
-    }
-
-    private Iterator<Page> readPages()
-    {
         checkState(writable.getAndSet(false), "Repeated reads are disallowed to prevent potential resource leaks");
 
         try {
             Optional<SecretKey> encryptionKey = this.encryptionKey;
             checkState(encrypted == encryptionKey.isPresent(), "encryptionKey has been discarded");
             PageDeserializer deserializer = serdeFactory.createDeserializer(encryptionKey);
-            // encryption key is safe to discard since it now belongs to the PageDeserializer and repeated reads are disallowed
             this.encryptionKey = Optional.empty();
-            InputStream input = closer.register(targetFile.newInputStream());
-            Iterator<Page> pages = PagesSerdeUtil.readPages(deserializer, input);
-            return closeWhenExhausted(pages, input);
+
+            List<Iterator<Iterator<Page>>> segmentsPerFile = new ArrayList<>();
+            for (FileHolder file : targetFiles) {
+                segmentsPerFile.add(readSegments(deserializer, file, closer));
+            }
+
+            int fileCount = segmentsPerFile.size();
+
+            return new AbstractIterator<>()
+            {
+                int fileIndex;
+                Iterator<Page> current = ImmutableList.<Page>of().iterator();
+
+                @Override
+                protected Page computeNext()
+                {
+                    while (true) {
+                        if (current.hasNext()) {
+                            return current.next();
+                        }
+
+                        int start = fileIndex;
+                        boolean found = false;
+                        do {
+                            Iterator<Iterator<Page>> segments = segmentsPerFile.get(fileIndex);
+                            if (segments.hasNext()) {
+                                current = segments.next();
+                                fileIndex = (fileIndex + 1) % fileCount;
+                                found = true;
+                                break;
+                            }
+                            fileIndex = (fileIndex + 1) % fileCount;
+                        } while (fileIndex != start);
+
+                        if (!found) {
+                            return endOfData();
+                        }
+                    }
+                }
+            };
         }
         catch (IOException e) {
             fileSystemErrorHandler.run();
             throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to read spilled pages", e);
         }
+    }
+
+    @Override
+    public ListenableFuture<List<Page>> getAllSpilledPages()
+    {
+        checkNoSpillInProgress();
+        checkState(writable.getAndSet(false), "Repeated reads are disallowed to prevent potential resource leaks");
+
+        Optional<SecretKey> encryptionKey = this.encryptionKey;
+        checkState(encrypted == encryptionKey.isPresent(), "encryptionKey has been discarded");
+        this.encryptionKey = Optional.empty();
+
+        List<ListenableFuture<List<List<Page>>>> futures = new ArrayList<>();
+        for (FileHolder file : targetFiles) {
+            futures.add(executor.submit(() -> {
+                PageDeserializer deserializer = serdeFactory.createDeserializer(encryptionKey);
+                ImmutableList.Builder<List<Page>> segments = ImmutableList.builder();
+                try (Closer closer = Closer.create()) {
+                    Iterator<Iterator<Page>> segmentIterator = readSegments(deserializer, file, closer);
+                    // materialize all segments from the file using executor thread
+                    while (segmentIterator.hasNext()) {
+                        segments.add(ImmutableList.copyOf(segmentIterator.next()));
+                    }
+                }
+                return segments.build();
+            }));
+        }
+
+        // Combine pages from all spill files according to the segment order.
+        return Futures.transform(Futures.allAsList(futures), segmentsPerFile -> {
+            ImmutableList.Builder<Page> builder = ImmutableList.builder();
+            int fileCount = segmentsPerFile.size();
+            List<Iterator<List<Page>>> iterators = new ArrayList<>(fileCount);
+            for (List<List<Page>> segments : segmentsPerFile) {
+                iterators.add(segments.iterator());
+            }
+
+            int fileIndex = 0;
+            while (true) {
+                boolean found = false;
+                for (int i = 0; i < fileCount; i++) {
+                    int index = (fileIndex + i) % fileCount;
+                    Iterator<List<Page>> segments = iterators.get(index);
+                    if (segments.hasNext()) {
+                        segments.next().forEach(builder::add);
+                        fileIndex = (index + 1) % fileCount;
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    break;
+                }
+            }
+            return builder.build();
+        }, executor);
+    }
+
+    private DataSize writePages(Iterator<Page> pages)
+    {
+        checkState(writable.get(), "Spilling no longer allowed. The spiller has been made non-writable on first read for subsequent reads to be consistent");
+
+        Optional<SecretKey> encryptionKey = this.encryptionKey;
+        checkState(encrypted == encryptionKey.isPresent(), "encryptionKey has been discarded");
+        PageSerializer serializer = serdeFactory.createSerializer(encryptionKey);
+
+        long spilledPagesBytes = 0;
+        int fileIndex = currentFileIndex;
+
+        try {
+            while (pages.hasNext()) {
+                long segmentBytes = currentSegmentBytes;
+                try (SliceOutput out = newSliceOutput(fileIndex)) {
+                    while (pages.hasNext()) {
+                        Page page = pages.next();
+                        long pageSizeInBytes = page.getSizeInBytes();
+                        Slice serialized = serializer.serialize(page);
+                        long serializedPageSize = serialized.length();
+
+                        // check if the next page would exceed the segment size
+                        if (targetFiles.size() > 1 && segmentBytes > 0 && segmentBytes + serializedPageSize > segmentSize) {
+                            pages = Iterators.concat(ImmutableList.of(page).iterator(), pages);
+                            break;
+                        }
+
+                        out.writeBytes(serialized);
+
+                        segmentBytes += serializedPageSize;
+                        spilledPagesBytes += pageSizeInBytes;
+
+                        spilledPagesInMemorySize.addAndGet(pageSizeInBytes);
+                        localSpillContext.updateBytes(serializedPageSize);
+                        spillerStats.addToTotalSpilledBytes(serializedPageSize);
+
+                        // check if the segment is full
+                        if (targetFiles.size() > 1 && segmentBytes >= segmentSize) {
+                            break;
+                        }
+                    }
+                }
+
+                currentSegmentBytes = segmentBytes;
+
+                // switch to the next file if the segment is full or there are more pages to read
+                if (targetFiles.size() > 1 && (segmentBytes >= segmentSize || pages.hasNext())) {
+                    fileIndex = (fileIndex + 1) % targetFiles.size();
+                    currentSegmentBytes = 0;
+                }
+            }
+
+            currentFileIndex = fileIndex;
+        }
+        catch (UncheckedIOException | IOException e) {
+            fileSystemErrorHandler.run();
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to spill pages", e);
+        }
+
+        return DataSize.ofBytes(spilledPagesBytes);
     }
 
     @Override
@@ -213,6 +368,82 @@ public class FileSingleStreamSpiller
     private void checkNoSpillInProgress()
     {
         checkState(spillInProgress.isDone(), "spill in progress");
+    }
+
+    private SliceOutput newSliceOutput(int fileIndex)
+            throws IOException
+    {
+        return new OutputStreamSliceOutput(targetFiles.get(fileIndex).newOutputStream(APPEND), BUFFER_SIZE);
+    }
+
+    /**
+     * Returns an iterator producing page iterators for each segment in the given file.
+     * Segments are split based on the configured {@code segmentSize} so that only
+     * one segment of pages needs to be materialized at a time. The returned
+     * iterators lazily deserialize pages from the file.
+     */
+    private Iterator<Iterator<Page>> readSegments(PageDeserializer deserializer, FileHolder file, Closer closer)
+            throws IOException
+    {
+        InputStream input = closer.register(file.newInputStream());
+        Iterator<Slice> serializedPages = closeWhenExhausted(PagesSerdeUtil.readSerializedPages(input), input);
+
+        return new AbstractIterator<>()
+        {
+            @Nullable
+            Slice nextSlice;
+
+            @Override
+            protected Iterator<Page> computeNext()
+            {
+                if (nextSlice == null && !serializedPages.hasNext()) {
+                    return endOfData();
+                }
+
+                Slice first = nextSlice != null ? nextSlice : serializedPages.next();
+                nextSlice = null;
+
+                return new AbstractIterator<>()
+                {
+                    long bytes;
+                    Slice slice = first;
+                    boolean finished;
+
+                    @Override
+                    protected Page computeNext()
+                    {
+                        if (finished) {
+                            return endOfData();
+                        }
+
+                        if (slice == null) {
+                            if (!serializedPages.hasNext()) {
+                                return endOfData();
+                            }
+                            slice = serializedPages.next();
+                        }
+
+                        // check if the next page would exceed the segment size
+                        long size = slice.length();
+                        if (targetFiles.size() > 1 && bytes > 0 && bytes + size > segmentSize) {
+                            nextSlice = slice;
+                            slice = null;
+                            finished = true;
+                            return endOfData();
+                        }
+
+                        bytes += size;
+                        Page page = deserializer.deserialize(slice);
+                        slice = null;
+                        // If the segment is full, we finish reading it
+                        if (targetFiles.size() > 1 && bytes >= segmentSize) {
+                            finished = true;
+                        }
+                        return page;
+                    }
+                };
+            }
+        };
     }
 
     private static <T> Iterator<T> closeWhenExhausted(Iterator<T> iterator, Closeable resource)

--- a/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpillerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpillerFactory.java
@@ -22,6 +22,7 @@ import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.FeaturesConfig;
 import io.trino.cache.NonKeyEvictableLoadingCache;
+import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.buffer.CompressionCodec;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.memory.context.LocalMemoryContext;
@@ -80,11 +81,12 @@ public class FileSingleStreamSpillerFactory
     private final SpillerStats spillerStats;
     private final double maxUsedSpaceThreshold;
     private final boolean spillEncryptionEnabled;
+    private final int spillFileCount;
     private int roundRobinIndex;
     private final NonKeyEvictableLoadingCache<Path, Boolean> spillPathHealthCache;
 
     @Inject
-    public FileSingleStreamSpillerFactory(BlockEncodingSerde blockEncodingSerde, SpillerStats spillerStats, FeaturesConfig featuresConfig, NodeSpillConfig nodeSpillConfig)
+    public FileSingleStreamSpillerFactory(BlockEncodingSerde blockEncodingSerde, SpillerStats spillerStats, FeaturesConfig featuresConfig, NodeSpillConfig nodeSpillConfig, TaskManagerConfig taskManagerConfig)
     {
         this(
                 listeningDecorator(newFixedThreadPool(
@@ -93,6 +95,7 @@ public class FileSingleStreamSpillerFactory
                 requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"),
                 spillerStats,
                 featuresConfig.getSpillerSpillPaths(),
+                Math.min(featuresConfig.getSpillerThreads(), taskManagerConfig.getTaskConcurrency()),
                 featuresConfig.getSpillMaxUsedSpaceThreshold(),
                 nodeSpillConfig.getSpillCompressionCodec(),
                 nodeSpillConfig.isSpillEncryptionEnabled());
@@ -104,6 +107,7 @@ public class FileSingleStreamSpillerFactory
             BlockEncodingSerde blockEncodingSerde,
             SpillerStats spillerStats,
             List<Path> spillPaths,
+            int spillFileCount,
             double maxUsedSpaceThreshold,
             CompressionCodec compressionCodec,
             boolean spillEncryptionEnabled)
@@ -124,6 +128,7 @@ public class FileSingleStreamSpillerFactory
                 throw new IllegalArgumentException(format("spill path %s is not accessible, it must be +rwx; adjust %s config property or filesystem permissions", path, SPILLER_SPILL_PATH));
             }
         });
+        this.spillFileCount = spillFileCount;
         this.maxUsedSpaceThreshold = maxUsedSpaceThreshold;
         this.spillEncryptionEnabled = spillEncryptionEnabled;
         this.roundRobinIndex = 0;
@@ -165,14 +170,19 @@ public class FileSingleStreamSpillerFactory
     }
 
     @Override
-    public SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext)
+    public SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext, boolean parallelSpill)
     {
         Optional<SecretKey> encryptionKey = spillEncryptionEnabled ? Optional.of(createRandomAesEncryptionKey()) : Optional.empty();
+        ImmutableList.Builder<Path> paths = ImmutableList.builder();
+        int spillFileCount = parallelSpill ? this.spillFileCount : 1;
+        for (int i = 0; i < spillFileCount; i++) {
+            paths.add(getNextSpillPath());
+        }
         return new FileSingleStreamSpiller(
                 serdeFactory,
                 encryptionKey,
                 executor,
-                getNextSpillPath(),
+                paths.build(),
                 spillerStats,
                 spillContext,
                 memoryContext,

--- a/core/trino-main/src/main/java/io/trino/spiller/SingleStreamSpillerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/SingleStreamSpillerFactory.java
@@ -21,11 +21,16 @@ import java.util.List;
 
 public interface SingleStreamSpillerFactory
 {
-    SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext);
+    default SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext)
+    {
+        return create(types, spillContext, memoryContext, false);
+    }
+
+    SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext, boolean parallelSpill);
 
     static SingleStreamSpillerFactory unsupportedSingleStreamSpillerFactory()
     {
-        return (types, spillContext, memoryContext) -> {
+        return (types, spillContext, memoryContext, parallelSpill) -> {
             throw new UnsupportedOperationException();
         };
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -177,12 +177,12 @@ public final class TaskTestUtils
                 new JoinFilterFunctionCompiler(PLANNER_CONTEXT.getFunctionManager()),
                 new IndexJoinLookupStats(),
                 new TaskManagerConfig(),
-                new GenericSpillerFactory((types, spillContext, memoryContext) -> {
+                new GenericSpillerFactory((types, spillContext, memoryContext, parallelSpill) -> {
                     throw new UnsupportedOperationException();
                 }),
                 new QueryDataEncoders(new SpoolingEnabledConfig(), Set.of()),
                 Optional.empty(),
-                (types, spillContext, memoryContext) -> {
+                (types, spillContext, memoryContext, parallelSpill) -> {
                     throw new UnsupportedOperationException();
                 },
                 (types, partitionFunction, spillContext, memoryContext) -> {

--- a/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
@@ -317,7 +317,7 @@ public final class JoinTestUtils
         }
 
         @Override
-        public SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext)
+        public SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext, boolean parallelSpill)
         {
             return new SingleStreamSpiller()
             {

--- a/core/trino-main/src/test/java/io/trino/operator/spiller/BenchmarkBinaryFileSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/operator/spiller/BenchmarkBinaryFileSpiller.java
@@ -117,6 +117,7 @@ public class BenchmarkBinaryFileSpiller
                     BLOCK_ENCODING_SERDE,
                     spillerStats,
                     ImmutableList.of(SPILL_PATH),
+                    1,
                     1.0,
                     compressionCodec,
                     encryptionEnabled);

--- a/core/trino-main/src/test/java/io/trino/spiller/TestBinaryFileSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestBinaryFileSpiller.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
 import io.trino.FeaturesConfig;
 import io.trino.RowPagesBuilder;
+import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.buffer.PageSerializer;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.memory.context.AggregatedMemoryContext;
@@ -82,7 +83,7 @@ public class TestBinaryFileSpiller
         featuresConfig.setSpillMaxUsedSpaceThreshold(1.0);
         NodeSpillConfig nodeSpillConfig = new NodeSpillConfig();
         BlockEncodingSerde blockEncodingSerde = new TestingBlockEncodingSerde();
-        singleStreamSpillerFactory = new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig, nodeSpillConfig);
+        singleStreamSpillerFactory = new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig, nodeSpillConfig, new TaskManagerConfig());
         factory = new GenericSpillerFactory(singleStreamSpillerFactory);
         PagesSerdeFactory pagesSerdeFactory = createSpillingPagesSerdeFactory(blockEncodingSerde, nodeSpillConfig.getSpillCompressionCodec());
         serializer = pagesSerdeFactory.createSerializer(Optional.empty());

--- a/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpiller.java
@@ -18,7 +18,10 @@ import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import io.trino.execution.buffer.CompressionCodec;
+import io.trino.execution.buffer.PageSerializer;
+import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.execution.buffer.PagesSerdeUtil;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.PageAssertions;
@@ -36,15 +39,19 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.MoreFiles.listFiles;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.execution.buffer.CompressionCodec.LZ4;
 import static io.trino.execution.buffer.CompressionCodec.NONE;
 import static io.trino.execution.buffer.PagesSerdeUtil.isSerializedPageCompressed;
 import static io.trino.execution.buffer.PagesSerdeUtil.isSerializedPageEncrypted;
+import static io.trino.execution.buffer.PagesSerdes.createSpillingPagesSerdeFactory;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -99,6 +106,65 @@ public class TestFileSingleStreamSpiller
         assertSpill(LZ4, true);
     }
 
+    @Test
+    public void testMultiFileSpill()
+            throws Exception
+    {
+        // Spills four pages in a single call and verifies spilled bytes,
+        // non-empty spill files, and correct page order for different
+        // segment size boundaries.
+        PagesSerdeFactory serdeFactory = createSpillingPagesSerdeFactory(new TestingBlockEncodingSerde(), NONE);
+        PageSerializer serializer = serdeFactory.createSerializer(Optional.empty());
+        int pageSize = serializer.serialize(buildPage(0)).length();
+
+        // small segment triggers oversized page branch
+        assertMultiFileSpill(spiller -> ImmutableList.copyOf(spiller.getSpilledPages()), 1, false);
+        // segment slightly larger than one page triggers rotation on the second page
+        assertMultiFileSpill(spiller -> ImmutableList.copyOf(spiller.getSpilledPages()), pageSize + 1, false);
+    }
+
+    @Test
+    public void testMultiFileSpillMultipleCalls()
+            throws Exception
+    {
+        // Performs two spill() calls to ensure rotation resumes on the same file
+        // when the previous segment is not yet full and spilled bytes are tracked.
+        PagesSerdeFactory serdeFactory = createSpillingPagesSerdeFactory(new TestingBlockEncodingSerde(), NONE);
+        PageSerializer serializer = serdeFactory.createSerializer(Optional.empty());
+        int pageSize = serializer.serialize(buildPage(0)).length();
+
+        assertMultiFileSpill(spiller -> ImmutableList.copyOf(spiller.getSpilledPages()), pageSize + 1, true);
+    }
+
+    @Test
+    public void testGetAllSpilledPagesMultiFile()
+            throws Exception
+    {
+        // Retrieves all spilled pages asynchronously from multiple files
+        // and verifies the combined result is ordered correctly for
+        // different segment size thresholds.
+        PagesSerdeFactory serdeFactory = createSpillingPagesSerdeFactory(new TestingBlockEncodingSerde(), NONE);
+        PageSerializer serializer = serdeFactory.createSerializer(Optional.empty());
+        int pageSize = serializer.serialize(buildPage(0)).length();
+
+        assertMultiFileSpill(spiller -> getFutureValue(spiller.getAllSpilledPages()), 1, false);
+        assertMultiFileSpill(spiller -> getFutureValue(spiller.getAllSpilledPages()), pageSize + 1, false);
+    }
+
+    @Test
+    public void testGetAllSpilledPagesMultiFileMultipleCalls()
+            throws Exception
+    {
+        // Uses getAllSpilledPages() after spilling in multiple batches to
+        // confirm that partial segments are preserved between calls and the
+        // returned pages remain in order.
+        PagesSerdeFactory serdeFactory = createSpillingPagesSerdeFactory(new TestingBlockEncodingSerde(), NONE);
+        PageSerializer serializer = serdeFactory.createSerializer(Optional.empty());
+        int pageSize = serializer.serialize(buildPage(0)).length();
+
+        assertMultiFileSpill(spiller -> getFutureValue(spiller.getAllSpilledPages()), pageSize + 1, true);
+    }
+
     private void assertSpill(CompressionCodec compressionCodec, boolean encryption)
             throws Exception
     {
@@ -109,6 +175,7 @@ public class TestFileSingleStreamSpiller
                     new TestingBlockEncodingSerde(),
                     new SpillerStats(),
                     ImmutableList.of(spillPath.toPath()),
+                    1,
                     1.0,
                     compressionCodec,
                     encryption);
@@ -166,15 +233,92 @@ public class TestFileSingleStreamSpiller
         }
     }
 
+    private void assertMultiFileSpill(Function<FileSingleStreamSpiller, List<Page>> readPages, int segmentSize, boolean multipleCalls)
+            throws Exception
+    {
+        // Create two temporary directories to be used for spilling
+        File spillPath1 = Files.createTempDirectory("tmp1").toFile();
+        File spillPath2 = Files.createTempDirectory("tmp2").toFile();
+        try {
+            // Set up serializer and memory tracking objects
+            SpillerStats stats = new SpillerStats();
+            PagesSerdeFactory serdeFactory = createSpillingPagesSerdeFactory(new TestingBlockEncodingSerde(), NONE);
+            LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
+            PageSerializer serializer = serdeFactory.createSerializer(Optional.empty());
+
+            // Rotate between the two files using the given segment size
+            FileSingleStreamSpiller spiller = new FileSingleStreamSpiller(
+                    serdeFactory,
+                    Optional.empty(),
+                    executor,
+                    ImmutableList.of(spillPath1.toPath(), spillPath2.toPath()),
+                    stats,
+                    bytes -> {},
+                    memoryContext,
+                    () -> {},
+                    segmentSize);
+
+            // Build a sequence of pages with distinct numbers
+            Page p0 = buildPage(0);
+            Page p1 = buildPage(1);
+            Page p2 = buildPage(2);
+            Page p3 = buildPage(3);
+
+            long expectedRawBytes = p0.getSizeInBytes() + p1.getSizeInBytes() + p2.getSizeInBytes() + p3.getSizeInBytes();
+            long expectedSerializedBytes =
+                    serializer.serialize(p0).length() +
+                            serializer.serialize(p1).length() +
+                            serializer.serialize(p2).length() +
+                            serializer.serialize(p3).length();
+
+            DataSize spilled;
+            if (multipleCalls) {
+                DataSize d1 = spiller.spill(Iterators.forArray(p0, p1)).get();
+                DataSize d2 = spiller.spill(Iterators.forArray(p2, p3)).get();
+                spilled = DataSize.ofBytes(d1.toBytes() + d2.toBytes());
+            }
+            else {
+                spilled = spiller.spill(Iterators.forArray(p0, p1, p2, p3)).get();
+            }
+            assertThat(spilled.toBytes()).isEqualTo(expectedRawBytes);
+            assertThat(stats.getTotalSpilledBytes()).isEqualTo(expectedSerializedBytes);
+
+            // Validate that two non-empty spill files were created
+            assertThat(listFiles(spillPath1.toPath()).size() + listFiles(spillPath2.toPath()).size()).isEqualTo(2);
+            assertThat(Files.size(listFiles(spillPath1.toPath()).get(0))).isGreaterThan(0);
+            assertThat(Files.size(listFiles(spillPath2.toPath()).get(0))).isGreaterThan(0);
+
+            // Read pages using the provided function and verify order
+            List<Page> pages = readPages.apply(spiller);
+            assertThat(pages).hasSize(4);
+            for (int i = 0; i < pages.size(); i++) {
+                assertThat(BIGINT.getLong(pages.get(i).getBlock(0), 0)).isEqualTo(i);
+            }
+
+            // Close spiller to release resources
+            spiller.close();
+        }
+        finally {
+            // Clean up temporary directories
+            deleteRecursively(spillPath1.toPath(), ALLOW_INSECURE);
+            deleteRecursively(spillPath2.toPath(), ALLOW_INSECURE);
+        }
+    }
+
     private Page buildPage()
+    {
+        return buildPage(42);
+    }
+
+    private Page buildPage(int pageNumber)
     {
         BlockBuilder col1 = BIGINT.createFixedSizeBlockBuilder(1);
         BlockBuilder col2 = DOUBLE.createFixedSizeBlockBuilder(1);
         BlockBuilder col3 = VARBINARY.createBlockBuilder(null, 1);
 
-        BIGINT.writeLong(col1, 42);
-        DOUBLE.writeDouble(col2, 43.0);
-        VARBINARY.writeSlice(col3, Slices.allocate(16).getOutput().appendDouble(43.0).appendLong(1).slice());
+        BIGINT.writeLong(col1, pageNumber);
+        DOUBLE.writeDouble(col2, pageNumber + 0.5);
+        VARBINARY.writeSlice(col3, Slices.allocate(16).getOutput().appendInt(pageNumber).appendLong(1).slice());
 
         return new Page(col1.build(), col2.build(), col3.build());
     }

--- a/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestFileSingleStreamSpillerFactory.java
@@ -279,6 +279,7 @@ public class TestFileSingleStreamSpillerFactory
                 blockEncodingSerde,
                 new SpillerStats(),
                 paths,
+                1,
                 maxUsedSpaceThreshold,
                 NONE,
                 false);

--- a/core/trino-main/src/test/java/io/trino/spiller/TestGenericPartitioningSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestGenericPartitioningSpiller.java
@@ -19,6 +19,7 @@ import com.google.common.io.Closer;
 import io.trino.FeaturesConfig;
 import io.trino.RowPagesBuilder;
 import io.trino.SequencePageBuilder;
+import io.trino.execution.TaskManagerConfig;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.PartitionFunction;
 import io.trino.operator.SpillContext;
@@ -85,7 +86,8 @@ public class TestGenericPartitioningSpiller
                 new TestingBlockEncodingSerde(),
                 new SpillerStats(),
                 featuresConfig,
-                new NodeSpillConfig());
+                new NodeSpillConfig(),
+                new TaskManagerConfig());
         factory = new GenericPartitioningSpillerFactory(singleStreamSpillerFactory);
         scheduledExecutor = newSingleThreadScheduledExecutor();
     }


### PR DESCRIPTION
HashBuilderOperator is unspilling sequentially partition by partition. This commit improves join unspilling performance by making FileSingleStreamSpiller unspill single partition in parallel. FileSingleStreamSpiller is enhanced so it can spill to/unspill from multiple files.

This improves unspilling time for join from minutes to seconds on larger machines

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of spilling join queries. ({issue}`issuenumber`)
```

Fixes https://github.com/trinodb/trino/issues/26007
