### PR TITLE
Increase S3 delete batch size to 1000

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -69,6 +69,8 @@ import static java.util.stream.Collectors.toMap;
 final class S3FileSystem
         implements TrinoFileSystem
 {
+    static final int DELETE_BATCH_SIZE = 1000;
+
     private final Executor uploadExecutor;
     private final S3Client client;
     private final S3Presigner preSigner;
@@ -188,7 +190,7 @@ final class S3FileSystem
             String bucket = entry.getKey();
             Collection<String> allKeys = entry.getValue();
 
-            for (List<String> keys : partition(allKeys, 250)) {
+            for (List<String> keys : partition(allKeys, DELETE_BATCH_SIZE)) {
                 List<ObjectIdentifier> objects = keys.stream()
                         .map(key -> ObjectIdentifier.builder().key(key).build())
                         .toList();

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -1214,7 +1214,7 @@ public abstract class AbstractTestTrinoFileSystem
             throws IOException
     {
         try (Closer closer = Closer.create()) {
-            List<TempBlob> blobs = randomBlobs(closer);
+            List<TempBlob> blobs = randomBlobs(closer, 100);
 
             List<Location> sortedLocations = blobs.stream()
                         .map(TempBlob::location)
@@ -1538,11 +1538,11 @@ public abstract class AbstractTestTrinoFileSystem
         return tempBlob;
     }
 
-    private List<TempBlob> randomBlobs(Closer closer)
+    protected List<TempBlob> randomBlobs(Closer closer, int count)
     {
         char[] chars = new char[] {'a', 'b', 'c', 'd', 'A', 'B', 'C', 'D'};
         ImmutableList.Builder<TempBlob> names = ImmutableList.builder();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < count; i++) {
             StringBuilder name = new StringBuilder();
             for (int j = 0; j < 10; j++) {
                 name.append(chars[ThreadLocalRandom.current().nextInt(chars.length)]);


### PR DESCRIPTION
## Description
Matches batch size used in legacy FS io.trino.hdfs.s3.TrinoS3FileSystem#DELETE_BATCH_SIZE
1000 is the maximum batch size supported by S3 client 
Reduces potential of getting throttled by S3

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reduce query failures from deletes on S3 failing due to throttling errors. ({issue}`26432`)
```
