### PR TITLE
Add support for INTERVAL types in Exasol connector

### DIFF
--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -103,6 +103,12 @@ Trino data type mapping:
 * - `HASHTYPE`
   - `VARBINARY`
   -
+* - `INTERVAL YEAR(y) TO MONTH`
+  - `BIGINT`
+  -
+* - `INTERVAL DAY(d) TO SECOND(s)`
+  - `BIGINT`
+  -
 :::
 
 No other types are supported.

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/type/interval/ExasolIntervalDayTimeParser.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/type/interval/ExasolIntervalDayTimeParser.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol.type.interval;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Long.parseLong;
+import static java.lang.Math.addExact;
+import static java.lang.Math.multiplyExact;
+import static java.lang.String.format;
+
+public final class ExasolIntervalDayTimeParser
+{
+    private static final long MILLIS_IN_SECOND = 1000;
+    private static final long MILLIS_IN_MINUTE = 60 * MILLIS_IN_SECOND;
+    private static final long MILLIS_IN_HOUR = 60 * MILLIS_IN_MINUTE;
+    private static final long MILLIS_IN_DAY = 24 * MILLIS_IN_HOUR;
+
+    private static final String LONG_MIN_VALUE = "-106751991167 07:12:55.808";
+
+    private static final Pattern FORMAT = Pattern.compile("(\\d+) (\\d+):(\\d+):(\\d+).(\\d+)");
+
+    private ExasolIntervalDayTimeParser() {}
+
+    public static String formatMillis(long millis)
+    {
+        if (millis == Long.MIN_VALUE) {
+            return LONG_MIN_VALUE;
+        }
+        String sign = "";
+        if (millis < 0) {
+            sign = "-";
+            millis = -millis;
+        }
+
+        long day = millis / MILLIS_IN_DAY;
+        millis %= MILLIS_IN_DAY;
+        long hour = millis / MILLIS_IN_HOUR;
+        millis %= MILLIS_IN_HOUR;
+        long minute = millis / MILLIS_IN_MINUTE;
+        millis %= MILLIS_IN_MINUTE;
+        long second = millis / MILLIS_IN_SECOND;
+        millis %= MILLIS_IN_SECOND;
+
+        return format("%s%d %02d:%02d:%02d.%03d", sign, day, hour, minute, second, millis);
+    }
+
+    public static long parse(String value)
+    {
+        return parseMillis(normalizeIntervalDayTimeString(value));
+    }
+
+    private static long parseMillis(String value)
+    {
+        if (value.equals(LONG_MIN_VALUE)) {
+            return Long.MIN_VALUE;
+        }
+
+        long signum = 1;
+        if (value.startsWith("-")) {
+            signum = -1;
+            value = value.substring(1);
+        }
+
+        Matcher matcher = FORMAT.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid day-time interval: " + value);
+        }
+
+        long days = parseLong(matcher.group(1));
+        long hours = parseLong(matcher.group(2));
+        long minutes = parseLong(matcher.group(3));
+        long seconds = parseLong(matcher.group(4));
+        long millis = parseLong(matcher.group(5));
+
+        return toMillis(days, hours, minutes, seconds, millis) * signum;
+    }
+
+    private static long toMillis(long day, long hour, long minute, long second, long millis)
+    {
+        try {
+            long value = millis;
+            value = addExact(value, multiplyExact(day, MILLIS_IN_DAY));
+            value = addExact(value, multiplyExact(hour, MILLIS_IN_HOUR));
+            value = addExact(value, multiplyExact(minute, MILLIS_IN_MINUTE));
+            value = addExact(value, multiplyExact(second, MILLIS_IN_SECOND));
+            return value;
+        }
+        catch (ArithmeticException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    // normalize the value to fit the expected format for parseMillis
+    private static String normalizeIntervalDayTimeString(String original)
+    {
+        String result = original.replaceFirst("^\\+", ""); // remove leading '+'
+
+        // Remove trailing zeros starting from 4th fractional digit
+        result = result.replaceAll("(\\.\\d{3}\\d*?)0+$", "$1");
+
+        // Ensure at least 3 fractional digits
+        if (result.contains(".")) {
+            int fractionLength = result.length() - result.indexOf('.') - 1;
+            if (fractionLength < 3) {
+                result = result + "0".repeat(3 - fractionLength);
+            }
+        }
+        else {
+            result += ".000";
+        }
+
+        return result;
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/type/interval/ExasolIntervalYearMonthParser.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/type/interval/ExasolIntervalYearMonthParser.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol.type.interval;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.Math.addExact;
+import static java.lang.Math.multiplyExact;
+import static java.lang.String.format;
+
+public final class ExasolIntervalYearMonthParser
+{
+    private static final String INT_MIN_VALUE = "-178956970-8";
+
+    private static final Pattern FORMAT = Pattern.compile("(\\d+)-(\\d+)");
+
+    private ExasolIntervalYearMonthParser() {}
+
+    public static String formatMonths(int months)
+    {
+        if (months == Integer.MIN_VALUE) {
+            return INT_MIN_VALUE;
+        }
+
+        String sign = "";
+        if (months < 0) {
+            sign = "-";
+            months = -months;
+        }
+
+        return format("%s%d-%d", sign, months / 12, months % 12);
+    }
+
+    public static int parse(String value)
+    {
+        return parseMonths(normalizeIntervalYearMonthString(value));
+    }
+
+    private static int parseMonths(String value)
+    {
+        if (value.equals(INT_MIN_VALUE)) {
+            return Integer.MIN_VALUE;
+        }
+
+        int signum = 1;
+        if (value.startsWith("-")) {
+            signum = -1;
+            value = value.substring(1);
+        }
+
+        Matcher matcher = FORMAT.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid year-month interval: " + value);
+        }
+
+        int years = parseInt(matcher.group(1));
+        int months = parseInt(matcher.group(2));
+
+        return toMonths(years, months) * signum;
+    }
+
+    private static int toMonths(int year, int months)
+    {
+        try {
+            return addExact(multiplyExact(year, 12), months);
+        }
+        catch (ArithmeticException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    // normalize the value to fit the expected format for parseMonths
+    private static String normalizeIntervalYearMonthString(String original)
+    {
+        return original.startsWith("+") ? original.substring(1) : original;
+    }
+}


### PR DESCRIPTION
## Description

Added Exasol Trino connector support for **INTERVAL YEAR TO MONTH** and **INTERVAL DAY TO SECOND** JDBC data types

## Additional context and related issues

- added correspondent tests for **interval year(y) to month** with precision data type
- added correspondent tests for **interval day(d) to second(s)** with precision data type


## Release notes

```markdown
## Exasol Connect
* Add support for `interval year to month` and `interval day to second` types. 
```
