### PR TITLE
[Draft] Add support for JOIN PUSHDOWN in Exasol connector

### DIFF
--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -208,3 +208,16 @@ FROM
 
 ```{include} query-table-function-ordering.fragment
 ```
+
+(exasol-pushdown)=
+### Pushdown
+
+The connector supports pushdown for the following operations:
+
+- {ref}`join-pushdown`
+
+```{include} pushdown-correctness-behavior.fragment
+```
+
+```{include} join-pushdown-enabled-true.fragment
+```

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClient.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClient.java
@@ -15,8 +15,8 @@ package io.trino.plugin.exasol;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
-import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.airlift.slice.Slices;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.base.mapping.IdentifierMapping;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
@@ -89,11 +89,11 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
-import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
@@ -250,8 +250,7 @@ public class ExasolClient
     @Override
     protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
-        // Deactivated because test 'testJoinPushdown()' requires write access which is not implemented for Exasol
-        return false;
+        return true;
     }
 
     @Override

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientConvertPredicate.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientConvertPredicate.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
+import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryParameter;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.NullIf;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.ConnectorExpressionTranslator;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.function.OperatorType.ADD;
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.function.OperatorType.MODULUS;
+import static io.trino.spi.function.OperatorType.MULTIPLY;
+import static io.trino.spi.function.OperatorType.SUBTRACT;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.ir.IrExpressions.not;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestExasolClientConvertPredicate
+{
+    private static final JdbcClient JDBC_CLIENT = new ExasolClient(
+            new BaseJdbcConfig(),
+            session -> {
+                throw new UnsupportedOperationException();
+            },
+            new DefaultQueryBuilder(RemoteQueryModifier.NONE),
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
+
+    private static final ConnectorSession SESSION = TestingConnectorSession
+            .builder()
+            .setPropertyMetadata(ImmutableList.<PropertyMetadata<?>>builder()
+                    .addAll(new JdbcMetadataSessionProperties(new JdbcMetadataConfig(), Optional.empty()).getSessionProperties())
+                    .build())
+            .build();
+
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction NEGATION_BIGINT = FUNCTIONS.resolveOperator(OperatorType.NEGATION, ImmutableList.of(BIGINT));
+
+    private static final JdbcColumnHandle BIGINT_COLUMN =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_bigint")
+                    .setColumnType(BIGINT)
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("int8"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    private static final JdbcColumnHandle VARCHAR_COLUMN =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_varchar")
+                    .setColumnType(createVarcharType(10))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    private static final JdbcColumnHandle VARCHAR_COLUMN2 =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_varchar2")
+                    .setColumnType(createVarcharType(10))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    @Test
+    public void testConvertOr()
+    {
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new Logical(
+                                        Logical.Operator.OR,
+                                        List.of(
+                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L)),
+                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol_2"), new Constant(BIGINT, 415L))))),
+                        Map.of(
+                                "c_bigint_symbol", BIGINT_COLUMN,
+                                "c_bigint_symbol_2", BIGINT_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("((\"c_bigint\") = (?)) OR ((\"c_bigint\") = (?))");
+        assertThat(converted.parameters()).isEqualTo(List.of(
+                new QueryParameter(BIGINT, Optional.of(42L)),
+                new QueryParameter(BIGINT, Optional.of(415L))));
+    }
+
+    @Test
+    public void testConvertOrWithAnd()
+    {
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new Logical(
+                                        Logical.Operator.OR,
+                                        List.of(
+                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L)),
+                                                new Logical(
+                                                        Logical.Operator.AND,
+                                                        List.of(
+                                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 43L)),
+                                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol_2"), new Constant(BIGINT, 44L))))))),
+                        Map.of(
+                                "c_bigint_symbol", BIGINT_COLUMN,
+                                "c_bigint_symbol_2", BIGINT_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("((\"c_bigint\") = (?)) OR (((\"c_bigint\") = (?)) AND ((\"c_bigint\") = (?)))");
+        assertThat(converted.parameters()).isEqualTo(List.of(
+                new QueryParameter(BIGINT, Optional.of(42L)),
+                new QueryParameter(BIGINT, Optional.of(43L)),
+                new QueryParameter(BIGINT, Optional.of(44L))));
+    }
+
+    @Test
+    public void testConvertComparison()
+    {
+        for (Comparison.Operator operator : Comparison.Operator.values()) {
+            Optional<ParameterizedExpression> converted = JDBC_CLIENT.convertPredicate(
+                    SESSION,
+                    translateToConnectorExpression(
+                            new Comparison(operator, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L))),
+                    Map.of("c_bigint_symbol", BIGINT_COLUMN));
+
+            switch (operator) {
+                case EQUAL:
+                case NOT_EQUAL:
+                case LESS_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN:
+                case GREATER_THAN_OR_EQUAL:
+                    assertThat(converted).isPresent();
+                    assertThat(converted.get().expression()).isEqualTo(format("(\"c_bigint\") %s (?)", operator.getValue()));
+                    assertThat(converted.get().parameters()).isEqualTo(List.of(new QueryParameter(BIGINT, Optional.of(42L))));
+                    break;
+                case IDENTICAL:
+                    assertThat(converted).isPresent();
+                    assertThat(converted.get().expression()).isEqualTo(format("((\"c_bigint\") = (?) OR ((\"c_bigint\") IS NULL AND (?) IS NULL))"));
+                    assertThat(converted.get().parameters()).isEqualTo(List.of(new QueryParameter(BIGINT, Optional.of(42L)),
+                            new QueryParameter(BIGINT, Optional.of(42L))));
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void testConvertArithmeticBinary()
+    {
+        TestingFunctionResolution resolver = new TestingFunctionResolution();
+
+        for (OperatorType operator : EnumSet.of(ADD, SUBTRACT, MULTIPLY, DIVIDE, MODULUS)) {
+            ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(
+                            SESSION,
+                            translateToConnectorExpression(
+                                    new Call(resolver.resolveOperator(
+                                            operator,
+                                            ImmutableList.of(BIGINT, BIGINT)), ImmutableList.of(new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L)))),
+                            Map.of("c_bigint_symbol", BIGINT_COLUMN))
+                    .orElseThrow();
+
+            assertThat(converted.parameters()).isEqualTo(List.of(new QueryParameter(BIGINT, Optional.of(42L))));
+        }
+    }
+
+    @Test
+    public void testConvertArithmeticUnaryMinus()
+    {
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new Call(NEGATION_BIGINT, ImmutableList.of(new Reference(BIGINT, "c_bigint_symbol")))),
+                        Map.of("c_bigint_symbol", BIGINT_COLUMN))
+                .orElseThrow();
+
+        assertThat(converted.expression()).isEqualTo("-(\"c_bigint\")");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    public void testConvertIsNull()
+    {
+        // c_varchar IS NULL
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(SESSION,
+                        translateToConnectorExpression(
+                                new IsNull(
+                                        new Reference(VARCHAR, "c_varchar_symbol"))),
+                        Map.of("c_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IS NULL");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    public void testConvertIsNotNull()
+    {
+        // c_varchar IS NOT NULL
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(SESSION,
+                        translateToConnectorExpression(
+                                not(FUNCTIONS.getMetadata(), new IsNull(new Reference(VARCHAR, "c_varchar_symbol")))),
+                        Map.of("c_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IS NOT NULL");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    public void testConvertNullIf()
+    {
+        // nullif(a_varchar, b_varchar)
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(SESSION,
+                        translateToConnectorExpression(
+                                new NullIf(
+                                        new Reference(VARCHAR, "a_varchar_symbol"),
+                                        new Reference(VARCHAR, "b_varchar_symbol"))),
+                        ImmutableMap.of("a_varchar_symbol", VARCHAR_COLUMN, "b_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("NULLIF((\"c_varchar\"), (\"c_varchar\"))");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    public void testConvertNotExpression()
+    {
+        // NOT(expression)
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(SESSION,
+                        translateToConnectorExpression(
+                                not(
+                                        FUNCTIONS.getMetadata(),
+                                        not(FUNCTIONS.getMetadata(), new IsNull(new Reference(VARCHAR, "c_varchar_symbol"))))),
+                        Map.of("c_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("NOT ((\"c_varchar\") IS NOT NULL)");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    public void testConvertIn()
+    {
+        ParameterizedExpression converted = JDBC_CLIENT.convertPredicate(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new In(
+                                        new Reference(createVarcharType(10), "c_varchar"),
+                                        List.of(
+                                                new Constant(VARCHAR_COLUMN.getColumnType(), utf8Slice("value1")),
+                                                new Constant(VARCHAR_COLUMN.getColumnType(), utf8Slice("value2")),
+                                                new Reference(createVarcharType(10), "c_varchar2")))),
+                        Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN, VARCHAR_COLUMN2.getColumnName(), VARCHAR_COLUMN2))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IN (?, ?, \"c_varchar2\")");
+        assertThat(converted.parameters()).isEqualTo(List.of(
+                new QueryParameter(createVarcharType(10), Optional.of(utf8Slice("value1"))),
+                new QueryParameter(createVarcharType(10), Optional.of(utf8Slice("value2")))));
+    }
+
+    private ConnectorExpression translateToConnectorExpression(Expression expression)
+    {
+        return ConnectorExpressionTranslator.translate(TEST_SESSION, expression)
+                .orElseThrow();
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientConvertPredicate.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientConvertPredicate.java
@@ -59,7 +59,6 @@ import static io.trino.spi.function.OperatorType.MODULUS;
 import static io.trino.spi.function.OperatorType.MULTIPLY;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.ir.IrExpressions.not;

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientToWriteMapping.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientToWriteMapping.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
+import io.trino.plugin.jdbc.*;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Optional;
+
+import static com.google.common.reflect.Reflection.newProxy;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestExasolClientToWriteMapping
+{
+    private static final JdbcClient CLIENT = new ExasolClient(
+            new BaseJdbcConfig(),
+            session -> {
+                throw new UnsupportedOperationException();
+            },
+            new DefaultQueryBuilder(RemoteQueryModifier.NONE),
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
+
+    private static final ConnectorSession SESSION = TestingConnectorSession.SESSION;
+
+    @Test
+    public void testTypedWriteMapping()
+            throws SQLException
+    {
+        testLongWriteMapping(TINYINT, Types.TINYINT, "tinyint", "setByte", 1L, Byte.valueOf("1"));
+        testLongWriteMapping(SMALLINT, Types.SMALLINT, "smallint", "setShort", 256L, Short.valueOf("256"));
+        testLongWriteMapping(INTEGER, Types.INTEGER, "integer", "setInt", 123456L, 123456);
+        testLongWriteMapping(BIGINT, Types.BIGINT, "bigint", "setLong", 123456789L, 123456789L);
+        testLongWriteMapping(createDecimalType(16, 6), Types.DECIMAL, "decimal(16, 6)", "setBigDecimal", 123456123456L, BigDecimal.valueOf(123456.123456));
+        testInt128WriteMapping(createDecimalType(36, 12), Types.DECIMAL, "decimal(36, 12)", "setBigDecimal", Int128.valueOf("123456789012345612345678901234567890"), new BigDecimal("123456789012345612345678.901234567890"));
+
+        testBooleanWriteMapping(Boolean.TRUE);
+        testDoubleWriteMapping(1.2567);
+
+        testSliceWriteMapping(createCharType(25), Types.NCHAR, "char(25)", "test");
+        testSliceWriteMapping(createUnboundedVarcharType(), Types.VARCHAR, "varchar(20000)", "u".repeat(20000));
+        testSliceWriteMapping(createVarcharType(123), Types.VARCHAR, "varchar(123)", "9".repeat(123));
+    }
+
+    private void testLongWriteMapping(Type type, int expectedJdbcType, String expectedDataType, String expectedJdbcMethodName,
+                                                   Long inputValue, Object expectedJdbcValue)
+            throws SQLException
+    {
+        WriteMapping writeMapping = CLIENT.toWriteMapping(SESSION, type);
+        assertEquals(writeMapping.getWriteFunction().getJavaType(), long.class);
+        assertEquals(writeMapping.getDataType(), expectedDataType);
+        assertTrue(writeMapping.getWriteFunction() instanceof LongWriteFunction);
+        assertThat(writeMapping.getWriteFunction().getBindExpression()).isEqualTo("?");
+        PreparedStatement statementMock = preparedStatementMock(expectedJdbcType, expectedJdbcMethodName, expectedJdbcValue);
+        LongWriteFunction longWriteFunction = (LongWriteFunction) writeMapping.getWriteFunction();
+        longWriteFunction.set(statementMock, expectedJdbcType, inputValue);
+    }
+
+    private void testBooleanWriteMapping(boolean inputValue)
+            throws SQLException
+    {
+        WriteMapping writeMapping = CLIENT.toWriteMapping(SESSION, BOOLEAN);
+        assertEquals(writeMapping.getWriteFunction().getJavaType(), boolean.class);
+        assertEquals(writeMapping.getDataType(), "boolean");
+        assertTrue(writeMapping.getWriteFunction() instanceof BooleanWriteFunction);
+        assertThat(writeMapping.getWriteFunction().getBindExpression()).isEqualTo("?");
+        PreparedStatement statementMock = preparedStatementMock(Types.BOOLEAN, "setBoolean", inputValue);
+        BooleanWriteFunction booleanWriteFunction = (BooleanWriteFunction) writeMapping.getWriteFunction();
+        booleanWriteFunction.set(statementMock, Types.BOOLEAN, inputValue);
+    }
+
+    private void testDoubleWriteMapping(double inputValue)
+            throws SQLException
+    {
+        WriteMapping writeMapping = CLIENT.toWriteMapping(SESSION, DOUBLE);
+        assertEquals(writeMapping.getWriteFunction().getJavaType(), double.class);
+        assertEquals(writeMapping.getDataType(), "double");
+        assertTrue(writeMapping.getWriteFunction() instanceof DoubleWriteFunction);
+        assertThat(writeMapping.getWriteFunction().getBindExpression()).isEqualTo("?");
+        PreparedStatement statementMock = preparedStatementMock(Types.DOUBLE, "setDouble", inputValue);
+        DoubleWriteFunction doubleWriteFunction = (DoubleWriteFunction) writeMapping.getWriteFunction();
+        doubleWriteFunction.set(statementMock, Types.DOUBLE, inputValue);
+    }
+
+    private void testInt128WriteMapping(Type type, int expectedJdbcType, String expectedDataType, String expectedJdbcMethodName,
+                                      Int128 inputValue, BigDecimal expectedJdbcValue)
+            throws SQLException
+    {
+        WriteMapping writeMapping = CLIENT.toWriteMapping(SESSION, type);
+        assertEquals(writeMapping.getWriteFunction().getJavaType(), Int128.class);
+        assertEquals(writeMapping.getDataType(), expectedDataType);
+        assertTrue(writeMapping.getWriteFunction() instanceof ObjectWriteFunction);
+        assertThat(writeMapping.getWriteFunction().getBindExpression()).isEqualTo("?");
+        PreparedStatement statementMock = preparedStatementMock(expectedJdbcType, expectedJdbcMethodName, expectedJdbcValue);
+        ObjectWriteFunction objectWriteFunction = (ObjectWriteFunction) writeMapping.getWriteFunction();
+        objectWriteFunction.set(statementMock, expectedJdbcType, inputValue);
+    }
+
+    private void testSliceWriteMapping(Type type, int expectedJdbcType, String expectedDataType, String inputValue)
+            throws SQLException
+    {
+        WriteMapping writeMapping = CLIENT.toWriteMapping(SESSION, type);
+        assertEquals(writeMapping.getWriteFunction().getJavaType(), Slice.class);
+        assertEquals(writeMapping.getDataType(), expectedDataType);
+        assertTrue(writeMapping.getWriteFunction() instanceof SliceWriteFunction);
+        assertThat(writeMapping.getWriteFunction().getBindExpression()).isEqualTo("?");
+        PreparedStatement statementMock = preparedStatementMock(expectedJdbcType, "setString", inputValue);
+        SliceWriteFunction sliceWriteFunction = (SliceWriteFunction) writeMapping.getWriteFunction();
+        sliceWriteFunction.set(statementMock, expectedJdbcType, Slices.utf8Slice(inputValue));
+    }
+
+    private PreparedStatement preparedStatementMock(int expectedJdbcType, String expectedMethodName, Object expectedValue)
+    {
+        return newProxy(PreparedStatement.class, (proxy, method, args) ->
+        {
+            assertThat(method.getName()).isEqualTo(expectedMethodName);
+            assertThat(args.length).isEqualTo(2);
+            assertThat(args[0]).isEqualTo(expectedJdbcType);
+            assertThat(args[1])
+                    .describedAs("expected jdbc value")
+                    .isEqualTo(expectedValue);
+
+            return null;
+        });
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientToWriteMapping.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientToWriteMapping.java
@@ -13,14 +13,20 @@
  */
 package io.trino.plugin.exasol;
 
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
-import io.trino.plugin.jdbc.*;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.BooleanWriteFunction;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.DoubleWriteFunction;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.ObjectWriteFunction;
+import io.trino.plugin.jdbc.SliceWriteFunction;
+import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 import io.trino.testing.TestingConnectorSession;
@@ -30,7 +36,6 @@ import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.Optional;
 
 import static com.google.common.reflect.Reflection.newProxy;
 import static io.trino.spi.type.BigintType.BIGINT;

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolConnectorTest.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolConnectorTest.java
@@ -61,25 +61,25 @@ final class TestExasolConnectorTest
         return switch (connectorBehavior) {
             // Tests requires write access which is not implemented
             case SUPPORTS_AGGREGATION_PUSHDOWN,
-                 SUPPORTS_JOIN_PUSHDOWN,
-                 SUPPORTS_LIMIT_PUSHDOWN,
-                 SUPPORTS_TOPN_PUSHDOWN -> false;
+                     SUPPORTS_JOIN_PUSHDOWN,
+                     SUPPORTS_LIMIT_PUSHDOWN,
+                     SUPPORTS_TOPN_PUSHDOWN -> false;
 
             // Parallel writing is not supported due to restrictions of the Exasol JDBC driver.
             case SUPPORTS_ADD_COLUMN,
-                 SUPPORTS_ARRAY,
-                 SUPPORTS_COMMENT_ON_TABLE,
-                 SUPPORTS_CREATE_SCHEMA,
-                 SUPPORTS_CREATE_TABLE,
-                 SUPPORTS_DELETE,
-                 SUPPORTS_INSERT,
-                 SUPPORTS_MAP_TYPE,
-                 SUPPORTS_NEGATIVE_DATE, // min date is 0001-01-01
-                 SUPPORTS_RENAME_COLUMN,
-                 SUPPORTS_RENAME_TABLE,
-                 SUPPORTS_ROW_TYPE,
-                 SUPPORTS_SET_COLUMN_TYPE,
-                 SUPPORTS_UPDATE -> false;
+                     SUPPORTS_ARRAY,
+                     SUPPORTS_COMMENT_ON_TABLE,
+                     SUPPORTS_CREATE_SCHEMA,
+                     SUPPORTS_CREATE_TABLE,
+                     SUPPORTS_DELETE,
+                     SUPPORTS_INSERT,
+                     SUPPORTS_MAP_TYPE,
+                     SUPPORTS_NEGATIVE_DATE, // min date is 0001-01-01
+                     SUPPORTS_RENAME_COLUMN,
+                     SUPPORTS_RENAME_TABLE,
+                     SUPPORTS_ROW_TYPE,
+                     SUPPORTS_SET_COLUMN_TYPE,
+                     SUPPORTS_UPDATE -> false;
 
             default -> super.hasBehavior(connectorBehavior);
         };


### PR DESCRIPTION
## Description

Added Exasol Trino connector support for **JOIN PUSHDOWN** by implementing connectorExpressionRewriter and convertPredicate in ExasolClient

## Additional context and related issues

- enabled testJoinPushDown() test in BaseJdbcConnectorTest
- had to additionally implement toWriteMapping() in ExasolClient, because even some read-only parameterized queries require it for some scenarios.

## Release notes

```markdown
## Exasol Connect
* Add support for `join pushdown`
```
