### PR TITLE
Add explicitly cast for merge tests in `BaseConnectorSmokeTest`

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -325,11 +325,11 @@ public abstract class BaseConnectorSmokeTest
 
         try (TestTable table = createTestTableForWrites("test_update_")) {
             assertUpdate("INSERT INTO " + table.getName() + " (a, b) SELECT regionkey, regionkey * 2.5 FROM region", "SELECT count(*) FROM region");
-            assertThat(query("SELECT a, b FROM " + table.getName()))
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
                     .matches(expectedValues("(0, 0.0), (1, 2.5), (2, 5.0), (3, 7.5), (4, 10.0)"));
 
             assertUpdate("UPDATE " + table.getName() + " SET b = b + 1.2 WHERE a % 2 = 0", 3);
-            assertThat(query("SELECT a, b FROM " + table.getName()))
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
                     .matches(expectedValues("(0, 1.2), (1, 2.5), (2, 6.2), (3, 7.5), (4, 11.2)"));
         }
     }
@@ -351,7 +351,7 @@ public abstract class BaseConnectorSmokeTest
 
         try (TestTable table = createTestTableForWrites("test_merge_")) {
             assertUpdate("INSERT INTO " + table.getName() + " (a, b) SELECT regionkey, regionkey * 2.5 FROM region", "SELECT count(*) FROM region");
-            assertThat(query("SELECT a, b FROM " + table.getName()))
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
                     .matches(expectedValues("(0, 0.0), (1, 2.5), (2, 5.0), (3, 7.5), (4, 10.0)"));
 
             assertUpdate("MERGE INTO " + table.getName() + " t " +
@@ -361,7 +361,7 @@ public abstract class BaseConnectorSmokeTest
                     "WHEN MATCHED AND s.b = 0 THEN DELETE " +
                     "WHEN NOT MATCHED THEN INSERT VALUES (s.a, s.b)",
                     4);
-            assertThat(query("SELECT a, b FROM " + table.getName()))
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
                     .matches(expectedValues("(0, 1.3), (1, 2.5), (2, 7.9), (4, 10.0), (5, 5.7)"));
         }
     }


### PR DESCRIPTION
Cast column to bigint in smoke test queries when selecting data for assertions, prevents potential mismatches during test validation.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
