### PR TITLE
Return only published main branch snapshots in history metadata table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
@@ -25,11 +25,14 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
+import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.util.SnapshotUtil;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -76,8 +79,13 @@ public class HistoryTable
 
         Set<Long> ancestorIds = ImmutableSet.copyOf(SnapshotUtil.currentAncestorIds(icebergTable));
         TimeZoneKey timeZoneKey = session.getTimeZoneKey();
-        for (Snapshot snapshot : icebergTable.snapshots()) {
-            long snapshotId = snapshot.snapshotId();
+        Map<Long, Snapshot> snapshots = new HashMap<>();
+        for (Snapshot snap : icebergTable.snapshots()) {
+            snapshots.put(snap.snapshotId(), snap);
+        }
+        for (HistoryEntry historyEntry : icebergTable.history()) {
+            Long snapshotId = historyEntry.snapshotId();
+            Snapshot snapshot = snapshots.get(snapshotId);
 
             table.addRow(
                     packDateTimeWithZone(snapshot.timestampMillis(), timeZoneKey),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

History table returns all snapshots right now. But it must only return published snapshots in main branch. 
Modified the implementation to iterate over history entry instead of all snapshots.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Iceberg/Spark reference implementation - https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/HistoryTable.java#L106


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
