### PR TITLE
Add redirect guards

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/DisallowLocalRedirectInterceptor.java
+++ b/client/trino-client/src/main/java/io/trino/client/DisallowLocalRedirectInterceptor.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+import static java.lang.String.format;
+
+public class DisallowLocalRedirectInterceptor
+        implements Interceptor
+{
+    public DisallowLocalRedirectInterceptor() {}
+
+    @Override
+    public Response intercept(Chain chain)
+            throws IOException
+    {
+        Response response = chain.proceed(chain.request());
+        if (response.isRedirect()) {
+            String location = response.header("Location");
+            if (!redirectAllowed(location)) {
+                throw new ClientException(format("Following redirect to '%s' is disallowed", location));
+            }
+        }
+        return response;
+    }
+
+    boolean redirectAllowed(String location)
+    {
+        if (location == null) {
+            return true;
+        }
+
+        try {
+            String host = new URI(location).getHost();
+            if (host == null) {
+                return true;
+            }
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            for (InetAddress address : addresses) {
+                if (isLocalAddress(address)) {
+                    return false;
+                }
+            }
+        }
+        catch (URISyntaxException | UnknownHostException ignored) {
+            // This will fail later anyway
+        }
+        return true;
+    }
+
+    static boolean isLocalAddress(InetAddress addr)
+    {
+        return addr.isAnyLocalAddress() ||
+                addr.isLoopbackAddress() ||
+                addr.isLinkLocalAddress() ||
+                addr.isSiteLocalAddress();
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -116,6 +116,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, Map<String, String>> RESOURCE_ESTIMATES = new ResourceEstimates();
     public static final ConnectionProperty<String, List<String>> SQL_PATH = new SqlPath();
     public static final ConnectionProperty<String, Boolean> VALIDATE_CONNECTION = new ValidateConnection();
+    public static final ConnectionProperty<String, Boolean> DISALLOW_LOCAL_REDIRECT = new LocalRedirectDisallowed();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             // Keep sorted
@@ -128,6 +129,7 @@ final class ConnectionProperties
             .add(CLIENT_INFO)
             .add(CLIENT_TAGS)
             .add(DISABLE_COMPRESSION)
+            .add(DISALLOW_LOCAL_REDIRECT)
             .add(DNS_RESOLVER)
             .add(DNS_RESOLVER_CONTEXT)
             .add(ENCODING)
@@ -955,6 +957,15 @@ final class ConnectionProperties
         public AssumeNullCatalogMeansCurrentCatalog()
         {
             super(PropertyName.ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class LocalRedirectDisallowed
+            extends AbstractConnectionProperty<String, Boolean>
+    {
+        public LocalRedirectDisallowed()
+        {
+            super(PropertyName.DISALLOW_LOCAL_REDIRECT, Optional.of(false), NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
@@ -14,6 +14,7 @@
 package io.trino.client.uri;
 
 import io.trino.client.ClientException;
+import io.trino.client.DisallowLocalRedirectInterceptor;
 import io.trino.client.DnsResolver;
 import io.trino.client.auth.external.CompositeRedirectHandler;
 import io.trino.client.auth.external.ExternalAuthenticator;
@@ -124,6 +125,10 @@ public class HttpClientFactory
         setupHttpProxy(builder, uri.getHttpProxy());
         setupTimeouts(builder, toIntExact(uri.getTimeout().toMillis()), TimeUnit.MILLISECONDS);
         setupHttpLogging(builder, uri.getHttpLoggingLevel());
+
+        if (uri.isLocalRedirectDisallowed()) {
+            builder.addNetworkInterceptor(new DisallowLocalRedirectInterceptor());
+        }
 
         if (uri.isUseSecureConnection()) {
             ConnectionProperties.SslVerificationMode sslVerificationMode = uri.getSslVerification();

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -76,6 +76,7 @@ public enum PropertyName
     TIMEZONE("timezone"),
     TRACE_TOKEN("traceToken"),
     USER("user"),
+    DISALLOW_LOCAL_REDIRECT("disallowLocalRedirect"),
     VALIDATE_CONNECTION("validateConnection");
 
     private final String key;

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -51,6 +51,7 @@ import static io.trino.client.uri.ConnectionProperties.CATALOG;
 import static io.trino.client.uri.ConnectionProperties.CLIENT_INFO;
 import static io.trino.client.uri.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.client.uri.ConnectionProperties.DISABLE_COMPRESSION;
+import static io.trino.client.uri.ConnectionProperties.DISALLOW_LOCAL_REDIRECT;
 import static io.trino.client.uri.ConnectionProperties.DNS_RESOLVER;
 import static io.trino.client.uri.ConnectionProperties.DNS_RESOLVER_CONTEXT;
 import static io.trino.client.uri.ConnectionProperties.ENCODING;
@@ -421,6 +422,11 @@ public class TrinoUri
     public boolean isCompressionDisabled()
     {
         return resolveWithDefault(DISABLE_COMPRESSION, false);
+    }
+
+    public boolean isLocalRedirectDisallowed()
+    {
+        return resolveWithDefault(DISALLOW_LOCAL_REDIRECT, false);
     }
 
     public Optional<String> getEncoding()
@@ -1056,6 +1062,11 @@ public class TrinoUri
         public Builder setValidateConnection(boolean value)
         {
             return setProperty(VALIDATE_CONNECTION, value);
+        }
+
+        public Builder setDisallowLocalRedirect(boolean value)
+        {
+            return setProperty(DISALLOW_LOCAL_REDIRECT, value);
         }
 
         <V, T> Builder setProperty(ConnectionProperty<V, T> connectionProperty, T value)

--- a/client/trino-client/src/test/java/io/trino/client/TestDisallowLocalRedirectInterceptor.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestDisallowLocalRedirectInterceptor.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestDisallowLocalRedirectInterceptor
+{
+    private static final String BASE_URL = "https://example.com";
+
+    @Test
+    public void testRedirectValidation()
+            throws IOException
+    {
+        DisallowLocalRedirectInterceptor redirector = new DisallowLocalRedirectInterceptor();
+
+        // Valid external URIs
+        assertThat(redirector.intercept(chainWithRedirectLocation("https://www.example.com")))
+                .isNotNull();
+
+        assertThat(redirector.intercept(chainWithRedirectLocation("https://api.github.com")))
+                .isNotNull();
+
+        // Invalid URI
+        assertThat(redirector.intercept(chainWithRedirectLocation("not a valid uri")))
+                .isNotNull();
+
+        // Unresolvable host
+        assertThat(redirector.intercept(chainWithRedirectLocation("https://nonexistent.example.invalid")))
+                .isNotNull();
+
+        // Local URIs
+        assertThatThrownBy(() -> redirector.intercept(chainWithRedirectLocation("https://127.0.0.1")))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("Following redirect to 'https://127.0.0.1' is disallowed");
+
+        assertThatThrownBy(() -> redirector.intercept(chainWithRedirectLocation("https://localhost")))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("Following redirect to 'https://localhost' is disallowed");
+
+        assertThatThrownBy(() -> redirector.intercept(chainWithRedirectLocation("http://192.168.1.1")))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("Following redirect to 'http://192.168.1.1' is disallowed");
+
+        assertThatThrownBy(() -> redirector.intercept(chainWithRedirectLocation("https://0.0.0.0")))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("Following redirect to 'https://0.0.0.0' is disallowed");
+
+        assertThatThrownBy(() -> redirector.intercept(chainWithRedirectLocation("https://172.16.0.1/uri")))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("Following redirect to 'https://172.16.0.1/uri' is disallowed");
+
+        assertThatThrownBy(() -> redirector.intercept(chainWithRedirectLocation("https://169.254.169.254")))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("Following redirect to 'https://169.254.169.254' is disallowed");
+    }
+
+    private static Interceptor.Chain chainWithRedirectLocation(String location)
+    {
+        return new TestingInterceptorChain(new Response.Builder()
+                .request(new Request.Builder().url(BASE_URL).build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(302)
+                .message("Found")
+                .header("Location", location)
+                .build());
+    }
+
+    private static class TestingInterceptorChain
+            implements Interceptor.Chain
+    {
+        private final Response response;
+
+        TestingInterceptorChain(Response response)
+        {
+            this.response = response;
+        }
+
+        @Override
+        public Request request()
+        {
+            return response.request();
+        }
+
+        @Override
+        public Response proceed(Request request)
+        {
+            return response;
+        }
+
+        @Override
+        public int connectTimeoutMillis()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Interceptor.Chain withConnectTimeout(int timeout, java.util.concurrent.TimeUnit unit)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int readTimeoutMillis()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Interceptor.Chain withReadTimeout(int timeout, java.util.concurrent.TimeUnit unit)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int writeTimeoutMillis()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Interceptor.Chain withWriteTimeout(int timeout, java.util.concurrent.TimeUnit unit)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public okhttp3.Connection connection()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public okhttp3.Call call()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
This is my first PR for Trino. We are using this patch in production to prevent the attack described below. Offering this upstream if you guys want it.

The driver will currently follow any redirects from the server. This can cause problems. For example when running on AWS there is a service running on a link-local address which provides IAM credentials (IMDS). If the server redirects to this address, the driver will return an error message with the IAM credentials.

(x) Release notes are required. Please propose a release note for me.

Note: I emailed the signed CLA form last week.