### PR TITLE
Don't set max_commit_retry Iceberg table property by default

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -43,7 +43,6 @@ import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 
 @DefunctConfig({
         "iceberg.allow-legacy-snapshot-syntax",
@@ -61,7 +60,7 @@ public class IcebergConfig
 
     private IcebergFileFormat fileFormat = PARQUET;
     private HiveCompressionOption compressionCodec = HiveCompressionOption.ZSTD;
-    private int maxCommitRetry = COMMIT_NUM_RETRIES_DEFAULT;
+    private Optional<Integer> maxCommitRetry = Optional.empty();
     private boolean useFileSizeFromMetadata = true;
     private int maxPartitionsPerWriter = 100;
     private boolean uniqueTableLocation = true;
@@ -138,17 +137,16 @@ public class IcebergConfig
         return this;
     }
 
-    @Min(0)
-    public int getMaxCommitRetry()
+    public Optional<@Min(0) Integer> getMaxCommitRetry()
     {
         return maxCommitRetry;
     }
 
     @Config("iceberg.max-commit-retry")
     @ConfigDescription("Number of times to retry a commit before failing")
-    public IcebergConfig setMaxCommitRetry(int maxCommitRetry)
+    public IcebergConfig setMaxCommitRetry(Integer maxCommitRetry)
     {
-        this.maxCommitRetry = maxCommitRetry;
+        this.maxCommitRetry = Optional.ofNullable(maxCommitRetry);
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -49,7 +49,6 @@ import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_COLUMNS;
@@ -150,7 +149,7 @@ public class IcebergTableProperties
                 .add(integerProperty(
                         MAX_COMMIT_RETRY,
                         "Number of times to retry a commit before failing",
-                        icebergConfig.getMaxCommitRetry(),
+                        icebergConfig.getMaxCommitRetry().orElse(null),
                         value -> {
                             if (value < 0) {
                                 throw new TrinoException(INVALID_TABLE_PROPERTY, "max_commit_retry must be greater than or equal to 0");
@@ -291,9 +290,9 @@ public class IcebergTableProperties
         };
     }
 
-    public static int getMaxCommitRetry(Map<String, Object> tableProperties)
+    public static Optional<Integer> getMaxCommitRetry(Map<String, Object> tableProperties)
     {
-        return (int) tableProperties.getOrDefault(MAX_COMMIT_RETRY, COMMIT_NUM_RETRIES_DEFAULT);
+        return Optional.ofNullable((Integer) tableProperties.get(MAX_COMMIT_RETRY));
     }
 
     public static List<String> getOrcBloomFilterColumns(Map<String, Object> tableProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -904,7 +904,8 @@ public final class IcebergUtil
         IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
         propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toIceberg().toString());
         propertiesBuilder.put(FORMAT_VERSION, Integer.toString(IcebergTableProperties.getFormatVersion(tableMetadata.getProperties())));
-        propertiesBuilder.put(COMMIT_NUM_RETRIES, Integer.toString(IcebergTableProperties.getMaxCommitRetry(tableMetadata.getProperties())));
+        IcebergTableProperties.getMaxCommitRetry(tableMetadata.getProperties())
+                .ifPresent(value -> propertiesBuilder.put(COMMIT_NUM_RETRIES, Integer.toString(value)));
 
         Optional<HiveCompressionCodec> compressionCodec = IcebergTableProperties.getCompressionCodec(tableMetadata.getProperties());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -115,8 +115,7 @@ public abstract class BaseIcebergConnectorSmokeTest
                         "WITH \\(\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
-                        format("   location = '.*/" + schemaName + "/region.*',\n" +
-                        "   max_commit_retry = 4\n") +
+                        format("   location = '.*/" + schemaName + "/region.*'\n") +
                         "\\)");
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -383,8 +383,7 @@ public abstract class BaseIcebergConnectorTest
                         "WITH (\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
-                        "   location = '\\E.*/tpch/orders-.*\\Q',\n" +
-                        "   max_commit_retry = 4\n" +
+                        "   location = '\\E.*/tpch/orders-.*\\Q'\n" +
                         ")\\E");
     }
 
@@ -1287,7 +1286,6 @@ public abstract class BaseIcebergConnectorTest
                         "   format = '%s',\n" +
                         "   format_version = 2,\n" +
                         "   location = '%s',\n" +
-                        "   max_commit_retry = 4,\n" +
                         "   partitioning = ARRAY['order_status','ship_priority','bucket(\"order key\", 9)']\n" +
                         ")",
                 getSession().getCatalog().orElseThrow(),
@@ -1650,8 +1648,7 @@ public abstract class BaseIcebergConnectorTest
                 "WITH (\n" +
                 format("   format = '%s',\n", format) +
                 "   format_version = 2,\n" +
-                format("   location = '%s',\n", tempDirPath) +
-                "   max_commit_retry = 4\n" +
+                format("   location = '%s'\n", tempDirPath) +
                 ")";
         String createTableWithoutComment = "" +
                 "CREATE TABLE iceberg.tpch.test_table_comments (\n" +
@@ -1660,8 +1657,7 @@ public abstract class BaseIcebergConnectorTest
                 "WITH (\n" +
                 "   format = '" + format + "',\n" +
                 "   format_version = 2,\n" +
-                "   location = '" + tempDirPath + "',\n" +
-                "   max_commit_retry = 4\n" +
+                "   location = '" + tempDirPath + "'\n" +
                 ")";
         String createTableSql = format(createTableTemplate, "test table comment", format);
         assertUpdate(createTableSql);
@@ -1958,7 +1954,6 @@ public abstract class BaseIcebergConnectorTest
                            format = '%s',
                            format_version = 2,
                            location = '%s',
-                           max_commit_retry = 4,
                            partitioning = ARRAY['adate']
                         )""",
                 format,
@@ -1974,8 +1969,7 @@ public abstract class BaseIcebergConnectorTest
                         WITH (
                            format = '%s',
                            format_version = 2,
-                           location = '%s',
-                           max_commit_retry = 4
+                           location = '%s'
                         )""",
                 format,
                 getTableLocation("test_create_table_like_copy1")));
@@ -1986,8 +1980,7 @@ public abstract class BaseIcebergConnectorTest
                         WITH (
                            format = '%s',
                            format_version = 2,
-                           location = '%s',
-                           max_commit_retry = 4
+                           location = '%s'
                         )""",
                 format,
                 getTableLocation("test_create_table_like_copy2")));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -215,7 +215,6 @@ public abstract class BaseIcebergMaterializedViewTest
                                 "   format = 'ORC',\n" +
                                 "   format_version = 2,\n" +
                                 "   location = '" + getSchemaDirectory() + "/test_mv_show_create-\\E[0-9a-f]+\\Q',\n" +
-                                "   max_commit_retry = 4,\n" +
                                 "   orc_bloom_filter_columns = ARRAY['_date'],\n" +
                                 "   orc_bloom_filter_fpp = 1E-1,\n" +
                                 "   partitioning = ARRAY['_date'],\n" +
@@ -532,7 +531,6 @@ public abstract class BaseIcebergMaterializedViewTest
                         "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         "   location = '" + getSchemaDirectory() + "/materialized_view_window-\\E[0-9a-f]+\\Q',\n" +
-                        "   max_commit_retry = 4,\n" +
                         "   partitioning = ARRAY['_date'],\n" +
                         "   storage_schema = '" + schema + "'\n" +
                         ") AS\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -856,8 +856,7 @@ public abstract class BaseIcebergSystemTables
                     entry("location", icebergTable.location()),
                     entry("format-version", "2"),
                     entry("sort-order", "y ASC NULLS FIRST"),
-                    entry("write.format.default", format.name()),
-                    entry("commit.retry.num-retries", "4"));
+                    entry("write.format.default", format.name()));
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -47,7 +47,7 @@ public class TestIcebergConfig
         assertRecordedDefaults(recordDefaults(IcebergConfig.class)
                 .setFileFormat(PARQUET)
                 .setCompressionCodec(ZSTD)
-                .setMaxCommitRetry(4)
+                .setMaxCommitRetry(null)
                 .setUseFileSizeFromMetadata(true)
                 .setMaxPartitionsPerWriter(100)
                 .setUniqueTableLocation(true)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -132,8 +132,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
                                 "WITH (\n" +
                                 "   format = 'PARQUET',\n" +
                                 "   format_version = 2,\n" +
-                                "   location = '%2$s/%1$s.db/region-\\E.*\\Q',\n" +
-                                "   max_commit_retry = 4\n" +
+                                "   location = '%2$s/%1$s.db/region-\\E.*\\Q'\n" +
                                 ")\\E",
                         schemaName,
                         schemaPath()));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
@@ -178,8 +178,7 @@ final class TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest
                         "WITH \\(\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
-                        format("   location = '.*/" + schemaName + "/region.*',\n" +
-                        "   max_commit_retry = 4\n") +
+                        format("   location = '.*/" + schemaName + "/region.*'\n") +
                         "\\)");
     }
 

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
@@ -133,7 +133,6 @@ public abstract class BaseLakehouseConnectorSmokeTest
                    format = 'ORC',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/create_iceberg-.*'\\Q,
-                   max_commit_retry = 4,
                    type = 'ICEBERG'
                 )\\E""");
 

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
@@ -362,7 +362,6 @@ public class TestLakehouseConnectorTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/orders-.*'\\Q,
-                   max_commit_retry = 4,
                    type = 'ICEBERG'
                 )\\E""");
     }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFileConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFileConnectorSmokeTest.java
@@ -100,7 +100,6 @@ public class TestLakehouseFileConnectorSmokeTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = 's3://test-bucket/tpch/region-\\E.*\\Q',
-                   max_commit_retry = 4,
                    type = 'ICEBERG'
                 )\\E""");
     }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -41,7 +41,6 @@ public class TestLakehouseIcebergConnectorSmokeTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/region-.*'\\Q,
-                   max_commit_retry = 4,
                    type = 'ICEBERG'
                 )\\E""");
     }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseMotoConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseMotoConnectorSmokeTest.java
@@ -78,7 +78,6 @@ public class TestLakehouseMotoConnectorSmokeTest
                    format = 'PARQUET',
                    format_version = 2,
                    location = 's3://test-bucket/tpch/region-\\E.*\\Q',
-                   max_commit_retry = 4,
                    type = 'ICEBERG'
                 )\\E""");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -298,7 +298,6 @@ public class TestHiveRedirectionToIceberg
                         "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         format("   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/%s-\\E.*\\Q',\n", tableName) +
-                        "   max_commit_retry = 4,\n" +
                         "   partitioning = ARRAY['regionkey']\n" + // 'partitioning' comes from Iceberg
                         ")\\E");
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -54,7 +54,6 @@ public class TestIcebergPartitionEvolution
                                 "   format = 'PARQUET',\n" +
                                 "   format_version = 1,\n" +
                                 "   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/test_dropped_partition_field-\\E.*\\Q',\n" +
-                                "   max_commit_retry = 4,\n" +
                                 "   partitioning = ARRAY[" + (dropFirst ? "'void(a)','b'" : "'a','void(b)'") + "]\n" +
                                 ")\\E");
 


### PR DESCRIPTION
## Description

Setting the table property to Iceberg's default value is redundant. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
