### PR TITLE
Fix(mongodb): bump test container to MongoDB 8.0 (#26526)

### DIFF
--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -23,9 +23,11 @@ public class MongoServer
 {
     private final MongoDBContainer dockerContainer;
 
+    private static final String MONGO_VERSION = "6.0";
+
     public MongoServer()
     {
-        this("4.2.0");
+        this(MONGO_VERSION);
     }
 
     public MongoServer(String mongoVersion)
@@ -33,7 +35,7 @@ public class MongoServer
         this.dockerContainer = new MongoDBContainer("mongo:" + mongoVersion)
                 .withStartupAttempts(3)
                 .withEnv("MONGO_INITDB_DATABASE", "tpch")
-                .withCommand("--bind_ip 0.0.0.0");
+                .withCommand("--bind_ip_all");
         this.dockerContainer.start();
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -23,7 +23,7 @@ public class MongoServer
 {
     private final MongoDBContainer dockerContainer;
 
-    private static final String MONGO_VERSION = "6.0";
+    private static final String MONGO_VERSION = "8.0";
 
     public MongoServer()
     {

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoLatestConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoLatestConnectorSmokeTest.java
@@ -15,14 +15,16 @@ package io.trino.plugin.mongodb;
 
 import io.trino.testing.QueryRunner;
 
-public class TestMongo4LatestConnectorSmokeTest
+public class TestMongoLatestConnectorSmokeTest
         extends BaseMongoConnectorSmokeTest
 {
+    private static final String MONGO_LATEST_IMAGE = "mongo:8.0";
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        MongoServer server = closeAfterClass(new MongoServer("4.4.1"));
+        MongoServer server = closeAfterClass(new MongoServer(MONGO_LATEST_IMAGE));
         return MongoQueryRunner.builder(server)
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoLatestConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoLatestConnectorSmokeTest.java
@@ -18,7 +18,7 @@ import io.trino.testing.QueryRunner;
 public class TestMongoLatestConnectorSmokeTest
         extends BaseMongoConnectorSmokeTest
 {
-    private static final String MONGO_LATEST_IMAGE = "mongo:8.0";
+    private static final String MONGO_LATEST_IMAGE = "8.0";
 
     @Override
     protected QueryRunner createQueryRunner()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Update the MongoDB test container used in `MongoServer` from `mongo:6.0`
to the latest stable `mongo:8.0`. This ensures that MongoDB connector
smoke tests run against a current version of MongoDB, aligning with
upstream support and avoiding test drift on deprecated releases.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
This change updates the MongoDB connector test environment to use the
latest stable `mongo:8.0` container. Running tests against a current
MongoDB release ensures early detection of compatibility issues and
avoids reliance on an older series that will eventually be unsupported.

Fixes #26526.

Relates to issue #26526 (MongoDB image bump).  
Local test run with Docker confirmed all `:trino-mongodb` tests pass.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## MongoDB connector
* Update test container to use MongoDB 8.0 for connector smoke tests. (#26526)