### PR TITLE
Update vm options for running dev server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Trino comes with sample configuration that should work out-of-the-box for
 development. Use the following options to create a run configuration:
 
 * Main Class: `io.trino.server.DevelopmentServer`
-* VM Options: `-ea -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties -Djdk.attach.allowAttachSelf=true`
+* VM Options: `-ea -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties -Djdk.attach.allowAttachSelf=true --sun-misc-unsafe-memory-access=allow`
 * Working directory: `$MODULE_DIR$`
 * Use classpath of module: `trino-server-dev`
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Follow the instructions https://github.com/trinodb/trino?tab=readme-ov-file#running-the-full-server
I encountered 
```
1) Error: Connector 'cassandra' requires additional JVM argument(s). Please add the following to the JVM configuration: '--sun-misc-unsafe-memory-access=allow'
  at java.base/DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
