### PR TITLE
Improve BlockEncoding null bits packing

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -175,6 +175,7 @@ public final class ArrayBlock
         return offsets;
     }
 
+    @Nullable
     boolean[] getRawValueIsNull()
     {
         return valueIsNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
@@ -56,7 +56,7 @@ public class ArrayBlockEncoding
         for (int position = 0; position < positionCount + 1; position++) {
             sliceOutput.writeInt(offsets[offsetBase + position] - valuesStartOffset);
         }
-        encodeNullsAsBits(sliceOutput, arrayBlock);
+        encodeNullsAsBits(sliceOutput, arrayBlock.getRawValueIsNull(), offsetBase, positionCount);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
@@ -70,7 +70,10 @@ final class EncoderUtil
 
     /**
      * Append null values for the block as a stream of bits.
+     *
+     * @deprecated Use {@link EncoderUtil#encodeNullsAsBits(SliceOutput, boolean[], int, int)} instead
      */
+    @Deprecated(forRemoval = true)
     @SuppressWarnings({"NarrowingCompoundAssignment", "ImplicitNumericConversion"})
     public static void encodeNullsAsBits(SliceOutput sliceOutput, Block block)
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
@@ -29,6 +29,49 @@ final class EncoderUtil
      * Append null values for the block as a stream of bits.
      */
     @SuppressWarnings({"NarrowingCompoundAssignment", "ImplicitNumericConversion"})
+    public static void encodeNullsAsBits(SliceOutput sliceOutput, @Nullable boolean[] isNull, int offset, int length)
+    {
+        sliceOutput.writeBoolean(isNull != null);
+        if (isNull == null) {
+            return;
+        }
+        // inlined from Objects.checkFromIndexSize
+        if ((length | offset) < 0 || length > isNull.length - offset) {
+            throw new IndexOutOfBoundsException("Invalid offset: %s, length: %s for size: %s".formatted(offset, length, isNull.length));
+        }
+        byte[] packedIsNull = new byte[(length + 7) / 8];
+        int currentByte = 0;
+        for (int position = 0; position < (length & ~0b111); position += 8) {
+            byte value = 0;
+            value |= (isNull[position + offset] ? 1 : 0) << 7;
+            value |= (isNull[position + offset + 1] ? 1 : 0) << 6;
+            value |= (isNull[position + offset + 2] ? 1 : 0) << 5;
+            value |= (isNull[position + offset + 3] ? 1 : 0) << 4;
+            value |= (isNull[position + offset + 4] ? 1 : 0) << 3;
+            value |= (isNull[position + offset + 5] ? 1 : 0) << 2;
+            value |= (isNull[position + offset + 6] ? 1 : 0) << 1;
+            value |= (isNull[position + offset + 7] ? 1 : 0);
+            packedIsNull[currentByte++] = value;
+        }
+
+        // write last null bits
+        if ((length & 0b111) > 0) {
+            byte value = 0;
+            int mask = 0b1000_0000;
+            for (int position = length & ~0b111; position < length; position++) {
+                value |= isNull[position + offset] ? mask : 0;
+                mask >>>= 1;
+            }
+            packedIsNull[currentByte++] = value;
+        }
+
+        sliceOutput.writeBytes(packedIsNull, 0, currentByte);
+    }
+
+    /**
+     * Append null values for the block as a stream of bits.
+     */
+    @SuppressWarnings({"NarrowingCompoundAssignment", "ImplicitNumericConversion"})
     public static void encodeNullsAsBits(SliceOutput sliceOutput, Block block)
     {
         boolean mayHaveNull = block.mayHaveNull();

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockEncoding.java
@@ -15,9 +15,11 @@ package io.trino.spi.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
 
 import static io.trino.spi.block.EncoderUtil.decodeNullBits;
 import static io.trino.spi.block.EncoderUtil.encodeNullsAsBits;
+import static java.util.Objects.checkFromIndexSize;
 
 public class Fixed12BlockEncoding
         implements BlockEncoding
@@ -43,21 +45,26 @@ public class Fixed12BlockEncoding
         int positionCount = fixed12Block.getPositionCount();
         sliceOutput.appendInt(positionCount);
 
-        encodeNullsAsBits(sliceOutput, fixed12Block);
+        int rawArrayOffset = fixed12Block.getRawOffset();
+        @Nullable
+        boolean[] isNull = fixed12Block.getRawValueIsNull();
+        int[] rawValues = fixed12Block.getRawValues();
+        checkFromIndexSize(rawArrayOffset * 3, positionCount * 3, rawValues.length);
 
-        if (!fixed12Block.mayHaveNull()) {
-            sliceOutput.writeInts(fixed12Block.getRawValues(), fixed12Block.getRawOffset() * 3, fixed12Block.getPositionCount() * 3);
+        encodeNullsAsBits(sliceOutput, isNull, rawArrayOffset, positionCount);
+
+        if (isNull == null) {
+            sliceOutput.writeInts(rawValues, rawArrayOffset * 3, positionCount * 3);
         }
         else {
             int[] valuesWithoutNull = new int[positionCount * 3];
             int nonNullPositionCount = 0;
             for (int i = 0; i < positionCount; i++) {
-                valuesWithoutNull[nonNullPositionCount] = fixed12Block.getInt(i, 0);
-                valuesWithoutNull[nonNullPositionCount + 1] = fixed12Block.getInt(i, 4);
-                valuesWithoutNull[nonNullPositionCount + 2] = fixed12Block.getInt(i, 8);
-                if (!fixed12Block.isNull(i)) {
-                    nonNullPositionCount += 3;
-                }
+                int rawIntOffset = (i + rawArrayOffset) * 3;
+                valuesWithoutNull[nonNullPositionCount] = rawValues[rawIntOffset];
+                valuesWithoutNull[nonNullPositionCount + 1] = rawValues[rawIntOffset + 1];
+                valuesWithoutNull[nonNullPositionCount + 2] = rawValues[rawIntOffset + 2];
+                nonNullPositionCount += isNull[i + rawArrayOffset] ? 0 : 3;
             }
 
             sliceOutput.writeInt(nonNullPositionCount / 3);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -207,6 +207,12 @@ public final class MapBlock
         return valueBlock;
     }
 
+    @Nullable
+    boolean[] getRawMapIsNull()
+    {
+        return mapIsNull;
+    }
+
     MapHashTables getHashTables()
     {
         return hashTables;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
@@ -75,7 +75,7 @@ public class MapBlockEncoding
         for (int position = 0; position < positionCount + 1; position++) {
             sliceOutput.writeInt(offsets[offsetBase + position] - entriesStartOffset);
         }
-        EncoderUtil.encodeNullsAsBits(sliceOutput, block);
+        EncoderUtil.encodeNullsAsBits(sliceOutput, mapBlock.getRawMapIsNull(), offsetBase, positionCount);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -148,6 +148,7 @@ public final class RowBlock
         return false;
     }
 
+    @Nullable
     boolean[] getRawRowIsNull()
     {
         return rowIsNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
@@ -49,7 +49,7 @@ public class RowBlockEncoding
             blockEncodingSerde.writeBlock(sliceOutput, rawFieldBlock);
         }
 
-        EncoderUtil.encodeNullsAsBits(sliceOutput, block);
+        EncoderUtil.encodeNullsAsBits(sliceOutput, rowBlock.getRawRowIsNull(), 0, rowBlock.getPositionCount());
     }
 
     @Override


### PR DESCRIPTION
## Description
Improve block serialization logic to prefer using primitive arrays over virtual calls when checking positions for nulls.

Benchmarks: [BenchmarkBlockSerde.serialize*](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/ed61da9bd57b3bc742bf0a55920bf78b/raw/f8237b39edca6dbc77122909ab921d2d62c7f5b8/null_packing_baseline.json,https://gist.githubusercontent.com/pettyjamesm/ed61da9bd57b3bc742bf0a55920bf78b/raw/83526f49bd05cf957663443375b79aa0283fe4d3/null_packing_improved_v3.json)

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
