### PR TITLE
Document default value of LDAP timeout

### DIFF
--- a/docs/src/main/sphinx/security/ldap.md
+++ b/docs/src/main/sphinx/security/ldap.md
@@ -105,9 +105,9 @@ ldap.user-bind-pattern=<Refer below for usage>
 * - `ldap.cache-ttl`
   - LDAP cache duration. Defaults to `1h`.
 * - `ldap.timeout.connect`
-  - Timeout for establishing an LDAP connection.
+  - Timeout for establishing an LDAP connection. Defaults to `1m`.
 * - `ldap.timeout.read`
-  - Timeout for reading data from an LDAP connection.
+  - Timeout for reading data from an LDAP connection. Defaults to `1m`.
 :::
 
 Based on the LDAP server implementation type, the property


### PR DESCRIPTION
## Description

Follow-up of #26382

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
