### PR TITLE
Add spooling shared secret key note

### DIFF
--- a/docs/src/main/sphinx/client/client-protocol.md
+++ b/docs/src/main/sphinx/client/client-protocol.md
@@ -74,6 +74,11 @@ protocol.spooling.enabled=true
 protocol.spooling.shared-secret-key=jxTKysfCBuMZtFqUf8UJDQ1w9ez8rynEJsJqgJf66u0=
 ```
 
+:::{note}
+The `protocol.spooling.shared-secret-key` property requires a 256-bit,
+base64-encoded secret key.
+:::
+
 Refer to [](prop-protocol-spooling) for further optional configuration.
 
 Suitable object storage systems for spooling are S3 and compatible systems,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add note on the `client-protocol.md` page explicitly stating that the `protocol.spooling.shared-secret-key` property requires a 256 bit, base64-encoded secret key.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
