### PR TITLE
Avoid eval-rst in Exasol documentation

### DIFF
--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -75,36 +75,35 @@ each direction.
 Trino supports selecting Exasol database types. This table shows the Exasol to
 Trino data type mapping:
 
-```{eval-rst}
-.. list-table:: Exasol to Trino type mapping
-  :widths: 25, 25, 50
-  :header-rows: 1
+:::{list-table} Exasol to Trino type mapping
+:widths: 25, 25, 50
+:header-rows: 1
 
-  * - Exasol database type
-    - Trino type
-    - Notes
-  * - ``BOOLEAN``
-    - ``BOOLEAN``
-    -
-  * - ``DOUBLE PRECISION``
-    - ``REAL``
-    -
-  * - ``DECIMAL(p, s)``
-    - ``DECIMAL(p, s)``
-    -  See :ref:`exasol-number-mapping`
-  * - ``CHAR(n)``
-    - ``CHAR(n)``
-    -
-  * - ``VARCHAR(n)``
-    - ``VARCHAR(n)``
-    -
-  * - ``DATE``
-    - ``DATE``
-    -       
-  * - ``HASHTYPE``
-    - ``VARBINARY``
-    -   
-```
+* - Exasol database type
+  - Trino type
+  - Notes
+* - `BOOLEAN`
+  - `BOOLEAN`
+  -
+* - `DOUBLE PRECISION`
+  - `REAL`
+  -
+* - `DECIMAL(p, s)`
+  - `DECIMAL(p, s)`
+  -  See {ref}`exasol-number-mapping`
+* - `CHAR(n)`
+  - `CHAR(n)`
+  -
+* - `VARCHAR(n)`
+  - `VARCHAR(n)`
+  -
+* - `DATE`
+  - `DATE`
+  -
+* - `HASHTYPE`
+  - `VARBINARY`
+  -
+:::
 
 No other types are supported.
 


### PR DESCRIPTION
## Description

Only Exasol documentation uses `eval-rst` hack. The generated image after this change:

<img width="1452" height="1252" alt="Screenshot 2025-09-10 at 8 18 18" src="https://github.com/user-attachments/assets/74da8ef4-0dd7-44d1-9207-451c7468c6d5" />

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
