### PR TITLE
Handle already closed JDBC connections gracefully

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionAlreadyClosedException.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionAlreadyClosedException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+public class ConnectionAlreadyClosedException
+        extends RuntimeException
+{
+    public ConnectionAlreadyClosedException(String message)
+    {
+        super(message);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -238,6 +238,9 @@ public class JdbcPageSink
                 connection.close();
             }
         }
+        catch (ConnectionAlreadyClosedException e) {
+            // the connection already closed
+        }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
@@ -22,7 +22,6 @@ import jakarta.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -70,7 +69,10 @@ public final class LazyConnectionFactory
         protected synchronized Connection delegate()
                 throws SQLException
         {
-            checkState(!closed, "Connection is already closed");
+            if (closed) {
+                throw new ConnectionAlreadyClosedException("Connection is already closed");
+            }
+
             if (connection == null) {
                 connection = requireNonNull(connectionSupplier.get(), "connectionSupplier.get() is null");
             }


### PR DESCRIPTION
Introduces `ConnectionAlreadyClosedException` to signal attempts to
use closed JDBC connections. Updates `LazyConnectionFactory` to throw
this exception when a closed connection is accessed, and updates
`JdbcPageSink` to handle this exception without error

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
