### PR TITLE
Fix column type index in MemoryPagesStore

### DIFF
--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPagesStore.java
@@ -117,7 +117,7 @@ public class MemoryPagesStore
             }
             // Append missing columns with null values. This situation happens when a new column is added without additional insert.
             for (int j = page.getChannelCount(); j < columnIndexes.length; j++) {
-                page = page.appendColumn(RunLengthEncodedBlock.create(columnTypes.get(i), null, page.getPositionCount()));
+                page = page.appendColumn(RunLengthEncodedBlock.create(columnTypes.get(j), null, page.getPositionCount()));
             }
             partitionedPages.add(page.getColumns(columnIndexes));
         }


### PR DESCRIPTION
## Description
Follows up on https://github.com/trinodb/trino/pull/26140 by addressing [this comment](https://github.com/trinodb/trino/pull/26140#discussion_r2195668539) pointing out that the wrong loop index variable was being used for the RLE blocks attached.

Marking this change as not user visible since the introduced bug has not yet been released.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
