### PR TITLE
Support reading from CSV tables with null escape and quote characters

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/csv/CsvDeserializer.java
@@ -60,7 +60,11 @@ public class CsvDeserializer
         checkArgument(separatorChar != '\0', "Separator cannot be the null character (ASCII 0)");
         checkArgument(separatorChar != quoteChar, "Separator and quote character cannot be the same");
         checkArgument(separatorChar != escapeChar, "Separator and escape character cannot be the same");
-        checkArgument(quoteChar != escapeChar, "Quote and escape character cannot be the same");
+
+        // Quote and escape character can be the same when both are the null character (quoting and escaping are disabled)
+        if (quoteChar != '\0' || escapeChar != '\0') {
+            checkArgument(quoteChar != escapeChar, "Quote and escape character cannot be the same");
+        }
         this.separatorChar = separatorChar;
         this.quoteChar = quoteChar;
         this.escapeChar = escapeChar;

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/csv/TestCsvFormat.java
@@ -126,6 +126,10 @@ public class TestCsvFormat
         assertTrinoHiveByteForByte(true, Arrays.asList("f**", "b*r", "b*z"), Optional.of('\t'), Optional.of('*'), Optional.of('#'));
         assertTrinoHiveByteForByte(false, Arrays.asList("f**", "b*r", "b*z"), Optional.of('\t'), Optional.of('*'), Optional.of('\0'));
 
+        // If both the quote character and escape character are `\0` then quoting and escaping is simply disabled, even if this would cause output that does not round trip
+        assertTrinoHiveByteForByte(true, Arrays.asList("foo", "bar", "baz"), Optional.of('\t'), Optional.of('\0'), Optional.of('\0'));
+        assertTrinoHiveByteForByte(false, Arrays.asList("f\t\t", "\tbar\t", "baz"), Optional.of('\t'), Optional.of('\0'), Optional.of('\0'));
+
         // These cases don't round trip, because Hive uses different default escape characters for serialization and deserialization.
         // For serialization the pipe character is escaped with a quote char, but for deserialization escape character is the backslash character
         assertTrinoHiveByteForByte(false, Arrays.asList("|", "a", "b"), Optional.empty(), Optional.of('|'), Optional.empty());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Similar to #16754 and #18952, this change maintains a bug from the original OpenCSV reader in the native CSV reader. In the original [CSVParser logic ](https://github.com/quux00/opencsv/blob/master/src/au/com/bytecode/opencsv/CSVParser.java#L203-L209), quote/escape characters were not considered equivalent if either of the characters was the null character `\0`. This is because setting both of them to the null character would disable both quoting and escaping and this is a valid configuration.

Even though writing with the quote and escape character being disabled could lead to data not round tripping, this support should be maintained in the native CSV reader implementation.


## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix incompatibility issue with Hive OpenCSV to allow reading from tables with quoting and escaping disabled   ({issue}`issuenumber`)
```
