### PR TITLE
Release memory eagerly in ordering and distinct accumulators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -24,6 +24,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.type.Type;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -101,7 +102,8 @@ public class DistinctAccumulatorFactory
             implements Accumulator
     {
         private final Accumulator accumulator;
-        private final MarkDistinctHash hash;
+        @Nullable
+        private MarkDistinctHash hash; // null after evaluateFinal() is called
 
         private DistinctAccumulator(
                 Accumulator accumulator,
@@ -120,7 +122,11 @@ public class DistinctAccumulatorFactory
         @Override
         public long getEstimatedSize()
         {
-            return hash.getEstimatedSize() + accumulator.getEstimatedSize();
+            long estimatedSize = accumulator.getEstimatedSize();
+            if (hash != null) {
+                estimatedSize += hash.getEstimatedSize();
+            }
+            return estimatedSize;
         }
 
         @Override
@@ -132,6 +138,7 @@ public class DistinctAccumulatorFactory
         @Override
         public void addInput(Page arguments, AggregationMask mask)
         {
+            checkState(hash != null, "evaluateFinal() has already been called");
             // 1. filter out positions based on mask, if present
             Page filtered = mask.filterPage(arguments);
 
@@ -166,6 +173,8 @@ public class DistinctAccumulatorFactory
         @Override
         public void evaluateFinal(BlockBuilder blockBuilder)
         {
+            // release hash memory since it's no longer needed
+            hash = null;
             accumulator.evaluateFinal(blockBuilder);
         }
     }
@@ -174,7 +183,8 @@ public class DistinctAccumulatorFactory
             implements GroupedAccumulator
     {
         private final GroupedAccumulator accumulator;
-        private final MarkDistinctHash hash;
+        @Nullable
+        private MarkDistinctHash hash; // null after prepareFinal() is called
 
         private DistinctGroupedAccumulator(
                 GroupedAccumulator accumulator,
@@ -196,7 +206,11 @@ public class DistinctAccumulatorFactory
         @Override
         public long getEstimatedSize()
         {
-            return hash.getEstimatedSize() + accumulator.getEstimatedSize();
+            long estimatedSize = accumulator.getEstimatedSize();
+            if (hash != null) {
+                estimatedSize += hash.getEstimatedSize();
+            }
+            return estimatedSize;
         }
 
         @Override
@@ -208,6 +222,7 @@ public class DistinctAccumulatorFactory
         @Override
         public void addInput(int[] groupIds, Page page, AggregationMask mask)
         {
+            checkState(hash != null, "prepareFinal() has already been called");
             // 1. filter out positions based on mask
             groupIds = maskGroupIds(groupIds, mask);
             page = mask.filterPage(page);
@@ -261,6 +276,10 @@ public class DistinctAccumulatorFactory
         }
 
         @Override
-        public void prepareFinal() {}
+        public void prepareFinal()
+        {
+            // release hash memory after all inputs have been added
+            hash = null;
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -228,15 +228,17 @@ public class InMemoryHashAggregationBuilder
     @Override
     public WorkProcessor<Page> buildResult()
     {
+        groupByHash.startReleasingOutput();
         for (GroupedAggregator groupedAggregator : groupedAggregators) {
             groupedAggregator.prepareFinal();
         }
-        // Only incrementally release memory for final aggregations, since partial aggregations have a fixed
-        // memory limit and can be expected to fully flush and release their output quickly
+        // Always update the current memory usage after calling GroupedAggregator#prepareFinal(), since it can increase
+        // memory consumption significantly in some situations. This also captures any memory usage reduction the
+        // groupByHash may have initiated for releasing output
+        updateMemory();
+        // Only incrementally release memory while producing output for final aggregations, since partial aggregations
+        // have a fixed memory limit and can be expected to fully flush and release their output quickly
         boolean releaseMemoryOnOutput = !partial;
-        if (releaseMemoryOnOutput) {
-            groupByHash.startReleasingOutput();
-        }
         return buildResult(consecutiveGroupIds(), new PageBuilder(buildTypes()), false, releaseMemoryOnOutput);
     }
 


### PR DESCRIPTION
## Description
Releases `PagesIndex` from `Ordering(Grouped)Accumulator` and `MarkDistinctHash` from `Distinct(Grouped)Accumulator` instances after `prepareFinal()` or `evaluateFinal()` is called.

This helps mitigate an issue exposed by https://github.com/trinodb/trino/pull/25879 - which was that `HashAggreationOperator` wouldn't track any changes in memory consumption after output started. However, ordered grouped aggregations significantly _increase_ their memory consumption at the beginning of output as a result of transferring the contents of their `PagesIndex` into their underlying accumulators.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce memory required for distinct and ordered grouped aggregations ({issue}`26276`)
* Fix memory tracking for ordered grouped aggregations ({issue}`26276`)
```
