### PR TITLE
Add random suffix to fix flaky Hive tests

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4554,44 +4554,42 @@ public abstract class BaseHiveConnectorTest
 
     private void testCreateTableWithHeaderAndFooter(String format)
     {
-        String name = format.toLowerCase(ENGLISH);
-        String catalog = getSession().getCatalog().get();
-        String schema = getSession().getSchema().get();
+        String tableName = "%s.%s.%s_table_skip_header_%s".formatted(getSession().getCatalog().get(), getSession().getSchema().get(), format.toLowerCase(ENGLISH), randomNameSuffix());
 
         @Language("SQL") String createTableSql = format("" +
-                        "CREATE TABLE %s.%s.%s_table_skip_header (\n" +
+                        "CREATE TABLE %s (\n" +
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   format = '%s',\n" +
                         "   skip_header_line_count = 1\n" +
                         ")",
-                catalog, schema, name, format);
+                tableName, format);
 
         assertUpdate(createTableSql);
 
-        MaterializedResult actual = computeActual(format("SHOW CREATE TABLE %s_table_skip_header", format));
+        MaterializedResult actual = computeActual("SHOW CREATE TABLE " + tableName);
         assertThat(actual.getOnlyValue()).isEqualTo(createTableSql);
-        assertUpdate(format("DROP TABLE %s_table_skip_header", format));
+        assertUpdate("DROP TABLE " + tableName);
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.%s_table_skip_footer (\n" +
+                        "CREATE TABLE %s (\n" +
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   format = '%s',\n" +
                         "   skip_footer_line_count = 1\n" +
                         ")",
-                catalog, schema, name, format);
+                tableName, format);
 
         assertUpdate(createTableSql);
 
-        actual = computeActual(format("SHOW CREATE TABLE %s_table_skip_footer", format));
+        actual = computeActual("SHOW CREATE TABLE " + tableName);
         assertThat(actual.getOnlyValue()).isEqualTo(createTableSql);
-        assertUpdate(format("DROP TABLE %s_table_skip_footer", format));
+        assertUpdate("DROP TABLE " + tableName);
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.%s_table_skip_header_footer (\n" +
+                        "CREATE TABLE %s (\n" +
                         "   name varchar\n" +
                         ")\n" +
                         "WITH (\n" +
@@ -4599,31 +4597,31 @@ public abstract class BaseHiveConnectorTest
                         "   skip_footer_line_count = 1,\n" +
                         "   skip_header_line_count = 1\n" +
                         ")",
-                catalog, schema, name, format);
+                tableName, format);
 
         assertUpdate(createTableSql);
 
-        actual = computeActual(format("SHOW CREATE TABLE %s_table_skip_header_footer", format));
+        actual = computeActual("SHOW CREATE TABLE " + tableName);
         assertThat(actual.getOnlyValue()).isEqualTo(createTableSql);
-        assertUpdate(format("DROP TABLE %s_table_skip_header_footer", format));
+        assertUpdate("DROP TABLE " + tableName);
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.%s_table_skip_header " +
+                        "CREATE TABLE %s " +
                         "WITH (\n" +
                         "   format = '%s',\n" +
                         "   skip_header_line_count = 1\n" +
                         ") AS SELECT CAST(1 AS VARCHAR) AS col_name1, CAST(2 AS VARCHAR) as col_name2",
-                catalog, schema, name, format);
+                tableName, format);
 
         assertUpdate(createTableSql, 1);
-        assertUpdate(format("INSERT INTO %s.%s.%s_table_skip_header VALUES('3', '4')", catalog, schema, name), 1);
-        MaterializedResult materializedRows = computeActual(format("SELECT * FROM %s_table_skip_header", name));
+        assertUpdate("INSERT INTO " + tableName + " VALUES('3', '4')", 1);
+        MaterializedResult materializedRows = computeActual("SELECT * FROM " + tableName);
         assertEqualsIgnoreOrder(materializedRows, resultBuilder(getSession(), VARCHAR, VARCHAR)
                 .row("1", "2")
                 .row("3", "4")
                 .build()
                 .getMaterializedRows());
-        assertUpdate(format("DROP TABLE %s_table_skip_header", format));
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
@@ -4641,50 +4639,43 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testInsertTableWithHeaderAndFooterForCsv()
     {
+        String tableName = "%s.%s.csv_table_skip_header_%s".formatted(getSession().getCatalog().get(), getSession().getSchema().get(), randomNameSuffix());
         @Language("SQL") String createTableSql = format("" +
-                        "CREATE TABLE %s.%s.csv_table_skip_header (\n" +
+                        "CREATE TABLE %s (\n" +
                         "   name VARCHAR\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   format = 'CSV',\n" +
                         "   skip_header_line_count = 2\n" +
                         ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
+                tableName);
 
         assertUpdate(createTableSql);
 
-        assertThatThrownBy(() -> assertUpdate(
-                format("INSERT INTO %s.%s.csv_table_skip_header VALUES ('name')",
-                        getSession().getCatalog().get(),
-                        getSession().getSchema().get())))
+        assertThatThrownBy(() -> assertUpdate("INSERT INTO " + tableName + " VALUES ('name')"))
                 .hasMessageMatching("Inserting into Hive table with value of skip.header.line.count property greater than 1 is not supported");
 
-        assertUpdate("DROP TABLE csv_table_skip_header");
+        assertUpdate("DROP TABLE " + tableName);
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.csv_table_skip_footer (\n" +
+                        "CREATE TABLE %s (\n" +
                         "   name VARCHAR\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   format = 'CSV',\n" +
                         "   skip_footer_line_count = 1\n" +
                         ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
+                tableName);
 
         assertUpdate(createTableSql);
 
-        assertThatThrownBy(() -> assertUpdate(
-                format("INSERT INTO %s.%s.csv_table_skip_footer VALUES ('name')",
-                        getSession().getCatalog().get(),
-                        getSession().getSchema().get())))
+        assertThatThrownBy(() -> assertUpdate("INSERT INTO " + tableName + " VALUES ('name')"))
                 .hasMessageMatching("Inserting into Hive table with skip.footer.line.count property not supported");
 
-        assertUpdate("DROP TABLE csv_table_skip_footer");
+        assertUpdate("DROP TABLE " + tableName);
 
         createTableSql = format("" +
-                        "CREATE TABLE %s.%s.csv_table_skip_header_footer (\n" +
+                        "CREATE TABLE %s (\n" +
                         "   name VARCHAR\n" +
                         ")\n" +
                         "WITH (\n" +
@@ -4692,18 +4683,14 @@ public abstract class BaseHiveConnectorTest
                         "   skip_footer_line_count = 1,\n" +
                         "   skip_header_line_count = 1\n" +
                         ")",
-                getSession().getCatalog().get(),
-                getSession().getSchema().get());
+                tableName);
 
         assertUpdate(createTableSql);
 
-        assertThatThrownBy(() -> assertUpdate(
-                format("INSERT INTO %s.%s.csv_table_skip_header_footer VALUES ('name')",
-                        getSession().getCatalog().get(),
-                        getSession().getSchema().get())))
+        assertThatThrownBy(() -> assertUpdate("INSERT INTO " + tableName + " VALUES ('name')"))
                 .hasMessageMatching("Inserting into Hive table with skip.footer.line.count property not supported");
 
-        assertUpdate("DROP TABLE csv_table_skip_header_footer");
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test


### PR DESCRIPTION
## Description

This fixes flaky `testCreateTableWithHeaderAndFooter(CSV)` and `testCreateTableWithHeaderAndFooterForCsv()`. 

https://github.com/trinodb/trino/actions/runs/17478884174/job/49645203991

```
Error:  io.trino.plugin.hive.TestHiveConnectorTest.testCreateTableWithHeaderAndFooterForCsv -- Time elapsed: 0.011 s <<< ERROR!
io.trino.testing.QueryFailedException: line 1:1: Table 'hive.tpch.csv_table_skip_header' already exists
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:586)
	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:575)
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:106)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:60)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:416)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:411)
	at io.trino.plugin.hive.BaseHiveConnectorTest.testCreateTableWithHeaderAndFooter(BaseHiveConnectorTest.java:4571)
	at io.trino.plugin.hive.BaseHiveConnectorTest.testCreateTableWithHeaderAndFooterForCsv(BaseHiveConnectorTest.java:4638)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1394)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1970)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
