### PR TITLE
Reuse compiled PagesIndexOrdering

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -414,12 +414,7 @@ public class PagesIndex
 
     public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders)
     {
-        sort(sortChannels, sortOrders, 0, getPositionCount());
-    }
-
-    public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders, int startPosition, int endPosition)
-    {
-        sort(createPagesIndexComparator(sortChannels, sortOrders), startPosition, endPosition);
+        sort(createPagesIndexComparator(sortChannels, sortOrders), 0, getPositionCount());
     }
 
     public void sort(PagesIndexOrdering pagesIndexOrdering)

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -419,8 +419,19 @@ public class PagesIndex
 
     public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders, int startPosition, int endPosition)
     {
+        sort(createPagesIndexComparator(sortChannels, sortOrders), startPosition, endPosition);
+    }
+
+    public void sort(PagesIndexOrdering pagesIndexOrdering)
+    {
+        sort(pagesIndexOrdering, 0, getPositionCount());
+    }
+
+    public void sort(PagesIndexOrdering pagesIndexOrdering, int startPosition, int endPosition)
+    {
+        requireNonNull(pagesIndexOrdering, "pagesIndexOrdering is null");
         modificationCount++;
-        createPagesIndexComparator(sortChannels, sortOrders).sort(this, startPosition, endPosition);
+        pagesIndexOrdering.sort(this, startPosition, endPosition);
     }
 
     public boolean positionIdenticalToPosition(PagesHashStrategy partitionHashStrategy, int leftPosition, int rightPosition)
@@ -445,7 +456,7 @@ public class PagesIndex
         return pagesHashStrategy.positionIdenticalToRow(pageIndex, pagePosition, rightPosition, rightPage);
     }
 
-    private PagesIndexOrdering createPagesIndexComparator(List<Integer> sortChannels, List<SortOrder> sortOrders)
+    public PagesIndexOrdering createPagesIndexComparator(List<Integer> sortChannels, List<SortOrder> sortOrders)
     {
         List<Type> sortTypes = sortChannels.stream()
                 .map(types::get)

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -38,6 +38,7 @@ import io.trino.spiller.Spiller;
 import io.trino.spiller.SpillerFactory;
 import io.trino.sql.gen.OrderingCompiler;
 import io.trino.sql.planner.plan.PlanNodeId;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -525,8 +526,8 @@ public class WindowOperator
             implements Transformation<Page, PagesIndexWithHashStrategies>
     {
         final PagesIndexWithHashStrategies pagesIndexWithHashStrategies;
-        final List<Integer> orderChannels;
-        final List<SortOrder> ordering;
+        @Nullable
+        final PagesIndexOrdering pagesIndexOrdering; // null when ordering channels is empty
         final LocalMemoryContext memoryContext;
 
         boolean resetPagesIndex;
@@ -538,8 +539,12 @@ public class WindowOperator
                 List<SortOrder> ordering)
         {
             this.pagesIndexWithHashStrategies = pagesIndexWithHashStrategies;
-            this.orderChannels = orderChannels;
-            this.ordering = ordering;
+            if (orderChannels.isEmpty()) {
+                pagesIndexOrdering = null;
+            }
+            else {
+                pagesIndexOrdering = pagesIndexWithHashStrategies.pagesIndex.createPagesIndexComparator(orderChannels, ordering);
+            }
             this.memoryContext = operatorContext.aggregateUserMemoryContext().newLocalMemoryContext(PagesToPagesIndexes.class.getSimpleName());
         }
 
@@ -565,7 +570,7 @@ public class WindowOperator
 
             // If we have unused input or are finishing, then we have buffered a full group
             if (finishing || pendingInputPosition < pendingInput.getPositionCount()) {
-                sortPagesIndexIfNecessary(pagesIndexWithHashStrategies, orderChannels, ordering);
+                sortPagesIndexIfNecessary(pagesIndexWithHashStrategies.pagesIndex, pagesIndexWithHashStrategies.preSortedPartitionHashStrategy, pagesIndexOrdering);
                 resetPagesIndex = true;
                 return TransformationState.ofResult(pagesIndexWithHashStrategies, false);
             }
@@ -662,9 +667,9 @@ public class WindowOperator
     {
         final PagesIndexWithHashStrategies inMemoryPagesIndexWithHashStrategies;
         final PagesIndexWithHashStrategies mergedPagesIndexWithHashStrategies;
+        @Nullable
+        final PagesIndexOrdering inMemoryPagesIndexOrdering; // null when ordering channels is empty
         final List<Type> sourceTypes;
-        final List<Integer> orderChannels;
-        final List<SortOrder> ordering;
         final LocalMemoryContext localRevocableMemoryContext;
         final LocalMemoryContext localUserMemoryContext;
         final SpillerFactory spillerFactory;
@@ -691,8 +696,12 @@ public class WindowOperator
             this.inMemoryPagesIndexWithHashStrategies = inMemoryPagesIndexWithHashStrategies;
             this.mergedPagesIndexWithHashStrategies = mergedPagesIndexWithHashStrategies;
             this.sourceTypes = sourceTypes;
-            this.orderChannels = orderChannels;
-            this.ordering = ordering;
+            if (orderChannels.isEmpty()) {
+                this.inMemoryPagesIndexOrdering = null;
+            }
+            else {
+                this.inMemoryPagesIndexOrdering = inMemoryPagesIndexWithHashStrategies.pagesIndex.createPagesIndexComparator(orderChannels, ordering);
+            }
             this.localUserMemoryContext = operatorContext.aggregateUserMemoryContext().newLocalMemoryContext(SpillablePagesToPagesIndexes.class.getSimpleName());
             this.localRevocableMemoryContext = operatorContext.aggregateRevocableMemoryContext().newLocalMemoryContext(SpillablePagesToPagesIndexes.class.getSimpleName());
             this.spillerFactory = spillerFactory;
@@ -770,7 +779,7 @@ public class WindowOperator
                 }
             }
 
-            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies, orderChannels, ordering);
+            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies.pagesIndex, inMemoryPagesIndexWithHashStrategies.preSortedPartitionHashStrategy, inMemoryPagesIndexOrdering);
             resetPagesIndex = true;
             return TransformationState.ofResult(unspill(), false);
         }
@@ -796,7 +805,7 @@ public class WindowOperator
             }
 
             verify(inMemoryPagesIndexWithHashStrategies.pagesIndex.getPositionCount() > 0);
-            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies, orderChannels, ordering);
+            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies.pagesIndex, inMemoryPagesIndexWithHashStrategies.preSortedPartitionHashStrategy, inMemoryPagesIndexOrdering);
             PeekingIterator<Page> sortedPages = peekingIterator(inMemoryPagesIndexWithHashStrategies.pagesIndex.getSortedPages());
             Page anyPage = sortedPages.peek();
             verify(anyPage.getPositionCount() != 0, "PagesIndex.getSortedPages returned an empty page");
@@ -896,13 +905,13 @@ public class WindowOperator
         return startPosition;
     }
 
-    private void sortPagesIndexIfNecessary(PagesIndexWithHashStrategies pagesIndexWithHashStrategies, List<Integer> orderChannels, List<SortOrder> ordering)
+    private static void sortPagesIndexIfNecessary(PagesIndex pagesIndex, PagesHashStrategy preSortedPartitionHashStrategy, @Nullable PagesIndexOrdering pagesIndexOrdering)
     {
-        if (pagesIndexWithHashStrategies.pagesIndex.getPositionCount() > 1 && !orderChannels.isEmpty()) {
+        if (pagesIndex.getPositionCount() > 1 && pagesIndexOrdering != null) {
             int startPosition = 0;
-            while (startPosition < pagesIndexWithHashStrategies.pagesIndex.getPositionCount()) {
-                int endPosition = findGroupEnd(pagesIndexWithHashStrategies.pagesIndex, pagesIndexWithHashStrategies.preSortedPartitionHashStrategy, startPosition);
-                pagesIndexWithHashStrategies.pagesIndex.sort(orderChannels, ordering, startPosition, endPosition);
+            while (startPosition < pagesIndex.getPositionCount()) {
+                int endPosition = findGroupEnd(pagesIndex, preSortedPartitionHashStrategy, startPosition);
+                pagesIndex.sort(pagesIndexOrdering, startPosition, endPosition);
                 startPosition = endPosition;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.operator.PagesIndex;
+import io.trino.operator.PagesIndexOrdering;
 import io.trino.operator.window.PagesWindowIndex;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
@@ -35,10 +36,9 @@ public class OrderedWindowAccumulator
 {
     private final PagesIndex.Factory pagesIndexFactory;
     private final PagesIndex pagesIndex;
+    private final PagesIndexOrdering pagesIndexOrdering;
     private final List<Type> argumentTypes;
     private final List<Integer> argumentChannels;
-    private final List<Integer> sortKeysArguments;
-    private final List<SortOrder> sortOrders;
 
     private WindowAccumulator delegate;
     private final WindowAccumulator initialDelegate;
@@ -54,36 +54,36 @@ public class OrderedWindowAccumulator
             List<Integer> sortKeysArguments,
             List<SortOrder> sortOrders)
     {
-        this(pagesIndexFactory, pagesIndexFactory.newPagesIndex(argumentTypes, 10_000), delegate, argumentTypes, argumentChannels, sortKeysArguments, sortOrders);
+        this(
+                pagesIndexFactory,
+                createPagesIndexWithOrdering(
+                        pagesIndexFactory,
+                        argumentTypes,
+                        requireNonNull(argumentChannels, "argumentChannels is null").size(),
+                        sortKeysArguments,
+                        sortOrders),
+                delegate,
+                argumentTypes,
+                argumentChannels);
     }
 
     private OrderedWindowAccumulator(
             PagesIndex.Factory pagesIndexFactory,
-            PagesIndex pagesIndex,
+            PagesIndexWithOrdering pagesIndexWithOrdering,
             WindowAccumulator delegate,
             List<Type> argumentTypes,
-            List<Integer> argumentChannels,
-            List<Integer> sortKeysArguments,
-            List<SortOrder> sortOrders)
+            List<Integer> argumentChannels)
     {
         this.pagesIndexFactory = requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
-        this.pagesIndex = requireNonNull(pagesIndex, "pagesIndex is null");
+        requireNonNull(pagesIndexWithOrdering, "pagesIndexWithOrdering is null");
+        this.pagesIndex = pagesIndexWithOrdering.pagesIndex;
+        this.pagesIndexOrdering = pagesIndexWithOrdering.pagesIndexOrdering;
 
         requireNonNull(argumentTypes, "argumentTypes is null");
         requireNonNull(argumentChannels, "argumentChannels is null");
         checkArgument(argumentTypes.size() == argumentChannels.size(), "argumentTypes and argumentChannels must have the same size");
         this.argumentTypes = ImmutableList.copyOf(argumentTypes);
         this.argumentChannels = ImmutableList.copyOf(argumentChannels);
-        requireNonNull(sortOrders, "sortOrders is null");
-        requireNonNull(sortKeysArguments, "sortChannels is null");
-        checkArgument(sortOrders.size() == sortKeysArguments.size(), "sortOrders and sortChannels must have the same size");
-        sortKeysArguments.forEach(argument -> {
-            checkArgument(
-                    argument < argumentChannels.size(),
-                    "invalid argument %s referenced; total number of arguments is %s", argument, argumentChannels.size());
-        });
-        this.sortOrders = ImmutableList.copyOf(sortOrders);
-        this.sortKeysArguments = ImmutableList.copyOf(sortKeysArguments);
 
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.initialDelegate = delegate.copy();
@@ -102,7 +102,7 @@ public class OrderedWindowAccumulator
     {
         PagesIndex pagesIndexCopy = pagesIndexFactory.newPagesIndex(argumentTypes, pagesIndex.getPositionCount());
         pagesIndex.getPages().forEachRemaining(pagesIndexCopy::addPage);
-        return new OrderedWindowAccumulator(pagesIndexFactory, pagesIndexCopy, delegate.copy(), argumentTypes, argumentChannels, sortKeysArguments, sortOrders);
+        return new OrderedWindowAccumulator(pagesIndexFactory, new PagesIndexWithOrdering(pagesIndexCopy, pagesIndexOrdering), delegate.copy(), argumentTypes, argumentChannels);
     }
 
     @Override
@@ -145,7 +145,7 @@ public class OrderedWindowAccumulator
                 delegate.output(blockBuilder);
                 return;
             }
-            pagesIndex.sort(sortKeysArguments, sortOrders);
+            pagesIndex.sort(pagesIndexOrdering);
             WindowIndex sortedWindowIndex = new PagesWindowIndex(pagesIndex, 0, positionCount);
             delegate.addInput(sortedWindowIndex, 0, positionCount - 1);
             pagesIndexSorted = true;
@@ -153,5 +153,35 @@ public class OrderedWindowAccumulator
         checkState(pageBuilder.isEmpty());
 
         delegate.output(blockBuilder);
+    }
+
+    private static PagesIndexWithOrdering createPagesIndexWithOrdering(
+            PagesIndex.Factory pagesIndexFactory,
+            List<Type> argumentTypes,
+            int argumentChannelCount,
+            List<Integer> sortKeysArguments,
+            List<SortOrder> sortOrders)
+    {
+        requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
+        requireNonNull(sortOrders, "sortOrders is null");
+        requireNonNull(sortKeysArguments, "sortChannels is null");
+        checkArgument(sortOrders.size() == sortKeysArguments.size(), "sortOrders and sortChannels must have the same size");
+        sortKeysArguments.forEach(argument -> {
+            checkArgument(
+                    argument < argumentChannelCount,
+                    "invalid argument %s referenced; total number of arguments is %s", argument, argumentChannelCount);
+        });
+        PagesIndex pagesIndex = pagesIndexFactory.newPagesIndex(argumentTypes, 10_000);
+        PagesIndexOrdering pagesIndexOrdering = pagesIndex.createPagesIndexComparator(sortKeysArguments, sortOrders);
+        return new PagesIndexWithOrdering(pagesIndex, pagesIndexOrdering);
+    }
+
+    private record PagesIndexWithOrdering(PagesIndex pagesIndex, PagesIndexOrdering pagesIndexOrdering)
+    {
+        private PagesIndexWithOrdering
+        {
+            requireNonNull(pagesIndex, "pagesIndex is null");
+            requireNonNull(pagesIndexOrdering, "pagesIndexOrdering is null");
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
@@ -27,6 +27,7 @@ import io.trino.operator.OperatorFactory;
 import io.trino.operator.PageBuffer;
 import io.trino.operator.PagesHashStrategy;
 import io.trino.operator.PagesIndex;
+import io.trino.operator.PagesIndexOrdering;
 import io.trino.operator.WorkProcessor;
 import io.trino.operator.function.RegularTableFunctionPartition.PassThroughColumnSpecification;
 import io.trino.spi.Page;
@@ -37,6 +38,7 @@ import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.function.table.TableFunctionProcessorProvider;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -360,8 +362,8 @@ public class TableFunctionOperator
         final PagesHashStrategy prePartitionedStrategy;
         final PagesHashStrategy remainingPartitionStrategy;
         final PagesHashStrategy preSortedStrategy;
-        final List<Integer> remainingPartitionAndSortChannels;
-        final List<SortOrder> remainingSortOrders;
+        @Nullable
+        final PagesIndexOrdering remainingPartitionAndSortOrdering; // null when remaining partitioning and sort channels are empty
         final int[] prePartitionedChannelsArray;
 
         public HashStrategies(
@@ -384,16 +386,26 @@ public class TableFunctionOperator
                     .collect(toImmutableList());
             this.preSortedStrategy = pagesIndex.createPagesHashStrategy(preSortedChannels);
 
+            List<Integer> remainingPartitionAndSortChannels;
+            List<SortOrder> remainingSortOrders;
             if (preSortedPrefix > 0) {
                 // preSortedPrefix > 0 implies that all partition channels are already pre-partitioned (enforced by check in the constructor), so we only need to do the remaining sort
-                this.remainingPartitionAndSortChannels = ImmutableList.copyOf(Iterables.skip(sortChannels, preSortedPrefix));
-                this.remainingSortOrders = ImmutableList.copyOf(Iterables.skip(sortOrders, preSortedPrefix));
+                remainingPartitionAndSortChannels = ImmutableList.copyOf(Iterables.skip(sortChannels, preSortedPrefix));
+                remainingSortOrders = ImmutableList.copyOf(Iterables.skip(sortOrders, preSortedPrefix));
             }
             else {
                 // we need to sort by the remaining partition channels so that the input is fully partitioned,
                 // and then need to we sort by all the sort channels so that the input is fully sorted
-                this.remainingPartitionAndSortChannels = ImmutableList.copyOf(concat(remainingPartitionChannels, sortChannels));
-                this.remainingSortOrders = ImmutableList.copyOf(concat(nCopies(remainingPartitionChannels.size(), ASC_NULLS_LAST), sortOrders));
+                remainingPartitionAndSortChannels = ImmutableList.copyOf(concat(remainingPartitionChannels, sortChannels));
+                remainingSortOrders = ImmutableList.copyOf(concat(nCopies(remainingPartitionChannels.size(), ASC_NULLS_LAST), sortOrders));
+            }
+
+            checkArgument(remainingPartitionAndSortChannels.size() == remainingSortOrders.size(), "sort channels and orders sizes must match");
+            if (remainingPartitionAndSortChannels.isEmpty()) {
+                this.remainingPartitionAndSortOrdering = null;
+            }
+            else {
+                this.remainingPartitionAndSortOrdering = pagesIndex.createPagesIndexComparator(remainingPartitionAndSortChannels, remainingSortOrders);
             }
 
             this.prePartitionedChannelsArray = Ints.toArray(prePartitionedChannels);
@@ -498,14 +510,13 @@ public class TableFunctionOperator
     private static void sortCurrentGroup(PagesIndex pagesIndex, HashStrategies hashStrategies)
     {
         PagesHashStrategy preSortedStrategy = hashStrategies.preSortedStrategy;
-        List<Integer> remainingPartitionAndSortChannels = hashStrategies.remainingPartitionAndSortChannels;
-        List<SortOrder> remainingSortOrders = hashStrategies.remainingSortOrders;
+        PagesIndexOrdering remainingPartitionAndSortOrdering = hashStrategies.remainingPartitionAndSortOrdering;
 
-        if (pagesIndex.getPositionCount() > 1 && !remainingPartitionAndSortChannels.isEmpty()) {
+        if (pagesIndex.getPositionCount() > 1 && remainingPartitionAndSortOrdering != null) {
             int startPosition = 0;
             while (startPosition < pagesIndex.getPositionCount()) {
                 int endPosition = findGroupEnd(pagesIndex, preSortedStrategy, startPosition);
-                pagesIndex.sort(remainingPartitionAndSortChannels, remainingSortOrders, startPosition, endPosition);
+                pagesIndex.sort(remainingPartitionAndSortOrdering, startPosition, endPosition);
                 startPosition = endPosition;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1210,7 +1210,6 @@ public class LocalExecutionPlanner
                                         pagesIndexFactory,
                                         finalAccumulatorSupplier.apply(lambdaProviders),
                                         argumentTypes,
-                                        argumentChannels,
                                         sortKeysArguments,
                                         sortOrders);
                     }


### PR DESCRIPTION
## Description
Avoids calling into code generation logic inside of `PagesIndex#sort(List<Integer>, List<SortOrder>, int startIndex, int endIndex)` by refactoring existing usages to eagerly create and then keep an instance of `PagesIndexOrdering` for reuse. Some scenarios (such as window operators) could repeatedly call into the code generation path which creates cache contention and a severe performance hazard if the entry was evicted from cache between calls.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
