### PR TITLE
Add query stage pipeline operator task statistics to Preview Web UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
@@ -282,6 +282,11 @@ export interface QueryStageStats {
     operatorSummaries: QueryStageOperatorSummary[]
 }
 
+export interface QueryPipeline {
+    pipelineId: number
+    operatorSummaries: QueryStageOperatorSummary[]
+}
+
 export interface QueryTask {
     lastHeartbeat: string
     needsPlan: boolean
@@ -303,6 +308,7 @@ export interface QueryTask {
         totalCpuTime: string
         totalScheduledTime: string
         userMemoryReservation: string
+        pipelines: QueryPipeline[]
         firstStartTime: string
         lastStartTime: string
         lastEndTime: string

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StageOperatorNode.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StageOperatorNode.tsx
@@ -11,14 +11,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Box, Card, CardContent, Grid2 as Grid, Typography } from '@mui/material'
+
+import { useState } from 'react'
+import {
+    Box,
+    Card,
+    CardContent,
+    CardActionArea,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    Grid2 as Grid,
+    Typography,
+    DialogActions,
+    Button,
+    TableContainer,
+    Table,
+    TableBody,
+    TableRow,
+    TableCell,
+    Divider,
+} from '@mui/material'
+import { BarChart } from '@mui/x-charts/BarChart'
 import { Handle, Position } from '@xyflow/react'
 import { STAGE_OPERATOR_NODE_WIDTH } from './layout'
-import { QueryStageOperatorSummary } from '../../api/webapp/api.ts'
+import { QueryStageOperatorSummary, QueryTask } from '../../api/webapp/api.ts'
 import {
     formatCount,
     formatDataSize,
     formatDuration,
+    getTaskNumber,
     parseAndFormatDataSize,
     parseDataSize,
     parseDuration,
@@ -29,6 +51,7 @@ export interface IStageOperatorNodeProps {
     data: {
         label: string
         stats: QueryStageOperatorSummary
+        tasks: QueryTask[]
         layoutDirection: LayoutDirectionType
     }
 }
@@ -45,7 +68,8 @@ export interface IStageOperatorNodeProps {
  * - Connected via edges showing data flow between operators in the pipeline
  */
 export const StageOperatorNode = (props: IStageOperatorNodeProps) => {
-    const { label, layoutDirection, stats } = props.data
+    const { label, layoutDirection, stats, tasks } = props.data
+    const [showModal, setShowModal] = useState<boolean>(false)
 
     const getTotalWallTime = (stats: QueryStageOperatorSummary) => {
         return (
@@ -64,11 +88,230 @@ export const StageOperatorNode = (props: IStageOperatorNodeProps) => {
         )
     }
 
+    const getOperatorTasks = (
+        tasks: QueryTask[],
+        operatorSummary: QueryStageOperatorSummary
+    ): QueryStageOperatorSummary[] => {
+        return tasks
+            .slice()
+            .sort((taskA, taskB) => getTaskNumber(taskA.taskStatus.taskId) - getTaskNumber(taskB.taskStatus.taskId))
+            .flatMap(
+                (task) =>
+                    task.stats.pipelines
+                        .filter((pipeline) => pipeline.pipelineId === operatorSummary.pipelineId)
+                        .flatMap((pipeline) =>
+                            pipeline.operatorSummaries.filter(
+                                (operator) => operator.operatorId === operatorSummary.operatorId
+                            )
+                        ) ?? []
+            )
+    }
+
+    const operatorTasks = getOperatorTasks(tasks, stats)
     const totalWallTime = getTotalWallTime(stats)
     const totalCpuTime = getTotalCpuTime(stats)
 
     const rowInputRate = totalWallTime === 0 ? 0 : stats.inputPositions / (totalWallTime / 1000.0)
     const byteInputRate = totalWallTime === 0 ? 0 : (parseDataSize(stats.inputDataSize) || 0) / (totalWallTime / 1000.0)
+
+    const rowOutputRate = totalWallTime === 0 ? 0 : stats.outputPositions / totalWallTime
+    const byteOutputRate =
+        totalWallTime === 0 ? 0 : (parseDataSize(stats.outputDataSize) || 0) / (totalWallTime / 1000.0)
+
+    const handleClick = () => {
+        setShowModal(true)
+    }
+
+    const handleModalClose = () => {
+        setShowModal(false)
+    }
+
+    const StatisticRow = ({
+        label,
+        operatorTasks,
+        supplier,
+        valueFormatter,
+    }: {
+        label: string
+        supplier: (stats: QueryStageOperatorSummary) => number | null
+        operatorTasks: QueryStageOperatorSummary[]
+        valueFormatter: typeof formatCount | typeof formatDataSize | typeof formatDuration
+    }) => {
+        const xAxisData: string[] = operatorTasks.map((_, index) => `Task ${index}`)
+        const seriesData = operatorTasks.map((operatorTask) => supplier(operatorTask))
+
+        return (
+            <>
+                <Grid size={{ xs: 3 }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ flex: 1, textAlign: 'right', pr: 2 }}>
+                        {label}
+                    </Typography>
+                </Grid>
+                <Grid size={{ xs: 9 }}>
+                    <BarChart
+                        xAxis={[
+                            {
+                                scaleType: 'band',
+                                data: xAxisData,
+                                disableTicks: true,
+                            },
+                        ]}
+                        yAxis={[{ disableTicks: true }]}
+                        series={[
+                            {
+                                data: seriesData,
+                                valueFormatter: valueFormatter,
+                            },
+                        ]}
+                        margin={{ left: 6, right: 0, top: 10, bottom: 6 }}
+                        height={60}
+                    />
+                </Grid>
+            </>
+        )
+    }
+
+    const OperatorDetailDialog = () => (
+        <Dialog open={showModal} onClose={handleModalClose} maxWidth="md" fullWidth>
+            <DialogTitle>
+                <Typography variant="subtitle2" component="span">
+                    Pipeline {stats.pipelineId}
+                </Typography>
+                <Typography variant="h6" component="span" color="text.secondary" display="block">
+                    {stats.operatorType}
+                </Typography>
+            </DialogTitle>
+            <DialogContent>
+                <Grid container spacing={3}>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <TableContainer>
+                            <Table aria-label="simple table">
+                                <TableBody>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Input</TableCell>
+                                        <TableCell>
+                                            {formatCount(stats.inputPositions) +
+                                                ' rows (' +
+                                                parseAndFormatDataSize(stats.inputDataSize) +
+                                                ')'}
+                                        </TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Input rate</TableCell>
+                                        <TableCell>
+                                            {formatCount(rowInputRate) +
+                                                ' rows/s (' +
+                                                formatDataSize(byteInputRate) +
+                                                '/s)'}
+                                        </TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Output</TableCell>
+                                        <TableCell>
+                                            {formatCount(stats.outputPositions) +
+                                                ' rows (' +
+                                                parseAndFormatDataSize(stats.outputDataSize) +
+                                                ')'}
+                                        </TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Output rate</TableCell>
+                                        <TableCell>
+                                            {formatCount(rowOutputRate) +
+                                                ' rows/s (' +
+                                                formatDataSize(byteOutputRate) +
+                                                '/s)'}
+                                        </TableCell>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <TableContainer>
+                            <Table aria-label="simple table">
+                                <TableBody>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>CPU time</TableCell>
+                                        <TableCell>{formatDuration(totalCpuTime)}</TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Wall time</TableCell>
+                                        <TableCell>{formatDuration(totalWallTime)}</TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Blocked</TableCell>
+                                        <TableCell>{formatDuration(parseDuration(stats.blockedWall) || 0)}</TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Drivers</TableCell>
+                                        <TableCell>{stats.totalDrivers}</TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell sx={{ fontWeight: 'bold' }}>Tasks</TableCell>
+                                        <TableCell>{operatorTasks.length}</TableCell>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    </Grid>
+                    <Grid size={{ xs: 3 }}>
+                        <Box sx={{ pt: 2 }}>
+                            <Typography variant="h6">Statistics</Typography>
+                            <Divider />
+                        </Box>
+                    </Grid>
+                    <Grid size={{ xs: 9 }}>
+                        <Box sx={{ pt: 2 }}>
+                            <Typography variant="h6">Tasks</Typography>
+                            <Divider />
+                        </Box>
+                    </Grid>
+                    <StatisticRow
+                        label="Total CPU time"
+                        operatorTasks={operatorTasks}
+                        supplier={getTotalCpuTime}
+                        valueFormatter={formatDuration}
+                    />
+                    <StatisticRow
+                        label="Total wall time"
+                        supplier={getTotalWallTime}
+                        operatorTasks={operatorTasks}
+                        valueFormatter={formatDuration}
+                    />
+                    <StatisticRow
+                        label="Input rows"
+                        operatorTasks={operatorTasks}
+                        supplier={(stats: QueryStageOperatorSummary) => stats.inputPositions}
+                        valueFormatter={formatCount}
+                    />
+                    <StatisticRow
+                        label="Input data size"
+                        operatorTasks={operatorTasks}
+                        supplier={(stats: QueryStageOperatorSummary) => parseDataSize(stats.inputDataSize)}
+                        valueFormatter={formatDataSize}
+                    />
+                    <StatisticRow
+                        label="Output rows"
+                        operatorTasks={operatorTasks}
+                        supplier={(stats: QueryStageOperatorSummary) => stats.outputPositions}
+                        valueFormatter={formatCount}
+                    />
+                    <StatisticRow
+                        label="Output data size"
+                        operatorTasks={operatorTasks}
+                        supplier={(stats: QueryStageOperatorSummary) => parseDataSize(stats.outputDataSize)}
+                        valueFormatter={formatDataSize}
+                    />
+                </Grid>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleModalClose} autoFocus>
+                    Close
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
 
     return (
         <Box>
@@ -79,90 +322,94 @@ export const StageOperatorNode = (props: IStageOperatorNodeProps) => {
                     width: STAGE_OPERATOR_NODE_WIDTH,
                 }}
             >
-                <CardContent sx={{ p: 1 }}>
-                    <Grid container spacing={1} sx={{ p: 1, textAlign: 'center' }}>
-                        <Grid size={{ xs: 12 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {label}
-                            </Typography>
+                <CardActionArea onClick={handleClick}>
+                    <CardContent sx={{ p: 1 }}>
+                        <Grid container spacing={1} sx={{ p: 1, textAlign: 'center' }}>
+                            <Grid size={{ xs: 12 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {label}
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 12 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    {formatCount(rowInputRate) + ' rows/s (' + formatDataSize(byteInputRate) + '/s)'}
+                                </Typography>
+                            </Grid>
                         </Grid>
-                        <Grid size={{ xs: 12 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                {formatCount(rowInputRate) + ' rows/s (' + formatDataSize(byteInputRate) + '/s)'}
-                            </Typography>
-                        </Grid>
-                    </Grid>
 
-                    <Grid container spacing={1}>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                Output
-                            </Typography>
+                        <Grid container spacing={1}>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Output
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {formatCount(stats.outputPositions) +
+                                        ' rows (' +
+                                        parseAndFormatDataSize(stats.outputDataSize) +
+                                        ')'}
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Drivers
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {stats.totalDrivers}
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    CPU time
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {formatDuration(totalCpuTime)}
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Wall time
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {formatDuration(totalWallTime)}
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Blocked
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {formatDuration(parseDuration(stats.blockedWall) || 0)}
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Input
+                                </Typography>
+                            </Grid>
+                            <Grid size={{ xs: 6 }}>
+                                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                    {formatCount(stats.inputPositions) +
+                                        ' rows (' +
+                                        parseAndFormatDataSize(stats.inputDataSize) +
+                                        ')'}
+                                </Typography>
+                            </Grid>
                         </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {formatCount(stats.outputPositions) +
-                                    ' rows (' +
-                                    parseAndFormatDataSize(stats.outputDataSize) +
-                                    ')'}
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                Drivers
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {stats.totalDrivers}
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                CPU time
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {formatDuration(totalCpuTime)}
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                Wall time
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {formatDuration(totalWallTime)}
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                Blocked
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {formatDuration(parseDuration(stats.blockedWall) || 0)}
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                Input
-                            </Typography>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                {formatCount(stats.inputPositions) +
-                                    ' rows (' +
-                                    parseAndFormatDataSize(stats.inputDataSize) +
-                                    ')'}
-                            </Typography>
-                        </Grid>
-                    </Grid>
-                </CardContent>
+                    </CardContent>
+                </CardActionArea>
             </Card>
+
+            <OperatorDetailDialog />
 
             <Handle
                 style={{ opacity: 0 }}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/flowUtils.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/flowUtils.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 import { MarkerType, type Edge, type Node } from '@xyflow/react'
-import { QueryStage, QueryStages, QueryStageNodeInfo, QueryStageOperatorSummary } from '../../api/webapp/api'
+import { QueryStage, QueryStages, QueryStageNodeInfo, QueryStageOperatorSummary, QueryTask } from '../../api/webapp/api'
 import { formatRows, parseAndFormatDataSize } from '../../utils/utils'
 import { IFlowElements, IPlanFragmentNodeInfo, IPlanNodeProps, LayoutDirectionType } from './types'
 
@@ -121,6 +121,7 @@ export const createStageOperatorNode = (
     pipelineId: string,
     key: string,
     operatorSummary: QueryStageOperatorSummary,
+    tasks: QueryTask[],
     index: number,
     layoutDirection: LayoutDirectionType
 ): Node => ({
@@ -131,6 +132,7 @@ export const createStageOperatorNode = (
         index,
         label: operatorSummary.operatorType,
         stats: operatorSummary,
+        tasks,
         layoutDirection,
     },
     parentId: pipelineId,
@@ -390,6 +392,7 @@ const countOperatorChainDepth = (stageOperatorSummary: QueryStageOperatorSummary
 const generateStageOperatorNodes = (
     pipelineId: string,
     stageOperatorSummary: QueryStageOperatorSummary,
+    tasks: QueryTask[],
     childIndex: number,
     layoutDirection: LayoutDirectionType
 ): Node[] => {
@@ -398,6 +401,7 @@ const generateStageOperatorNodes = (
             pipelineId,
             stageOperatorSummary.operatorId.toString(),
             stageOperatorSummary,
+            tasks,
             childIndex,
             layoutDirection
         ),
@@ -405,7 +409,13 @@ const generateStageOperatorNodes = (
 
     if (stageOperatorSummary.child) {
         nodes.push(
-            ...generateStageOperatorNodes(pipelineId, stageOperatorSummary.child, childIndex + 1, layoutDirection)
+            ...generateStageOperatorNodes(
+                pipelineId,
+                stageOperatorSummary.child,
+                tasks,
+                childIndex + 1,
+                layoutDirection
+            )
         )
     }
 
@@ -441,7 +451,13 @@ export const getStagePerformanceFlowElements = (
             key,
             layoutDirection
         )
-        const childNodes: Node[] = generateStageOperatorNodes(pipelineId, stageOperatorSummary, 0, layoutDirection)
+        const childNodes: Node[] = generateStageOperatorNodes(
+            pipelineId,
+            stageOperatorSummary,
+            stage.tasks,
+            0,
+            layoutDirection
+        )
 
         return [pipelineStageNode, ...childNodes]
     })

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
@@ -113,6 +113,10 @@ export function getTaskIdSuffix(taskId: string): string {
     return taskId.slice(taskId.indexOf('.') + 1, taskId.length)
 }
 
+export function getTaskNumber(taskId: string): number {
+    return Number.parseInt(getTaskIdSuffix(getTaskIdSuffix(taskId)))
+}
+
 export function getHostname(url: string): string {
     let hostname = new URL(url).hostname
     if (hostname.charAt(0) === '[' && hostname.charAt(hostname.length - 1) === ']') {
@@ -145,7 +149,11 @@ export function precisionRound(n: number | null): string {
     return Math.round(n).toString()
 }
 
-export function formatDuration(duration: number): string {
+export function formatDuration(duration: number | null): string {
+    if (duration == null) {
+        return ''
+    }
+
     let unit = 'ms'
     if (duration > 1000) {
         duration /= 1000


### PR DESCRIPTION
## Description

Add pipeline operator task statistics for the stage performance flows to the preview UI. Statistics popup is now shown when clicking on operator tasks within pipelines. Partially addressing https://github.com/trinodb/trino/issues/22697

## Additional context and related issues

Retains the same functionality as the existing web UI, enhanced with the updated layout, design, and user experience.

## Screenshots

<img width="1867" height="1218" alt="image" src="https://github.com/user-attachments/assets/52b95c07-3c5b-46b6-afba-d2a0620f1a71" />

<img width="1875" height="1212" alt="image" src="https://github.com/user-attachments/assets/bacaf2ef-5c05-456f-a17e-b9cde0929df7" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Preview Web UI
* Add query live plan flow page to Preview Web UI. ({issue}`26638`)
```