### PR TITLE
Add query references page to Preview Web UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
@@ -206,6 +206,19 @@ export interface Session {
     catalogProperties: { [key: string]: string | number | boolean }
 }
 
+export interface QueryTable {
+    catalog: string
+    schema: string
+    table: string
+    authorization: string
+    directlyReferenced: boolean
+}
+
+export interface QueryRoutine {
+    routine: string
+    authorization: string
+}
+
 export interface QueryStatusInfo extends QueryInfoBase {
     session: Session
     query: string
@@ -214,6 +227,8 @@ export interface QueryStatusInfo extends QueryInfoBase {
     retryPolicy: string
     pruned: boolean
     finalQueryInfo: boolean
+    referencedTables: QueryTable[]
+    routines: QueryRoutine[]
 }
 
 export async function statsApi(): Promise<ApiResponse<Stats>> {
@@ -232,6 +247,6 @@ export async function queryApi(): Promise<ApiResponse<QueryInfo[]>> {
     return await api.get<QueryInfo[]>('/ui/api/query')
 }
 
-export async function queryStatusApi(queryId: string): Promise<ApiResponse<QueryStatusInfo>> {
-    return await api.get<QueryStatusInfo>(`/ui/api/query/${queryId}`)
+export async function queryStatusApi(queryId: string, pruned: boolean = false): Promise<ApiResponse<QueryStatusInfo>> {
+    return await api.get<QueryStatusInfo>(`/ui/api/query/${queryId}${pruned ? '?pruned=true' : ''}`)
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
@@ -15,6 +15,7 @@ import React, { ReactNode, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 import { Alert, Box, Divider, Grid2 as Grid, Tabs, Tab, Typography } from '@mui/material'
 import { QueryJson } from './QueryJson'
+import { QueryReferences } from './QueryReferences'
 import { QueryOverview } from './QueryOverview'
 import { Texts } from '../constant.ts'
 
@@ -26,7 +27,7 @@ const tabComponentMap: Record<TabValue, ReactNode> = {
     stagePerformance: <Alert severity="error">{Texts.Error.NotImplemented}</Alert>,
     splits: <Alert severity="error">{Texts.Error.NotImplemented}</Alert>,
     json: <QueryJson />,
-    references: <Alert severity="error">{Texts.Error.NotImplemented}</Alert>,
+    references: <QueryReferences />,
 }
 export const QueryDetails = () => {
     const { queryId } = useParams()
@@ -60,7 +61,7 @@ export const QueryDetails = () => {
                                 <Tab value="stagePerformance" label="Stage performance" disabled />
                                 <Tab value="splits" label="Splits" disabled />
                                 <Tab value="json" label="JSON" />
-                                <Tab value="references" label="References" disabled />
+                                <Tab value="references" label="References" />
                             </Tabs>
                         </Box>
                     </Grid>

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryReferences.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryReferences.tsx
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useParams } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import {
+    Alert,
+    Box,
+    CircularProgress,
+    Divider,
+    Grid2 as Grid,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableRow,
+    Typography,
+} from '@mui/material'
+import { queryStatusApi, QueryRoutine, QueryStatusInfo, QueryTable } from '../api/webapp/api.ts'
+import { Texts } from '../constant.ts'
+import { ApiResponse } from '../api/base.ts'
+import { QueryProgressBar } from './QueryProgressBar.tsx'
+
+interface IQueryStatus {
+    info: QueryStatusInfo | null
+    ended: boolean
+}
+
+export const QueryReferences = () => {
+    const { queryId } = useParams()
+    const initialQueryStatus: IQueryStatus = {
+        info: null,
+        ended: false,
+    }
+
+    const [queryStatus, setQueryStatus] = useState<IQueryStatus>(initialQueryStatus)
+
+    const [loading, setLoading] = useState<boolean>(true)
+    const [error, setError] = useState<string | null>(null)
+    const queryStatusRef = useRef(queryStatus)
+
+    useEffect(() => {
+        queryStatusRef.current = queryStatus
+    }, [queryStatus])
+
+    useEffect(() => {
+        const runLoop = () => {
+            const queryEnded = !!queryStatusRef.current.info?.finalQueryInfo
+            if (!queryEnded) {
+                getQueryStatus()
+                setTimeout(runLoop, 3000)
+            }
+        }
+
+        if (queryId) {
+            queryStatusRef.current = initialQueryStatus
+        }
+
+        runLoop()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [queryId])
+
+    const getQueryStatus = () => {
+        if (queryId) {
+            queryStatusApi(queryId, false).then((apiResponse: ApiResponse<QueryStatusInfo>) => {
+                setLoading(false)
+                if (apiResponse.status === 200 && apiResponse.data) {
+                    setQueryStatus({
+                        info: apiResponse.data,
+                        ended: apiResponse.data.finalQueryInfo,
+                    })
+                    setError(null)
+                } else {
+                    setError(`${Texts.Error.Communication} ${apiResponse.status}: ${apiResponse.message}`)
+                }
+            })
+        }
+    }
+
+    const renderReferencedTables = (tables: QueryTable[]) => {
+        if (!tables || tables.length === 0) {
+            return (
+                <Box sx={{ width: '100%', mt: 1 }}>
+                    <Alert severity="info">No referenced tables.</Alert>
+                </Box>
+            )
+        }
+
+        return (
+            <TableContainer>
+                <Table aria-label="simple table">
+                    <TableBody>
+                        {tables.map((table: QueryTable) => {
+                            const tableName = `${table.catalog}.${table.schema}.${table.table}`
+                            return (
+                                <TableRow key={tableName}>
+                                    <TableCell sx={{ width: '50%' }}>{tableName}</TableCell>
+                                    <TableCell sx={{ width: '50%' }}>
+                                        {`Authorization: ${table.authorization}, Directly Referenced: ${table.directlyReferenced}`}
+                                    </TableCell>
+                                </TableRow>
+                            )
+                        })}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        )
+    }
+
+    const renderRoutines = (routines: QueryRoutine[]) => {
+        if (!routines || routines.length === 0) {
+            return (
+                <Box sx={{ width: '100%', mt: 1 }}>
+                    <Alert severity="info">No referenced routines.</Alert>
+                </Box>
+            )
+        }
+
+        return (
+            <TableContainer>
+                <Table aria-label="simple table">
+                    <TableBody>
+                        {routines.map((routine: QueryRoutine, idx: number) => (
+                            <TableRow key={`${routine.routine}-${idx}`}>
+                                <TableCell sx={{ width: '50%' }}>{`${routine.routine}`}</TableCell>
+                                <TableCell sx={{ width: '50%' }}>{`Authorization: ${routine.authorization}`}</TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        )
+    }
+
+    return (
+        <>
+            {loading && <CircularProgress />}
+            {error && <Alert severity="error">{Texts.Error.QueryNotFound}</Alert>}
+
+            {!loading && !error && queryStatus.info && (
+                <Grid container spacing={0}>
+                    <Grid size={{ xs: 12 }}>
+                        <Box sx={{ pt: 2 }}>
+                            <Box sx={{ width: '100%' }}>
+                                <QueryProgressBar queryInfoBase={queryStatus.info} />
+                            </Box>
+
+                            {queryStatus.ended ? (
+                                <Grid container spacing={3}>
+                                    <Grid size={{ xs: 12, md: 12 }}>
+                                        <Box sx={{ pt: 2 }}>
+                                            <Typography variant="h6">Referenced Tables</Typography>
+                                            <Divider />
+                                        </Box>
+                                        {renderReferencedTables(queryStatus.info.referencedTables)}
+                                        <Box sx={{ pt: 2 }}>
+                                            <Typography variant="h6">Routines</Typography>
+                                            <Divider />
+                                        </Box>
+                                        {renderRoutines(queryStatus.info.routines)}
+                                    </Grid>
+                                </Grid>
+                            ) : (
+                                <>
+                                    <Box sx={{ width: '100%', mt: 1 }}>
+                                        <Alert severity="info">
+                                            References will appear automatically when query completes.
+                                        </Alert>
+                                    </Box>
+                                </>
+                            )}
+                        </Box>
+                    </Grid>
+                </Grid>
+            )}
+        </>
+    )
+}


### PR DESCRIPTION
## Description

Add query references page to the preview UI. Partially addressing https://github.com/trinodb/trino/issues/22697

## Additional context and related issues

Retains the same functionality as the existing web UI, enhanced with the updated layout, design, and user experience.

## Screenshots

<img width="1497" height="648" alt="image" src="https://github.com/user-attachments/assets/2c199aa9-4d2d-4f89-ac9e-22e6a8acb78e" />

<img width="1507" height="656" alt="image" src="https://github.com/user-attachments/assets/ccedf4c1-8ad1-49d6-9276-3c53793b5384" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Add query references page to the Preview Web UI. ({issue}`26327`)
```