### PR TITLE
Fix internal error if pattern variables are not uppercase

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -739,7 +739,7 @@ class RelationPlanner
         }
 
         Set<IrLabel> skipToLabels = skipTo.flatMap(SkipTo::getIdentifier)
-                .map(Identifier::getValue)
+                .map(analysis::getResolvedLabel)
                 .map(label -> rewrittenSubsets.getOrDefault(new IrLabel(label), ImmutableSet.of(new IrLabel(label))))
                 .orElse(ImmutableSet.of());
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
@@ -782,8 +782,32 @@ public class TestRowPatternMatching
                         "     (5, 2, 70, 'B'), " +
                         "     (6, 2, 80, 'C') ");
 
+        // after rows 1, 2, 3, 4 are matched, matching starts at row 4. Another match is found starting at row 4.
+        // test using lowercase label
+        assertThat(assertions.query(format(query, "AFTER MATCH SKIP TO FIRST c")))
+                .matches("VALUES " +
+                        "     (1, CAST(1 AS bigint), 90, VARCHAR 'A'), " +
+                        "     (2, 1, 80, 'B'), " +
+                        "     (3, 1, 70, 'B'), " +
+                        "     (4, 1, 80, 'C'), " +
+                        "     (4, 2, 80, 'A'), " +
+                        "     (5, 2, 70, 'B'), " +
+                        "     (6, 2, 80, 'C') ");
+
         // after rows 1, 2, 3, 4 are matched, matching starts at row 3. Another match is found starting at row 4.
         assertThat(assertions.query(format(query, "AFTER MATCH SKIP TO LAST B")))
+                .matches("VALUES " +
+                        "     (1, CAST(1 AS bigint), 90, VARCHAR 'A'), " +
+                        "     (2, 1, 80, 'B'), " +
+                        "     (3, 1, 70, 'B'), " +
+                        "     (4, 1, 80, 'C'), " +
+                        "     (4, 2, 80, 'A'), " +
+                        "     (5, 2, 70, 'B'), " +
+                        "     (6, 2, 80, 'C') ");
+
+        // after rows 1, 2, 3, 4 are matched, matching starts at row 3. Another match is found starting at row 4.
+        // test using lowercase label
+        assertThat(assertions.query(format(query, "AFTER MATCH SKIP TO LAST b")))
                 .matches("VALUES " +
                         "     (1, CAST(1 AS bigint), 90, VARCHAR 'A'), " +
                         "     (2, 1, 80, 'B'), " +
@@ -804,9 +828,34 @@ public class TestRowPatternMatching
                         "     (5, 2, 70, 'B'), " +
                         "     (6, 2, 80, 'C') ");
 
+        // 'SKIP TO B' defaults to 'SKIP TO LAST B', which is the same as above
+        // test using lowercase label
+        assertThat(assertions.query(format(query, "AFTER MATCH SKIP TO b")))
+                .matches("VALUES " +
+                        "     (1, CAST(1 AS bigint), 90, VARCHAR 'A'), " +
+                        "     (2, 1, 80, 'B'), " +
+                        "     (3, 1, 70, 'B'), " +
+                        "     (4, 1, 80, 'C'), " +
+                        "     (4, 2, 80, 'A'), " +
+                        "     (5, 2, 70, 'B'), " +
+                        "     (6, 2, 80, 'C') ");
+
         // 'SKIP TO U' skips to last C or D. D never matches, so it skips to the last C, which is the last row of the match.
         // after rows 1, 2, 3, 4 are matched, matching starts at row 4. Another match is found starting at row 4.
         assertThat(assertions.query(format(query, "AFTER MATCH SKIP TO U")))
+                .matches("VALUES " +
+                        "     (1, CAST(1 AS bigint), 90, VARCHAR 'A'), " +
+                        "     (2, 1, 80, 'B'), " +
+                        "     (3, 1, 70, 'B'), " +
+                        "     (4, 1, 80, 'C'), " +
+                        "     (4, 2, 80, 'A'), " +
+                        "     (5, 2, 70, 'B'), " +
+                        "     (6, 2, 80, 'C') ");
+
+        // 'SKIP TO U' skips to last C or D. D never matches, so it skips to the last C, which is the last row of the match.
+        // after rows 1, 2, 3, 4 are matched, matching starts at row 4. Another match is found starting at row 4.
+        // test using lowercase label
+        assertThat(assertions.query(format(query, "AFTER MATCH SKIP TO u")))
                 .matches("VALUES " +
                         "     (1, CAST(1 AS bigint), 90, VARCHAR 'A'), " +
                         "     (2, 1, 80, 'B'), " +


### PR DESCRIPTION
Fix internal error if pattern variables are not uppercase

Fixes https://github.com/trinodb/trino/issues/26464

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Replaced using directly skipTo.identifier.value, and used analysis::getResolvedLabel method, which is used in other places in RelationPlanner.planPatternRecognitionComponents method.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix internal planner error if query pattern variables are not uppercase ({issue}`26464`)
```
