### PR TITLE
Set default ldap client timeouts to 1m

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/JdkLdapClient.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/JdkLdapClient.java
@@ -16,7 +16,6 @@ package io.trino.plugin.base.ldap;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
-import io.airlift.units.Duration;
 import io.trino.plugin.base.ssl.SslUtils;
 import io.trino.spi.security.AccessDeniedException;
 
@@ -65,15 +64,9 @@ public class JdkLdapClient
                 .put(PROVIDER_URL, ldapUrl)
                 .put(REFERRAL, ldapConfig.isIgnoreReferrals() ? "ignore" : "follow");
 
-        ldapConfig.getLdapConnectionTimeout()
-                .map(Duration::toMillis)
-                .map(String::valueOf)
-                .ifPresent(timeout -> builder.put("com.sun.jndi.ldap.connect.timeout", timeout));
+        builder.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(ldapConfig.getLdapConnectionTimeout().toMillis()));
 
-        ldapConfig.getLdapReadTimeout()
-                .map(Duration::toMillis)
-                .map(String::valueOf)
-                .ifPresent(timeout -> builder.put("com.sun.jndi.ldap.read.timeout", timeout));
+        builder.put("com.sun.jndi.ldap.read.timeout", String.valueOf(ldapConfig.getLdapReadTimeout().toMillis()));
 
         this.basicEnvironment = builder.buildOrThrow();
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/LdapClientConfig.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ldap/LdapClientConfig.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.util.Optional;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static io.airlift.units.Duration.succinctDuration;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class LdapClientConfig
 {
@@ -37,8 +39,8 @@ public class LdapClientConfig
     private File trustStorePath;
     private String truststorePassword;
     private boolean ignoreReferrals;
-    private Optional<Duration> ldapConnectionTimeout = Optional.empty();
-    private Optional<Duration> ldapReadTimeout = Optional.empty();
+    private Duration ldapConnectionTimeout = succinctDuration(1, MINUTES);
+    private Duration ldapReadTimeout = succinctDuration(1, MINUTES);
 
     @NotNull
     @Pattern(regexp = "^ldaps?://.*", message = "Invalid LDAP server URL. Expected ldap:// or ldaps://")
@@ -142,7 +144,8 @@ public class LdapClientConfig
         return this;
     }
 
-    public Optional<Duration> getLdapConnectionTimeout()
+    @NotNull
+    public Duration getLdapConnectionTimeout()
     {
         return ldapConnectionTimeout;
     }
@@ -151,11 +154,12 @@ public class LdapClientConfig
     @ConfigDescription("Timeout for establishing a connection")
     public LdapClientConfig setLdapConnectionTimeout(Duration ldapConnectionTimeout)
     {
-        this.ldapConnectionTimeout = Optional.ofNullable(ldapConnectionTimeout);
+        this.ldapConnectionTimeout = ldapConnectionTimeout;
         return this;
     }
 
-    public Optional<Duration> getLdapReadTimeout()
+    @NotNull
+    public Duration getLdapReadTimeout()
     {
         return ldapReadTimeout;
     }
@@ -164,7 +168,7 @@ public class LdapClientConfig
     @ConfigDescription("Timeout for reading data from LDAP")
     public LdapClientConfig setLdapReadTimeout(Duration ldapReadTimeout)
     {
-        this.ldapReadTimeout = Optional.ofNullable(ldapReadTimeout);
+        this.ldapReadTimeout = ldapReadTimeout;
         return this;
     }
 }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/ldap/TestLdapConfig.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/ldap/TestLdapConfig.java
@@ -31,6 +31,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.testing.ValidationAssertions.assertValidates;
+import static io.airlift.units.Duration.succinctDuration;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestLdapConfig
 {
@@ -45,8 +47,8 @@ public class TestLdapConfig
                 .setTrustStorePath(null)
                 .setTruststorePassword(null)
                 .setIgnoreReferrals(false)
-                .setLdapConnectionTimeout(null)
-                .setLdapReadTimeout(null));
+                .setLdapConnectionTimeout(succinctDuration(1, MINUTES))
+                .setLdapReadTimeout(succinctDuration(1, MINUTES)));
     }
 
     @Test
@@ -104,5 +106,7 @@ public class TestLdapConfig
         assertFailsValidation(new LdapClientConfig().setLdapUrl("ldaps:/localhost"), "ldapUrl", "Invalid LDAP server URL. Expected ldap:// or ldaps://", Pattern.class);
 
         assertFailsValidation(new LdapClientConfig(), "ldapUrl", "must not be null", NotNull.class);
+        assertFailsValidation(new LdapClientConfig().setLdapConnectionTimeout(null), "ldapConnectionTimeout", "must not be null", NotNull.class);
+        assertFailsValidation(new LdapClientConfig().setLdapReadTimeout(null), "ldapReadTimeout", "must not be null", NotNull.class);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Missing timeouts can cause ldap client to be stuck executing request indefinitely in case of network issues.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
## Section
* Set default connection and read timeout for the LDAP client to 1 minute
```
