### PR TITLE
fixing spooling

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/SpoolingController.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpoolingController.java
@@ -70,8 +70,8 @@ public interface SpoolingController
 
         public void recordPage(long positions, long size)
         {
-            verify(positions > 0, "Expected positions to be non-negative");
-            verify(size > 0, "Expected size to be non-negative");
+            verify(positions >= 0, "Expected positions to be non-negative");
+            verify(size >= 0, "Expected size to be non-negative");
             this.pages++;
             this.positions += positions;
             this.size += size;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Sometimes, when working with Spooling with large result set, getting this error:
<img width="2682" height="1126" alt="image" src="https://github.com/user-attachments/assets/9bc0f2be-e513-41a9-8b2b-ec74c984e967" />

The error seems could be due to a small mistake in the verify condition, the comment is right but the code is slightly off.
@wendigo 

<img width="2682" height="1126" alt="image" src="https://github.com/user-attachments/assets/31582551-d3bb-4b09-a289-c100c84eadcf" />



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
