### PR TITLE
Expose column default in `information_schema.columns` table

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -255,7 +255,7 @@ public class InformationSchemaPageSource
                         tableName.getTableName(),
                         column.getName(),
                         ordinalPosition,
-                        null,
+                        column.getDefaultValue().orElse(null),
                         column.isNullable() ? "YES" : "NO",
                         getDisplayLabel(column.getType(), isOmitDateTimeTypePrecision(session)),
                         column.getComment(),

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryDefaultColumnValue.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryDefaultColumnValue.java
@@ -194,6 +194,15 @@ public class TestMemoryDefaultColumnValue
         assertDefaultValue("TIMESTAMP(12) WITH TIME ZONE", "TIMESTAMP '1970-01-01 00:00:00.999999999999 UTC'");
     }
 
+    @Test
+    void testInformationSchema()
+    {
+        try (TestTable table = newTrinoTable("test_default_value", "(id int, data int DEFAULT 123)")) {
+            assertThat((String) computeScalar("SELECT column_default FROM information_schema.columns WHERE table_name = '" + table.getName() + "' AND column_name = 'data'"))
+                    .isEqualTo("123");
+        }
+    }
+
     private void assertDefaultValue(@Language("SQL") String columnType, @Language("SQL") String defaultValue)
     {
         assertDefaultValue(columnType, defaultValue, defaultValue);


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
