### PR TITLE
Remove cleanExtraOutputFiles for FTE inserts in iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
-import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 
 import java.util.List;
@@ -36,7 +35,6 @@ public record IcebergWritableTableHandle(
         String outputPath,
         IcebergFileFormat fileFormat,
         Map<String, String> storageProperties,
-        RetryMode retryMode,
         Map<String, String> fileIoProperties)
         implements ConnectorInsertTableHandle, ConnectorOutputTableHandle
 {
@@ -50,7 +48,6 @@ public record IcebergWritableTableHandle(
         requireNonNull(outputPath, "outputPath is null");
         requireNonNull(fileFormat, "fileFormat is null");
         storageProperties = ImmutableMap.copyOf(requireNonNull(storageProperties, "storageProperties is null"));
-        requireNonNull(retryMode, "retryMode is null");
         checkArgument(partitionsSpecsAsJson.containsKey(partitionSpecId), "partitionSpecId missing from partitionSpecs");
         fileIoProperties = ImmutableMap.copyOf(requireNonNull(fileIoProperties, "fileIoProperties is null"));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergOptimizeHandle.java
@@ -34,8 +34,7 @@ public record IcebergOptimizeHandle(
         List<TrinoSortField> sortOrder,
         IcebergFileFormat fileFormat,
         Map<String, String> tableStorageProperties,
-        DataSize maxScannedFileSize,
-        boolean retriesEnabled)
+        DataSize maxScannedFileSize)
         implements IcebergProcedureHandle
 {
     public IcebergOptimizeHandle


### PR DESCRIPTION
## Description
Clean up of any unused files from failed tasks should be left to remove_orphan_files procedure
Directory listing is a time consuming operation, adding it to the commit of every write operation adds latency


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Improve performance of writes on iceberg tables when task retries are enabled. ({issue}`26620`)
```
