### PR TITLE
Fix physical input read time metric for text files

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSource.java
@@ -41,16 +41,18 @@ public class LinePageSource
     private final LineDeserializer deserializer;
     private final LineBuffer lineBuffer;
     private final Location filePath;
+    private final long smallFileReadTimeNanos;
 
     private final PageBuilder pageBuilder;
     private long completedPositions;
 
-    public LinePageSource(LineReader lineReader, LineDeserializer deserializer, LineBuffer lineBuffer, Location filePath)
+    public LinePageSource(LineReader lineReader, LineDeserializer deserializer, LineBuffer lineBuffer, Location filePath, long smallFileReadTimeNanos)
     {
         this.lineReader = requireNonNull(lineReader, "lineReader is null");
         this.deserializer = requireNonNull(deserializer, "deserializer is null");
         this.lineBuffer = requireNonNull(lineBuffer, "lineBuffer is null");
         this.filePath = requireNonNull(filePath, "filePath is null");
+        this.smallFileReadTimeNanos = smallFileReadTimeNanos;
 
         this.pageBuilder = new PageBuilder(deserializer.getTypes());
     }
@@ -105,7 +107,7 @@ public class LinePageSource
     @Override
     public long getReadTimeNanos()
     {
-        return lineReader.getReadTimeNanos();
+        return smallFileReadTimeNanos + lineReader.getReadTimeNanos();
     }
 
     @Override


### PR DESCRIPTION
## Description
Time taken for reading small files was not included in the existing implementation


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix physical input read time metric for tables containing text files. ({issue}`26612`)
```
