### PR TITLE
Fix UI splits timeline aggregation

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/assets/js/timeline.js
+++ b/core/trino-web-ui/src/main/resources/webapp/assets/js/timeline.js
@@ -24,7 +24,7 @@ $(document).ready(function () {
         tasks = []
 
         data.stages.stages.forEach((stage) => {
-            tasks.push.apply(stage.tasks)
+            Array.prototype.push.apply(tasks, stage.tasks)
         })
 
         tasks = tasks.map(function (task) {


### PR DESCRIPTION
## Description

Fix UI timeline aggregation The `tasks` array was always empty causing the timeline to render blank. 

Bug introduced by this PR: https://github.com/trinodb/trino/pull/26113 - It hasn’t been included in a release yet so end users are not affected. However, without this fix, the issue will appear in the next 477 release.

## Additional context and related issues

This happened because we incorrectly called:
```
tasks.push.apply(stage.tasks)
```

which used the wrong receiver and didn’t append anything. The fix switches to:
```
Array.prototype.push.apply(tasks, stage.tasks)
```

so that tasks is properly populated with the combined list.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix UI splits timeline aggregation. ({26685}`26685`)
```
