### PR TITLE
Implement `toString` method in InformationSchemaTableHandle and InformationSchemaColumnHandle

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaColumnHandle.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaColumnHandle.java
@@ -24,4 +24,10 @@ public record InformationSchemaColumnHandle(String columnName)
     {
         requireNonNull(columnName, "columnName is null");
     }
+
+    @Override
+    public String toString()
+    {
+        return columnName;
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaTableHandle.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaTableHandle.java
@@ -32,4 +32,17 @@ public record InformationSchemaTableHandle(String catalogName, InformationSchema
         prefixes = ImmutableSet.copyOf(requireNonNull(prefixes, "prefixes is null"));
         requireNonNull(limit, "limit is null");
     }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("catalog=").append(catalogName);
+        builder.append(" table=").append(table);
+        if (!prefixes.isEmpty()) {
+            builder.append(" prefixes=").append(prefixes);
+        }
+        limit.ifPresent(limit -> builder.append(" limit=").append(limit));
+        return builder.toString();
+    }
 }


### PR DESCRIPTION
## Description

This simplifies EXPLAIN result:
```
trino> explain table memory.information_schema.tables;
                                                                    Query Plan
--------------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [table_catalog, table_schema, table_name, table_type]
     Output partitioning: SINGLE []
     Output[columnNames = [table_catalog, table_schema, table_name, table_type]]
     │   Layout: [table_catalog:varchar, table_schema:varchar, table_name:varchar, table_type:varchar]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = memory:InformationSchemaTableHandle[catalogName=memory, table=TABLES, prefixes=[memory.*.*], limit=OptionalLong.empty]]
            Layout: [table_catalog:varchar, table_schema:varchar, table_name:varchar, table_type:varchar]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            table_type := InformationSchemaColumnHandle[columnName=table_type]
            table_catalog := InformationSchemaColumnHandle[columnName=table_catalog]
            table_schema := InformationSchemaColumnHandle[columnName=table_schema]
            table_name := InformationSchemaColumnHandle[columnName=table_name]
```

↓

```
                                                Query Plan
----------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Fragment 0 [SOURCE]
     Output layout: [table_catalog, table_schema, table_name, table_type]
     Output partitioning: SINGLE []
     Output[columnNames = [table_catalog, table_schema, table_name, table_type]]
     │   Layout: [table_catalog:varchar, table_schema:varchar, table_name:varchar, table_type:varchar]
     │   Estimates: {rows: ? (?), cpu: 0, memory: 0B, network: 0B}
     └─ TableScan[table = memory:catalog=memory table=TABLES prefixes=[memory.*.*]]
            Layout: [table_catalog:varchar, table_schema:varchar, table_name:varchar, table_type:varchar]
            Estimates: {rows: ? (?), cpu: ?, memory: 0B, network: 0B}
            table_catalog := table_catalog
            table_schema := table_schema
            table_type := table_type
            table_name := table_name
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.