### PR TITLE
Fix Create or replace Materialized view error in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -157,4 +157,80 @@ public class TestIcebergMaterializedView
         assertUpdate(defaultIceberg, "DROP TABLE common_base_table");
         assertUpdate("DROP MATERIALIZED VIEW mv_on_iceberg2");
     }
+
+    /**
+     * Test CREATE OR REPLACE MATERIALIZED VIEW and with all configurations for
+     * unique table location and hiding storage table.
+     */
+    @Test
+    public void testReplaceAndDropMaterializedView() {
+        testReplaceAndDropMaterializedView(false, false);
+        testReplaceAndDropMaterializedView(false, true);
+        testReplaceAndDropMaterializedView(true, false);
+        testReplaceAndDropMaterializedView(true, true);
+    }
+
+    /**
+     * Test CREATE OR REPLACE MATERIALIZED VIEW and DROP MATERIALIZED VIEW statements.
+     * The test creates an Iceberg table and a materialized view on top of it,
+     * then replaces the materialized view definition twice, and finally drops the materialized view.
+     */
+    private void testReplaceAndDropMaterializedView(boolean uniqueTableLocation, boolean hideStorageTable) {
+        QueryRunner queryRunner = getQueryRunner();
+        String catalog = String.format("iceberg_%s_%s", uniqueTableLocation ? "unique" : "not_unique",
+                hideStorageTable ? "storage" : "not_storage");
+        queryRunner.createCatalog(catalog, "iceberg", Map.of(
+                "iceberg.catalog.type", "TESTING_FILE_METASTORE",
+                "iceberg.unique-table-location", uniqueTableLocation ? "true" : "false",
+                "hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve(catalog + "-catalog").toString(),
+                "iceberg.hive-catalog-name", "hive",
+                "iceberg.materialized-views.hide-storage-table", hideStorageTable ? "true" : "false",
+                "fs.hadoop.enabled", "true"));
+        Session session = Session.builder(queryRunner.getDefaultSession())
+                .setCatalog(catalog)
+                .setSchema("default")
+                .build();
+        assertUpdate(session, "CREATE SCHEMA default");
+
+        assertUpdate(session, "CREATE TABLE replace_base_table AS SELECT 10 value", 1);
+
+        // A new materialized view is created and fresh results are stored in its storage table
+        // Test that the materialized view works as expected (one row with proper value)
+        assertUpdate(session, "CREATE OR REPLACE MATERIALIZED VIEW replace_view" +
+                " AS SELECT sum(value) AS s FROM replace_base_table");
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW replace_view", 1);
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertQuery(session, "SELECT * FROM replace_view", "VALUES 10");
+
+        // The materialized view is replaced with a new definition and fresh results are stored in its storage table
+        // Test that the materialized view works as expected (one row with proper value)
+        assertUpdate(session, "CREATE OR REPLACE MATERIALIZED VIEW replace_view" +
+                " AS SELECT 2 * sum(value) AS t FROM replace_base_table");
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW replace_view", 1);
+        assertQuery(session, "SELECT * FROM replace_view", "VALUES 20");
+
+        // The materialized view is replaced again and tested
+        assertUpdate(session, "CREATE OR REPLACE MATERIALIZED VIEW replace_view" +
+                " AS SELECT 3 * sum(value) AS v FROM replace_base_table");
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW replace_view", 1);
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertQuery(session, "SELECT * FROM replace_view", "VALUES 30");
+
+        // The materialized view is dropped and tested for absence
+        assertUpdate(session, "DROP MATERIALIZED VIEW replace_view");
+        assertQueryFails(session, "SELECT count(*) FROM replace_view", "line 1:22: Table '" + catalog +".default.replace_view' does not exist");
+
+        // Re-create the materialized view after dropping and test it again
+        assertUpdate(session, "CREATE OR REPLACE MATERIALIZED VIEW replace_view" +
+                " AS SELECT 4 * sum(value) AS v FROM replace_base_table");
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW replace_view", 1);
+        assertQuery(session, "SELECT count(*) FROM replace_view", "VALUES 1");
+        assertQuery(session, "SELECT * FROM replace_view", "VALUES 40");
+
+        assertUpdate(session, "DROP MATERIALIZED VIEW replace_view");
+    }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
@@ -34,7 +34,6 @@ import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -58,7 +57,6 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -122,7 +120,6 @@ public class TestTrinoHiveCatalogWithFileMetastore
     }
 
     @Test
-    @Disabled
     public void testDropMaterializedView()
     {
         testDropMaterializedView(false);
@@ -169,13 +166,5 @@ public class TestTrinoHiveCatalogWithFileMetastore
                 log.warn("Failed to clean up namespace: %s", namespace);
             }
         }
-    }
-
-    @Test
-    @Override
-    public void testListTables()
-    {
-        // the test actually works but when cleanup up the materialized view the error is thrown
-        assertThatThrownBy(super::testListTables).hasMessageMatching("Table 'ns2.*.mv' not found");
     }
 }


### PR DESCRIPTION
Fix Create or replace Materialized view error
Fixes #25610

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The previous files for materialized views were not cleaned properly:
- during view replace, the existing view was deleted after creating the new one, not before (this case caused the error from the [#25610](https://github.com/trinodb/trino/issues/25610) issue),
- during view drop, there was an attempt to delete the files twice (this case caused an error when dropping the materialized view).
- some leftover metadata and data files remained after recreate

Now, when recreating the materialized view, we are always deleting the existing storage using the dropMaterializedViewStorage method at the beginning of the process.

The dropMaterializedViewStorage had an extra metastore.dropTable call, which caused the DROP error, as the metastore.dropTable call needed files that were deleted by the call before.

In dropMaterializedViewStorage we are making sure the table is cleared from the metastore.

Enabled some unit tests that were ignored before due to the existing issues.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`25610`)
```
