### PR TITLE
[Draft] Implement Basic convertPredicate in ExasolClient

### DIFF
--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientConvertPredicate.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolClientConvertPredicate.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
+import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryParameter;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.ConnectorExpressionTranslator;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.ir.IrExpressions.not;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestExasolClientConvertPredicate
+{
+    private static final ExasolClient EXASOL_CLIENT = new ExasolClient(
+            new BaseJdbcConfig(),
+            session -> {
+                throw new UnsupportedOperationException();
+            },
+            new DefaultQueryBuilder(RemoteQueryModifier.NONE),
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
+
+    private static final ConnectorSession SESSION = TestingConnectorSession
+            .builder()
+            .setPropertyMetadata(ImmutableList.<PropertyMetadata<?>>builder()
+                    .addAll(new JdbcMetadataSessionProperties(new JdbcMetadataConfig(), Optional.empty()).getSessionProperties())
+                    .build())
+            .build();
+
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+
+    private static final JdbcColumnHandle BIGINT_COLUMN =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_bigint")
+                    .setColumnType(BIGINT)
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("int8"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    private static final JdbcColumnHandle VARCHAR_COLUMN =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_varchar")
+                    .setColumnType(createVarcharType(10))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    private static final JdbcColumnHandle VARCHAR_COLUMN2 =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_varchar2")
+                    .setColumnType(createVarcharType(10))
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    @Test
+    void testConvertOr()
+    {
+        ParameterizedExpression converted = EXASOL_CLIENT.convertPredicateTemporary(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new Logical(
+                                        Logical.Operator.OR,
+                                        List.of(
+                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L)),
+                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol_2"), new Constant(BIGINT, 415L))))),
+                        Map.of(
+                                "c_bigint_symbol", BIGINT_COLUMN,
+                                "c_bigint_symbol_2", BIGINT_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("((\"c_bigint\") = (?)) OR ((\"c_bigint\") = (?))");
+        assertThat(converted.parameters()).isEqualTo(List.of(
+                new QueryParameter(BIGINT, Optional.of(42L)),
+                new QueryParameter(BIGINT, Optional.of(415L))));
+    }
+
+    @Test
+    void testConvertOrWithAnd()
+    {
+        ParameterizedExpression converted = EXASOL_CLIENT.convertPredicateTemporary(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new Logical(
+                                        Logical.Operator.OR,
+                                        List.of(
+                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L)),
+                                                new Logical(
+                                                        Logical.Operator.AND,
+                                                        List.of(
+                                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 43L)),
+                                                                new Comparison(Comparison.Operator.EQUAL, new Reference(BIGINT, "c_bigint_symbol_2"), new Constant(BIGINT, 44L))))))),
+                        Map.of(
+                                "c_bigint_symbol", BIGINT_COLUMN,
+                                "c_bigint_symbol_2", BIGINT_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("((\"c_bigint\") = (?)) OR (((\"c_bigint\") = (?)) AND ((\"c_bigint\") = (?)))");
+        assertThat(converted.parameters()).isEqualTo(List.of(
+                new QueryParameter(BIGINT, Optional.of(42L)),
+                new QueryParameter(BIGINT, Optional.of(43L)),
+                new QueryParameter(BIGINT, Optional.of(44L))));
+    }
+
+    @Test
+    void testConvertComparison()
+    {
+        for (Comparison.Operator operator : Comparison.Operator.values()) {
+            Optional<ParameterizedExpression> converted = EXASOL_CLIENT.convertPredicateTemporary(
+                    SESSION,
+                    translateToConnectorExpression(
+                            new Comparison(operator, new Reference(BIGINT, "c_bigint_symbol"), new Constant(BIGINT, 42L))),
+                    Map.of("c_bigint_symbol", BIGINT_COLUMN));
+
+            switch (operator) {
+                case EQUAL:
+                case NOT_EQUAL:
+                case LESS_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN:
+                case GREATER_THAN_OR_EQUAL:
+                    assertThat(converted).isPresent();
+                    assertThat(converted.get().expression()).isEqualTo(format("(\"c_bigint\") %s (?)", operator.getValue()));
+                    assertThat(converted.get().parameters()).isEqualTo(List.of(new QueryParameter(BIGINT, Optional.of(42L))));
+                    break;
+                case IDENTICAL:
+                    assertThat(converted).isPresent();
+                    assertThat(converted.get().expression()).isEqualTo(format("((\"c_bigint\") = (?) OR ((\"c_bigint\") IS NULL AND (?) IS NULL))"));
+                    assertThat(converted.get().parameters()).isEqualTo(List.of(new QueryParameter(BIGINT, Optional.of(42L)),
+                            new QueryParameter(BIGINT, Optional.of(42L))));
+                    break;
+            }
+        }
+    }
+
+    @Test
+    void testConvertIsNull()
+    {
+        // c_varchar IS NULL
+        ParameterizedExpression converted = EXASOL_CLIENT.convertPredicateTemporary(SESSION,
+                        translateToConnectorExpression(
+                                new IsNull(
+                                        new Reference(VARCHAR, "c_varchar_symbol"))),
+                        Map.of("c_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IS NULL");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    void testConvertIsNotNull()
+    {
+        // c_varchar IS NOT NULL
+        ParameterizedExpression converted = EXASOL_CLIENT.convertPredicateTemporary(SESSION,
+                        translateToConnectorExpression(
+                                not(FUNCTIONS.getMetadata(), new IsNull(new Reference(VARCHAR, "c_varchar_symbol")))),
+                        Map.of("c_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IS NOT NULL");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    void testConvertNotExpression()
+    {
+        // NOT(expression)
+        ParameterizedExpression converted = EXASOL_CLIENT.convertPredicateTemporary(SESSION,
+                        translateToConnectorExpression(
+                                not(
+                                        FUNCTIONS.getMetadata(),
+                                        not(FUNCTIONS.getMetadata(), new IsNull(new Reference(VARCHAR, "c_varchar_symbol"))))),
+                        Map.of("c_varchar_symbol", VARCHAR_COLUMN))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("NOT ((\"c_varchar\") IS NOT NULL)");
+        assertThat(converted.parameters()).isEqualTo(List.of());
+    }
+
+    @Test
+    void testConvertIn()
+    {
+        ParameterizedExpression converted = EXASOL_CLIENT.convertPredicateTemporary(
+                        SESSION,
+                        translateToConnectorExpression(
+                                new In(
+                                        new Reference(createVarcharType(10), "c_varchar"),
+                                        List.of(
+                                                new Constant(VARCHAR_COLUMN.getColumnType(), utf8Slice("value1")),
+                                                new Constant(VARCHAR_COLUMN.getColumnType(), utf8Slice("value2")),
+                                                new Reference(createVarcharType(10), "c_varchar2")))),
+                        Map.of(VARCHAR_COLUMN.getColumnName(), VARCHAR_COLUMN, VARCHAR_COLUMN2.getColumnName(), VARCHAR_COLUMN2))
+                .orElseThrow();
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IN (?, ?, \"c_varchar2\")");
+        assertThat(converted.parameters()).isEqualTo(List.of(
+                new QueryParameter(createVarcharType(10), Optional.of(utf8Slice("value1"))),
+                new QueryParameter(createVarcharType(10), Optional.of(utf8Slice("value2")))));
+    }
+
+    private ConnectorExpression translateToConnectorExpression(Expression expression)
+    {
+        return ConnectorExpressionTranslator.translate(TEST_SESSION, expression)
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## Description

Implement Basic convertPredicate in ExasolClient

## Additional context and related issues

- This feature is required for Exasol Trino connector **JOIN PUSHDOWN** support.
- Without this feature, **testJoinPushDown** from **BaseJdbcConnectorTest** fails.

## Release notes

```markdown
## Exasol Connect
* Implement Basic `convertPredicate` in `ExasolClient`
```
