### PR TITLE
Recheck that operator is not waiting for memory in hash builder finish

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
@@ -506,7 +506,7 @@ public class HashBuilderOperator
             reserved = localUserMemoryContext.setBytes(memoryRequired);
         }
 
-        if (!reserved.isDone()) {
+        if (!reserved.isDone() || !operatorContext.isWaitingForMemory().isDone() || !operatorContext.isWaitingForRevocableMemory().isDone()) {
             // wait for memory
             return;
         }
@@ -561,7 +561,8 @@ public class HashBuilderOperator
         verify(unspillInProgress.isEmpty());
 
         long spilledPagesInMemorySize = getSpiller().getSpilledPagesInMemorySize();
-        if (!localUserMemoryContext.setBytes(spilledPagesInMemorySize + index.getEstimatedSize().toBytes()).isDone()) {
+        ListenableFuture<Void> reserved = localUserMemoryContext.setBytes(spilledPagesInMemorySize + index.getEstimatedSize().toBytes());
+        if (!reserved.isDone() || !operatorContext.isWaitingForMemory().isDone()) {
             // wait for memory
             return;
         }
@@ -617,7 +618,7 @@ public class HashBuilderOperator
                 hashArraySizeSupplier,
                 sortChannel,
                 hashChannels));
-        if (!reserved.isDone()) {
+        if (!reserved.isDone() || !operatorContext.isWaitingForMemory().isDone()) {
             // Wait for memory
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
@@ -388,10 +388,10 @@ public class HashBuilderOperator
                 lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
                 lookupSourceNotNeeded = Optional.empty();
                 index.clear();
-                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
-                localRevocableMemoryContext.setBytes(0);
                 lookupSourceChecksum = OptionalLong.of(lookupSourceSupplier.checksum());
                 lookupSourceSupplier = null;
+                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+                localRevocableMemoryContext.setBytes(0);
                 state = State.INPUT_SPILLED;
             });
             return spillIndex();

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/HashBuilderOperator.java
@@ -319,7 +319,7 @@ public class HashBuilderOperator
                 hashArraySizeSupplier,
                 sortChannel,
                 hashChannels));
-        if (!reserved.isDone()) {
+        if (!reserved.isDone() || !operatorContext.isWaitingForMemory().isDone()) {
             // Yield when not enough memory is available to proceed, finish is expected to be called again when some memory is freed
             return;
         }

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
@@ -1252,6 +1252,17 @@ public class TestHashJoinOperator
                 assertThat(operatorContext.isWaitingForMemory()).isNotDone();
             }
 
+            // still not enough memory to create lookup source
+            operator.finish();
+            assertThat(operator.getState()).isEqualTo(HashBuilderOperator.State.CONSUMING_INPUT);
+            assertThat(operator.isFinished()).isFalse();
+            if (spillEnabled) {
+                assertThat(operatorContext.isWaitingForRevocableMemory()).isNotDone();
+            }
+            else {
+                assertThat(operatorContext.isWaitingForMemory()).isNotDone();
+            }
+
             // free memory and let finish() proceed
             anotherOperatorContext.getOperatorMemoryContext().localUserMemoryContext().setBytes(0);
             operator.finish();

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashBuilderOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestHashBuilderOperator.java
@@ -139,6 +139,13 @@ public class TestHashBuilderOperator
             assertThat(whenBuildFinishes).isNotDone();
             assertThat(operatorContext.isWaitingForMemory()).isNotDone();
 
+            // still not enough memory to create lookup source
+            operator.finish();
+            assertThat(operator.getState()).isEqualTo(CONSUMING_INPUT);
+            assertThat(operator.isFinished()).isFalse();
+            assertThat(whenBuildFinishes).isNotDone();
+            assertThat(operatorContext.isWaitingForMemory()).isNotDone();
+
             anotherOperatorContext.getOperatorMemoryContext().localUserMemoryContext().setBytes(0);
 
             operator.finish();


### PR DESCRIPTION
Operator#finish might be called even if operator is blocked (e.g. waiting for memory). Therefore, memory available condition needs to be re-checked every time finish is called.

## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce number of worker OOMs when running join queries. ({issue}`issuenumber`)
```
