### PR TITLE
Avoid recording page loading time in projection profiling

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -320,8 +320,9 @@ public class PageProcessor
                     blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
                 }
                 else {
+                    SourcePage inputChannelsSourcePage = projection.getInputChannels().getInputChannels(page);
                     expressionProfiler.start();
-                    Block result = projection.project(session, projection.getInputChannels().getInputChannels(page), positionsBatch);
+                    Block result = projection.project(session, inputChannelsSourcePage, positionsBatch);
                     long projectionTimeNanos = expressionProfiler.stop(positionsBatch.size());
                     metrics.recordProjectionTime(projectionTimeNanos);
 


### PR DESCRIPTION
## Description
Fixes potential issue from mistakenly including page loading time from the changes in https://github.com/trinodb/trino/pull/26485/commits/73a455e349991ae3bdbb1ddab3cb4d0dc50e486b


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
