### PR TITLE
Fix domain-wide delegation for Google Sheets connector

### DIFF
--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -295,7 +295,7 @@ public class SheetsClient
             throws IOException
     {
         GoogleCredential credential = GoogleCredential.fromStream(inputStream).createScoped(SCOPES);
-        delegatedUserEmail.ifPresent(credential::createDelegated);
+        credential = delegatedUserEmail.map(credential::createDelegated).orElse(credential);
         return credential;
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
I wasn't able to make the domain-wide delegation works, and I think it's because the `credentials` is not reassigned, and the `createDelegated` returns a new instance. See [this](https://github.com/googleapis/google-api-java-client/blob/665acbe3f733fd5e0be33331d405f325e505836c/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java#L493)


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
