### PR TITLE
Preserve the active tab in the URL on the query details page in the preview UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryDetails.tsx
@@ -11,8 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode, useState } from 'react'
-import { useLocation, useParams } from 'react-router-dom'
+import React, { ReactNode } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { Box, Divider, Grid, Tab, Tabs, Typography } from '@mui/material'
 import { QueryJson } from './QueryJson'
 import { QueryReferences } from './QueryReferences'
@@ -33,15 +33,24 @@ const tabComponentMap: Record<TabValue, ReactNode> = {
 }
 export const QueryDetails = () => {
     const { queryId } = useParams()
-    const location = useLocation()
-    const queryParams = new URLSearchParams(location.search)
-    const requestedTab = queryParams.get('tab')
-    const [tabValue, setTabValue] = useState<TabValue>(
-        tabValues.includes(requestedTab as TabValue) ? (requestedTab as TabValue) : 'overview'
-    )
+    const [searchParams, setSearchParams] = useSearchParams()
+    const requestedTab = searchParams.get('tab')
+    const tabValue: TabValue = tabValues.includes(requestedTab as TabValue) ? (requestedTab as TabValue) : 'overview'
 
     const handleTabChange = (_: React.SyntheticEvent, newTab: TabValue) => {
-        setTabValue(newTab)
+        const nextParams = new URLSearchParams(searchParams)
+
+        if (newTab === 'overview') {
+            nextParams.delete('tab')
+        } else {
+            nextParams.set('tab', newTab)
+        }
+
+        if (nextParams.toString() === searchParams.toString()) {
+            return
+        }
+
+        setSearchParams(nextParams)
     }
 
     return (


### PR DESCRIPTION
## Description

Currently the query details page (Preview UI) always keep the same URI across all tabs. As a result, refreshing the page would reset the view to the first tab.

This PR updates the implementation so that the active tab is encoded in the URL. This enables:
* Preserving the correct tab after a page refresh
* Sharing direct links to specific tabs

Example URL with a new `tab` parameter in the URL:
```
http://localhost:8080/ui/preview#/queries/20250924_200340_00000_ypahm?tab=livePlan
```

## Additional context and related issues

Active tab state is now synced with the URL by using `useSearchParams` hook in`react-router-dom`.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`26709`)
```
