### PR TITLE
Disable Vertica tests due to missing test container

### DIFF
--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestingVerticaServer.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestingVerticaServer.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.base.util.AutoCloseableCloser;
 import io.trino.testing.ResourcePresence;
 import io.trino.testing.sql.SqlExecutor;
+import org.junit.jupiter.api.Assumptions;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -65,6 +66,7 @@ public class TestingVerticaServer
     public TestingVerticaServer(String version, String database, String user, String password)
     {
         super(DockerImageName.parse("vertica/vertica-ce").withTag(version));
+        Assumptions.abort("Disabled until Vertica image is fixed");
         this.database = requireNonNull(database, "database is null");
         this.user = requireNonNull(user, "user is null");
         this.password = requireNonNull(password, "password is null");


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
