### PR TITLE
Add Top-N pushdown support for the MongoDB connector

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mongodb.DBRef;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -530,15 +531,57 @@ public class MongoSession
 
         MongoCollection<Document> collection = getCollection(tableHandle.remoteTableName());
         Document filter = buildFilter(tableHandle);
-        FindIterable<Document> iterable = collection.find(filter).projection(projection).collation(SIMPLE_COLLATION);
-        tableHandle.limit().ifPresent(iterable::limit);
+
         log.debug("Find documents: collection: %s, filter: %s, projection: %s", tableHandle.schemaTableName(), filter, projection);
 
-        if (cursorBatchSize != 0) {
-            iterable.batchSize(cursorBatchSize);
-        }
+        boolean useFind = tableHandle.sort().isEmpty() ||
+                (tableHandle.sort().get().size() == 1 && tableHandle.sort().get().getFirst().sortNullFields().isEmpty());
 
-        return iterable.iterator();
+        if (useFind) {
+            FindIterable<Document> iterable = collection.find(filter).projection(projection).collation(SIMPLE_COLLATION);
+            tableHandle.sort().ifPresent(sortList -> {
+                iterable.sort(sortList.getFirst().sort());
+                iterable.limit(toIntExact(sortList.getFirst().limit()));
+            });
+            tableHandle.limit().ifPresent(iterable::limit);
+
+            if (cursorBatchSize != 0) {
+                iterable.batchSize(cursorBatchSize);
+            }
+
+            return iterable.iterator();
+        }
+        else {
+            // MongoDB considers null values to be less than any other value.
+            // We can handle sort items with SortOrder.ASC_NULLS_LAST or SortOrder.DESC_NULLS_FIRST
+            // with an aggregation pipeline.
+            List<MongoTableSort> tableSortList = tableHandle.sort().get();
+            for (MongoTableSort tableSort : tableSortList) {
+                for (String sortField : tableSort.sort().keySet()) {
+                    // Sorting on the field does not work unless we add it to the projection
+                    if (!projection.containsKey(sortField)) {
+                        projection.append(sortField, MongoMetadata.MONGO_SORT_ASC);
+                    }
+                }
+            }
+
+            ImmutableList.Builder<Document> aggregatePipeline = ImmutableList.builder();
+            aggregatePipeline.add(new Document("$match", filter));
+            for (MongoTableSort tableSort : tableSortList) {
+                tableSort.sortNullFields().ifPresent(sortNullFields -> aggregatePipeline.add(new Document("$addFields", sortNullFields)));
+                aggregatePipeline.add(new Document("$sort", tableSort.sort()));
+                aggregatePipeline.add(new Document("$limit", tableSort.limit()));
+            }
+            tableHandle.limit().ifPresent(limit -> aggregatePipeline.add(new Document("$limit", limit)));
+            aggregatePipeline.add(new Document("$project", projection));
+            AggregateIterable<Document> aggregateIterable = collection.aggregate(aggregatePipeline.build()).collation(SIMPLE_COLLATION);
+
+            if (cursorBatchSize != 0) {
+                aggregateIterable.batchSize(cursorBatchSize);
+            }
+
+            return aggregateIterable.iterator();
+        }
     }
 
     @VisibleForTesting

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -32,12 +33,13 @@ public record MongoTableHandle(
         Optional<String> filter,
         TupleDomain<ColumnHandle> constraint,
         Set<MongoColumnHandle> projectedColumns,
+        Optional<List<MongoTableSort>> sort,
         OptionalInt limit)
         implements ConnectorTableHandle
 {
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
     {
-        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty());
+        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), Optional.empty(), OptionalInt.empty());
     }
 
     public MongoTableHandle
@@ -47,6 +49,7 @@ public record MongoTableHandle(
         requireNonNull(filter, "filter is null");
         requireNonNull(constraint, "constraint is null");
         projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
+        requireNonNull(sort, "sort is null");
         requireNonNull(limit, "limit is null");
     }
 
@@ -68,6 +71,7 @@ public record MongoTableHandle(
         if (!projectedColumns.isEmpty()) {
             builder.append(" columns=").append(projectedColumns);
         }
+        sort.ifPresent(value -> builder.append(" TopNPartial").append(value));
         limit.ifPresent(value -> builder.append(" limit=").append(value));
         return builder.toString();
     }
@@ -80,6 +84,7 @@ public record MongoTableHandle(
                 filter,
                 constraint,
                 projectedColumns,
+                sort,
                 limit);
     }
 
@@ -91,6 +96,7 @@ public record MongoTableHandle(
                 filter,
                 constraint,
                 projectedColumns,
+                sort,
                 limit);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableSort.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableSort.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import org.bson.Document;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record MongoTableSort(Document sort, Optional<Document> sortNullFields, int limit)
+{
+    public MongoTableSort
+    {
+        requireNonNull(sort, "sort is null");
+        requireNonNull(sortNullFields, "sortNullFields is null");
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("count = ").append(limit);
+        List<String> sortEntries = sort.entrySet().stream()
+                .map(entry -> entry.getKey() + " " + ("1".equals(entry.getValue()) ? "ASC" : "DESC"))
+                .toList();
+        builder.append(", orderBy = ").append(sortEntries);
+        if (sortNullFields.isPresent()) {
+            List<String> nullFields = ImmutableList.copyOf(sortNullFields.get().keySet());
+            builder.append(", nullFields=").append(nullFields);
+        }
+        return builder.toString();
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -112,7 +112,6 @@ public class TestMongoConnectorTest
                  SUPPORTS_RENAME_FIELD,
                  SUPPORTS_RENAME_SCHEMA,
                  SUPPORTS_SET_FIELD_TYPE,
-                 SUPPORTS_TOPN_PUSHDOWN,
                  SUPPORTS_TRUNCATE,
                  SUPPORTS_UPDATE -> false;
             default -> super.hasBehavior(connectorBehavior);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -125,6 +125,7 @@ public class TestMongoTableHandle
                 Optional.empty(),
                 TupleDomain.all(),
                 projectedColumns,
+                Optional.empty(),
                 OptionalInt.empty());
 
         String json = codec.toJson(expected);


### PR DESCRIPTION
## Description

Add Top-N (ORDER BY + LIMIT) pushdown support for the MongoDB connector.

## Additional context and related issues

MongoDB considers null values to be less than any other value. We can handle sort items with SortOrder.ASC_NULLS_LAST or SortOrder.DESC_NULLS_FIRST with a MongoDB aggregation pipeline, where we add computed fields to sort correctly.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Implement feature. ({issue}`26366`)
```
