### PR TITLE
Fix batch size condition in AsyncResultIterator

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AsyncResultIterator.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AsyncResultIterator.java
@@ -75,7 +75,7 @@ public class AsyncResultIterator
                     warningsManager.addWarnings(results.getWarnings());
                     for (List<Object> row : client.currentRows()) {
                         rowQueue.put(row);
-                        if (rowsProcessed++ % BATCH_SIZE == 0) {
+                        if (++rowsProcessed == BATCH_SIZE) {
                             semaphore.release(rowsProcessed);
                             rowsProcessed = 0;
                         }


### PR DESCRIPTION
Previously, rows were not handled in batch

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
