### PR TITLE
iceberg: add printing underlying failure cause for page sources

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -756,6 +756,9 @@ public class IcebergPageSourceProvider
                 throw new TrinoException(ICEBERG_BAD_DATA, e);
             }
             String message = "Error opening Iceberg split %s (offset=%s, length=%s): %s".formatted(inputFile.location(), start, length, e.getMessage());
+            if (e.getCause() != null) {
+                message += " " + e.getCause().getMessage();
+            }
             throw new TrinoException(ICEBERG_CANNOT_OPEN_SPLIT, message, e);
         }
     }
@@ -1047,6 +1050,9 @@ public class IcebergPageSourceProvider
                 throw new TrinoException(ICEBERG_BAD_DATA, e);
             }
             String message = "Error opening Iceberg split %s (offset=%s, length=%s): %s".formatted(inputFile.location(), start, length, e.getMessage());
+            if (e.getCause() != null) {
+                message += " " + e.getCause().getMessage();
+            }
             throw new TrinoException(ICEBERG_CANNOT_OPEN_SPLIT, message, e);
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Current implementation hides the details of the underlying exception, and that includes decompression failures.
As a result, Trino will get a "Could not decode the dictionary for X" message, with the actual cause -- e.g. decompression failure -- not being mentioned at all.

With the change applied, hopefully users can see more detailed failures, e.g. that their file is corrupted or that there was a compression algorithm mismatch.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Error messages when creating page sources now include underlying error cause if present
```
