### PR TITLE
Fix web-ui.preview.enabled default value in documentaion

### DIFF
--- a/docs/src/main/sphinx/admin/preview-web-interface.md
+++ b/docs/src/main/sphinx/admin/preview-web-interface.md
@@ -16,12 +16,12 @@ encouraged. Find collaborators and discussions in ongoing pull requests and the
 
 ## Activation
 
-The Preview Web UI is not available by default, and must be enabled in
+The Preview Web UI is available by default, but can be disabled in
 [](config-properties) with the following configuration:
 
 
 ```properties
-web-ui.preview.enabled=true
+web-ui.preview.enabled=false
 ```
 
 ## Access


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/pull/26709 changed default value of `web-ui.preview.enabled` from `false` to `true`. This PR updates the documentation to reflect that change.

## Additional context and related issues

-

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
