### PR TITLE
Run Loki integration test in past.

### DIFF
--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestLokiIntegration.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/TestLokiIntegration.java
@@ -213,27 +213,27 @@ final class TestLokiIntegration
     {
         assertQueryFails(
                 """
-                SELECT to_iso8601(timestamp), value FROM
-                TABLE(system.query_range(
-                 'count_over_time({test="timestamp_metrics_query"}[5m])',
-                 TIMESTAMP '2012-08-08',
-                 TIMESTAMP '2012-08-09',
-                 -300
-                ))
-                LIMIT 1
-                """,
+                        SELECT to_iso8601(timestamp), value FROM
+                        TABLE(system.query_range(
+                         'count_over_time({test="timestamp_metrics_query"}[5m])',
+                         TIMESTAMP '2012-08-08',
+                         TIMESTAMP '2012-08-09',
+                         -300
+                        ))
+                        LIMIT 1
+                        """,
                 "step must be positive");
         assertQueryFails(
                 """
-                SELECT to_iso8601(timestamp), value FROM
-                TABLE(system.query_range(
-                 'count_over_time({test="timestamp_metrics_query"}[5m])',
-                 TIMESTAMP '2012-08-08',
-                 TIMESTAMP '2012-08-09',
-                 NULL
-                ))
-                LIMIT 1
-                """,
+                        SELECT to_iso8601(timestamp), value FROM
+                        TABLE(system.query_range(
+                         'count_over_time({test="timestamp_metrics_query"}[5m])',
+                         TIMESTAMP '2012-08-08',
+                         TIMESTAMP '2012-08-09',
+                         NULL
+                        ))
+                        LIMIT 1
+                        """,
                 "step must be positive");
     }
 }


### PR DESCRIPTION
## Description
By running the Loki integration test in the past we try to avoid the situations when the end timestamps align. 

Fixes #25035 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

