### PR TITLE
Trino Case Sensitivity support : Introduce NameCanonicalizer to the metadata

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
@@ -97,7 +97,7 @@ public class AddColumnTask
     {
         Session session = stateMachine.getSession();
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
-        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getName(), plannerContext.getMetadata());
         RedirectionAwareTableHandle redirectionAwareTableHandle = plannerContext.getMetadata().getRedirectionAwareTableHandle(session, originalTableName);
         if (redirectionAwareTableHandle.tableHandle().isEmpty()) {
             if (!statement.isTableExists()) {

--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -102,7 +102,7 @@ public class CallTask
         }
 
         Session session = stateMachine.getSession();
-        QualifiedObjectName procedureName = createQualifiedObjectName(session, call, call.getName());
+        QualifiedObjectName procedureName = createQualifiedObjectName(session, call, call.getName(), plannerContext.getMetadata());
         CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), stateMachine.getSession(), call, procedureName.catalogName());
         Procedure procedure = procedureRegistry.resolve(catalogHandle, procedureName.asSchemaTableName());
 

--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -89,7 +89,7 @@ public class CommentTask
 
     private void commentOnTable(Comment statement, Session session)
     {
-        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getName(), metadata);
         if (metadata.isMaterializedView(session, originalTableName)) {
             throw semanticException(
                     TABLE_NOT_FOUND,
@@ -116,7 +116,7 @@ public class CommentTask
 
     private void commentOnView(Comment statement, Session session)
     {
-        QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getName(), metadata);
         if (!metadata.isView(session, viewName)) {
             String additionalInformation;
             if (metadata.getMaterializedView(session, viewName).isPresent()) {
@@ -140,7 +140,7 @@ public class CommentTask
         QualifiedName prefix = statement.getName().getPrefix()
                 .orElseThrow(() -> semanticException(MISSING_TABLE, statement, "Table must be specified"));
 
-        QualifiedObjectName originalObjectName = createQualifiedObjectName(session, statement, prefix);
+        QualifiedObjectName originalObjectName = createQualifiedObjectName(session, statement, prefix, metadata);
         Optional<ViewDefinition> view = metadata.getView(session, originalObjectName);
         if (view.isPresent()) {
             ViewDefinition viewDefinition = view.get();

--- a/core/trino-main/src/main/java/io/trino/execution/CreateBranchTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateBranchTask.java
@@ -76,7 +76,7 @@ public class CreateBranchTask
     {
         Session session = stateMachine.getSession();
 
-        QualifiedObjectName table = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName table = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
         String branch = statement.getBranchName().getValue();
         Optional<String> fromBranch = statement.getFromBranch().map(Identifier::getValue);
 

--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -109,7 +109,7 @@ public class CreateMaterializedViewTask
             WarningCollector warningCollector,
             PlanOptimizersStatsCollector planOptimizersStatsCollector)
     {
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName(), plannerContext.getMetadata());
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
 
         String sql = getFormattedSql(statement.getQuery(), sqlParser);

--- a/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
@@ -91,7 +91,7 @@ public class CreateSchemaTask
             Session session,
             List<Expression> parameters)
     {
-        CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()));
+        CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()), plannerContext.getMetadata());
 
         String catalogName = schema.getCatalogName();
         CatalogHandle catalogHandle = getRequiredCatalogHandle(plannerContext.getMetadata(), session, statement, catalogName);

--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -134,7 +134,7 @@ public class CreateTableTask
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName(), plannerContext.getMetadata());
         Optional<TableHandle> tableHandle;
         try {
             tableHandle = plannerContext.getMetadata().getTableHandle(session, tableName);
@@ -216,7 +216,7 @@ public class CreateTableTask
                         .build());
             }
             else if (element instanceof LikeClause likeClause) {
-                QualifiedObjectName originalLikeTableName = createQualifiedObjectName(session, statement, likeClause.getTableName());
+                QualifiedObjectName originalLikeTableName = createQualifiedObjectName(session, statement, likeClause.getTableName(), plannerContext.getMetadata());
                 if (plannerContext.getMetadata().getCatalogHandle(session, originalLikeTableName.catalogName()).isEmpty()) {
                     throw semanticException(CATALOG_NOT_FOUND, statement, "LIKE table catalog '%s' not found", originalLikeTableName.catalogName());
                 }

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -91,7 +91,7 @@ public class CreateViewTask
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
 
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName(), plannerContext.getMetadata());
 
         accessControl.checkCanCreateView(session.toSecurityContext(), name);
 

--- a/core/trino-main/src/main/java/io/trino/execution/DenyTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DenyTask.java
@@ -87,7 +87,7 @@ public class DenyTask
             throw semanticException(NOT_SUPPORTED, statement, "Denying on branch is not supported");
         }
 
-        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()));
+        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()), metadata);
 
         if (!metadata.schemaExists(session, schemaName)) {
             throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schemaName);
@@ -103,7 +103,7 @@ public class DenyTask
 
     private static void executeDenyOnTable(Session session, Deny statement, Metadata metadata, AccessControl accessControl)
     {
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName(), metadata);
         Optional<Identifier> branch = statement.getGrantObject().getBranch();
 
         if (!metadata.isMaterializedView(session, tableName) && !metadata.isView(session, tableName)) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropBranchTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropBranchTask.java
@@ -59,7 +59,7 @@ public class DropBranchTask
     {
         Session session = stateMachine.getSession();
 
-        QualifiedObjectName table = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName table = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
         String branch = statement.getBranchName().getValue();
 
         if (metadata.isMaterializedView(session, table)) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropColumnTask.java
@@ -73,7 +73,7 @@ public class DropColumnTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable(), metadata);
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, tableName);
         if (redirectionAwareTableHandle.tableHandle().isEmpty()) {
             if (!statement.isTableExists()) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
@@ -58,7 +58,7 @@ public class DropMaterializedViewTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName(), metadata);
 
         if (!metadata.isMaterializedView(session, name)) {
             if (metadata.isView(session, name)) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropNotNullConstraintTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropNotNullConstraintTask.java
@@ -64,7 +64,7 @@ public class DropNotNullConstraintTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable(), metadata);
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, tableName);
         if (redirectionAwareTableHandle.tableHandle().isEmpty()) {
             String exceptionMessage = "Table '%s' does not exist".formatted(tableName);

--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -61,7 +61,7 @@ public class DropSchemaTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()));
+        CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()), metadata);
 
         if (!metadata.schemaExists(session, schema)) {
             if (!statement.isExists()) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -60,7 +60,7 @@ public class DropTableTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
         if (metadata.isMaterializedView(session, originalTableName)) {
             throw semanticException(
                     GENERIC_USER_ERROR,

--- a/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
@@ -58,7 +58,7 @@ public class DropViewTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName(), metadata);
 
         if (metadata.isMaterializedView(session, name)) {
             throw semanticException(

--- a/core/trino-main/src/main/java/io/trino/execution/FastForwardBranchTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/FastForwardBranchTask.java
@@ -59,7 +59,7 @@ public class FastForwardBranchTask
     {
         Session session = stateMachine.getSession();
 
-        QualifiedObjectName table = createQualifiedObjectName(session, statement, statement.geTableName());
+        QualifiedObjectName table = createQualifiedObjectName(session, statement, statement.geTableName(), metadata);
         String sourceBranch = statement.getSourceBranchName().getValue();
         String targetBranch = statement.getTargetBranchName().getValue();
 

--- a/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
@@ -91,7 +91,7 @@ public class GrantTask
             throw semanticException(NOT_SUPPORTED, statement, "Granting on branch is not supported");
         }
 
-        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()));
+        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()), metadata);
 
         if (!metadata.schemaExists(session, schemaName)) {
             throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schemaName);
@@ -107,7 +107,7 @@ public class GrantTask
 
     private void executeGrantOnTable(Session session, Grant statement)
     {
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName(), metadata);
         Optional<Identifier> branch = statement.getGrantObject().getBranch();
 
         if (!metadata.isMaterializedView(session, tableName) && !metadata.isView(session, tableName)) {

--- a/core/trino-main/src/main/java/io/trino/execution/RefreshViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RefreshViewTask.java
@@ -86,7 +86,7 @@ public class RefreshViewTask
     {
         Metadata metadata = plannerContext.getMetadata();
         Session session = stateMachine.getSession();
-        QualifiedObjectName viewName = createQualifiedObjectName(session, refreshView, refreshView.getName());
+        QualifiedObjectName viewName = createQualifiedObjectName(session, refreshView, refreshView.getName(), metadata);
 
         ViewDefinition viewDefinition = metadata.getView(session, viewName)
                 .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, refreshView, "View '%s' not found", viewName));

--- a/core/trino-main/src/main/java/io/trino/execution/RenameColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameColumnTask.java
@@ -74,7 +74,7 @@ public class RenameColumnTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTable());
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTable(), metadata);
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, originalTableName);
         if (redirectionAwareTableHandle.tableHandle().isEmpty()) {
             if (!statement.isTableExists()) {

--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -61,7 +61,7 @@ public class RenameMaterializedViewTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName materializedViewName = createQualifiedObjectName(session, statement, statement.getSource());
+        QualifiedObjectName materializedViewName = createQualifiedObjectName(session, statement, statement.getSource(), metadata);
         if (!metadata.isMaterializedView(session, materializedViewName)) {
             if (metadata.isView(session, materializedViewName)) {
                 throw semanticException(
@@ -83,7 +83,7 @@ public class RenameMaterializedViewTask
             throw semanticException(TABLE_NOT_FOUND, statement, "Materialized View '%s' does not exist", materializedViewName);
         }
 
-        QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget());
+        QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget(), metadata);
         if (metadata.getCatalogHandle(session, target.catalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' not found", target.catalogName());
         }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameSchemaTask.java
@@ -60,7 +60,7 @@ public class RenameSchemaTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()));
+        CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()), metadata);
         CatalogSchemaName target = new CatalogSchemaName(source.getCatalogName(), statement.getTarget().getValue());
 
         if (!metadata.schemaExists(session, source)) {

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -68,7 +68,7 @@ public class RenameTableTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource(), metadata);
 
         if (metadata.isMaterializedView(session, tableName)) {
             throw semanticException(

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -62,7 +62,7 @@ public class RenameViewTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getSource());
+        QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getSource(), metadata);
         if (metadata.isMaterializedView(session, viewName)) {
             throw semanticException(
                     TABLE_NOT_FOUND,
@@ -81,7 +81,7 @@ public class RenameViewTask
             throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName);
         }
 
-        QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget());
+        QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget(), metadata);
         if (metadata.getCatalogHandle(session, target.catalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' not found", target.catalogName());
         }

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
@@ -92,7 +92,7 @@ public class RevokeTask
             throw semanticException(NOT_SUPPORTED, statement, "Revoking on branch is not supported");
         }
 
-        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()));
+        CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getGrantObject().getName()), metadata);
 
         if (!metadata.schemaExists(session, schemaName)) {
             throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schemaName);
@@ -108,7 +108,7 @@ public class RevokeTask
 
     private void executeRevokeOnTable(Session session, Revoke statement)
     {
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getGrantObject().getName(), metadata);
         Optional<Identifier> branch = statement.getGrantObject().getBranch();
 
         if (!metadata.isMaterializedView(session, tableName) && !metadata.isView(session, tableName)) {

--- a/core/trino-main/src/main/java/io/trino/execution/SetAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetAuthorizationTask.java
@@ -81,7 +81,7 @@ public class SetAuthorizationTask
         // Preprocess SCHEMA, TABLE and VIEW to generate error messages in the order compatible with existing tests
         switch (statement.getOwnedEntityKind()) {
             case "SCHEMA" -> {
-                CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()));
+                CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()), metadata);
                 if (!metadata.schemaExists(session, source)) {
                     throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", source);
                 }

--- a/core/trino-main/src/main/java/io/trino/execution/SetColumnTypeTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetColumnTypeTask.java
@@ -85,7 +85,7 @@ public class SetColumnTypeTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName qualifiedObjectName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName qualifiedObjectName = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
         RedirectionAwareTableHandle redirectionAwareTableHandle = metadata.getRedirectionAwareTableHandle(session, qualifiedObjectName);
         if (redirectionAwareTableHandle.tableHandle().isEmpty()) {
             String exceptionMessage = format("Table '%s' does not exist", qualifiedObjectName);

--- a/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
@@ -72,7 +72,7 @@ public class SetPropertiesTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName objectName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName objectName = createQualifiedObjectName(session, statement, statement.getName(), plannerContext.getMetadata());
 
         String catalogName = objectName.catalogName();
         if (statement.getType() == TABLE) {

--- a/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
@@ -60,7 +60,7 @@ public class TruncateTableTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName(), metadata);
 
         if (metadata.isMaterializedView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot truncate a materialized view");

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -901,4 +901,9 @@ public interface Metadata
      * Returns list of functions authorization info
      */
     Set<FunctionAuthorization> getFunctionsAuthorizationInfo(Session session, QualifiedObjectPrefix prefix);
+
+    /**
+     * Canonicalizes the provided SQL identifier according to connector-specific rules
+     */
+    NameCanonicalizer getNameCanonicalizer(Session session, String catalogName);
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -3004,4 +3004,17 @@ public final class MetadataManager
         }
         return ImmutableSet.of();
     }
+
+    @Override
+    public NameCanonicalizer getNameCanonicalizer(Session session, String catalogName)
+    {
+        Optional<CatalogMetadata> metadata = getOptionalCatalogMetadata(session, catalogName);
+
+        if (metadata.isPresent()) {
+            CatalogHandle catalogHandle = metadata.get().getCatalogHandle();
+            return (identifier, delimited) ->
+                    metadata.get().getMetadata(session).canonicalize(session.toConnectorSession(catalogHandle), identifier, delimited);
+        }
+        return NameCanonicalizer.LEGACY_NAME_CANONICALIZER;
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/NameCanonicalizer.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/NameCanonicalizer.java
@@ -11,12 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.spi.connector;
+package io.trino.metadata;
 
-public enum ConnectorCapabilities
+import static java.util.Locale.ENGLISH;
+
+public interface NameCanonicalizer
 {
-    DEFAULT_COLUMN_VALUE,
-    NOT_NULL_COLUMN_CONSTRAINT,
-    MATERIALIZED_VIEW_GRACE_PERIOD,
-    MIXED_CASE_IDENTIFIER_SUPPORTED,
+    NameCanonicalizer LEGACY_NAME_CANONICALIZER = (identifier, delimited) -> identifier.toLowerCase(ENGLISH);
+
+    String canonicalize(String identifier, boolean delimited);
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -573,7 +573,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitInsert(Insert insert, Optional<Scope> scope)
         {
-            QualifiedObjectName targetTable = createQualifiedObjectName(session, insert, insert.getTarget());
+            QualifiedObjectName targetTable = createQualifiedObjectName(session, insert, insert.getTarget(), metadata);
 
             if (metadata.isMaterializedView(session, targetTable)) {
                 throw semanticException(NOT_SUPPORTED, insert, "Inserting into materialized views is not supported");
@@ -709,7 +709,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitRefreshMaterializedView(RefreshMaterializedView refreshMaterializedView, Optional<Scope> scope)
         {
-            QualifiedObjectName name = createQualifiedObjectName(session, refreshMaterializedView, refreshMaterializedView.getName());
+            QualifiedObjectName name = createQualifiedObjectName(session, refreshMaterializedView, refreshMaterializedView.getName(), metadata);
             MaterializedViewDefinition view = metadata.getMaterializedView(session, name)
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, refreshMaterializedView, "Materialized view '%s' does not exist", name));
 
@@ -730,7 +730,7 @@ class StatementAnalyzer
             QualifiedName storageName = getMaterializedViewStorageTableName(view)
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, refreshMaterializedView, "Storage Table for materialized view '%s' does not exist", name));
 
-            QualifiedObjectName targetTable = createQualifiedObjectName(session, refreshMaterializedView, storageName);
+            QualifiedObjectName targetTable = createQualifiedObjectName(session, refreshMaterializedView, storageName, metadata);
             checkStorageTableNotRedirected(targetTable);
 
             // analyze the query that creates the data
@@ -837,7 +837,7 @@ class StatementAnalyzer
         protected Scope visitDelete(Delete node, Optional<Scope> scope)
         {
             Table table = node.getTable();
-            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
+            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName(), metadata);
             if (metadata.isMaterializedView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Deleting from materialized views is not supported");
             }
@@ -891,7 +891,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitAnalyze(Analyze node, Optional<Scope> scope)
         {
-            QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getTableName());
+            QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getTableName(), metadata);
             if (metadata.isView(session, tableName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Analyzing views is not supported");
             }
@@ -939,7 +939,7 @@ class StatementAnalyzer
         protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Optional<Scope> scope)
         {
             // turn this into a query that has a new table writer node on top.
-            QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName());
+            QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName(), metadata);
 
             Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
             if (targetTableHandle.isPresent() && node.getSaveMode() != REPLACE) {
@@ -1055,7 +1055,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitCreateView(CreateView node, Optional<Scope> scope)
         {
-            QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName());
+            QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName(), metadata);
 
             node.getQuery().getFunctions().stream().findFirst().ifPresent(function -> {
                 throw semanticException(NOT_SUPPORTED, function, "Views cannot contain inline functions");
@@ -1254,7 +1254,7 @@ class StatementAnalyzer
         protected Scope visitTableExecute(TableExecute node, Optional<Scope> scope)
         {
             Table table = node.getTable();
-            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
+            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName(), metadata);
             String procedureName = node.getProcedureName().getCanonicalValue();
 
             if (metadata.isMaterializedView(session, originalName)) {
@@ -1456,7 +1456,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitCreateMaterializedView(CreateMaterializedView node, Optional<Scope> scope)
         {
-            QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName());
+            QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName(), metadata);
 
             if (node.isReplace() && node.isNotExists()) {
                 throw semanticException(NOT_SUPPORTED, node, "'CREATE OR REPLACE' and 'IF NOT EXISTS' clauses can not be used together");
@@ -2160,7 +2160,7 @@ class StatementAnalyzer
                     }
                     if (candidates.isEmpty()) {
                         // qualify the name using current schema and catalog
-                        QualifiedObjectName fullyQualifiedName = createQualifiedObjectName(session, name.getOriginalParts().get(0), name);
+                        QualifiedObjectName fullyQualifiedName = createQualifiedObjectName(session, name.getOriginalParts().get(0), name, metadata);
                         candidates = qualifiedInputs.get(QualifiedName.of(fullyQualifiedName.catalogName(), fullyQualifiedName.schemaName(), fullyQualifiedName.objectName()));
                     }
                     if (candidates.isEmpty()) {
@@ -2274,7 +2274,7 @@ class StatementAnalyzer
                 }
             }
 
-            QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName());
+            QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName(), metadata);
             analysis.setRelationName(table, QualifiedName.of(name.catalogName(), name.schemaName(), name.objectName()));
 
             Optional<MaterializedViewDefinition> optionalMaterializedView = metadata.getMaterializedView(session, name);
@@ -2285,7 +2285,7 @@ class StatementAnalyzer
                     // If materialized view is sufficiently fresh with respect to its grace period, answer the query using the storage table
                     QualifiedName storageName = getMaterializedViewStorageTableName(materializedViewDefinition)
                             .orElseThrow(() -> semanticException(INVALID_VIEW, table, "Materialized view '%s' is fresh but does not have storage table name", name));
-                    QualifiedObjectName storageTableName = createQualifiedObjectName(session, table, storageName);
+                    QualifiedObjectName storageTableName = createQualifiedObjectName(session, table, storageName, metadata);
                     checkStorageTableNotRedirected(storageTableName);
                     TableHandle tableHandle = metadata.getTableHandle(session, storageTableName)
                             .orElseThrow(() -> semanticException(INVALID_VIEW, table, "Storage table '%s' does not exist", storageTableName));
@@ -2571,13 +2571,13 @@ class StatementAnalyzer
         {
             Statement statement = analysis.getStatement();
             if (statement instanceof CreateView viewStatement) {
-                QualifiedObjectName viewNameFromStatement = createQualifiedObjectName(session, viewStatement, viewStatement.getName());
+                QualifiedObjectName viewNameFromStatement = createQualifiedObjectName(session, viewStatement, viewStatement.getName(), metadata);
                 if (viewStatement.isReplace() && viewNameFromStatement.equals(name)) {
                     throw semanticException(VIEW_IS_RECURSIVE, table, "Statement would create a recursive view");
                 }
             }
             if (statement instanceof CreateMaterializedView viewStatement) {
-                QualifiedObjectName viewNameFromStatement = createQualifiedObjectName(session, viewStatement, viewStatement.getName());
+                QualifiedObjectName viewNameFromStatement = createQualifiedObjectName(session, viewStatement, viewStatement.getName(), metadata);
                 if (viewStatement.isReplace() && viewNameFromStatement.equals(name)) {
                     throw semanticException(VIEW_IS_RECURSIVE, table, "Statement would create a recursive materialized view");
                 }
@@ -2634,7 +2634,7 @@ class StatementAnalyzer
         {
             TableSchema tableSchema = metadata.getTableSchema(session, storageTable);
             Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, storageTable);
-            QualifiedObjectName tableName = createQualifiedObjectName(session, table, table.getName());
+            QualifiedObjectName tableName = createQualifiedObjectName(session, table, table.getName(), metadata);
             checkStorageTableNotRedirected(tableName);
             List<Field> tableFields = analyzeTableOutputFields(table, tableName, tableSchema, columnHandles)
                     .stream()
@@ -3471,7 +3471,7 @@ class StatementAnalyzer
         protected Scope visitUpdate(Update update, Optional<Scope> scope)
         {
             Table table = update.getTable();
-            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
+            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName(), metadata);
             if (metadata.isMaterializedView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, update, "Updating materialized views is not supported");
             }
@@ -3609,7 +3609,7 @@ class StatementAnalyzer
         {
             Relation relation = merge.getTarget();
             Table table = getMergeTargetTable(relation);
-            QualifiedObjectName originalTableName = createQualifiedObjectName(session, table, table.getName());
+            QualifiedObjectName originalTableName = createQualifiedObjectName(session, table, table.getName(), metadata);
             if (metadata.isMaterializedView(session, originalTableName)) {
                 throw semanticException(NOT_SUPPORTED, merge, "Merging into materialized views is not supported");
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -960,7 +960,7 @@ public class LogicalPlanner
     private RelationPlan createTableExecutePlan(Analysis analysis, TableExecute statement)
     {
         Table table = statement.getTable();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, table.getName());
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, table.getName(), metadata);
         TableExecuteHandle executeHandle = analysis.getTableExecuteHandle().orElseThrow();
 
         if (!analysis.isTableExecuteReadsData()) {

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -245,7 +245,7 @@ public final class ShowQueriesRewrite
         @Override
         protected Node visitShowTables(ShowTables showTables, Void context)
         {
-            CatalogSchemaName schema = createCatalogSchemaName(session, showTables, showTables.getSchema());
+            CatalogSchemaName schema = createCatalogSchemaName(session, showTables, showTables.getSchema(), metadata);
 
             accessControl.checkCanShowTables(session.toSecurityContext(), schema);
 
@@ -284,7 +284,7 @@ public final class ShowQueriesRewrite
             // TODO: Should this handle any entityKind?
             Optional<QualifiedName> tableName = showGrants.getGrantObject().map(GrantObject::getName);
             if (tableName.isPresent()) {
-                QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, showGrants, tableName.get());
+                QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, showGrants, tableName.get(), metadata);
                 if (!metadata.isView(session, qualifiedTableName)) {
                     RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, qualifiedTableName);
                     if (redirection.tableHandle().isEmpty()) {
@@ -446,7 +446,7 @@ public final class ShowQueriesRewrite
         @Override
         protected Node visitShowColumns(ShowColumns showColumns, Void context)
         {
-            QualifiedObjectName tableName = createQualifiedObjectName(session, showColumns, showColumns.getTable());
+            QualifiedObjectName tableName = createQualifiedObjectName(session, showColumns, showColumns.getTable(), metadata);
             getRequiredCatalogHandle(metadata, session, showColumns, tableName.catalogName());
             if (!metadata.schemaExists(session, new CatalogSchemaName(tableName.catalogName(), tableName.schemaName()))) {
                 throw semanticException(SCHEMA_NOT_FOUND, showColumns, "Schema '%s' does not exist", tableName.schemaName());
@@ -526,7 +526,7 @@ public final class ShowQueriesRewrite
 
         private Query showCreateMaterializedView(ShowCreate node)
         {
-            QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
+            QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName(), metadata);
             Optional<MaterializedViewDefinition> viewDefinition = metadata.getMaterializedView(session, objectName);
 
             if (viewDefinition.isEmpty()) {
@@ -568,7 +568,7 @@ public final class ShowQueriesRewrite
 
         private Query showCreateView(ShowCreate node)
         {
-            QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
+            QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName(), metadata);
 
             if (metadata.isMaterializedView(session, objectName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a view", objectName);
@@ -610,7 +610,7 @@ public final class ShowQueriesRewrite
 
         private Query showCreateTable(ShowCreate node)
         {
-            QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
+            QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName(), metadata);
 
             if (metadata.isMaterializedView(session, objectName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a table", objectName);
@@ -674,7 +674,7 @@ public final class ShowQueriesRewrite
 
         private Query showCreateSchema(ShowCreate node)
         {
-            CatalogSchemaName schemaName = createCatalogSchemaName(session, node, Optional.of(node.getName()));
+            CatalogSchemaName schemaName = createCatalogSchemaName(session, node, Optional.of(node.getName()), metadata);
 
             if (!metadata.schemaExists(session, schemaName)) {
                 throw semanticException(SCHEMA_NOT_FOUND, node, "Schema '%s' does not exist", schemaName);
@@ -724,7 +724,7 @@ public final class ShowQueriesRewrite
         {
             Collection<FunctionMetadata> functions;
             if (node.getSchema().isPresent()) {
-                CatalogSchemaName schema = createCatalogSchemaName(session, node, node.getSchema());
+                CatalogSchemaName schema = createCatalogSchemaName(session, node, node.getSchema(), metadata);
                 accessControl.checkCanShowFunctions(session.toSecurityContext(), schema);
                 functions = listFunctions(schema);
             }
@@ -822,7 +822,7 @@ public final class ShowQueriesRewrite
         @Override
         protected Node visitShowBranches(ShowBranches showBranches, Void context)
         {
-            QualifiedObjectName tableName = createQualifiedObjectName(session, showBranches, showBranches.getTableName());
+            QualifiedObjectName tableName = createQualifiedObjectName(session, showBranches, showBranches.getTableName(), metadata);
             accessControl.checkCanShowBranches(session.toSecurityContext(), tableName);
             getRequiredCatalogHandle(metadata, session, showBranches, tableName.catalogName());
             if (!metadata.schemaExists(session, new CatalogSchemaName(tableName.catalogName(), tableName.schemaName()))) {

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -1485,6 +1485,15 @@ public class TracingConnectorMetadata
         }
     }
 
+    @Override
+    public String canonicalize(ConnectorSession session, String identifier, boolean delimited)
+    {
+        Span span = startSpan("canonicalize");
+        try (var _ = scopedSpan(span)) {
+            return delegate.canonicalize(session, identifier, delimited);
+        }
+    }
+
     private Span startSpan(String methodName)
     {
         return tracer.spanBuilder("ConnectorMetadata." + methodName)

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -29,6 +29,7 @@ import io.trino.metadata.InsertTableHandle;
 import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.MergeHandle;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.NameCanonicalizer;
 import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.OutputTableHandle;
 import io.trino.metadata.QualifiedObjectName;
@@ -1643,6 +1644,15 @@ public class TracingMetadata
         Span span = startSpan("getFunctionsAuthorizationInfo", prefix);
         try (var ignored = scopedSpan(span)) {
             return delegate.getFunctionsAuthorizationInfo(session, prefix);
+        }
+    }
+
+    @Override
+    public NameCanonicalizer getNameCanonicalizer(Session session, String catalogName)
+    {
+        Span span = startSpan("getNameCanonicalizer", catalogName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getNameCanonicalizer(session, catalogName);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -26,6 +26,7 @@ import io.trino.metadata.ColumnPropertyManager;
 import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.MetadataManager;
+import io.trino.metadata.NameCanonicalizer;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.QualifiedTablePrefix;
 import io.trino.metadata.ResolvedFunction;
@@ -716,6 +717,12 @@ public abstract class BaseDataDefinitionTaskTest
             MockConnectorTableMetadata table = tables.get(tableName.asSchemaTableName());
             requireNonNull(table, "table is null");
             return table.branches().contains(branch);
+        }
+
+        @Override
+        public NameCanonicalizer getNameCanonicalizer(Session session, String catalogName)
+        {
+            return NameCanonicalizer.LEGACY_NAME_CANONICALIZER;
         }
 
         private static ColumnMetadata withComment(ColumnMetadata tableColumn, Optional<String> comment)

--- a/core/trino-main/src/test/java/io/trino/execution/TestAddColumnTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestAddColumnTask.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.NameCanonicalizer;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AllowAllAccessControl;
@@ -60,6 +61,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_DEFAULT_COLUMN_VALUE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.connector.ConnectorCapabilities.DEFAULT_COLUMN_VALUE;
+import static io.trino.spi.connector.ConnectorCapabilities.MIXED_CASE_IDENTIFIER_SUPPORTED;
 import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static io.trino.spi.connector.SaveMode.FAIL;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -73,6 +75,7 @@ import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.TestingPlannerContext.plannerContextBuilder;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAddColumnTask
@@ -606,6 +609,15 @@ public class TestAddColumnTask
         public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, CatalogHandle catalogHandle)
         {
             return capabilities;
+        }
+
+        @Override
+        public NameCanonicalizer getNameCanonicalizer(Session session, String catalogName)
+        {
+            if (capabilities.contains(MIXED_CASE_IDENTIFIER_SUPPORTED)) {
+                return (identifier, delimited) -> delimited ? identifier : identifier.toLowerCase(ENGLISH);
+            }
+            return NameCanonicalizer.LEGACY_NAME_CANONICALIZER;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -1109,4 +1109,10 @@ public abstract class AbstractMockMetadata
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public NameCanonicalizer getNameCanonicalizer(Session session, String catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/CatalogSchemaName.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/CatalogSchemaName.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-import static java.util.Locale.ENGLISH;
-
 public final class CatalogSchemaName
 {
     private final String catalogName;
@@ -30,8 +28,8 @@ public final class CatalogSchemaName
             @JsonProperty("catalogName") String catalogName,
             @JsonProperty("schemaName") String schemaName)
     {
-        this.catalogName = catalogName.toLowerCase(ENGLISH);
-        this.schemaName = schemaName.toLowerCase(ENGLISH);
+        this.catalogName = catalogName;
+        this.schemaName = schemaName;
     }
 
     @JsonProperty

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1824,4 +1824,13 @@ public interface ConnectorMetadata
     {
         return WriterScalingOptions.DISABLED;
     }
+
+    /**
+     * Canonicalizes the provided SQL identifier according to connector-specific rules
+     * for the purpose of providing the name in metadata APIs
+     */
+    default String canonicalize(ConnectorSession session, String identifier, boolean delimited)
+    {
+        return identifier.toLowerCase(ENGLISH);
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SchemaTableName.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SchemaTableName.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.connector.SchemaUtil.checkNotEmpty;
-import static java.util.Locale.ENGLISH;
 
 public final class SchemaTableName
 {
@@ -33,8 +32,8 @@ public final class SchemaTableName
     @JsonCreator
     public SchemaTableName(@JsonProperty("schema") String schemaName, @JsonProperty("table") String tableName)
     {
-        this.schemaName = checkNotEmpty(schemaName, "schemaName").toLowerCase(ENGLISH);
-        this.tableName = checkNotEmpty(tableName, "tableName").toLowerCase(ENGLISH);
+        this.schemaName = checkNotEmpty(schemaName, "schemaName");
+        this.tableName = checkNotEmpty(tableName, "tableName");
     }
 
     public static SchemaTableName schemaTableName(String schemaName, String tableName)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -1350,4 +1350,12 @@ public class ClassLoaderSafeConnectorMetadata
             return delegate.getInsertWriterScalingOptions(session, tableHandle);
         }
     }
+
+    @Override
+    public String canonicalize(ConnectorSession session, String identifier, boolean delimited)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.canonicalize(session, identifier, delimited);
+        }
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteTableName.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteTableName.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import io.trino.spi.connector.SchemaTableName;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -61,7 +62,7 @@ public final class RemoteTableName
 
     public SchemaTableName getSchemaTableName()
     {
-        return new SchemaTableName(schemaName.orElseThrow(), tableName);
+        return new SchemaTableName(schemaName.orElseThrow().toLowerCase(Locale.ENGLISH), tableName.toLowerCase(Locale.ENGLISH));
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -8797,7 +8797,7 @@ public abstract class BaseHiveConnectorTest
                 .setCatalog(Optional.empty())
                 .setSchema(Optional.empty())
                 .build();
-        assertQueryFails(sessionNoCatalog, "SELECT count(*) FROM " + viewName, ".*Schema must be specified when session schema is not set.*");
+        assertQueryFails(sessionNoCatalog, "SELECT count(*) FROM " + viewName, ".*Catalog must be specified when session catalog is not set.*");
         assertQuery(sessionNoCatalog, "SELECT count(*) FROM hive.tpch." + viewName, "VALUES 1");
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -43,6 +43,7 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Locale.ENGLISH;
 
 /**
  * An interface to allow different Iceberg catalog implementations in IcebergMetadata.
@@ -200,4 +201,9 @@ public interface TrinoCatalog
     void updateColumnComment(ConnectorSession session, SchemaTableName schemaTableName, ColumnIdentity columnIdentity, Optional<String> comment);
 
     Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName, String hiveCatalogName);
+
+    default String canonicalize(String name, boolean delimited)
+    {
+        return name.toLowerCase(ENGLISH);
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -285,7 +285,7 @@ public class TrinoRestCatalog
                     throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list tables", e);
                 }
             }).stream()
-                    .map(id -> new TableInfo(SchemaTableName.schemaTableName(toSchemaName(id.namespace()), id.name()), TableInfo.ExtendedRelationType.TABLE))
+                    .map(id -> new TableInfo(SchemaTableName.schemaTableName(canonicalize(toSchemaName(id.namespace()), true), canonicalize(id.name(), true)), TableInfo.ExtendedRelationType.TABLE))
                     .forEach(tables::add);
             if (viewEndpointsEnabled) {
                 listTableIdentifiers(restNamespace, () -> {
@@ -296,7 +296,7 @@ public class TrinoRestCatalog
                         throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list views", e);
                     }
                 }).stream()
-                        .map(id -> new TableInfo(SchemaTableName.schemaTableName(toSchemaName(id.namespace()), id.name()), TableInfo.ExtendedRelationType.OTHER_VIEW))
+                        .map(id -> new TableInfo(SchemaTableName.schemaTableName(canonicalize(toSchemaName(id.namespace()), true), canonicalize(id.name(), true)), TableInfo.ExtendedRelationType.OTHER_VIEW))
                         .forEach(tables::add);
             }
         }
@@ -440,7 +440,7 @@ public class TrinoRestCatalog
     @Override
     public void registerTable(ConnectorSession session, SchemaTableName tableName, TableMetadata tableMetadata)
     {
-        TableIdentifier tableIdentifier = TableIdentifier.of(toRemoteNamespace(session, toNamespace(tableName.getSchemaName())), tableName.getTableName());
+        TableIdentifier tableIdentifier = TableIdentifier.of(toRemoteNamespace(session, toNamespace(tableName.getSchemaName())), tableName.getTableName().toLowerCase(ENGLISH));
         try {
             restSessionCatalog.registerTable(convert(session), tableIdentifier, tableMetadata.metadataFileLocation());
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -174,7 +174,7 @@ public abstract class BaseTrinoCatalogTest
         TrinoCatalog catalog = createTrinoCatalog(false);
         String namespace = "test_create_table_" + randomNameSuffix();
         String table = "tableName";
-        SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
+        SchemaTableName schemaTableName = new SchemaTableName(namespace, table.toLowerCase(ENGLISH));
         Map<String, String> tableProperties = Map.of("test_key", "test_value");
         try {
             catalog.createNamespace(SESSION, namespace, defaultNamespaceProperties(namespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
@@ -220,7 +220,7 @@ public abstract class BaseTrinoCatalogTest
         TrinoCatalog catalog = createTrinoCatalog(false);
         String namespace = "test_create_sort_table_" + randomNameSuffix();
         String table = "tableName";
-        SchemaTableName schemaTableName = new SchemaTableName(namespace, table);
+        SchemaTableName schemaTableName = new SchemaTableName(namespace, table.toLowerCase(ENGLISH));
         try {
             catalog.createNamespace(SESSION, namespace, defaultNamespaceProperties(namespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
             Schema tableSchema = new Schema(Types.NestedField.optional(1, "col1", Types.LongType.get()),
@@ -290,7 +290,7 @@ public abstract class BaseTrinoCatalogTest
         String targetNamespace = "test_rename_table_" + randomNameSuffix();
 
         String table = "tableName";
-        SchemaTableName sourceSchemaTableName = new SchemaTableName(namespace, table);
+        SchemaTableName sourceSchemaTableName = new SchemaTableName(namespace, table.toLowerCase(ENGLISH));
         try {
             catalog.createNamespace(SESSION, namespace, defaultNamespaceProperties(namespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
             catalog.createNamespace(SESSION, targetNamespace, defaultNamespaceProperties(targetNamespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
@@ -306,7 +306,7 @@ public abstract class BaseTrinoCatalogTest
             assertThat(catalog.listTables(SESSION, Optional.of(namespace))).contains(new TableInfo(sourceSchemaTableName, TABLE));
 
             // Rename within the same schema
-            SchemaTableName targetSchemaTableName = new SchemaTableName(sourceSchemaTableName.getSchemaName(), "newTableName");
+            SchemaTableName targetSchemaTableName = new SchemaTableName(sourceSchemaTableName.getSchemaName(), "newtablename");
             catalog.renameTable(SESSION, sourceSchemaTableName, targetSchemaTableName);
             assertThat(catalog.listTables(SESSION, Optional.empty()).stream().map(TableInfo::tableName).toList()).doesNotContain(sourceSchemaTableName);
             assertThat(catalog.listTables(SESSION, Optional.of(namespace))).contains(new TableInfo(targetSchemaTableName, TABLE));
@@ -377,8 +377,8 @@ public abstract class BaseTrinoCatalogTest
         String namespace = "test_create_view_" + randomNameSuffix();
         String viewName = "viewName";
         String renamedViewName = "renamedViewName";
-        SchemaTableName schemaTableName = new SchemaTableName(namespace, viewName);
-        SchemaTableName renamedSchemaTableName = new SchemaTableName(namespace, renamedViewName);
+        SchemaTableName schemaTableName = new SchemaTableName(namespace, viewName.toLowerCase(ENGLISH));
+        SchemaTableName renamedSchemaTableName = new SchemaTableName(namespace, renamedViewName.toLowerCase(ENGLISH));
         ConnectorViewDefinition viewDefinition = new ConnectorViewDefinition(
                 "SELECT name FROM local.tiny.nation",
                 Optional.empty(),

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
@@ -77,7 +77,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
     {
         TableDescriptionSupplier tableDescriptionSupplier = createTableDescriptionSupplier();
         String topicName = "camelCase_Topic";
-        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_NAME, topicName);
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_NAME, topicName.toLowerCase(ENGLISH));
         String subject = topicName + "-key";
 
         SCHEMA_REGISTRY_CLIENT.register(subject, getAvroSchema(schemaTableName.getTableName(), ""));
@@ -125,7 +125,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
     {
         TableDescriptionSupplier tableDescriptionSupplier = createTableDescriptionSupplier();
         String topicName = "base_Topic";
-        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_NAME, topicName);
+        SchemaTableName schemaTableName = new SchemaTableName(DEFAULT_NAME, topicName.toLowerCase(ENGLISH));
         String subject = topicName + "-value";
         SCHEMA_REGISTRY_CLIENT.register(subject, getAvroSchema(schemaTableName.getTableName(), ""));
         String overriddenSubject = "overriddenSubject";
@@ -146,7 +146,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
 
         assertThat(getKafkaTopicDescription(
                 tableDescriptionSupplier,
-                new SchemaTableName(DEFAULT_NAME, format("%s&value-subject=%s", topicName, overriddenSubject))))
+                new SchemaTableName(DEFAULT_NAME, format("%s&value-subject=%s", topicName, overriddenSubject.toLowerCase(ENGLISH)))))
                 .isEqualTo(
                         new KafkaTopicDescription(
                                 schemaTableName.getTableName(),
@@ -174,7 +174,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
                         TestingConnectorSession.builder()
                                 .setPropertyMetadata(new ConfluentSessionProperties(new ConfluentSchemaRegistryConfig()).getSessionProperties())
                                 .build(),
-                        new SchemaTableName(DEFAULT_NAME, format("%s&value-subject=%s", topicName, overriddenSubject))))
+                        new SchemaTableName(DEFAULT_NAME, format("%s&value-subject=%s", topicName, overriddenSubject).toLowerCase(ENGLISH))))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Subject 'ambiguousoverriddensubject' is ambiguous, and may refer to one of the following: AMBIGUOUSOVERRIDDENSUBJECT, ambiguousOverriddenSubject");
     }

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
@@ -100,6 +100,7 @@ import io.trino.spi.type.Type;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -932,6 +933,12 @@ public class LakehouseMetadata
     public WriterScalingOptions getInsertWriterScalingOptions(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return forHandle(tableHandle).getInsertWriterScalingOptions(session, tableHandle);
+    }
+
+    @Override
+    public String canonicalize(ConnectorSession session, String identifier, boolean delimited)
+    {
+        return identifier.toLowerCase(Locale.ENGLISH);
     }
 
     private ConnectorMetadata forHandle(ConnectorTableHandle handle)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotSqlFormatter.java
@@ -73,6 +73,7 @@ import static io.trino.plugin.pinot.query.PinotPatterns.transformFunctionName;
 import static io.trino.plugin.pinot.query.PinotPatterns.transformFunctionType;
 import static io.trino.plugin.pinot.query.PinotTransformFunctionTypeResolver.getTransformFunctionType;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.apache.pinot.common.function.TransformFunctionType.CASE;
@@ -283,7 +284,7 @@ public class PinotSqlFormatter
 
     public static PinotColumnHandle getColumnHandle(String name, SchemaTableName schemaTableName, Map<String, ColumnHandle> columnHandles)
     {
-        PinotColumnHandle columnHandle = (PinotColumnHandle) columnHandles.get(name);
+        PinotColumnHandle columnHandle = (PinotColumnHandle) columnHandles.get(name.toLowerCase(ENGLISH));
         if (columnHandle == null) {
             throw new ColumnNotFoundException(schemaTableName, name);
         }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestDynamicTable.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestDynamicTable.java
@@ -306,7 +306,7 @@ public class TestDynamicTable
         DynamicTable dynamicTable = buildFromPql(pinotMetadata, new SchemaTableName("default", query), mockClusterInfoFetcher, TESTING_TYPE_CONVERTER);
         String expectedPql =
                 """
-                SELECT "OriginCityName" FROM %s WHERE text_match("OriginCityName", 'new and york') LIMIT 70""".formatted(tableNameWithSuffix);
+                SELECT "OriginCityName" FROM %s WHERE text_match("OriginCityName", 'new AND york') LIMIT 70""".formatted(tableNameWithSuffix);
         assertThat(extractPql(dynamicTable, TupleDomain.all())).isEqualTo(expectedPql);
         assertThat(dynamicTable.tableName()).isEqualTo(tableName);
     }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotMetadata.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotMetadata.java
@@ -38,9 +38,9 @@ public class TestPinotMetadata
         ConnectorSession session = TestPinotSplitManager.createSessionWithNumSplits(1, false, pinotConfig);
         List<SchemaTableName> schemaTableNames = metadata.listTables(session, Optional.empty());
         assertThat(ImmutableSet.copyOf(schemaTableNames)).isEqualTo(ImmutableSet.builder()
-                .add(new SchemaTableName("default", TestPinotSplitManager.realtimeOnlyTable.tableName()))
-                .add(new SchemaTableName("default", TestPinotSplitManager.hybridTable.tableName()))
-                .add(new SchemaTableName("default", TEST_TABLE))
+                .add(new SchemaTableName("default", metadata.canonicalize(session, TestPinotSplitManager.realtimeOnlyTable.tableName(), true)))
+                .add(new SchemaTableName("default", metadata.canonicalize(session, TestPinotSplitManager.hybridTable.tableName(), true)))
+                .add(new SchemaTableName("default", metadata.canonicalize(session, TEST_TABLE, true)))
                 .build());
         List<String> schemas = metadata.listSchemaNames(session);
         assertThat(ImmutableList.copyOf(schemas)).isEqualTo(ImmutableList.of("default"));

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
@@ -98,8 +98,11 @@ public class PrometheusMetadata
                 .orElseGet(() -> ImmutableSet.copyOf(ImmutableSet.of("default")));
 
         return schemaNames.stream()
+                .map(schemaName -> canonicalize(session, schemaName, true))
                 .flatMap(schemaName ->
-                        prometheusClient.getTableNames(schemaName).stream().map(tableName -> new SchemaTableName(schemaName, tableName)))
+                        prometheusClient.getTableNames(schemaName).stream()
+                                .map(tableName -> canonicalize(session, tableName, false))
+                                .map(tableName -> new SchemaTableName(schemaName, tableName)))
                 .collect(toImmutableList());
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
@@ -472,7 +472,7 @@ public abstract class AbstractTestHiveViews
 
         QueryExecutor executor = connectToTrino("trino_no_default_catalog");
         assertQueryFailure(() -> executor.executeQuery("SELECT count(*) FROM no_catalog_schema_view"))
-                .hasMessageMatching(".*Schema must be specified when session schema is not set.*");
+                .hasMessageMatching(".*Catalog must be specified when session catalog is not set.*");
         assertThat(executor.executeQuery("SELECT count(*) FROM hive.default.no_catalog_schema_view"))
                 .containsOnly(row(1L));
     }

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -165,30 +165,35 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.schemata WHERE schema_name LIKE 'test_sch_ma1'",
                 "VALUES 1",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .build());
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.schemata WHERE schema_name LIKE 'test_sch_ma1' AND schema_name IN ('test_schema1', 'test_schema2')",
                 "VALUES 1",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables",
                 "VALUES (3008, 3008)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getRelationTypes")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .build());
@@ -196,6 +201,7 @@ public class TestInformationSchemaConnector
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1' AND table_schema IN ('test_schema1', 'test_schema2')",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .add("ConnectorMetadata.getRelationTypes(schema=test_schema2)")
                         .build());
@@ -209,6 +215,7 @@ public class TestInformationSchemaConnector
                                 .collect(joining(",", "(", ")")),
                 "VALUES (3000, 3000)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getRelationTypes")
                         .build());
         assertMetadataCalls(
@@ -220,6 +227,7 @@ public class TestInformationSchemaConnector
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 4)
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 4)
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema2, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema3_empty, table=test_table1)")
@@ -241,6 +249,7 @@ public class TestInformationSchemaConnector
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1'",
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .add("ConnectorMetadata.getRelationTypes(schema=test_schema2)")
@@ -260,6 +269,7 @@ public class TestInformationSchemaConnector
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table2)", 4)
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 4)
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table2)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema2, table=test_table2)")
@@ -298,6 +308,7 @@ public class TestInformationSchemaConnector
                 "VALUES 100",
                 ImmutableMultiset.<String>builder()
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
@@ -307,12 +318,15 @@ public class TestInformationSchemaConnector
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'wrong'",
                 "VALUES 0",
-                ImmutableMultiset.of());
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
+                        .build());
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'test_catalog' AND table_schema = 'wrong_schema1' AND table_name = 'test_table1'",
                 "VALUES 0",
                 ImmutableMultiset.<String>builder()
                         .addCopies("ConnectorMetadata.getSystemTable(schema=wrong_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getMaterializedView(schema=wrong_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getView(schema=wrong_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=wrong_schema1, table=test_table1)")
@@ -323,6 +337,7 @@ public class TestInformationSchemaConnector
                 "VALUES 0",
                 ImmutableMultiset.<String>builder()
                         .addCopies("ConnectorMetadata.getSystemTable(schema=wrong_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.getMaterializedView(schema=wrong_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getView(schema=wrong_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=wrong_schema1, table=test_table1)")
@@ -332,12 +347,14 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) FROM (SELECT * from test_catalog.information_schema.columns LIMIT 1)",
                 "VALUES 1",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .build());
         assertMetadataCalls(
                 "SELECT count(*) FROM (SELECT * from test_catalog.information_schema.columns LIMIT 1000)",
                 "VALUES 1000",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.streamRelationColumns(schema=test_schema1)")
                         .build());
@@ -346,19 +363,24 @@ public class TestInformationSchemaConnector
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = '' AND table_name = ''",
                 "VALUES (0, 0)",
-                ImmutableMultiset.of());
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
+                        .build());
 
         // Empty table schema
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = ''",
                 "VALUES (0, 0)",
-                ImmutableMultiset.of());
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
+                        .build());
 
         // Empty table name
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name = ''",
                 "VALUES (0, 0)",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .build());
 
@@ -367,6 +389,7 @@ public class TestInformationSchemaConnector
                 "SELECT count(table_name) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
                 "VALUES 1000",
                 ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.canonicalize", 2)
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.listTables(schema=test_schema1)")
                         // view-related methods such as listViews not being called


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->

## Description
Related to issue: [#17](https://github.com/trinodb/trino/issues/17)

Supersedes: [pr #7837](https://github.com/trinodb/trino/pull/7837) and [pr #2350](https://github.com/trinodb/trino/pull/2350)

Adding base connector support for Name canonicalization to enable case sensitivity support at the connector level. This enabled connectors to decide what is the conical form for a database/schema or table identifier when loading table metadata. 

Connectors can use this method to determine how to handle delimited and non delimited identifiers within a given query. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
Currently Trino table metadata handles table and schema names in a case insensitive manner. All table names are downcased meaning the engine cannot distinguish `"name"` from `"Name"` 

This change is a prerequisite to enabling support for case sensitive table and schema names within supported connectors. 



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
