### PR TITLE
Change the visibility of shared variables in TimeSharingTaskHandle from protected to private

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskHandle.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskHandle.java
@@ -41,15 +41,15 @@ public class TimeSharingTaskHandle
     private final DoubleSupplier utilizationSupplier;
 
     @GuardedBy("this")
-    protected final Queue<PrioritizedSplitRunner> queuedLeafSplits = new ArrayDeque<>(10);
+    private final Queue<PrioritizedSplitRunner> queuedLeafSplits = new ArrayDeque<>(10);
     @GuardedBy("this")
-    protected final List<PrioritizedSplitRunner> runningLeafSplits = new ArrayList<>(10);
+    private final List<PrioritizedSplitRunner> runningLeafSplits = new ArrayList<>(10);
     @GuardedBy("this")
-    protected final List<PrioritizedSplitRunner> runningIntermediateSplits = new ArrayList<>(10);
+    private final List<PrioritizedSplitRunner> runningIntermediateSplits = new ArrayList<>(10);
     @GuardedBy("this")
-    protected long scheduledNanos;
+    private long scheduledNanos;
     @GuardedBy("this")
-    protected final SplitConcurrencyController concurrencyController;
+    private final SplitConcurrencyController concurrencyController;
 
     private final AtomicInteger nextSplitId = new AtomicInteger();
 


### PR DESCRIPTION
## Description

Keeping the shared variable here to have protected access makes it possible that its values get mutated outside of this class without proper synchronization

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
