### PR TITLE
Fix preview UI button condition in the classic UI header

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/components/PageTitle.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/PageTitle.jsx
@@ -126,7 +126,7 @@ export class PageTitle extends React.Component<Props, State> {
                         </div>
                         <div id="navbar" className="navbar-collapse collapse">
                             <ul className="nav navbar-nav navbar-right">
-                                {info.previewEnabled && (
+                                {info.previewUiEnabled && (
                                     <li>
                                         <span className="navbar-cluster-info">
                                             <span className="text">


### PR DESCRIPTION
## Description

Fix the visibility condition for the Preview UI button in the classic UI header.

## Additional context and related issues

 [#26705](https://github.com/trinodb/trino/pull/26705) introduced a button in the UI to redirect to the preview UI but it's never visible due to a mismatched variable name. The condition incorrectly referenced `previewEnabled` instead of the correct `previewUiEnabled`.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
