### PR TITLE
 metadata.catalogs should only list loaded catalogs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogConnector.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogConnector.java
@@ -55,7 +55,8 @@ public class CatalogConnector
                 connectorName,
                 catalogConnector,
                 informationSchemaConnector,
-                systemConnector);
+                systemConnector,
+                true);
     }
 
     public CatalogHandle getCatalogHandle()

--- a/core/trino-main/src/main/java/io/trino/connector/system/CatalogSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/CatalogSystemTable.java
@@ -29,6 +29,9 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.metadata.MetadataListing.listCatalogs;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.connector.SystemTable.Distribution.SINGLE_COORDINATOR;
@@ -72,7 +75,10 @@ public class CatalogSystemTable
     {
         Session session = ((FullConnectorSession) connectorSession).getSession();
         Builder table = InMemoryRecordSet.builder(CATALOG_TABLE);
-        for (CatalogInfo catalogInfo : listCatalogs(session, metadata, accessControl)) {
+        List<CatalogInfo> catalogInfos = listCatalogs(session, metadata, accessControl).stream()
+                .filter(CatalogInfo::loaded)
+                .collect(toImmutableList());
+        for (CatalogInfo catalogInfo : catalogInfos) {
             table.addRow(
                     catalogInfo.catalogName(),
                     catalogInfo.catalogName(),

--- a/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
@@ -38,6 +38,7 @@ public class Catalog
     private final ConnectorServices catalogConnector;
     private final ConnectorServices informationSchemaConnector;
     private final ConnectorServices systemConnector;
+    private final boolean loaded;
 
     public Catalog(
             CatalogName catalogName,
@@ -45,7 +46,8 @@ public class Catalog
             ConnectorName connectorName,
             ConnectorServices catalogConnector,
             ConnectorServices informationSchemaConnector,
-            ConnectorServices systemConnector)
+            ConnectorServices systemConnector,
+            boolean loaded)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
@@ -54,14 +56,15 @@ public class Catalog
         this.catalogConnector = requireNonNull(catalogConnector, "catalogConnector is null");
         this.informationSchemaConnector = requireNonNull(informationSchemaConnector, "informationSchemaConnector is null");
         this.systemConnector = requireNonNull(systemConnector, "systemConnector is null");
+        this.loaded = loaded;
     }
 
     public static Catalog failedCatalog(CatalogName catalogName, CatalogHandle catalogHandle, ConnectorName connectorName)
     {
-        return new Catalog(catalogName, catalogHandle, connectorName);
+        return new Catalog(catalogName, catalogHandle, connectorName, false);
     }
 
-    private Catalog(CatalogName catalogName, CatalogHandle catalogHandle, ConnectorName connectorName)
+    private Catalog(CatalogName catalogName, CatalogHandle catalogHandle, ConnectorName connectorName, boolean loaded)
     {
         this.catalogName = catalogName;
         this.catalogHandle = catalogHandle;
@@ -69,6 +72,7 @@ public class Catalog
         this.catalogConnector = null;
         this.informationSchemaConnector = null;
         this.systemConnector = null;
+        this.loaded = loaded;
     }
 
     public CatalogName getCatalogName()
@@ -84,6 +88,11 @@ public class Catalog
     public ConnectorName getConnectorName()
     {
         return connectorName;
+    }
+
+    public boolean isLoaded()
+    {
+        return loaded;
     }
 
     public boolean isFailed()

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogInfo.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogInfo.java
@@ -18,7 +18,7 @@ import io.trino.spi.connector.ConnectorName;
 
 import static java.util.Objects.requireNonNull;
 
-public record CatalogInfo(String catalogName, CatalogHandle catalogHandle, ConnectorName connectorName)
+public record CatalogInfo(String catalogName, CatalogHandle catalogHandle, ConnectorName connectorName, boolean loaded)
 {
     public CatalogInfo
     {

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -467,7 +467,7 @@ public interface Metadata
     Optional<CatalogHandle> getCatalogHandle(Session session, String catalogName);
 
     /**
-     * Gets all the loaded catalogs
+     * Lists all defined catalogs (both loaded properly and failed ones).
      */
     List<CatalogInfo> listCatalogs(Session session);
 

--- a/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
@@ -423,7 +423,7 @@ public class InMemoryTransactionManager
                     .distinct()
                     .map(key -> registeredCatalogs.getOrDefault(key, Optional.empty()))
                     .flatMap(Optional::stream)
-                    .map(catalog -> new CatalogInfo(catalog.getCatalogName().toString(), catalog.getCatalogHandle(), catalog.getConnectorName()))
+                    .map(catalog -> new CatalogInfo(catalog.getCatalogName().toString(), catalog.getCatalogHandle(), catalog.getConnectorName(), catalog.isLoaded()))
                     .collect(toImmutableList());
         }
 
@@ -436,7 +436,7 @@ public class InMemoryTransactionManager
             return registeredCatalogs.values().stream()
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .map(catalog -> new CatalogInfo(catalog.getCatalogName().toString(), catalog.getCatalogHandle(), catalog.getConnectorName()))
+                    .map(catalog -> new CatalogInfo(catalog.getCatalogName().toString(), catalog.getCatalogHandle(), catalog.getConnectorName(), catalog.isLoaded()))
                     .collect(toImmutableList());
         }
 

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/TestSystemMetadataCatalogTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/TestSystemMetadataCatalogTable.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector.system;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Key;
+import io.trino.Session;
+import io.trino.connector.ConnectorServicesProvider;
+import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.catalog.CatalogProperties;
+import io.trino.spi.catalog.CatalogStore;
+import io.trino.spi.connector.ConnectorName;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Execution(SAME_THREAD)
+public class TestSystemMetadataCatalogTable
+        extends AbstractTestQueryFramework
+{
+    private CatalogStore catalogStore;
+    private ConnectorServicesProvider catalogManager;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().build();
+        QueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setWorkerCount(0)
+                .build();
+        queryRunner.installPlugin(new MemoryPlugin());
+        queryRunner.createCatalog("healthy_catalog", "memory", ImmutableMap.of("memory.max-data-per-node", "128MB"));
+        catalogStore = queryRunner.getCoordinator().getInstance(new Key<>() {});
+        catalogManager = queryRunner.getCoordinator().getInstance(new Key<>() {});
+        return queryRunner;
+    }
+
+    @Test
+    public void testCatalogTableShowsOnlyLoadedCatalogs()
+    {
+        assertQuery("SELECT * FROM system.metadata.catalogs", "VALUES" +
+                "('healthy_catalog', 'healthy_catalog', 'memory'), " +
+                "('system', 'system', 'system')");
+
+        assertUpdate("CREATE CATALOG brain USING memory WITH (\"memory.max-data-per-node\" = '128MB')");
+        assertQuery("SELECT * FROM system.metadata.catalogs", "VALUES" +
+                "('healthy_catalog', 'healthy_catalog', 'memory'), " +
+                "('brain', 'brain', 'memory'), " +
+                "('system', 'system', 'system')");
+        CatalogProperties catalogProperties = catalogStore.createCatalogProperties(new CatalogName("broken"), new ConnectorName("memory"), ImmutableMap.of("memory.max-data-per-n", "128MB"));
+        catalogStore.addOrReplaceCatalog(catalogProperties);
+        catalogManager.loadInitialCatalogs();
+
+        assertQuery("SELECT * FROM system.metadata.catalogs", "VALUES" +
+                "('healthy_catalog', 'healthy_catalog', 'memory'), " +
+                "('brain', 'brain', 'memory'), " +
+                "('system', 'system', 'system')");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
metadata.catalogs should only list loaded catalogs


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Make `metadata.catalogs` not return unloaded catalogs. ({issue}`26493`)
```
