### PR TITLE
Fix reading mixed-type array in Mongodb

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.md
+++ b/docs/src/main/sphinx/connector/mongodb.md
@@ -39,29 +39,28 @@ will create a catalog named `sales` using the configured connector.
 
 The following configuration properties are available:
 
-| Property name                            | Description                                                                         |
-|------------------------------------------|-------------------------------------------------------------------------------------|
-| `mongodb.connection-url`                 | The connection url that the driver uses to connect to a MongoDB deployment          |
-| `mongodb.schema-collection`              | A collection which contains schema information                                      |
-| `mongodb.case-insensitive-name-matching` | Match database and collection names case insensitively                              |
-| `mongodb.min-connections-per-host`       | The minimum size of the connection pool per host                                    |
-| `mongodb.connections-per-host`           | The maximum size of the connection pool per host                                    |
-| `mongodb.max-wait-time`                  | The maximum wait time                                                               |
-| `mongodb.max-connection-idle-time`       | The maximum idle time of a pooled connection                                        |
-| `mongodb.connection-timeout`             | The socket connect timeout                                                          |
-| `mongodb.socket-timeout`                 | The socket timeout                                                                  |
-| `mongodb.tls.enabled`                    | Use TLS/SSL for connections to mongod/mongos                                        |
-| `mongodb.tls.keystore-path`              | Path to the  or JKS key store                                                       |
-| `mongodb.tls.truststore-path`            | Path to the  or JKS trust store                                                     |
-| `mongodb.tls.keystore-password`          | Password for the key store                                                          |
-| `mongodb.tls.truststore-password`        | Password for the trust store                                                        |
-| `mongodb.read-preference`                | The read preference                                                                 |
-| `mongodb.write-concern`                  | The write concern                                                                   |
-| `mongodb.required-replica-set`           | The required replica set name                                                       |
-| `mongodb.cursor-batch-size`              | The number of elements to return in a batch                                         |
-| `mongodb.allow-local-scheduling`         | Assign MongoDB splits to a specific worker                                          |
-| `mongodb.dynamic-filtering.wait-timeout` | Duration to wait for completion of dynamic filters during split generation          |
-| `mongodb.implicit-row-field-prefix`      | Prefix for auto-generated field names when mapping mixed-type arrays to `ROW` types |
+| Property name                            | Description                                                                |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `mongodb.connection-url`                 | The connection url that the driver uses to connect to a MongoDB deployment |
+| `mongodb.schema-collection`              | A collection which contains schema information                             |
+| `mongodb.case-insensitive-name-matching` | Match database and collection names case insensitively                     |
+| `mongodb.min-connections-per-host`       | The minimum size of the connection pool per host                           |
+| `mongodb.connections-per-host`           | The maximum size of the connection pool per host                           |
+| `mongodb.max-wait-time`                  | The maximum wait time                                                      |
+| `mongodb.max-connection-idle-time`       | The maximum idle time of a pooled connection                               |
+| `mongodb.connection-timeout`             | The socket connect timeout                                                 |
+| `mongodb.socket-timeout`                 | The socket timeout                                                         |
+| `mongodb.tls.enabled`                    | Use TLS/SSL for connections to mongod/mongos                               |
+| `mongodb.tls.keystore-path`              | Path to the  or JKS key store                                              |
+| `mongodb.tls.truststore-path`            | Path to the  or JKS trust store                                            |
+| `mongodb.tls.keystore-password`          | Password for the key store                                                 |
+| `mongodb.tls.truststore-password`        | Password for the trust store                                               |
+| `mongodb.read-preference`                | The read preference                                                        |
+| `mongodb.write-concern`                  | The write concern                                                          |
+| `mongodb.required-replica-set`           | The required replica set name                                              |
+| `mongodb.cursor-batch-size`              | The number of elements to return in a batch                                |
+| `mongodb.allow-local-scheduling`         | Assign MongoDB splits to a specific worker                                 |
+| `mongodb.dynamic-filtering.wait-timeout` | Duration to wait for completion of dynamic filters during split generation |
 
 ### `mongodb.connection-url`
 
@@ -220,32 +219,6 @@ This property is optional, and defaults to false.
 Duration to wait for completion of dynamic filters during split generation.
 
 This property is optional; the default is `5s`.
-
-### `mongodb.implicit-row-field-prefix`
-
-When reading documents that contain arrays with different element types,
-the connector cannot represent the array as a single `ARRAY` because no
-single common element type exists. In this case, the connector maps the array
-to a `ROW` type, where each element of the array is represented as a separate
-field.
-
-Since `ROW` fields require names, the connector automatically generates names
-by combining this prefix with the element index. For example, with the default
-implicit row field prefix `_pos`:
-
-```json
-{
-  "data": [ {"a": 1}, 42, "foo" ]
-}
-```
-
-is mapped to the following Trino type:
-
-```sql
-ROW(_pos1 ROW(a BIGINT), _pos2 BIGINT, _pos3 VARCHAR)
-```
-
-This property is optional; the default is `_pos`.
 
 (table-definition-label)=
 ## Table definition

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigHidden;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
@@ -212,6 +213,7 @@ public class MongoClientConfig
         return implicitRowFieldPrefix;
     }
 
+    @ConfigHidden
     @Config("mongodb.implicit-row-field-prefix")
     public MongoClientConfig setImplicitRowFieldPrefix(String implicitRowFieldPrefix)
     {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSourceProvider.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSourceProvider.java
@@ -37,11 +37,13 @@ public class MongoPageSourceProvider
     private static final int MONGO_DOMAIN_COMPACTION_THRESHOLD = 1000;
 
     private final MongoSession mongoSession;
+    private final String implicitPrefix;
 
     @Inject
-    public MongoPageSourceProvider(MongoSession mongoSession)
+    public MongoPageSourceProvider(MongoSession mongoSession, MongoClientConfig config)
     {
         this.mongoSession = requireNonNull(mongoSession, "mongoSession is null");
+        this.implicitPrefix = config.getImplicitRowFieldPrefix();
     }
 
     @Override
@@ -80,6 +82,6 @@ public class MongoPageSourceProvider
             return new EmptyPageSource();
         }
 
-        return new MongoPageSource(mongoSession, newTableHandle, handles.build());
+        return new MongoPageSource(mongoSession, newTableHandle, handles.build(), implicitPrefix);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -21,6 +21,7 @@ import io.trino.spi.type.VarcharType;
 
 import java.util.Set;
 
+import static com.google.common.base.Verify.verify;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -63,5 +64,26 @@ public final class TypeUtils
                 || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+    }
+
+    public static boolean isImplicitRowField(String fieldName, String implicitPrefix)
+    {
+        return getImplicitRowFieldIndex(fieldName, implicitPrefix) != -1;
+    }
+
+    public static int getImplicitRowFieldIndex(String fieldName, String implicitPrefix)
+    {
+        if (fieldName.length() <= implicitPrefix.length() || !fieldName.startsWith(implicitPrefix)) {
+            return -1;
+        }
+
+        try {
+            int fieldIndex = Integer.parseInt(fieldName.substring(implicitPrefix.length()));
+            verify(fieldIndex >= 1, "Field index must be >= 1");
+            return fieldIndex;
+        }
+        catch (NumberFormatException e) {
+            return -1;
+        }
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -55,7 +55,7 @@ public class TestMongoSession
     {
         List<MongoColumnHandle> columns = ImmutableList.of(COL1, COL2);
 
-        Document output = MongoSession.buildProjection(columns);
+        Document output = MongoSession.buildProjection(columns, "_pos");
         Document expected = new Document()
                 .append(COL1.baseName(), 1)
                 .append(COL2.baseName(), 1)
@@ -69,7 +69,7 @@ public class TestMongoSession
     {
         List<MongoColumnHandle> columns = ImmutableList.of(COL1, COL2, ID_COL);
 
-        Document output = MongoSession.buildProjection(columns);
+        Document output = MongoSession.buildProjection(columns, "_pos");
         Document expected = new Document()
                 .append(COL1.baseName(), 1)
                 .append(COL2.baseName(), 1)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Currently, reading mixed-type array type in Mongo fails with message:
```
ClassCastException on nested arrays: ArrayList cannot be cast to BSON Document
```

Reproduce by below test:
```
    void testMongoMixedTypeArrayType()
    {
        String schema = getSession().getSchema().orElseThrow();
        String table = "test_mixed_array_" + randomNameSuffix();
        MongoDatabase db = client.getDatabase(schema);

        db.createCollection(table);
        db.getCollection(table)
                .insertOne(new Document("mixed_array_col", ImmutableList.of(1, "two", 3.0, new Document("nested_arr", ImmutableList.of(4, 5)))));

        assertThat(query("SHOW COLUMNS FROM " + table))
                .skippingTypesCheck()
                .matches("VALUES " +
                         "('mixed_array_col', 'row(_pos1 bigint, _pos2 varchar, _pos3 double, _pos4 row(nested_arr array(bigint)))', '', '')");

        assertThat(query("SELECT mixed_array_col._pos1, mixed_array_col._pos2, mixed_array_col._pos3 FROM " + table))
                .matches("VALUES (BIGINT '1', VARCHAR 'two', DOUBLE '3.0')");
        assertThat(query("SELECT mixed_array_col._pos4.nested_arr[1], mixed_array_col._pos4.nested_arr[2] FROM " + table))
                .matches("VALUES (BIGINT '4', BIGINT '5')");

        assertUpdate("DROP TABLE " + table);
    }
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Revert https://github.com/trinodb/trino/pull/26576 since we are going to hide the configuration `implicit-row-field-prefix`



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## MongoDB
* Fix failure when reading array type with different element types. ({issue}`26585`)
```
