### PR TITLE
Remove redundant backtick from CLI documentation

### DIFF
--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -468,7 +468,7 @@ history by scrolling or searching. Use the up and down arrows to scroll and
 press {kbd}`Enter`.
 
 By default, you can locate the Trino history file in `~/.trino_history`.
-Use the `--history-file` option or the `` `TRINO_HISTORY_FILE `` environment variable
+Use the `--history-file` option or the `TRINO_HISTORY_FILE` environment variable
 to change the default.
 
 ### Auto suggestion


### PR DESCRIPTION
## Description

Before:
<img width="2130" height="166" alt="Screenshot 2025-08-12 at 21 31 00" src="https://github.com/user-attachments/assets/05932e12-724d-47fb-898b-8f21b834e90d" />

After: 
<img width="2154" height="150" alt="Screenshot 2025-08-12 at 21 31 30" src="https://github.com/user-attachments/assets/d263093d-03e2-4ddb-a1c6-3facd82d725d" />

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
