### PR TITLE
Change isHierarchicalNamespaceEnabled check path for fabric endpoint

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -592,8 +592,13 @@ public class AzureFileSystem
             throws IOException
     {
         try {
+            String rootPath = "/";
+            if (location.endpoint().equals("fabric.microsoft.com")) {
+                // For OneLake, users do not have access to the root directory, so we need to check the path
+                rootPath += location.path();
+            }
             BlockBlobClient blockBlobClient = createBlobContainerClient(location, Optional.empty())
-                    .getBlobClient("/")
+                    .getBlobClient(rootPath)
                     .getBlockBlobClient();
             return blockBlobClient.exists();
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Change `isHierarchicalNamespaceEnabled` check path for fabric endpoint to fix errors on Microsoft OneLake destinations.
Please run the cloud tests to make sure that this doesn't impact the standard azure blob containers.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Follow on from #25457


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
