### PR TITLE
Add SCRAM/SASL config support to Kafka event listener

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-kafka.md
+++ b/docs/src/main/sphinx/admin/event-listeners-kafka.md
@@ -144,6 +144,15 @@ Use the following properties for further configuration.
     `TRINO_INSIGHTS_CLUSTER_ID=foo`, then the Kafka payload metadata contains
     `CLUSTER_ID=foo`.
   -
+* - `kafka-event-listener.sasl-mechanism`
+  - SASL mechanism for Kafka authentication (e.g., `SCRAM-SHA-256`, `SCRAM-SHA-512`).
+  -
+* - `kafka-event-listener.security-protocol`
+  - Kafka security protocol (e.g., `SASL_PLAINTEXT`, `SASL_SSL`).
+  -
+* - `kafka-event-listener.sasl-jaas-config`
+  - JAAS config for SASL authentication (e.g., username/password for SCRAM). Example: `org.apache.kafka.common.security.scram.ScramLoginModule required username="user" password="pass";`
+  -
 * - `kafka-event-listener.config.resources`
   - A comma-separated list of Kafka client configuration files. These files
     must exist on the machines running Trino. Only specify this if absolutely

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerConfig.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerConfig.java
@@ -59,9 +59,53 @@ public class KafkaEventListenerConfig
     private Optional<String> environmentVariablePrefix = Optional.empty();
     private List<File> resourceConfigFiles = ImmutableList.of();
 
+    // SCRAM/SASL/Kafka security configs
+    private Optional<String> saslMechanism = Optional.empty();
+    private Optional<String> securityProtocol = Optional.empty();
+    private Optional<String> saslJaasConfig = Optional.empty();
+
     public boolean isAnonymizationEnabled()
     {
         return anonymizationEnabled;
+    }
+
+    public Optional<String> getSaslMechanism()
+    {
+        return saslMechanism;
+    }
+
+    @Config("kafka-event-listener.sasl-mechanism")
+    @ConfigDescription("SASL mechanism for Kafka authentication (e.g., SCRAM-SHA-256, SCRAM-SHA-512)")
+    public KafkaEventListenerConfig setSaslMechanism(String saslMechanism)
+    {
+        this.saslMechanism = Optional.ofNullable(saslMechanism);
+        return this;
+    }
+
+    public Optional<String> getSecurityProtocol()
+    {
+        return securityProtocol;
+    }
+
+    @Config("kafka-event-listener.security-protocol")
+    @ConfigDescription("Kafka security protocol (e.g., SASL_PLAINTEXT, SASL_SSL)")
+    public KafkaEventListenerConfig setSecurityProtocol(String securityProtocol)
+    {
+        this.securityProtocol = Optional.ofNullable(securityProtocol);
+        return this;
+    }
+
+    public Optional<String> getSaslJaasConfig()
+    {
+        return saslJaasConfig;
+    }
+
+    @Config("kafka-event-listener.sasl-jaas-config")
+    @ConfigDescription("JAAS config for SASL authentication (e.g., username/password for SCRAM)")
+    public KafkaEventListenerConfig setSaslJaasConfig(String saslJaasConfig)
+    {
+        this.saslJaasConfig = Optional.ofNullable(saslJaasConfig);
+        return this;
     }
 
     @Config("kafka-event-listener.anonymization.enabled")

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/BaseKafkaProducerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/producer/BaseKafkaProducerFactory.java
@@ -15,8 +15,10 @@
 package io.trino.plugin.eventlistener.kafka.producer;
 
 import io.trino.plugin.eventlistener.kafka.KafkaEventListenerConfig;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.HashMap;
@@ -35,13 +37,25 @@ abstract class BaseKafkaProducerFactory
     {
         Map<String, Object> kafkaClientConfig = new HashMap<>();
         kafkaClientConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBrokerEndpoints());
-        config.getClientId().ifPresent(clientId -> kafkaClientConfig.put(ProducerConfig.CLIENT_ID_CONFIG, clientId));
+        config.getClientId().ifPresent(clientId ->
+                kafkaClientConfig.put(ProducerConfig.CLIENT_ID_CONFIG, clientId));
         kafkaClientConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         kafkaClientConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         kafkaClientConfig.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "zstd");
         kafkaClientConfig.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, Long.toString(config.getMaxRequestSize().toBytes()));
         kafkaClientConfig.put(ProducerConfig.BATCH_SIZE_CONFIG, Long.toString(config.getBatchSize().toBytes()));
         kafkaClientConfig.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, Long.toString(config.getRequestTimeout().toMillis()));
+
+        // Add SCRAM/SASL configs if present
+        config.getSaslMechanism()
+                .ifPresent(mechanism -> kafkaClientConfig.put(SaslConfigs.SASL_MECHANISM, mechanism));
+
+        config.getSecurityProtocol()
+                .ifPresent(protocol -> kafkaClientConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, protocol));
+
+        config.getSaslJaasConfig()
+                .ifPresent(jaasConfig -> kafkaClientConfig.put(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig));
+
         return kafkaClientConfig;
     }
 }

--- a/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerConfig.java
+++ b/plugin/trino-kafka-event-listener/src/test/java/io/trino/plugin/eventlistener/kafka/TestKafkaEventListenerConfig.java
@@ -57,7 +57,10 @@ final class TestKafkaEventListenerConfig
                 .setRequestTimeout(new Duration(10, TimeUnit.SECONDS))
                 .setTerminateOnInitializationFailure(true)
                 .setResourceConfigFiles(List.of())
-                .setEnvironmentVariablePrefix(null));
+                .setEnvironmentVariablePrefix(null)
+                .setSaslMechanism(null)
+                .setSecurityProtocol(null)
+                .setSaslJaasConfig(null));
     }
 
     @Test
@@ -84,6 +87,9 @@ final class TestKafkaEventListenerConfig
                 .put("kafka-event-listener.anonymization.enabled", "true")
                 .put("kafka-event-listener.terminate-on-initialization-failure", "false")
                 .put("kafka-event-listener.config.resources", resource1.toString() + "," + resource2.toString())
+                .put("kafka-event-listener.sasl-mechanism", "SCRAM-SHA-256")
+                .put("kafka-event-listener.security-protocol", "SCRAM-SHA-256")
+                .put("kafka-event-listener.sasl-jaas-config", "org.apache.kafka.common.security.scram.ScramLoginModule")
                 .buildOrThrow();
 
         KafkaEventListenerConfig expected = new KafkaEventListenerConfig()
@@ -102,7 +108,10 @@ final class TestKafkaEventListenerConfig
                 .setRequestTimeout(new Duration(3, TimeUnit.SECONDS))
                 .setEnvironmentVariablePrefix("INSIGHTS_")
                 .setResourceConfigFiles(ImmutableList.of(resource1.toString(), resource2.toString()))
-                .setTerminateOnInitializationFailure(false);
+                .setTerminateOnInitializationFailure(false)
+                .setSaslMechanism("SCRAM-SHA-256")
+                .setSecurityProtocol("SCRAM-SHA-256")
+                .setSaslJaasConfig("org.apache.kafka.common.security.scram.ScramLoginModule");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR adds support for Kafka SCRAM/SASL authentication to the Kafka event listener plugin. It introduces new configuration properties—`kafka-event-listener.sasl-mechanism`, `kafka-event-listener.security-protocol`, and `kafka-event-listener.sasl-jaas-config`—allowing Trino to connect to Kafka clusters that require secure authentication mechanisms such as SCRAM-SHA-256 or SCRAM-SHA-512.
The documentation is updated to describe these new options.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The new properties are optional and can be set in the event listener configuration file.
If provided, these properties are passed to the Kafka producer, enabling secure connections to Kafka clusters with SASL/SCRAM authentication.
This enhancement improves the plugin's usability in production environments with secure Kafka clusters.
No breaking changes; existing configurations will continue to work as before.
Related to requests for secure Kafka integration in enterprise deployments.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Kafka event Listener
* Support for Kafka SCRAM/SASL authentication. ({issue}`26253`)
```
Closes: #26253
