### PR TITLE
Fix : Remove disabling autocommit from Vertica connector

### DIFF
--- a/plugin/trino-vertica/src/main/java/io/trino/plugin/vertica/VerticaClient.java
+++ b/plugin/trino-vertica/src/main/java/io/trino/plugin/vertica/VerticaClient.java
@@ -174,7 +174,6 @@ public class VerticaClient
     public PreparedStatement getPreparedStatement(Connection connection, String sql, Optional<Integer> columnCount)
             throws SQLException
     {
-        connection.setAutoCommit(false);
         PreparedStatement statement = connection.prepareStatement(sql);
         statement.setFetchSize(1000);
         return statement;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Vertica client documentation
https://github.com/vertica/vertica-python#autocommit
 does not require autocommit to be disabled to use fetchsize, and its presence leads to errors on recent Vertica versions (25.3) during cumulative high load: queries start failing with INSUFFICIENT RESOURCES- EXCEEDED_TIME_LIMIT, while Vertica still shows opened sessions with no lines having been read.

Removing the line fixes all the issues with the latest Vertica version and does not cause regressions in our production workloads.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix https://github.com/trinodb/trino/issues/26622
```
