### PR TITLE
Use queryDataEncoding from session to avoid building queryInfo

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -48,7 +48,6 @@ import jakarta.ws.rs.core.Response.ResponseBuilder;
 import java.net.URLEncoder;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -215,13 +214,12 @@ public class ExecutingStatementResource
     {
         ListenableFuture<QueryResultsResponse> queryResultsFuture = query.waitForResults(token, externalUriInfo, MAX_WAIT_TIME);
 
-        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, results ->
-                toResponse(results, query.getQueryInfo().getSession().getQueryDataEncoding()), directExecutor());
+        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, this::toResponse, directExecutor());
 
         bindAsyncResponse(asyncResponse, response, responseExecutor);
     }
 
-    private Response toResponse(QueryResultsResponse resultsResponse, Optional<String> queryDataEncoding)
+    private Response toResponse(QueryResultsResponse resultsResponse)
     {
         ResponseBuilder response = Response.ok(resultsResponse.queryResults());
 
@@ -275,7 +273,7 @@ public class ExecutingStatementResource
             response.encoding("identity");
         }
 
-        queryDataEncoding
+        resultsResponse.queryDataEncoding()
                 .ifPresent(encoding -> response.header(TRINO_HEADERS.responseQueryDataEncoding(), encoding));
 
         return response.build();

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -560,7 +560,8 @@ class Query
                 startedTransactionId,
                 clearTransactionId,
                 session.getProtocolHeaders(),
-                queryResults);
+                queryResults,
+                session.getQueryDataEncoding());
     }
 
     private synchronized QueryResultRows removePagesFromExchange(ResultQueryInfo queryInfo)

--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultsResponse.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultsResponse.java
@@ -39,7 +39,8 @@ record QueryResultsResponse(
         Optional<TransactionId> startedTransactionId,
         boolean clearTransactionId,
         ProtocolHeaders protocolHeaders,
-        QueryResults queryResults)
+        QueryResults queryResults,
+        Optional<String> queryDataEncoding)
 {
     QueryResultsResponse {
         requireNonNull(setCatalog, "setCatalog is null");
@@ -55,5 +56,6 @@ record QueryResultsResponse(
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(protocolHeaders, "protocolHeaders is null");
         requireNonNull(queryResults, "queryResults is null");
+        requireNonNull(queryDataEncoding, "queryDataEncoding is null");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Coordinator seems collecting query info & metrics in every query response only for `QueryDataEncoding`, which is already available in Session. 
Trying to optimize and save coordinator resource.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
example jstack:
```
Query-20250722_170536_20208_gu27x-5473983 RUNNABLE #5473983
  at io.airlift.stats.TDigest.merge(TDigest.java:446)
  at io.airlift.stats.TDigest.mergeWith(TDigest.java:219)
  at io.trino.plugin.base.metrics.TDigestHistogram.mergeTo(TDigestHistogram.java:97)
  at io.trino.plugin.base.metrics.TDigestHistogram.mergeWith(TDigestHistogram.java:90)
  at io.trino.plugin.base.metrics.TDigestHistogram.mergeWith(TDigestHistogram.java:32)
  at io.trino.spi.metrics.Metrics$Accumulator.merge(Metrics.java:115)
  at io.trino.spi.metrics.Metrics$Accumulator.lambda$get$2(Metrics.java:108)
  at io.trino.spi.metrics.Metrics$Accumulator$$Lambda/0x00007f35d942e190.accept(:-1)
  at java.util.HashMap.forEach(HashMap.java:1430)
  at io.trino.spi.metrics.Metrics$Accumulator.get(Metrics.java:108)
  at io.trino.operator.OperatorStats.add(OperatorStats.java:601)
  at io.trino.operator.OperatorStats.add(OperatorStats.java:463)
  at io.trino.execution.StageStateMachine.combineTaskOperatorSummaries(StageStateMachine.java:730)
  at io.trino.execution.StageStateMachine.getStageInfo(StageStateMachine.java:597)
  at io.trino.execution.SqlStage.getStageInfo(SqlStage.java:225)
  at io.trino.execution.scheduler.StageManager$$Lambda/0x00007f35d93d1b48.apply(:-1)
  at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:215)
  at com.google.common.collect.CollectSpliterators$1WithCharacteristics.lambda$forEachRemaining$1(CollectSpliterators.java:72)
  at com.google.common.collect.CollectSpliterators$1WithCharacteristics$$Lambda/0x00007f35d731ade0.accept(:-1)
  at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(Streams.java:104)
  at com.google.common.collect.CollectSpliterators$1WithCharacteristics.forEachRemaining(CollectSpliterators.java:72)
  at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
  at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
  at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
  at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
  at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:727)
  at io.trino.execution.scheduler.StageManager.getStageInfo(StageManager.java:245)
  at io.trino.execution.scheduler.PipelinedQueryScheduler.getStageInfo(PipelinedQueryScheduler.java:461)
  at io.trino.execution.SqlQueryExecution.buildQueryInfo(SqlQueryExecution.java:746)
  at io.trino.execution.SqlQueryExecution.lambda$getQueryInfo$6(SqlQueryExecution.java:715)
  at io.trino.execution.SqlQueryExecution$$Lambda/0x00007f35d93d1920.get(:-1)
  at java.util.Optional.orElseGet(Optional.java:364)
  at io.trino.execution.SqlQueryExecution.getQueryInfo(SqlQueryExecution.java:715)
  at io.trino.execution.SqlQueryManager.getFullQueryInfo(SqlQueryManager.java:206)
  at io.trino.server.protocol.Query.getQueryInfo(Query.java:294)
  at io.trino.server.protocol.ExecutingStatementResource.lambda$asyncQueryResults$2(ExecutingStatementResource.java:238)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
