### PR TITLE
Improve readability of ReadRowsHelper debug log

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadRowsHelper.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadRowsHelper.java
@@ -85,7 +85,7 @@ public class ReadRowsHelper
             do {
                 try {
                     ReadRowsResponse response = serverResponses.next();
-                    log.debug("ReadRowsResponse from BigQuery: %s", response);
+                    log.debug("ReadRowsResponse from BigQuery stream: %s at offset: %s", helper.streamName, nextOffset);
                     nextOffset += response.getRowCount();
                     return response;
                 }


### PR DESCRIPTION
## Description

The existing log statement in `ReadRowsHelper` logs the full `ReadRowsResponse` object, which can contain large and unreadable serialized Arrow batches. This clutters the logs and makes debugging difficult.

Example:
```
2025-03-25T15:37:20.578+0900	DEBUG	bigquery-bigquery-5	io.trino.plugin.bigquery.ReadRowsHelper	ReadRowsResponse from BigQuery: stats {
  progress {
    at_response_end: 0.001469222130253911
  }
}
arrow_record_batch {
  serialized_record_batch: "\377\377\377\377\360\a\000\000\024\000\000\000\000\000\000\000\f\000\030\000\006\000\005\000\b\000\f\000\f\000\000\000\000\003\004\000\034\000\000\0000)\001\000\000\000\000\000\000\000\000\000\f\000\036\000\020\000\004\000\b\000\f\000\f\000\000\000\320\005\000\000$\000\000\000\030\000\000\000\300\003\000\000\000\000\000\000\000\000\000\000\000\000\006\000\b\000\a\000\006\000\000\000\000\000\000\001Z\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\310\t\000\000\000\000\000\000\310\t\000\000\000\000\000\000\036\000\000\000\000\000\000\000\350\t\000\000\000\000\000\000\000\000\000\000\000\000\000\000\350\t\000\000\000\000\000\000\310\t\000\000\000\000\000\000\260\023\000\000\000\000\000\000\036\000\000\000\000\000\000\000\320\023\000\000\000\000\000\000\000\000\000\000\000\000\000\000\320\023\000\000\000\000\000\000\310\t\000\000\000\000\000\000\230\035\000\000\000\000\000\000\036\000\000\000\000\000\000\000\270\035\000\000\000\000\000\000\000\000\000\000\000\000\000\000\270\035\000\000\000\000\000\000\310\t\000\000\000\000\000\000\200\'\000\000\000\000\000\000\036\000\000\000\000\000\000\000\240\'\000\000\000\000\000\000\000\000\000\000\000\000\000\000\240\'\000\000\000\000\000\000\310\t\000\000\000\000\000\000h1\000\000\000\000\000\000\036\000\000\000\000\000\000\000\2101\000\000\000\000\000\000\000\000\000\000\000\000\000\000\2101\000\000\000\000\000\000\310\t\000\000\000\000\000\000P;\000\000\000\000\000\000\036\000\000\000\000\000\000\000p;\000\000\000\000\000\000\000\000\000\000\000\000\000\000p;\000\000\000\000\000\000\310\t\000\000\000\000\000\0008E\000\000\000\000\000\000\036\000\000\000\000\000\000\000XE\000\000\000\000\000\000\000\000\000\000\000\000\000\000XE\000\000\000\000\000\000\310\t\000\000\000\000\000\000 O\000\000\000\000\000\000\036\000\000\000\000\000\000\000@O\000\000\000\000\000\000\000\000\000\000\000\000\000\000@O\000\000\000\000\000\000\310\t\000\000\000\000\000\000\bY\000\000\000\000\000\000\036\000\000\000\000\000\000\000(Y\000\000\000\000\000\000\000\000\000\000\000\000\000\000
...
...
...
```

This change updates the log to:
```
log.debug("ReadRowsResponse from BigQuery stream: %s at offset: %s", helper.streamName, nextOffset);
```

This preserves useful logging for monitoring progress while avoiding unnecessary output of serialized record data.

## Additional context and related issues

Fixes [#25409](https://github.com/trinodb/trino/issues/25409) by replacing a verbose debug log that printed the entire `ReadRowsResponse` with a concise message logging only the stream name and offset.

## Screenshot (local run)

Trino running locally and logging expected debug message:
<img width="1567" height="56" alt="Screenshot 2025-08-31 at 11 43 17 AM" src="https://github.com/user-attachments/assets/8557fa90-e459-408a-919e-01c1190ba224" />


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: