### PR TITLE
Add query stage performance flow to Preview Web UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
@@ -217,12 +217,42 @@ export interface QueryRoutine {
     authorization: string
 }
 
+export interface QueryStageNodeInfo {
+    '@type': string
+    id: string
+    source: QueryStageNodeInfo
+    sources: QueryStageNodeInfo[]
+    filteringSource: QueryStageNodeInfo
+    probeSource: QueryStageNodeInfo
+    indexSource: QueryStageNodeInfo
+    left: QueryStageNodeInfo
+    right: QueryStageNodeInfo
+}
+
 export interface QueryStagePlan {
     id: string
     jsonRepresentation: string
-    root: {
-        id: string
-    }
+    root: QueryStageNodeInfo
+}
+
+export interface QueryStageOperatorSummary {
+    pipelineId: number
+    planNodeId: string
+    operatorId: number
+    operatorType: string
+    child: QueryStageOperatorSummary
+    outputPositions: number
+    outputDataSize: string
+    totalDrivers: number
+    addInputCpu: string
+    getOutputCpu: string
+    finishCpu: string
+    addInputWall: string
+    getOutputWall: string
+    finishWall: string
+    blockedWall: string
+    inputDataSize: string
+    inputPositions: number
 }
 
 export interface QueryStageStats {
@@ -249,6 +279,7 @@ export interface QueryStageStats {
     totalBufferedBytes: number
     failedCumulativeUserMemory: number
     peakUserMemoryReservation: string
+    operatorSummaries: QueryStageOperatorSummary[]
 }
 
 export interface QueryTask {

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
@@ -18,6 +18,7 @@ import { QueryJson } from './QueryJson'
 import { QueryReferences } from './QueryReferences'
 import { QueryLivePlan } from './QueryLivePlan'
 import { QueryOverview } from './QueryOverview'
+import { QueryStagePerformance } from './QueryStagePerformance'
 import { Texts } from '../constant.ts'
 
 const tabValues = ['overview', 'livePlan', 'stagePerformance', 'splits', 'json', 'references'] as const
@@ -25,7 +26,7 @@ type TabValue = (typeof tabValues)[number]
 const tabComponentMap: Record<TabValue, ReactNode> = {
     overview: <QueryOverview />,
     livePlan: <QueryLivePlan />,
-    stagePerformance: <Alert severity="error">{Texts.Error.NotImplemented}</Alert>,
+    stagePerformance: <QueryStagePerformance />,
     splits: <Alert severity="error">{Texts.Error.NotImplemented}</Alert>,
     json: <QueryJson />,
     references: <QueryReferences />,
@@ -59,7 +60,7 @@ export const QueryDetails = () => {
                             <Tabs value={tabValue} onChange={handleTabChange}>
                                 <Tab value="overview" label="Overview" />
                                 <Tab value="livePlan" label="Live plan" />
-                                <Tab value="stagePerformance" label="Stage performance" disabled />
+                                <Tab value="stagePerformance" label="Stage performance" />
                                 <Tab value="splits" label="Splits" disabled />
                                 <Tab value="json" label="JSON" />
                                 <Tab value="references" label="References" />

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryLivePlan.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryLivePlan.tsx
@@ -18,9 +18,9 @@ import { ReactFlow, type Edge, type Node, useNodesState, useEdgesState } from '@
 import '@xyflow/react/dist/style.css'
 import { queryStatusApi, QueryStatusInfo } from '../api/webapp/api.ts'
 import { QueryProgressBar } from './QueryProgressBar'
-import { nodeTypes, getLayoutedElements } from './flow/layout'
+import { nodeTypes, getLayoutedPlanFlowElements } from './flow/layout'
 import { HelpMessage } from './flow/HelpMessage'
-import { getFlowElements } from './flow/flowUtils'
+import { getPlanFlowElements } from './flow/flowUtils'
 import { IQueryStatus, LayoutDirectionType } from './flow/types'
 import { ApiResponse } from '../api/base.ts'
 import { Texts } from '../constant.ts'
@@ -48,8 +48,8 @@ export const QueryLivePlan = () => {
 
     useEffect(() => {
         if (queryStatus.info?.stages) {
-            const flowElements = getFlowElements(queryStatus.info.stages, layoutDirection)
-            const layoutedElements = getLayoutedElements(flowElements.nodes, flowElements.edges, {
+            const flowElements = getPlanFlowElements(queryStatus.info.stages, layoutDirection)
+            const layoutedElements = getLayoutedPlanFlowElements(flowElements.nodes, flowElements.edges, {
                 direction: layoutDirection,
             })
 

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryStagePerformance.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryStagePerformance.tsx
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useParams } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import {
+    Alert,
+    Box,
+    CircularProgress,
+    FormControl,
+    Grid2 as Grid,
+    InputLabel,
+    MenuItem,
+    Select,
+    SelectChangeEvent,
+} from '@mui/material'
+import { type Edge, type Node, ReactFlow, useEdgesState, useNodesState } from '@xyflow/react'
+import { queryStatusApi, QueryStatusInfo, QueryStage } from '../api/webapp/api.ts'
+import { ApiResponse } from '../api/base.ts'
+import { Texts } from '../constant.ts'
+import { QueryProgressBar } from './QueryProgressBar.tsx'
+import { HelpMessage } from './flow/HelpMessage'
+import { nodeTypes, getLayoutedStagePerformanceElements } from './flow/layout'
+import { LayoutDirectionType } from './flow/types'
+import { getStagePerformanceFlowElements } from './flow/flowUtils.ts'
+
+interface IQueryStatus {
+    info: QueryStatusInfo | null
+    ended: boolean
+}
+
+export const QueryStagePerformance = () => {
+    const { queryId } = useParams()
+    const initialQueryStatus: IQueryStatus = {
+        info: null,
+        ended: false,
+    }
+
+    const [queryStatus, setQueryStatus] = useState<IQueryStatus>(initialQueryStatus)
+    const [stagePlanIds, setStagePlanIds] = useState<string[]>([])
+    const [stagePlanId, setStagePlanId] = useState<string>()
+    const [stage, setStage] = useState<QueryStage>()
+    const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
+    const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+    const [layoutDirection, setLayoutDirection] = useState<LayoutDirectionType>('BT')
+
+    const [loading, setLoading] = useState<boolean>(true)
+    const [error, setError] = useState<string | null>(null)
+    const queryStatusRef = useRef(queryStatus)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        queryStatusRef.current = queryStatus
+    }, [queryStatus])
+
+    useEffect(() => {
+        if (queryStatus.info?.stages) {
+            const allStagePlanIds = queryStatus.info.stages.stages.map((stage) => stage.plan.id)
+            setStagePlanIds(allStagePlanIds)
+            setStagePlanId(allStagePlanIds[0])
+        }
+    }, [queryStatus])
+
+    useEffect(() => {
+        if (queryStatus.ended && stagePlanId) {
+            const stage = queryStatus.info?.stages.stages.find((stage) => stage.plan.id === stagePlanId)
+            setStage(stage)
+
+            if (stage) {
+                const flowElements = getStagePerformanceFlowElements(stage, layoutDirection)
+                const layoutedElements = getLayoutedStagePerformanceElements(flowElements.nodes, flowElements.edges, {
+                    direction: layoutDirection,
+                })
+
+                setNodes(layoutedElements.nodes)
+                setEdges(layoutedElements.edges)
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [queryStatus, stagePlanId, layoutDirection])
+
+    useEffect(() => {
+        const runLoop = () => {
+            const queryEnded = !!queryStatusRef.current.info?.finalQueryInfo
+            if (!queryEnded) {
+                getQueryStatus()
+                setTimeout(runLoop, 3000)
+            }
+        }
+
+        if (queryId) {
+            queryStatusRef.current = initialQueryStatus
+        }
+
+        runLoop()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [queryId])
+
+    const getQueryStatus = () => {
+        if (queryId) {
+            queryStatusApi(queryId, false).then((apiResponse: ApiResponse<QueryStatusInfo>) => {
+                setLoading(false)
+                if (apiResponse.status === 200 && apiResponse.data) {
+                    setQueryStatus({
+                        info: apiResponse.data,
+                        ended: apiResponse.data.finalQueryInfo,
+                    })
+                    setError(null)
+                } else {
+                    setError(`${Texts.Error.Communication} ${apiResponse.status}: ${apiResponse.message}`)
+                }
+            })
+        }
+    }
+
+    const smallFormControlSx = {
+        fontSize: '0.8rem',
+    }
+
+    const smallDropdownMenuPropsSx = {
+        PaperProps: {
+            sx: {
+                '& .MuiMenuItem-root': smallFormControlSx,
+            },
+        },
+    }
+
+    const handleStageIdChange = (event: SelectChangeEvent) => {
+        setStagePlanId(event.target.value as string)
+    }
+
+    return (
+        <>
+            {loading && <CircularProgress />}
+            {error && <Alert severity="error">{Texts.Error.QueryNotFound}</Alert>}
+
+            {!loading && !error && queryStatus.info && (
+                <Grid container spacing={0}>
+                    <Grid size={{ xs: 12 }}>
+                        <Box sx={{ pt: 2 }}>
+                            <Box sx={{ width: '100%' }}>
+                                <QueryProgressBar queryInfoBase={queryStatus.info} />
+                            </Box>
+
+                            {queryStatus.ended ? (
+                                <Grid container spacing={3}>
+                                    <Grid size={{ xs: 12, md: 12 }}>
+                                        <Box sx={{ pt: 2 }}>
+                                            <Box
+                                                ref={containerRef}
+                                                sx={{ width: '100%', height: '80vh', border: '1px solid #ccc' }}
+                                            >
+                                                {stage ? (
+                                                    <ReactFlow
+                                                        nodes={nodes}
+                                                        edges={edges}
+                                                        onNodesChange={onNodesChange}
+                                                        onEdgesChange={onEdgesChange}
+                                                        nodeTypes={nodeTypes}
+                                                        minZoom={0.1}
+                                                        proOptions={{ hideAttribution: true }}
+                                                        defaultViewport={{ x: 200, y: 20, zoom: 0.8 }}
+                                                    >
+                                                        <HelpMessage
+                                                            layoutDirection={layoutDirection}
+                                                            onLayoutDirectionChange={setLayoutDirection}
+                                                            additionalContent={
+                                                                <Box sx={{ mt: 2 }}>
+                                                                    <FormControl size="small" sx={{ minWidth: 200 }}>
+                                                                        <InputLabel sx={smallFormControlSx}>
+                                                                            Stage
+                                                                        </InputLabel>
+                                                                        <Select
+                                                                            label="Stage"
+                                                                            sx={smallFormControlSx}
+                                                                            MenuProps={smallDropdownMenuPropsSx}
+                                                                            value={stagePlanId}
+                                                                            onChange={handleStageIdChange}
+                                                                        >
+                                                                            {stagePlanIds.map((stageId) => (
+                                                                                <MenuItem key={stageId} value={stageId}>
+                                                                                    {stageId}
+                                                                                </MenuItem>
+                                                                            ))}
+                                                                        </Select>
+                                                                    </FormControl>
+                                                                </Box>
+                                                            }
+                                                        />
+                                                    </ReactFlow>
+                                                ) : (
+                                                    <Alert severity="error">Stage not found.</Alert>
+                                                )}
+                                            </Box>
+                                        </Box>
+                                    </Grid>
+                                </Grid>
+                            ) : (
+                                <>
+                                    <Box sx={{ width: '100%', mt: 1 }}>
+                                        <Alert severity="info">
+                                            Operator graph will appear automatically when query completes.
+                                        </Alert>
+                                    </Box>
+                                </>
+                            )}
+                        </Box>
+                    </Grid>
+                </Grid>
+            )}
+        </>
+    )
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/HelpMessage.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/HelpMessage.tsx
@@ -18,9 +18,10 @@ import { LayoutDirectionType } from './types'
 interface IHelpMessageProps {
     layoutDirection: LayoutDirectionType
     onLayoutDirectionChange: (layoutDirection: LayoutDirectionType) => void
+    additionalContent?: React.ReactNode
 }
 
-export const HelpMessage = ({ layoutDirection, onLayoutDirectionChange }: IHelpMessageProps) => {
+export const HelpMessage = ({ layoutDirection, onLayoutDirectionChange, additionalContent }: IHelpMessageProps) => {
     const handleLayoutChange = (_event: React.MouseEvent<HTMLElement>, newDirection: LayoutDirectionType | null) => {
         if (newDirection !== null) {
             onLayoutDirectionChange(newDirection)
@@ -64,6 +65,8 @@ export const HelpMessage = ({ layoutDirection, onLayoutDirectionChange }: IHelpM
                     <Typography variant="caption">Horizontal</Typography>
                 </ToggleButton>
             </ToggleButtonGroup>
+
+            {additionalContent}
         </Box>
     )
 }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StageOperatorNode.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StageOperatorNode.tsx
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Box, Card, CardContent, Grid2 as Grid, Typography } from '@mui/material'
+import { Handle, Position } from '@xyflow/react'
+import { STAGE_OPERATOR_NODE_WIDTH } from './layout'
+import { QueryStageOperatorSummary } from '../../api/webapp/api.ts'
+import {
+    formatCount,
+    formatDataSize,
+    formatDuration,
+    parseAndFormatDataSize,
+    parseDataSize,
+    parseDuration,
+} from '../../utils/utils.ts'
+import { LayoutDirectionType } from './types.ts'
+
+export interface IStageOperatorNodeProps {
+    data: {
+        label: string
+        stats: QueryStageOperatorSummary
+        layoutDirection: LayoutDirectionType
+    }
+}
+
+/**
+ * Represents individual execution operators within a pipeline (e.g., TableScan, Filter, Join, Aggregate).
+ * These are the building blocks that show performance metrics and represent specific operations
+ * that process data within a pipeline during query execution.
+ *
+ * Features:
+ * - Displays the operator type (label) and detailed performance statistics
+ * - Shows execution metrics (CPU time, wall time, input/output data rates, driver counts)
+ * - Positioned as child nodes within StagePipelineNode containers
+ * - Connected via edges showing data flow between operators in the pipeline
+ */
+export const StageOperatorNode = (props: IStageOperatorNodeProps) => {
+    const { label, layoutDirection, stats } = props.data
+
+    const getTotalWallTime = (stats: QueryStageOperatorSummary) => {
+        return (
+            (parseDuration(stats.addInputWall) || 0) +
+            (parseDuration(stats.getOutputWall) || 0) +
+            (parseDuration(stats.finishWall) || 0) +
+            (parseDuration(stats.blockedWall) || 0)
+        )
+    }
+
+    const getTotalCpuTime = (stats: QueryStageOperatorSummary) => {
+        return (
+            (parseDuration(stats.addInputCpu) || 0) +
+            (parseDuration(stats.getOutputCpu) || 0) +
+            (parseDuration(stats.finishCpu) || 0)
+        )
+    }
+
+    const totalWallTime = getTotalWallTime(stats)
+    const totalCpuTime = getTotalCpuTime(stats)
+
+    const rowInputRate = totalWallTime === 0 ? 0 : stats.inputPositions / (totalWallTime / 1000.0)
+    const byteInputRate = totalWallTime === 0 ? 0 : (parseDataSize(stats.inputDataSize) || 0) / (totalWallTime / 1000.0)
+
+    return (
+        <Box>
+            <Card
+                elevation={6}
+                sx={{
+                    border: '1px solid grey',
+                    width: STAGE_OPERATOR_NODE_WIDTH,
+                }}
+            >
+                <CardContent sx={{ p: 1 }}>
+                    <Grid container spacing={1} sx={{ p: 1, textAlign: 'center' }}>
+                        <Grid size={{ xs: 12 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {label}
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 12 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                {formatCount(rowInputRate) + ' rows/s (' + formatDataSize(byteInputRate) + '/s)'}
+                            </Typography>
+                        </Grid>
+                    </Grid>
+
+                    <Grid container spacing={1}>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Output
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {formatCount(stats.outputPositions) +
+                                    ' rows (' +
+                                    parseAndFormatDataSize(stats.outputDataSize) +
+                                    ')'}
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Drivers
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {stats.totalDrivers}
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                CPU time
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {formatDuration(totalCpuTime)}
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Wall time
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {formatDuration(totalWallTime)}
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Blocked
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {formatDuration(parseDuration(stats.blockedWall) || 0)}
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Input
+                            </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {formatCount(stats.inputPositions) +
+                                    ' rows (' +
+                                    parseAndFormatDataSize(stats.inputDataSize) +
+                                    ')'}
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                </CardContent>
+            </Card>
+
+            <Handle
+                style={{ opacity: 0 }}
+                id="handle-target"
+                type="target"
+                position={layoutDirection === 'BT' ? Position.Bottom : Position.Right}
+            />
+            <Handle
+                style={{ opacity: 0 }}
+                id="handle-source"
+                type="source"
+                position={layoutDirection === 'BT' ? Position.Top : Position.Left}
+            />
+        </Box>
+    )
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StagePipelineNode.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StagePipelineNode.tsx
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Box, Card, CardHeader, Typography } from '@mui/material'
+import {
+    STAGE_PIPELINE_NODE_WIDTH,
+    STAGE_PIPELINE_NODE_PADDING_TOP,
+    STAGE_OPERATOR_NODE_HEIGHT,
+    STAGE_OPERATOR_NODE_GAP,
+} from './layout.ts'
+import { LayoutDirectionType } from './types.ts'
+
+export interface IStagePipelineNodeProps {
+    data: {
+        label: string
+        nrOfNodes: number
+        layoutDirection: LayoutDirectionType
+    }
+}
+
+/**
+ * Container nodes representing a pipeline within a given stage in the stage performance flow.
+ * StagePipelineNodes serve as organizational units that group multiple StageOperatorNodes
+ * and coordinate operators that execute together in the same pipeline.
+ *
+ * Features:
+ * - Contains and organizes multiple StageOperatorNode components within its boundaries
+ * - Displays pipeline identifier and manages spatial layout of child operators
+ * - Provides visual grouping for operators that share the same execution pipeline
+ * - Positioned alongside other pipelines within the stage performance visualization
+ */
+export const StagePipelineNode = (props: IStagePipelineNodeProps) => {
+    const { label, nrOfNodes, layoutDirection } = props.data
+
+    return (
+        <Box>
+            <Card
+                elevation={3}
+                sx={{
+                    border: '1px solid #e0e0e0',
+                    borderRadius: 2,
+                    width: layoutDirection === 'BT' ? STAGE_PIPELINE_NODE_WIDTH : STAGE_PIPELINE_NODE_WIDTH * nrOfNodes,
+                    height:
+                        layoutDirection === 'BT'
+                            ? STAGE_PIPELINE_NODE_PADDING_TOP +
+                              nrOfNodes * STAGE_OPERATOR_NODE_HEIGHT +
+                              nrOfNodes * STAGE_OPERATOR_NODE_GAP
+                            : STAGE_PIPELINE_NODE_PADDING_TOP + STAGE_OPERATOR_NODE_HEIGHT + STAGE_OPERATOR_NODE_GAP,
+                    backgroundColor: 'action.hover',
+                }}
+            >
+                <CardHeader
+                    title={
+                        <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '1rem' }}>
+                            {label}
+                        </Typography>
+                    }
+                    sx={{ pb: 1, mr: 1 }}
+                />
+            </Card>
+        </Box>
+    )
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/flowUtils.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/flowUtils.ts
@@ -12,9 +12,31 @@
  * limitations under the License.
  */
 import { MarkerType, type Edge, type Node } from '@xyflow/react'
-import { QueryStage, QueryStages, QueryStagePlan } from '../../api/webapp/api'
+import { QueryStage, QueryStages, QueryStageNodeInfo, QueryStageOperatorSummary } from '../../api/webapp/api'
 import { formatRows, parseAndFormatDataSize } from '../../utils/utils'
 import { IFlowElements, IPlanFragmentNodeInfo, IPlanNodeProps, LayoutDirectionType } from './types'
+
+// Constants for ID generation
+const ID_PREFIXES = {
+    PIPELINE: 'pipeline-',
+    OPERATOR: 'operator-',
+    STAGE: 'stage-',
+    NODE: 'node-',
+} as const
+
+const ID_SEPARATORS = {
+    OPERATOR: '-operator-',
+    STAGE: '-stage-',
+} as const
+
+// ID Generation Helper Functions
+const IdGenerator = {
+    pipeline: (key: number | string): string => `${ID_PREFIXES.PIPELINE}${key}`,
+    operator: (pipelineId: string, operatorId: string): string => `${pipelineId}${ID_SEPARATORS.OPERATOR}${operatorId}`,
+    stage: (key: string): string => `${ID_PREFIXES.STAGE}${key}`,
+    node: (key: string): string => `${ID_PREFIXES.NODE}${key}`,
+    edge: (source: string, target: string): string => `${source}-${target}`,
+}
 
 export const parseRemoteSources = (sourceFragmentIds: string | undefined): string[] => {
     if (!sourceFragmentIds || sourceFragmentIds.trim() === '[]') {
@@ -33,7 +55,7 @@ export const createEdge = (
         remoteEdge?: { targetStageId: string }
     } = {}
 ): Edge => ({
-    id: `${source}-${target}`,
+    id: IdGenerator.edge(source, target),
     source,
     target,
     markerEnd: options.hasArrow ? { type: MarkerType.ArrowClosed } : undefined,
@@ -49,7 +71,7 @@ export const createPlanFragmentNode = (
     stageNodeInfo: IPlanFragmentNodeInfo,
     layoutDirection: LayoutDirectionType
 ): Node => ({
-    id: `stage-${key}`,
+    id: IdGenerator.stage(key),
     type: 'planFragmentNode',
     position: { x: 0, y: 0 },
     data: {
@@ -64,7 +86,7 @@ export const createPlanFragmentNode = (
 export const createChildNode = (stageId: string, key: string, node: IPlanNodeProps, index: number): Node => {
     const remoteSources = parseRemoteSources(node.descriptor?.['sourceFragmentIds'])
     return {
-        id: `node-${key}`,
+        id: IdGenerator.node(key),
         type: remoteSources.length === 0 ? 'operatorNode' : 'remoteExchangeNode',
         position: { x: 0, y: 0 },
         draggable: false,
@@ -78,8 +100,45 @@ export const createChildNode = (stageId: string, key: string, node: IPlanNodePro
     }
 }
 
+export const createStagePipelineNode = (
+    key: string,
+    nrOfNodes: number,
+    index: number,
+    layoutDirection: LayoutDirectionType
+): Node => ({
+    id: IdGenerator.pipeline(key),
+    type: 'stagePipelineNode',
+    position: { x: 0, y: 0 },
+    data: {
+        index,
+        label: `Pipeline ${key}`,
+        nrOfNodes,
+        layoutDirection,
+    },
+})
+
+export const createStageOperatorNode = (
+    pipelineId: string,
+    key: string,
+    operatorSummary: QueryStageOperatorSummary,
+    index: number,
+    layoutDirection: LayoutDirectionType
+): Node => ({
+    id: IdGenerator.operator(pipelineId, key),
+    type: 'stageOperatorNode',
+    position: { x: 0, y: 0 },
+    data: {
+        index,
+        label: operatorSummary.operatorType,
+        stats: operatorSummary,
+        layoutDirection,
+    },
+    parentId: pipelineId,
+    extent: 'parent',
+})
+
 export const flattenNode = (
-    rootNodeInfo: QueryStagePlan['root'],
+    rootNodeInfo: QueryStageNodeInfo,
     node: IPlanNodeProps,
     result: Map<string, IPlanNodeProps>
 ) => {
@@ -116,11 +175,11 @@ export const getPlanFragmentsNodeInfo = (queryStages: QueryStages): Map<string, 
     return planFragments
 }
 
-export const getFlowElements = (queryStages: QueryStages, layoutDirection: LayoutDirectionType): IFlowElements => {
+export const getPlanFlowElements = (queryStages: QueryStages, layoutDirection: LayoutDirectionType): IFlowElements => {
     const stages: Map<string, IPlanFragmentNodeInfo> = getPlanFragmentsNodeInfo(queryStages)
 
     const nodes: Node[] = Array.from(stages).flatMap(([key, planFragmentNodeInfo]) => {
-        const stageId: string = `stage-${key}`
+        const stageId: string = IdGenerator.stage(key)
         const stageNode: Node = createPlanFragmentNode(key, planFragmentNodeInfo, layoutDirection)
         const childNodes: Node[] = Array.from(planFragmentNodeInfo.nodes).map(([childKey, node], childIndex) =>
             createChildNode(stageId, childKey, node, childIndex)
@@ -129,17 +188,17 @@ export const getFlowElements = (queryStages: QueryStages, layoutDirection: Layou
     })
 
     const edges: Edge[] = Array.from(stages).flatMap(([key, planFragmentNodeInfo]) => {
-        const stageId: string = `stage-${key}`
+        const stageId: string = IdGenerator.stage(key)
         return Array.from(planFragmentNodeInfo.nodes).flatMap(([nodeKey, node]) => {
-            const targetNodeId: string = `node-${nodeKey}`
+            const targetNodeId: string = IdGenerator.node(nodeKey)
 
             const sourceEdges: Edge[] = Array.from(node.sources || []).map((sourceKey) =>
-                createEdge(`node-${sourceKey}`, targetNodeId, { hasArrow: true })
+                createEdge(IdGenerator.node(sourceKey), targetNodeId, { hasArrow: true })
             )
 
             const remoteSources = parseRemoteSources(node.descriptor?.['sourceFragmentIds'])
             const remoteSourceEdges: Edge[] = remoteSources.map((sourceKey) =>
-                createEdge(`stage-${sourceKey}`, targetNodeId, {
+                createEdge(IdGenerator.stage(sourceKey), targetNodeId, {
                     isAnimated: true,
                     hasArrow: false,
                     label: `${parseAndFormatDataSize(planFragmentNodeInfo.stageStats.outputDataSize)} / ${formatRows(planFragmentNodeInfo.stageStats.outputPositions)}`,
@@ -149,6 +208,247 @@ export const getFlowElements = (queryStages: QueryStages, layoutDirection: Layou
 
             return [...sourceEdges, ...remoteSourceEdges]
         })
+    })
+
+    return { nodes, edges }
+}
+
+const getStageNodeChildren = (nodeInfo: QueryStageNodeInfo) => {
+    // TODO: Remove this function by migrating StageDetail to use node JSON representation
+    switch (nodeInfo['@type']) {
+        case 'aggregation':
+        case 'assignUniqueId':
+        case 'cacheData':
+        case 'delete':
+        case 'distinctLimit':
+        case 'dynamicFilterSource':
+        case 'explainAnalyze':
+        case 'filter':
+        case 'groupId':
+        case 'limit':
+        case 'markDistinct':
+        case 'mergeProcessor':
+        case 'mergeWriter':
+        case 'output':
+        case 'project':
+        case 'rowNumber':
+        case 'sample':
+        case 'scalar':
+        case 'simpleTableExecuteNode':
+        case 'sort':
+        case 'tableCommit':
+        case 'tableExecute':
+        case 'tableWriter':
+        case 'topN':
+        case 'topNRanking':
+        case 'unnest':
+        case 'window':
+            return [nodeInfo.source]
+        case 'join':
+            return [nodeInfo.left, nodeInfo.right]
+        case 'semiJoin':
+            return [nodeInfo.source, nodeInfo.filteringSource]
+        case 'spatialJoin':
+            return [nodeInfo.left, nodeInfo.right]
+        case 'indexJoin':
+            return [nodeInfo.probeSource, nodeInfo.indexSource]
+        case 'exchange':
+        case 'intersect':
+        case 'union':
+            return nodeInfo.sources
+        case 'indexSource':
+        case 'loadCachedData':
+        case 'refreshMaterializedView':
+        case 'remoteSource':
+        case 'tableDelete':
+        case 'tableScan':
+        case 'tableUpdate':
+        case 'values':
+            break
+        default:
+            console.log('NOTE: Unhandled PlanNode: ' + nodeInfo['@type'])
+    }
+
+    return []
+}
+
+const computeStageOperatorMap = (stage: QueryStage) => {
+    const operatorMap: Map<string, QueryStageOperatorSummary[]> = new Map()
+
+    for (const operator of stage.stageStats.operatorSummaries ?? []) {
+        const list = operatorMap.get(operator.planNodeId) ?? []
+        list.push(operator)
+        operatorMap.set(operator.planNodeId, list)
+    }
+
+    return operatorMap
+}
+
+// Group operators by pipeline ID
+const groupOperatorsByPipeline = (operators: QueryStageOperatorSummary[]): Map<number, QueryStageOperatorSummary[]> => {
+    const pipelineOperators = new Map<number, QueryStageOperatorSummary[]>()
+    operators.forEach((operator) => {
+        if (!pipelineOperators.has(operator.pipelineId)) {
+            pipelineOperators.set(operator.pipelineId, [])
+        }
+        pipelineOperators.get(operator.pipelineId)!.push(operator)
+    })
+    return pipelineOperators
+}
+
+const sortOperatorsInPipeline = (operators: QueryStageOperatorSummary[]): QueryStageOperatorSummary[] => {
+    return operators.map((operator) => ({ ...operator })).sort((a, b) => a.operatorId - b.operatorId)
+}
+
+const chainOperators = (operators: QueryStageOperatorSummary[]): QueryStageOperatorSummary => {
+    if (operators.length === 0) throw new Error('Cannot chain empty operators array')
+
+    let currentOperator = operators[0]
+    operators.slice(1).forEach((nextOperator) => {
+        nextOperator.child = currentOperator
+        currentOperator = nextOperator
+    })
+
+    return currentOperator // Return sink operator (last in chain)
+}
+
+const mergeSourceResults = (
+    sourceResults: Map<number, QueryStageOperatorSummary>,
+    pipelineResults: Map<number, QueryStageOperatorSummary>
+): Map<number, QueryStageOperatorSummary> => {
+    const merged = new Map(pipelineResults)
+    sourceResults.forEach((operator, pipelineId) => {
+        if (!merged.has(pipelineId)) {
+            merged.set(pipelineId, operator)
+        }
+    })
+    return merged
+}
+
+const processNodeOperators = (
+    nodeOperators: QueryStageOperatorSummary[],
+    sourceResults: Map<number, QueryStageOperatorSummary>
+): Map<number, QueryStageOperatorSummary> => {
+    const pipelineGroups = groupOperatorsByPipeline(nodeOperators)
+    const pipelineResults = new Map<number, QueryStageOperatorSummary>()
+
+    pipelineGroups.forEach((operators, pipelineId) => {
+        const sortedOperators = sortOperatorsInPipeline(operators)
+
+        // Link with source results if available
+        if (sourceResults.has(pipelineId)) {
+            const sourceResult = sourceResults.get(pipelineId)
+            if (sourceResult && sortedOperators.length > 0) {
+                sortedOperators[0].child = sourceResult
+            }
+        }
+
+        const chainedOperator = chainOperators(sortedOperators)
+        pipelineResults.set(pipelineId, chainedOperator)
+    })
+
+    return pipelineResults
+}
+
+const computeStageOperatorGraphs = (
+    stageNodeInfo: QueryStageNodeInfo,
+    operatorMap: Map<string, QueryStageOperatorSummary[]>
+): Map<number, QueryStageOperatorSummary> => {
+    const sources = getStageNodeChildren(stageNodeInfo).filter((source) => source)
+
+    // Recursively process all source nodes
+    const sourceResults = new Map<number, QueryStageOperatorSummary>()
+    sources.forEach((source) => {
+        const sourceResult = computeStageOperatorGraphs(source, operatorMap)
+        sourceResult.forEach((operator, pipelineId) => {
+            if (sourceResults.has(pipelineId)) {
+                console.error('Multiple sources for', stageNodeInfo['@type'], 'had the same pipeline ID')
+                return
+            }
+            sourceResults.set(pipelineId, operator)
+        })
+    })
+
+    // Get operators for current node
+    const nodeOperators = operatorMap.get(stageNodeInfo.id)
+    if (!nodeOperators || nodeOperators.length === 0) {
+        return sourceResults
+    }
+
+    // Process current node's operators
+    const pipelineResults = processNodeOperators(nodeOperators, sourceResults)
+
+    // Merge with source results
+    return mergeSourceResults(sourceResults, pipelineResults)
+}
+
+const countOperatorChainDepth = (stageOperatorSummary: QueryStageOperatorSummary | null): number => {
+    if (!stageOperatorSummary || !stageOperatorSummary.child) return 0
+    return countOperatorChainDepth(stageOperatorSummary.child) + 1
+}
+
+const generateStageOperatorNodes = (
+    pipelineId: string,
+    stageOperatorSummary: QueryStageOperatorSummary,
+    childIndex: number,
+    layoutDirection: LayoutDirectionType
+): Node[] => {
+    const nodes = [
+        createStageOperatorNode(
+            pipelineId,
+            stageOperatorSummary.operatorId.toString(),
+            stageOperatorSummary,
+            childIndex,
+            layoutDirection
+        ),
+    ]
+
+    if (stageOperatorSummary.child) {
+        nodes.push(
+            ...generateStageOperatorNodes(pipelineId, stageOperatorSummary.child, childIndex + 1, layoutDirection)
+        )
+    }
+
+    return nodes
+}
+
+// Generate stage operator edges recursively
+const generateStageOperatorEdges = (pipelineId: string, stageOperatorSummary: QueryStageOperatorSummary): Edge[] => {
+    const edges: Edge[] = []
+
+    if (stageOperatorSummary.child) {
+        const source: string = IdGenerator.operator(pipelineId, stageOperatorSummary.child.operatorId.toString())
+        const target: string = IdGenerator.operator(pipelineId, stageOperatorSummary.operatorId.toString())
+        edges.push(createEdge(source, target, { hasArrow: true }))
+        edges.push(...generateStageOperatorEdges(pipelineId, stageOperatorSummary.child))
+    }
+
+    return edges
+}
+
+export const getStagePerformanceFlowElements = (
+    stage: QueryStage,
+    layoutDirection: LayoutDirectionType
+): IFlowElements => {
+    const operatorMap = computeStageOperatorMap(stage)
+    const operatorGraphs = computeStageOperatorGraphs(stage.plan.root, operatorMap)
+
+    const nodes: Node[] = Array.from(operatorGraphs).flatMap(([key, stageOperatorSummary]) => {
+        const pipelineId: string = IdGenerator.pipeline(key)
+        const pipelineStageNode: Node = createStagePipelineNode(
+            key.toString(),
+            countOperatorChainDepth(stageOperatorSummary) + 1,
+            key,
+            layoutDirection
+        )
+        const childNodes: Node[] = generateStageOperatorNodes(pipelineId, stageOperatorSummary, 0, layoutDirection)
+
+        return [pipelineStageNode, ...childNodes]
+    })
+
+    const edges: Edge[] = Array.from(operatorGraphs).flatMap(([key, stageOperatorSummary]) => {
+        const pipelineId: string = IdGenerator.pipeline(key)
+        return generateStageOperatorEdges(pipelineId, stageOperatorSummary)
     })
 
     return { nodes, edges }


### PR DESCRIPTION
## Description

Add Query stage performance flow page to the preview UI. Partially addressing https://github.com/trinodb/trino/issues/22697

## Additional context and related issues

Retains the same functionality as the existing web UI, enhanced with the updated layout, design, and user experience.

**Additional features not available in the current UI**
* Draggable stage nodes
* Toggle for horizontal and vertical auto layout

## Screenshots

<img width="1615" height="1208" alt="image" src="https://github.com/user-attachments/assets/29c6ed21-6e83-4e02-882d-e386aad6d99c" />

<img width="1617" height="1215" alt="image" src="https://github.com/user-attachments/assets/e3b1d6be-0b0f-43a8-91a3-bde603fc44d8" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Preview Web UI
* Add query live plan flow page to Preview Web UI. ({issue}`26610`)
```