### PR TITLE
Attach authenticateIdentity groups to canImpersonate check

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -218,6 +218,7 @@ public class HttpRequestSessionContextFactory
                 // load enabled roles for authenticated identity, so impersonation permissions can be assigned to roles
                 authenticatedIdentity = Identity.from(authenticatedIdentity)
                         .withEnabledRoles(metadata.listEnabledRoles(authenticatedIdentity))
+                        .withGroups(groupProvider.getGroups(authenticatedIdentity.getUser()))
                         .build();
                 accessControl.checkCanImpersonateUser(authenticatedIdentity, originalIdentity.getUser());
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Pretty self-explanatory - for AccessControls that have Role -> Group assignments, not including groups on this impersonation check can fail unexpectedly.

This test feels a little naive, though i am not sure how else to test it. Hopefully someone can steer me in the right direction there.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
