### PR TITLE
Collect page source metrics before finish

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PageSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageSourceOperator.java
@@ -92,17 +92,18 @@ public class PageSourceOperator
     public Page getOutput()
     {
         SourcePage sourcePage = pageSource.getNextSourcePage();
-        if (sourcePage == null) {
-            return null;
+        Page page = null;
+        if (sourcePage != null) {
+            page = sourcePage.getPage();
         }
-
-        Page page = sourcePage.getPage();
 
         // update operator stats
         long endCompletedBytes = pageSource.getCompletedBytes();
         long endReadTimeNanos = pageSource.getReadTimeNanos();
-        operatorContext.recordPhysicalInputWithTiming(endCompletedBytes - completedBytes, page.getPositionCount(), endReadTimeNanos - readTimeNanos);
-        operatorContext.recordProcessedInput(page.getSizeInBytes(), page.getPositionCount());
+        long positionCount = page == null ? 0 : page.getPositionCount();
+        long sizeInBytes = page == null ? 0 : page.getSizeInBytes();
+        operatorContext.recordPhysicalInputWithTiming(endCompletedBytes - completedBytes, positionCount, endReadTimeNanos - readTimeNanos);
+        operatorContext.recordProcessedInput(sizeInBytes, positionCount);
         completedBytes = endCompletedBytes;
         readTimeNanos = endReadTimeNanos;
 

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -324,19 +324,19 @@ public class ScanFilterAndProjectOperator
             SourcePage page = pageSource.getNextSourcePage();
             pageSourceMemoryContext.setBytes(pageSource.getMemoryUsage());
 
+            // update operator stats
+            processedPositions += page == null ? 0 : page.getPositionCount();
+            physicalBytes = pageSource.getCompletedBytes();
+            physicalPositions = pageSource.getCompletedPositions().orElse(processedPositions);
+            readTimeNanos = pageSource.getReadTimeNanos();
+            metrics = pageSource.getMetrics();
+
             if (page == null) {
                 if (pageSource.isFinished()) {
                     return ProcessState.finished();
                 }
                 return ProcessState.yielded();
             }
-
-            // update operator stats
-            processedPositions += page.getPositionCount();
-            physicalBytes = pageSource.getCompletedBytes();
-            physicalPositions = pageSource.getCompletedPositions().orElse(processedPositions);
-            readTimeNanos = pageSource.getReadTimeNanos();
-            metrics = pageSource.getMetrics();
 
             return ProcessState.ofResult(page);
         }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -263,21 +263,22 @@ public class TableScanOperator
         Page page = null;
         if (sourcePage != null) {
             page = sourcePage.getPage();
-
-            // update operator stats
-            long endCompletedBytes = source.getCompletedBytes();
-            long endReadTimeNanos = source.getReadTimeNanos();
-            long positionCount = page.getPositionCount();
-            long endCompletedPositions = source.getCompletedPositions().orElse(completedPositions + positionCount);
-            operatorContext.recordPhysicalInputWithTiming(
-                    endCompletedBytes - completedBytes,
-                    endCompletedPositions - completedPositions,
-                    endReadTimeNanos - readTimeNanos);
-            operatorContext.recordProcessedInput(page.getSizeInBytes(), positionCount);
-            completedBytes = endCompletedBytes;
-            completedPositions = endCompletedPositions;
-            readTimeNanos = endReadTimeNanos;
         }
+
+        // update operator stats
+        long endCompletedBytes = source.getCompletedBytes();
+        long endReadTimeNanos = source.getReadTimeNanos();
+        long positionCount = page == null ? 0 : page.getPositionCount();
+        long sizeInBytes = page == null ? 0 : page.getSizeInBytes();
+        long endCompletedPositions = source.getCompletedPositions().orElse(completedPositions + positionCount);
+        operatorContext.recordPhysicalInputWithTiming(
+                endCompletedBytes - completedBytes,
+                endCompletedPositions - completedPositions,
+                endReadTimeNanos - readTimeNanos);
+        operatorContext.recordProcessedInput(sizeInBytes, positionCount);
+        completedBytes = endCompletedBytes;
+        completedPositions = endCompletedPositions;
+        readTimeNanos = endReadTimeNanos;
 
         // updating memory usage should happen after page is loaded.
         memoryContext.setBytes(source.getMemoryUsage());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -9087,6 +9087,9 @@ public abstract class BaseHiveConnectorTest
         assertExplainAnalyze(
                 "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation WHERE nationkey > 1",
                 "Physical input time: .*s");
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation WHERE nationkey > 1000",
+                "Physical input time: .*s");
     }
 
     @Test


### PR DESCRIPTION
## Description
Current code was missing updating metrics like physical input size and physical input read time when the page source produces only a null Page. 
This scenario is encountered when splits are pruned by predicate pushdown to parquet


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix physical input metrics in output of EXPLAIN ANALYZE. ({issue}`26637`)
```
