### PR TITLE
Improve distribution of splits with filesystem caching

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CachingHostAddressProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CachingHostAddressProvider.java
@@ -22,5 +22,12 @@ public interface CachingHostAddressProvider
     /**
      * Returns a lists of hosts which are preferred to cache the split with the given path.
      */
-    List<HostAddress> getHosts(String splitPath, List<HostAddress> defaultAddresses);
+    List<HostAddress> getHosts(String splitKey, List<HostAddress> defaultAddresses);
+
+    // Include offset and length in key to allow different splits belonging to the same file to be cached on different nodes
+    // This can help with avoiding hotspots when multiple splits are created from a file
+    static String getSplitKey(String splitPath, long offset, long length)
+    {
+        return splitPath + ":" + offset + ":" + length;
+    }
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/ConsistentHashingHostAddressProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/ConsistentHashingHostAddressProvider.java
@@ -60,9 +60,9 @@ public class ConsistentHashingHostAddressProvider
     }
 
     @Override
-    public List<HostAddress> getHosts(String splitPath, List<HostAddress> defaultAddresses)
+    public List<HostAddress> getHosts(String splitKey, List<HostAddress> defaultAddresses)
     {
-        return consistentHashRing.locate(splitPath, replicationFactor)
+        return consistentHashRing.locate(splitKey, replicationFactor)
                 .stream()
                 .map(TrinoNode::getHostAndPort)
                 .sorted(hostAddressComparator)

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/DefaultCachingHostAddressProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/DefaultCachingHostAddressProvider.java
@@ -21,7 +21,7 @@ public class DefaultCachingHostAddressProvider
         implements CachingHostAddressProvider
 {
     @Override
-    public List<HostAddress> getHosts(String splitPath, List<HostAddress> defaultAddresses)
+    public List<HostAddress> getHosts(String splitKey, List<HostAddress> defaultAddresses)
     {
         return defaultAddresses;
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -56,6 +56,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.filesystem.cache.CachingHostAddressProvider.getSplitKey;
 import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode.FULL_REFRESH;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getDynamicFilteringWaitTimeout;
@@ -328,7 +329,7 @@ public class DeltaLakeSplitManager
                     Optional.empty(),
                     addFileEntry.getModificationTime(),
                     addFileEntry.getDeletionVector(),
-                    cachingHostAddressProvider.getHosts(splitPath, ImmutableList.of()),
+                    cachingHostAddressProvider.getHosts(getSplitKey(splitPath, currentOffset, splitSize), ImmutableList.of()),
                     SplitWeight.fromProportion(clamp((double) splitSize / maxSplitSize, minimumAssignedSplitWeight, 1.0)),
                     statisticsPredicate,
                     partitionKeys));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -97,6 +97,7 @@ import static io.airlift.concurrent.MoreFutures.toCompletableFuture;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.filesystem.cache.CachingHostAddressProvider.getSplitKey;
 import static io.trino.plugin.iceberg.ExpressionConverter.isConvertibleToIcebergExpression;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
 import static io.trino.plugin.iceberg.IcebergExceptions.translateMetadataException;
@@ -730,7 +731,7 @@ public class IcebergSplitSource
                 SplitWeight.fromProportion(clamp(getSplitWeight(task), minimumAssignedSplitWeight, 1.0)),
                 taskWithDomain.fileStatisticsDomain(),
                 fileIoProperties,
-                cachingHostAddressProvider.getHosts(task.file().location(), ImmutableList.of()),
+                cachingHostAddressProvider.getHosts(getSplitKey(task.file().location(), task.start(), task.length()), ImmutableList.of()),
                 task.file().dataSequenceNumber());
     }
 


### PR DESCRIPTION
## Description
Allows multiple splits from a file to be scheduled on different nodes to reduce chances of a hotspot in the cluster


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg, Hive, Delta Lake
* Improve uniformity of load distribution among workers when filesystem caching is enabled. ({issue}`26672`)
```
