### PR TITLE
Relax locking in ThreadPerDriverTaskExecutor when removing tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -143,10 +143,12 @@ public class ThreadPerDriverTaskExecutor
     }
 
     @Override
-    public synchronized void removeTask(TaskHandle handle)
+    public void removeTask(TaskHandle handle)
     {
         TaskEntry entry = (TaskEntry) handle;
-        tasks.remove(entry.taskId());
+        synchronized (this) {
+            tasks.remove(entry.taskId());
+        }
         if (!entry.isDestroyed()) {
             entry.destroy();
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Before the fix, `ThreadPerDriverTaskExecutor.removeTask` performed task destruction under a global lock which may lead to an unnecessary contention with HTTP threads attempting to add new tasks.  This might cause cluster-wide instability because HTTP worker threads may wait for the same lock when submitting new tasks.

After the fix, the task destructor logic is executed outside the lock.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve cluster stability when rolling back writes to slow data sources
```
