### PR TITLE
fixed typo in documentation for kafka-event-listener example "kafka.config.resources"

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-kafka.md
+++ b/docs/src/main/sphinx/admin/event-listeners-kafka.md
@@ -61,7 +61,7 @@ kafka-event-listener.broker-endpoints=kafka.example.com:9093
 kafka-event-listener.created-event.topic=query_create
 kafka-event-listener.completed-event.topic=query_complete
 kafka-event-listener.client-id=trino-example
-kafka.config.resources=/etc/kafka-configuration.properties
+kafka-event-listener.config.resources=/etc/kafka-configuration.properties
 ```
 
 The contents of `/etc/kafka-configuration.properties` can for example be:


### PR DESCRIPTION

## Description
There is a little typo in the kafka-event-listener configuration example which leads to errors when copy-pasting the config into trino deployments leading to trino failing with following exception

```
Configuration property 'kafka.config.resources' was not used
```

Got my trino up and running and producing to kafka after setting it to the property key listed in the documentation below

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
