### PR TITLE
Support copy-on-write change for Iceberg Connector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -54,6 +54,7 @@ import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -106,6 +107,21 @@ public interface Metadata
      * Returns a table handle for the specified table name.
      */
     Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName);
+
+    /**
+     * Returns a table handle for the specified table name with updateKind.
+     */
+    Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<UpdateKind> updateKind);
+
+    /**
+     * Returns a table handle for the specified table name with a specified version.
+     */
+    Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion);
+
+    /**
+     * Returns a table handle for the specified table name with a specified version and updateKind.
+     */
+    Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion, Optional<UpdateKind> updateKind);
 
     Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName);
 
@@ -851,14 +867,14 @@ public interface Metadata
     RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName);
 
     /**
-     * Get the target table handle after performing redirection with a table version.
+     * Get the target table handle after performing redirection with updateKind.
      */
-    RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion);
+    RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<UpdateKind> updateKind);
 
     /**
-     * Returns a table handle for the specified table name with a specified version
+     * Get the target table handle after performing redirection with a table version and updateKind.
      */
-    Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion);
+    RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion, Optional<UpdateKind> updateKind);
 
     /**
      * Returns maximum number of tasks that can be created while writing data to specific connector.

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -68,6 +68,7 @@ import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -141,6 +142,15 @@ public class TracingConnectorMetadata
         Span span = startSpan("getTableHandle", tableName);
         try (var _ = scopedSpan(span)) {
             return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion, Optional<UpdateKind> updateKind)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion, updateKind);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -85,6 +85,7 @@ import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -185,7 +186,34 @@ public class TracingMetadata
     {
         Span span = startSpan("getTableHandle", tableName);
         try (var _ = scopedSpan(span)) {
-            return delegate.getTableHandle(session, tableName);
+            return delegate.getTableHandle(session, tableName, Optional.empty());
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<UpdateKind> updateKind)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName, updateKind);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion, Optional<UpdateKind> updateKind)
+    {
+        Span span = startSpan("getTableHandle", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion, updateKind);
         }
     }
 
@@ -1548,6 +1576,15 @@ public class TracingMetadata
     }
 
     @Override
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<UpdateKind> updateKind)
+    {
+        Span span = startSpan("getRedirectionAwareTableHandle", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getRedirectionAwareTableHandle(session, tableName, updateKind);
+        }
+    }
+
+    @Override
     public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName)
     {
         Span span = startSpan("getRedirectionAwareTableHandle", tableName);
@@ -1557,20 +1594,11 @@ public class TracingMetadata
     }
 
     @Override
-    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion, Optional<UpdateKind> updateKind)
     {
         Span span = startSpan("getRedirectionAwareTableHandle", tableName);
         try (var _ = scopedSpan(span)) {
-            return delegate.getRedirectionAwareTableHandle(session, tableName, startVersion, endVersion);
-        }
-    }
-
-    @Override
-    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
-    {
-        Span span = startSpan("getTableHandle", tableName);
-        try (var _ = scopedSpan(span)) {
-            return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+            return delegate.getRedirectionAwareTableHandle(session, tableName, startVersion, endVersion, updateKind);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -58,6 +58,7 @@ import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -141,6 +142,24 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<UpdateKind> updateKind)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName table, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion, Optional<UpdateKind> updateKind)
     {
         throw new UnsupportedOperationException();
     }
@@ -1048,17 +1067,18 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<UpdateKind> updateKind)
     {
-        if (startVersion.isEmpty() || endVersion.isEmpty()) {
-            return noRedirection(getTableHandle(session, tableName));
-        }
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName table, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion, Optional<UpdateKind> updateKind)
     {
+        if (startVersion.isEmpty() || endVersion.isEmpty()) {
+            return noRedirection(getTableHandle(session, tableName));
+        }
+
         throw new UnsupportedOperationException();
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -116,6 +116,26 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Returns a table handle for the specified table name, version and updateKind, or {@code null} if {@code tableName} relation does not exist
+     * or is not a table (e.g. is a view, or a materialized view).
+     *
+     * @throws TrinoException implementation can throw this exception when {@code tableName} refers to a table that
+     * cannot be queried.
+     * @see #getView(ConnectorSession, SchemaTableName)
+     * @see #getMaterializedView(ConnectorSession, SchemaTableName)
+     */
+    @Nullable
+    default ConnectorTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion,
+            Optional<UpdateKind> updateKind)
+    {
+        return getTableHandle(session, tableName, startVersion, endVersion);
+    }
+
+    /**
      * Create initial handle for execution of table procedure. The handle will be used through planning process. It will be converted to final
      * handle used for execution via @{link {@link ConnectorMetadata#beginTableExecute}
      * <p>
@@ -394,7 +414,7 @@ public interface ConnectorMetadata
                         return RelationCommentMetadata.forRedirectedTable(tableName);
                     }
                     try {
-                        ConnectorTableHandle tableHandle = getTableHandle(session, tableName, Optional.empty(), Optional.empty());
+                        ConnectorTableHandle tableHandle = getTableHandle(session, tableName, Optional.empty(), Optional.empty(), Optional.empty());
                         if (tableHandle == null) {
                             // disappeared during listing
                             return null;
@@ -967,7 +987,7 @@ public interface ConnectorMetadata
      * Gets the view data for the specified view name. Returns {@link Optional#empty()} if {@code viewName}
      * relation does not or is not a view (e.g. is a table, or a materialized view).
      *
-     * @see #getTableHandle(ConnectorSession, SchemaTableName, Optional, Optional)
+     * @see #getTableHandle(ConnectorSession, SchemaTableName, Optional, Optional, Optional)
      * @see #getMaterializedView(ConnectorSession, SchemaTableName)
      */
     default Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
@@ -1755,7 +1775,7 @@ public interface ConnectorMetadata
      * Gets the materialized view data for the specified materialized view name. Returns {@link Optional#empty()}
      * if {@code viewName} relation does not or is not a materialized view (e.g. is a table, or a view).
      *
-     * @see #getTableHandle(ConnectorSession, SchemaTableName, Optional, Optional)
+     * @see #getTableHandle(ConnectorSession, SchemaTableName, Optional, Optional, Optional)
      * @see #getView(ConnectorSession, SchemaTableName)
      */
     default Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/UpdateKind.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/UpdateKind.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+public enum UpdateKind
+{
+    DELETE,
+    UPDATE,
+    MERGE
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -68,6 +68,7 @@ import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -1294,6 +1295,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion, Optional<UpdateKind> updateKind)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion, updateKind);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -29,7 +29,8 @@ public record CommitTaskData(
         Optional<String> partitionDataJson,
         FileContent content,
         Optional<String> referencedDataFile,
-        Optional<List<Long>> fileSplitOffsets)
+        Optional<List<Long>> fileSplitOffsets,
+        boolean copyOnWriteDelete)
 {
     public CommitTaskData
     {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -58,6 +58,27 @@ public class IcebergColumnHandle
     public static final int DATA_CHANGE_TIMESTAMP_ID = Integer.MIN_VALUE + 5;
     public static final String DATA_CHANGE_ORDINAL_NAME = "_change_ordinal";
     public static final int DATA_CHANGE_ORDINAL_ID = Integer.MIN_VALUE + 6;
+    public static final int DATA_FILE_DATA_SEQUENCE_NUMBER_ID = Integer.MIN_VALUE + 7;
+    public static final int DELETE_FILES_CONTENT_ID = Integer.MIN_VALUE + 8;
+    public static final int DELETE_FILES_CONTENT_ELEMENT_ID = Integer.MIN_VALUE + 9;
+    public static final int DELETE_FILES_PATH_ID = Integer.MIN_VALUE + 10;
+    public static final int DELETE_FILES_PATH_ELEMENT_ID = Integer.MIN_VALUE + 11;
+
+    public static final int DELETE_FILES_FORMAT_ID = Integer.MIN_VALUE + 12;
+    public static final int DELETE_FILES_FORMAT_ELEMENT_ID = Integer.MIN_VALUE + 13;
+    public static final int DELETE_FILES_RECORD_COUNT_ID = Integer.MIN_VALUE + 14;
+    public static final int DELETE_FILES_RECORD_COUNT_ELEMENT_ID = Integer.MIN_VALUE + 15;
+    public static final int DELETE_FILES_FILE_SIZE_IN_BYTES_ID = Integer.MIN_VALUE + 16;
+    public static final int DELETE_FILES_FILE_SIZE_IN_BYTES_ELEMENT_ID = Integer.MIN_VALUE + 17;
+    public static final int DELETE_FILES_EQUALITY_FIELD_IDS_ID = Integer.MIN_VALUE + 18;
+    public static final int DELETE_FILES_EQUALITY_FIELD_ID_ID = Integer.MIN_VALUE + 19;
+    public static final int DELETE_FILES_EQUALITY_FIELD_ID_ELEMENT_ID = Integer.MIN_VALUE + 20;
+    public static final int DELETE_FILES_ROW_POSITION_LOWER_BOUND_ID = Integer.MIN_VALUE + 21;
+    public static final int DELETE_FILES_ROW_POSITION_LOWER_BOUND_ELEMENT_ID = Integer.MIN_VALUE + 22;
+    public static final int DELETE_FILES_ROW_POSITION_UPPER_BOUND_ID = Integer.MIN_VALUE + 23;
+    public static final int DELETE_FILES_ROW_POSITION_UPPER_BOUND_ELEMENT_ID = Integer.MIN_VALUE + 24;
+    public static final int DELETE_FILES_DATA_SEQUENCE_NUMBER_ID = Integer.MIN_VALUE + 25;
+    public static final int DELETE_FILES_DATA_SEQUENCE_NUMBER_ELEMENT_ID = Integer.MIN_VALUE + 26;
 
     private final ColumnIdentity baseColumnIdentity;
     private final Type baseType;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -98,6 +98,9 @@ public class IcebergConfig
     private int metadataParallelism = 8;
     private boolean bucketExecutionEnabled = true;
     private boolean fileBasedConflictDetectionEnabled = true;
+    private WriteChangeMode writeDeleteMode = WriteChangeMode.MOR;
+    private WriteChangeMode writeUpdateMode = WriteChangeMode.MOR;
+    private WriteChangeMode writeMergeMode = WriteChangeMode.MOR;
 
     public CatalogType getCatalogType()
     {
@@ -620,6 +623,45 @@ public class IcebergConfig
     public IcebergConfig setFileBasedConflictDetectionEnabled(boolean fileBasedConflictDetectionEnabled)
     {
         this.fileBasedConflictDetectionEnabled = fileBasedConflictDetectionEnabled;
+        return this;
+    }
+
+    public WriteChangeMode getWriteDeleteMode()
+    {
+        return writeDeleteMode;
+    }
+
+    @Config("iceberg.write-delete-mode")
+    @ConfigDescription("Set mode used for table delete command: copy-on-write or merge-on-read")
+    public IcebergConfig setWriteDeleteMode(WriteChangeMode writeDeleteMode)
+    {
+        this.writeDeleteMode = writeDeleteMode;
+        return this;
+    }
+
+    public WriteChangeMode getWriteUpdateMode()
+    {
+        return writeUpdateMode;
+    }
+
+    @Config("iceberg.write-update-mode")
+    @ConfigDescription("Set mode used for table update command: copy-on-write or merge-on-read")
+    public IcebergConfig setWriteUpdateMode(WriteChangeMode writeUpdateMode)
+    {
+        this.writeUpdateMode = writeUpdateMode;
+        return this;
+    }
+
+    public WriteChangeMode getWriteMergeMode()
+    {
+        return writeMergeMode;
+    }
+
+    @Config("iceberg.write-merge-mode")
+    @ConfigDescription("Set mode used for table merge command: copy-on-write or merge-on-read")
+    public IcebergConfig setWriteMergeMode(WriteChangeMode writeMergeMode)
+    {
+        this.writeMergeMode = writeMergeMode;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
@@ -13,41 +13,66 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
+import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.plugin.iceberg.delete.DeleteFile;
 import io.trino.plugin.iceberg.delete.PositionDeleteWriter;
 import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.MergePage;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.connector.UpdateKind;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.types.Type;
 import org.roaringbitmap.longlong.ImmutableLongBitmapDataProvider;
 import org.roaringbitmap.longlong.LongBitmapDataProvider;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_CLOSE_ERROR;
+import static io.trino.plugin.iceberg.IcebergUtil.getWriteChangeMode;
 import static io.trino.spi.connector.MergePage.createDeleteAndInsertPages;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Predicate.not;
+import static org.apache.iceberg.FileContent.DATA;
+import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
 
 public class IcebergMergeSink
         implements ConnectorMergeSink
@@ -63,7 +88,11 @@ public class IcebergMergeSink
     private final Map<Integer, PartitionSpec> partitionsSpecs;
     private final ConnectorPageSink insertPageSink;
     private final int columnCount;
+    private final List<IcebergColumnHandle> regularColumns;
+    private final Optional<NameMapping> nameMapping;
     private final Map<Slice, FileDeletion> fileDeletions = new HashMap<>();
+    private final IcebergPageSourceProvider icebergPageSourceProvider;
+    private final UpdateKind updateKind;
 
     public IcebergMergeSink(
             LocationProvider locationProvider,
@@ -76,7 +105,11 @@ public class IcebergMergeSink
             Schema schema,
             Map<Integer, PartitionSpec> partitionsSpecs,
             ConnectorPageSink insertPageSink,
-            int columnCount)
+            int columnCount,
+            List<IcebergColumnHandle> regularColumns,
+            Optional<NameMapping> nameMapping,
+            IcebergPageSourceProvider icebergPageSourceProvider,
+            UpdateKind updateKind)
     {
         this.locationProvider = requireNonNull(locationProvider, "locationProvider is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
@@ -89,6 +122,10 @@ public class IcebergMergeSink
         this.partitionsSpecs = ImmutableMap.copyOf(requireNonNull(partitionsSpecs, "partitionsSpecs is null"));
         this.insertPageSink = requireNonNull(insertPageSink, "insertPageSink is null");
         this.columnCount = columnCount;
+        this.regularColumns = requireNonNull(regularColumns, "regularColumns is null");
+        this.nameMapping = requireNonNull(nameMapping, "nameMapping is null");
+        this.icebergPageSourceProvider = requireNonNull(icebergPageSourceProvider, "icebergPageSourceProvider is null");
+        this.updateKind = requireNonNull(updateKind, "writeOperation is null");
     }
 
     @Override
@@ -104,15 +141,27 @@ public class IcebergMergeSink
             Block rowPositionBlock = fields.get(1);
             Block partitionSpecIdBlock = fields.get(2);
             Block partitionDataBlock = fields.get(3);
+
             for (int position = 0; position < fieldPathBlock.getPositionCount(); position++) {
                 Slice filePath = VarcharType.VARCHAR.getSlice(fieldPathBlock, position);
                 long rowPosition = BIGINT.getLong(rowPositionBlock, position);
+                final OptionalLong dataSequenceNumber;
+
+                final List<DeleteFile> deleteFiles;
+                if (getWriteChangeMode(storageProperties, updateKind).equals(WriteChangeMode.COW)) {
+                    dataSequenceNumber = OptionalLong.of(BIGINT.getLong(fields.get(4), position));
+                    deleteFiles = extractDeleteFilesFromFields(fields, position, 5);
+                }
+                else {
+                    dataSequenceNumber = OptionalLong.empty();
+                    deleteFiles = List.of();
+                }
 
                 int index = position;
                 FileDeletion deletion = fileDeletions.computeIfAbsent(filePath, _ -> {
                     int partitionSpecId = INTEGER.getInt(partitionSpecIdBlock, index);
                     String partitionData = VarcharType.VARCHAR.getSlice(partitionDataBlock, index).toStringUtf8();
-                    return new FileDeletion(partitionSpecId, partitionData);
+                    return new FileDeletion(partitionSpecId, partitionData, deleteFiles, dataSequenceNumber);
                 });
 
                 deletion.rowsToDelete().addLong(rowPosition);
@@ -120,19 +169,86 @@ public class IcebergMergeSink
         });
     }
 
+    private static List<DeleteFile> extractDeleteFilesFromFields(List<Block> fields, int position, int startIdx)
+    {
+        ArrayType integerArrayType = new ArrayType(INTEGER);
+        ArrayType bigintArrayType = new ArrayType(BIGINT);
+        ArrayType varcharArrayType = new ArrayType(VarcharType.VARCHAR);
+        ArrayType integerArrayArrayType = new ArrayType(new ArrayType(INTEGER));
+
+        Block fileContentBlock = integerArrayType.getObject(fields.get(startIdx), position);
+        Block pathBlock = varcharArrayType.getObject(fields.get(startIdx + 1), position);
+        Block formatBlock = varcharArrayType.getObject(fields.get(startIdx + 2), position);
+        Block recordCountBlock = bigintArrayType.getObject(fields.get(startIdx + 3), position);
+        Block fileSizeBlock = bigintArrayType.getObject(fields.get(startIdx + 4), position);
+        Block equalityFieldIdsBlock = integerArrayArrayType.getObject(fields.get(startIdx + 5), position);
+        Block lowerBoundBlock = bigintArrayType.getObject(fields.get(startIdx + 6), position);
+        Block upperBoundBlock = bigintArrayType.getObject(fields.get(startIdx + 7), position);
+        Block sequenceBlock = bigintArrayType.getObject(fields.get(startIdx + 8), position);
+
+        int count = fileContentBlock.getPositionCount();
+        List<DeleteFile> result = new ArrayList<>(count);
+
+        Function<Integer, FileContent> id2FileContent = id -> switch (id) {
+            case 0 -> FileContent.DATA;
+            case 1 -> FileContent.POSITION_DELETES;
+            case 2 -> FileContent.EQUALITY_DELETES;
+            default -> throw new IllegalArgumentException("Unknown FileContent id: " + id);
+        };
+
+        for (int i = 0; i < count; i++) {
+            FileContent content = id2FileContent.apply(INTEGER.getInt(fileContentBlock, i));
+            String path = VarcharType.VARCHAR.getSlice(pathBlock, i).toStringUtf8();
+            FileFormat format = FileFormat.fromString(VarcharType.VARCHAR.getSlice(formatBlock, i).toStringUtf8());
+            long recordCount = BIGINT.getLong(recordCountBlock, i);
+            long fileSizeInBytes = BIGINT.getLong(fileSizeBlock, i);
+
+            Block equalityFieldIdsSingleFileBlock = integerArrayType.getObject(equalityFieldIdsBlock, i);
+            List<Integer> equalityFieldIds = new ArrayList<>();
+            IntStream.range(0, equalityFieldIdsSingleFileBlock.getPositionCount())
+                    .mapToObj(j -> INTEGER.getInt(equalityFieldIdsSingleFileBlock, j))
+                    .forEach(equalityFieldIds::add);
+
+            Optional<Long> rowPositionLowerBound = lowerBoundBlock.isNull(i) ? Optional.empty() : Optional.of(BIGINT.getLong(lowerBoundBlock, i));
+            Optional<Long> rowPositionUpperBound = upperBoundBlock.isNull(i) ? Optional.empty() : Optional.of(BIGINT.getLong(upperBoundBlock, i));
+            long sequenceNum = BIGINT.getLong(sequenceBlock, i);
+
+            result.add(new DeleteFile(
+                    content,
+                    path,
+                    format,
+                    recordCount,
+                    fileSizeInBytes,
+                    equalityFieldIds,
+                    rowPositionLowerBound,
+                    rowPositionUpperBound,
+                    sequenceNum));
+        }
+
+        return result;
+    }
+
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        List<Slice> fragments = new ArrayList<>(insertPageSink.finish().join());
+        List<Slice> fragments = new ArrayList<>();
 
-        fileDeletions.forEach((dataFilePath, deletion) -> {
-            PositionDeleteWriter writer = createPositionDeleteWriter(
-                    dataFilePath.toStringUtf8(),
-                    partitionsSpecs.get(deletion.partitionSpecId()),
-                    deletion.partitionDataJson());
+        if (getWriteChangeMode(storageProperties, updateKind).equals(WriteChangeMode.COW)) {
+            fileDeletions.forEach((dataFilePath, deletion) ->
+                    fragments.addAll(rewriteFile(dataFilePath.toStringUtf8(), deletion)));
+        }
+        else {
+            fileDeletions.forEach((dataFilePath, deletion) -> {
+                PositionDeleteWriter writer = createPositionDeleteWriter(
+                        dataFilePath.toStringUtf8(),
+                        partitionsSpecs.get(deletion.partitionSpecId()),
+                        deletion.partitionDataJson());
 
-            fragments.addAll(writePositionDeletes(writer, deletion.rowsToDelete()));
-        });
+                fragments.addAll(writePositionDeletes(writer, deletion.rowsToDelete()));
+            });
+        }
+
+        fragments.addAll(insertPageSink.finish().join());
 
         return completedFuture(fragments);
     }
@@ -177,16 +293,20 @@ public class IcebergMergeSink
         }
     }
 
-    private static class FileDeletion
+    public static class FileDeletion
     {
         private final int partitionSpecId;
         private final String partitionDataJson;
         private final LongBitmapDataProvider rowsToDelete = new Roaring64Bitmap();
+        private final List<DeleteFile> deleteFiles;
+        private final OptionalLong dataSequenceNumber;
 
-        public FileDeletion(int partitionSpecId, String partitionDataJson)
+        public FileDeletion(int partitionSpecId, String partitionDataJson, List<DeleteFile> deleteFiles, OptionalLong dataSequenceNumber)
         {
             this.partitionSpecId = partitionSpecId;
             this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
+            this.deleteFiles = requireNonNull(deleteFiles, "deleteFilePaths is null");
+            this.dataSequenceNumber = requireNonNull(dataSequenceNumber, "dataSequenceNumber is null");
         }
 
         public int partitionSpecId()
@@ -202,6 +322,152 @@ public class IcebergMergeSink
         public LongBitmapDataProvider rowsToDelete()
         {
             return rowsToDelete;
+        }
+
+        public List<DeleteFile> getDeleteFiles()
+        {
+            return deleteFiles;
+        }
+
+        public OptionalLong getDataSequenceNumber()
+        {
+            return dataSequenceNumber;
+        }
+    }
+
+    private List<Slice> rewriteFile(String dataFilePath, FileDeletion deletion)
+    {
+        try {
+            TrinoInputFile dataFile = fileSystem.newInputFile(Location.of(dataFilePath));
+            // Fetch size early to use in task data + createParquetPageSource
+            long dataFileSize = dataFile.length();
+            copyOnWriteRewriteFile(dataFile, dataFileSize, deletion);
+            CommitTaskData task = new CommitTaskData(
+                    dataFilePath,
+                    fileFormat,
+                    dataFileSize,
+                    // metrics is not used for OverwriteFiles.deleteFile, just pass a dummy one
+                    new MetricsWrapper(0L, null, null, null, null, null, null),
+                    PartitionSpecParser.toJson(partitionsSpecs.get(deletion.partitionSpecId)),
+                    Optional.of(deletion.partitionDataJson),
+                    DATA,
+                    Optional.empty(),
+                    Optional.empty(),
+                    true);
+            return ImmutableList.of(utf8Slice(jsonCodec.toJson(task)));
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_WRITER_CLOSE_ERROR, "Unable to rewrite Parquet file", e);
+        }
+    }
+
+    private void copyOnWriteRewriteFile(TrinoInputFile sourceDataFile, long sourceDataFileSize, FileDeletion deletion)
+            throws IOException
+    {
+        LongBitmapDataProvider rowsDeletedByDelete = deletion.rowsToDelete();
+        try (PageSourceWithPosition pageSourceWithPosition =
+                     createCopyOnWritePageSource(sourceDataFile, sourceDataFileSize, deletion)) {
+            // grab the inner source once, or inline the method call
+            ConnectorPageSource pageSource = pageSourceWithPosition.pageSource();
+
+            while (!pageSource.isFinished()) {
+                SourcePage sourcePage = pageSource.getNextSourcePage();
+                if (sourcePage == null) {
+                    continue;
+                }
+                // fully load page
+                Page page = sourcePage.getPage();
+
+                int positionCount = page.getPositionCount();
+                int[] retained = new int[positionCount];
+                int retainedCount = 0;
+                Block rowPositionBlock = page.getBlock(pageSourceWithPosition.posColumnIdx());
+                for (int position = 0; position < positionCount; position++) {
+                    long rowId = BIGINT.getLong(rowPositionBlock, position);
+                    if (!rowsDeletedByDelete.contains(rowId)) {
+                        retained[retainedCount++] = position;
+                    }
+                }
+
+                if (retainedCount != positionCount) {
+                    page = page.getPositions(retained, 0, retainedCount);
+                }
+                page = page.getColumns(IntStream.range(0, page.getChannelCount()).filter(col -> col != pageSourceWithPosition.posColumnIdx).toArray());
+                insertPageSink.appendPage(page);
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_WRITER_CLOSE_ERROR,
+                    "Unable to rewrite parquet file", e);
+        }
+    }
+
+    private PageSourceWithPosition createCopyOnWritePageSource(TrinoInputFile inputFile, long fileSize, FileDeletion deletion)
+    {
+        PartitionSpec partitionSpec = partitionsSpecs.get(deletion.partitionSpecId);
+        Type[] columnTypes = partitionSpec.fields().stream()
+                .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
+                .toArray(Type[]::new);
+        PartitionData partitionData = PartitionData.fromJson(deletion.partitionDataJson, columnTypes);
+
+        List<IcebergColumnHandle> requiredColumns = new ArrayList<>(regularColumns);
+
+        List<DeleteFile> deletes = deletion.getDeleteFiles();
+
+        Set<IcebergColumnHandle> deleteFilterRequiredColumns = icebergPageSourceProvider.requiredColumnsForDeletes(schema, deletes);
+
+        deleteFilterRequiredColumns.stream()
+                .filter(not(regularColumns::contains))
+                .forEach(requiredColumns::add);
+
+        int posColumnIdx = -1;
+
+        for (int i = 0; i < requiredColumns.size(); i++) {
+            if (requiredColumns.get(i).isRowPositionColumn()) {
+                posColumnIdx = i;
+                break;
+            }
+        }
+
+        if (posColumnIdx == -1) {
+            requiredColumns.add(icebergPageSourceProvider.getColumnHandle(ROW_POSITION));
+            posColumnIdx = requiredColumns.size() - 1;
+        }
+
+        ConnectorPageSource pageSource = icebergPageSourceProvider.createPageSource(
+                session,
+                inputFile,
+                fileSystem,
+                0,
+                fileSize,
+                fileSize,
+                partitionSpec,
+                partitionData,
+                deletion.partitionDataJson,
+                fileFormat,
+                schema,
+                requiredColumns,
+                requiredColumns,
+                TupleDomain.all(),
+                nameMapping,
+                partitionSpec.partitionToPath(partitionData),
+                IcebergUtil.getPartitionKeys(partitionData, partitionSpec),
+                deletion.getDeleteFiles(),
+                deletion.getDataSequenceNumber(),
+                Optional.empty());
+        return new PageSourceWithPosition(pageSource, posColumnIdx);
+    }
+
+    private record PageSourceWithPosition(
+            ConnectorPageSource pageSource,
+            int posColumnIdx
+    ) implements AutoCloseable
+    {
+        @Override
+        public void close()
+                throws IOException
+        {
+            pageSource.close();
         }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -431,7 +431,8 @@ public class IcebergPageSink
                 writeContext.getPartitionData().map(PartitionData::toJson),
                 DATA,
                 Optional.empty(),
-                writer.getFileMetrics().splitOffsets());
+                writer.getFileMetrics().splitOffsets(),
+                false);
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -22,6 +22,7 @@ import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.units.DataSize;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.Locale;
@@ -73,6 +74,8 @@ public class IcebergTableHandle
     // ANALYZE only. Coordinator-only
     private final Optional<Boolean> forAnalyze;
 
+    private final Optional<UpdateKind> updateKind;
+
     @JsonCreator
     @DoNotCall // For JSON deserialization only
     public static IcebergTableHandle fromJsonForDeserializationOnly(
@@ -89,7 +92,8 @@ public class IcebergTableHandle
             @JsonProperty("projectedColumns") Set<IcebergColumnHandle> projectedColumns,
             @JsonProperty("nameMappingJson") Optional<String> nameMappingJson,
             @JsonProperty("tableLocation") String tableLocation,
-            @JsonProperty("storageProperties") Map<String, String> storageProperties)
+            @JsonProperty("storageProperties") Map<String, String> storageProperties,
+            @JsonProperty("updateKind") Optional<UpdateKind> updateKind)
     {
         return new IcebergTableHandle(
                 schemaName,
@@ -110,7 +114,8 @@ public class IcebergTableHandle
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.empty(),
+                updateKind);
     }
 
     public IcebergTableHandle(
@@ -132,7 +137,8 @@ public class IcebergTableHandle
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize,
             Set<IcebergColumnHandle> constraintColumns,
-            Optional<Boolean> forAnalyze)
+            Optional<Boolean> forAnalyze,
+            Optional<UpdateKind> updateKind)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -153,6 +159,7 @@ public class IcebergTableHandle
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.constraintColumns = ImmutableSet.copyOf(requireNonNull(constraintColumns, "constraintColumns is null"));
         this.forAnalyze = requireNonNull(forAnalyze, "forAnalyze is null");
+        this.updateKind = requireNonNull(updateKind, "updateKind is null");
     }
 
     @JsonProperty
@@ -273,6 +280,12 @@ public class IcebergTableHandle
         return forAnalyze;
     }
 
+    @JsonProperty
+    public Optional<UpdateKind> getUpdateKind()
+    {
+        return updateKind;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -304,7 +317,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                updateKind);
     }
 
     public IcebergTableHandle forAnalyze()
@@ -328,7 +342,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                Optional.of(true));
+                Optional.of(true),
+                updateKind);
     }
 
     public IcebergTableHandle forOptimize(boolean recordScannedFiles, DataSize maxScannedFileSize)
@@ -352,7 +367,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 Optional.of(maxScannedFileSize),
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                updateKind);
     }
 
     public IcebergTableHandle withTablePartitioning(Optional<IcebergTablePartitioning> requiredTablePartitioning)
@@ -376,7 +392,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                updateKind);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -70,6 +70,9 @@ public class IcebergTableProperties
     public static final String OBJECT_STORE_LAYOUT_ENABLED_PROPERTY = "object_store_layout_enabled";
     public static final String DATA_LOCATION_PROPERTY = "data_location";
     public static final String EXTRA_PROPERTIES_PROPERTY = "extra_properties";
+    public static final String WRITE_DELETE_MODE = "write_delete_mode";
+    public static final String WRITE_UPDATE_MODE = "write_update_mode";
+    public static final String WRITE_MERGE_MODE = "write_merge_mode";
 
     public static final Set<String> SUPPORTED_PROPERTIES = ImmutableSet.<String>builder()
             .add(FILE_FORMAT_PROPERTY)
@@ -85,6 +88,9 @@ public class IcebergTableProperties
             .add(DATA_LOCATION_PROPERTY)
             .add(EXTRA_PROPERTIES_PROPERTY)
             .add(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY)
+            .add(WRITE_DELETE_MODE)
+            .add(WRITE_UPDATE_MODE)
+            .add(WRITE_MERGE_MODE)
             .build();
 
     // These properties are used by Trino or Iceberg internally and cannot be set directly by users through extra_properties
@@ -216,6 +222,24 @@ public class IcebergTableProperties
                         "File system location URI for the table's data files",
                         null,
                         false))
+                .add(enumProperty(
+                        WRITE_DELETE_MODE,
+                        "Mode used for table delete command: copy-on-write or merge-on-read (v2 only)",
+                        WriteChangeMode.class,
+                        icebergConfig.getWriteDeleteMode(),
+                        false))
+                .add(enumProperty(
+                        WRITE_UPDATE_MODE,
+                        "Mode used for table update command: copy-on-write or merge-on-read (v2 only)",
+                        WriteChangeMode.class,
+                        icebergConfig.getWriteUpdateMode(),
+                        false))
+                .add(enumProperty(
+                        WRITE_MERGE_MODE,
+                        "Mode used for table merge command: copy-on-write or merge-on-read (v2 only)",
+                        WriteChangeMode.class,
+                        icebergConfig.getWriteMergeMode(),
+                        false))
                 .build();
 
         checkState(SUPPORTED_PROPERTIES.containsAll(tableProperties.stream()
@@ -327,6 +351,21 @@ public class IcebergTableProperties
     public static Optional<String> getDataLocation(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((String) tableProperties.get(DATA_LOCATION_PROPERTY));
+    }
+
+    public static Optional<WriteChangeMode> getWriteDeleteMode(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((WriteChangeMode) tableProperties.get(WRITE_DELETE_MODE));
+    }
+
+    public static Optional<WriteChangeMode> getWriteUpdateMode(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((WriteChangeMode) tableProperties.get(WRITE_UPDATE_MODE));
+    }
+
+    public static Optional<WriteChangeMode> getWriteMergeMode(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((WriteChangeMode) tableProperties.get(WRITE_MERGE_MODE));
     }
 
     public static Optional<Map<String, String>> getExtraProperties(Map<String, Object> tableProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/WriteChangeMode.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/WriteChangeMode.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+public enum WriteChangeMode
+{
+    MOR("merge-on-read"),
+    COW("copy-on-write");
+
+    private final String icebergValue;
+
+    WriteChangeMode(String icebergValue)
+    {
+        this.icebergValue = icebergValue;
+    }
+
+    public String toIcebergString()
+    {
+        return icebergValue;
+    }
+
+    public WriteChangeMode alternate()
+    {
+        return this == MOR ? COW : MOR;
+    }
+
+    public static WriteChangeMode fromIcebergString(String value)
+    {
+        return switch (value) {
+            case "merge-on-read" -> MOR;
+            case "copy-on-write" -> COW;
+            default -> throw new IllegalArgumentException("Unexpected value: " + value);
+        };
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
@@ -100,7 +100,8 @@ public class PositionDeleteWriter
                 partition.map(PartitionData::toJson),
                 FileContent.POSITION_DELETES,
                 Optional.of(dataFilePath),
-                writer.getFileMetrics().splitOffsets());
+                writer.getFileMetrics().splitOffsets(),
+                false);
 
         return List.of(wrappedBuffer(jsonCodec.toJsonBytes(task)));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -132,7 +132,8 @@ public class TableChangesFunctionProcessor
                 split.fileFormat(),
                 split.fileIoProperties(),
                 0,
-                functionHandle.nameMappingJson().map(NameMappingParser::fromJson));
+                functionHandle.nameMappingJson().map(NameMappingParser::fromJson),
+                Optional.empty());
         this.delegateColumnMap = delegateColumnMap;
 
         this.changeTypeIndex = changeTypeIndex;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -115,7 +115,10 @@ public abstract class BaseIcebergConnectorSmokeTest
                         "WITH \\(\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
-                        format("   location = '.*/" + schemaName + "/region.*'\n") +
+                        format("   location = '.*/" + schemaName + "/region.*',\n") +
+                        "   write_delete_mode = 'MOR',\n" +
+                        "   write_merge_mode = 'MOR',\n" +
+                        "   write_update_mode = 'MOR'\n" +
                         "\\)");
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -218,7 +218,10 @@ public abstract class BaseIcebergMaterializedViewTest
                                 "   orc_bloom_filter_columns = ARRAY['_date'],\n" +
                                 "   orc_bloom_filter_fpp = 1E-1,\n" +
                                 "   partitioning = ARRAY['_date'],\n" +
-                                "   storage_schema = '" + schema + "'\n" +
+                                "   storage_schema = '" + schema + "',\n" +
+                                "   write_delete_mode = 'MOR',\n" +
+                                "   write_merge_mode = 'MOR',\n" +
+                                "   write_update_mode = 'MOR'\n" +
                                 ") AS\n" +
                                 "SELECT\n" +
                                 "  _bigint\n" +
@@ -532,7 +535,10 @@ public abstract class BaseIcebergMaterializedViewTest
                         "   format_version = 2,\n" +
                         "   location = '" + getSchemaDirectory() + "/materialized_view_window-\\E[0-9a-f]+\\Q',\n" +
                         "   partitioning = ARRAY['_date'],\n" +
-                        "   storage_schema = '" + schema + "'\n" +
+                        "   storage_schema = '" + schema + "',\n" +
+                        "   write_delete_mode = 'MOR',\n" +
+                        "   write_merge_mode = 'MOR',\n" +
+                        "   write_update_mode = 'MOR'\n" +
                         ") AS\n" +
                         "SELECT\n" +
                         "  _date\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -53,6 +53,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.BigintType;
 import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.Type;
 import io.trino.testing.QueryRunner;
@@ -109,6 +110,13 @@ public final class IcebergTestUtils
                 .build();
     }
 
+    public static Session withLowMaxWriterCount(Session session)
+    {
+        return Session.builder(session)
+                .setSystemProperty("task_max_writer_count", "1")
+                .build();
+    }
+
     public static boolean checkOrcFileSorting(TrinoFileSystem fileSystem, Location path, String sortColumnName)
     {
         return checkOrcFileSorting(() -> {
@@ -162,6 +170,7 @@ public final class IcebergTestUtils
     {
         return switch (orcTypeKind) {
             case OrcType.OrcTypeKind.STRING, OrcType.OrcTypeKind.VARCHAR -> VARCHAR;
+            case OrcType.OrcTypeKind.LONG -> BigintType.BIGINT;
             default -> throw new IllegalArgumentException("Unsupported orc type: " + orcTypeKind);
         };
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
@@ -211,10 +211,10 @@ class TestFileBasedConflictDetection
                 {"partitionValues":[40]}
                 """;
         CommitTaskData commitTaskData1 = new CommitTaskData("test_location/data/new.parquet", IcebergFileFormat.PARQUET, 0, new MetricsWrapper(new Metrics()), PartitionSpecParser.toJson(currentPartitionSpec),
-                Optional.of(partitionDataJson), DATA, Optional.empty(), Optional.empty());
+                Optional.of(partitionDataJson), DATA, Optional.empty(), Optional.empty(), false);
         // Remove file from version with previous partition specification
         CommitTaskData commitTaskData2 = new CommitTaskData("test_location/data/old.parquet", IcebergFileFormat.PARQUET, 0, new MetricsWrapper(new Metrics()), PartitionSpecParser.toJson(previousPartitionSpec),
-                Optional.of(partitionDataJson), POSITION_DELETES, Optional.empty(), Optional.empty());
+                Optional.of(partitionDataJson), POSITION_DELETES, Optional.empty(), Optional.empty(), false);
         TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(currentPartitionSpec), icebergTable, List.of(commitTaskData1, commitTaskData2), null);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEmpty();
 
@@ -233,7 +233,8 @@ class TestFileBasedConflictDetection
                 partitionDataJson,
                 DATA,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                false);
         CommitTaskData commitTaskData2 = new CommitTaskData(
                 "test_location/data/old.parquet",
                 IcebergFileFormat.PARQUET,
@@ -243,7 +244,8 @@ class TestFileBasedConflictDetection
                 partitionDataJson,
                 POSITION_DELETES,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                false);
 
         return List.of(commitTaskData1, commitTaskData2);
     }
@@ -270,7 +272,8 @@ class TestFileBasedConflictDetection
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
     }
 
     private static Table createIcebergTable(PartitionSpec partitionSpec)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAvroConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAvroConnectorTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.iceberg.IcebergFileFormat.AVRO;
+import static io.trino.plugin.iceberg.WriteChangeMode.MOR;
 import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestIcebergAvroConnectorTest
@@ -23,7 +24,7 @@ public class TestIcebergAvroConnectorTest
 {
     public TestIcebergAvroConnectorTest()
     {
-        super(AVRO);
+        super(AVRO, MOR);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -35,6 +35,8 @@ import static io.trino.plugin.iceberg.CatalogType.GLUE;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.WriteChangeMode.COW;
+import static io.trino.plugin.iceberg.WriteChangeMode.MOR;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -82,7 +84,10 @@ public class TestIcebergConfig
                 .setObjectStoreLayoutEnabled(false)
                 .setMetadataParallelism(8)
                 .setBucketExecutionEnabled(true)
-                .setFileBasedConflictDetectionEnabled(true));
+                .setFileBasedConflictDetectionEnabled(true)
+                .setWriteDeleteMode(MOR)
+                .setWriteUpdateMode(MOR)
+                .setWriteMergeMode(MOR));
     }
 
     @Test
@@ -126,6 +131,9 @@ public class TestIcebergConfig
                 .put("iceberg.metadata.parallelism", "10")
                 .put("iceberg.bucket-execution", "false")
                 .put("iceberg.file-based-conflict-detection", "false")
+                .put("iceberg.write-delete-mode", "COW")
+                .put("iceberg.write-update-mode", "COW")
+                .put("iceberg.write-merge-mode", "COW")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -166,7 +174,10 @@ public class TestIcebergConfig
                 .setObjectStoreLayoutEnabled(true)
                 .setMetadataParallelism(10)
                 .setBucketExecutionEnabled(false)
-                .setFileBasedConflictDetectionEnabled(false);
+                .setFileBasedConflictDetectionEnabled(false)
+                .setWriteDeleteMode(COW)
+                .setWriteUpdateMode(COW)
+                .setWriteMergeMode(COW);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergCopyOnWriteConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergCopyOnWriteConnectorTest.java
@@ -1,0 +1,674 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.filesystem.Location;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.plugin.iceberg.IcebergTestUtils.withLowMaxWriterCount;
+import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
+import static io.trino.plugin.iceberg.WriteChangeMode.COW;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_DELETE;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_MERGE;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergCopyOnWriteConnectorTest
+        extends BaseIcebergConnectorTest
+{
+    @Override
+    protected IcebergQueryRunner.Builder createQueryRunnerBuilder()
+    {
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(ImmutableMap.<String, String>builder()
+                        .put("iceberg.file-format", format.name())
+                        // Allows testing the sorting writer flushing to the file system with smaller tables
+                        .put("iceberg.allowed-extra-properties", "extra.property.one,extra.property.two,extra.property.three,sorted_by")
+                        .put("iceberg.writer-sort-buffer-size", "1MB")
+                        .put("iceberg.write-delete-mode", "cow")
+                        .put("iceberg.write-update-mode", "cow")
+                        .put("iceberg.write-merge-mode", "cow")
+                        .buildOrThrow())
+                .setInitialTables(REQUIRED_TPCH_TABLES);
+    }
+
+    public TestIcebergCopyOnWriteConnectorTest()
+    {
+        super(PARQUET, COW);
+    }
+
+    @Override
+    protected boolean supportsIcebergFileStatistics(String typeName)
+    {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsRowGroupStatistics(String typeName)
+    {
+        return
+            !(typeName.equalsIgnoreCase("varbinary") ||
+                    typeName.equalsIgnoreCase("time") ||
+                    typeName.equalsIgnoreCase("time(6)") ||
+                    typeName.equalsIgnoreCase("timestamp(3) with time zone") ||
+                    typeName.equalsIgnoreCase("timestamp(6) with time zone"));
+    }
+
+    @Override
+    protected boolean supportsPhysicalPushdown()
+    {
+        return true;
+    }
+
+    @Test
+    public void testMergeSimpleUpdate()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_MERGE));
+
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String targetTable = "merge_simple_target_" + randomNameSuffix();
+            String sourceTable = "merge_simple_source_" + randomNameSuffix();
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) " + "with (format = '" + fileFormat + "')", targetTable, Optional.of("customer"));
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch')", targetTable), 1);
+
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR) " + "with (format = '" + fileFormat + "')", sourceTable, Optional.empty());
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Arches')", sourceTable), 1);
+
+            assertUpdate(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
+                    "    WHEN MATCHED AND s.address = 'Centreville' THEN DELETE" +
+                    "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address" +
+                    "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)", 1);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 11, 'Arches')");
+
+            assertUpdate("DROP TABLE " + sourceTable);
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testMergeSimpleDelete()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_MERGE));
+
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String targetTable = "merge_simple_target_" + randomNameSuffix();
+            String sourceTable = "merge_simple_source_" + randomNameSuffix();
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", targetTable, Optional.of("customer"));
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch')", targetTable), 1);
+
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", sourceTable, Optional.empty());
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Arches')", sourceTable), 1);
+
+            assertUpdate(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
+                    "    WHEN MATCHED AND s.address = 'Arches' THEN DELETE" +
+                    "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address" +
+                    "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)", 1);
+
+            assertQuery("SELECT count(*) FROM " + targetTable, "SELECT 0");
+
+            assertUpdate("DROP TABLE " + sourceTable);
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testMergeSimpleInsert()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_MERGE));
+
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String targetTable = "merge_simple_target_" + randomNameSuffix();
+            String sourceTable = "merge_simple_source_" + randomNameSuffix();
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", targetTable, Optional.of("customer"));
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
+
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", sourceTable, Optional.empty());
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Arches'), ('Ed', 7, 'Etherville'), ('Carol', 9, 'Centreville'), ('Dave', 11, 'Darbyshire')", sourceTable), 4);
+
+            assertUpdate(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
+                    "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)", 1);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon'), ('Ed', 7, 'Etherville')");
+
+            assertUpdate("DROP TABLE " + sourceTable);
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testSimpleDelete()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_DELETE));
+
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String targetTable = "delete_simple_target_" + randomNameSuffix();
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", targetTable, Optional.of("customer"));
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'),('Dog', 6, 'Dogma'), ('Carol', 3, 'Cambridge')", targetTable), 3);
+
+            assertUpdate("DELETE FROM " + targetTable + " WHERE purchases <= 4", 1);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 5, 'Antioch'),('Dog', 6, 'Dogma')");
+
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Test
+    public void testMergeSimpleUpdateInsert()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_MERGE));
+
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String targetTable = "merge_simple_target_" + randomNameSuffix();
+            String sourceTable = "merge_simple_source_" + randomNameSuffix();
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", targetTable, Optional.of("customer"));
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
+
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", sourceTable, Optional.empty());
+
+            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Arches'), ('Ed', 7, 'Etherville'), ('Carol', 9, 'Centreville'), ('Dave', 11, 'Darbyshire')", sourceTable), 4);
+
+            assertUpdate(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
+                    "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address" +
+                    "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)", 4);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 11, 'Arches'), ('Ed', 7, 'Etherville'), ('Bill', 7, 'Buena'), ('Carol', 12, 'Centreville'), ('Dave', 22, 'Darbyshire')");
+
+            assertUpdate("DROP TABLE " + sourceTable);
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+//    @Test
+//    public void testMergeSimpleSelect()
+//    {
+//        skipTestUnless(hasBehavior(SUPPORTS_MERGE));
+//
+//        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+//            String targetTable = "merge_simple_target_" + randomNameSuffix();
+//            String sourceTable = "merge_simple_source_" + randomNameSuffix();
+//            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", targetTable, Optional.of("customer"));
+//
+//            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 5, 'Antioch'), ('Bill', 7, 'Buena'), ('Carol', 3, 'Cambridge'), ('Dave', 11, 'Devon')", targetTable), 4);
+//
+//            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchases INT, address VARCHAR)" + "with (format = '" + fileFormat + "')", sourceTable, Optional.empty());
+//
+//            assertUpdate(format("INSERT INTO %s (customer, purchases, address) VALUES ('Aaron', 6, 'Arches'), ('Ed', 7, 'Etherville'), ('Carol', 9, 'Centreville'), ('Dave', 11, 'Darbyshire')", sourceTable), 4);
+//
+//            assertUpdate(format("MERGE INTO %s t USING %s s ON (t.customer = s.customer)", targetTable, sourceTable) +
+//                    "    WHEN MATCHED AND s.address = 'Centreville' THEN DELETE" +
+//                    "    WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address" +
+//                    "    WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES(s.customer, s.purchases, s.address)", 4);
+//
+//            assertQuery("SELECT * FROM " + targetTable, "VALUES ('Aaron', 11, 'Arches'), ('Ed', 7, 'Etherville'), ('Bill', 7, 'Buena'), ('Dave', 22, 'Darbyshire')");
+//
+//            assertUpdate("DROP TABLE " + sourceTable);
+//            assertUpdate("DROP TABLE " + targetTable);
+//        }
+//    }
+
+    @Test
+    public void testCopyOnWriteUpdate()
+    {
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String tableName = "test_update" + randomNameSuffix();
+            assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "')" + " AS SELECT * FROM nation", 25);
+
+            assertUpdate("UPDATE " + tableName + " SET nationkey = 100 + nationkey WHERE regionkey = 2", 5);
+            assertThat(query("SELECT * FROM " + tableName))
+                    .skippingTypesCheck()
+                    .matches("SELECT IF(regionkey=2, nationkey + 100, nationkey) nationkey, name, regionkey, comment FROM tpch.tiny.nation");
+            assertQuery(
+                    "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                    "VALUES '0'");
+
+            // UPDATE after UPDATE
+            assertUpdate("UPDATE " + tableName + " SET nationkey = nationkey * 2 WHERE regionkey IN (2,3)", 10);
+            assertThat(query("SELECT * FROM " + tableName))
+                    .skippingTypesCheck()
+                    .matches("SELECT CASE regionkey WHEN 2 THEN 2*(nationkey+100) WHEN 3 THEN 2*nationkey ELSE nationkey END nationkey, name, regionkey, comment FROM tpch.tiny.nation");
+            // Undeterministic number of files added, just check there is no delete files
+            assertQuery(
+                    "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                    "VALUES '0'");
+        }
+    }
+
+    @Test
+    public void testCopyOnWriteUpdateMixed()
+    {
+        for (WriteChangeMode mode : WriteChangeMode.values()) {
+            for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+                String tableName = "test_update" + randomNameSuffix();
+                assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "')" + " AS SELECT * FROM nation", 25);
+
+                mode = mode.alternate();
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_update_mode = '" + mode + "'");
+                assertUpdate("UPDATE " + tableName + " SET nationkey = 100 + nationkey WHERE regionkey = 2", 5);
+                assertThat(query("SELECT * FROM " + tableName))
+                        .skippingTypesCheck()
+                        .matches("SELECT IF(regionkey=2, nationkey + 100, nationkey) nationkey, name, regionkey, comment FROM tpch.tiny.nation");
+
+                // UPDATE after UPDATE
+                mode = mode.alternate();
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_update_mode = '" + mode + "'");
+                assertUpdate("UPDATE " + tableName + " SET nationkey = nationkey * 2 WHERE regionkey IN (2,3)", 10);
+                assertThat(query("SELECT * FROM " + tableName))
+                        .skippingTypesCheck()
+                        .matches("SELECT CASE regionkey WHEN 2 THEN 2*(nationkey+100) WHEN 3 THEN 2*nationkey ELSE nationkey END nationkey, name, regionkey, comment FROM tpch.tiny.nation");
+            }
+        }
+    }
+
+    @Test
+    public void testCopyOnWriteMerge()
+    {
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            String targetTable = "merge_various_target_" + randomNameSuffix();
+            String sourceTable = "merge_various_source_" + randomNameSuffix();
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR)" + " with (format = '" + fileFormat + "')", targetTable, Optional.empty());
+
+            assertUpdate(format("INSERT INTO %s (customer, purchase) VALUES ('Dave', 'dates'), ('Lou', 'limes'), ('Carol', 'candles')", targetTable), 3);
+
+            createTableForWrites("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR)" + " with (format = '" + fileFormat + "')", sourceTable, Optional.empty());
+
+            assertUpdate(format("INSERT INTO %s (customer, purchase) VALUES ('Craig', 'candles'), ('Len', 'limes'), ('Joe', 'jellybeans')", sourceTable), 3);
+
+            assertUpdate(format("MERGE INTO %s t USING %s s ON (t.purchase = s.purchase)", targetTable, sourceTable) +
+                    "    WHEN MATCHED AND s.purchase = 'limes' THEN DELETE" +
+                    "    WHEN MATCHED THEN UPDATE SET customer = CONCAT(t.customer, '_', s.customer)" +
+                    "    WHEN NOT MATCHED THEN INSERT (customer, purchase) VALUES(s.customer, s.purchase)", 3);
+
+            assertQuery("SELECT * FROM " + targetTable, "VALUES ('Dave', 'dates'), ('Carol_Craig', 'candles'), ('Joe', 'jellybeans')");
+
+            assertQuery(
+                    "SELECT summary['total-delete-files'] FROM \"" + targetTable + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(targetTable),
+                    "VALUES '0'");
+
+            assertUpdate("DROP TABLE " + sourceTable);
+            assertUpdate("DROP TABLE " + targetTable);
+        }
+    }
+
+    @Override
+    protected Optional<TypeCoercionTestSetup> filterTypeCoercionOnCreateTableAsSelectProvider(TypeCoercionTestSetup setup)
+    {
+        return Optional.of(setup);
+    }
+
+    @Test
+    public void testCopyOnWriteDeleteMixed()
+    {
+        // delete successive parts of the table
+        for (WriteChangeMode mode : WriteChangeMode.values()) {
+            for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+                String tableName = "test_delete_" + randomNameSuffix();
+                assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "')" + " AS SELECT * FROM orders", 15000);
+
+                mode = mode.alternate();
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_delete_mode = '" + mode + "'");
+                assertUpdate("DELETE FROM " + tableName + " WHERE custkey <= 100", "SELECT count(*) FROM orders WHERE custkey <= 100");
+                assertQuery("SELECT * FROM " + tableName, "SELECT * FROM orders WHERE custkey > 100");
+
+                mode = mode.alternate();
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_delete_mode = '" + mode + "'");
+                assertUpdate("DELETE FROM " + tableName + " WHERE custkey <= 300", "SELECT count(*) FROM orders WHERE custkey > 100 AND custkey <= 300");
+                assertQuery("SELECT * FROM " + tableName, "SELECT * FROM orders WHERE custkey > 300");
+
+                mode = mode.alternate();
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_delete_mode = '" + mode + "'");
+                assertUpdate("DELETE FROM " + tableName + " WHERE custkey <= 500", "SELECT count(*) FROM orders WHERE custkey > 300 AND custkey <= 500");
+                assertQuery("SELECT * FROM " + tableName, "SELECT * FROM orders WHERE custkey > 500");
+            }
+        }
+    }
+
+    @Override
+    @Test
+    public void testOptimizeTableAfterDeleteWithFormatVersion2()
+    {
+        String tableName = "test_optimize_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", 25);
+
+        List<String> initialFiles = getActiveFiles(tableName);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 7", 1);
+
+        // Verify that delete files do not exist
+        assertQuery(
+                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                "VALUES '0'");
+
+        // Verify that data files are added and removed
+        assertQuery(
+                "SELECT summary['added-data-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                "VALUES '1'");
+
+        // For optimize we need to set task_writer_count to 1, otherwise it will create more than one file.
+        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+
+        List<String> updatedFiles = getActiveFiles(tableName);
+        assertThat(updatedFiles)
+                .hasSize(1)
+                .isNotEqualTo(initialFiles);
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("SELECT * FROM nation WHERE nationkey != 7");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private List<String> getActiveFiles(String tableName)
+    {
+        return computeActual(format("SELECT file_path FROM \"%s$files\"", tableName)).getOnlyColumn()
+                .map(String.class::cast)
+                .collect(toImmutableList());
+    }
+
+    private Session withSingleWriterPerTask(Session session)
+    {
+        return Session.builder(session)
+                .setSystemProperty("task_min_writer_count", "1")
+                .build();
+    }
+
+    private Session with(Session session)
+    {
+        return Session.builder(session)
+                .setSystemProperty("task_min_writer_count", "1")
+                .build();
+    }
+
+    private long getCurrentSnapshotId(String tableName)
+    {
+        return (long) computeScalar("SELECT snapshot_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES");
+    }
+
+    @Override
+    @Test
+    public void testOptimizeCleansUpDeleteFiles()
+            throws IOException
+    {
+        String tableName = "test_optimize_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM nation", 25);
+
+        List<String> allDataFilesInitially = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(allDataFilesInitially).hasSize(5);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 7", 1);
+
+        assertQuery(
+                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                "VALUES '0'");
+
+        List<String> allDataFilesAfterDelete = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(allDataFilesAfterDelete).hasSize(6);
+
+        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE WHERE regionkey = 3");
+        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        assertQuery(
+                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                "VALUES '0'");
+        List<String> allDataFilesAfterOptimizeWithWhere = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(allDataFilesAfterOptimizeWithWhere)
+                .hasSize(5)
+                .doesNotContain(allDataFilesInitially.stream().filter(file -> file.contains("regionkey=3"))
+                        .toArray(String[]::new))
+                .contains(allDataFilesInitially.stream().filter(file -> !file.contains("regionkey=3"))
+                        .toArray(String[]::new));
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("SELECT * FROM nation WHERE nationkey != 7");
+
+        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        assertQuery(
+                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
+                "VALUES '0'");
+        List<String> allDataFilesAfterFullOptimize = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(allDataFilesAfterFullOptimize)
+                .hasSize(5)
+                // All files skipped from OPTIMIZE as they have no deletes and there's only one file per partition
+                .contains(allDataFilesAfterOptimizeWithWhere.toArray(new String[0]));
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("SELECT * FROM nation WHERE nationkey != 7");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Override
+    @Test
+    public void testOptimizeFilesDoNotInheritSequenceNumber()
+            throws IOException
+    {
+        String tableName = "test_optimize_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation", 25);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 7", 1);
+
+        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+
+        List<IcebergEntry> activeEntries = getIcebergEntries(tableName);
+        assertThat(activeEntries).hasSize(2);
+
+        assertThat(activeEntries.stream().filter(entry -> entry.status() == 2))
+                .hasSize(1)
+                .allMatch(entry -> entry.sequenceNumber().equals(entry.fileSequenceNumber()));
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("SELECT * FROM nation WHERE nationkey != 7");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testRowGroupResetDictionary()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_row_group_reset_dictionary",
+                "(plain_col varchar, dict_col int)")) {
+            String tableName = table.getName();
+            String values = IntStream.range(0, 100)
+                    .mapToObj(i -> "('ABCDEFGHIJ" + i + "' , " + (i < 20 ? "1" : "null") + ")")
+                    .collect(Collectors.joining(", "));
+            assertUpdate(withSmallRowGroups(getSession()), "INSERT INTO " + tableName + " VALUES " + values, 100);
+
+            MaterializedResult result = getDistributedQueryRunner().execute(String.format("SELECT * FROM %s", tableName));
+            assertThat(result.getRowCount()).isEqualTo(100);
+        }
+    }
+
+    @Test
+    public void testMixedTableChange()
+    {
+        // This test iterates through every file format and every combination of write modes (COW vs. MOR)
+        // to ensure the final table state is correct regardless of the underlying mechanism used for each DML operation.
+        for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+            for (WriteChangeMode updateMode : WriteChangeMode.values()) {
+                for (WriteChangeMode deleteMode : WriteChangeMode.values()) {
+                    for (WriteChangeMode mergeMode : WriteChangeMode.values()) {
+                        String tableName = "test_mixed_table_" + randomNameSuffix();
+                        String sourceName = "test_mixed_source_" + randomNameSuffix();
+
+                        try {
+                            // 1. SETUP: Create a target table with 25 rows and a source for the MERGE
+                            assertUpdate("CREATE TABLE " + tableName +
+                                    " WITH (format = '" + fileFormat + "')" +
+                                    " AS SELECT nationkey AS id, name AS data, regionkey FROM nation", 25);
+                            assertUpdate("CREATE TABLE " + sourceName +
+                                    " WITH (format = '" + fileFormat + "')" +
+                                    " AS SELECT nationkey AS id, name AS data, regionkey FROM nation WHERE regionkey = 1", 5);
+
+                            // 2. UPDATE: Use the mode for the current iteration (cow or merge-on-read)
+                            assertUpdate(format("ALTER TABLE %s SET PROPERTIES write_update_mode = '%s'", tableName, updateMode.name()));
+                            assertUpdate("UPDATE " + tableName + " SET data = 'UPDATED' WHERE id = 1", 1);
+                            // Simple verification that the update was successful
+                            assertQuery("SELECT data FROM " + tableName + " WHERE id = 1", "VALUES 'UPDATED'");
+
+                            // 3. DELETE: Use the mode for the current iteration
+                            assertUpdate(format("ALTER TABLE %s SET PROPERTIES write_delete_mode = '%s'", tableName, deleteMode.name()));
+                            assertUpdate("DELETE FROM " + tableName + " WHERE id = 10", 1);
+                            // Simple verification that the delete was successful
+                            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 24");
+
+                            // 4. MERGE: Use the mode for the current iteration
+                            // Add a new row to the source to test the 'NOT MATCHED' clause
+                            assertUpdate("INSERT INTO " + sourceName + " (id, data, regionkey) VALUES (100, 'NEW_ROW', 42)", 1);
+                            assertUpdate(format("ALTER TABLE %s SET PROPERTIES write_merge_mode = '%s'", tableName, mergeMode.name()));
+                            String mergeSql = format(
+                                    "MERGE INTO %s t USING %s s ON (t.id = s.id) " +
+                                            "WHEN MATCHED AND s.id = 1 THEN UPDATE SET data = 'MERGED' " +
+                                            "WHEN MATCHED AND s.id = 2 THEN DELETE " +
+                                            "WHEN NOT MATCHED THEN INSERT (id, data, regionkey) VALUES (s.id, s.data, s.regionkey)",
+                                    tableName, sourceName);
+                            assertUpdate(mergeSql, 3);
+
+                            // 5. FINAL VERIFICATION: Check the final state of the data.
+                            // This block of assertions is the same for all mode combinations.
+                            // Initial 25 -> DELETE -> 24 -> MERGE (1 delete, 1 insert) -> 24 rows final
+                            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 24");
+                            assertQuery("SELECT data FROM " + tableName + " WHERE id = 1", "VALUES 'MERGED'"); // Row was updated by MERGE
+                            assertQuery("SELECT count(*) FROM " + tableName + " WHERE id = 2", "SELECT 0"); // Row was deleted by MERGE
+                            assertQuery("SELECT data FROM " + tableName + " WHERE id = 100", "VALUES 'NEW_ROW'"); // Row was inserted by MERGE
+                            assertQuery("SELECT count(*) FROM " + tableName + " WHERE id = 10", "SELECT 0"); // Row from earlier DELETE is still gone
+                        }
+                        finally {
+                            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+                            assertUpdate("DROP TABLE IF EXISTS " + sourceName);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMixedTableChange2()
+    {
+        for (WriteChangeMode mode : WriteChangeMode.values()) {
+            for (IcebergFileFormat fileFormat : IcebergFileFormat.values()) {
+                String tableName = "test_mixed_" + randomNameSuffix();
+
+                // Create and populate the target table
+                assertUpdate("CREATE TABLE " + tableName + " (id integer, value varchar) with (format = '" + fileFormat + "')");
+                assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')", 4);
+
+                // Update with mode
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_update_mode = '" + mode + "'");
+                assertUpdate("UPDATE " + tableName + " SET value = 'updated_' || value WHERE id = 2", 1);
+
+                // Delete with alternate mode
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_delete_mode = '" + mode.alternate() + "'");
+                assertUpdate("DELETE FROM " + tableName + " WHERE id = 3", 1);
+
+                // Create and populate the source table for merge
+                String sourceTable = "source_" + randomNameSuffix();
+                assertUpdate("CREATE TABLE " + sourceTable + " (id integer, value varchar) with (format = '" + fileFormat + "')");
+                assertUpdate("INSERT INTO " + sourceTable + " VALUES (2, 'merged_two'), (5, 'five')", 2);
+
+                // Merge with mode
+                assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES write_merge_mode = '" + mode + "'");
+                assertUpdate(
+                        "MERGE INTO " + tableName + " t USING " + sourceTable + " s ON t.id = s.id " +
+                                "WHEN MATCHED THEN UPDATE SET value = s.value " +
+                                "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)",
+                        2);
+
+                // Verify the final state
+                assertQuery(
+                        "SELECT * FROM " + tableName + " ORDER BY id",
+                        "VALUES (1, 'one'), (2, 'merged_two'), (4, 'four'), (5, 'five')");
+
+                // Clean up
+                assertUpdate("DROP TABLE " + sourceTable);
+                assertUpdate("DROP TABLE " + tableName);
+            }
+        }
+    }
+
+    @Override
+    protected Optional<SetColumnTypeSetup> filterSetColumnTypesDataProvider(SetColumnTypeSetup setup)
+    {
+        switch ("%s -> %s".formatted(setup.sourceColumnType(), setup.newColumnType())) {
+            case "row(x integer) -> row(y integer)":
+                // TODO https://github.com/trinodb/trino/issues/15822 The connector returns incorrect NULL when a field in row type doesn't exist in Parquet files
+                return Optional.of(setup.withNewValueLiteral("NULL"));
+        }
+        return super.filterSetColumnTypesDataProvider(setup);
+    }
+
+    @Override
+    @Test
+    public void testUpdateWithSortOrder()
+    {
+        Session withSmallRowGroupsAndLowMaxWriterCount = withLowMaxWriterCount(withSmallRowGroups(getSession()));
+
+        try (TestTable table = newTrinoTable(
+                "test_sorted_update",
+                "WITH (sorted_by = ARRAY['comment']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
+            assertUpdate(
+                    withSmallRowGroupsAndLowMaxWriterCount,
+                    "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
+                    "VALUES 1500");
+            assertUpdate(withSmallRowGroupsAndLowMaxWriterCount, "UPDATE " + table.getName() + " SET comment = substring(comment, 2)", 1500);
+            assertQuery(
+                    "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, comment FROM " + table.getName(),
+                    "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, substring(comment, 2) FROM customer");
+            for (Object filePath : computeActual("SELECT file_path from \"" + table.getName() + "$files\" WHERE content != 1").getOnlyColumnAsSet()) {
+                assertThat(isFileSorted((String) filePath, "comment")).isTrue();
+            }
+        }
+    }
+
+    @Override
+    protected boolean isFileSorted(String path, String sortColumnName)
+    {
+        return checkParquetFileSorting(
+                fileSystem.newInputFile(Location.of(path)),
+                sortColumnName);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -31,6 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.io.Resources.getResource;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
+import static io.trino.plugin.iceberg.WriteChangeMode.MOR;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
@@ -50,7 +51,7 @@ public class TestIcebergMinioOrcConnectorTest
 
     public TestIcebergMinioOrcConnectorTest()
     {
-        super(ORC);
+        super(ORC, MOR);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -175,7 +175,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             TupleDomain<ColumnHandle> splitPruningPredicate = TupleDomain.withColumnDomains(
@@ -235,7 +236,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             try (ConnectorPageSource emptyPageSource = createTestingPageSource(transaction, icebergConfig, split, tableHandle, ImmutableList.of(keyColumnHandle, dataColumnHandle), getDynamicFilter(splitPruningPredicate))) {
@@ -345,7 +347,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably
@@ -506,7 +509,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
@@ -35,6 +35,7 @@ import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getParquetFileMetadata;
 import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
+import static io.trino.plugin.iceberg.WriteChangeMode.MOR;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,7 +45,7 @@ public class TestIcebergParquetConnectorTest
 {
     public TestIcebergParquetConnectorTest()
     {
-        super(PARQUET);
+        super(PARQUET, MOR);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -475,6 +475,7 @@ public class TestIcebergSplitSource
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
@@ -178,8 +178,11 @@ final class TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest
                         "WITH \\(\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
-                        format("   location = '.*/" + schemaName + "/region.*'\n") +
-                        "\\)");
+                        format("   location = '.*/" + schemaName + "/region.*',\n" +
+                        "   write_delete_mode = 'MOR',\n" +
+                        "   write_merge_mode = 'MOR',\n" +
+                        "   write_update_mode = 'MOR'\n" +
+                        "\\)"));
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -175,7 +175,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -259,7 +260,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle column = IcebergColumnHandle.optional(primitiveColumnIdentity(1, "a")).columnType(INTEGER).build();
@@ -310,7 +312,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle columnA = IcebergColumnHandle.optional(primitiveColumnIdentity(0, "a")).columnType(INTEGER).build();
@@ -371,7 +374,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle bigintColumn = IcebergColumnHandle.optional(primitiveColumnIdentity(1, "just_bigint")).columnType(BIGINT).build();

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
@@ -82,6 +82,7 @@ import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.connector.UpdateKind;
 import io.trino.spi.connector.WriterScalingOptions;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -151,8 +152,14 @@ public class LakehouseMetadata
     @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion)
     {
+        return getTableHandle(session, tableName, startVersion, endVersion, Optional.empty());
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion, Optional<UpdateKind> updateKind)
+    {
         if (isIcebergTableName(tableName.getTableName()) && isMaterializedViewStorage(tableName.getTableName())) {
-            return icebergMetadata.getTableHandle(session, tableName, startVersion, endVersion);
+            return icebergMetadata.getTableHandle(session, tableName, startVersion, endVersion, updateKind);
         }
 
         Table table = hiveMetadata.getMetastore()
@@ -162,7 +169,7 @@ public class LakehouseMetadata
             return null;
         }
         if (isIcebergTable(table)) {
-            return icebergMetadata.getTableHandle(session, tableName, startVersion, endVersion);
+            return icebergMetadata.getTableHandle(session, tableName, startVersion, endVersion, updateKind);
         }
         if (isDeltaLakeTable(table)) {
             return deltaMetadata.getTableHandle(session, tableName, startVersion, endVersion);

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
@@ -133,7 +133,10 @@ public abstract class BaseLakehouseConnectorSmokeTest
                    format = 'ORC',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/create_iceberg-.*'\\Q,
-                   type = 'ICEBERG'
+                   type = 'ICEBERG',
+                   write_delete_mode = 'MOR',
+                   write_merge_mode = 'MOR',
+                   write_update_mode = 'MOR'
                 )\\E""");
 
         assertUpdate("DROP TABLE create_iceberg");

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
@@ -362,7 +362,10 @@ public class TestLakehouseConnectorTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/orders-.*'\\Q,
-                   type = 'ICEBERG'
+                   type = 'ICEBERG',
+                   write_delete_mode = 'MOR',
+                   write_merge_mode = 'MOR',
+                   write_update_mode = 'MOR'
                 )\\E""");
     }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFileConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFileConnectorSmokeTest.java
@@ -100,7 +100,10 @@ public class TestLakehouseFileConnectorSmokeTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = 's3://test-bucket/tpch/region-\\E.*\\Q',
-                   type = 'ICEBERG'
+                   type = 'ICEBERG',
+                   write_delete_mode = 'MOR',
+                   write_merge_mode = 'MOR',
+                   write_update_mode = 'MOR'
                 )\\E""");
     }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -41,7 +41,10 @@ public class TestLakehouseIcebergConnectorSmokeTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/region-.*'\\Q,
-                   type = 'ICEBERG'
+                   type = 'ICEBERG',
+                   write_delete_mode = 'MOR',
+                   write_merge_mode = 'MOR',
+                   write_update_mode = 'MOR'
                 )\\E""");
     }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseMotoConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseMotoConnectorSmokeTest.java
@@ -78,7 +78,10 @@ public class TestLakehouseMotoConnectorSmokeTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = 's3://test-bucket/tpch/region-\\E.*\\Q',
-                   type = 'ICEBERG'
+                   type = 'ICEBERG',
+                   write_delete_mode = 'MOR',
+                   write_merge_mode = 'MOR',
+                   write_update_mode = 'MOR'
                 )\\E""");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -298,7 +298,10 @@ public class TestHiveRedirectionToIceberg
                         "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         format("   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/%s-\\E.*\\Q',\n", tableName) +
-                        "   partitioning = ARRAY['regionkey']\n" + // 'partitioning' comes from Iceberg
+                        "   partitioning = ARRAY['regionkey'],\n" + // 'partitioning' comes from Iceberg
+                        "   write_delete_mode = 'MOR',\n" +
+                        "   write_merge_mode = 'MOR',\n" +
+                        "   write_update_mode = 'MOR'\n" +
                         ")\\E");
 
         onTrino().executeQuery("DROP TABLE " + icebergTableName);


### PR DESCRIPTION
This PR adds support for COW support for Iceberg Connector.

For the user interface part, we respect iceberg specification https://iceberg.apache.org/docs/latest/configuration/#write-properties add add three table properties ```write_delete_mode```, ```write_update_mode```, ```write_merge_mode```, to control the write behavior of each specific table change operation, node that this is consistent with other popular engines like Spark and Dremio: https://docs.dremio.com/25.x/sonar/query-manage/data-formats/apache-iceberg/table-properties/.

Since all three operations(delete, write, merge) would use the same ```MergeWriterOperator```during table write, the engine is not able to tell which operation is in changing the table from inside ```MergeWriterOperator``` and ```IcebergMeatdata.getMergeRowIdColumnHandle``` to decide either to use COW or MOR to perform the table change. This PR adds an optional field called ```UpdateKind``` in ```IcebertTableHandle``` in order to the record operation being performed on the table. This field is populated by ```metata.getTableHandle``` by adding a new parameter ```UpdateKind```, which is retrieved at ```StatementAnalyzer```. 


As for the COW implementation part, we choose to implement it based on the current MOR implementation framework(MergeProcessOperator+MergeWriterOperator) similar to the COW implementation in Deltalake Connector. The general idea is to rewrite the changed data files based on current data file contents and the delta information from the current change operation. The current data file path is already embedded in the pages for the MOR implementation, and we can read the current data file contents from this path, the delta calculating is also already available for the MOR implementation, however, one caveat is that the data file may also contain several delete files, which should be used to calculate the new version of the data file but is not being embeded in the pages in the current MOR implementation, so we also embed delete files information for the COW implementation.

User facing docs will be updated as when the reviewers are satisfied with the implementation. 

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix https://github.com/trinodb/trino/issues/17272

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```