### PR TITLE
Fix TestHttpEventListener.testNoServerCertificateShouldNotSendRequest

### DIFF
--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -52,6 +52,7 @@ import javax.net.ssl.X509TrustManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ProtocolException;
 import java.net.URI;
 import java.security.KeyStore;
 import java.time.Duration;
@@ -395,7 +396,9 @@ final class TestHttpEventListener
 
         assertThat(recordedRequest)
                 .describedAs("Handshake should have failed")
-                .isNull();
+                .satisfiesAnyOf(
+                        request -> assertThat(request).isNull(),
+                        request -> assertThat(request.getFailure()).isInstanceOf(ProtocolException.class));
     }
 
     @Test


### PR DESCRIPTION
Handshake failure can happen in different paths in the MockWebserver

Fixes https://github.com/trinodb/trino/issues/14895

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
