### PR TITLE
Fix Pinot connector to respect pinot.broker-url when proxy is enabled

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConfig.java
@@ -270,4 +270,10 @@ public class PinotConfig
                 .distinct()
                 .count() == 1;
     }
+
+    @AssertTrue(message = "Invalid configuration: pinot.broker-url and pinot.proxy.enabled cannot both be set.")
+    public boolean isValidBrokerProxyConfiguration()
+    {
+        return !(brokerUrl.isPresent() && proxyEnabled);
+    }
 }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -170,7 +170,7 @@ public class PinotClient
                 asyncReloading(CacheLoader.from(this::getAllTables), executor));
         this.controllerAuthenticationProvider = controllerAuthenticationProvider;
         this.brokerAuthenticationProvider = brokerAuthenticationProvider;
-        brokerHostAndPort = config.getBrokerUrl();
+        this.brokerHostAndPort = config.getBrokerUrl();
     }
 
     public static void addJsonBinders(JsonCodecBinder jsonCodecBinder)

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConfig.java
@@ -68,7 +68,6 @@ public class TestPinotConfig
                 .put("pinot.max-rows-for-broker-queries", "5000")
                 .put("pinot.aggregation-pushdown.enabled", "false")
                 .put("pinot.count-distinct-pushdown.enabled", "false")
-                .put("pinot.proxy.enabled", "true")
                 .put("pinot.target-segment-page-size", "2MB")
                 .buildOrThrow();
 
@@ -85,7 +84,6 @@ public class TestPinotConfig
                 .setMaxRowsForBrokerQueries(5000)
                 .setAggregationPushdownEnabled(false)
                 .setCountDistinctPushdownEnabled(false)
-                .setProxyEnabled(true)
                 .setTargetSegmentPageSize(DataSize.of(2, MEGABYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);
@@ -100,6 +98,18 @@ public class TestPinotConfig
                         .setCountDistinctPushdownEnabled(true),
                 "validConfiguration",
                 "Invalid configuration: pinot.aggregation-pushdown.enabled must be enabled if pinot.count-distinct-pushdown.enabled",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testInvalidBrokerProxyConfiguration()
+    {
+        assertFailsValidation(
+                new PinotConfig()
+                        .setBrokerUrl(HostAndPort.fromString("host1:1111"))
+                        .setProxyEnabled(true),
+                "validBrokerProxyConfiguration",
+                "Invalid configuration: pinot.broker-url and pinot.proxy.enabled cannot both be set.",
                 AssertTrue.class);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->

<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add configuration validation to prevent conflicting `pinot.broker-url` and `pinot.proxy.enabled` settings in the Pinot connector. 

Previously, users could configure both `pinot.broker-url` and `pinot.proxy.enabled=true` simultaneously, which would result in confusing behavior where the explicit broker URL would silently take precedence over the proxy setting without any indication to the user.

**Changes made:**
- Add `@AssertTrue` validation in `PinotConfig.isValidBrokerProxyConfiguration()` to reject conflicting settings

Related to: https://github.com/trinodb/trino/issues/25747

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
