### PR TITLE
Allow skipping of data deletion in expire_snapshots

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -884,7 +884,7 @@ with the `retention_threshold` parameter.
 `expire_snapshots` can be run as follows:
 
 ```sql
-ALTER TABLE test_table EXECUTE expire_snapshots(retention_threshold => '7d');
+ALTER TABLE test_table EXECUTE expire_snapshots(retention_threshold => '7d', delete_files => true);
 ```
 
 The value for `retention_threshold` must be higher than or equal to
@@ -892,6 +892,10 @@ The value for `retention_threshold` must be higher than or equal to
 procedure fails with a similar message: `Retention specified (1.00d) is shorter
 than the minimum retention configured in the system (7.00d)`. The default value
 for this property is `7d`.
+
+The value for `delete_files` can be `true` or `false`. When set to `false` 
+files associated with the expired snapshots will NOT be deleted. The default 
+value for this property is `true`.
 
 (iceberg-remove-orphan-files)=
 ##### remove_orphan_files

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/ExpireSnapshotsTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/ExpireSnapshotsTableProcedure.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.TableProcedureMetadata;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.EXPIRE_SNAPSHOTS;
 import static io.trino.spi.connector.TableProcedureExecutionMode.coordinatorOnly;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 
 public class ExpireSnapshotsTableProcedure
         implements Provider<TableProcedureMetadata>
@@ -36,6 +37,11 @@ public class ExpireSnapshotsTableProcedure
                                 "retention_threshold",
                                 "Only snapshots older than threshold should be removed",
                                 Duration.valueOf("7d"),
+                                false),
+                        booleanProperty(
+                                "delete_files",
+                                "Delete underlying files associated to the expired snapshot(s)",
+                                true,
                                 false)));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
@@ -17,7 +17,7 @@ import io.airlift.units.Duration;
 
 import static java.util.Objects.requireNonNull;
 
-public record IcebergExpireSnapshotsHandle(Duration retentionThreshold)
+public record IcebergExpireSnapshotsHandle(Duration retentionThreshold, boolean deleteFiles)
         implements IcebergProcedureHandle
 {
     public IcebergExpireSnapshotsHandle


### PR DESCRIPTION
## Description
Allow skipping of file deletion in `expire_snapshots` to allow for more efficient out-of-band deletes.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
