### PR TITLE
Pre-populate file length and modifiedTime in LinePageSourceFactory

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineReaderFactory.java
@@ -13,6 +13,8 @@
  */
 package io.trino.hive.formats.line;
 
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 
 import java.io.IOException;
@@ -31,4 +33,10 @@ public interface LineReaderFactory
             int headerCount,
             int footerCount)
             throws IOException;
+
+    TrinoInputFile newInputFile(
+            TrinoFileSystem trinoFileSystem,
+            Location path,
+            long estimatedFileSize,
+            long fileModifiedTime);
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReaderFactory.java
@@ -14,6 +14,8 @@
 package io.trino.hive.formats.line.sequence;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.hive.formats.line.FooterAwareLineReader;
 import io.trino.hive.formats.line.LineBuffer;
@@ -74,6 +76,14 @@ public class SequenceFileReaderFactory
             lineReader = new FooterAwareLineReader(lineReader, footerCount, this::createLineBuffer);
         }
         return lineReader;
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(TrinoFileSystem trinoFileSystem, Location path, long estimatedFileSize, long fileModifiedTime)
+    {
+        // estimatedFileSize contains padded bytes
+        // The reads in SequenceFileReader rely on non-padded file length to detect end of file
+        return trinoFileSystem.newInputFile(path);
     }
 
     private void skipHeader(LineReader lineReader, int headerCount)

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
@@ -14,6 +14,8 @@
 package io.trino.hive.formats.line.text;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.hive.formats.compression.Codec;
 import io.trino.hive.formats.compression.CompressionKind;
@@ -25,6 +27,7 @@ import io.trino.hive.formats.line.LineReaderFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
 
@@ -99,6 +102,12 @@ public class TextLineReaderFactory
                 throw throwable;
             }
         }
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(TrinoFileSystem trinoFileSystem, Location path, long estimatedFileSize, long fileModifiedTime)
+    {
+        return trinoFileSystem.newInputFile(path, estimatedFileSize, Instant.ofEpochMilli(fileModifiedTime));
     }
 
     private void skipHeader(LineReader lineReader, int headerCount)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
@@ -96,7 +96,7 @@ public abstract class LinePageSourceFactory
 
         checkArgument(acidInfo.isEmpty(), "Acid is not supported");
 
-        return Optional.of(projectColumnDereferences(columns, baseColumns -> createPageSource(session, path, start, length, estimatedFileSize, schema, baseColumns)));
+        return Optional.of(projectColumnDereferences(columns, baseColumns -> createPageSource(session, path, start, length, estimatedFileSize, fileModifiedTime, schema, baseColumns)));
     }
 
     private ConnectorPageSource createPageSource(
@@ -105,6 +105,7 @@ public abstract class LinePageSourceFactory
             long start,
             long length,
             long estimatedFileSize,
+            long fileModifiedTime,
             Schema schema,
             List<HiveColumnHandle> columns)
     {
@@ -129,7 +130,7 @@ public abstract class LinePageSourceFactory
         }
 
         TrinoFileSystem trinoFileSystem = fileSystemFactory.create(session);
-        TrinoInputFile inputFile = trinoFileSystem.newInputFile(path);
+        TrinoInputFile inputFile = lineReaderFactory.newInputFile(trinoFileSystem, path, estimatedFileSize, fileModifiedTime);
         try {
             // buffer file if small
             long smallFileReadTimeNanos = 0;


### PR DESCRIPTION
## Description
Allows S3InputStream#closeStream to avoid aborting connections 
Allows filsystem cache to avoid extra FS operations

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
