### PR TITLE
Add support for BigLake metastore in Iceberg REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -488,7 +488,7 @@ following properties:
     `s3://my_bucket/warehouse_location`
 * - `iceberg.rest-catalog.security`
   - The type of security to use (default: `NONE`). Possible values are `NONE`, 
-    `SIGV4` or `OAUTH2`. `OAUTH2` requires either a `token` or `credential`.
+    `SIGV4`, `GOOGLE` or `OAUTH2`. `OAUTH2` requires either a `token` or a `credential`.
 * - `iceberg.rest-catalog.session`
   - Session information included when communicating with the REST Catalog.
     Options are `NONE` or `USER` (default: `NONE`).
@@ -522,6 +522,9 @@ following properties:
   - Enable view endpoints. Defaults to `true`.
 * - `iceberg.rest-catalog.signing-name`
   - AWS SigV4 signing service name. Defaults to `execute-api`.
+* - `iceberg.rest-catalog.google-project-id`
+  - Google Cloud project name. This property must be set when `iceberg.rest-catalog.security` 
+    config property is set to `GOOGLE`. Example: `development-123456`.
 * - `iceberg.rest-catalog.case-insensitive-name-matching`
   - Match namespace, table, and view names case insensitively. Defaults to `false`.
 * - `iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl`
@@ -548,6 +551,22 @@ iceberg.rest-catalog.uri=https://dbc-12345678-9999.cloud.databricks.com/api/2.1/
 iceberg.security=read_only
 iceberg.rest-catalog.security=OAUTH2
 iceberg.rest-catalog.oauth2.token=***
+```
+
+`iceberg.rest-catalog.security` must be `GOOGLE` when connecting to BigLake metastore
+using an Iceberg REST catalog.
+
+```properties
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.unique-table-location=false
+iceberg.rest-catalog.warehouse=gs://example-bucket
+iceberg.rest-catalog.uri=https://biglake.googleapis.com/iceberg/v1beta/restcatalog
+iceberg.rest-catalog.security=GOOGLE
+iceberg.rest-catalog.google-project-id=example-project-id
+iceberg.rest-catalog.view-endpoints-enabled=false
+fs.native-gcs.enable=true
+gcs.json-key-file-path=/path/to/gcs_keyfile.json
 ```
 
 The REST catalog supports [view management](sql-view-management) 

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -227,6 +227,11 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-gcp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-nessie</artifactId>
             <version>${dep.iceberg.version}</version>
         </dependency>
@@ -404,6 +409,12 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-gcs</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -761,6 +772,7 @@
                                 <exclude>**/TestIcebergGlueCatalogSkipArchive.java</exclude>
                                 <exclude>**/TestIcebergS3AndGlueMetastoreTest.java</exclude>
                                 <exclude>**/TestIcebergS3TablesConnectorSmokeTest.java</exclude>
+                                <exclude>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
@@ -827,6 +839,7 @@
                                 <include>**/TestIcebergGlueCatalogSkipArchive.java</include>
                                 <include>**/TestIcebergS3AndGlueMetastoreTest.java</include>
                                 <include>**/TestIcebergS3TablesConnectorSmokeTest.java</include>
+                                <include>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</include>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.util.Map;
+
+import static org.apache.iceberg.gcp.auth.GoogleAuthManager.GCP_CREDENTIALS_PATH_PROPERTY;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE_GOOGLE;
+
+public class GoogleAuthProperties
+        implements SecurityProperties
+{
+    private final Map<String, String> properties;
+
+    @Inject
+    public GoogleAuthProperties(GoogleSecurityConfig config)
+    {
+        properties = ImmutableMap.<String, String>builder()
+                .put(AUTH_TYPE, AUTH_TYPE_GOOGLE)
+                .put(GCP_CREDENTIALS_PATH_PROPERTY, config.getJsonKeyFilePath())
+                .put("header.x-goog-user-project", config.getProjectId())
+                .buildOrThrow();
+    }
+
+    @Override
+    public Map<String, String> get()
+    {
+        return properties;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.validation.FileExists;
+import jakarta.validation.constraints.NotNull;
+
+public class GoogleSecurityConfig
+{
+    private String projectId;
+    private String jsonKeyFilePath;
+
+    @NotNull
+    public String getProjectId()
+    {
+        return projectId;
+    }
+
+    @Config("iceberg.rest-catalog.google-project-id")
+    @ConfigDescription("Google project ID")
+    public GoogleSecurityConfig setProjectId(String projectId)
+    {
+        this.projectId = projectId;
+        return this;
+    }
+
+    @NotNull
+    @FileExists
+    public String getJsonKeyFilePath()
+    {
+        return jsonKeyFilePath;
+    }
+
+    // Duplicated from GcsFileSystemConfig to enforce the property in BigLake metastore
+    @Config("gcs.json-key-file-path")
+    @ConfigDescription("JSON key file used to access Google Cloud Storage")
+    public GoogleSecurityConfig setJsonKeyFilePath(String jsonKeyFilePath)
+    {
+        this.jsonKeyFilePath = jsonKeyFilePath;
+        return this;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityModule.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class GoogleSecurityModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(GoogleSecurityConfig.class);
+        binder.bind(SecurityProperties.class).to(GoogleAuthProperties.class);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -38,6 +38,7 @@ public class IcebergRestCatalogConfig
         NONE,
         OAUTH2,
         SIGV4,
+        GOOGLE,
     }
 
     public enum SessionType

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
@@ -44,6 +44,10 @@ public class IcebergRestCatalogModule
                 new SigV4SecurityModule()));
         install(conditionalModule(
                 IcebergRestCatalogConfig.class,
+                config -> config.getSecurity() == Security.GOOGLE,
+                new GoogleSecurityModule()));
+        install(conditionalModule(
+                IcebergRestCatalogConfig.class,
                 config -> config.getSecurity() == Security.NONE,
                 new NoneSecurityModule()));
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -24,6 +24,7 @@ import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.Security;
 import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIoFactory;
 import io.trino.spi.NodeVersion;
@@ -59,6 +60,7 @@ public class TrinoIcebergRestCatalogFactory
     private final Optional<String> prefix;
     private final Optional<String> warehouse;
     private final boolean nestedNamespaceEnabled;
+    private final Security security;
     private final SessionType sessionType;
     private final Duration sessionTimeout;
     private final boolean vendedCredentialsEnabled;
@@ -93,6 +95,7 @@ public class TrinoIcebergRestCatalogFactory
         this.prefix = restConfig.getPrefix();
         this.warehouse = restConfig.getWarehouse();
         this.nestedNamespaceEnabled = restConfig.isNestedNamespaceEnabled();
+        this.security = restConfig.getSecurity();
         this.sessionType = restConfig.getSessionType();
         this.sessionTimeout = restConfig.getSessionTimeout();
         this.vendedCredentialsEnabled = restConfig.isVendedCredentialsEnabled();
@@ -152,8 +155,10 @@ public class TrinoIcebergRestCatalogFactory
         Map<String, String> credentials = Maps.filterKeys(securityProperties.get(), key -> Set.of(TOKEN, CREDENTIAL).contains(key));
 
         return new TrinoRestCatalog(
+                fileSystemFactory,
                 icebergCatalog,
                 catalogName,
+                security,
                 sessionType,
                 credentials,
                 nestedNamespaceEnabled,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -229,6 +229,18 @@ public abstract class BaseIcebergConnectorSmokeTest
     }
 
     @Test
+    public void testRecreateTableWithSameName()
+    {
+        String tableName = "test_recreate_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x, 'INDIA' y", 1);
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'INDIA')");
+        assertUpdate("DROP TABLE " + tableName);
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 'Trino' data", 1);
+        assertQuery("SELECT * FROM " + tableName, "VALUES ('Trino')");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testRegisterTableWithTableLocation()
     {
         String tableName = "test_register_table_with_table_location_" + randomNameSuffix();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.json.ObjectMapperProvider;
 import io.airlift.log.Level;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
@@ -42,6 +43,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -50,6 +52,7 @@ import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
+import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
@@ -215,6 +218,40 @@ public final class IcebergQueryRunner
                     .build();
 
             Logger log = Logger.get(IcebergRestQueryRunnerMain.class);
+            log.info("======== SERVER STARTED ========");
+            log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+        }
+    }
+
+    public static final class IcebergBigLakeMetastoreQueryRunnerMain
+    {
+        private IcebergBigLakeMetastoreQueryRunnerMain() {}
+
+        public static void main(String[] args)
+                throws Exception
+        {
+            byte[] jsonKeyBytes = Base64.getDecoder().decode(requireEnv("GCP_CREDENTIALS_KEY"));
+            Path gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json");
+            gcpCredentialsFile.toFile().deleteOnExit();
+            Files.write(gcpCredentialsFile, jsonKeyBytes);
+            String projectId = new ObjectMapperProvider().get().readTree(jsonKeyBytes).get("project_id").asText();
+
+            DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
+                    .addCoordinatorProperty("http-server.http.port", "8080")
+                    .addIcebergProperty("iceberg.register-table-procedure.enabled", "true")
+                    .addIcebergProperty("iceberg.unique-table-location", "false")
+                    .addIcebergProperty("iceberg.catalog.type", "rest")
+                    .addIcebergProperty("iceberg.rest-catalog.uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog")
+                    .addIcebergProperty("iceberg.rest-catalog.warehouse", "gs://" + requireEnv("GCP_STORAGE_BUCKET"))
+                    .addIcebergProperty("iceberg.rest-catalog.security", "GOOGLE")
+                    .addIcebergProperty("iceberg.rest-catalog.google-project-id", projectId)
+                    .addIcebergProperty("iceberg.rest-catalog.view-endpoints-enabled", "false")
+                    .addIcebergProperty("fs.native-gcs.enabled", "true")
+                    .addIcebergProperty("gcs.json-key-file-path", gcpCredentialsFile.toString())
+                    .disableSchemaInitializer()
+                    .build();
+
+            Logger log = Logger.get(IcebergBigLakeMetastoreQueryRunnerMain.class);
             log.info("======== SERVER STARTED ========");
             log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -20,9 +20,11 @@ import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -234,6 +236,24 @@ public class TestIcebergPlugin
                                 "iceberg.catalog.type", "rest",
                                 "iceberg.rest-catalog.uri", "https://foo:1234",
                                 "bootstrap.quiet", "true"),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+
+    @Test
+    void testRestCatalogWithBigLakeMetastore(@TempDir Path jsonKeyFilePath)
+    {
+        ConnectorFactory factory = getConnectorFactory();
+        factory.create(
+                        "test",
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", "https://foo:1234")
+                                .put("iceberg.rest-catalog.security", "GOOGLE")
+                                .put("iceberg.rest-catalog.google-project-id", "dev")
+                                .put("gcs.json-key-file-path", jsonKeyFilePath.toString())
+                                .put("bootstrap.quiet", "true")
+                                .buildOrThrow(),
                         new TestingConnectorContext())
                 .shutdown();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestGoogleSecurityConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestGoogleSecurityConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestGoogleSecurityConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(GoogleSecurityConfig.class)
+                .setProjectId(null)
+                .setJsonKeyFilePath(null));
+    }
+
+    @Test
+    void testExplicitPropertyMappings(@TempDir Path config)
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.rest-catalog.google-project-id", "gcp")
+                .put("gcs.json-key-file-path", config.toString())
+                .buildOrThrow();
+
+        GoogleSecurityConfig expected = new GoogleSecurityConfig()
+                .setProjectId("gcp")
+                .setJsonKeyFilePath(config.toString());
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
+import io.trino.plugin.iceberg.IcebergConfig;
+import io.trino.plugin.iceberg.IcebergConnector;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.plugin.iceberg.SchemaInitializer;
+import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import org.apache.iceberg.BaseTable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
+
+final class TestIcebergBigLakeMetastoreConnectorSmokeTest
+        extends BaseIcebergConnectorSmokeTest
+{
+    private static final String SCHEMA = "test_iceberg_biglake_" + randomNameSuffix();
+    private static final String GCP_STORAGE_BUCKET = requireEnv("GCP_STORAGE_BUCKET");
+    private static final byte[] GCS_JSON_KEY_BYTES = Base64.getDecoder().decode(requireEnv("GCP_CREDENTIALS_KEY"));
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
+
+    public TestIcebergBigLakeMetastoreConnectorSmokeTest()
+    {
+        super(new IcebergConfig().getFileFormat().toIceberg());
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_RENAME_MATERIALIZED_VIEW,
+                 SUPPORTS_RENAME_SCHEMA,
+                 SUPPORTS_RENAME_TABLE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Path gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json");
+        gcpCredentialsFile.toFile().deleteOnExit();
+        Files.write(gcpCredentialsFile, GCS_JSON_KEY_BYTES);
+        String projectId = OBJECT_MAPPER.readTree(GCS_JSON_KEY_BYTES).get("project_id").asText();
+
+        return IcebergQueryRunner.builder(SCHEMA)
+                .addIcebergProperty("iceberg.file-format", format.name())
+                .addIcebergProperty("iceberg.register-table-procedure.enabled", "true")
+                .addIcebergProperty("iceberg.unique-table-location", "false")
+                .addIcebergProperty("iceberg.catalog.type", "rest")
+                .addIcebergProperty("iceberg.rest-catalog.uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog")
+                .addIcebergProperty("iceberg.rest-catalog.warehouse", "gs://" + GCP_STORAGE_BUCKET)
+                .addIcebergProperty("iceberg.rest-catalog.security", "GOOGLE")
+                .addIcebergProperty("iceberg.rest-catalog.google-project-id", projectId)
+                .addIcebergProperty("iceberg.rest-catalog.view-endpoints-enabled", "false")
+                .addIcebergProperty("iceberg.writer-sort-buffer-size", "1MB")
+                .addIcebergProperty("iceberg.allowed-extra-properties", "write.metadata.delete-after-commit.enabled,write.metadata.previous-versions-max")
+                .addIcebergProperty("fs.native-gcs.enabled", "true")
+                .addIcebergProperty("gcs.json-key-file-path", gcpCredentialsFile.toString())
+                .setSchemaInitializer(SchemaInitializer.builder()
+                        .withSchemaName(SCHEMA)
+                        .withClonedTpchTables(REQUIRED_TPCH_TABLES)
+                        .withSchemaProperties(ImmutableMap.of("location", "'gs://%s/%s'".formatted(GCP_STORAGE_BUCKET, SCHEMA)))
+                        .build())
+                .build();
+    }
+
+    @AfterAll
+    void cleanup()
+            throws Exception
+    {
+        // Avoid DROP SCHEMA CASCADE since BigLake metastore returns null when loading a table with missing metadata file by testDropTableWithMissingMetadataFile
+        // TODO Use DROP SCHEMA CASCADE once the above issue is fixed
+        fileSystem.deleteDirectory(Location.of(schemaPath()));
+        for (Object tableName : computeActual("SHOW TABLES IN " + SCHEMA).getOnlyColumnAsSet()) {
+            dropTableFromCatalog((String) tableName);
+        }
+        getQueryRunner().execute("DROP SCHEMA " + SCHEMA);
+    }
+
+    @Override
+    protected String getMetadataLocation(String tableName)
+    {
+        TrinoCatalogFactory catalogFactory = ((IcebergConnector) getQueryRunner().getCoordinator().getConnector("iceberg")).getInjector().getInstance(TrinoCatalogFactory.class);
+        TrinoCatalog trinoCatalog = catalogFactory.create(getSession().getIdentity().toConnectorIdentity());
+        BaseTable table = trinoCatalog.loadTable(getSession().toConnectorSession(), new SchemaTableName(getSession().getSchema().orElseThrow(), tableName));
+        return table.operations().current().metadataFileLocation();
+    }
+
+    @Override
+    protected String schemaPath()
+    {
+        return "gs://%s/%s".formatted(GCP_STORAGE_BUCKET, SCHEMA);
+    }
+
+    @Override
+    protected boolean locationExists(String location)
+    {
+        try {
+            return fileSystem.newInputFile(Location.of(location)).exists();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    protected boolean isFileSorted(Location path, String sortColumnName)
+    {
+        return checkParquetFileSorting(fileSystem.newInputFile(path), sortColumnName);
+    }
+
+    @Override
+    protected void deleteDirectory(String location)
+    {
+        try {
+            fileSystem.deleteDirectory(Location.of(location));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    protected void dropTableFromCatalog(String tableName)
+    {
+        assertUpdate("CALL system.unregister_table(CURRENT_SCHEMA, '" + tableName + "')");
+    }
+
+    @Test
+    @Override // Override because the location pattern differs
+    public void testShowCreateTable()
+    {
+        assertThat((String) computeScalar("SHOW CREATE TABLE region"))
+                .matches("CREATE TABLE iceberg." + SCHEMA + ".region \\(\n" +
+                        "   regionkey bigint,\n" +
+                        "   name varchar,\n" +
+                        "   comment varchar\n" +
+                        "\\)\n" +
+                        "WITH \\(\n" +
+                        "   format = 'PARQUET',\n" +
+                        "   format_version = 2,\n" +
+                        "   location = 'gs://.*'\n" +
+                        "\\)");
+    }
+
+    @Test
+    @Override
+    public void testRenameSchema()
+    {
+        assertThatThrownBy(super::testRenameSchema)
+                .hasMessageContaining("renameNamespace is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testMaterializedView()
+    {
+        assertThatThrownBy(super::testMaterializedView)
+                .hasMessageContaining("createMaterializedView is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRenameTable()
+    {
+        assertThatThrownBy(super::testRenameTable)
+                .hasStackTraceContaining("Server does not support endpoint: POST /v1/{prefix}/tables/rename");
+    }
+
+    @Test
+    @Override
+    public void testView()
+    {
+        assertThatThrownBy(super::testView)
+                .hasMessageContaining("Server does not support endpoint: POST /v1/{prefix}/namespaces/{namespace}/views");
+    }
+
+    @Test
+    @Override
+    public void testCommentViewColumn()
+    {
+        assertThatThrownBy(super::testCommentViewColumn)
+                .hasMessageContaining("Server does not support endpoint: POST /v1/{prefix}/namespaces/{namespace}/views");
+    }
+
+    @Test
+    @Override
+    public void testCommentView()
+    {
+        assertThatThrownBy(super::testCommentView)
+                .hasMessageContaining("Server does not support endpoint: POST /v1/{prefix}/namespaces/{namespace}/views");
+    }
+
+    @Test
+    @Override // TODO (https://github.com/trinodb/trino/issues/27679) Enable this test once Google fixes a bug. January 2026 release will contain the fix.
+    public void testRegisterTableWithComments()
+    {
+        abort("skipped");
+    }
+
+    @Test
+    @Override // TODO Enable once timeout issue is fixed
+    public void testDeleteRowsConcurrently()
+    {
+        abort("skipped");
+    }
+
+    @Test
+    @Override // Override because BigLake metastore requires table location to start with the prefix with the table name without following spaces
+    public void testCreateTableWithTrailingSpaceInLocation()
+    {
+        String tableName = "test_create_table_with_trailing_space_" + randomNameSuffix();
+        String tableLocationWithoutTrailingSpace = schemaPath() + "/" + tableName;
+        String tableLocationWithTrailingSpace = tableLocationWithoutTrailingSpace + " ";
+
+        assertThat(query(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS a, 'INDIA' AS b, true AS c", tableName, tableLocationWithTrailingSpace))).failure()
+                        .hasMessage("Failed to create transaction")
+                .hasStackTraceContaining("Malformed request: The table `location` property can only point to the default location");
+    }
+
+    @Test
+    @Override // BigLake metastore requires table location to start with the prefix with the table name
+    public void testRegisterTableWithDifferentTableName()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
+                .hasMessageContaining("Failed to register table")
+                .hasStackTraceContaining("does not start with the expected prefix");
+    }
+
+    @Test
+    @Override // BigLake metastore requires table location to start with the prefix with the table name
+    public void testRegisterTableWithTrailingSpaceInLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
+                .hasMessageContaining("Failed to register table")
+                .hasStackTraceContaining("does not start with the expected prefix");
+    }
+
+    @Test
+    @Override // BigLake metastore doesn't show a table if its metadata file is missing
+    public void testDropTableWithMissingMetadataFile()
+            throws Exception
+    {
+        String tableName = "test_drop_table_with_missing_metadata_file_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x, 'INDIA' y", 1);
+
+        Location metadataLocation = Location.of(getMetadataLocation(tableName));
+
+        // Delete current metadata file
+        fileSystem.deleteFile(metadataLocation);
+        assertThat(fileSystem.newInputFile(metadataLocation).exists())
+                .describedAs("Current metadata file should not exist")
+                .isFalse();
+
+        assertThat(getQueryRunner().tableExists(getSession(), tableName)).isFalse();
+    }
+
+    @Test
+    @Override // BigLake metastore doesn't show a table if its location is missing
+    public void testDropTableWithNonExistentTableLocation()
+            throws Exception
+    {
+        String tableName = "test_drop_table_with_non_existent_table_location_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x, 'INDIA' y", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'POLAND')", 1);
+
+        Location tableLocation = Location.of(getTableLocation(tableName));
+
+        // Delete table location
+        fileSystem.deleteDirectory(tableLocation);
+        assertThat(fileSystem.listFiles(tableLocation).hasNext())
+                .describedAs("Table location should not exist")
+                .isFalse();
+
+        assertThat(getQueryRunner().tableExists(getSession(), tableName)).isFalse();
+    }
+
+    private List<String> listFiles(Location location)
+            throws IOException
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        FileIterator iterator = fileSystem.listFiles(location);
+        while (iterator.hasNext()) {
+            builder.add(iterator.next().location().toString());
+        }
+        return builder.build();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
@@ -279,6 +279,14 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
 
     @Test
     @Override
+    public void testRecreateTableWithSameName()
+    {
+        assertThatThrownBy(super::testRecreateTableWithSameName)
+                .hasMessageContaining("Access Denied");
+    }
+
+    @Test
+    @Override
     public void testRegisterTableWithTableLocation()
     {
         assertThatThrownBy(super::testRegisterTableWithTableLocation)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -15,12 +15,15 @@ package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.cache.EvictableCacheBuilder;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.metastore.TableInfo;
 import io.trino.plugin.iceberg.CommitTaskData;
+import io.trino.plugin.iceberg.DefaultIcebergFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergMetadata;
 import io.trino.plugin.iceberg.TableStatisticsWriter;
 import io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.Security;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
 import io.trino.spi.catalog.CatalogName;
@@ -42,6 +45,8 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.metastore.TableInfo.ExtendedRelationType.OTHER_VIEW;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
 import static io.trino.plugin.iceberg.IcebergTestUtils.TABLE_STATISTICS_READER;
 import static io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType.NONE;
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
@@ -89,8 +94,10 @@ public class TestTrinoRestCatalog
         restSessionCatalog.initialize(catalogName, properties);
 
         return new TrinoRestCatalog(
+                new DefaultIcebergFileSystemFactory(new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS)),
                 restSessionCatalog,
                 new CatalogName(catalogName),
+                Security.NONE,
                 NONE,
                 ImmutableMap.of(),
                 false,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
@@ -284,6 +284,14 @@ public class TestIcebergSnowflakeCatalogConnectorSmokeTest
 
     @Test
     @Override
+    public void testRecreateTableWithSameName()
+    {
+        assertThatThrownBy(super::testRecreateTableWithSameName)
+                .hasMessageContaining("Snowflake managed Iceberg tables do not support modifications");
+    }
+
+    @Test
+    @Override
     public void testRegisterTableWithTableLocation()
     {
         assertThatThrownBy(super::testRegisterTableWithTableLocation)

--- a/pom.xml
+++ b/pom.xml
@@ -1959,6 +1959,12 @@
 
             <dependency>
                 <groupId>org.apache.iceberg</groupId>
+                <artifactId>iceberg-gcp</artifactId>
+                <version>${dep.iceberg.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.iceberg</groupId>
                 <artifactId>iceberg-orc</artifactId>
                 <version>${dep.iceberg.version}</version>
                 <exclusions>


### PR DESCRIPTION
## Description

Add `BIGLAKE` to `iceberg.rest-catalog.security` config property for supporting BigLake metastore. 
Also, this PR adds `iceberg.rest-catalog.google-project-id` config property. 

Relates to https://cloud.google.com/bigquery/docs/blms-rest-catalog
Supersedes #26054

## Release notes

```markdown
## Iceberg
* Add support for BigLake metastore in Iceberg REST catalog. ({issue}`26219`)
```
