### PR TITLE
Update release artifact download urls

### DIFF
--- a/docs/src/main/sphinx/ext/download.py
+++ b/docs/src/main/sphinx/ext/download.py
@@ -17,80 +17,78 @@ from docutils import nodes, utils
 # noinspection PyUnresolvedReferences
 from sphinx.errors import SphinxError
 
-GROUP_ID = 'io.trino'
 ARTIFACTS = {
-    'server': ('trino-server', 'tar.gz', None),
-    'server-core': ('trino-server-core', 'tar.gz', None),
-    'cli': ('trino-cli', 'jar', 'executable'),
-    'jdbc': ('trino-jdbc', 'jar', None),
+    'server': ('trino-server', 'tar.gz'),
+    'server-core': ('trino-server-core', 'tar.gz'),
+    'cli': ('trino-cli', None),
+    'jdbc': ('trino-jdbc', 'jar'),
     #plugins
-    'ai-functions':  ('trino-ai-functions', 'zip', None),
-    'bigquery':  ('trino-bigquery', 'zip', None),
-    'blackhole':  ('trino-blackhole', 'zip', None),
-    'cassandra':  ('trino-cassandra', 'zip', None),
-    'clickhouse':  ('trino-clickhouse', 'zip', None),
-    'delta-lake':  ('trino-delta-lake', 'zip', None),
-    'druid':  ('trino-druid', 'zip', None),
-    'duckdb':  ('trino-duckdb', 'zip', None),
-    'elasticsearch':  ('trino-elasticsearch', 'zip', None),
-    'example-http':  ('trino-example-http', 'zip', None),
-    'exasol':  ('trino-exasol', 'zip', None),
-    'exchange-filesystem':  ('trino-exchange-filesystem', 'zip', None),
-    'exchange-hdfs':  ('trino-exchange-hdfs', 'zip', None),
-    'faker':  ('trino-faker', 'zip', None),
-    'functions-python':  ('trino-functions-python', 'zip', None),
-    'geospatial':  ('trino-geospatial', 'zip', None),
-    'google-sheets':  ('trino-google-sheets', 'zip', None),
-    'hive':  ('trino-hive', 'zip', None),
-    'http-event-listener':  ('trino-http-event-listener', 'zip', None),
-    'http-server-event-listener':  ('trino-http-server-event-listener', 'zip', None),
-    'hudi':  ('trino-hudi', 'zip', None),
-    'iceberg':  ('trino-iceberg', 'zip', None),
-    'ignite':  ('trino-ignite', 'zip', None),
-    'jmx':  ('trino-jmx', 'zip', None),
-    'kafka':  ('trino-kafka', 'zip', None),
-    'kafka-event-listener':  ('trino-kafka-event-listener', 'zip', None),
-    'loki':  ('trino-loki', 'zip', None),
-    'mariadb':  ('trino-mariadb', 'zip', None),
-    'memory':  ('trino-memory', 'zip', None),
-    'ml':  ('trino-ml', 'zip', None),
-    'mongodb':  ('trino-mongodb', 'zip', None),
-    'mysql':  ('trino-mysql', 'zip', None),
-    'mysql-event-listener':  ('trino-mysql-event-listener', 'zip', None),
-    'opa':  ('trino-opa', 'zip', None),
-    'openlineage':  ('trino-openlineage', 'zip', None),
-    'opensearch':  ('trino-opensearch', 'zip', None),
-    'oracle':  ('trino-oracle', 'zip', None),
-    'password-authenticators':  ('trino-password-authenticators', 'zip', None),
-    'pinot':  ('trino-pinot', 'zip', None),
-    'postgresql':  ('trino-postgresql', 'zip', None),
-    'prometheus':  ('trino-prometheus', 'zip', None),
-    'ranger':  ('trino-ranger', 'zip', None),
-    'redis':  ('trino-redis', 'zip', None),
-    'redshift':  ('trino-redshift', 'zip', None),
-    'resource-group-managers':  ('trino-resource-group-managers', 'zip', None),
-    'session-property-managers':  ('trino-session-property-managers', 'zip', None),
-    'singlestore':  ('trino-singlestore', 'zip', None),
-    'snowflake':  ('trino-snowflake', 'zip', None),
-    'spooling-filesystem':  ('trino-spooling-filesystem', 'zip', None),
-    'sqlserver':  ('trino-sqlserver', 'zip', None),
-    'teradata-functions':  ('trino-teradata-functions', 'zip', None),
-    'thrift':  ('trino-thrift', 'zip', None),
-    'tpcds':  ('trino-tpcds', 'zip', None),
-    'tpch':  ('trino-tpch', 'zip', None),
-    'vertica':  ('trino-vertica', 'zip', None),
+    'ai-functions':  ('trino-ai-functions', 'zip'),
+    'bigquery':  ('trino-bigquery', 'zip'),
+    'blackhole':  ('trino-blackhole', 'zip'),
+    'cassandra':  ('trino-cassandra', 'zip'),
+    'clickhouse':  ('trino-clickhouse', 'zip'),
+    'delta-lake':  ('trino-delta-lake', 'zip'),
+    'druid':  ('trino-druid', 'zip'),
+    'duckdb':  ('trino-duckdb', 'zip'),
+    'elasticsearch':  ('trino-elasticsearch', 'zip'),
+    'example-http':  ('trino-example-http', 'zip'),
+    'exasol':  ('trino-exasol', 'zip'),
+    'exchange-filesystem':  ('trino-exchange-filesystem', 'zip'),
+    'exchange-hdfs':  ('trino-exchange-hdfs', 'zip'),
+    'faker':  ('trino-faker', 'zip'),
+    'functions-python':  ('trino-functions-python', 'zip'),
+    'geospatial':  ('trino-geospatial', 'zip'),
+    'google-sheets':  ('trino-google-sheets', 'zip'),
+    'hive':  ('trino-hive', 'zip'),
+    'http-event-listener':  ('trino-http-event-listener', 'zip'),
+    'http-server-event-listener':  ('trino-http-server-event-listener', 'zip'),
+    'hudi':  ('trino-hudi', 'zip'),
+    'iceberg':  ('trino-iceberg', 'zip'),
+    'ignite':  ('trino-ignite', 'zip'),
+    'jmx':  ('trino-jmx', 'zip'),
+    'kafka':  ('trino-kafka', 'zip'),
+    'kafka-event-listener':  ('trino-kafka-event-listener', 'zip'),
+    'loki':  ('trino-loki', 'zip'),
+    'mariadb':  ('trino-mariadb', 'zip'),
+    'memory':  ('trino-memory', 'zip'),
+    'ml':  ('trino-ml', 'zip'),
+    'mongodb':  ('trino-mongodb', 'zip'),
+    'mysql':  ('trino-mysql', 'zip'),
+    'mysql-event-listener':  ('trino-mysql-event-listener', 'zip'),
+    'opa':  ('trino-opa', 'zip'),
+    'openlineage':  ('trino-openlineage', 'zip'),
+    'opensearch':  ('trino-opensearch', 'zip'),
+    'oracle':  ('trino-oracle', 'zip'),
+    'password-authenticators':  ('trino-password-authenticators', 'zip'),
+    'pinot':  ('trino-pinot', 'zip'),
+    'postgresql':  ('trino-postgresql', 'zip'),
+    'prometheus':  ('trino-prometheus', 'zip'),
+    'ranger':  ('trino-ranger', 'zip'),
+    'redis':  ('trino-redis', 'zip'),
+    'redshift':  ('trino-redshift', 'zip'),
+    'resource-group-managers':  ('trino-resource-group-managers', 'zip'),
+    'session-property-managers':  ('trino-session-property-managers', 'zip'),
+    'singlestore':  ('trino-singlestore', 'zip'),
+    'snowflake':  ('trino-snowflake', 'zip'),
+    'spooling-filesystem':  ('trino-spooling-filesystem', 'zip'),
+    'sqlserver':  ('trino-sqlserver', 'zip'),
+    'teradata-functions':  ('trino-teradata-functions', 'zip'),
+    'thrift':  ('trino-thrift', 'zip'),
+    'tpcds':  ('trino-tpcds', 'zip'),
+    'tpch':  ('trino-tpch', 'zip'),
+    'vertica':  ('trino-vertica', 'zip'),
 }
 
-def maven_filename(artifact, version, packaging, classifier):
-    classifier = '-' + classifier if classifier else ''
-    return '%s-%s%s.%s' % (artifact, version, classifier, packaging)
+def filename(artifact, version, extension):
+    extension = '.' + extension if extension else ''
+    return artifact + '-' + version + extension
 
 
-def maven_download(group, artifact, version, packaging, classifier):
-    base = 'https://repo1.maven.org/maven2/'
-    group_path = group.replace('.', '/')
-    filename = maven_filename(artifact, version, packaging, classifier)
-    return base + '/'.join((group_path, artifact, version, filename))
+def download_url(artifact, version, extension):
+    base = 'https://github.com/trinodb/trino/releases/download'
+    file = filename(artifact, version, extension)
+    return '%s/%s/%s' % (base, version, file)
 
 
 def setup(app):
@@ -102,10 +100,10 @@ def setup(app):
             inliner.reporter.error('Unsupported download type: ' + text, line=lineno)
             return [], []
 
-        artifact, packaging, classifier = ARTIFACTS[text]
+        artifact, extension = ARTIFACTS[text]
 
-        title = maven_filename(artifact, version, packaging, classifier)
-        uri = maven_download(GROUP_ID, artifact, version, packaging, classifier)
+        title = filename(artifact, version, extension)
+        uri = download_url(artifact, version, extension)
 
         node = nodes.reference(title, title, internal=False, refuri=uri)
 


### PR DESCRIPTION
Going forward, binary artifacts will be available under GitHub releases
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
