### PR TITLE
Use icebergScanExecutor for reading manifests in optimize and expire_snapshots

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2029,6 +2029,7 @@ public class IcebergMetadata
         // Set dataSequenceNumber to avoid contention between OPTIMIZE and concurrent writing of equality deletes
         rewriteFiles.dataSequenceNumber(snapshot.sequenceNumber());
         rewriteFiles.validateFromSnapshot(snapshot.snapshotId());
+        rewriteFiles.scanManifestsWith(icebergScanExecutor);
         commitUpdateAndTransaction(rewriteFiles, session, transaction, "optimize");
 
         // TODO (https://github.com/trinodb/trino/issues/15439) this may not exactly be the snapshot we committed, if there is another writer
@@ -2129,11 +2130,14 @@ public class IcebergMetadata
 
         beginTransaction(icebergTable);
         RewriteManifests rewriteManifests = transaction.rewriteManifests();
-        rewriteManifests.clusterBy(file -> {
-            // Use the first partition field as the clustering key
-            StructLike partition = file.partition();
-            return partition.size() > 1 ? Optional.ofNullable(partition.get(0, Object.class)) : partition;
-        }).commit();
+        rewriteManifests
+                .clusterBy(file -> {
+                    // Use the first partition field as the clustering key
+                    StructLike partition = file.partition();
+                    return partition.size() > 1 ? Optional.ofNullable(partition.get(0, Object.class)) : partition;
+                })
+                .scanManifestsWith(icebergScanExecutor)
+                .commit();
         commitTransaction(transaction, "optimize manifests");
         transaction = null;
     }
@@ -2198,6 +2202,7 @@ public class IcebergMetadata
             table.expireSnapshots()
                     .expireOlderThan(expireTimestampMillis)
                     .deleteWith(deleteFunction)
+                    .planWith(icebergScanExecutor)
                     .commit();
 
             fileSystem.deleteFiles(pathsToDelete);
@@ -3154,6 +3159,7 @@ public class IcebergMetadata
         // Ensure a row that is updated by this commit was not deleted by a separate commit
         rowDelta.validateDeletedFiles();
         rowDelta.validateNoConflictingDeleteFiles();
+        rowDelta.scanManifestsWith(icebergScanExecutor);
 
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
         ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();


### PR DESCRIPTION
## Description
Reduces bottleneck on the default iceberg worker pool


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
