### PR TITLE
Fix 'IS NOT DISTINCT FROM' not working in JOIN when nulls are used

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/JoinDomainBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinDomainBuilder.java
@@ -99,6 +99,14 @@ public class JoinDomainBuilder
 
     private long retainedSizeInBytes = INSTANCE_SIZE;
 
+    /**
+     * Indicates whether null values are allowed in the join domain.
+     * This is set to true if any null values are observed in the input blocks
+     * during domain building, and is used to determine whether the resulting
+     * domain should include nulls.
+     */
+    private boolean nullAllowed;
+
     public JoinDomainBuilder(
             Type type,
             int maxDistinctValues,
@@ -160,6 +168,9 @@ public class JoinDomainBuilder
 
     public void add(Block block)
     {
+        if (block.hasNull()) {
+            nullAllowed = true;
+        }
         if (collectDistinctValues) {
             switch (block) {
                 case ValueBlock valueBlock -> {
@@ -290,24 +301,22 @@ public class JoinDomainBuilder
                     }
                 }
             }
-            // Inner and right join doesn't match rows with null key column values.
-            return Domain.create(ValueSet.copyOf(type, values.build()), false);
+            return Domain.create(ValueSet.copyOf(type, values.build()), nullAllowed);
         }
         if (collectMinMax) {
             if (minValue == null) {
                 // all values were null
-                return Domain.none(type);
+                return nullAllowed ? Domain.onlyNull(type) : Domain.none(type);
             }
             Object min = readNativeValue(type, minValue, 0);
             Object max = readNativeValue(type, maxValue, 0);
-            return Domain.create(ValueSet.ofRanges(range(type, min, true, max, true)), false);
+            return Domain.create(ValueSet.ofRanges(range(type, min, true, max, true)), nullAllowed);
         }
         return Domain.all(type);
     }
 
     private void add(ValueBlock block, int position)
     {
-        // Inner and right join doesn't match rows with null key column values.
         if (block.isNull(position)) {
             return;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
@@ -296,20 +296,21 @@ public final class DynamicFilters
                 return domain;
             }
             if (domain.isNone()) {
-                // Dynamic filter collection skips nulls
-                // In case of IS NOT DISTINCT FROM, an empty Domain should still allow null
-                if (nullAllowed) {
-                    return Domain.onlyNull(domain.getType());
-                }
                 return domain;
+            }
+            if (domain.isOnlyNull()) {
+                if (nullAllowed) {
+                    return domain;
+                }
+                return Domain.none(domain.getType());
             }
             Range span = domain.getValues().getRanges().getSpan();
             return switch (operator) {
                 case EQUAL -> {
                     if (nullAllowed) {
-                        yield Domain.create(domain.getValues(), true);
+                        yield domain;
                     }
-                    yield domain;
+                    yield Domain.create(domain.getValues(), false);
                 }
                 case LESS_THAN -> {
                     Range range = Range.lessThan(span.getType(), span.getHighBoundedValue());

--- a/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDynamicFilterSourceOperator.java
@@ -287,7 +287,7 @@ public class TestDynamicFilterSourceOperator
 
         assertThat(partitions.build()).isEqualTo(ImmutableList.of(
                 TupleDomain.withColumnDomains(ImmutableMap.of(
-                        new DynamicFilterId("0"), Domain.create(ValueSet.of(INTEGER, 1L, 2L, 3L, 4L, 5L), false)))));
+                        new DynamicFilterId("0"), Domain.create(ValueSet.of(INTEGER, 1L, 2L, 3L, 4L, 5L), true)))));
     }
 
     @Test
@@ -490,7 +490,13 @@ public class TestDynamicFilterSourceOperator
                 maxDistinctValues,
                 ImmutableList.of(BIGINT, BIGINT),
                 ImmutableList.of(largePage),
-                ImmutableList.of(TupleDomain.none()));
+                ImmutableList.of(TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new DynamicFilterId("0"),
+                        Domain.onlyNull(BIGINT),
+                        new DynamicFilterId("1"),
+                        Domain.create(
+                                ValueSet.ofRanges(range(BIGINT, 200L, true, 300L, true)),
+                                false)))));
     }
 
     @Test
@@ -570,7 +576,7 @@ public class TestDynamicFilterSourceOperator
                 ImmutableList.of(largePage, nullsPage),
                 ImmutableList.of(TupleDomain.withColumnDomains(ImmutableMap.of(
                         new DynamicFilterId("0"),
-                        Domain.create(ValueSet.of(BIGINT, 7L), false)))));
+                        Domain.create(ValueSet.of(BIGINT, 7L), true)))));
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -246,6 +246,12 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
                 Set.of(SS_SOLD_SK_HANDLE),
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         SS_SOLD_SK_HANDLE,
+                        Domain.none(BIGINT))));
+        assertQueryDynamicFilters(
+                "SELECT * FROM store_sales JOIN tpcds.tiny.store ON store_sales.ss_sold_date_sk IS NOT DISTINCT FROM store.s_closed_date_sk AND (store.s_closed_date_sk < 0 OR store.s_closed_date_sk IS NULL)",
+                Set.of(SS_SOLD_SK_HANDLE),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        SS_SOLD_SK_HANDLE,
                         Domain.onlyNull(BIGINT))));
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestJoinIsNotDistinct.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestJoinIsNotDistinct.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+@Execution(ExecutionMode.SAME_THREAD)
+class TestJoinIsNotDistinct
+{
+    private static final String LOCAL_CATALOG = "local";
+    private static final String DEFAULT_SCHEMA = "default";
+
+    private final QueryRunner queryRunner;
+
+    private final QueryAssertions assertions;
+
+    TestJoinIsNotDistinct()
+    {
+        queryRunner = new StandaloneQueryRunner(testSessionBuilder()
+                .setCatalog(LOCAL_CATALOG)
+                .setSchema(DEFAULT_SCHEMA)
+                .build());
+        queryRunner.installPlugin(new MemoryPlugin());
+        queryRunner.createCatalog(LOCAL_CATALOG, "memory", ImmutableMap.of());
+
+        assertions = new QueryAssertions(queryRunner);
+    }
+
+    @AfterAll
+    void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    void testJoinWithIsNotDistinctFromOnNulls()
+    {
+        String tableName1 = "test_tab_" + randomNameSuffix();
+        String tableName2 = "test_tab_" + randomNameSuffix();
+        queryRunner.execute(format("CREATE TABLE %s (k1 INT, k2 INT)", tableName1));
+        queryRunner.execute(format("CREATE TABLE %s (k1 INT, k2 INT)", tableName2));
+
+        queryRunner.execute(format("INSERT INTO %s VALUES (1, NULL), (NULL, NULL), (NULL, 2), (2, 2)", tableName1));
+        queryRunner.execute(format("INSERT INTO %s VALUES (1, NULL), (NULL, NULL), (3, NULL), (2, 2)", tableName2));
+
+        assertThat(assertions.query(format("""
+                SELECT *
+                FROM %s t
+                INNER JOIN %s AS s
+                    ON  s.k1 IS NOT DISTINCT FROM t.k1
+                    AND s.k2 IS NOT DISTINCT FROM t.k2
+                """, tableName1, tableName2)))
+                .matches("VALUES (1, CAST(NULL AS INTEGER), 1, CAST(NULL AS INTEGER))," +
+                         " (CAST(NULL AS INTEGER), CAST(NULL AS INTEGER), CAST(NULL AS INTEGER), CAST(NULL AS INTEGER))," +
+                         " (2, 2, 2, 2)");
+    }
+
+    @Test
+    void testJoinWithIsNotDistinctFromOnNullsOnDerivedTables()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM (SELECT 1 AS k1, NULL AS k2) t
+                INNER JOIN (SELECT 1 AS k1, NULL AS k2) AS s
+                    ON s.k1 IS NOT DISTINCT FROM t.k1
+                    AND s.k2 IS NOT DISTINCT FROM t.k2
+                """))
+                .matches("VALUES (1, NULL, 1, NULL)");
+
+        assertThat(assertions.query("""
+                SELECT *
+                FROM (SELECT NULL AS k1, NULL AS k2) t
+                INNER JOIN (SELECT NULL AS k1, NULL AS k2) AS s
+                    ON s.k1 IS NOT DISTINCT FROM t.k1
+                    AND s.k2 IS NOT DISTINCT FROM t.k2
+                """))
+                .matches("VALUES (NULL, NULL, NULL, NULL)");
+
+        assertThat(assertions.query("""
+                SELECT *
+                FROM (SELECT NULL AS k1, 2 AS k2) t
+                INNER JOIN (SELECT 3 AS k1, NULL AS k2) AS s
+                    ON s.k1 IS NOT DISTINCT FROM t.k1
+                    AND s.k2 IS NOT DISTINCT FROM t.k2
+                """))
+                .returnsEmptyResult();
+    }
+}


### PR DESCRIPTION
Fix 'IS NOT DISTINCT FROM' not working in JOIN when nulls are the only value.

Fixes issue: https://github.com/trinodb/trino/issues/26257

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The changes try to enable Domain with only null value to be used.

Modify JoinDomainBuilder to take into consideration the nulls from the value blocks.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`26257`)
```
