### PR TITLE
Refresh Catalog Task

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
@@ -42,9 +42,19 @@ public class DynamicCatalogManagerModule
             binder.bind(CatalogManager.class).to(CoordinatorDynamicCatalogManager.class).in(Scopes.SINGLETON);
             binder.bind(CoordinatorLazyRegister.class).asEagerSingleton();
 
+            // TODO: Refresh Config (only in coordinator)
             configBinder(binder).bindConfig(CatalogPruneTaskConfig.class);
             binder.bind(CatalogPruneTask.class).in(Scopes.SINGLETON);
             install(internalHttpClientModule("catalog-prune", ForCatalogPrune.class)
+                    .withConfigDefaults(config -> {
+                        config.setIdleTimeout(new Duration(30, SECONDS));
+                        config.setRequestTimeout(new Duration(10, SECONDS));
+                    }).build());
+
+            // Catalog Refresh Task
+            configBinder(binder).bindConfig(RefreshCatalogsTaskConfig.class);
+            binder.bind(RefreshCatalogsTask.class).in(Scopes.SINGLETON);
+            install(internalHttpClientModule("catalog-refresh", ForCatalogRefresh.class)
                     .withConfigDefaults(config -> {
                         config.setIdleTimeout(new Duration(30, SECONDS));
                         config.setRequestTimeout(new Duration(10, SECONDS));

--- a/core/trino-main/src/main/java/io/trino/connector/ForCatalogRefresh.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ForCatalogRefresh.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForCatalogRefresh
+{
+}

--- a/core/trino-main/src/main/java/io/trino/connector/RefreshCatalogsTask.java
+++ b/core/trino-main/src/main/java/io/trino/connector/RefreshCatalogsTask.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.airlift.concurrent.ThreadPoolExecutorMBean;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.metadata.CatalogManager;
+import io.trino.node.AllNodes;
+import io.trino.node.InternalNode;
+import io.trino.node.InternalNodeManager;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.net.URI;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class RefreshCatalogsTask
+{
+    private static final Logger log = Logger.get(RefreshCatalogsTask.class);
+
+    private final CatalogManager catalogManager;
+    private final InternalNode currentNode;
+    private final InternalNodeManager internalNodeManager;
+    private final HttpClient httpClient;
+
+    private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("catalog-refresh"));
+    private final ThreadPoolExecutorMBean executorMBean = new ThreadPoolExecutorMBean(executor);
+
+    private final boolean enabled;
+    private final Duration refreshInterval;
+
+    private final AtomicBoolean started = new AtomicBoolean();
+
+    @Inject
+    public RefreshCatalogsTask(
+            CatalogManager catalogManager,
+            InternalNode currentNode,
+            InternalNodeManager internalNodeManager,
+            @ForCatalogRefresh HttpClient httpClient,
+            RefreshCatalogsTaskConfig refreshCatalogsTaskConfig)
+    {
+        this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
+        this.currentNode = requireNonNull(currentNode, "currentNode is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+
+        this.enabled = refreshCatalogsTaskConfig.isEnabled();
+        this.refreshInterval = refreshCatalogsTaskConfig.getRefreshInterval();
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        if (enabled && !started.getAndSet(true)) {
+            executor.scheduleWithFixedDelay(() -> {
+                try {
+                    refreshCatalogs();
+                }
+                catch (Throwable e) {
+                    // ignore to avoid getting unscheduled
+                    log.warn(e, "Error refreshing catalogs");
+                }
+            }, refreshInterval.toMillis(), refreshInterval.toMillis(), MILLISECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Managed
+    @Nested
+    public ThreadPoolExecutorMBean getExecutor()
+    {
+        return executorMBean;
+    }
+
+    @VisibleForTesting
+    public void refreshCatalogs()
+    {
+        // First refresh the coordinator's catalogs
+        if (catalogManager instanceof CoordinatorDynamicCatalogManager dynamicCatalogManager) {
+            try {
+                log.debug("Refreshing catalogs on coordinator");
+                dynamicCatalogManager.refreshCatalogs();
+                log.info("Successfully refreshed catalogs on coordinator");
+            }
+            catch (Exception e) {
+                log.warn(e, "Failed to refresh catalogs on coordinator");
+            }
+        }
+        else {
+            log.debug("Catalog manager does not support dynamic refresh: %s", catalogManager.getClass().getSimpleName());
+        }
+
+        // Send refresh signal to all workers
+        AllNodes allNodes = internalNodeManager.getAllNodes();
+        Set<URI> workers = Stream.of(allNodes.activeNodes(), allNodes.inactiveNodes(), allNodes.drainingNodes(), allNodes.drainedNodes(), allNodes.shuttingDownNodes())
+                .flatMap(Set::stream)
+                .map(InternalNode::getInternalUri)
+                .filter(uri -> !uri.equals(currentNode.getInternalUri()))
+                .collect(toImmutableSet());
+
+        refreshWorkerCatalogs(workers);
+    }
+
+    @VisibleForTesting
+    void refreshWorkerCatalogs(Set<URI> workers)
+    {
+        for (URI uri : workers) {
+            uri = uriBuilderFrom(uri).appendPath("/v1/task/refreshCatalogs").build();
+            Request request = preparePost()
+                    .setUri(uri)
+                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .build();
+            httpClient.executeAsync(request, new ResponseHandler<>()
+            {
+                @Override
+                public Exception handleException(Request request, Exception exception)
+                {
+                    log.debug(exception, "Error refreshing catalogs on server: %s", request.getUri());
+                    return exception;
+                }
+
+                @Override
+                public Object handle(Request request, Response response)
+                {
+                    log.debug("Refreshed catalogs on server: %s", request.getUri());
+                    return null;
+                }
+            });
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/RefreshCatalogsTaskConfig.java
+++ b/core/trino-main/src/main/java/io/trino/connector/RefreshCatalogsTaskConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.NotNull;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class RefreshCatalogsTaskConfig
+{
+    private boolean enabled; // Disabled by default
+    private Duration refreshInterval = new Duration(5, MINUTES);
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("catalog.refresh.enabled")
+    public RefreshCatalogsTaskConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @MinDuration("1s")
+    @NotNull
+    public Duration getRefreshInterval()
+    {
+        return refreshInterval;
+    }
+
+    @Config("catalog.refresh.interval")
+    public RefreshCatalogsTaskConfig setRefreshInterval(Duration interval)
+    {
+        this.refreshInterval = interval;
+        return this;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

 This PR introduces the `RefreshCatalogTask` component that enables periodic synchronization of Trino's internal catalog state with external sources of truth, eliminating the need for engine restarts when managing catalogs.

The implementation consists of two main components:
       RefreshCatalogTask - A scheduled task that periodically polls external catalog stores and synchronizes changes with the `CoordinatorDynamicCatalogManager`. It follows the same architectural patterns as the existing `CatalogPruneTask`, ensuring consistency with Trino's design principles.

       Configuration Integration - Adds new configuration properties (`catalog.refresh.enabled`, `catalog.refresh.interval`) that enable dynamic catalog management while maintaining backward compatibility (disabled by default).

The RefreshCatalogTask integrates seamlessly with the existing `CoordinatorDynamicCatalogManager` by calling its `refreshCatalogs()` method, which performs thread-safe catalog updates using the established `catalogsUpdateLock`.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
