### PR TITLE
Document `bigquery.arrow-serialization.max-allocation` property

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -212,6 +212,9 @@ a few caveats:
   - Enable using Apache Arrow serialization when reading data from BigQuery.
     Read this [section](bigquery-arrow-serialization-support) before using this feature.
   - `true`
+* - `bigquery.arrow-serialization.max-allocation`
+  - The maximum amount of memory the Apache Arrow buffer allocator is allowed to use.
+  - `100MB`
 * - `bigquery.max-parallelism`
   - The max number of partitions to split the data into. Reduce this number if
     the default parallelism (number of workers x 3) is too high.


### PR DESCRIPTION

-----

### Description

This pull request updates the documentation for the BigQuery connector to include the **`bigquery.arrow-serialization.max-allocation`** property. This property allows users to increase the maximum memory usage for the Apache Arrow buffer allocator, which can help prevent memory leaks and out-of-memory errors.

-----

### Additional context and related issues

The issue is linked to a bug in the BigQuery connector's Arrow serialization process. Despite ample memory resources on the worker nodes, the Arrow allocator would fail to reserve memory, leading to an `OutOfMemoryException`. Disabling Arrow serialization (`bigquery.arrow-serialization.enabled=false`) resolved the issue but sacrificed performance. This fix allows us to keep the performance benefits of Arrow serialization while preventing memory allocation failures.

Fixes #26400

-----

### Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
