### PR TITLE
Implement setTypeMap and getTypeMap in TrinoConnection

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -468,13 +468,18 @@ public class TrinoConnection
     public Map<String, Class<?>> getTypeMap()
             throws SQLException
     {
-        throw new SQLFeatureNotSupportedException("getTypeMap");
+        checkOpen();
+        return ImmutableMap.of();
     }
 
     @Override
     public void setTypeMap(Map<String, Class<?>> map)
             throws SQLException
     {
+        checkOpen();
+        if (map == null || map.isEmpty()) {
+            return;
+        }
         throw new SQLFeatureNotSupportedException("setTypeMap");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

We are trying to connect IBM WebSphere to Trino via the trino JDBC Driver.

WebSphere® Application Server requires JDBC providers to implement one or both data source interfaces. These interfaces enable the application to run in a single-phase or two-phase transaction protocol.

- ConnectionPoolDataSource -  For Connection Pooling (One-Phase)
     - A data source that supports application participation in local and global transactions, expecting two-phase commit transactions. 

- XADataSource -  For Distributed (Two-Phase) Transactions
     - A data source that supports application participation in any single-phase or two-phase transaction environment.

Currently, the Trino JDBC driver does not implement any of the above data sources. Alternatively, there is another way where we could use Apache Commons DBCP Library to connect IBM WebSphere to trino.

Apache Commons DBCP Library (https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2) provides a Java DataSource implementation that works as an abstraction layer between the application and different JDBC drivers. This library already implements ConnectionPoolDataSource, and we can use it to integrate IBM WebSphere with the Trino JDBC Driver. However, connecting IBM WebSphere to Trino via the Trino JDBC Driver throws the following exception.

```
Exception in thread "P=829982:O=0:CT" java.lang.RuntimeException: java.sql.SQLFeatureNotSupportedException: getTypeMap DSRA0010E: SQL State = null, Error Code = 0
	at org.example.Main.main(Main.java:67)
Caused by: java.sql.SQLFeatureNotSupportedException: getTypeMap DSRA0010E: SQL State = null, Error Code = 0
	at io.trino.jdbc.TrinoConnection.getTypeMap(TrinoConnection.java:392)
	at org.apache.commons.dbcp2.DelegatingConnection.getTypeMap(DelegatingConnection.java:505)
	at com.ibm.ws.rsadapter.spi.WSRdbManagedConnectionImpl.initializeConnectionProperties(WSRdbManagedConnectionImpl.java:1573)
	at com.ibm.ws.rsadapter.spi.WSRdbManagedConnectionImpl.<init>(WSRdbManagedConnectionImpl.java:928)
	at com.ibm.ws.rsadapter.spi.WSManagedConnectionFactoryImpl.createManagedConnection(WSManagedConnectionFactoryImpl.java:1600)
	at com.ibm.ws.rsadapter.spi.WSManagedConnectionFactoryImpl.createManagedConnection(WSManagedConnectionFactoryImpl.java:1137)
	at com.ibm.ws.rsadapter.spi.WSDefaultConnectionManagerImpl.allocateConnection(WSDefaultConnectionManagerImpl.java:83)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:646)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:613)
	at org.example.Main.main(Main.java:35)
```

To fix this issue, we can implement `getTypeMap` and `setTypeMap` in `TrinoConnection`.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Configurations:

Data Source Provider Config:

- Implementation class: org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS
- Class Path: /home/ubuntu/lib/commons-pool2-2.12.0.jar;/home/ubuntu/lib/commons-dbcp2-2.12.0.jar;/home/ubuntu/lib/trino-jdbc-466-SNAPSHOT.jar;

Libraries used:

- Trino JDBC Library (trino-jdbc-*.jar)
- Apache Common DBCP Library (commons-dbcp2-2.12.0.jar)
- commons-pool2-2.12.0.jar

Data source custom properties:

- url: jdbc:trino://localhost:7778?SSL=true&SSLVerification=NONE
- driver: io.trino.jdbc.TrinoDriver  
- user: test
- password: test


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Implement `setTypeMap` and `getTypeMap` in `TrinoConnection`. ({issue}`issuenumber`)
```
