### PR TITLE
Add ST_Multi Geospatial Function and tests

### DIFF
--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -2005,6 +2005,24 @@ public class TestGeoFunctions
     }
 
     @Test
+    private void testSTMulti()
+    {
+        testMultiConversion("POINT (0 0)", "MULTIPOINT ((0 0))");
+        testMultiConversion("MULTIPOINT ((1 1))", "MULTIPOINT ((1 1))");
+        testMultiConversion("LINESTRING (1 2, 3 4, 5 6, 7 8)", "MULTILINESTRING ((1 2, 3 4, 5 6, 7 8))");
+        testMultiConversion("MULTILINESTRING ((1 2, 3 4, 5 6, 7 8))", "MULTILINESTRING ((1 2, 3 4, 5 6, 7 8))");
+        testMultiConversion("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))");
+        testMultiConversion("MULTIPOLYGON (((1 1, 1 4, 4 4, 4 1)), ((1 1, 1 4, 4 4, 4 1)))", "MULTIPOLYGON (((1 1, 1 4, 4 4, 4 1)), ((1 1, 1 4, 4 4, 4 1)))");
+    }
+
+    public void testMultiConversion(String wkt, String expected) {
+        assertThat(assertions.expression("ST_AsText(ST_Multi(geometry))")
+                .binding("geometry", "ST_GeometryFromText('%s')".formatted(wkt)))
+                .hasType(VARCHAR)
+                .isEqualTo(expected);
+    }
+
+    @Test
     public void testSTPointN()
     {
         assertPointN("LINESTRING(1 2, 3 4, 5 6, 7 8)", 1, "POINT (1 2)");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
We have a need to natively convert non-multi types to multi-types, in the same way as the PostGIS function [ST_Multi](https://postgis.net/docs/ST_Multi.html). It is possible todo with a UDF, but is quite inefficient.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
No related issues as far as I can tell.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
