### PR TITLE
Support ClientId Param in iceberg catalog OAuth2 credentials flow

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -504,6 +504,9 @@ following properties:
 * - `iceberg.rest-catalog.oauth2.scope`
   - Scope to be used when communicating with the REST Catalog. Applicable only
     when using `credential`.
+* - `iceberg.rest-catalog.oauth2.client-id`
+  - OAuth2 client ID. This parameter is required by some OAuth2 providers such as
+    Microsoft Entra (Azure Active Directory).
 * - `iceberg.rest-catalog.oauth2.server-uri`
   - The endpoint to retrieve access token from OAuth2 Server.
 * - `iceberg.rest-catalog.oauth2.token-refresh-enabled`

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityConfig.java
@@ -28,6 +28,7 @@ public class OAuth2SecurityConfig
     private String scope;
     private String token;
     private URI serverUri;
+    private String clientId;
     private boolean tokenRefreshEnabled = OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT;
 
     public Optional<String> getCredential()
@@ -94,6 +95,19 @@ public class OAuth2SecurityConfig
     public OAuth2SecurityConfig setTokenRefreshEnabled(boolean tokenRefreshEnabled)
     {
         this.tokenRefreshEnabled = tokenRefreshEnabled;
+        return this;
+    }
+
+    public Optional<String> getClientId()
+    {
+        return Optional.ofNullable(clientId);
+    }
+
+    @Config("iceberg.rest-catalog.oauth2.client-id")
+    @ConfigDescription("OAuth2 client ID")
+    public OAuth2SecurityConfig setClientId(String clientId)
+    {
+        this.clientId = clientId;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
@@ -25,6 +25,8 @@ import static java.util.Objects.requireNonNull;
 public class OAuth2SecurityProperties
         implements SecurityProperties
 {
+    private static final String CLIENT_ID = "client_id";
+    
     private final Map<String, String> securityProperties;
 
     @Inject
@@ -44,6 +46,8 @@ public class OAuth2SecurityProperties
                 value -> propertiesBuilder.put(OAuth2Properties.TOKEN, value));
         securityConfig.getServerUri().ifPresent(
                 value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
+        securityConfig.getClientId().ifPresent(
+                value -> propertiesBuilder.put(CLIENT_ID, value));
         propertiesBuilder.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, String.valueOf(securityConfig.isTokenRefreshEnabled()));
 
         this.securityProperties = propertiesBuilder.buildOrThrow();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2SecurityConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2SecurityConfig.java
@@ -35,6 +35,7 @@ public class TestOAuth2SecurityConfig
                 .setToken(null)
                 .setScope(null)
                 .setServerUri(null)
+                .setClientId(null)
                 .setTokenRefreshEnabled(OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT));
     }
 
@@ -46,6 +47,7 @@ public class TestOAuth2SecurityConfig
                 .put("iceberg.rest-catalog.oauth2.credential", "credential")
                 .put("iceberg.rest-catalog.oauth2.scope", "scope")
                 .put("iceberg.rest-catalog.oauth2.server-uri", "http://localhost:8080/realms/iceberg/protocol/openid-connect/token")
+                .put("iceberg.rest-catalog.oauth2.client-id", "client-id")
                 .put("iceberg.rest-catalog.oauth2.token-refresh-enabled", "false")
                 .buildOrThrow();
 
@@ -54,6 +56,7 @@ public class TestOAuth2SecurityConfig
                 .setToken("token")
                 .setScope("scope")
                 .setServerUri(URI.create("http://localhost:8080/realms/iceberg/protocol/openid-connect/token"))
+                .setClientId("client-id")
                 .setTokenRefreshEnabled(false);
         assertThat(expected.credentialOrTokenPresent()).isTrue();
         assertThat(expected.scopePresentOnlyWithCredential()).isFalse();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Iceberg's `OAuth2Util` supports passing a `ClientId` param for client credentials flow - which [Microsoft Entra needs to work](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#first-case-access-token-request-with-a-shared-secret) via `setClientId()`. This flow is ideal for Trino => Catalog auth (machine to machine), but Trino does not expose the `ClientId` property in configs for iceberg.

This PR just adds the optional `client-id` config to an iceberg catalog so that Microsoft Entra (and any other IDP that needs `ClientId`) can work for catalog auth.  


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
See the underlying [Apache Iceberg code](https://github.com/apache/iceberg/blob/e73344323ddc26f9f45db15d50394e25069821d2/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java#L80) for details. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
