### PR TITLE
Add support setMaxCacheRows for TrinoStatement

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -22,6 +22,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Verify.verify;
@@ -42,21 +44,21 @@ public class TrinoResultSet
     @GuardedBy("this")
     private boolean closeStatementOnClose;
 
-    static TrinoResultSet create(Statement statement, StatementClient client, long maxRows, Consumer<QueryStats> progressCallback, WarningsManager warningsManager)
+    static TrinoResultSet create(Statement statement, StatementClient client, long maxRows, int maxCacheRows, Consumer<QueryStats> progressCallback, WarningsManager warningsManager)
             throws SQLException
     {
         requireNonNull(client, "client is null");
         List<Column> columns = getColumns(client, progressCallback);
-        return new TrinoResultSet(statement, client, columns, maxRows, progressCallback, warningsManager);
+        return new TrinoResultSet(statement, client, columns, maxRows, maxCacheRows, progressCallback, warningsManager);
     }
 
-    private TrinoResultSet(Statement statement, StatementClient client, List<Column> columns, long maxRows, Consumer<QueryStats> progressCallback, WarningsManager warningsManager)
+    private TrinoResultSet(Statement statement, StatementClient client, List<Column> columns, long maxRows, int maxCacheRows, Consumer<QueryStats> progressCallback, WarningsManager warningsManager)
             throws SQLException
     {
         super(
                 Optional.of(requireNonNull(statement, "statement is null")),
                 columns,
-                limit(new AsyncResultIterator(requireNonNull(client, "client is null"), progressCallback, warningsManager, Optional.empty()), maxRows));
+                limit(new AsyncResultIterator(requireNonNull(client, "client is null"), progressCallback, warningsManager, generateCacheQueue(maxCacheRows)), maxRows));
 
         this.statement = statement;
         this.client = requireNonNull(client, "client is null");
@@ -141,5 +143,10 @@ public class TrinoResultSet
             throw new SQLException(format("Query has no columns (#%s)", results.getId()));
         }
         throw resultsException(results);
+    }
+
+    private static Optional<BlockingQueue<List<Object>>> generateCacheQueue(int maxCacheRows)
+    {
+        return maxCacheRows > 0 ? Optional.of(new ArrayBlockingQueue<>(maxCacheRows)) : Optional.empty();
     }
 }


### PR DESCRIPTION
## Description
To reduce high client memory usage caused by long strings in results, we propose making the `rowQueue` size in `AsyncResultIterator` (currently 50,000) a customizable setting.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## JDBC
* Add support user-defined max cache row size when fetch results
```
