### PR TITLE
Require implementing shutdown method on a Connector 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/transaction/InternalConnector.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/InternalConnector.java
@@ -27,4 +27,7 @@ public interface InternalConnector
     }
 
     ConnectorTransactionHandle beginTransaction(TransactionId transactionId, IsolationLevel isolationLevel, boolean readOnly);
+
+    @Override
+    default void shutdown() {}
 }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -372,6 +372,9 @@ public class MockConnector
     }
 
     @Override
+    public void shutdown() {}
+
+    @Override
     public Set<Procedure> getProcedures()
     {
         return procedures;

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -7930,5 +7930,8 @@ public class TestAnalyzer
                     stringProperty("p1", "test string property", "", false),
                     integerProperty("p2", "test integer property", 0, false));
         }
+
+        @Override
+        public void shutdown() {}
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -458,5 +458,8 @@ public class TestMaterializedViews
         {
             return metadata;
         }
+
+        @Override
+        public void shutdown() {}
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -818,6 +818,20 @@
                                     <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.Block io.trino.spi.block.RowBlock::getFieldBlock(int)</old>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.noLongerDefault</code>
+                                    <old>method void io.trino.spi.connector.Connector::shutdown()</old>
+                                    <new>method void io.trino.spi.connector.Connector::shutdown()</new>
+                                    <justification>Require connector to implement shutdown to prevent leaks</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.nowAbstract</code>
+                                    <old>method void io.trino.spi.connector.Connector::shutdown()</old>
+                                    <new>method void io.trino.spi.connector.Connector::shutdown()</new>
+                                    <justification>Require connector to implement shutdown to prevent leaks</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -246,7 +246,7 @@ public interface Connector
      * no methods will be called on the connector or any objects that
      * have been returned from the connector.
      */
-    default void shutdown() {}
+    void shutdown();
 
     default Set<ConnectorCapabilities> getCapabilities()
     {

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiConnector.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiConnector.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.ai.functions;
 
 import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
@@ -28,12 +29,14 @@ import static java.util.Objects.requireNonNull;
 public class AiConnector
         implements Connector
 {
+    private final LifeCycleManager lifeCycleManager;
     private final ConnectorMetadata metadata;
     private final FunctionProvider functionProvider;
 
     @Inject
-    public AiConnector(ConnectorMetadata metadata, FunctionProvider functionProvider)
+    public AiConnector(LifeCycleManager lifeCycleManager, ConnectorMetadata metadata, FunctionProvider functionProvider)
     {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
     }
@@ -54,5 +57,11 @@ public class AiConnector
     public Optional<FunctionProvider> getFunctionProvider()
     {
         return Optional.of(functionProvider);
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
     }
 }

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerConnector.java
@@ -16,6 +16,7 @@ package io.trino.plugin.faker;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Connector;
@@ -54,6 +55,7 @@ import static java.util.Objects.requireNonNull;
 public class FakerConnector
         implements Connector
 {
+    private final LifeCycleManager lifeCycleManager;
     private final FakerMetadata metadata;
     private final FakerSplitManager splitManager;
     private final FakerPageSourceProvider pageSourceProvider;
@@ -62,12 +64,14 @@ public class FakerConnector
 
     @Inject
     public FakerConnector(
+            LifeCycleManager lifeCycleManager,
             FakerMetadata metadata,
             FakerSplitManager splitManager,
             FakerPageSourceProvider pageSourceProvider,
             FakerPageSinkProvider pageSinkProvider,
             FakerFunctionProvider functionProvider)
     {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
@@ -237,5 +241,11 @@ public class FakerConnector
     public Optional<FunctionProvider> getFunctionProvider()
     {
         return Optional.of(functionProvider);
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
     }
 }

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
@@ -24,9 +24,13 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
 import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class JmxConnectorFactory
         implements ConnectorFactory
@@ -54,6 +58,8 @@ public class JmxConnectorFactory
                     binder.bind(JmxSplitManager.class).in(Scopes.SINGLETON);
                     binder.bind(JmxPeriodicSampler.class).in(Scopes.SINGLETON);
                     binder.bind(JmxRecordSetProvider.class).in(Scopes.SINGLETON);
+                    binder.bind(ScheduledExecutorService.class).toInstance(newSingleThreadScheduledExecutor(daemonThreadsNamed("jmx-history-%s")));
+                    closingBinder(binder).registerExecutor(ScheduledExecutorService.class);
                 });
 
         Injector injector = app

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxPeriodicSampler.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxPeriodicSampler.java
@@ -67,7 +67,7 @@ public class JmxPeriodicSampler
     @PostConstruct
     public void start()
     {
-        if (tableHandles.size() > 0) {
+        if (!tableHandles.isEmpty()) {
             lastDumpTimestamp = roundToPeriod(currentTimeMillis());
             schedule();
         }

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxPeriodicSampler.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxPeriodicSampler.java
@@ -22,11 +22,9 @@ import jakarta.annotation.PostConstruct;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class JmxPeriodicSampler
@@ -34,20 +32,23 @@ public class JmxPeriodicSampler
 {
     private static final Logger log = Logger.get(JmxPeriodicSampler.class);
 
+    private final ScheduledExecutorService executor;
     private final JmxHistoricalData jmxHistoricalData;
     private final JmxRecordSetProvider jmxRecordSetProvider;
-    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("jmx-history-%s"));
     private final long period;
     private final List<JmxTableHandle> tableHandles;
+
     private long lastDumpTimestamp;
 
     @Inject
     public JmxPeriodicSampler(
+            ScheduledExecutorService executor,
             JmxHistoricalData jmxHistoricalData,
             JmxMetadata jmxMetadata,
             JmxRecordSetProvider jmxRecordSetProvider,
             JmxConnectorConfig jmxConfig)
     {
+        this.executor = requireNonNull(executor, "executor is null");
         this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxHistoricalData is null");
         requireNonNull(jmxMetadata, "jmxMetadata is null");
         this.jmxRecordSetProvider = requireNonNull(jmxRecordSetProvider, "jmxRecordSetProvider is null");
@@ -128,10 +129,5 @@ public class JmxPeriodicSampler
         }
 
         schedule();
-    }
-
-    public void shutdown()
-    {
-        executor.shutdown();
     }
 }

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnector.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiConnector.java
@@ -15,6 +15,7 @@ package io.trino.plugin.loki;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
@@ -31,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 public class LokiConnector
         implements Connector
 {
+    private final LifeCycleManager lifeCycleManager;
     private final ConnectorMetadata metadata;
     private final ConnectorSplitManager splitManager;
     private final ConnectorRecordSetProvider recordSetProvider;
@@ -38,11 +40,13 @@ public class LokiConnector
 
     @Inject
     public LokiConnector(
+            LifeCycleManager lifeCycleManager,
             ConnectorMetadata metadata,
             ConnectorSplitManager splitManager,
             ConnectorRecordSetProvider recordSetProvider,
             Set<ConnectorTableFunction> connectorTableFunctions)
     {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
@@ -83,5 +87,11 @@ public class LokiConnector
     public ConnectorRecordSetProvider getRecordSetProvider()
     {
         return recordSetProvider;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -37,6 +37,7 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class MongoClientModule
@@ -67,6 +68,7 @@ public class MongoClientModule
                 internalBinder -> internalBinder.bind(MongoServerDetailsProvider.class).toInstance(ImmutableList::of),
                 internalBinder -> internalBinder.bind(MongoServerDetailsProvider.class).to(SessionBasedMongoServerDetailsProvider.class).in(Scopes.SINGLETON)));
 
+        closingBinder(binder).registerCloseable(MongoSession.class);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -36,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class MongoConnector
         implements Connector
 {
-    private final MongoSession mongoSession;
+    private final LifeCycleManager lifeCycleManager;
     private final MongoTransactionManager transactionManager;
     private final MongoSplitManager splitManager;
     private final MongoPageSourceProvider pageSourceProvider;
@@ -46,7 +47,7 @@ public class MongoConnector
 
     @Inject
     public MongoConnector(
-            MongoSession mongoSession,
+            LifeCycleManager lifeCycleManager,
             MongoTransactionManager transactionManager,
             MongoSplitManager splitManager,
             MongoPageSourceProvider pageSourceProvider,
@@ -54,7 +55,7 @@ public class MongoConnector
             Set<ConnectorTableFunction> connectorTableFunctions,
             Set<SessionPropertiesProvider> sessionPropertiesProviders)
     {
-        this.mongoSession = mongoSession;
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
@@ -122,6 +123,6 @@ public class MongoConnector
     @Override
     public void shutdown()
     {
-        mongoSession.shutdown();
+        lifeCycleManager.stop();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -69,6 +69,7 @@ import org.bson.types.Binary;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
+import java.io.Closeable;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -130,6 +131,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class MongoSession
+        implements Closeable
 {
     private static final Logger log = Logger.get(MongoSession.class);
     private static final Set<String> SYSTEM_DATABASES = Set.of("admin", "local", "config");
@@ -195,7 +197,8 @@ public class MongoSession
                 .build();
     }
 
-    public void shutdown()
+    @Override
+    public void close()
     {
         client.close();
     }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnector.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnector.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.tpch;
 
 import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -28,14 +29,16 @@ import static java.util.Objects.requireNonNull;
 public class TpchConnector
         implements Connector
 {
+    private final LifeCycleManager lifeCycleManager;
     private final ConnectorMetadata metadata;
     private final ConnectorSplitManager splitManager;
     private final ConnectorNodePartitioningProvider nodePartitioningProvider;
     private final ConnectorPageSourceProvider pageSourceProvider;
 
     @Inject
-    public TpchConnector(ConnectorMetadata metadata, ConnectorSplitManager splitManager, ConnectorNodePartitioningProvider nodePartitioningProvider, ConnectorPageSourceProvider pageSourceProvider)
+    public TpchConnector(LifeCycleManager lifeCycleManager, ConnectorMetadata metadata, ConnectorSplitManager splitManager, ConnectorNodePartitioningProvider nodePartitioningProvider, ConnectorPageSourceProvider pageSourceProvider)
     {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.nodePartitioningProvider = requireNonNull(nodePartitioningProvider, "nodePartitioningProvider is null");
@@ -70,5 +73,11 @@ public class TpchConnector
     public ConnectorNodePartitioningProvider getNodePartitioningProvider()
     {
         return nodePartitioningProvider;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
@@ -110,6 +110,9 @@ public class IndexedTpchConnectorFactory
             {
                 return new TpchNodePartitioningProvider(nodeManager, splitsPerNode);
             }
+
+            @Override
+            public void shutdown() {}
         };
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -661,5 +661,8 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
         {
             return new TestingPageSinkProvider();
         }
+
+        @Override
+        public void shutdown() {}
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestBeginQuery.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestBeginQuery.java
@@ -214,6 +214,9 @@ public class TestBeginQuery
         {
             return new TestingPageSinkProvider();
         }
+
+        @Override
+        public void shutdown() {}
     }
 
     private static class TestMetadata


### PR DESCRIPTION
This ensures that at least every Connector will call LifeCycleManager.stop()
which is important because every Bootstrap creates one LifeCycleManager
which registers itself with the shutdown hook creating a shutdown Thread.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
