### PR TITLE
Add buttons to toggle between old and preview UI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/ClusterResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/ClusterResource.java
@@ -36,19 +36,21 @@ public class ClusterResource
     private final NodeVersion version;
     private final String environment;
     private final long startTime = System.nanoTime();
+    private final boolean previewUiEnabled;
 
     @Inject
-    public ClusterResource(NodeVersion nodeVersion, NodeInfo nodeInfo)
+    public ClusterResource(NodeVersion nodeVersion, NodeInfo nodeInfo, WebUiConfig webUiConfig)
     {
         this.version = requireNonNull(nodeVersion, "nodeVersion is null");
         this.environment = nodeInfo.getEnvironment();
+        this.previewUiEnabled = webUiConfig.isPreviewEnabled();
     }
 
     @GET
     @Produces(APPLICATION_JSON)
     public ClusterInfo getInfo()
     {
-        return new ClusterInfo(version, environment, nanosSince(startTime));
+        return new ClusterInfo(version, environment, nanosSince(startTime), previewUiEnabled);
     }
 
     @Immutable
@@ -57,12 +59,14 @@ public class ClusterResource
         private final NodeVersion nodeVersion;
         private final String environment;
         private final Duration uptime;
+        private final boolean previewUiEnabled;
 
-        public ClusterInfo(NodeVersion nodeVersion, String environment, Duration uptime)
+        public ClusterInfo(NodeVersion nodeVersion, String environment, Duration uptime, boolean previewUiEnabled)
         {
             this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
             this.environment = requireNonNull(environment, "environment is null");
             this.uptime = requireNonNull(uptime, "uptime is null");
+            this.previewUiEnabled = previewUiEnabled;
         }
 
         @JsonProperty
@@ -81,6 +85,12 @@ public class ClusterResource
         public Duration getUptime()
         {
             return uptime;
+        }
+
+        @JsonProperty
+        public boolean isPreviewUiEnabled()
+        {
+            return previewUiEnabled;
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
@@ -18,7 +18,7 @@ import io.airlift.configuration.Config;
 public class WebUiConfig
 {
     private boolean enabled = true;
-    private boolean previewEnabled;
+    private boolean previewEnabled = true;
 
     public boolean isEnabled()
     {

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUiConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUiConfig.java
@@ -29,7 +29,7 @@ public class TestWebUiConfig
     {
         assertRecordedDefaults(recordDefaults(WebUiConfig.class)
                 .setEnabled(true)
-                .setPreviewEnabled(false));
+                .setPreviewEnabled(true));
     }
 
     @Test
@@ -37,11 +37,11 @@ public class TestWebUiConfig
     {
         Map<String, String> properties = ImmutableMap.of(
                 "web-ui.enabled", "false",
-                "web-ui.preview.enabled", "true");
+                "web-ui.preview.enabled", "false");
 
         WebUiConfig expected = new WebUiConfig()
                 .setEnabled(false)
-                .setPreviewEnabled(true);
+                .setPreviewEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-web-ui/src/main/resources/webapp-preview/README.md
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/README.md
@@ -14,9 +14,8 @@ end users once all functionalities have been migrated.
 ## Building the Preview Web UI
 
 Preview Web UI is a potential new web interface featuring modernized tools
-and an updated look and feel. It is disabled by default and enabled only
-in the full development server by setting the `web-ui.preview.enabled=true`
-property.
+and an updated look and feel. It is enabled by default. To turn it off,
+set the `web-ui.preview.enabled=false` property.
 
 1. Run the `WebUiPreviewQueryRunner` class. This will start a minimalistic
    development server configured with the Preview UI.

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Layout.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/Layout.tsx
@@ -124,6 +124,11 @@ export const RootLayout = (props: { children: React.ReactNode }) => {
         }
     }, [error, showSnackbar])
 
+    const onClassicUi = () => {
+        closeUserMenu()
+        window.location.assign('/ui')
+    }
+
     const onLogout = () => {
         logout({ redirect: authInfo?.authType != 'form' })
     }
@@ -156,6 +161,13 @@ export const RootLayout = (props: { children: React.ReactNode }) => {
         {
             key: 'username',
             caption: username,
+        },
+        {
+            key: 'classicui',
+            caption: Texts.Menu.Header.ClassicUi,
+            onClick: () => {
+                onClassicUi()
+            },
             divider: true,
         },
         {

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/constant.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/constant.ts
@@ -53,6 +53,7 @@ export const Texts = {
             Settings: 'Settings',
             Profile: 'Profile',
             Logout: 'Logout',
+            ClassicUi: 'Classic UI',
         },
         Drawer: {
             Dashboard: 'Dashboard',

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/PageTitle.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/PageTitle.jsx
@@ -126,6 +126,17 @@ export class PageTitle extends React.Component<Props, State> {
                         </div>
                         <div id="navbar" className="navbar-collapse collapse">
                             <ul className="nav navbar-nav navbar-right">
+                                {info.previewEnabled && (
+                                    <li>
+                                        <span className="navbar-cluster-info">
+                                            <span className="text">
+                                                <a className="btn btn-info" href="/ui/preview">
+                                                    Preview UI
+                                                </a>
+                                            </span>
+                                        </span>
+                                    </li>
+                                )}
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Version</span>


### PR DESCRIPTION
## Description

This PR introduces a button that allows users to switch between the current UI and the preview UI. There are feature parity between the two interfaces and it makes the preview UI more accessible to a wider audience.

## Additional context and related issues

Changes
* Added a button to switch between the current and preview UIs.
* The button is only visible when `web-ui.preview.enabled` is set to `true`.
* Updated the default value of `web-ui.preview.enabled` to `true`, so more users will see the toggle by default.
* The current UI remains the default interface.

Documentation will need to be updated at: https://trino.io/docs/current/admin/preview-web-interface.html

## Screenshots

<img width="1669" height="733" alt="image" src="https://github.com/user-attachments/assets/aa58d82f-d825-4d3c-96d9-0b652940267a" />

<img width="1708" height="832" alt="image" src="https://github.com/user-attachments/assets/c0c031c7-8e53-49e9-8284-983ec1679a4e" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Set web-ui.preview.enabled property to default to true. ({issue}`26705`)
```
