### PR TITLE
Resolve ConnectorSession for scalar functions with multiple arguments

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/CustomFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/CustomFunctions.java
@@ -14,10 +14,15 @@
 package io.trino.operator.scalar;
 
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.block.SqlRow;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
+import io.trino.spi.function.TypeParameter;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.StandardTypes;
 
 public final class CustomFunctions
@@ -51,5 +56,20 @@ public final class CustomFunctions
     public static long customIdentityFunction(@SqlType(StandardTypes.BIGINT) long x)
     {
         return x;
+    }
+
+    @ScalarFunction("connector_session_varchar")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice varchar(ConnectorSession session, @SqlType(StandardTypes.VARCHAR) Slice greeting)
+    {
+        return Slices.utf8Slice(greeting.toStringUtf8() + " " + session.getUser());
+    }
+
+    @ScalarFunction("connector_session_row")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice row(ConnectorSession session, @TypeParameter("row(greeting varchar)") RowType rowType, @SqlType("row(varchar)") SqlRow sqlRow)
+    {
+        Slice message = rowType.getFields().getFirst().getType().getSlice(sqlRow.getRawFieldBlock(0), sqlRow.getRawIndex());
+        return Slices.utf8Slice(message.toStringUtf8() + " " + session.getUser());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestCustomFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestCustomFunctions.java
@@ -83,4 +83,18 @@ public class TestCustomFunctions
         assertThat(assertions.function("identity.function", "\"identity&function\"(123)"))
                 .isEqualTo(123L);
     }
+
+    @Test
+    public void testConnectorSessionBinding()
+    {
+        assertThat(assertions.function("connector_session_varchar", "'hello'"))
+                .isEqualTo("hello user");
+    }
+
+    @Test
+    public void testComplexConnectorSessionBinding()
+    {
+        assertThat(assertions.function("connector_session_row", "row('goodbye')"))
+                .isEqualTo("goodbye user");
+    }
 }


### PR DESCRIPTION
## Description
Currently, the following scalar functions are possible:

```java
@SqlType(VARCHAR)
public static Slice currentUser(ConnectorSession session) {
```

```java
@SqlType(VARCHAR)
public static Slice varchar(ConnectorSession session, @SqlType(VARCHAR) Slice greeting) {
```

The following arguments raised an exception:
```java
@SqlType(VARCHAR)
public static Slice row(ConnectorSession session,
    @TypeParameter("row(greeting varchar)") RowType rowType,
    @SqlType("row(varchar)") SqlRow sqlRow) {
```
```text
Cannot cast io.trino.spi.type.RowType to io.trino.spi.connector.ConnectorSession
```

This branch allows that kind of usage.

## Additional context and related issues
The exception is thrown in `ParametricFunctionHelpers#bindDependencies`, as it forgets that the ConnectorSession is an argument as well. The `ParametricScalarImplementationChoice` contains a `hasConnectorSession`, but as the dependencies are solved in a for loop, I couldn't find a nice way to use the choice boolean there. I also noticed that the `bindDependencies()` is used in `ParametricAggregation`, but there is no `ParametricScalarImplementationChoice` available there to get the `hasConnectorSession` from. My changes fixes the problem, but  I somehow feel like the fix can also be achieved with mentioned boolean.


## Release notes

( x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
