### PR TITLE
Make Trino headers case insensitive

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -292,7 +292,10 @@ public class HttpRequestSessionContextFactory
 
     private static List<String> splitHttpHeader(MultivaluedMap<String, String> headers, String name)
     {
-        List<String> values = firstNonNull(headers.get(name), ImmutableList.of());
+        List<String> values = headers.entrySet().stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream())
+                .collect(toImmutableList());
         Splitter splitter = Splitter.on(',').trimResults().omitEmptyStrings();
         return values.stream()
                 .map(splitter::splitToList)

--- a/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
@@ -37,6 +37,7 @@ import static io.trino.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.client.ProtocolHeaders.createProtocolHeaders;
 import static io.trino.metadata.TestMetadataManager.createTestMetadataManager;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -71,7 +72,7 @@ public class TestHttpRequestSessionContextFactory
                 .put(protocolHeaders.requestRole(), "bar_connector=NONE")
                 .put(protocolHeaders.requestRole(), "foobar_connector=ROLE{catalog-role}")
                 .put(protocolHeaders.requestExtraCredential(), "test.token.foo=bar")
-                .put(protocolHeaders.requestExtraCredential(), "test.token.abc=xyz")
+                .put(protocolHeaders.requestExtraCredential().toLowerCase(ENGLISH), "test.token.abc=xyz")
                 .build());
 
         SessionContext context = sessionContextFactory(protocolHeaders).createSessionContext(


### PR DESCRIPTION
## Description

From [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
