### PR TITLE
Handle long running queries in DirectTrinoClient

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -758,6 +758,19 @@ public class TestingTrinoServer
             return this;
         }
 
+        public Builder overrideProperties(Map<String, String> properties)
+        {
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+            this.properties.forEach((k, v) -> {
+                if (!properties.containsKey(k)) {
+                    builder.put(k, v);
+                }
+            });
+            builder.putAll(properties);
+            this.properties = builder.buildOrThrow();
+            return this;
+        }
+
         public Builder setProperties(Map<String, String> properties)
         {
             this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));

--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.trino.Session;
 import io.trino.cost.StatsCalculator;
 import io.trino.execution.FailureInjector.InjectedFailureType;
+import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionBundle;
 import io.trino.metadata.MetadataUtil;
@@ -91,6 +92,7 @@ public final class StandaloneQueryRunner
         this.trinoClient = new TestingDirectTrinoClient(
                 server.getDispatchManager(),
                 server.getQueryManager(),
+                server.getInstance(Key.get(QueryManagerConfig.class)),
                 server.getInstance(Key.get(DirectExchangeClientSupplier.class)),
                 server.getInstance(Key.get(BlockEncodingSerde.class)));
     }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingDirectTrinoClient.java
@@ -20,6 +20,7 @@ import io.trino.dispatcher.DispatchManager;
 import io.trino.dispatcher.DispatchQuery;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryManager;
+import io.trino.execution.QueryManagerConfig;
 import io.trino.operator.DirectExchangeClientSupplier;
 import io.trino.server.ResultQueryInfo;
 import io.trino.server.SessionContext;
@@ -49,9 +50,9 @@ public class TestingDirectTrinoClient
 {
     private final DirectTrinoClient directTrinoClient;
 
-    public TestingDirectTrinoClient(DispatchManager dispatchManager, QueryManager queryManager, DirectExchangeClientSupplier directExchangeClientSupplier, BlockEncodingSerde blockEncodingSerde)
+    public TestingDirectTrinoClient(DispatchManager dispatchManager, QueryManager queryManager, QueryManagerConfig queryManagerConfig, DirectExchangeClientSupplier directExchangeClientSupplier, BlockEncodingSerde blockEncodingSerde)
     {
-        directTrinoClient = new DirectTrinoClient(dispatchManager, queryManager, directExchangeClientSupplier, blockEncodingSerde);
+        directTrinoClient = new DirectTrinoClient(dispatchManager, queryManager, queryManagerConfig, directExchangeClientSupplier, blockEncodingSerde);
     }
 
     public Result execute(Session session, @Language("SQL") String sql)

--- a/testing/trino-tests/src/test/java/io/trino/client/direct/TestDirectTrinoClient.java
+++ b/testing/trino-tests/src/test/java/io/trino/client/direct/TestDirectTrinoClient.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.direct;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.blackhole.BlackHolePlugin;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestDirectTrinoClient
+{
+    private QueryRunner queryRunner;
+
+    @BeforeAll
+    public void setup()
+            throws Exception
+    {
+        queryRunner = new StandaloneQueryRunner(
+                TEST_SESSION,
+                builder -> builder.overrideProperties(ImmutableMap.of(
+                        "query.client.timeout", "1s")));
+        queryRunner.installPlugin(new BlackHolePlugin());
+        queryRunner.createCatalog("blackhole", "blackhole");
+        queryRunner.execute("CREATE SCHEMA blackhole.test_schema");
+        queryRunner.execute("CREATE TABLE blackhole.test_schema.slow_test_table (col1 VARCHAR, col2 INTEGER)" +
+                "WITH (" +
+                "   split_count = 1, " +
+                "   pages_per_split = 1, " +
+                "   rows_per_page = 1, " +
+                "   page_processing_delay = '3s'" +
+                ")");
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    public void testDirectTrinoClientLongQuery()
+    {
+        queryRunner.execute(TEST_SESSION, "SELECT * FROM blackhole.test_schema.slow_test_table");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When a query being executed by DirectTrinoClient takes longer than the query.client.timeout, the query is then canceled. This client is used in some cases when executing queries from within the coordinator

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The `QueryTracker` uses this timeout in its `private boolean isAbandoned(T query)` method to check it vs the last heartbeat. @lukasz-stec recommended i periodically record a heartbeat while waiting for this future to avoid falling into that case.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
