### PR TITLE
Fix wrong hive.user-metastore-cache-ttl in documentation

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -83,7 +83,7 @@ are also available. They are discussed later in this topic.
 * - `hive.user-metastore-cache-ttl`
   - [Duration](prop-type-duration) of how long cached metastore statistics, which are user specific
     in user impersonation scenarios, are considered valid.
-  - `10s`
+  - `0s`
 * - `hive.user-metastore-cache-maximum-size`
   - Maximum number of metastore data objects in the Hive metastore cache,
     which are user specific in user impersonation scenarios.


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/blob/1c54e8b3d4a46bc40b68ecfc29da1bbd871e53a6/lib/trino-metastore/src/main/java/io/trino/metastore/cache/ImpersonationCachingConfig.java#L25

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
