### PR TITLE
Enable Vertica test and change Vertica image location and version

### DIFF
--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestingVerticaServer.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/TestingVerticaServer.java
@@ -39,7 +39,7 @@ public class TestingVerticaServer
         extends JdbcDatabaseContainer<TestingVerticaServer>
 {
     public static final String LATEST_VERSION = "25.3.0-0";
-    public static final String DEFAULT_VERSION = "25.3.0-0";
+    public static final String DEFAULT_VERSION = "11.0.0-0";
 
     public static final Integer PORT = 5433;
 


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

A follow-up on https://github.com/trinodb/trino/pull/26456
Opentext acquired Microfocus and recently changed the location of vertical images.
I have updated image location and latest version, and re-enabled Vertica connector tests


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
