### PR TITLE
Document TRUNCATE statement in Iceberg

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -747,7 +747,7 @@ WHERE system.bucket(custkey, 16) = 2;
 ### Data management
 
 The {ref}`sql-data-management` functionality includes support for `INSERT`,
-`UPDATE`, `DELETE`, and `MERGE` statements.
+`UPDATE`, `DELETE`, `TRUNCATE`, and `MERGE` statements.
 
 (iceberg-delete)=
 #### Deletion by partition


### PR DESCRIPTION
## Description

Follow-up of https://github.com/trinodb/trino/pull/22340

The `sql-data-management` fragment contains TRUNCATE:
https://github.com/trinodb/trino/blob/4f50ae66de7af866c8ad354499a2503c93027be5/docs/src/main/sphinx/language/sql-support.md?plain=1#L85-L92

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
