### PR TITLE
Don't encode crs in GeoJSON

### DIFF
--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
@@ -179,6 +179,8 @@ public final class GeometryUtils
 
     public static String jsonFromJtsGeometry(org.locationtech.jts.geom.Geometry geometry)
     {
-        return new GeoJsonWriter().write(geometry);
+        GeoJsonWriter geoJsonWriter = new GeoJsonWriter();
+        geoJsonWriter.setEncodeCRS(false);
+        return geoJsonWriter.write(geometry);
     }
 }

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestGeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestGeometryUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+import static io.trino.geospatial.GeometryUtils.jsonFromJtsGeometry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestGeometryUtils
+{
+    @Test
+    void testJsonFromJtsGeometry()
+            throws ParseException
+    {
+        String json = jsonFromJtsGeometry(new WKTReader().read("POINT (1 1)"));
+        assertThat(json)
+                .isNotNull()
+                .doesNotContain("crs");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Don't encode crs in GeoJSON. The crs attribute is no longer allowed in GeoJSON: https://datatracker.ietf.org/doc/html/rfc7946#section-4. It is also pointless in trino since geometries are stripped of srid. It will always be 0 (unknown).

```
> select to_geojson_geometry(to_spherical_geography(st_geometryFromText('POINT (1 1)')));
> {"type":"Point","coordinates":[1,1],"crs":{"type":"name","properties":{"name":"EPSG:0"}}}
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Split from #26451


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

I don't think a release note is required. Compliant GeoJSON consumers should ignore the crs attribute. For completeness a note could be added.

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text: 

```markdown
# General
* Don't encode crs in GeoJSON. ({issue}`26499`)
```
