### PR TITLE
Adding retry for on the fly trino_queries table creation for MySql event listener

### DIFF
--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -33,14 +33,12 @@ import io.trino.spi.eventlistener.SplitCompletedEvent;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import jakarta.annotation.PostConstruct;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Implement an EventListener that stores information in a MySQL database
@@ -173,11 +171,11 @@ public class MysqlEventListener
                     log.info("Successfully created table and starting to store query event.");
                 }
                 catch (Exception retryEx) {
-                    log.error("Retry failed: Could not create table or store query event (%s): %s", retryEx.getClass().getSimpleName(), retryEx.getMessage(), retryEx);
+                    log.error("Retry failed: Could not create table or store query event (%s): %s", retryEx.getClass().getSimpleName(), retryEx.getMessage());
                 }
             }
             else {
-                log.error("Failed to store query event (%s): %s", e.getClass().getSimpleName(), e.getMessage(), e);
+                log.error("Failed to store query event (%s): %s", e.getClass().getSimpleName(), e.getMessage());
             }
         }
     }

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -173,11 +173,11 @@ public class MysqlEventListener
                     log.info("Successfully created table and starting to store query event.");
                 }
                 catch (Exception retryEx) {
-                    log.error("Retry failed: Could not create table or store query event (%s): %s", retryEx.getClass().getSimpleName(), retryEx.getMessage(), retryEx);
+                    log.error("Retry failed: Could not create table or store query event (%s): %s", retryEx.getClass().getSimpleName(), retryEx.getMessage());
                 }
             }
             else {
-                log.error("Failed to store query event (%s): %s", e.getClass().getSimpleName(), e.getMessage(), e);
+                log.error("Failed to store query event (%s): %s", e.getClass().getSimpleName(), e.getMessage());
             }
         }
     }

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -173,11 +173,11 @@ public class MysqlEventListener
                     log.info("Successfully created table and starting to store query event.");
                 }
                 catch (Exception retryEx) {
-                    log.error("Retry failed: Could not create table or store query event (%s): %s", retryEx.getClass().getSimpleName(), retryEx.getMessage());
+                    log.error("Retry failed: Could not create table or store query event (%s): %s", retryEx.getClass().getSimpleName(), retryEx.getMessage(), retryEx);
                 }
             }
             else {
-                log.error("Failed to store query event (%s): %s", e.getClass().getSimpleName(), e.getMessage());
+                log.error("Failed to store query event (%s): %s", e.getClass().getSimpleName(), e.getMessage(), e);
             }
         }
     }

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -33,12 +33,14 @@ import io.trino.spi.eventlistener.SplitCompletedEvent;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import jakarta.annotation.PostConstruct;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implement an EventListener that stores information in a MySQL database


### PR DESCRIPTION
adding retry for trino to recreate the trino_queries table for mysql event listener incase the table or schema is dropped on the fly

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

While the trino coordinator is running, if the trino_queries table is dropped or the MySql database/schema is dropped and then the database/schema is recreated, then trino is not automatically able to recreate the trino_queries table again, and the query metrics are not pushed anywhere and the trino coordinator needs to be restarted to recreate the trino_queries table again.

This simply adds a retry in case of a tablenotfoundexception, so if due to any reason the database/schema needs to be regenerated, then trino coordinator can perform a retry to recreate the trino_queries table to continue pushing the query metrics.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
