### PR TITLE
Increase s3.max-error-retries to 20 in documentation

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -105,7 +105,7 @@ support:
     throttling.
 * - `s3.max-error-retries`
   - Specifies maximum number of retries the client will make on errors.
-    Defaults to `10`.
+    Defaults to `20`.
 * - `s3.use-web-identity-token-credentials-provider`
   - Set to `true` to only use the web identity token credentials provider,
     instead of the default providers chain. This can be useful when running


### PR DESCRIPTION
## Description

Follow-up of #26407

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
