### PR TITLE
Add support for row-level modification in Cassandra connector

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -42,11 +42,13 @@ import io.trino.spi.connector.NotFoundException;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.expression.Constant;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.ComputedStatistics;
@@ -78,6 +80,7 @@ import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.connector.RelationColumnsMetadata.forTable;
 import static io.trino.spi.connector.RelationCommentMetadata.forRelation;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
+import static io.trino.spi.connector.RowChangeParadigm.CHANGE_ONLY_UPDATED_COLUMNS;
 import static io.trino.spi.connector.SaveMode.REPLACE;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -290,6 +293,7 @@ public class CassandraMetadata
 
         String clusteringKeyPredicates = "";
         TupleDomain<ColumnHandle> unenforcedConstraint;
+        Boolean includesAllClusteringColumnsAndHasAllEqPredicates = null;
         if (partitionResult.unpartitioned() || partitionResult.indexedColumnPredicatePushdown()) {
             // When the filter is missing at least one of the partition keys or when the table is not partitioned,
             // use the raw unenforced constraint of the partitionResult
@@ -302,6 +306,7 @@ public class CassandraMetadata
                     partitionResult.unenforcedConstraint());
             clusteringKeyPredicates = clusteringPredicatesExtractor.getClusteringKeyPredicates();
             unenforcedConstraint = clusteringPredicatesExtractor.getUnenforcedConstraints();
+            includesAllClusteringColumnsAndHasAllEqPredicates = clusteringPredicatesExtractor.includesAllClusteringColumnsAndHasAllEqPredicates();
         }
 
         Optional<List<CassandraPartition>> currentPartitions = handle.getPartitions();
@@ -318,7 +323,8 @@ public class CassandraMetadata
                         handle.getTableName(),
                         Optional.of(partitionResult.partitions()),
                         // TODO this should probably be AND-ed with handle.getClusteringKeyPredicates()
-                        clusteringKeyPredicates)),
+                        clusteringKeyPredicates,
+                        includesAllClusteringColumnsAndHasAllEqPredicates)),
                         unenforcedConstraint,
                         constraint.getExpression(),
                         false));
@@ -478,9 +484,66 @@ public class CassandraMetadata
     }
 
     @Override
-    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
+    public RowChangeParadigm getRowChangeParadigm(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        throw new TrinoException(NOT_SUPPORTED, "Delete without primary key or partition key is not supported");
+        return CHANGE_ONLY_UPDATED_COLUMNS;
+    }
+
+    /**
+     * Attempt to push down an update operation into the connector. If a connector
+     * can execute an update for the table handle on its own, it should return a
+     * table handle, which will be passed back to {@link #executeUpdate} during
+     * query executing to actually execute the update.
+     */
+    @Override
+    public Optional<ConnectorTableHandle> applyUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, Map<ColumnHandle, Constant> assignments)
+    {
+        CassandraNamedRelationHandle table = ((CassandraTableHandle) tableHandle).getRequiredNamedRelation();
+        if (cassandraSession.isMaterializedView(table.getSchemaTableName())) {
+            throw new TrinoException(NOT_SUPPORTED, "Updating materialized views not yet supported");
+        }
+
+        CassandraNamedRelationHandle handle = ((CassandraTableHandle) tableHandle).getRequiredNamedRelation();
+        List<CassandraPartition> partitions = handle.getPartitions()
+                .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "Updating without partition key is not supported"));
+        if (partitions.isEmpty()) {
+            // there are no records of a given partition key
+            throw new TrinoException(NOT_SUPPORTED, "Updating without partition key is not supported");
+        }
+        if (!handle.getIncludesAllClusteringColumnsAndHasAllEqPredicates()) {
+            throw new TrinoException(NOT_SUPPORTED, "Updating without all clustering keys or with non-eq predicates is not supported");
+        }
+
+        Map<String, String> assignmentsMap = new HashMap<>();
+        for (Map.Entry<ColumnHandle, Constant> entry : assignments.entrySet()) {
+            CassandraColumnHandle column = (CassandraColumnHandle) entry.getKey();
+            if (isHiddenIdColumn(column)) {
+                throw new TrinoException(NOT_SUPPORTED, "Updating the hidden id column is not supported");
+            }
+            Object value = entry.getValue().getValue();
+            if (value == null) {
+                throw new TrinoException(NOT_SUPPORTED, "Updating columns to null is not supported");
+            }
+            String cqlLiteral = cassandraTypeManager.toCqlLiteral(column.cassandraType(), value); // validate that the value can be converted to the cassandra type
+            assignmentsMap.put(column.name(), cqlLiteral);
+        }
+
+        return Optional.of(new CassandraUpdateTableHandle(tableHandle, assignmentsMap));
+    }
+
+    /**
+     * Execute the update operation on the handle returned from {@link #applyUpdate}.
+     */
+    @Override
+    public OptionalLong executeUpdate(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        CassandraUpdateTableHandle updateTableHandle = ((CassandraUpdateTableHandle) tableHandle);
+        CassandraTableHandle cassandraTableHandle = (CassandraTableHandle) updateTableHandle.tableHandle();
+        CassandraNamedRelationHandle namedRelationHandle = cassandraTableHandle.getRequiredNamedRelation();
+        for (String cql : CassandraCqlUtils.getUpdateQueries(namedRelationHandle, updateTableHandle.assignments())) {
+            cassandraSession.execute(cql);
+        }
+        return OptionalLong.empty();
     }
 
     @Override
@@ -490,25 +553,32 @@ public class CassandraMetadata
     }
 
     @Override
-    public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
-    {
-        return Optional.of(handle);
-    }
-
-    @Override
-    public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle deleteHandle)
+    public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle deleteHandle)
     {
         CassandraNamedRelationHandle handle = ((CassandraTableHandle) deleteHandle).getRequiredNamedRelation();
         List<CassandraPartition> partitions = handle.getPartitions()
                 .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "Deleting without partition key is not supported"));
         if (partitions.isEmpty()) {
             // there are no records of a given partition key
-            return OptionalLong.empty();
+            return Optional.empty();
         }
+        return Optional.of(deleteHandle);
+    }
+
+    @Override
+    public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle deleteHandle)
+    {
+        CassandraNamedRelationHandle handle = ((CassandraTableHandle) deleteHandle).getRequiredNamedRelation();
         for (String cql : CassandraCqlUtils.getDeleteQueries(handle)) {
             cassandraSession.execute(cql);
         }
         return OptionalLong.empty();
+    }
+
+    @Override
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, Map<Integer, Collection<ColumnHandle>> updateCaseColumns, RetryMode retryMode)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support modifying table rows");
     }
 
     @Override

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraNamedRelationHandle.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraNamedRelationHandle.java
@@ -34,10 +34,11 @@ public class CassandraNamedRelationHandle
     private final String tableName;
     private final Optional<List<CassandraPartition>> partitions;
     private final String clusteringKeyPredicates;
+    private final Boolean includesAllClusteringColumnsAndHasAllEqPredicates;
 
     public CassandraNamedRelationHandle(String schemaName, String tableName)
     {
-        this(schemaName, tableName, Optional.empty(), "");
+        this(schemaName, tableName, Optional.empty(), "", null);
     }
 
     @JsonCreator
@@ -45,12 +46,14 @@ public class CassandraNamedRelationHandle
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("partitions") Optional<List<CassandraPartition>> partitions,
-            @JsonProperty("clusteringKeyPredicates") String clusteringKeyPredicates)
+            @JsonProperty("clusteringKeyPredicates") String clusteringKeyPredicates,
+            @JsonProperty("includesAllClusteringColumnsAndHasAllEqPredicates") Boolean includesAllClusteringColumnsAndHasAllEqPredicates)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.partitions = partitions.map(ImmutableList::copyOf);
         this.clusteringKeyPredicates = requireNonNull(clusteringKeyPredicates, "clusteringKeyPredicates is null");
+        this.includesAllClusteringColumnsAndHasAllEqPredicates = includesAllClusteringColumnsAndHasAllEqPredicates;
     }
 
     @JsonProperty
@@ -77,6 +80,12 @@ public class CassandraNamedRelationHandle
         return clusteringKeyPredicates;
     }
 
+    @JsonProperty
+    public Boolean getIncludesAllClusteringColumnsAndHasAllEqPredicates()
+    {
+        return includesAllClusteringColumnsAndHasAllEqPredicates;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -101,7 +110,8 @@ public class CassandraNamedRelationHandle
         return Objects.equals(this.schemaName, other.schemaName) &&
                 Objects.equals(this.tableName, other.tableName) &&
                 Objects.equals(this.partitions, other.partitions) &&
-                Objects.equals(this.clusteringKeyPredicates, other.clusteringKeyPredicates);
+                Objects.equals(this.clusteringKeyPredicates, other.clusteringKeyPredicates) &&
+                Objects.equals(this.includesAllClusteringColumnsAndHasAllEqPredicates, other.includesAllClusteringColumnsAndHasAllEqPredicates);
     }
 
     @Override
@@ -121,6 +131,9 @@ public class CassandraNamedRelationHandle
         }
         if (!clusteringKeyPredicates.isEmpty()) {
             result += format(" constraint(%s)", clusteringKeyPredicates);
+        }
+        if (includesAllClusteringColumnsAndHasAllEqPredicates != null) {
+            result += format(" includesAllClusteringColumnsAndHasAllEqPredicates(%s)", includesAllClusteringColumnsAndHasAllEqPredicates);
         }
         return result;
     }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraUpdateTableHandle.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraUpdateTableHandle.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.cassandra;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record CassandraUpdateTableHandle(
+        ConnectorTableHandle tableHandle,
+        Map<String, String> assignments)
+        implements ConnectorTableHandle
+{
+    public CassandraUpdateTableHandle
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(assignments, "assignments is null");
+    }
+
+    @Override
+    public String toString()
+    {
+        return "cassandra:" + tableHandle;
+    }
+}

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
@@ -462,7 +462,7 @@ public class TestCassandraConnector
     private CassandraTableHandle getTableHandle(Optional<List<CassandraPartition>> partitions, String clusteringKeyPredicates)
     {
         CassandraNamedRelationHandle handle = ((CassandraTableHandle) getTableHandle(tableForDelete)).getRequiredNamedRelation();
-        return new CassandraTableHandle(new CassandraNamedRelationHandle(handle.getSchemaName(), handle.getTableName(), partitions, clusteringKeyPredicates));
+        return new CassandraTableHandle(new CassandraNamedRelationHandle(handle.getSchemaName(), handle.getTableName(), partitions, clusteringKeyPredicates, null));
     }
 
     private CassandraPartition createPartition(long value1, long value2)

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -103,8 +103,7 @@ public class TestCassandraConnectorTest
                  SUPPORTS_RENAME_TABLE,
                  SUPPORTS_ROW_TYPE,
                  SUPPORTS_SET_COLUMN_TYPE,
-                 SUPPORTS_TOPN_PUSHDOWN,
-                 SUPPORTS_UPDATE -> false;
+                 SUPPORTS_TOPN_PUSHDOWN -> false;
             default -> super.hasBehavior(connectorBehavior);
         };
     }
@@ -1526,6 +1525,143 @@ public class TestCassandraConnectorTest
 
     @Test
     @Override
+    public void testUpdate()
+    {
+        try (TestCassandraTable testCassandraTable = testTable(
+                "table_update_data",
+                ImmutableList.of(
+                        partitionColumn("partition_one", "bigint"),
+                        partitionColumn("partition_two", "int"),
+                        clusterColumn("clust_one", "text"),
+                        clusterColumn("clust_two", "text"),
+                        generalColumn("data", "text")),
+                ImmutableList.of(
+                        "1, 1, 'clust_one_1', 'clust_two_1', null",
+                        "2, 2, 'clust_one_2', 'clust_two_2', null",
+                        "3, 3, 'clust_one_3', 'clust_two_3', null",
+                        "4, 4, 'clust_one_4', 'clust_two_4', null",
+                        "5, 5, 'clust_one_5', 'clust_two_5', null",
+                        "6, 6, 'clust_one_6', 'clust_two_6', null",
+                        "7, 7, 'clust_one_7', 'clust_two_7', null",
+                        "8, 8, 'clust_one_8', 'clust_two_8', null",
+                        "9, 9, 'clust_one_9', 'clust_two_9', null",
+                        "1, 1, 'clust_one_1', 'clust_two_2', null",
+                        "1, 1, 'clust_one_2', 'clust_two_1', null",
+                        "1, 1, 'clust_one_2', 'clust_two_2', null",
+                        "1, 2, 'clust_one_2', 'clust_two_1', null",
+                        "1, 2, 'clust_one_2', 'clust_two_2', null",
+                        "2, 2, 'clust_one_1', 'clust_two_1', null"))) {
+            String keyspaceAndTable = testCassandraTable.getTableName();
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
+
+            // error
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'"))
+                    .failure().hasMessage("Updating without partition key is not supported");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String wherePartialPartitionKey = " WHERE partition_one=1 AND clust_one='clust_one_1' AND clust_two>='clust_two_1'";
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'" + wherePartialPartitionKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String whereInvalidRangePartitionKey = " WHERE partition_one=3 AND partition_two>=3 AND clust_one='clust_one_2' AND clust_two='clust_two_3'";
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'" + whereInvalidRangePartitionKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String whereClusteringKeyOnly = " WHERE clust_one='clust_one_2'";
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'" + whereClusteringKeyOnly))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String whereIncompleteClusteringKey = " WHERE partition_one=3 AND partition_two=3 AND clust_one='clust_one_2'";
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'" + whereIncompleteClusteringKey))
+                    .failure().hasMessage("Updating without all clustering keys or with non-eq predicates is not supported");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String whereInvalidRangeClusteringKey = " WHERE partition_one=3 AND partition_two=3 AND clust_one>='clust_one_2' AND clust_two='clust_two_3'";
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'" + whereInvalidRangeClusteringKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String whereMultiplePartitionKeyWithClusteringKey = " WHERE " +
+                    " (partition_one=1 AND partition_two=1 AND clust_one='clust_one_1') OR " +
+                    " (partition_one=1 AND partition_two=2 AND clust_one='clust_one_2') ";
+            assertThat(query("UPDATE " + keyspaceAndTable + " SET data='new_data'" + whereMultiplePartitionKeyWithClusteringKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
+
+            // success
+            String wherePrimaryKey = " WHERE partition_one=3 AND partition_two=3 AND clust_one='clust_one_3' AND clust_two='clust_two_3'";
+            assertUpdate("UPDATE " + keyspaceAndTable + " SET data='new_data'" + wherePrimaryKey);
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(14);
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data='new_data'").getRowCount()).isEqualTo(1);
+
+            String whereClusteringKeysUsingIn = " WHERE partition_one=1 AND partition_two=1 AND clust_one IN ('clust_one_1', 'clust_one_2') AND clust_two IN ('clust_two_1', 'clust_two_2')";
+            assertUpdate("UPDATE " + keyspaceAndTable + " SET data='new_data2'" + whereClusteringKeysUsingIn);
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(10);
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data='new_data2'").getRowCount()).isEqualTo(4);
+        }
+    }
+
+    @Test
+    @Override
+    public void testUpdateWithPredicates()
+    {
+        assertThatThrownBy(super::testUpdateWithPredicates)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
+    public void testUpdateWithNullValues()
+    {
+        assertThatThrownBy(super::testUpdateWithNullValues)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
+    public void testRowLevelUpdate()
+    {
+        assertThatThrownBy(super::testRowLevelUpdate)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
+    public void testUpdateAllValues()
+    {
+        assertThatThrownBy(super::testUpdateAllValues)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
+    public void testUpdateCaseSensitivity()
+    {
+        assertThatThrownBy(super::testUpdateCaseSensitivity)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
+    public void testUpdateMultipleCondition()
+    {
+        assertThatThrownBy(super::testUpdateMultipleCondition)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
+    public void testUpdateRowConcurrently()
+    {
+        assertThatThrownBy(super::testUpdateRowConcurrently)
+                .hasStackTraceContaining("This connector does not support modifying table rows");
+    }
+
+    @Test
+    @Override
     public void testDelete()
     {
         try (TestCassandraTable testCassandraTable = testTable(
@@ -1534,23 +1670,24 @@ public class TestCassandraConnectorTest
                         partitionColumn("partition_one", "bigint"),
                         partitionColumn("partition_two", "int"),
                         clusterColumn("clust_one", "text"),
+                        clusterColumn("clust_two", "text"),
                         generalColumn("data", "text")),
                 ImmutableList.of(
-                        "1, 1, 'clust_one_1', null",
-                        "2, 2, 'clust_one_2', null",
-                        "3, 3, 'clust_one_3', null",
-                        "4, 4, 'clust_one_4', null",
-                        "5, 5, 'clust_one_5', null",
-                        "6, 6, 'clust_one_6', null",
-                        "7, 7, 'clust_one_7', null",
-                        "8, 8, 'clust_one_8', null",
-                        "9, 9, 'clust_one_9', null",
-                        "1, 1, 'clust_one_2', null",
-                        "1, 1, 'clust_one_3', null",
-                        "1, 2, 'clust_one_1', null",
-                        "1, 2, 'clust_one_2', null",
-                        "1, 2, 'clust_one_3', null",
-                        "2, 2, 'clust_one_1', null"))) {
+                        "1, 1, 'clust_one_1', 'clust_two_1', null",
+                        "2, 2, 'clust_one_2', 'clust_two_2', null",
+                        "3, 3, 'clust_one_3', 'clust_two_3', null",
+                        "4, 4, 'clust_one_4', 'clust_two_4', null",
+                        "5, 5, 'clust_one_5', 'clust_two_5', null",
+                        "6, 6, 'clust_one_6', 'clust_two_6', null",
+                        "7, 7, 'clust_one_7', 'clust_two_7', null",
+                        "8, 8, 'clust_one_8', 'clust_two_8', null",
+                        "9, 9, 'clust_one_9', 'clust_two_9', null",
+                        "1, 1, 'clust_one_2', 'clust_two_2', null",
+                        "1, 1, 'clust_one_3', 'clust_two_1', null",
+                        "1, 2, 'clust_one_1', 'clust_two_2', null",
+                        "1, 2, 'clust_one_2', 'clust_two_1', null",
+                        "1, 2, 'clust_one_3', 'clust_two_2', null",
+                        "2, 2, 'clust_one_1', 'clust_two_1', null"))) {
             String keyspaceAndTable = testCassandraTable.getTableName();
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
 
@@ -1559,20 +1696,35 @@ public class TestCassandraConnectorTest
                     .failure().hasMessage("Deleting without partition key is not supported");
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
 
+            String wherePartialPartitionKey = " WHERE partition_one=1 AND clust_one='clust_one_1' AND clust_two='clust_two_1'";
+            assertThat(query("DELETE FROM " + keyspaceAndTable + wherePartialPartitionKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
+
+            String whereInvalidRangePartitionKey = " WHERE partition_one=3 AND partition_two>=3 AND clust_one='clust_one_2' AND clust_two='clust_two_3'";
+            assertThat(query("DELETE FROM " + keyspaceAndTable + whereInvalidRangePartitionKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + " WHERE data IS NULL").getRowCount()).isEqualTo(15);
+
+            String whereInvalidClusteringKey = " WHERE partition_one=1 AND partition_two=1 AND clust_two='clust_two_1'";
+            assertThat(query("DELETE FROM " + keyspaceAndTable + whereInvalidClusteringKey))
+                    .failure().hasMessage("This connector does not support modifying table rows");
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
+
             String whereClusteringKeyOnly = " WHERE clust_one='clust_one_2'";
             assertThat(query("DELETE FROM " + keyspaceAndTable + whereClusteringKeyOnly))
-                    .failure().hasMessage("Delete without primary key or partition key is not supported");
+                    .failure().hasMessage("This connector does not support modifying table rows");
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
 
             String whereMultiplePartitionKeyWithClusteringKey = " WHERE " +
                     " (partition_one=1 AND partition_two=1 AND clust_one='clust_one_1') OR " +
                     " (partition_one=1 AND partition_two=2 AND clust_one='clust_one_2') ";
             assertThat(query("DELETE FROM " + keyspaceAndTable + whereMultiplePartitionKeyWithClusteringKey))
-                    .failure().hasMessage("Delete without primary key or partition key is not supported");
+                    .failure().hasMessage("This connector does not support modifying table rows");
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(15);
 
             // success
-            String wherePrimaryKey = " WHERE partition_one=3 AND partition_two=3 AND clust_one='clust_one_3'";
+            String wherePrimaryKey = " WHERE partition_one=3 AND partition_two=3 AND clust_one='clust_one_3' AND clust_two='clust_two_3'";
             assertUpdate("DELETE FROM " + keyspaceAndTable + wherePrimaryKey);
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(14);
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + wherePrimaryKey).getRowCount()).isEqualTo(0);
@@ -1586,6 +1738,11 @@ public class TestCassandraConnectorTest
             assertUpdate("DELETE FROM " + keyspaceAndTable + whereMultiplePartitionKey);
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(9);
             assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + whereMultiplePartitionKey).getRowCount()).isEqualTo(0);
+
+            String whereClusteringKeysUsingIn = " WHERE partition_one=4 AND partition_two=4 AND clust_one IN ('clust_one_4', 'clust_one_5') AND clust_two IN ('clust_two_4', 'clust_two_5')";
+            assertUpdate("DELETE FROM " + keyspaceAndTable + whereClusteringKeysUsingIn);
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable).getRowCount()).isEqualTo(8);
+            assertThat(computeActual("SELECT * FROM " + keyspaceAndTable + whereClusteringKeysUsingIn).getRowCount()).isEqualTo(0);
         }
     }
 
@@ -1594,7 +1751,7 @@ public class TestCassandraConnectorTest
     public void testDeleteWithLike()
     {
         assertThatThrownBy(super::testDeleteWithLike)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     @Test
@@ -1602,7 +1759,7 @@ public class TestCassandraConnectorTest
     public void testDeleteWithComplexPredicate()
     {
         assertThatThrownBy(super::testDeleteWithComplexPredicate)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     @Test
@@ -1610,7 +1767,7 @@ public class TestCassandraConnectorTest
     public void testDeleteWithSemiJoin()
     {
         assertThatThrownBy(super::testDeleteWithSemiJoin)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     @Test
@@ -1618,7 +1775,7 @@ public class TestCassandraConnectorTest
     public void testDeleteWithSubquery()
     {
         assertThatThrownBy(super::testDeleteWithSubquery)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     @Test
@@ -1626,7 +1783,7 @@ public class TestCassandraConnectorTest
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
         assertThatThrownBy(super::testExplainAnalyzeWithDeleteWithSubquery)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     @Test
@@ -1634,7 +1791,7 @@ public class TestCassandraConnectorTest
     public void testDeleteWithVarcharPredicate()
     {
         assertThatThrownBy(super::testDeleteWithVarcharPredicate)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     @Test
@@ -1650,7 +1807,7 @@ public class TestCassandraConnectorTest
     public void testRowLevelDelete()
     {
         assertThatThrownBy(super::testRowLevelDelete)
-                .hasStackTraceContaining("Delete without primary key or partition key is not supported");
+                .hasStackTraceContaining("This connector does not support modifying table rows");
     }
 
     // test polymorphic table function

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
@@ -94,7 +94,7 @@ final class TestCassandraSplitManager
         CassandraSplitManager splitManager = new CassandraSplitManager(config, session, null, partitionManager, CASSANDRA_TYPE_MANAGER);
 
         CassandraTableHandle tableHandle = new CassandraTableHandle(
-                new CassandraNamedRelationHandle(KEYSPACE, tableName, Optional.of(partitions.build()), ""));
+                new CassandraNamedRelationHandle(KEYSPACE, tableName, Optional.of(partitions.build()), "", null));
         try (ConnectorSplitSource splitSource = splitManager.getSplits(null, null, tableHandle, null, null)) {
             List<ConnectorSplit> splits = splitSource.getNextBatch(100).get().getSplits();
             assertThat(splits).hasSize(2);

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestJsonCassandraHandles.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestJsonCassandraHandles.java
@@ -109,7 +109,7 @@ public class TestJsonCassandraHandles
     public void testTable2HandleSerialize()
             throws Exception
     {
-        CassandraTableHandle tableHandle = new CassandraTableHandle(new CassandraNamedRelationHandle("cassandra_schema", "cassandra_table", PARTITIONS, "clusteringKey1 = 33"));
+        CassandraTableHandle tableHandle = new CassandraTableHandle(new CassandraNamedRelationHandle("cassandra_schema", "cassandra_table", PARTITIONS, "clusteringKey1 = 33", null));
         String json = OBJECT_MAPPER.writeValueAsString(tableHandle);
         testJsonEquals(json, TABLE2_HANDLE_AS_MAP);
     }


### PR DESCRIPTION
Add support for row-level modification in Cassandra connector

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The WHERE clause in an UPDATE statement for Cassandra must specify the full primary key (all columns in the partition key and all columns in the clustering key, if any). The conditions in the WHERE clause must be EQ conditions.

Fixes #26489

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`26489`)
```
