### PR TITLE
Add support for write operations (INSERT/UPDATE/DELETE/MERGE) with branch

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -70,8 +70,10 @@ statement
          (COMMENT string)?
          (WITH properties)?                                            #createTable
     | DROP TABLE (IF EXISTS)? qualifiedName                            #dropTable
-    | INSERT INTO qualifiedName columnAliases? rootQuery               #insertInto
-    | DELETE FROM qualifiedName (WHERE booleanExpression)?             #delete
+    | INSERT INTO qualifiedName ('@' branch=identifier)?
+       columnAliases? rootQuery                                        #insertInto
+    | DELETE FROM qualifiedName ('@' branch=identifier)?
+         (WHERE booleanExpression)?                                    #delete
     | TRUNCATE TABLE qualifiedName                                     #truncateTable
     | COMMENT ON TABLE qualifiedName IS (string | NULL)                #commentTable
     | COMMENT ON VIEW qualifiedName IS (string | NULL)                 #commentView
@@ -197,10 +199,11 @@ statement
     | DESCRIBE OUTPUT identifier                                       #describeOutput
     | SET PATH pathSpecification                                       #setPath
     | SET TIME ZONE (LOCAL | expression)                               #setTimeZone
-    | UPDATE qualifiedName
+    | UPDATE qualifiedName ('@' branch=identifier)?
         SET updateAssignment (',' updateAssignment)*
         (WHERE where=booleanExpression)?                               #update
-    | MERGE INTO qualifiedName (AS? identifier)?
+    | MERGE INTO
+        qualifiedName ('@' branch=identifier)? (AS? alias=identifier)?
         USING relation ON expression mergeCase+                        #merge
     ;
 

--- a/core/trino-main/src/main/java/io/trino/metadata/TableVersion.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableVersion.java
@@ -16,6 +16,9 @@ package io.trino.metadata;
 import io.trino.spi.connector.PointerType;
 import io.trino.spi.type.Type;
 
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.connector.PointerType.TARGET_ID;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public record TableVersion(PointerType pointerType, Type objectType, Object pointer)
@@ -23,5 +26,10 @@ public record TableVersion(PointerType pointerType, Type objectType, Object poin
     public TableVersion
     {
         requireNonNull(objectType, "objectType is null");
+    }
+
+    public static TableVersion toTableVersion(String branchName)
+    {
+        return new TableVersion(TARGET_ID, VARCHAR, utf8Slice(branchName));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -125,6 +125,7 @@ public class MockConnectorFactory
     private final BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties;
     private final BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges;
     private final Collection<FunctionMetadata> functions;
+    private final Collection<String> branches;
     private final Function<SchemaTableName, List<List<?>>> data;
     private final Function<SchemaTableName, Metrics> metrics;
     private final Set<Procedure> procedures;
@@ -182,6 +183,7 @@ public class MockConnectorFactory
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
             BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges,
             Collection<FunctionMetadata> functions,
+            Collection<String> branches,
             Function<SchemaTableName, List<List<?>>> data,
             Function<SchemaTableName, Metrics> metrics,
             Set<Procedure> procedures,
@@ -235,6 +237,7 @@ public class MockConnectorFactory
         this.getTableProperties = requireNonNull(getTableProperties, "getTableProperties is null");
         this.listTablePrivileges = requireNonNull(listTablePrivileges, "listTablePrivileges is null");
         this.functions = ImmutableList.copyOf(functions);
+        this.branches = ImmutableList.copyOf(branches);
         this.analyzeProperties = requireNonNull(analyzeProperties, "analyzeProperties is null");
         this.schemaProperties = requireNonNull(schemaProperties, "schemaProperties is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
@@ -298,6 +301,7 @@ public class MockConnectorFactory
                 getTableProperties,
                 listTablePrivileges,
                 functions,
+                branches,
                 roleGrants,
                 partitioningProvider,
                 accessControl,
@@ -442,6 +446,7 @@ public class MockConnectorFactory
         private BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties = defaultGetTableProperties();
         private BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges = defaultListTablePrivileges();
         private Collection<FunctionMetadata> functions = ImmutableList.of();
+        private Collection<String> branches = ImmutableList.of();
         private ApplyTopN applyTopN = (session, handle, topNCount, sortItems, assignments) -> Optional.empty();
         private ApplyFilter applyFilter = (session, handle, constraint) -> Optional.empty();
         private ApplyTableFunction applyTableFunction = (session, handle) -> Optional.empty();
@@ -685,6 +690,12 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withBranches(Collection<String> branches)
+        {
+            this.branches = ImmutableList.copyOf(branches);
+            return this;
+        }
+
         public Builder withData(Function<SchemaTableName, List<List<?>>> data)
         {
             this.data = requireNonNull(data, "data is null");
@@ -861,6 +872,7 @@ public class MockConnectorFactory
                     getTableProperties,
                     listTablePrivileges,
                     functions,
+                    branches,
                     data,
                     metrics,
                     procedures,

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -1022,6 +1022,9 @@ public abstract class AbstractMockMetadata
     @Override
     public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
     {
+        if (startVersion.isEmpty() || endVersion.isEmpty()) {
+            return noRedirection(getTableHandle(session, tableName));
+        }
         throw new UnsupportedOperationException();
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestBranching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestBranching.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.MockConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_DATA;
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@TestInstance(PER_CLASS)
+@Execution(SAME_THREAD)
+final class TestBranching
+{
+    private final QueryAssertions assertions;
+
+    public TestBranching()
+    {
+        QueryRunner runner = new StandaloneQueryRunner(TEST_SESSION);
+
+        runner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withGetTableHandle((_, schemaTableName) -> new MockConnectorTableHandle(schemaTableName))
+                .withGetColumns(schemaTableName -> {
+                    if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
+                        return TPCH_NATION_SCHEMA;
+                    }
+                    throw new UnsupportedOperationException();
+                })
+                .withBranches(ImmutableList.of("main"))
+                .withData(schemaTableName -> {
+                    if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
+                        return TPCH_NATION_DATA;
+                    }
+                    throw new UnsupportedOperationException();
+                })
+                .build()));
+        runner.createCatalog("mock", "mock", ImmutableMap.of());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterAll
+    void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    void testInsert()
+    {
+        assertThat(assertions.query("INSERT INTO mock.tiny.nation @ main VALUES (101, 'POLAND', 0, 'No comment')"))
+                .matches("SELECT BIGINT '1'");
+
+        assertThat(assertions.query("INSERT INTO mock.tiny.nation @ stale VALUES (26, 'POLAND', 11, 'No comment')"))
+                .failure().hasMessage("line 1:1: Branch 'stale' does not exist");
+    }
+
+    @Test
+    void testDelete()
+    {
+        assertThat(assertions.query("DELETE FROM mock.tiny.nation @ main WHERE nationkey < 3"))
+                .matches("SELECT BIGINT '3'");
+
+        assertThat(assertions.query("DELETE FROM mock.tiny.nation @ stale WHERE nationkey IN (1, 2, 3)"))
+                .failure().hasMessage("line 1:1: Branch 'stale' does not exist");
+    }
+
+    @Test
+    void testUpdate()
+    {
+        assertThat(assertions.query("UPDATE mock.tiny.nation @ main SET regionkey = regionkey + 1"))
+                .matches("SELECT BIGINT '25'");
+
+        assertThat(assertions.query("UPDATE mock.tiny.nation @ stale SET regionkey = regionkey * 10"))
+                .failure().hasMessage("line 1:1: Branch 'stale' does not exist");
+    }
+
+    @Test
+    void testMergeInsert()
+    {
+        assertThat(assertions.query(
+                """
+                MERGE INTO mock.tiny.nation @ main USING (VALUES 42) t(dummy) ON false
+                WHEN NOT MATCHED THEN INSERT VALUES (101, 'POLAND', 0, 'No comment')
+                """))
+                .matches("SELECT BIGINT '1'");
+
+        assertThat(assertions.query(
+                """
+                MERGE INTO mock.tiny.nation @ stale USING (VALUES 42) t(dummy) ON false
+                WHEN NOT MATCHED THEN INSERT VALUES (101, 'POLAND', 10, 'No comment')
+                """))
+                .failure().hasMessage("line 1:1: Branch 'stale' does not exist");
+    }
+
+    @Test
+    void testMergeDelete()
+    {
+        assertThat(assertions.query(
+                """
+                MERGE INTO mock.tiny.nation @ main USING (VALUES 1,2) t(x) ON nationkey = x
+                WHEN MATCHED THEN DELETE
+                """))
+                .matches("SELECT BIGINT '2'");
+
+        assertThat(assertions.query(
+                """
+                MERGE INTO mock.tiny.nation @ stale USING (VALUES 1,2) t(x) ON nationkey = x
+                WHEN MATCHED THEN DELETE
+                """))
+                .failure().hasMessage("line 1:1: Branch 'stale' does not exist");
+    }
+
+    @Test
+    void testMergeUpdate()
+    {
+        assertThat(assertions.query(
+                """
+                MERGE INTO mock.tiny.nation @ main USING (VALUES 5) t(x) ON nationkey = x
+                WHEN MATCHED THEN UPDATE SET regionkey = regionkey * 2
+                """))
+                .matches("SELECT BIGINT '1'");
+
+        assertThat(assertions.query(
+                """
+                MERGE INTO mock.tiny.nation @ stale USING (VALUES 5) t(x) ON nationkey = x
+                WHEN MATCHED THEN UPDATE SET regionkey = regionkey * 2
+                """))
+                .failure().hasMessage("line 1:1: Branch 'stale' does not exist");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1099,6 +1099,8 @@ public final class SqlFormatter
             builder.append("MERGE INTO ")
                     .append(formatName(node.getTargetTable().getName()));
 
+            node.getTargetTable().getBranch().ifPresent(branch -> builder.append("@").append(formatName(branch)));
+
             node.getTargetAlias().ifPresent(value -> builder
                     .append(' ')
                     .append(formatName(value)));
@@ -1484,6 +1486,8 @@ public final class SqlFormatter
         {
             builder.append("DELETE FROM ")
                     .append(formatName(node.getTable().getName()));
+
+            node.getTable().getBranch().ifPresent(branch -> builder.append("@").append(formatName(branch)));
 
             node.getWhere().ifPresent(where -> builder
                     .append(" WHERE ")
@@ -1900,6 +1904,8 @@ public final class SqlFormatter
             builder.append("INSERT INTO ")
                     .append(formatName(node.getTarget()));
 
+            node.getTable().getBranch().ifPresent(branch -> builder.append("@").append(formatName(branch)));
+
             node.getColumns().ifPresent(columns -> builder
                     .append(" (")
                     .append(Joiner.on(", ").join(columns))
@@ -1916,8 +1922,11 @@ public final class SqlFormatter
         protected Void visitUpdate(Update node, Integer indent)
         {
             builder.append("UPDATE ")
-                    .append(formatName(node.getTable().getName()))
-                    .append(" SET");
+                    .append(formatName(node.getTable().getName()));
+            node.getTable().getBranch().ifPresent(branch -> builder.append("@").append(formatName(branch)));
+
+            builder.append(" SET");
+
             int setCounter = node.getAssignments().size() - 1;
             for (UpdateAssignment assignment : node.getAssignments()) {
                 builder.append("\n")

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -673,7 +673,7 @@ class AstBuilder
 
         return new Insert(
                 getLocation(context),
-                new Table(getQualifiedName(context.qualifiedName())),
+                new Table(getLocation(context), getQualifiedName(context.qualifiedName()), visitIfPresent(context.branch, Identifier.class)),
                 columnAliases,
                 (Query) visit(context.rootQuery()));
     }
@@ -683,7 +683,7 @@ class AstBuilder
     {
         return new Delete(
                 getLocation(context),
-                new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
+                new Table(getLocation(context), getQualifiedName(context.qualifiedName()), visitIfPresent(context.branch, Identifier.class)),
                 visitIfPresent(context.booleanExpression(), Expression.class));
     }
 
@@ -692,7 +692,7 @@ class AstBuilder
     {
         return new Update(
                 getLocation(context),
-                new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
+                new Table(getLocation(context), getQualifiedName(context.qualifiedName()), visitIfPresent(context.branch, Identifier.class)),
                 visit(context.updateAssignment(), UpdateAssignment.class),
                 visitIfPresent(context.booleanExpression(), Expression.class));
     }
@@ -712,10 +712,10 @@ class AstBuilder
     @Override
     public Node visitMerge(SqlBaseParser.MergeContext context)
     {
-        Table table = new Table(getLocation(context), getQualifiedName(context.qualifiedName()));
+        Table table = new Table(getLocation(context), getQualifiedName(context.qualifiedName()), visitIfPresent(context.branch, Identifier.class));
         Relation targetRelation = table;
-        if (context.identifier() != null) {
-            targetRelation = new AliasedRelation(table, (Identifier) visit(context.identifier()), null);
+        if (context.alias != null) {
+            targetRelation = new AliasedRelation(table, (Identifier) visit(context.alias), null);
         }
         return new Merge(
                 getLocation(context),
@@ -2066,7 +2066,7 @@ class AstBuilder
     public Node visitTableName(SqlBaseParser.TableNameContext context)
     {
         if (context.queryPeriod() != null) {
-            return new Table(getLocation(context), getQualifiedName(context.qualifiedName()), (QueryPeriod) visit(context.queryPeriod()));
+            return new Table(getLocation(context), getQualifiedName(context.qualifiedName()), (QueryPeriod) visit(context.queryPeriod()), Optional.empty());
         }
         return new Table(getLocation(context), getQualifiedName(context.qualifiedName()));
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Table.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Table.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class Table
@@ -27,27 +28,35 @@ public class Table
 {
     private final QualifiedName name;
     private final Optional<QueryPeriod> queryPeriod;
+    private final Optional<Identifier> branch;
 
     public Table(QualifiedName name)
     {
-        this(Optional.empty(), name, Optional.empty());
+        this(Optional.empty(), name, Optional.empty(), Optional.empty());
     }
 
     public Table(NodeLocation location, QualifiedName name)
     {
-        this(Optional.of(location), name, Optional.empty());
+        this(Optional.of(location), name, Optional.empty(), Optional.empty());
     }
 
-    public Table(NodeLocation location, QualifiedName name, QueryPeriod queryPeriod)
+    public Table(NodeLocation location, QualifiedName name, Optional<Identifier> branch)
     {
-        this(Optional.of(location), name, Optional.of(queryPeriod));
+        this(Optional.of(location), name, Optional.empty(), branch);
     }
 
-    private Table(Optional<NodeLocation> location, QualifiedName name, Optional<QueryPeriod> queryPeriod)
+    public Table(NodeLocation location, QualifiedName name, QueryPeriod queryPeriod, Optional<Identifier> branch)
+    {
+        this(Optional.of(location), name, Optional.of(queryPeriod), branch);
+    }
+
+    private Table(Optional<NodeLocation> location, QualifiedName name, Optional<QueryPeriod> queryPeriod, Optional<Identifier> branch)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.queryPeriod = requireNonNull(queryPeriod, "queryPeriod is null");
+        this.branch = requireNonNull(branch, "branch is null");
+        checkArgument(!(queryPeriod.isPresent() && branch.isPresent()), "Query period and branch cannot both be specified");
     }
 
     public QualifiedName getName()
@@ -76,6 +85,7 @@ public class Table
         return toStringHelper(this)
                 .addValue(name)
                 .addValue(queryPeriod)
+                .addValue(branch)
                 .toString();
     }
 
@@ -91,13 +101,14 @@ public class Table
 
         Table table = (Table) o;
         return Objects.equals(name, table.name) &&
-                Objects.equals(queryPeriod, table.getQueryPeriod());
+                Objects.equals(queryPeriod, table.getQueryPeriod()) &&
+                Objects.equals(branch, table.branch);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, queryPeriod);
+        return Objects.hash(name, queryPeriod, branch);
     }
 
     @Override
@@ -114,5 +125,10 @@ public class Table
     public Optional<QueryPeriod> getQueryPeriod()
     {
         return queryPeriod;
+    }
+
+    public Optional<Identifier> getBranch()
+    {
+        return branch;
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Table.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Table.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 public class Table
         extends QueryBody
@@ -45,8 +46,8 @@ public class Table
     private Table(Optional<NodeLocation> location, QualifiedName name, Optional<QueryPeriod> queryPeriod)
     {
         super(location);
-        this.name = name;
-        this.queryPeriod = queryPeriod;
+        this.name = requireNonNull(name, "name is null");
+        this.queryPeriod = requireNonNull(queryPeriod, "queryPeriod is null");
     }
 
     public QualifiedName getName()

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -16,6 +16,7 @@ package io.trino.sql;
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.AllColumns;
+import io.trino.sql.tree.BooleanLiteral;
 import io.trino.sql.tree.ColumnDefinition;
 import io.trino.sql.tree.ColumnPosition;
 import io.trino.sql.tree.Comment;
@@ -25,12 +26,16 @@ import io.trino.sql.tree.CreateMaterializedView;
 import io.trino.sql.tree.CreateTable;
 import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.CreateView;
+import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.DropBranch;
 import io.trino.sql.tree.ExecuteImmediate;
 import io.trino.sql.tree.FastForwardBranch;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.Merge;
+import io.trino.sql.tree.MergeDelete;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
@@ -43,11 +48,15 @@ import io.trino.sql.tree.ShowSchemas;
 import io.trino.sql.tree.ShowSession;
 import io.trino.sql.tree.ShowTables;
 import io.trino.sql.tree.StringLiteral;
+import io.trino.sql.tree.Table;
+import io.trino.sql.tree.Update;
+import io.trino.sql.tree.UpdateAssignment;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.function.BiFunction;
 
+import static io.trino.sql.QueryUtil.aliased;
 import static io.trino.sql.QueryUtil.identifier;
 import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
@@ -582,6 +591,67 @@ public class TestSqlFormatter
                         ImmutableList.of())))
                 .isEqualTo("EXECUTE IMMEDIATE\n" +
                         "'SELECT * FROM foo WHERE col1 = ''攻殻機動隊'''");
+    }
+
+    @Test
+    void testInsertWithBranch()
+    {
+        assertThat(formatSql(new Insert(
+                new NodeLocation(1, 1),
+                new Table(new NodeLocation(1, 1), QualifiedName.of("t"), Optional.of(new Identifier("main"))),
+                Optional.empty(),
+                simpleQuery(selectList(new AllColumns(new NodeLocation(1, 1))), table(QualifiedName.of("s"))))))
+                .isEqualTo(
+                        """
+                        INSERT INTO t@main
+                        SELECT *
+                        FROM
+                          s
+                        """);
+    }
+
+    @Test
+    void testDeleteWithBranch()
+    {
+        assertThat(formatSql(new Delete(
+                new NodeLocation(1, 1),
+                new Table(new NodeLocation(1, 1), QualifiedName.of("t"), Optional.of(new Identifier("main"))),
+                Optional.empty())))
+                .isEqualTo("DELETE FROM t@main");
+    }
+
+    @Test
+    void testUpdateWithBranch()
+    {
+        assertThat(formatSql(new Update(
+                new NodeLocation(1, 1),
+                new Table(new NodeLocation(1, 1), QualifiedName.of("t"), Optional.of(new Identifier("main"))),
+                ImmutableList.of(new UpdateAssignment(new Identifier("bar"), new LongLiteral(new NodeLocation(1, 1), "23"))),
+                Optional.empty())))
+                .isEqualTo(
+                        """
+                        UPDATE t@main SET
+                           bar = 23\
+                        """);
+    }
+
+    @Test
+    void testMergeWithBranch()
+    {
+        assertThat(formatSql(new Merge(
+                new NodeLocation(1, 1),
+                new Table(new NodeLocation(1, 1), QualifiedName.of("t"), Optional.of(new Identifier("main"))),
+                aliased(table(QualifiedName.of("changes")), "c"),
+                new BooleanLiteral(new NodeLocation(1, 1), "true"),
+                ImmutableList.of(new MergeDelete(new NodeLocation(1, 1), Optional.empty())))))
+                .isEqualTo(
+                        """
+                        MERGE INTO t@main
+                           USING changes c
+                           ON true
+                        WHEN MATCHED
+                           THEN DELETE\
+                        """);
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3411,6 +3411,24 @@ public class TestSqlParser
 
         assertStatement("INSERT INTO a.\"b/c\".d (c1, c2) SELECT * FROM t",
                 new Insert(location(1, 1), table, Optional.of(ImmutableList.of(identifier("c1"), identifier("c2"))), query));
+
+        assertThat(statement("INSERT INTO t @ dev VALUES 1"))
+                .isEqualTo(new Insert(
+                        location(1, 1),
+                        new Table(
+                                location(1, 1),
+                                QualifiedName.of(List.of(new Identifier(location(1, 13), "t", false))),
+                                Optional.of(new Identifier(location(1, 17), "dev", false))),
+                        Optional.empty(),
+                        new Query(
+                                location(1, 21),
+                                List.of(),
+                                List.of(),
+                                Optional.empty(),
+                                new Values(location(1, 21), List.of(new LongLiteral(location(1, 28), "1"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())));
     }
 
     @Test
@@ -3428,6 +3446,15 @@ public class TestSqlParser
                                 ComparisonExpression.Operator.EQUAL,
                                 new Identifier(location(1, 21), "a", false),
                                 new Identifier(location(1, 25), "b", false)))));
+
+        assertThat(statement("DELETE FROM t @ dev"))
+                .isEqualTo(new Delete(
+                        location(1, 1),
+                        new Table(
+                                location(1, 1),
+                                QualifiedName.of(ImmutableList.of(new Identifier(location(1, 13), "t", false))),
+                                Optional.of(new Identifier(location(1, 17), "dev", false))),
+                        Optional.empty()));
     }
 
     @Test
@@ -3468,6 +3495,30 @@ public class TestSqlParser
                                         Optional.of(equal(nameReference("c", "action"), new StringLiteral("new"))),
                                         ImmutableList.of(new Identifier("part"), new Identifier("qty")),
                                         ImmutableList.of(nameReference("c", "part"), nameReference("c", "qty"))))));
+
+        assertThat(statement(
+                """
+                MERGE INTO inventory @ dev AS i
+                  USING changes AS c
+                  ON true
+                WHEN MATCHED
+                  THEN DELETE
+                """)).isEqualTo(new Merge(
+                location,
+                new AliasedRelation(
+                        new Table(
+                                location(1, 1),
+                                QualifiedName.of(List.of(new Identifier(location(1, 12), "inventory", false))),
+                                Optional.of(new Identifier(location(1, 24), "dev", false))),
+                        new Identifier(location(1, 31), "i", false),
+                        null),
+                new AliasedRelation(
+                        location(2, 9),
+                        new Table(location(2, 9), QualifiedName.of(List.of(new Identifier(location(2, 9), "changes", false)))),
+                        new Identifier(location(2, 20), "c", false),
+                        null),
+                new BooleanLiteral(location(3, 6), "true"),
+                ImmutableList.of(new MergeDelete(location(4, 1), Optional.empty()))));
     }
 
     @Test
@@ -6389,6 +6440,19 @@ public class TestSqlParser
                         ImmutableList.of(
                                 new UpdateAssignment(new Identifier("bar"), new LongLiteral("23"))),
                         Optional.empty()));
+
+        assertThat(statement("UPDATE foo_table @ dev SET bar = 23"))
+                .isEqualTo(new Update(
+                        location(1, 1),
+                        new Table(
+                                location(1, 1),
+                                QualifiedName.of(List.of(new Identifier(location(1, 8), "foo_table", false))),
+                                Optional.of(new Identifier(location(1, 20), "dev", false))),
+                        ImmutableList.of(
+                                new UpdateAssignment(
+                                        new Identifier(location(1, 28), "bar", false),
+                                        new LongLiteral(location(1, 34), "23"))),
+                        Optional.empty()));
     }
 
     @Test
@@ -6396,7 +6460,7 @@ public class TestSqlParser
     {
         Expression rangeValue = new GenericLiteral(location(1, 37), "TIMESTAMP", "2021-03-01 00:00:01");
         QueryPeriod queryPeriod = new QueryPeriod(location(1, 17), QueryPeriod.RangeType.TIMESTAMP, rangeValue);
-        Table table = new Table(location(1, 15), qualifiedName(location(1, 15), "t"), queryPeriod);
+        Table table = new Table(location(1, 15), qualifiedName(location(1, 15), "t"), queryPeriod, Optional.empty());
         assertThat(statement("SELECT * FROM t FOR TIMESTAMP AS OF TIMESTAMP '2021-03-01 00:00:01'"))
                 .isEqualTo(
                         new Query(
@@ -6428,7 +6492,7 @@ public class TestSqlParser
 
         rangeValue = new StringLiteral(location(1, 35), "version1");
         queryPeriod = new QueryPeriod(new NodeLocation(1, 17), QueryPeriod.RangeType.VERSION, rangeValue);
-        table = new Table(location(1, 15), qualifiedName(location(1, 15), "t"), queryPeriod);
+        table = new Table(location(1, 15), qualifiedName(location(1, 15), "t"), queryPeriod, Optional.empty());
         assertThat(statement("SELECT * FROM t FOR VERSION AS OF 'version1'"))
                 .isEqualTo(
                         new Query(


### PR DESCRIPTION
## Description

Allow specifying a branch name like `{table}@{branch}` in INSERT/UPDATE/DELETE/MERGE statements:
```g4
    | INSERT INTO qualifiedName ('@' branch=identifier)?
       columnAliases? rootQuery                                        #insertInto
    | DELETE FROM qualifiedName ('@' branch=identifier)?
         (WHERE booleanExpression)?                                    #delete
    | UPDATE qualifiedName ('@' branch=identifier)?
        SET updateAssignment (',' updateAssignment)*
        (WHERE where=booleanExpression)?                               #update
    | MERGE INTO
        qualifiedName ('@' branch=identifier)? (AS? alias=identifier)?
        USING relation ON expression mergeCase+                        #merge
```
 
Relates to https://docs.google.com/document/d/1jEF4IkWu-2Gzk5ii2Nb0exuEnAUeo98UbiM3i0xtgWQ

## Release notes

```markdown
## General
* Add support for branching with `INSERT`, `DELETE`, `UPDATE`, and `MERGE` statements. ({issue}`26136`)
```
