### PR TITLE
Test: Update Parquet to 1.16.0

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java
@@ -79,6 +79,8 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.float16Type;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.geographyType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.geometryType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.listType;
@@ -87,6 +89,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.variantType;
 
 // based on org.apache.parquet.format.converter.ParquetMetadataConverter
 public final class ParquetMetadataConverter
@@ -156,6 +159,9 @@ public final class ParquetMetadataConverter
             }
             case UUID -> uuidType();
             case FLOAT16 -> float16Type();
+            case VARIANT -> variantType((byte) 1);
+            case GEOMETRY -> geometryType("OGC:CRS84");
+            case GEOGRAPHY -> geographyType();
         };
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <dep.kafka-clients.version>4.0.0</dep.kafka-clients.version>
         <dep.okhttp.version>5.1.0</dep.okhttp.version>
         <dep.okio.version>3.16.0</dep.okio.version>
-        <dep.parquet.version>1.15.2</dep.parquet.version>
+        <dep.parquet.version>1.16.0</dep.parquet.version>
         <dep.plugin.failsafe.version>${dep.plugin.surefire.version}</dep.plugin.failsafe.version>
         <dep.protobuf.version>3.25.8</dep.protobuf.version>
         <dep.snowflake.version>3.26.1</dep.snowflake.version>


### PR DESCRIPTION
## Description

Mirror PR of https://github.com/trinodb/trino/pull/26511 within the repository.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
