### PR TITLE
Fix copyWithAppendedNull for RowBlock with startOffset

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -249,13 +249,13 @@ public final class RowBlock
     {
         boolean[] newRowIsNull;
         if (rowIsNull != null) {
-            newRowIsNull = Arrays.copyOf(rowIsNull, positionCount + 1);
+            newRowIsNull = Arrays.copyOf(rowIsNull, startOffset + positionCount + 1);
         }
         else {
-            newRowIsNull = new boolean[positionCount + 1];
+            newRowIsNull = new boolean[startOffset + positionCount + 1];
         }
         // mark the (new) last element as null
-        newRowIsNull[positionCount] = true;
+        newRowIsNull[startOffset + positionCount] = true;
 
         Block[] newBlocks = new Block[fieldBlocks.length];
         for (int i = 0; i < fieldBlocks.length; i++) {


### PR DESCRIPTION
## Description
Fix a bug in #26405 where the ```rowIsNull``` is not properly adjusted with startOffset when calculating ```newRowIsNull```.

This change is not user visible for the purposes of release notes because the earlier bug has not yet been released.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

