### PR TITLE
Overload to_geojson_geometry to support geometries

### DIFF
--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
@@ -179,6 +179,8 @@ public final class GeometryUtils
 
     public static String jsonFromJtsGeometry(org.locationtech.jts.geom.Geometry geometry)
     {
-        return new GeoJsonWriter().write(geometry);
+        GeoJsonWriter geoJsonWriter = new GeoJsonWriter();
+        geoJsonWriter.setEncodeCRS(false);
+        return geoJsonWriter.write(geometry);
     }
 }

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -1426,7 +1426,16 @@ public final class GeoFunctions
     @ScalarFunction("to_geojson_geometry")
     @Description("Returns GeoJSON string based on the input spherical geography")
     @SqlType(VARCHAR)
-    public static Slice toGeoJsonGeometry(@SqlType(StandardTypes.SPHERICAL_GEOGRAPHY) Slice input)
+    public static Slice toGeoJsonGeometryFromGeography(@SqlType(StandardTypes.SPHERICAL_GEOGRAPHY) Slice input)
+    {
+        return Slices.utf8Slice(jsonFromJtsGeometry(JtsGeometrySerde.deserialize(input)));
+    }
+
+    @SqlNullable
+    @ScalarFunction("to_geojson_geometry")
+    @Description("Returns GeoJSON string based on the input geometry")
+    @SqlType(VARCHAR)
+    public static Slice toGeoJsonGeometryFromGeometry(@SqlType(StandardTypes.GEOMETRY) Slice input)
     {
         return Slices.utf8Slice(jsonFromJtsGeometry(JtsGeometrySerde.deserialize(input)));
     }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -2239,7 +2239,7 @@ public class TestGeoFunctions
     }
 
     @Test
-    public void testGeometryJsonConversion()
+    public void testSphericalGeographyJsonConversion()
     {
         // empty geometries should return empty
         // empty geometries are represented by an empty JSON array in GeoJSON
@@ -2324,6 +2324,52 @@ public class TestGeoFunctions
     {
         assertTrinoExceptionThrownBy(assertions.function("from_geojson_geometry", "'%s'".formatted(json))::evaluate)
                 .hasMessage(message);
+    }
+
+    @Test
+    public void testGeometryJsonConversion()
+    {
+        // empty geometries should return empty
+        // empty geometries are represented by an empty JSON array in GeoJSON
+        assertGeometryToAndFromJson("POINT EMPTY");
+        assertGeometryToAndFromJson("LINESTRING EMPTY");
+        assertGeometryToAndFromJson("POLYGON EMPTY");
+        assertGeometryToAndFromJson("MULTIPOINT EMPTY");
+        assertGeometryToAndFromJson("MULTILINESTRING EMPTY");
+        assertGeometryToAndFromJson("MULTIPOLYGON EMPTY");
+        assertGeometryToAndFromJson("GEOMETRYCOLLECTION EMPTY");
+
+        // valid nonempty geometries should return as is.
+        assertGeometryToAndFromJson("POINT (1 2)");
+        assertGeometryToAndFromJson("MULTIPOINT ((1 2), (3 4))");
+        assertGeometryToAndFromJson("LINESTRING (0 0, 1 2, 3 4)");
+        assertGeometryToAndFromJson("MULTILINESTRING (" +
+                "(1 1, 5 1), " +
+                "(2 4, 4 4))");
+        assertGeometryToAndFromJson("POLYGON (" +
+                "(0 0, 1 0, 1 1, 0 1, 0 0))");
+        assertGeometryToAndFromJson("POLYGON (" +
+                "(0 0, 3 0, 3 3, 0 3, 0 0), " +
+                "(1 1, 1 2, 2 2, 2 1, 1 1))");
+        assertGeometryToAndFromJson("MULTIPOLYGON (" +
+                "((1 1, 3 1, 3 3, 1 3, 1 1)), " +
+                "((2 4, 6 4, 6 6, 2 6, 2 4)))");
+        assertGeometryToAndFromJson("GEOMETRYCOLLECTION (" +
+                "POINT (1 2), " +
+                "LINESTRING (0 0, 1 2, 3 4), " +
+                "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)))");
+
+        // invalid geometries should return as is.
+        assertGeometryToAndFromJson("MULTIPOINT ((0 0), (0 1), (1 1), (0 1))");
+        assertGeometryToAndFromJson("LINESTRING (0 0, 0 1, 0 1, 1 1, 1 0, 0 0)");
+        assertGeometryToAndFromJson("LINESTRING (0 0, 1 1, 1 0, 0 1)");
+    }
+
+    private void assertGeometryToAndFromJson(String wkt)
+    {
+        assertThat(assertions.function("ST_AsText", "to_geometry(from_geojson_geometry(to_geojson_geometry(ST_GeometryFromText('%s'))))".formatted(wkt)))
+                .hasType(VARCHAR)
+                .isEqualTo(wkt);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Allow converting geometries, and not only spherical geographies, to GeoJSON

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This PR also removes the crs attribute. The crs attribute is no longer allowed in GeoJSON: https://datatracker.ietf.org/doc/html/rfc7946#section-4. It is also pointless in trino since geometries are stripped of srid. It will always be 0 (unknown).
```
> select to_geojson_geometry(to_spherical_geography(st_geometryFromText('POINT (1 1)')));
> {"type":"Point","coordinates":[1,1],"crs":{"type":"name","properties":{"name":"EPSG:0"}}}
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Overload to_geojson_geometry to support generating GeoJSON from geometries
```
