### PR TITLE
Return user visible error when catalog is misconfigured

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/TracingDataSource.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/TracingDataSource.java
@@ -15,6 +15,7 @@ package io.trino.plugin.jdbc;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry;
+import io.trino.spi.TrinoException;
 
 import javax.sql.DataSource;
 
@@ -26,6 +27,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static java.util.Objects.requireNonNull;
 
 public class TracingDataSource
@@ -67,7 +69,9 @@ public class TracingDataSource
                 throws SQLException
         {
             Connection connection = driver.connect(connectionUrl, properties);
-            checkState(connection != null, "Driver returned null connection, make sure the connection URL '%s' is valid for the driver %s", connectionUrl, driver);
+            if (connection == null) {
+                throw new TrinoException(JDBC_ERROR, "Driver returned null connection, make sure the connection URL '%s' and credentials are valid".formatted(connectionUrl));
+            }
             return connection;
         }
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -44,9 +44,9 @@ public final class PostgreSqlQueryRunner
     {
         return new Builder()
                 .addConnectorProperties(Map.of(
-                        "connection-url", server.getJdbcUrl(),
+                        "connection-url", "jdbc:"+ server.getJdbcUrl(),
                         "connection-user", server.getUser(),
-                        "connection-password", server.getPassword(),
+                        "connection-password", "x" + server.getPassword(),
                         "postgresql.include-system-tables", "true"));
     }
 
@@ -102,7 +102,7 @@ public final class PostgreSqlQueryRunner
                 runner.installPlugin(new PostgreSqlPlugin());
                 runner.createCatalog("postgresql", "postgresql", connectorProperties);
 
-                copyTpchTables(runner, "tpch", TINY_SCHEMA_NAME, initialTables);
+//                copyTpchTables(runner, "tpch", TINY_SCHEMA_NAME, initialTables);
             });
             return super.build();
         }
@@ -113,7 +113,7 @@ public final class PostgreSqlQueryRunner
     {
         QueryRunner queryRunner = builder(new TestingPostgreSqlServer(System.getProperty("testing.postgresql-image-name", DEFAULT_IMAGE_NAME), true))
                 .addCoordinatorProperty("http-server.http.port", "8080")
-                .setInitialTables(TpchTable.getTables())
+//                .setInitialTables(TpchTable.getTables())
                 .build();
 
         queryRunner.installPlugin(new JmxPlugin());


### PR DESCRIPTION
When Driver::connect returns null, most likely it catalog is
misconfigured and error message from the checkState was propagated to
the user making looking obscure.

Before:
Query 20250825_145634_00011_9263i failed: Error listing schemas for
catalog postgresql2:
com.google.common.util.concurrent.UncheckedExecutionException:
java.lang.IllegalStateException: Driver returned null connection, make
sure the connection URL 'jdbc:psql://test' is valid for the driver
org.postgresql.Driver@63a777ba

After:
Query 20250825_150832_00003_52kd7 failed: Error listing schemas for
catalog postgresql: Driver returned null connection, make sure the
connection URL 'jdbc:jdbc:postgresql://localhost:5432/tpch' and
credentials are valid

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
