### PR TITLE
Allow reusing SingleStore container

### DIFF
--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -176,6 +176,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
@@ -85,7 +85,7 @@ public final class SingleStoreQueryRunner
                 queryRunner.installPlugin(new SingleStorePlugin());
                 queryRunner.createCatalog("singlestore", "singlestore", connectorProperties);
 
-                queryRunner.execute("CREATE SCHEMA tpch");
+                queryRunner.execute("CREATE SCHEMA IF NOT EXISTS tpch");
                 copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
 
                 return queryRunner;


### PR DESCRIPTION
## Description

The initialization takes about 2 minutes. It would be nice to allow reusing a container. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
