### PR TITLE
Enable getRowFilter to be column aware

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -641,7 +641,7 @@ public interface AccessControl
      */
     void checkCanFastForwardBranch(SecurityContext context, QualifiedObjectName tableName, String sourceBranchName, String targetBranchName);
 
-    default List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
+    default List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
         return ImmutableList.of();
     }

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -1463,7 +1463,7 @@ public class AccessControlManager
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
+    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
         requireNonNull(context, "context is null");
         requireNonNull(tableName, "tableName is null");
@@ -1472,12 +1472,12 @@ public class AccessControlManager
         ConnectorAccessControl connectorAccessControl = getConnectorAccessControl(context.getTransactionId(), tableName.catalogName());
 
         if (connectorAccessControl != null) {
-            connectorAccessControl.getRowFilters(toConnectorSecurityContext(tableName.catalogName(), context), tableName.asSchemaTableName())
+            connectorAccessControl.getRowFilters(toConnectorSecurityContext(tableName.catalogName(), context), tableName.asSchemaTableName(), columns)
                     .forEach(filters::add);
         }
 
         for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {
-            systemAccessControl.getRowFilters(context.toSystemSecurityContext(), tableName.asCatalogSchemaTableName())
+            systemAccessControl.getRowFilters(context.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columns)
                     .forEach(filters::add);
         }
 

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -555,9 +555,9 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
+    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        return delegate().getRowFilters(context, tableName);
+        return delegate().getRowFilters(context, tableName, columns);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -565,13 +565,19 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
     {
         checkArgument(context == null, "context must be null");
-        if (accessControl.getRowFilters(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName())).isEmpty()) {
+        if (accessControl.getRowFilters(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), columns).isEmpty()) {
             return ImmutableList.of();
         }
         throw new TrinoException(NOT_SUPPORTED, "Row filtering not supported");
+    }
+
+    @Override
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
+    {
+        throw new UnsupportedOperationException("getRowFilters should be called with columns");
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -77,9 +77,9 @@ public class ViewAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
+    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
-        return delegate.getRowFilters(context, tableName);
+        return delegate.getRowFilters(context, tableName, columns);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -754,13 +754,13 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
+    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
         List<ViewExpression> viewExpressions = rowFilters.get(new RowFilterKey(context.getIdentity().getUser(), tableName));
         if (viewExpressions != null) {
             return viewExpressions;
         }
-        return super.getRowFilters(context, tableName);
+        return super.getRowFilters(context, tableName, columns);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
@@ -810,11 +810,11 @@ public class TracingAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
+    public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName, List<ColumnSchema> columns)
     {
         Span span = startSpan("getRowFilters");
         try (var _ = scopedSpan(span)) {
-            return delegate.getRowFilters(context, tableName);
+            return delegate.getRowFilters(context, tableName, columns);
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -789,6 +789,20 @@ public interface ConnectorAccessControl
      *
      * @return the list of filters, or empty list if not applicable
      */
+    default List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return getRowFilters(context, tableName);
+    }
+
+    /**
+     * Get row filters associated with the given table and identity.
+     * <p>
+     * Each filter must be a scalar SQL expression of boolean type over the columns in the table.
+     *
+     * @return the list of filters, or empty list if not applicable
+     * @deprecated use {@link #getRowFilters(ConnectorSecurityContext, SchemaTableName, List)}
+     */
+    @Deprecated
     default List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         return emptyList();

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -1023,6 +1023,20 @@ public interface SystemAccessControl
      *
      * @return the list of filters, or empty list if not applicable
      */
+    default List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return getRowFilters(context, tableName);
+    }
+
+    /**
+     * Get row filters associated with the given table and identity.
+     * <p>
+     * Each filter must be a scalar SQL expression of boolean type over the columns in the table.
+     *
+     * @return the list of filters, or empty list if not applicable
+     * @deprecated use {@link #getRowFilters(SystemSecurityContext, CatalogSchemaTableName, List)}
+     */
+    @Deprecated
     default List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName)
     {
         return List.of();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -631,6 +631,14 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getRowFilters(context, tableName, columns);
+        }
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -269,6 +269,12 @@ public class AllowAllAccessControl
     public void checkCanRevokeTableBranchPrivilege(ConnectorSecurityContext context, Privilege privilege, SchemaTableName tableName, String branchName, TrinoPrincipal revokee, boolean grantOption) {}
 
     @Override
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return getRowFilters(context, tableName);
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         return ImmutableList.of();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -369,6 +369,12 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return getRowFilters(context, tableName);
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName)
     {
         return emptyList();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -790,6 +790,12 @@ public class FileBasedAccessControl
     }
 
     @Override
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return getRowFilters(context, tableName);
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -1079,6 +1079,12 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
+    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName table, List<ColumnSchema> columns)
+    {
+        return getRowFilters(context, table);
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         SchemaTableName tableName = table.getSchemaTableName();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -491,6 +491,12 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return delegate().getRowFilters(context, tableName, columns);
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         return delegate().getRowFilters(context, tableName);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -594,6 +594,12 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
+    {
+        return delegate().getRowFilters(context, tableName, columns);
+    }
+
+    @Override
     public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName)
     {
         return delegate().getRowFilters(context, tableName);

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
@@ -397,7 +397,7 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         accessControl.checkCanDropTable(userGroup1Group2, myTable);
         accessControl.checkCanSelectFromColumns(userGroup1Group2, myTable, ImmutableSet.of());
         assertThat(accessControl.getColumnMask(userGroup1Group2, myTable, "col_a", VARCHAR)).isEqualTo(Optional.empty());
-        assertThat(accessControl.getRowFilters(userGroup1Group2, myTable)).isEqualTo(ImmutableList.of());
+        assertThat(accessControl.getRowFilters(userGroup1Group2, myTable, ImmutableList.of())).isEqualTo(ImmutableList.of());
 
         assertDenied(() -> accessControl.checkCanCreateTable(userGroup2, myTable, Map.of()));
         assertDenied(() -> accessControl.checkCanInsertIntoTable(userGroup2, myTable));
@@ -411,7 +411,7 @@ public abstract class BaseFileBasedConnectorAccessControlTest
                         .schema("my_schema")
                         .expression("'mask_a'")
                         .build());
-        assertThat(accessControl.getRowFilters(userGroup2, myTable)).isEqualTo(ImmutableList.of());
+        assertThat(accessControl.getRowFilters(userGroup2, myTable, ImmutableList.of())).isEqualTo(ImmutableList.of());
 
         ConnectorSecurityContext userGroup1Group3 = user("user_1_3", ImmutableSet.of("group1", "group3"));
         ConnectorSecurityContext userGroup3 = user("user_3", ImmutableSet.of("group3"));
@@ -436,7 +436,7 @@ public abstract class BaseFileBasedConnectorAccessControlTest
                         .expression("'mask_a'")
                         .build());
 
-        List<ViewExpression> rowFilters = accessControl.getRowFilters(userGroup3, myTable);
+        List<ViewExpression> rowFilters = accessControl.getRowFilters(userGroup3, myTable, ImmutableList.of());
         assertThat(rowFilters).hasSize(1);
         assertViewExpressionEquals(
                 rowFilters.get(0),

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -818,11 +818,13 @@ public abstract class BaseFileBasedSystemAccessControlTest
 
         assertThat(accessControl.getRowFilters(
                 userGroup1Group3,
-                new CatalogSchemaTableName("some-catalog", "my_schema", "my_table"))).isEqualTo(ImmutableList.of());
+                new CatalogSchemaTableName("some-catalog", "my_schema", "my_table"),
+                ImmutableList.of())).isEqualTo(ImmutableList.of());
 
         List<ViewExpression> rowFilters = accessControl.getRowFilters(
                 userGroup3,
-                new CatalogSchemaTableName("some-catalog", "my_schema", "my_table"));
+                new CatalogSchemaTableName("some-catalog", "my_schema", "my_table"),
+                ImmutableList.of());
         assertThat(rowFilters).hasSize(1);
         assertViewExpressionEquals(
                 rowFilters.get(0),
@@ -1465,9 +1467,9 @@ public abstract class BaseFileBasedSystemAccessControlTest
     {
         SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-access-table.json");
 
-        assertThat(accessControl.getRowFilters(ALICE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"))).isEqualTo(ImmutableList.of());
+        assertThat(accessControl.getRowFilters(ALICE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableList.of())).isEqualTo(ImmutableList.of());
 
-        List<ViewExpression> rowFilters = accessControl.getRowFilters(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"));
+        List<ViewExpression> rowFilters = accessControl.getRowFilters(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableList.of());
         assertThat(rowFilters).hasSize(1);
         assertViewExpressionEquals(
                 rowFilters.get(0),
@@ -1477,7 +1479,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         .expression("starts_with(value, 'filter')")
                         .build());
 
-        rowFilters = accessControl.getRowFilters(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns_with_grant"));
+        rowFilters = accessControl.getRowFilters(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns_with_grant"), ImmutableList.of());
         assertThat(rowFilters).hasSize(1);
         assertViewExpressionEquals(
                 rowFilters.get(0),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -704,9 +704,15 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
+    {
+        throw new UnsupportedOperationException("getRowFilters should be called with columns");
     }
 
     @Override

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -729,7 +729,7 @@ public sealed class OpaAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName)
+    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
     {
         List<OpaViewExpression> rowFilterExpressions = opaHighLevelClient.getRowFilterExpressionsFromOpa(buildQueryContext(context), tableName);
         return rowFilterExpressions.stream()

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -690,7 +690,7 @@ final class TestOpaAccessControl
     @Test
     void testGetRowFiltersThrowsForIllegalResponse()
     {
-        Consumer<OpaAccessControl> methodUnderTest = authorizer -> authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME);
+        Consumer<OpaAccessControl> methodUnderTest = authorizer -> authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME, ImmutableList.of());
         assertAccessControlMethodThrowsForIllegalResponses(methodUnderTest, rowFilteringOpaConfig(), OPA_ROW_FILTERING_URI);
 
         // Also test a valid JSON response, but containing invalid fields for a row filters request
@@ -763,7 +763,7 @@ final class TestOpaAccessControl
         InstrumentedHttpClient httpClient = createMockHttpClient(OPA_ROW_FILTERING_URI, buildValidatingRequestHandler(TEST_IDENTITY, new MockResponse(responseContent, 200)));
         OpaAccessControl authorizer = createOpaAuthorizer(rowFilteringOpaConfig(), httpClient);
 
-        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME);
+        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME, ImmutableList.of());
         assertThat(result).allSatisfy(expression -> {
             assertThat(expression.getCatalog()).contains("some_catalog");
             assertThat(expression.getSchema()).contains("some_schema");
@@ -803,7 +803,7 @@ final class TestOpaAccessControl
                 });
         OpaAccessControl authorizer = createOpaAuthorizer(simpleOpaConfig(), httpClient);
 
-        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME);
+        List<ViewExpression> result = authorizer.getRowFilters(TEST_SECURITY_CONTEXT, TEST_COLUMN_MASKING_TABLE_NAME, ImmutableList.of());
         assertThat(result).isEmpty();
         assertThat(httpClient.getRequests()).isEmpty();
     }

--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -20,6 +20,7 @@ import io.trino.spi.QueryId;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.EntityKindAndName;
 import io.trino.spi.connector.EntityPrivilege;
 import io.trino.spi.connector.SchemaTableName;
@@ -815,7 +816,7 @@ public class RangerSystemAccessControl
     }
 
     @Override
-    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName)
+    public List<ViewExpression> getRowFilters(SystemSecurityContext context, CatalogSchemaTableName tableName, List<ColumnSchema> columns)
     {
         RangerAccessResult result = getRowFilterResult(createAccessRequest(createTableResource(tableName), context, SELECT, "getRowFilters"));
 

--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.ranger;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.QueryId;
@@ -312,10 +313,10 @@ final class TestRangerSystemAccessControl
     @Test
     void testRowFilters()
     {
-        List<ViewExpression> retArray = accessControlManager.getRowFilters(context(ALICE), TABLE_ALICE_SCH1_TBL1);
+        List<ViewExpression> retArray = accessControlManager.getRowFilters(context(ALICE), TABLE_ALICE_SCH1_TBL1, ImmutableList.of());
         assertThat(retArray).isEmpty();
 
-        retArray = accessControlManager.getRowFilters(context(BOB), TABLE_ALICE_SCH1_TBL1);
+        retArray = accessControlManager.getRowFilters(context(BOB), TABLE_ALICE_SCH1_TBL1, ImmutableList.of());
         assertThat(retArray).isNotEmpty();
         assertThat(retArray).hasSize(1);
         assertThat(retArray.getFirst().getExpression()).isEqualTo("status = 'active'");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

### Summary
Enable getRowFilter to be column aware.

### Detail

Presently the access control interfaces provide `getRowFilter` with the security context, catalog name and schema name.

This works well when adding the row filter based on a restricted list of rules (`FileBasedAccessControl`) or where the metadata is known elsewhere (OPA or Ranger).

However this does not allow for filters to be dynamically added based on the columns.

For example - _whenever a table has a `security_group` column, add a filter to enable row-level security against the user's current groups._

To enable this use case, this PR modifies the `getRowFilter` so that the `List<ColumnSchema>` is also passed in as a parameter, matching `getColumnMasks`.

### Implementation Notes

* **Backwards Compatibility** - everything in `trino-main` calls the new method. However the old method is deprecated but called by the default implementation of the new method within the interfaces. Hopefully this preserves backwards compatibility?
* **Testing** - where is best to add coverage of this functionality?
* **FileBasedAccessControl** - I propose a follow on PR to make use of this functionality within `FileBasedAccessControl` and associated documentation.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
#1480 - original implementation of row filtering
#21046 - a question around this functionality


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Enable row filtering to be column aware ({issue}`issuenumber`)
```
