### PR TITLE
Remove deprecated ConnectorPageSource.getNextPage

### DIFF
--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorPageSource.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorPageSource.java
@@ -13,7 +13,6 @@
  */
 package io.trino.connector;
 
-import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.metrics.Metrics;
@@ -58,13 +57,6 @@ public class MockConnectorPageSource
     public boolean isFinished()
     {
         return delegate.isFinished();
-    }
-
-    @Override
-    @SuppressWarnings("removal")
-    public Page getNextPage()
-    {
-        return delegate.getNextPage();
     }
 
     @Override

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -662,6 +662,24 @@
                                     <code>java.annotation.removed</code>
                                     <annotationType>io.trino.spi.Experimental</annotationType>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.Page io.trino.spi.connector.EmptyPageSource::getNextPage()</old>
+                                    <justification>Deprecated</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.Page io.trino.spi.connector.FixedPageSource::getNextPage()</old>
+                                    <justification>Deprecated</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.Page io.trino.spi.connector.RecordPageSource::getNextPage()</old>
+                                    <justification>Deprecated</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
@@ -13,7 +13,6 @@
  */
 package io.trino.spi.connector;
 
-import io.trino.spi.Page;
 import io.trino.spi.metrics.Metrics;
 
 import java.io.Closeable;
@@ -54,26 +53,11 @@ public interface ConnectorPageSource
     boolean isFinished();
 
     /**
-     * Gets the next page of data.  This method is allowed to return null.
-     *
-     * @deprecated Use {@link #getNextSourcePage()} instead
-     */
-    @Deprecated(forRemoval = true)
-    default Page getNextPage()
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * Gets the next page of data. This method is allowed to return null.
      */
     default SourcePage getNextSourcePage()
     {
-        Page nextPage = getNextPage();
-        if (nextPage == null) {
-            return null;
-        }
-        return SourcePage.create(nextPage);
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/EmptyPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/EmptyPageSource.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.connector;
 
-import io.trino.spi.Page;
-
 public class EmptyPageSource
         implements ConnectorPageSource
 {
@@ -34,13 +32,6 @@ public class EmptyPageSource
     public boolean isFinished()
     {
         return true;
-    }
-
-    @Override
-    @SuppressWarnings("removal")
-    public Page getNextPage()
-    {
-        return null;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/FixedPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/FixedPageSource.java
@@ -74,15 +74,14 @@ public class FixedPageSource
     }
 
     @Override
-    @SuppressWarnings("removal")
-    public Page getNextPage()
+    public SourcePage getNextSourcePage()
     {
         if (isFinished()) {
             return null;
         }
         Page page = pages.next();
         completedBytes += page.getSizeInBytes();
-        return page;
+        return SourcePage.create(page);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/RecordPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/RecordPageSource.java
@@ -81,8 +81,7 @@ public class RecordPageSource
     }
 
     @Override
-    @SuppressWarnings("removal")
-    public Page getNextPage()
+    public SourcePage getNextSourcePage()
     {
         if (!closed) {
             for (int i = 0; i < ROWS_PER_REQUEST && !pageBuilder.isFull(); i++) {
@@ -125,7 +124,7 @@ public class RecordPageSource
         if ((closed && !pageBuilder.isEmpty()) || pageBuilder.isFull()) {
             Page page = pageBuilder.build();
             pageBuilder.reset();
-            return page;
+            return SourcePage.create(page);
         }
 
         return null;


### PR DESCRIPTION
## Release notes

```markdown
## SPI
* Remove deprecated `ConnectorPageSource.getNextPage` method. ({issue}`26222`)
```
