### PR TITLE
Fix no serializer error in Iceberg MV tests

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -1149,7 +1149,7 @@ public abstract class BaseIcebergMaterializedViewTest
         }
     }
 
-    public static class SequenceTableFunctionHandle
+    public record SequenceTableFunctionHandle()
             implements ConnectorTableFunctionHandle {}
 
     public static class SequenceTableFunctionProcessorProvider


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
## Description

```
Error:  io.trino.plugin.iceberg.TestIcebergMaterializedView.testMaterializedViewCreatedFromTableFunction -- Time elapsed: 0.344 s <<< ERROR!
io.trino.testing.QueryFailedException: unexpected error calling sendUpdate()
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:586)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:569)
	at io.trino.testing.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:319)
	at io.trino.testing.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:314)
	at io.trino.plugin.iceberg.BaseIcebergMaterializedViewTest.testMaterializedViewCreatedFromTableFunction(BaseIcebergMaterializedViewTest.java:858)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1434)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2197)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:495)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:662)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1394)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1970)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: SELECT * FROM materialized_view_for_ptf_nr482v23p6
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:593)
		... 14 more
Caused by: io.trino.spi.TrinoException: unexpected error calling sendUpdate()
	at io.trino.server.remotetask.HttpRemoteTask.sendUpdate(HttpRemoteTask.java:736)
	at io.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:79)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: java.lang.IllegalArgumentException: io.trino.server.TaskUpdateRequest could not be converted to JSON
	at io.airlift.json.JsonCodec.toJsonBytes(JsonCodec.java:222)
	at io.trino.server.remotetask.HttpRemoteTask.sendUpdateInternal(HttpRemoteTask.java:775)
	at io.trino.server.remotetask.HttpRemoteTask.sendUpdate(HttpRemoteTask.java:733)
	... 4 more
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class io.trino.plugin.iceberg.BaseIcebergMaterializedViewTest$SequenceTableFunctionHandle and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: io.trino.server.TaskUpdateRequest["fragment"]->io.trino.sql.planner.PlanFragment["root"]->io.trino.sql.planner.plan.OutputNode["source"]->io.trino.sql.planner.plan.TableFunctionProcessorNode["handle"]->io.trino.metadata.TableFunctionHandle["functionHandle"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77)
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1359)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:415)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.failForEmpty(UnknownSerializer.java:52)
	at com.fasterxml.jackson.databind.ser.impl.UnknownSerializer.serializeWithType(UnknownSerializer.java:39)
	at io.trino.metadata.AbstractTypedJacksonModule$InternalTypeSerializer.serialize(AbstractTypedJacksonModule.java:119)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:760)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:760)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeWithType(BeanSerializerBase.java:643)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:734)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:760)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeWithType(BeanSerializerBase.java:643)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:734)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:760)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
	at com.fasterxml.jackson.databind.ser.std.ReferenceTypeSerializer.serialize(ReferenceTypeSerializer.java:390)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:760)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:503)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:423)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1583)
	at com.fasterxml.jackson.databind.ObjectWriter._writeValueAndClose(ObjectWriter.java:1289)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValueAsBytes(ObjectWriter.java:1165)
	at io.airlift.json.JsonCodec.toJsonBytes(JsonCodec.java:219)
	... 6 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
