### PR TITLE
Update trino-wasm-python to 3.13-4

### DIFF
--- a/plugin/trino-functions-python/pom.xml
+++ b/plugin/trino-functions-python/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-wasm-python</artifactId>
-            <version>3.13-3</version>
+            <version>3.13-4</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-functions-python/src/test/java/io/trino/plugin/functions/python/TestPythonFunctions.java
+++ b/plugin/trino-functions-python/src/test/java/io/trino/plugin/functions/python/TestPythonFunctions.java
@@ -108,6 +108,25 @@ public class TestPythonFunctions
     }
 
     @Test
+    public void testImportingAndRunningBleach()
+    {
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION sanitize_html(html_input VARCHAR)
+                    RETURNS VARCHAR
+                    LANGUAGE PYTHON
+                    WITH (handler = 'sanitize_html')
+                    AS $$
+                    import bleach
+                    def sanitize_html(html_input):
+                        return bleach.clean(html_input, tags={'b'}, attributes={}, strip=True)
+                    $$
+                SELECT sanitize_html('<b><i>an example</i></b>')
+                """))
+                .matches("VALUES varchar '<b>an example</b>'");
+    }
+
+    @Test
     public void testInvalidHandler()
     {
         assertThat(assertions.query(


### PR DESCRIPTION
Migrate to new Chicory APIs for AOT generated Python machine

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Python UDF
* Fix running more complex Python-based UDFs ({issue}`issuenumber`)
```
