### PR TITLE
Add support for limit and top n pushdown in Exasol connector

### DIFF
--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -208,3 +208,16 @@ FROM
 
 ```{include} query-table-function-ordering.fragment
 ```
+
+## Performance
+
+The connector includes a number of performance improvements, detailed in the
+following sections.
+
+(exasol-pushdown)=
+### Pushdown
+
+The connector supports pushdown for a number of operations:
+
+- {ref}`limit-pushdown`
+- {ref}`topn-pushdown`

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolConnectorTest.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolConnectorTest.java
@@ -23,6 +23,7 @@ import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TestView;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
@@ -61,9 +62,7 @@ final class TestExasolConnectorTest
         return switch (connectorBehavior) {
             // Tests requires write access which is not implemented
             case SUPPORTS_AGGREGATION_PUSHDOWN,
-                 SUPPORTS_JOIN_PUSHDOWN,
-                 SUPPORTS_LIMIT_PUSHDOWN,
-                 SUPPORTS_TOPN_PUSHDOWN -> false;
+                 SUPPORTS_JOIN_PUSHDOWN -> false;
 
             // Parallel writing is not supported due to restrictions of the Exasol JDBC driver.
             case SUPPORTS_ADD_COLUMN,
@@ -83,6 +82,13 @@ final class TestExasolConnectorTest
 
             default -> super.hasBehavior(connectorBehavior);
         };
+    }
+
+    @Override
+    protected TestTable newTrinoTable(String namePrefix, @Language("SQL") String tableDefinition, List<String> rowsToInsert)
+    {
+        // Use Exasol executor because the connector does not support creating tables
+        return new TestTable(exasolServer.getSqlExecutor(), TEST_SCHEMA + "." + namePrefix, tableDefinition, rowsToInsert);
     }
 
     @Override


### PR DESCRIPTION
## Description

Added Exasol Trino connector support for LIMIT AND TOP N pushdown.

## Additional context and related issues

Added support for LIMIT and TOP N by overriding and implementing the required methods in ExasolClient.java
Made the necessary changes to test class TestExasolConnectorTest to enable tests for limit and top n.

## Release notes

```markdown
## Exasol
* Improve performance for queries involving `LIMIT`. ({issue}`26592`)
```
