### PR TITLE
Warn if the spooling is enabled but client lacks support

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -25,6 +25,7 @@ import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.memory.MemoryManagerConfig;
 import io.trino.memory.NodeMemoryConfig;
 import io.trino.operator.RetryPolicy;
+import io.trino.server.protocol.spooling.SpoolingEnabledConfig;
 import io.trino.spi.TrinoException;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.sql.planner.OptimizerConfig;
@@ -221,6 +222,7 @@ public final class SystemSessionProperties
     public static final String COLUMNAR_FILTER_EVALUATION_ENABLED = "columnar_filter_evaluation_enabled";
     public static final String SPOOLING_ENABLED = "spooling_enabled";
     public static final String DEBUG_ADAPTIVE_PLANNER = "debug_adaptive_planner";
+    public static final String SPOOLING_UNSUPPORTED_WARNING = "spooling_unsupported_warning";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -228,6 +230,7 @@ public final class SystemSessionProperties
     {
         this(
                 new QueryManagerConfig(),
+                new SpoolingEnabledConfig(),
                 new TaskManagerConfig(),
                 new MemoryManagerConfig(),
                 new FeaturesConfig(),
@@ -240,6 +243,7 @@ public final class SystemSessionProperties
     @Inject
     public SystemSessionProperties(
             QueryManagerConfig queryManagerConfig,
+            SpoolingEnabledConfig spoolingEnabledConfig,
             TaskManagerConfig taskManagerConfig,
             MemoryManagerConfig memoryManagerConfig,
             FeaturesConfig featuresConfig,
@@ -1140,7 +1144,17 @@ public final class SystemSessionProperties
                         DEBUG_ADAPTIVE_PLANNER,
                         "Enable debug information for the adaptive planner",
                         false,
-                        true));
+                        true),
+                booleanProperty(
+                        SPOOLING_UNSUPPORTED_WARNING,
+                        "Generate warning when client lacks support for spooling protocol",
+                        spoolingEnabledConfig.isEnabled() && spoolingEnabledConfig.isUnsupportedWarningEnabled(),
+                        _ -> {
+                            if (!spoolingEnabledConfig.isEnabled()) {
+                                throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s cannot be set when spooling is disabled", SPOOLING_UNSUPPORTED_WARNING));
+                            }
+                        },
+                        false));
     }
 
     @Override
@@ -2043,5 +2057,10 @@ public final class SystemSessionProperties
     public static boolean isDebugAdaptivePlannerEnabled(Session session)
     {
         return session.getSystemProperty(DEBUG_ADAPTIVE_PLANNER, Boolean.class);
+    }
+
+    public static boolean isSpoolingUnsupportedWarningEnabled(Session session)
+    {
+        return session.getSystemProperty(SPOOLING_UNSUPPORTED_WARNING, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -46,6 +46,7 @@ import io.trino.server.ResultQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
+import io.trino.spi.TrinoWarning;
 import io.trino.spi.eventlistener.RoutineInfo;
 import io.trino.spi.eventlistener.StageGcStatistics;
 import io.trino.spi.eventlistener.TableInfo;
@@ -92,6 +93,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.SystemSessionProperties.isSpoolingEnabled;
+import static io.trino.SystemSessionProperties.isSpoolingUnsupportedWarningEnabled;
 import static io.trino.execution.BasicStageStats.EMPTY_STAGE_STATS;
 import static io.trino.execution.QueryState.DISPATCHING;
 import static io.trino.execution.QueryState.FAILED;
@@ -108,6 +110,7 @@ import static io.trino.operator.RetryPolicy.TASK;
 import static io.trino.server.DynamicFilterService.DynamicFiltersStats;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.USER_CANCELED;
+import static io.trino.spi.connector.StandardWarningCode.SPOOLING_NOT_SUPPORTED;
 import static io.trino.spi.resourcegroups.QueryType.SELECT;
 import static io.trino.util.Ciphers.createRandomAesEncryptionKey;
 import static io.trino.util.Ciphers.serializeAesEncryptionKey;
@@ -317,13 +320,20 @@ public class QueryStateMachine
             session = session.withExchangeEncryption(serializeAesEncryptionKey(createRandomAesEncryptionKey()));
         }
 
-        if (!queryType.map(SELECT::equals).orElse(false) || !isSpoolingEnabled(session)) {
+        boolean isSelectQuery = queryType.map(SELECT::equals).orElse(false);
+
+        if (!isSelectQuery || !isSpoolingEnabled(session)) {
             session = session.withoutSpooling();
         }
 
         // Apply WITH SESSION properties which require transaction to be started to resolve catalog handles
         if (sessionPropertiesApplier.isPresent()) {
             session = sessionPropertiesApplier.orElseThrow().apply(session);
+        }
+
+        // This needs to be applied after the WITH SESSION properties are applied
+        if (isSelectQuery && isSpoolingEnabled(session) && isSpoolingUnsupportedWarningEnabled(session) && session.getQueryDataEncoding().isEmpty()) {
+            warningCollector.add(new TrinoWarning(SPOOLING_NOT_SUPPORTED, "The server supports the spooling protocol but the current client connection is not using it. Switch to the spooling protocol and/or upgrade your client library for improved performance."));
         }
 
         Span querySpan = session.getQuerySpan();

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingEnabledConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingEnabledConfig.java
@@ -15,10 +15,12 @@ package io.trino.server.protocol.spooling;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.AssertTrue;
 
 public class SpoolingEnabledConfig
 {
     private boolean enabled;
+    private boolean unsupportedWarningEnabled;
 
     public boolean isEnabled()
     {
@@ -31,5 +33,24 @@ public class SpoolingEnabledConfig
     {
         this.enabled = enabled;
         return this;
+    }
+
+    public boolean isUnsupportedWarningEnabled()
+    {
+        return unsupportedWarningEnabled;
+    }
+
+    @Config("protocol.spooling.unsupported-warning.enabled")
+    @ConfigDescription("Generates a warning when a client lacks spooling support and connects to a spooling-enabled server")
+    public SpoolingEnabledConfig setUnsupportedWarningEnabled(boolean unsupportedWarningEnabled)
+    {
+        this.unsupportedWarningEnabled = unsupportedWarningEnabled;
+        return this;
+    }
+
+    @AssertTrue(message = "protocol.spooling.unsupported-warning.enabled can only be enabled when protocol.spooling.enabled is also enabled")
+    public boolean isConfigurationValid()
+    {
+        return !unsupportedWarningEnabled || enabled;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -541,6 +541,7 @@ public class PlanTester
     {
         SystemSessionProperties sessionProperties = new SystemSessionProperties(
                 new QueryManagerConfig(),
+                new SpoolingEnabledConfig(),
                 taskManagerConfig,
                 new MemoryManagerConfig(),
                 new FeaturesConfig(),

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingEnabledConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingEnabledConfig.java
@@ -14,6 +14,7 @@
 package io.trino.server.protocol.spooling;
 
 import com.google.common.collect.ImmutableMap;
+import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -21,6 +22,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 
 class TestSpoolingEnabledConfig
 {
@@ -28,7 +30,8 @@ class TestSpoolingEnabledConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(SpoolingEnabledConfig.class)
-                .setEnabled(false));
+                .setEnabled(false)
+                .setUnsupportedWarningEnabled(false));
     }
 
     @Test
@@ -36,11 +39,27 @@ class TestSpoolingEnabledConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("protocol.spooling.enabled", "true")
+                .put("protocol.spooling.unsupported-warning.enabled", "true")
                 .buildOrThrow();
 
         SpoolingEnabledConfig expected = new SpoolingEnabledConfig()
-                .setEnabled(true);
+                .setEnabled(true)
+                .setUnsupportedWarningEnabled(true);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testInvalidConfig()
+    {
+        SpoolingEnabledConfig config = new SpoolingEnabledConfig()
+                .setEnabled(false)
+                .setUnsupportedWarningEnabled(true);
+
+        assertFailsValidation(
+                config,
+                "configurationValid",
+                "protocol.spooling.unsupported-warning.enabled can only be enabled when protocol.spooling.enabled is also enabled",
+                AssertTrue.class);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -69,6 +69,7 @@ import io.trino.security.AccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.security.AllowAllAccessControl;
+import io.trino.server.protocol.spooling.SpoolingEnabledConfig;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
@@ -1140,6 +1141,7 @@ public class TestAnalyzer
     {
         Session session = testSessionBuilder(new SessionPropertyManager(new SystemSessionProperties(
                 new QueryManagerConfig(),
+                new SpoolingEnabledConfig(),
                 new TaskManagerConfig(),
                 new MemoryManagerConfig(),
                 new FeaturesConfig().setMaxGroupingSets(2048),

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
@@ -22,6 +22,7 @@ import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.memory.MemoryManagerConfig;
 import io.trino.memory.NodeMemoryConfig;
 import io.trino.metadata.SessionPropertyManager;
+import io.trino.server.protocol.spooling.SpoolingEnabledConfig;
 import io.trino.sql.planner.OptimizerConfig;
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +69,7 @@ public class TestFilterHideInacessibleColumnsSession
     {
         return new SessionPropertyManager(new SystemSessionProperties(
                 new QueryManagerConfig(),
+                new SpoolingEnabledConfig(),
                 new TaskManagerConfig(),
                 new MemoryManagerConfig(),
                 featuresConfig,

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/StandardWarningCode.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/StandardWarningCode.java
@@ -22,6 +22,7 @@ public enum StandardWarningCode
     TOO_MANY_STAGES(0x0000_0001),
     REDUNDANT_ORDER_BY(0x0000_0002),
     DEPRECATED_FUNCTION(0x0000_0003),
+    SPOOLING_NOT_SUPPORTED(0x0000_0004)
 
     /**/;
     private final WarningCode warningCode;


### PR DESCRIPTION
Warning can be enabled on the server-side by setting configuration property
`protocol.spooling.unsupported-warning.enabled` to `true` (default is `false`)
and disabled via session property `spooling_unsupported_warning` set to `false`
(`true` by default).

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Spooling protocol
* Generate query-level warning if server supports spooling but client does not ({issue}`issuenumber`)
```
