### PR TITLE
Add query splits timeline view to Preview Web UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/package-lock.json
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.8.2",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
+        "react-calendar-timeline": "^0.30.0-beta.3",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.3.0",
         "react-syntax-highlighter": "^15.6.1",
@@ -1219,6 +1220,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@interactjs/types": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
+      "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -3313,6 +3321,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -3514,6 +3528,12 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
     "node_modules/clsx": {
@@ -3888,6 +3908,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4022,6 +4049,15 @@
       "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/element-resize-detector": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.4.tgz",
+      "integrity": "sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==",
+      "license": "MIT",
+      "dependencies": {
+        "batch-processor": "1.0.0"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5168,6 +5204,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/interactjs": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
+      "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@interactjs/types": "1.10.27"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5855,6 +5901,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6390,6 +6442,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar-timeline": {
+      "version": "0.30.0-beta.3",
+      "resolved": "https://registry.npmjs.org/react-calendar-timeline/-/react-calendar-timeline-0.30.0-beta.3.tgz",
+      "integrity": "sha512-TckfoAzJvK5FEQo83vejbVtSDX1XNxcFmfCq92lMZKQiEuzbk7adcQi+ySlL9uSZ1ulFZS6YMAS6rzEGsVtZ2A==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.5.1",
+        "element-resize-detector": "^1.2.4",
+        "lodash": "^4.17.21",
+        "memoize-one": "^6.0.0"
+      },
+      "peerDependencies": {
+        "dayjs": ">=1.10.0",
+        "interactjs": "1.10.27",
+        "react": "^18 || ^19.0.0-rc-66855b96-20241106",
+        "react-dom": "^18 || ^19.0.0-rc-66855b96-20241106"
       }
     },
     "node_modules/react-dom": {

--- a/core/trino-web-ui/src/main/resources/webapp-preview/package.json
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/package.json
@@ -27,6 +27,7 @@
     "axios": "^1.8.2",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
+    "react-calendar-timeline": "^0.30.0-beta.3",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.3.0",
     "react-syntax-highlighter": "^15.6.1",

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
@@ -303,6 +303,10 @@ export interface QueryTask {
         totalCpuTime: string
         totalScheduledTime: string
         userMemoryReservation: string
+        firstStartTime: string
+        lastStartTime: string
+        lastEndTime: string
+        endTime: string
     }
     taskStatus: {
         nodeId: string

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
@@ -13,13 +13,13 @@
  */
 import React, { ReactNode, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
-import { Alert, Box, Divider, Grid2 as Grid, Tabs, Tab, Typography } from '@mui/material'
+import { Box, Divider, Grid2 as Grid, Tabs, Tab, Typography } from '@mui/material'
 import { QueryJson } from './QueryJson'
 import { QueryReferences } from './QueryReferences'
 import { QueryLivePlan } from './QueryLivePlan'
 import { QueryOverview } from './QueryOverview'
 import { QueryStagePerformance } from './QueryStagePerformance'
-import { Texts } from '../constant.ts'
+import { QuerySplitsTimeline } from './QuerySplitsTimeline'
 
 const tabValues = ['overview', 'livePlan', 'stagePerformance', 'splits', 'json', 'references'] as const
 type TabValue = (typeof tabValues)[number]
@@ -27,7 +27,7 @@ const tabComponentMap: Record<TabValue, ReactNode> = {
     overview: <QueryOverview />,
     livePlan: <QueryLivePlan />,
     stagePerformance: <QueryStagePerformance />,
-    splits: <Alert severity="error">{Texts.Error.NotImplemented}</Alert>,
+    splits: <QuerySplitsTimeline />,
     json: <QueryJson />,
     references: <QueryReferences />,
 }
@@ -61,7 +61,7 @@ export const QueryDetails = () => {
                                 <Tab value="overview" label="Overview" />
                                 <Tab value="livePlan" label="Live plan" />
                                 <Tab value="stagePerformance" label="Stage performance" />
-                                <Tab value="splits" label="Splits" disabled />
+                                <Tab value="splits" label="Splits" />
                                 <Tab value="json" label="JSON" />
                                 <Tab value="references" label="References" />
                             </Tabs>

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QuerySplitsTimeline.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QuerySplitsTimeline.tsx
@@ -1,0 +1,345 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useParams } from 'react-router-dom'
+import { useEffect, useRef, useState, type ComponentProps, type HTMLAttributes, type Ref } from 'react'
+import { Alert, Box, CircularProgress, Divider, Grid2 as Grid, Tooltip, Typography } from '@mui/material'
+import { blue, green, purple, teal } from '@mui/material/colors'
+import { darken, useTheme } from '@mui/material/styles'
+import Timeline, { type TimelineGroupBase, type TimelineItemBase } from 'react-calendar-timeline'
+import { queryStatusApi, QueryStage, QueryStatusInfo, QueryTask } from '../api/webapp/api.ts'
+import { Texts } from '../constant.ts'
+import { ApiResponse } from '../api/base.ts'
+import { getTaskIdSuffix } from '../utils/utils'
+import { QueryProgressBar } from './QueryProgressBar'
+import 'react-calendar-timeline/dist/style.css'
+
+interface IQueryStatus {
+    info: QueryStatusInfo | null
+}
+
+type SplitTimelineItem = TimelineItemBase<number> & {
+    color: string
+    bgColor: string
+    borderColor: string
+}
+
+type TimelineItemRenderer = NonNullable<ComponentProps<typeof Timeline>['itemRenderer']>
+type TimelineItemRendererProps = Parameters<TimelineItemRenderer>[0]
+
+export const QuerySplitsTimeline = () => {
+    const { queryId } = useParams()
+    const theme = useTheme()
+    const initialQueryStatus: IQueryStatus = {
+        info: null,
+    }
+
+    const [queryStatus, setQueryStatus] = useState<IQueryStatus>(initialQueryStatus)
+
+    const [loading, setLoading] = useState<boolean>(true)
+    const [error, setError] = useState<string | null>(null)
+    const queryStatusRef = useRef(queryStatus)
+
+    useEffect(() => {
+        queryStatusRef.current = queryStatus
+    }, [queryStatus])
+
+    useEffect(() => {
+        const runLoop = () => {
+            const queryEnded = !!queryStatusRef.current.info?.finalQueryInfo
+            if (!queryEnded) {
+                getQueryStatus()
+                setTimeout(runLoop, 3000)
+            }
+        }
+
+        if (queryId) {
+            queryStatusRef.current = initialQueryStatus
+        }
+
+        runLoop()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [queryId])
+
+    const getQueryStatus = () => {
+        if (queryId) {
+            queryStatusApi(queryId).then((apiResponse: ApiResponse<QueryStatusInfo>) => {
+                setLoading(false)
+                if (apiResponse.status === 200 && apiResponse.data) {
+                    setQueryStatus({
+                        info: apiResponse.data,
+                    })
+                    setError(null)
+                } else {
+                    setError(`${Texts.Error.Communication} ${apiResponse.status}: ${apiResponse.message}`)
+                }
+            })
+        }
+    }
+
+    const renderSplitsTimeline = (stages: QueryStage[]) => {
+        const tasks = stages
+            .flatMap((stage) => stage.tasks)
+            .map((task: QueryTask) => ({
+                taskId: getTaskIdSuffix(task.taskStatus.taskId),
+                time: {
+                    create: task.stats.createTime,
+                    firstStart: task.stats.firstStartTime,
+                    lastStart: task.stats.lastStartTime,
+                    lastEnd: task.stats.lastEndTime,
+                    end: task.stats.endTime,
+                },
+            }))
+
+        const groups: TimelineGroupBase[] = []
+        const items: SplitTimelineItem[] = []
+        const timelineColors =
+            theme.palette.mode === 'light'
+                ? {
+                      created: teal[300],
+                      firstSplitStarted: purple[300],
+                      lastSplitStarted: blue[300],
+                      lastSplitEnded: green[300],
+                  }
+                : {
+                      created: teal[700],
+                      firstSplitStarted: purple[600],
+                      lastSplitStarted: blue[600],
+                      lastSplitEnded: green[600],
+                  }
+        const legendEntries = [
+            { key: 'created', label: 'Task created', color: timelineColors.created },
+            { key: 'firstSplitStarted', label: 'First split started', color: timelineColors.firstSplitStarted },
+            { key: 'lastSplitStarted', label: 'Last split started', color: timelineColors.lastSplitStarted },
+            { key: 'lastSplitEnded', label: 'Last split ended', color: timelineColors.lastSplitEnded },
+        ]
+        const applyColorProps = (background: string) => ({
+            bgColor: background,
+            color: theme.palette.getContrastText(background),
+            borderColor: darken(background, 0.5),
+        })
+        for (let i = 0; i < tasks.length; i++) {
+            const task = tasks[i]
+            const stageId = task.taskId.substring(0, task.taskId.indexOf('.'))
+            const taskNumber = getTaskIdSuffix(task.taskId)
+
+            if (taskNumber === '0.0') {
+                groups.push({
+                    id: stageId,
+                    title: `Stage ${stageId}`,
+                })
+            }
+            items.push({
+                id: `${task.taskId} - created`,
+                group: stageId,
+                title: `${task.taskId} - created`,
+                start_time: new Date(task.time.create).getTime(),
+                end_time: new Date(task.time.firstStart).getTime(),
+                ...applyColorProps(timelineColors.created),
+            })
+            items.push({
+                id: `${task.taskId} - first split started`,
+                group: stageId,
+                title: `${task.taskId} - first split started`,
+                start_time: new Date(task.time.firstStart).getTime(),
+                end_time: new Date(task.time.lastStart).getTime(),
+                ...applyColorProps(timelineColors.firstSplitStarted),
+            })
+            items.push({
+                id: `${task.taskId} - last split started`,
+                group: stageId,
+                title: `${task.taskId} - last split started`,
+                start_time: new Date(task.time.lastStart).getTime(),
+                end_time: new Date(task.time.lastEnd).getTime(),
+                ...applyColorProps(timelineColors.lastSplitStarted),
+            })
+            items.push({
+                id: `${task.taskId} - last split ended`,
+                group: stageId,
+                title: `${task.taskId} - last split ended`,
+                start_time: new Date(task.time.lastEnd).getTime(),
+                end_time: new Date(task.time.end).getTime(),
+                ...applyColorProps(timelineColors.lastSplitEnded),
+            })
+        }
+
+        if (items.length === 0) {
+            return <Alert severity="info">No split timeline data available.</Alert>
+        }
+
+        const timelineStartTime = items.reduce((min, item) => Math.min(min, item.start_time), items[0].start_time)
+        const timelineEndTime = items.reduce((max, item) => Math.max(max, item.end_time), items[0].end_time)
+
+        const itemRenderer: TimelineItemRenderer = ({ item, itemContext, getItemProps }: TimelineItemRendererProps) => {
+            const splitItem = item as SplitTimelineItem
+            const itemProps = getItemProps({
+                style: {
+                    color: splitItem.color,
+                    backgroundColor: splitItem.bgColor,
+                    borderColor: splitItem.borderColor,
+                    borderStyle: 'solid',
+                    borderWidth: 1,
+                    borderRadius: 4,
+                    borderLeftWidth: 1,
+                    borderRightWidth: 1,
+                },
+            })
+            const { key: itemKey, title, ref: itemRef, ...restItemProps } = itemProps
+            // Drop the react-calendar-timeline provided title to avoid default tooltips; MUI tooltip will handle hover info.
+            delete (restItemProps as { title?: string }).title
+            const timeFormatter = new Intl.DateTimeFormat(undefined, {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+            })
+            const formattedStart = timeFormatter.format(new Date(splitItem.start_time))
+            const formattedEnd = timeFormatter.format(new Date(splitItem.end_time))
+            return (
+                <Tooltip
+                    placement="top"
+                    title={
+                        <Grid container spacing={0.5} textAlign="center" justifyContent="center">
+                            <Grid size={{ xs: 12 }}>
+                                <Typography variant="subtitle2">{title}</Typography>
+                            </Grid>
+                            <Grid size={{ xs: 12 }}>
+                                <Typography variant="caption">{`${formattedStart} – ${formattedEnd}`}</Typography>
+                            </Grid>
+                        </Grid>
+                    }
+                >
+                    <Box
+                        key={itemKey ?? splitItem.id}
+                        ref={itemRef as Ref<HTMLDivElement>}
+                        {...(restItemProps as HTMLAttributes<HTMLDivElement>)}
+                    >
+                        <Box
+                            style={{
+                                height: itemContext.dimensions.height,
+                                overflow: 'hidden',
+                                paddingLeft: 3,
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                            }}
+                        >
+                            {itemContext.title}
+                        </Box>
+                    </Box>
+                </Tooltip>
+            )
+        }
+
+        return (
+            <Box
+                sx={{
+                    mt: 1,
+                    '& .react-calendar-timeline .rct-header-root': {
+                        backgroundColor:
+                            theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.background.paper,
+                        color: theme.palette.text.primary,
+                        borderBottomColor: theme.palette.divider,
+                    },
+                    '& .react-calendar-timeline .rct-dateHeader': {
+                        backgroundColor: theme.palette.background.default,
+                        color: theme.palette.text.secondary,
+                        borderLeftColor: theme.palette.divider,
+                        borderBottomColor: theme.palette.divider,
+                    },
+                    '& .react-calendar-timeline .rct-dateHeader-primary': {
+                        backgroundColor: theme.palette.background.paper,
+                        color: theme.palette.text.primary,
+                        borderColor: theme.palette.divider,
+                    },
+                    '& .react-calendar-timeline .rct-vertical-lines .rct-vl': {
+                        borderLeftColor: theme.palette.divider, // darker/custom color
+                        // borderLeft: 'none', // or comment this out and use display:'none' to remove
+                    },
+                }}
+            >
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center', mb: 1 }}>
+                    {legendEntries.map((entry) => (
+                        <Box key={entry.key} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Box
+                                sx={{
+                                    width: 14,
+                                    height: 14,
+                                    borderRadius: 0.5,
+                                    bgcolor: entry.color,
+                                    border: '1px solid',
+                                    borderColor: theme.palette.divider,
+                                }}
+                            />
+                            <Typography variant="body2" color="text.secondary">
+                                {entry.label}
+                            </Typography>
+                        </Box>
+                    ))}
+                </Box>
+
+                <Timeline
+                    groups={groups}
+                    items={items}
+                    defaultTimeStart={timelineStartTime}
+                    defaultTimeEnd={timelineEndTime}
+                    itemRenderer={itemRenderer}
+                    minZoom={60 * 1000}
+                    itemHeightRatio={0.65}
+                    itemTouchSendsClick={false}
+                    canMove={false}
+                    canResize={false}
+                    stackItems
+                    // traditionalZoom
+                />
+            </Box>
+        )
+    }
+
+    return (
+        <>
+            {loading && <CircularProgress />}
+            {error && <Alert severity="error">{Texts.Error.QueryNotFound}</Alert>}
+
+            {!loading && !error && queryStatus.info && (
+                <Grid container spacing={0}>
+                    <Grid size={{ xs: 12 }}>
+                        <Box sx={{ pt: 2 }}>
+                            <Box sx={{ width: '100%' }}>
+                                <QueryProgressBar queryInfoBase={queryStatus.info} />
+                            </Box>
+
+                            {queryStatus.info?.stages.stages ? (
+                                <Grid container spacing={3}>
+                                    <Grid size={{ xs: 12, md: 12 }}>
+                                        <Box sx={{ pt: 2 }}>
+                                            <Typography variant="h6">Splits timeline</Typography>
+                                            <Divider />
+                                        </Box>
+                                        {renderSplitsTimeline(queryStatus.info.stages.stages)}
+                                    </Grid>
+                                </Grid>
+                            ) : (
+                                <>
+                                    <Box sx={{ width: '100%', mt: 1 }}>
+                                        <Alert severity="info">
+                                            Splits timeline will appear automatically when query starts running.
+                                        </Alert>
+                                    </Box>
+                                </>
+                            )}
+                        </Box>
+                    </Grid>
+                </Grid>
+            )}
+        </>
+    )
+}


### PR DESCRIPTION
## Description

Add Query splits timeline page to the preview UI. Partially addressing https://github.com/trinodb/trino/issues/22697

## Additional context and related issues

Retains the same functionality as the existing web UI, enhanced with the updated layout, design, and user experience.

## Screenshots

<img width="1654" height="838" alt="image" src="https://github.com/user-attachments/assets/626d4a38-5416-448d-8d12-fc963241aff8" />


<img width="1649" height="836" alt="image" src="https://github.com/user-attachments/assets/84dfe253-b6b5-4dfb-924a-1c12d0afffb9" />


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Preview Web UI
* Add query live plan flow page to Preview Web UI. ({issue}`26654`)
```