### PR TITLE
Check if HNS is enabled for Azure storage account using Get Account Info

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -25,7 +25,6 @@ import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.models.UserDelegationKey;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
-import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.storage.common.sas.SasProtocol;
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
@@ -599,10 +598,10 @@ public class AzureFileSystem
             throws IOException
     {
         try {
-            BlockBlobClient blockBlobClient = createBlobContainerClient(location, Optional.empty())
-                    .getBlobClient("/")
-                    .getBlockBlobClient();
-            return blockBlobClient.exists();
+            return createBlobContainerClient(location, Optional.empty())
+                    .getServiceClient()
+                    .getAccountInfo()
+                    .isHierarchicalNamespaceEnabled();
         }
         catch (RuntimeException e) {
             throw new IOException("Checking whether hierarchical namespace is enabled for the location %s failed".formatted(location), e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
According to [this comment](https://github.com/Azure/azure-sdk-for-java/issues/38912#issuecomment-3160847541) from an Azure engineer, the version 12.31.0 of the azure-storage-blob dependency now supports OAuth for the [Get Account Info endpoint](https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures#authorization). This PR updates the check for HNS on a storage account to use the Get Account Info endpoint, rather than the "hack" introduced in  #20897.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
#20897
https://github.com/Azure/azure-sdk-for-java/issues/38912#issuecomment-3160847541

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
