### PR TITLE
Hive: Added  support for Twitter Elephant Bird protobufs in sequence files

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -47,7 +47,10 @@ In the case of serializable formats, only specific
 
 - RCText - RCFile using `ColumnarSerDe`
 - RCBinary - RCFile using `LazyBinaryColumnarSerDe`
-- SequenceFile
+- SequenceFile with `org.apache.hadoop.io.Text`
+- SequenceFile with `org.apache.hadoop.io.BytesWritable` containing protocol
+  buffer records using
+  `com.twitter.elephantbird.hive.serde.ProtobufDeserializer`
 - CSV - using `org.apache.hadoop.hive.serde2.OpenCSVSerde`
 - JSON - using `org.apache.hive.hcatalog.data.JsonSerDe`
 - OPENX_JSON - OpenX JSON SerDe from `org.openx.data.jsonserde.JsonSerDe`. Find
@@ -314,6 +317,18 @@ Hive connector documentation.
   - Number of threads used for retrieving metadata. Currently, only table loading
     is parallelized.
   - `8`
+* - `hive.protobuf.descriptors.location`
+  - Path to a directory where binary Protocol Buffer descriptor files are 
+    stored to be used for reading tables stored in the
+    `com.twitter.elephantbird.hive.serde.ProtobufDeserializer` format.
+  -
+* - `hive.protobuf.descriptors.cache.max-size`
+  - Maximum size of the Protocol Buffer descriptors cache
+  - `64`
+* - `hive.protobuf.descriptors.cache.refresh-interval`
+  - [Duration](prop-type-duration) after which loaded Protocol Buffer descriptors
+    should be reloaded from disk.
+  - `1d`
 :::
 
 (hive-file-system-configuration)=
@@ -551,6 +566,19 @@ CALL system.drop_stats(
     schema_name => 'web',
     table_name => 'page_views',
     partition_values => ARRAY[ARRAY['2016-08-09', 'US']]);
+```
+
+Tables created in Hive with
+[Twitter Elephantbird](https://github.com/twitter/elephant-bird/wiki/How-to-use-Elephant-Bird-with-Hive)
+are supported to read. The binary protobuf descriptor as mentioned in the
+`serialization.class` should be stored in a directory that is configured via
+`hive.protobuf.descriptors.location` on every worker.
+```
+...
+row format serde "com.twitter.elephantbird.hive.serde.ProtobufDeserializer"
+with serdeproperties (
+    "serialization.class"="com.example.proto.gen.Storage$User"
+)
 ```
 
 (hive-procedures)=

--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
@@ -53,6 +58,11 @@
             <groupId>io.airlift</groupId>
             <artifactId>aircompressor-v3</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
         </dependency>
 
         <dependency>
@@ -68,6 +78,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-cache</artifactId>
         </dependency>
 
         <dependency>
@@ -221,5 +236,77 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.os72</groupId>
+                    <artifactId>protoc-jar-maven-plugin</artifactId>
+                    <version>3.11.4</version>
+                    <configuration>
+                        <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}</protocArtifact>
+                        <protocVersion>${dep.protobuf.version}</protocVersion>
+                        <addSources>none</addSources>
+                        <inputDirectories>
+                            <include>src/test/resources/protobuf/sources</include>
+                        </inputDirectories>
+                        <outputDirectory>target/generated-test-sources/</outputDirectory>
+                        <outputTargets>
+                            <outputTarget>
+                                <type>java</type>
+                                <addSources>none</addSources>
+                                <outputDirectory>target/generated-test-sources/</outputDirectory>
+                            </outputTarget>
+                            <outputTarget>
+                                <type>descriptor</type>
+                                <addSources>none</addSources>
+                                <outputDirectory>target/test-classes/protobuf/descriptors</outputDirectory>
+                            </outputTarget>
+                        </outputTargets>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-test-sources</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-test-sources</id>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/target/generated-test-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveClassNames.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveClassNames.java
@@ -47,6 +47,7 @@ public final class HiveClassNames
     public static final String TEXT_INPUT_FORMAT_CLASS = "org.apache.hadoop.mapred.TextInputFormat";
     public static final String ESRI_SERDE_CLASS = "com.esri.hadoop.hive.serde.EsriJsonSerDe";
     public static final String ESRI_INPUT_FORMAT_CLASS = "com.esri.json.hadoop.EnclosedEsriJsonInputFormat";
+    public static final String TWITTER_ELEPHANTBIRD_PROTOBUF_SERDE_CLASS = "com.twitter.elephantbird.hive.serde.ProtobufDeserializer";
 
     private HiveClassNames() {}
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ReadWriteUtils.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ReadWriteUtils.java
@@ -23,6 +23,7 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
+import java.io.DataInput;
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -67,7 +68,7 @@ public final class ReadWriteUtils
         return value < -120 || (value >= -112 && value < 0);
     }
 
-    public static long readVInt(TrinoDataInputStream in)
+    public static long readVInt(DataInput in)
             throws IOException
     {
         byte firstByte = in.readByte();

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/protobuf/ProtobufDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/protobuf/ProtobufDeserializer.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.protobuf;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.EnumValueDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DynamicMessage;
+import io.airlift.slice.Slices;
+import io.trino.hive.formats.line.Column;
+import io.trino.hive.formats.line.LineBuffer;
+import io.trino.hive.formats.line.LineDeserializer;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToRawIntBits;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
+import static java.util.function.Function.identity;
+
+/**
+ * Deserializer based on the Twitter Elephantbird
+ * <a href="https://github.com/twitter/elephant-bird/blob/master/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializer.java">ProtobufDeserializer.java</a>.
+ * To improve speed, it could be rewritten using {@link com.google.protobuf.CodedInputStream} instead of the {@link DynamicMessage}.
+ */
+public class ProtobufDeserializer
+        implements LineDeserializer
+{
+    private final List<Column> columns;
+    private final Descriptor descriptor;
+    private final Map<String, FieldDescriptor> descriptorFields;
+
+    public ProtobufDeserializer(List<Column> columns, Descriptor descriptor)
+    {
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns"));
+        this.descriptor = requireNonNull(descriptor, "descriptor");
+        this.descriptorFields = descriptor.getFields().stream()
+                .collect(toImmutableMap(FieldDescriptor::getName, identity()));
+    }
+
+    @Override
+    public List<? extends Type> getTypes()
+    {
+        return columns.stream()
+                .map(Column::type)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public void deserialize(LineBuffer lineBuffer, PageBuilder builder)
+            throws IOException
+    {
+        DynamicMessage message;
+        try (InputStream in = new ByteArrayInputStream(lineBuffer.getBuffer(), 0, lineBuffer.getLength())) {
+            message = DynamicMessage.parseFrom(this.descriptor, in);
+        }
+
+        builder.declarePosition();
+        for (int columnIndex = 0; columnIndex < this.columns.size(); columnIndex++) {
+            Column column = columns.get(columnIndex);
+            BlockBuilder blockBuilder = builder.getBlockBuilder(columnIndex);
+            writeObject(blockBuilder, column.type(), getValue(message, this.descriptorFields, column.name()));
+        }
+    }
+
+    private static Object getValue(DynamicMessage message, Map<String, FieldDescriptor> fieldNameLookup, String fieldName)
+    {
+        FieldDescriptor fieldDescriptor = fieldNameLookup.get(fieldName);
+        if (fieldDescriptor == null) {
+            return null;
+        }
+        return requireNonNullElseGet(message.getField(fieldDescriptor),
+                () -> fieldDescriptor.hasDefaultValue() ? fieldDescriptor.getDefaultValue() : null);
+    }
+
+    private void writeObject(BlockBuilder blockBuilder, Type type, Object value)
+    {
+        if (type instanceof ArrayType t) {
+            ((ArrayBlockBuilder) blockBuilder).buildEntry(elementBuilder -> {
+                // Always create an array, even when the value is null
+                if (value instanceof Collection<?> collection) {
+                    collection.forEach(element -> {
+                        writeObject(elementBuilder, t.getElementType(), element);
+                    });
+                }
+            });
+        }
+        else if (value == null) {
+            blockBuilder.appendNull();
+        }
+        else if (type instanceof BigintType t && value instanceof Long l) {
+            t.writeLong(blockBuilder, l);
+        }
+        else if (type instanceof BooleanType t && value instanceof Boolean b) {
+            t.writeBoolean(blockBuilder, b);
+        }
+        else if (type instanceof DoubleType t && value instanceof Double d) {
+            t.writeDouble(blockBuilder, d);
+        }
+        else if (type instanceof VarcharType && value instanceof EnumValueDescriptor e) {
+            type.writeSlice(blockBuilder, utf8Slice(e.getName()));
+        }
+        else if (type instanceof IntegerType t && value instanceof Integer i) {
+            t.writeInt(blockBuilder, i);
+        }
+        else if (type instanceof RealType t && value instanceof Float f) {
+            t.writeLong(blockBuilder, floatToRawIntBits(f));
+        }
+        else if (type instanceof RowType rowType && value instanceof DynamicMessage rowMessage) {
+            Map<String, FieldDescriptor> fieldNameLookup = collectFieldsToDeserialize(rowMessage);
+            if (fieldNameLookup.isEmpty()) {
+                // The message has no set values nor default values
+                // In the Hive implementation, a struct where all fields are null is returned as null
+                blockBuilder.appendNull();
+            }
+            else {
+                ((RowBlockBuilder) blockBuilder).buildEntry(fieldBuilders -> {
+                    for (int i = 0; i < rowType.getFields().size(); i++) {
+                        RowType.Field rowField = rowType.getFields().get(i);
+                        if (rowField.getName().isPresent()) {
+                            writeObject(fieldBuilders.get(i), rowField.getType(), getValue(rowMessage, fieldNameLookup, rowField.getName().get()));
+                        }
+                        else {
+                            throw new IllegalStateException("Unable to apply value to row field with no name: " + i);
+                        }
+                    }
+                });
+            }
+        }
+        else if (type instanceof VarcharType t && value instanceof String s) {
+            t.writeSlice(blockBuilder, utf8Slice(s));
+        }
+        else if (type instanceof VarbinaryType t && value instanceof ByteString b) {
+            t.writeSlice(blockBuilder, Slices.wrappedBuffer(b.toByteArray()));
+        }
+        else {
+            throw new IllegalStateException("Unimplemented type " + type.getDisplayName());
+        }
+    }
+
+    private static Map<String, FieldDescriptor> collectFieldsToDeserialize(DynamicMessage message)
+    {
+        return Stream.concat(message.getAllFields().keySet().stream(),
+                        message.getDescriptorForType().getFields().stream().filter(FieldDescriptor::hasDefaultValue))
+                .collect(toImmutableMap(FieldDescriptor::getName, identity(), (l, r) -> l));
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/protobuf/ProtobufDeserializerFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/protobuf/ProtobufDeserializerFactory.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.protobuf;
+
+import com.google.common.base.Splitter;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import io.airlift.units.Duration;
+import io.trino.cache.EvictableCacheBuilder;
+import io.trino.hive.formats.line.Column;
+import io.trino.hive.formats.line.LineDeserializerFactory;
+import io.trino.spi.TrinoException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.hive.formats.HiveClassNames.TWITTER_ELEPHANTBIRD_PROTOBUF_SERDE_CLASS;
+import static io.trino.hive.formats.HiveFormatsErrorCode.HIVE_INVALID_METADATA;
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.nio.file.Files.isDirectory;
+import static java.nio.file.Files.newDirectoryStream;
+import static java.nio.file.Files.newInputStream;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+public class ProtobufDeserializerFactory
+        implements LineDeserializerFactory
+{
+    private LoadingCache<String, Descriptor> cache;
+
+    public ProtobufDeserializerFactory(Path descriptorsDirectory, Duration updateInterval, long maximumSize)
+    {
+        if (descriptorsDirectory != null) {
+            // When no directory is set in the config, the factory will fail when create() is used
+            // as the cache is null
+            cache = EvictableCacheBuilder.newBuilder()
+                    .refreshAfterWrite(updateInterval.toJavaTime())
+                    .maximumSize(maximumSize)
+                    .build(new DescriptorCacheLoader(descriptorsDirectory));
+        }
+    }
+
+    @Override
+    public Set<String> getHiveSerDeClassNames()
+    {
+        return ImmutableSet.of(TWITTER_ELEPHANTBIRD_PROTOBUF_SERDE_CLASS);
+    }
+
+    @Override
+    public ProtobufDeserializer create(List<Column> columns, Map<String, String> serdeProperties)
+    {
+        if (this.cache == null) {
+            throw new TrinoException(CONFIGURATION_INVALID, "No \"hive.protobufs.descriptors\" set in hive configuration");
+        }
+
+        String serializationClass = serdeProperties.get("serialization.class");
+        if (serializationClass == null) {
+            throw new TrinoException(HIVE_INVALID_METADATA, "Missing serdeproperties key \"serialization.class\"");
+        }
+        else if (!serializationClass.matches("^[^$]+\\$[^$]+$")) {
+            throw new TrinoException(HIVE_INVALID_METADATA, String.format("Expected serialization.class to contain {package}${protoname}, but was %s", serializationClass));
+        }
+
+        return new ProtobufDeserializer(columns, cache.getUnchecked(serializationClass));
+    }
+
+    private static class DescriptorCacheLoader
+            extends CacheLoader<String, Descriptor>
+    {
+        private final Path descriptorsDirectory;
+        private final ListeningExecutorService executor = listeningDecorator(newSingleThreadExecutor(daemonThreadsNamed("protobuf-deserializer-%d")));
+
+        DescriptorCacheLoader(Path descriptorsDirectory)
+        {
+            this.descriptorsDirectory = requireNonNull(descriptorsDirectory, "descriptorsDirectory is null");
+        }
+
+        @Override
+        public Descriptor load(String serializationClass)
+                throws IOException
+        {
+            List<String> javaClassAndProtoName = Splitter.on('$').limit(2).splitToList(serializationClass);
+
+            try (DirectoryStream<Path> stream = newDirectoryStream(descriptorsDirectory)) {
+                for (Path path : stream) {
+                    if (!isDirectory(path)) {
+                        try (InputStream in = newInputStream(path)) {
+                            FileDescriptorSet fileDescriptorSet = FileDescriptorSet.parseFrom(in);
+
+                            List<FileDescriptor> dependencies = new ArrayList<>();
+                            for (FileDescriptorProto proto : fileDescriptorSet.getFileList()) {
+                                try {
+                                    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(proto, dependencies.toArray(FileDescriptor[]::new));
+                                    dependencies.add(fileDescriptor);
+
+                                    if (javaClassAndProtoName.getFirst().equals(fileDescriptor.getOptions().getJavaPackage() + "." + fileDescriptor.getOptions().getJavaOuterClassname())) {
+                                        Descriptor descriptor = fileDescriptor.findMessageTypeByName(javaClassAndProtoName.getLast());
+                                        if (descriptor != null) {
+                                            return descriptor;
+                                        }
+                                    }
+                                }
+                                catch (DescriptorValidationException e) {
+                                    throw new TrinoException(CONFIGURATION_INVALID, String.format("Failed to load protobuf fileDescriptor %s from %s", proto.getName(), path), e);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            throw new TrinoException(HIVE_INVALID_METADATA, String.format("No file descriptor found for serialization class %s", serializationClass));
+        }
+
+        @Override
+        public ListenableFuture<Descriptor> reload(String serializationClass, Descriptor oldValue)
+        {
+            requireNonNull(serializationClass);
+            requireNonNull(oldValue);
+
+            // This executor executes using only one thread at a time,
+            // to avoid a mass file read when all descriptors are  refreshed at the same time or the file I/O is slow.
+            return executor.submit(() -> DescriptorCacheLoader.this.load(serializationClass));
+        }
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileWriterFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileWriterFactory.java
@@ -30,10 +30,12 @@ public class SequenceFileWriterFactory
         implements LineWriterFactory
 {
     private final String trinoVersion;
+    private final ValueType valueType;
 
-    public SequenceFileWriterFactory(String trinoVersion)
+    public SequenceFileWriterFactory(String trinoVersion, ValueType valueType)
     {
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
+        this.valueType = valueType;
     }
 
     @Override
@@ -53,6 +55,7 @@ public class SequenceFileWriterFactory
                 ImmutableMap.<String, String>builder()
                         .put("trino_version", trinoVersion)
                         .put("trino_query_id", session.getQueryId())
-                        .buildOrThrow());
+                        .buildOrThrow(),
+                valueType);
     }
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/ValueType.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/ValueType.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.sequence;
+
+import io.airlift.slice.SliceOutput;
+import io.trino.hive.formats.ReadWriteUtils;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.function.Function;
+
+import static io.trino.hive.formats.ReadWriteUtils.readVInt;
+import static io.trino.hive.formats.ReadWriteUtils.writeVInt;
+import static java.lang.Integer.reverseBytes;
+import static java.lang.Math.toIntExact;
+
+public enum ValueType
+{
+    TEXT("org.apache.hadoop.io.Text", ReadWriteUtils::computeVIntLength) {
+        @Override
+        public int readLengthField(DataInput input)
+                throws IOException
+        {
+            return toIntExact(readVInt(input));
+        }
+
+        @Override
+        public void writeLengthField(SliceOutput output, int length)
+        {
+            writeVInt(output, length);
+        }
+    },
+    BYTES("org.apache.hadoop.io.BytesWritable", i -> Integer.BYTES) {
+        @Override
+        public int readLengthField(DataInput input)
+                throws IOException
+        {
+            return reverseBytes(input.readInt());
+        }
+
+        @Override
+        public void writeLengthField(SliceOutput output, int length)
+        {
+            output.writeInt(reverseBytes(length));
+        }
+    };
+
+    private final String className;
+    private final Function<Integer, Integer> lengthOfLengthField;
+
+    ValueType(String className, Function<Integer, Integer> lengthOfLengthField)
+    {
+        this.className = className;
+        this.lengthOfLengthField = lengthOfLengthField;
+    }
+
+    public String getClassName()
+    {
+        return className;
+    }
+
+    public int computeLengthOfLengthField(int valueLength)
+    {
+        return lengthOfLengthField.apply(valueLength);
+    }
+
+    public abstract int readLengthField(DataInput input)
+            throws IOException;
+
+    public abstract void writeLengthField(SliceOutput output, int length);
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/protobuf/TestProtobufFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/protobuf/TestProtobufFormat.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.protobuf;
+
+import com.google.protobuf.ByteString;
+import io.airlift.units.Duration;
+import io.trino.hive.formats.line.Column;
+import io.trino.hive.formats.line.LineBuffer;
+import io.trino.hive.formats.line.protobuf.examples.DataRecordProtos.DataRecord;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.SqlVarbinary;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static io.trino.hive.formats.FormatTestUtils.readTrinoValues;
+import static io.trino.hive.formats.line.protobuf.examples.DataRecordProtos.DataRecord.EnumType.ENUM1;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class TestProtobufFormat
+{
+    private static Stream<Arguments> testCases()
+    {
+        return Stream.of(
+                argumentSet("empty fields", emptyFields(), expectedNoValues()),
+                argumentSet("all single fields", allSingleFields(), expectedSingleValues()),
+                argumentSet("all array fields", allArrayFields(), expectedArrayValues()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testAllProtobufTypes(DataRecord dataRecord, List<Object> expectedValues)
+            throws Exception
+    {
+        List<Column> columns = List.of(
+                new Column("doubleField", DOUBLE, 0),
+                new Column("floatField", REAL, 1),
+                new Column("int32Field", INTEGER, 2),
+                new Column("int64Field", BIGINT, 3),
+                new Column("uint32Field", INTEGER, 4),
+                new Column("uint64Field", BIGINT, 5),
+                new Column("sint32Field", INTEGER, 6),
+                new Column("sint64Field", BIGINT, 7),
+                new Column("fixed32Field", INTEGER, 8),
+                new Column("fixed64Field", BIGINT, 9),
+                new Column("sfixed32Field", INTEGER, 10),
+                new Column("sfixed64Field", BIGINT, 11),
+                new Column("boolField", BOOLEAN, 12),
+                new Column("stringField", VARCHAR, 13),
+                new Column("enumField", VARCHAR, 14),
+                new Column("bytesField", VARBINARY, 15),
+                new Column("innerRecord", rowType(
+                        field("doubleField", DOUBLE),
+                        field("floatField", REAL),
+                        field("int32Field", INTEGER),
+                        field("int64Field", BIGINT),
+                        field("uint32Field", INTEGER),
+                        field("uint64Field", BIGINT),
+                        field("sint32Field", INTEGER),
+                        field("sint64Field", BIGINT),
+                        field("fixed32Field", INTEGER),
+                        field("fixed64Field", BIGINT),
+                        field("sfixed32Field", INTEGER),
+                        field("sfixed64Field", BIGINT),
+                        field("boolField", BOOLEAN),
+                        field("stringField", VARCHAR),
+                        field("enumField", VARCHAR),
+                        field("bytesField", VARBINARY),
+                        field("innerRecord", rowType(
+                                field("doubleField", DOUBLE),
+                                field("floatField", REAL),
+                                field("int32Field", INTEGER),
+                                field("int64Field", BIGINT),
+                                field("uint32Field", INTEGER),
+                                field("uint64Field", BIGINT),
+                                field("sint32Field", INTEGER),
+                                field("sint64Field", BIGINT),
+                                field("fixed32Field", INTEGER),
+                                field("fixed64Field", BIGINT),
+                                field("sfixed32Field", INTEGER),
+                                field("sfixed64Field", BIGINT),
+                                field("boolField", BOOLEAN),
+                                field("stringField", VARCHAR),
+                                field("enumField", VARCHAR),
+                                field("bytesField", VARBINARY)))), 16),
+                new Column("doubleArrayField", new ArrayType(DOUBLE), 17),
+                new Column("floatArrayField", new ArrayType(REAL), 18),
+                new Column("int32ArrayField", new ArrayType(INTEGER), 19),
+                new Column("int64ArrayField", new ArrayType(BIGINT), 20),
+                new Column("uint32ArrayField", new ArrayType(INTEGER), 21),
+                new Column("uint64ArrayField", new ArrayType(BIGINT), 22),
+                new Column("sint32ArrayField", new ArrayType(INTEGER), 23),
+                new Column("sint64ArrayField", new ArrayType(BIGINT), 24),
+                new Column("fixed32ArrayField", new ArrayType(INTEGER), 25),
+                new Column("fixed64ArrayField", new ArrayType(BIGINT), 26),
+                new Column("sfixed32ArrayField", new ArrayType(INTEGER), 27),
+                new Column("sfixed64ArrayField", new ArrayType(BIGINT), 28),
+                new Column("boolArrayField", new ArrayType(BOOLEAN), 29),
+                new Column("stringArrayField", new ArrayType(VARCHAR), 30),
+                new Column("enumArrayField", new ArrayType(VARCHAR), 31),
+                new Column("bytesArrayField", new ArrayType(VARBINARY), 32),
+                new Column("innerRecordArray", new ArrayType(rowType(
+                        field("doubleArrayField", new ArrayType(DOUBLE)),
+                        field("floatArrayField", new ArrayType(REAL)),
+                        field("int32ArrayField", new ArrayType(INTEGER)),
+                        field("int64ArrayField", new ArrayType(BIGINT)),
+                        field("uint32ArrayField", new ArrayType(INTEGER)),
+                        field("uint64ArrayField", new ArrayType(BIGINT)),
+                        field("sint32ArrayField", new ArrayType(INTEGER)),
+                        field("sint64ArrayField", new ArrayType(BIGINT)),
+                        field("fixed32ArrayField", new ArrayType(INTEGER)),
+                        field("fixed64ArrayField", new ArrayType(BIGINT)),
+                        field("sfixed32ArrayField", new ArrayType(INTEGER)),
+                        field("sfixed64ArrayField", new ArrayType(BIGINT)),
+                        field("boolArrayField", new ArrayType(BOOLEAN)),
+                        field("stringArrayField", new ArrayType(VARCHAR)),
+                        field("enumArrayField", new ArrayType(VARCHAR)),
+                        field("bytesArrayField", new ArrayType(VARBINARY)),
+                        field("innerRecordArray", new ArrayType(rowType(
+                                field("doubleArrayField", new ArrayType(DOUBLE)),
+                                field("floatArrayField", new ArrayType(REAL)),
+                                field("int32ArrayField", new ArrayType(INTEGER)),
+                                field("int64ArrayField", new ArrayType(BIGINT)),
+                                field("uint32ArrayField", new ArrayType(INTEGER)),
+                                field("uint64ArrayField", new ArrayType(BIGINT)),
+                                field("sint32ArrayField", new ArrayType(INTEGER)),
+                                field("sint64ArrayField", new ArrayType(BIGINT)),
+                                field("fixed32ArrayField", new ArrayType(INTEGER)),
+                                field("fixed64ArrayField", new ArrayType(BIGINT)),
+                                field("sfixed32ArrayField", new ArrayType(INTEGER)),
+                                field("sfixed64ArrayField", new ArrayType(BIGINT)),
+                                field("boolArrayField", new ArrayType(BOOLEAN)),
+                                field("stringArrayField", new ArrayType(VARCHAR)),
+                                field("enumArrayField", new ArrayType(VARCHAR)),
+                                field("bytesArrayField", new ArrayType(VARBINARY))))))), 33));
+
+        ProtobufDeserializerFactory factory = new ProtobufDeserializerFactory(Paths.get(getClass().getResource("/protobuf/descriptors").toURI()), new Duration(1, HOURS), 1);
+        ProtobufDeserializer deserializer = factory.create(columns, Map.of("serialization.class", "io.trino.hive.formats.line.protobuf.examples.DataRecordProtos$DataRecord"));
+
+        LineBuffer lineBuffer = new LineBuffer(128, 1024);
+        PageBuilder pageBuilder = new PageBuilder(1, deserializer.getTypes());
+        lineBuffer.write(dataRecord.toByteArray());
+
+        deserializer.deserialize(lineBuffer, pageBuilder);
+
+        assertThat(readTrinoValues(columns, pageBuilder.build(), 0)).isEqualTo(expectedValues);
+    }
+
+    private static DataRecord allSingleFields()
+    {
+        return createSingleRecord()
+                .setInnerRecord(createSingleRecord().build())
+                .build();
+    }
+
+    private static DataRecord emptyFields()
+    {
+        return DataRecord.newBuilder().build();
+    }
+
+    private static DataRecord allArrayFields()
+    {
+        return createArrayRecord()
+                .addInnerRecordArray(createArrayRecord().addInnerRecordArray(createArrayRecord()))
+                .build();
+    }
+
+    private static List<Object> createPrimitiveDefaults()
+    {
+        List<Object> inner = new ArrayList<>();
+        for (int i = 0; i < 17; i++) {
+            inner.add(i == 13 ? "theDefault" : null);
+        }
+
+        return List.of(
+                0d,
+                0f,
+                0,
+                0L,
+                0,
+                0L,
+                0,
+                0L,
+                0,
+                0L,
+                0,
+                0L,
+                false,
+                "theDefault",
+                "ENUM0",
+                new SqlVarbinary(new byte[0]),
+                inner);
+    }
+
+    private static DataRecord.Builder createSingleRecord()
+    {
+        return DataRecord.newBuilder()
+                .setDoubleField(13.37d)
+                .setFloatField(13.37f)
+                .setInt32Field(1337)
+                .setInt64Field(1337L)
+                .setUint32Field(1337)
+                .setUint64Field(1337L)
+                .setSint32Field(1337)
+                .setSint64Field(1337L)
+                .setFixed32Field(1337)
+                .setFixed64Field(1337L)
+                .setSfixed32Field(1337)
+                .setSfixed64Field(1337)
+                .setBoolField(true)
+                .setStringField("foobar")
+                .setEnumField(ENUM1)
+                .setBytesField(ByteString.copyFrom("hello", UTF_8));
+    }
+
+    private static DataRecord.Builder createArrayRecord()
+    {
+        return DataRecord.newBuilder()
+                .addDoubleArrayField(13.37d)
+                .addFloatArrayField(13.37f)
+                .addInt32ArrayField(1337)
+                .addInt64ArrayField(1337L)
+                .addUint32ArrayField(1337)
+                .addUint64ArrayField(1337L)
+                .addSint32ArrayField(1337)
+                .addSint64ArrayField(1337L)
+                .addFixed32ArrayField(1337)
+                .addFixed64ArrayField(1337L)
+                .addSfixed32ArrayField(1337)
+                .addSfixed64ArrayField(1337)
+                .addBoolArrayField(true)
+                .addStringArrayField("foobar")
+                .addEnumArrayField(ENUM1)
+                .addBytesArrayField(ByteString.copyFrom("hello", UTF_8));
+    }
+
+    private static List<Object> expectedNoValues()
+    {
+        List<Object> expected = new ArrayList<>(createPrimitiveDefaults());
+
+        for (int i = 0; i < 17; i++) {
+            expected.add(List.of());
+        }
+        return expected;
+    }
+
+    private static List<Object> expectedSingleValues()
+    {
+        List<Object> dataRecordValues = new ArrayList<>(List.of(
+                13.37d,
+                13.37f,
+                1337,
+                1337L,
+                1337,
+                1337L,
+                1337,
+                1337L,
+                1337,
+                1337L,
+                1337,
+                1337L,
+                true,
+                "foobar",
+                "ENUM1",
+                new SqlVarbinary("hello".getBytes(UTF_8))));
+
+        List<Object> expected = new ArrayList<>(dataRecordValues);
+
+        dataRecordValues.add(null);
+        expected.add(dataRecordValues);
+
+        for (int i = 0; i < 17; i++) {
+            expected.add(List.of());
+        }
+
+        return expected;
+    }
+
+    private static List<Object> expectedArrayRowValues()
+    {
+        List<Object> expected = new ArrayList<>();
+        expected.add(List.of(13.37d));
+        expected.add(List.of(13.37f));
+        expected.add(List.of(1337));
+        expected.add(List.of(1337L));
+        expected.add(List.of(1337));
+        expected.add(List.of(1337L));
+        expected.add(List.of(1337));
+        expected.add(List.of(1337L));
+        expected.add(List.of(1337));
+        expected.add(List.of(1337L));
+        expected.add(List.of(1337));
+        expected.add(List.of(1337L));
+        expected.add(List.of(true));
+        expected.add(List.of("foobar"));
+        expected.add(List.of("ENUM1"));
+        expected.add(List.of(new SqlVarbinary("hello".getBytes(UTF_8))));
+
+        return expected;
+    }
+
+    private static List<Object> expectedArrayValues()
+    {
+        List<Object> expected = new ArrayList<>(createPrimitiveDefaults());
+        expected.addAll(expectedArrayRowValues());
+
+        List<Object> innerRow = expectedArrayRowValues();
+        expected.add(List.of(innerRow));
+        innerRow.add(List.of(expectedArrayRowValues()));
+
+        return expected;
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/sequence/TestSequenceFileWriterFactory.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/sequence/TestSequenceFileWriterFactory.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.hive.formats.line.sequence.ValueType.TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -41,7 +42,8 @@ public class TestSequenceFileWriterFactory
                 out,
                 Optional.empty(),
                 false,
-                ImmutableMap.of())) {
+                ImmutableMap.of(),
+                TEXT)) {
             writer.write(utf8Slice("header"));
             for (int i = 0; i < 1000; i++) {
                 writer.write(utf8Slice("data " + i));

--- a/lib/trino-hive-formats/src/test/resources/protobuf/sources/datarecord.proto
+++ b/lib/trino-hive-formats/src/test/resources/protobuf/sources/datarecord.proto
@@ -1,0 +1,51 @@
+syntax = "proto2";
+package io_trino_hive_formats_line_protobuf_examples;
+
+option java_package = "io.trino.hive.formats.line.protobuf.examples";
+option java_outer_classname = "DataRecordProtos";
+
+message DataRecord {
+
+    enum EnumType {
+        ENUM0 = 0;
+        ENUM1 = 1;
+        ENUM2 = 2;
+    }
+
+    optional double doubleField = 1;
+    optional float floatField = 2;
+    optional int32 int32Field = 3;
+    optional int64 int64Field = 4;
+    optional uint32 uint32Field = 5;
+    optional uint64 uint64Field = 6;
+    optional sint32 sint32Field = 7;
+    optional sint64 sint64Field = 8;
+    optional fixed32 fixed32Field = 9;
+    optional fixed64 fixed64Field = 10;
+    optional sfixed32 sfixed32Field = 11;
+    optional sfixed64 sfixed64Field = 12;
+    optional bool boolField = 13;
+    optional string stringField = 14 [default = "theDefault"];
+    optional bytes bytesField = 15;
+    optional EnumType enumField = 16;
+    optional DataRecord innerRecord = 17;
+
+    repeated double doubleArrayField = 18;
+    repeated float floatArrayField = 19;
+    repeated int32 int32ArrayField = 20;
+    repeated int64 int64ArrayField = 21;
+    repeated uint32 uint32ArrayField = 22;
+    repeated uint64 uint64ArrayField = 23;
+    repeated sint32 sint32ArrayField = 24;
+    repeated sint64 sint64ArrayField = 25;
+    repeated fixed32 fixed32ArrayField = 26;
+    repeated fixed64 fixed64ArrayField = 27;
+    repeated sfixed32 sfixed32ArrayField = 28;
+    repeated sfixed64 sfixed64ArrayField = 29;
+    repeated bool boolArrayField = 30;
+    repeated string stringArrayField = 31;
+    repeated bytes bytesArrayField = 32;
+    repeated EnumType enumArrayField = 33;
+    repeated DataRecord innerRecordArray = 34;
+}
+

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -32,11 +32,13 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.joda.time.DateTimeZone;
 
+import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -176,6 +178,10 @@ public class HiveConfig
     private S3GlacierFilter s3GlacierFilter = S3GlacierFilter.READ_ALL;
 
     private int metadataParallelism = 8;
+
+    private Path protobufDescriptorsLocation;
+    private Duration protobufDescriptorsCacheRefreshInterval = new Duration(1, TimeUnit.DAYS);
+    private long protobufDescriptorsCacheMaxSize = 64;
 
     public boolean isSingleStatementWritesOnly()
     {
@@ -1294,6 +1300,45 @@ public class HiveConfig
     public HiveConfig setMetadataParallelism(int metadataParallelism)
     {
         this.metadataParallelism = metadataParallelism;
+        return this;
+    }
+
+    public Path getProtobufDescriptorsLocation()
+    {
+        return protobufDescriptorsLocation;
+    }
+
+    @ConfigDescription("Directory where binary protobuf descriptors are stored to use for deserializing protobufs")
+    @Config("hive.protobuf.descriptors.location")
+    public HiveConfig setProtobufDescriptorsLocation(Path protobufDescriptorsLocation)
+    {
+        this.protobufDescriptorsLocation = protobufDescriptorsLocation;
+        return this;
+    }
+
+    public long getProtobufDescriptorsCacheMaxSize()
+    {
+        return protobufDescriptorsCacheMaxSize;
+    }
+
+    @ConfigDescription("The maximum amount of protobuf descriptors to keep in memory")
+    @Config("hive.protobuf.descriptors.cache.max-size")
+    public HiveConfig setProtobufDescriptorsCacheMaxSize(long size)
+    {
+        this.protobufDescriptorsCacheMaxSize = size;
+        return this;
+    }
+
+    public Duration getProtobufDescriptorsCacheRefreshInterval()
+    {
+        return protobufDescriptorsCacheRefreshInterval;
+    }
+
+    @ConfigDescription("Interval on when loaded descriptors should be refreshed")
+    @Config("hive.protobuf.descriptors.cache.refresh-interval")
+    public HiveConfig setProtobufDescriptorsCacheRefreshInterval(Duration refreshInterval)
+    {
+        this.protobufDescriptorsCacheRefreshInterval = refreshInterval;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -32,6 +32,7 @@ import io.trino.plugin.hive.line.JsonFileWriterFactory;
 import io.trino.plugin.hive.line.JsonPageSourceFactory;
 import io.trino.plugin.hive.line.OpenXJsonFileWriterFactory;
 import io.trino.plugin.hive.line.OpenXJsonPageSourceFactory;
+import io.trino.plugin.hive.line.ProtobufSequenceFilePageSourceFactory;
 import io.trino.plugin.hive.line.RegexFileWriterFactory;
 import io.trino.plugin.hive.line.RegexPageSourceFactory;
 import io.trino.plugin.hive.line.SimpleSequenceFilePageSourceFactory;
@@ -113,6 +114,7 @@ public class HiveModule
         pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(AvroPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(ProtobufSequenceFilePageSourceFactory.class).in(Scopes.SINGLETON);
 
         Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
         binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -53,6 +53,7 @@ import static io.trino.hive.formats.HiveClassNames.RCFILE_OUTPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.REGEX_SERDE_CLASS;
 import static io.trino.hive.formats.HiveClassNames.SEQUENCEFILE_INPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.TEXT_INPUT_FORMAT_CLASS;
+import static io.trino.hive.formats.HiveClassNames.TWITTER_ELEPHANTBIRD_PROTOBUF_SERDE_CLASS;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -82,6 +83,10 @@ public enum HiveStorageFormat
             RCFILE_OUTPUT_FORMAT_CLASS),
     SEQUENCEFILE(
             LAZY_SIMPLE_SERDE_CLASS,
+            SEQUENCEFILE_INPUT_FORMAT_CLASS,
+            HIVE_SEQUENCEFILE_OUTPUT_FORMAT_CLASS),
+    SEQUENCEFILE_PROTOBUF(
+            TWITTER_ELEPHANTBIRD_PROTOBUF_SERDE_CLASS,
             SEQUENCEFILE_INPUT_FORMAT_CLASS,
             HIVE_SEQUENCEFILE_OUTPUT_FORMAT_CLASS),
     JSON(
@@ -139,7 +144,7 @@ public enum HiveStorageFormat
     {
         // Only uncompressed text input format is splittable
         return switch (this) {
-            case ORC, PARQUET, AVRO, RCBINARY, RCTEXT, SEQUENCEFILE -> true;
+            case ORC, PARQUET, AVRO, RCBINARY, RCTEXT, SEQUENCEFILE, SEQUENCEFILE_PROTOBUF -> true;
             case JSON, OPENX_JSON, TEXTFILE, CSV, REGEX -> CompressionKind.forFile(path).isEmpty();
             case ESRI -> false;
         };

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/ProtobufSequenceFilePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/ProtobufSequenceFilePageSourceFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.line;
+
+import com.google.inject.Inject;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.hive.formats.line.protobuf.ProtobufDeserializerFactory;
+import io.trino.hive.formats.line.sequence.SequenceFileReaderFactory;
+import io.trino.plugin.hive.HiveConfig;
+
+import static java.lang.Math.toIntExact;
+
+public class ProtobufSequenceFilePageSourceFactory
+        extends LinePageSourceFactory
+{
+    @Inject
+    public ProtobufSequenceFilePageSourceFactory(TrinoFileSystemFactory trinoFileSystemFactory, HiveConfig config)
+    {
+        super(trinoFileSystemFactory,
+                new ProtobufDeserializerFactory(config.getProtobufDescriptorsLocation(), config.getProtobufDescriptorsCacheRefreshInterval(), config.getProtobufDescriptorsCacheMaxSize()),
+                new SequenceFileReaderFactory(1024, toIntExact(config.getTextMaxLineLength().toBytes())));
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/SimpleSequenceFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/SimpleSequenceFileWriterFactory.java
@@ -20,6 +20,8 @@ import io.trino.hive.formats.line.simple.SimpleSerializerFactory;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.spi.type.TypeManager;
 
+import static io.trino.hive.formats.line.sequence.ValueType.TEXT;
+
 public class SimpleSequenceFileWriterFactory
         extends LineFileWriterFactory
 {
@@ -29,7 +31,7 @@ public class SimpleSequenceFileWriterFactory
         super(trinoFileSystemFactory,
                 typeManager,
                 new SimpleSerializerFactory(),
-                new SequenceFileWriterFactory(nodeVersion.toString()),
+                new SequenceFileWriterFactory(nodeVersion.toString(), TEXT),
                 false);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -146,6 +146,7 @@ import static io.trino.plugin.hive.HiveStorageFormat.ESRI;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveStorageFormat.REGEX;
+import static io.trino.plugin.hive.HiveStorageFormat.SEQUENCEFILE_PROTOBUF;
 import static io.trino.plugin.hive.HiveTableProperties.AUTO_PURGE;
 import static io.trino.plugin.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
 import static io.trino.plugin.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
@@ -5700,6 +5701,7 @@ public abstract class BaseHiveConnectorTest
             case RCBINARY -> false;
             case RCTEXT -> false;
             case SEQUENCEFILE -> false;
+            case SEQUENCEFILE_PROTOBUF -> false;
             case OPENX_JSON -> false;
             case TEXTFILE -> false;
             case CSV -> false;
@@ -9511,6 +9513,10 @@ public abstract class BaseHiveConnectorTest
             }
             if (hiveStorageFormat == ESRI) {
                 // ESRI format is read-only
+                continue;
+            }
+            if (hiveStorageFormat == SEQUENCEFILE_PROTOBUF) {
+                // SEQUENCEFILE_PROTOBUF format is read-only
                 continue;
             }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
@@ -42,6 +42,7 @@ import io.trino.plugin.hive.line.JsonFileWriterFactory;
 import io.trino.plugin.hive.line.JsonPageSourceFactory;
 import io.trino.plugin.hive.line.OpenXJsonFileWriterFactory;
 import io.trino.plugin.hive.line.OpenXJsonPageSourceFactory;
+import io.trino.plugin.hive.line.ProtobufSequenceFilePageSourceFactory;
 import io.trino.plugin.hive.line.RegexFileWriterFactory;
 import io.trino.plugin.hive.line.RegexPageSourceFactory;
 import io.trino.plugin.hive.line.SimpleSequenceFilePageSourceFactory;
@@ -178,6 +179,7 @@ public final class HiveTestUtils
                 .add(new RcFilePageSourceFactory(fileSystemFactory, hiveConfig))
                 .add(new OrcPageSourceFactory(new OrcReaderConfig(), fileSystemFactory, stats, hiveConfig))
                 .add(new ParquetPageSourceFactory(fileSystemFactory, stats, new ParquetReaderConfig(), hiveConfig))
+                .add(new ProtobufSequenceFilePageSourceFactory(fileSystemFactory, hiveConfig))
                 .build();
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -20,6 +20,7 @@ import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -119,7 +120,10 @@ public class TestHiveConfig
                 .setAutoPurge(false)
                 .setPartitionProjectionEnabled(true)
                 .setS3GlacierFilter(S3GlacierFilter.READ_ALL)
-                .setMetadataParallelism(8));
+                .setMetadataParallelism(8)
+                .setProtobufDescriptorsLocation(null)
+                .setProtobufDescriptorsCacheRefreshInterval(new Duration(1, TimeUnit.DAYS))
+                .setProtobufDescriptorsCacheMaxSize(64));
     }
 
     @Test
@@ -207,6 +211,9 @@ public class TestHiveConfig
                 .put("hive.partition-projection-enabled", "false")
                 .put("hive.s3-glacier-filter", "READ_NON_GLACIER_AND_RESTORED")
                 .put("hive.metadata.parallelism", "10")
+                .put("hive.protobuf.descriptors.location", "/tmp")
+                .put("hive.protobuf.descriptors.cache.max-size", "8")
+                .put("hive.protobuf.descriptors.cache.refresh-interval", "10s")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -290,7 +297,10 @@ public class TestHiveConfig
                 .setAutoPurge(true)
                 .setPartitionProjectionEnabled(false)
                 .setS3GlacierFilter(S3GlacierFilter.READ_NON_GLACIER_AND_RESTORED)
-                .setMetadataParallelism(10);
+                .setMetadataParallelism(10)
+                .setProtobufDescriptorsLocation(Path.of("/tmp"))
+                .setProtobufDescriptorsCacheMaxSize(8)
+                .setProtobufDescriptorsCacheRefreshInterval(new Duration(10, TimeUnit.SECONDS));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -268,7 +268,7 @@ public final class TestHiveFileFormats
     }
 
     @Test(dataProvider = "validRowAndFileSizePadding")
-    public void testSequenceFile(int rowCount, long fileSizePadding)
+    public void testTextSequenceFile(int rowCount, long fileSizePadding)
             throws Exception
     {
         List<TestColumn> testColumns = TEST_COLUMNS.stream()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -126,6 +126,10 @@ public class TestHivePageSink
                 // ESRI format is readonly
                 continue;
             }
+            if (format == HiveStorageFormat.SEQUENCEFILE_PROTOBUF) {
+                // SEQUENCEFILE_PROTOBUF format is readonly
+                continue;
+            }
             config.setHiveStorageFormat(format);
             config.setHiveCompressionCodec(NONE);
             long uncompressedLength = writeTestFile(fileSystemFactory, config, sortingFileWriterConfig, metastore, makeFileName(config));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -305,6 +305,8 @@ public class TestHiveStorageFormats
                 .filter(format -> !"REGEX".equals(format))
                 // ESRI is read-only
                 .filter(format -> !"ESRI".equals(format))
+                // SEQUENCEFILE_PROTOBUF is read-only
+                .filter(format -> !"SEQUENCEFILE_PROTOBUF".equals(format))
                 // TODO when using JSON serde Hive fails with ClassNotFoundException: org.apache.hive.hcatalog.data.JsonSerDe
                 .filter(format -> !"JSON".equals(format))
                 // OPENX is not supported in Hive by default


### PR DESCRIPTION
## Description
A while ago, Twitter introduced a table format to Hive that is based on protocol buffers in a Hadoop sequence file: https://github.com/twitter/elephant-bird/blob/master/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializer.java
This PR adds that functionality to Trino, so Hive tables created in that format can be queried.

The PR consists of two parts:

* Extended the sequence file reader and writer to support `org.apache.hadoop.io.BytesWritable` instead of only `org.apache.hadoop.io.Text` as values #26305
  See diff https://github.com/trinodb/trino/pull/26353/commits/dcf5e42597fa3bf8858fc1f84968d578c25c2deb
* Added a deserializer for protobufs, using a directory that contains protobuf descriptors, a binary collection of proto files.

## Additional context and related issues
More information about the original deserializer can be found here: https://github.com/twitter/elephant-bird/wiki/How-to-use-Elephant-Bird-with-Hive

Tables that can be read have the following scheme:
```
create table users
  row format serde "com.twitter.elephantbird.hive.serde.ProtobufDeserializer"
  with serdeproperties (
    "serialization.class"="com.example.proto.gen.Storage$User")
  stored as
    inputformat "com.twitter.elephantbird.mapred.input.DeprecatedRawMultiInputFormat";
```

Closes #26305

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* Added support for Twitter Elephantbird protobuf deserialization. ({issue}`26305`)
```
