### PR TITLE
Ignore unrecognized JVM options

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,3 +1,4 @@
+-XX:+IgnoreUnrecognizedVMOptions
 -Xmx8192m
 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED


### PR DESCRIPTION
This allows ./mvnw to fail gracefully if the used JDK version is <24 which introduced sun-misc-unsafe-memory-access (https://openjdk.org/jeps/498)

After:
```
trino on  serafin/ignore-maven-unrecognized [$?] is 📦 v477-SNAPSHOT via ☕ via 🐍 on ☁️
❯ sdk use java 21-tem

Using java version 21-tem in this shell.

./mvnw clean install
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.0:enforce (default) on project trino-root:
[ERROR] Rule 11: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
[ERROR] Detected JDK /Users/mateusz.gajewski/.sdkman/candidates/java/21-tem is version 21 which is not in the allowed range [24.0.1,).
```

Before:
```
❯ ./mvnw clean install
Unrecognized option: --sun-misc-unsafe-memory-access=allow
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
