### PR TITLE
Use `RunLengthEncodedBlock` for null column appends

### DIFF
--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
@@ -19,7 +19,7 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
-import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 
 import java.util.ArrayList;
@@ -32,7 +32,6 @@ import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.memory.MemoryErrorCode.MEMORY_LIMIT_EXCEEDED;
@@ -118,10 +117,7 @@ public class MemoryPagesStore
             }
             // Append missing columns with null values. This situation happens when a new column is added without additional insert.
             for (int j = page.getChannelCount(); j < columnIndexes.length; j++) {
-                Type type = columnTypes.get(j);
-                BlockBuilder builder = type.createBlockBuilder(null, page.getPositionCount());
-                IntStream.range(0, page.getPositionCount()).forEach(_ -> builder.appendNull());
-                page = page.appendColumn(builder.build());
+                page = page.appendColumn(RunLengthEncodedBlock.create(columnTypes.get(i), null, page.getPositionCount()));
             }
             partitionedPages.add(page.getColumns(columnIndexes));
         }


### PR DESCRIPTION
Replaces manual null appending with `RunLengthEncodedBlock` when adding columns with null values

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
