### PR TITLE
Add fast path for single partition in PagePartitioner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
@@ -17,7 +17,8 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.ValueBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
-public interface PositionsAppender
+public sealed interface PositionsAppender
+        permits RowPositionsAppender, TypedPositionsAppender
 {
     void append(IntArrayList positions, ValueBlock source);
 

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppender.java
@@ -14,13 +14,21 @@
 package io.trino.operator.output;
 
 import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.ValueBlock;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 public sealed interface PositionsAppender
         permits RowPositionsAppender, TypedPositionsAppender
 {
+    /**
+     * Appends the positions from the list, in the specified order. Implementations are not permitted to modify
+     * the contents of the {@link IntArrayList} argument as it may be passed directly from {@link DictionaryBlock#getRawIds()}
+     * without a defensive copy.
+     */
     void append(IntArrayList positions, ValueBlock source);
+
+    void appendRange(ValueBlock block, int offset, int length);
 
     /**
      * Appends the specified value positionCount times.

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
-public class PositionsAppenderPageBuilder
+public final class PositionsAppenderPageBuilder
 {
     private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 8;
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -73,6 +73,17 @@ public final class PositionsAppenderPageBuilder
         }
     }
 
+    public void appendToOutputPartition(Page page)
+    {
+        int positionCount = page.getPositionCount();
+        declarePositions(positionCount);
+
+        for (int channel = 0; channel < channelAppenders.length; channel++) {
+            Block block = page.getBlock(channel);
+            channelAppenders[channel].appendRange(block, 0, positionCount);
+        }
+    }
+
     public void appendToOutputPartition(Page page, IntArrayList positions)
     {
         declarePositions(positions.size());

--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -31,7 +31,7 @@ import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySi
 import static io.trino.spi.block.RowBlock.fromNotNullSuppressedFieldBlocks;
 import static java.util.Objects.requireNonNull;
 
-public class RowPositionsAppender
+public final class RowPositionsAppender
         implements PositionsAppender
 {
     private static final int INSTANCE_SIZE = instanceSize(RowPositionsAppender.class);

--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -116,6 +116,47 @@ public final class RowPositionsAppender
     }
 
     @Override
+    public void appendRange(ValueBlock block, int offset, int length)
+    {
+        checkArgument(block instanceof RowBlock, "Block must be instance of %s", RowBlock.class);
+        if (length == 0) {
+            return;
+        }
+
+        RowBlock sourceRowBlock = (RowBlock) block;
+        ensureCapacity(length);
+
+        Block[] rawFieldBlocks = sourceRowBlock.getRawFieldBlocks();
+        int startOffset = sourceRowBlock.getOffsetBase();
+
+        for (int i = 0; i < fieldAppenders.length; i++) {
+            fieldAppenders[i].appendRange(rawFieldBlocks[i], startOffset + offset, length);
+        }
+
+        boolean[] rawRowIsNull = sourceRowBlock.getRawRowIsNull();
+        if (rawRowIsNull != null) {
+            for (int i = 0; i < length; i++) {
+                boolean isNull = rawRowIsNull[startOffset + offset + i];
+                hasNullRow |= isNull;
+                hasNonNullRow |= !isNull;
+                if (hasNullRow & hasNonNullRow) {
+                    System.arraycopy(rawRowIsNull, startOffset + offset + i, rowIsNull, positionCount + i, length - i);
+                    break;
+                }
+                else {
+                    rowIsNull[positionCount + i] = isNull;
+                }
+            }
+        }
+        else {
+            hasNonNullRow = true;
+        }
+
+        positionCount += length;
+        resetSize();
+    }
+
+    @Override
     public void appendRle(ValueBlock value, int rlePositionCount)
     {
         checkArgument(value instanceof RowBlock, "Block must be instance of %s", RowBlock.class);

--- a/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
@@ -45,6 +45,12 @@ final class TypedPositionsAppender
     }
 
     @Override
+    public void appendRange(ValueBlock block, int offset, int length)
+    {
+        blockBuilder.appendRange(block, offset, length);
+    }
+
+    @Override
     public void appendRle(ValueBlock block, int count)
     {
         blockBuilder.appendRepeated(block, 0, count);

--- a/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/TypedPositionsAppender.java
@@ -21,7 +21,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 
-class TypedPositionsAppender
+final class TypedPositionsAppender
         implements PositionsAppender
 {
     private static final int INSTANCE_SIZE = instanceSize(TypedPositionsAppender.class);

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Dispatches the {@link #append} and {@link #appendRle} methods to the {@link #delegate} depending on the input {@link Block} class.
  */
-public class UnnestingPositionsAppender
+public final class UnnestingPositionsAppender
 {
     private static final int INSTANCE_SIZE = instanceSize(UnnestingPositionsAppender.class);
 
@@ -235,7 +235,7 @@ public class UnnestingPositionsAppender
         return false;
     }
 
-    private static class DictionaryIdsBuilder
+    private static final class DictionaryIdsBuilder
     {
         private static final int INSTANCE_SIZE = instanceSize(DictionaryIdsBuilder.class);
 

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import jakarta.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -32,6 +33,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateBlockResetSize;
 import static io.trino.operator.output.PositionsAppenderUtil.calculateNewArraySize;
 import static java.lang.Math.max;
+import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -66,6 +68,50 @@ public final class UnnestingPositionsAppender
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.dictionaryIdsBuilder = new DictionaryIdsBuilder(1024);
         this.identicalOperator = identicalOperator.orElse(null);
+    }
+
+    public void appendRange(Block source, int offset, int length)
+    {
+        if (length == 0) {
+            return;
+        }
+
+        switch (source) {
+            case RunLengthEncodedBlock rleBlock -> {
+                appendRle(rleBlock.getValue(), length);
+            }
+            case DictionaryBlock dictionaryBlock -> {
+                ValueBlock dictionary = dictionaryBlock.getDictionary();
+                if (state == State.UNINITIALIZED) {
+                    state = State.DICTIONARY;
+                    this.dictionary = dictionary;
+                    dictionaryIdsBuilder.appendRange(dictionaryBlock, offset, length);
+                }
+                else if (state == State.DICTIONARY && this.dictionary == dictionary) {
+                    dictionaryIdsBuilder.appendRange(dictionaryBlock, offset, length);
+                }
+                else {
+                    transitionToDirect();
+
+                    int[] rawIds = dictionaryBlock.getRawIds();
+                    int rawOffset = dictionaryBlock.getRawIdsOffset();
+                    checkFromIndexSize(rawOffset + offset, length, rawIds.length);
+                    IntArrayList positionsList;
+                    if (rawOffset + offset == 0) {
+                        // Fast path, no copy necessary
+                        positionsList = IntArrayList.wrap(rawIds, length);
+                    }
+                    else {
+                        positionsList = IntArrayList.wrap(Arrays.copyOfRange(rawIds, rawOffset + offset, rawOffset + offset + length));
+                    }
+                    delegate.append(positionsList, dictionary);
+                }
+            }
+            case ValueBlock valueBlock -> {
+                transitionToDirect();
+                delegate.appendRange(valueBlock, offset, length);
+            }
+        }
     }
 
     public void append(IntArrayList positions, Block source)
@@ -273,6 +319,17 @@ public final class UnnestingPositionsAppender
                 dictionaryIds[size + i] = block.getId(positions.getInt(i));
             }
             size += positions.size();
+        }
+
+        public void appendRange(DictionaryBlock block, int offset, int length)
+        {
+            checkArgument(length > 0, "block has no positions");
+            checkFromIndexSize(offset, length, block.getPositionCount());
+            ensureCapacity(size + length);
+            int[] rawIds = block.getRawIds();
+            int rawIdsOffset = block.getRawIdsOffset();
+            System.arraycopy(rawIds, rawIdsOffset + offset, dictionaryIds, size, length);
+            size += length;
         }
 
         public DictionaryIdsBuilder newBuilderLike()

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -126,14 +126,23 @@ public class TestPagePartitioner
     public void testOutputForEmptyPage()
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page = new Page(createLongsBlock(ImmutableList.of()));
 
-        pagePartitioner.partitionPage(page, operatorContext());
-        pagePartitioner.close();
+        multiPartitionPartitioner.partitionPage(page, operatorContext());
+        multiPartitionPartitioner.close();
 
         List<Object> partitioned = readLongs(outputBuffer.getEnqueuedDeserialized(), 0);
         assertThat(partitioned).isEmpty();
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionResult = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionResult).isEmpty();
     }
 
     private OperatorContext operatorContext()
@@ -153,14 +162,23 @@ public class TestPagePartitioner
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
 
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page = new Page(createLongSequenceBlock(0, POSITIONS_PER_PAGE));
         List<Object> expected = readLongs(Stream.of(page), 0);
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partitioned = readLongs(outputBuffer.getEnqueuedDeserialized(), 0);
         assertThat(partitioned).containsExactlyInAnyOrderElementsOf(expected); // order is different due to 2 partitions joined
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionResult = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionResult).containsExactlyElementsOf(expected);
     }
 
     @Test
@@ -201,16 +219,28 @@ public class TestPagePartitioner
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
 
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page1 = new Page(createLongSequenceBlock(0, POSITIONS_PER_PAGE));
         Page page2 = new Page(createLongSequenceBlock(1, POSITIONS_PER_PAGE));
         Page page3 = new Page(createLongSequenceBlock(2, POSITIONS_PER_PAGE));
         List<Object> expected = readLongs(Stream.of(page1, page2, page3), 0);
 
-        processPages(pagePartitioner, partitioningMode, page1, page2, page3);
+        processPages(multiPartitionPartitioner, partitioningMode, page1, page2, page3);
 
         List<Object> partitioned = readLongs(outputBuffer.getEnqueuedDeserialized(), 0);
         assertThat(partitioned).containsExactlyInAnyOrderElementsOf(expected); // order is different due to 2 partitions joined
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        OperatorContext operatorContext = operatorContext();
+        singlePartitionPartitioner.partitionPage(page1, operatorContext);
+        singlePartitionPartitioner.partitionPage(page2, operatorContext);
+        singlePartitionPartitioner.partitionPage(page3, operatorContext);
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionResult = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionResult).containsExactlyElementsOf(expected);
     }
 
     @Test
@@ -223,15 +253,25 @@ public class TestPagePartitioner
     private void testOutputForSimplePageWithReplication(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).replicate().build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).replicate().build();
         Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).containsExactly(0L, 2L, null);
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).containsExactly(0L, 1L, 3L); // position 0 copied to all partitions
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .replicate()
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionResult = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionResult).containsExactly(0L, 1L, 2L, 3L, null);
     }
 
     @Test
@@ -244,15 +284,25 @@ public class TestPagePartitioner
     private void testOutputForSimplePageWithNullChannel(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).withNullChannel(0).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).withNullChannel(0).build();
         Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).containsExactlyInAnyOrder(0L, 2L, null);
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).containsExactlyInAnyOrder(1L, 3L, null); // null copied to all partitions
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withNullChannel(0)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionResult = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionResult).containsExactly(0L, 1L, 2L, 3L, null);
     }
 
     @Test
@@ -265,19 +315,30 @@ public class TestPagePartitioner
     private void testOutputForSimplePageWithPartitionConstant(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT)
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
                 .withPartitionConstants(ImmutableList.of(Optional.of(new NullableValue(BIGINT, 1L))))
                 .withPartitionChannels(-1)
                 .build();
         Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L, null));
         List<Object> allValues = readLongs(Stream.of(page), 0);
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).isEmpty();
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).containsExactlyElementsOf(allValues);
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionConstants(ImmutableList.of(Optional.of(new NullableValue(BIGINT, 1L))))
+                .withPartitionChannels(-1)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionResult = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionResult).containsExactlyElementsOf(allValues);
     }
 
     @Test
@@ -290,19 +351,31 @@ public class TestPagePartitioner
     private void testOutputForSimplePageWithPartitionConstantAndHashBlock(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT)
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
                 .withPartitionConstants(ImmutableList.of(Optional.empty(), Optional.of(new NullableValue(BIGINT, 1L))))
                 .withPartitionChannels(0, -1) // use first block and constant block at index 1 as input to partitionFunction
                 .withHashChannels(0, 1) // use both channels to calculate partition (a+b) mod 2
                 .build();
         Page page = new Page(createLongsBlock(0L, 1L, 2L, 3L));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).containsExactly(1L, 3L);
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).containsExactly(0L, 2L);
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionConstants(ImmutableList.of(Optional.empty(), Optional.of(new NullableValue(BIGINT, 1L))))
+                .withPartitionChannels(0, -1) // use first block and constant block at index 1 as input to partitionFunction
+                .withHashChannels(0, 1) // use both channels to calculate partition (a+b) mod 2
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionChannelZero = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionChannelZero).containsExactly(0L, 1L, 2L, 3L);
     }
 
     @Test
@@ -315,16 +388,27 @@ public class TestPagePartitioner
     private void testPartitionPositionsWithRleNotNull(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT).build();
         Page page = new Page(createRepeatedValuesBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 1);
         assertThat(partition0).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
         List<Object> partition0HashBlock = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0HashBlock).containsOnly(0L).hasSize(POSITIONS_PER_PAGE);
         assertThat(outputBuffer.getEnqueuedDeserialized(1)).isEmpty();
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionChannelZero = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionChannelZero).containsExactlyElementsOf(readLongs(Stream.of(page), 0));
+        List<Object> singlePartitionChannelOne = readLongs(outputBuffer.getEnqueuedDeserialized(0), 1);
+        assertThat(singlePartitionChannelOne).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
     }
 
     @Test
@@ -337,15 +421,27 @@ public class TestPagePartitioner
     private void testPartitionPositionsWithRleNotNullWithReplication(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT).replicate().build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT).replicate().build();
         Page page = new Page(createRepeatedValuesBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 1);
         assertThat(partition0).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 1);
         assertThat(partition1).containsExactly(0L); // position 0 copied to all partitions
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT)
+                .replicate()
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singePartitionChannelZero = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singePartitionChannelZero).containsExactlyElementsOf(readLongs(Stream.of(page), 0));
+        List<Object> singlePartitionChannelOne = readLongs(outputBuffer.getEnqueuedDeserialized(0), 1);
+        assertThat(singlePartitionChannelOne).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
     }
 
     @Test
@@ -358,15 +454,27 @@ public class TestPagePartitioner
     private void testPartitionPositionsWithRleNullWithNullChannel(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT).withNullChannel(0).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT).withNullChannel(0).build();
         Page page = new Page(RunLengthEncodedBlock.create(createLongsBlock((Long) null), POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 1);
         assertThat(partition0).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 1);
         assertThat(partition1).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT, BIGINT)
+                .withNullChannel(0)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionChannelZero = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
+        assertThat(singlePartitionChannelZero).containsExactlyElementsOf(readLongs(Stream.of(page), 0));
+        List<Object> singlePartitionChannelOne = readLongs(outputBuffer.getEnqueuedDeserialized(0), 1);
+        assertThat(singlePartitionChannelOne).containsExactlyElementsOf(readLongs(Stream.of(page), 1));
     }
 
     @Test
@@ -379,15 +487,24 @@ public class TestPagePartitioner
     private void testOutputForDictionaryBlock(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page = new Page(createLongDictionaryBlock(0, 10)); // must have at least 10 position to have non-trivial dict
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).containsExactlyElementsOf(nCopies(5, 0L));
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).containsExactlyElementsOf(nCopies(5, 1L));
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionedOutput = readChannel(outputBuffer.getEnqueuedDeserialized(0), 0, BIGINT);
+        assertThat(singlePartitionedOutput).containsExactlyElementsOf(readChannel(Stream.of(page), 0, BIGINT));
     }
 
     @Test
@@ -400,15 +517,24 @@ public class TestPagePartitioner
     private void testOutputForOneValueDictionaryBlock(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page = new Page(DictionaryBlock.create(4, createLongsBlock(0), new int[] {0, 0, 0, 0}));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).containsExactlyElementsOf(nCopies(4, 0L));
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).isEmpty();
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionOutput = readChannel(outputBuffer.getEnqueuedDeserialized(0), 0, BIGINT);
+        assertThat(singlePartitionOutput).containsExactlyElementsOf(readChannel(Stream.of(page), 0, BIGINT));
     }
 
     @Test
@@ -421,15 +547,24 @@ public class TestPagePartitioner
     private void testOutputForViewDictionaryBlock(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
-        PagePartitioner pagePartitioner = pagePartitioner(outputBuffer, BIGINT).build();
+        PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page = new Page(DictionaryBlock.create(4, createLongSequenceBlock(4, 8), new int[] {1, 0, 3, 2}));
 
-        processPages(pagePartitioner, partitioningMode, page);
+        processPages(multiPartitionPartitioner, partitioningMode, page);
 
         List<Object> partition0 = readLongs(outputBuffer.getEnqueuedDeserialized(0), 0);
         assertThat(partition0).containsExactlyInAnyOrder(4L, 6L);
         List<Object> partition1 = readLongs(outputBuffer.getEnqueuedDeserialized(1), 0);
         assertThat(partition1).containsExactlyInAnyOrder(5L, 7L);
+        outputBuffer.clear();
+
+        PagePartitioner singlePartitionPartitioner = pagePartitioner(outputBuffer, BIGINT)
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        singlePartitionPartitioner.partitionPage(page, operatorContext());
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionOutput = readChannel(outputBuffer.getEnqueuedDeserialized(0), 0, BIGINT);
+        assertThat(singlePartitionOutput).containsExactlyElementsOf(readChannel(Stream.of(page), 0, BIGINT));
     }
 
     @Test
@@ -595,7 +730,7 @@ public class TestPagePartitioner
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
         PagePartitionerBuilder pagePartitionerBuilder = pagePartitioner(outputBuffer, BIGINT, type, type);
-        PagePartitioner pagePartitioner = pagePartitionerBuilder.build();
+        PagePartitioner multiPartitionPartitioner = pagePartitionerBuilder.build();
         Page input = new Page(
                 createLongSequenceBlock(0, POSITIONS_PER_PAGE), // partition block
                 createBlockForType(type, POSITIONS_PER_PAGE),
@@ -603,14 +738,25 @@ public class TestPagePartitioner
 
         List<Object> expected = readChannel(Stream.of(input, input), 1, type);
 
-        mode1.partitionPage(pagePartitioner, input);
-        mode2.partitionPage(pagePartitioner, input);
+        mode1.partitionPage(multiPartitionPartitioner, input);
+        mode2.partitionPage(multiPartitionPartitioner, input);
 
-        pagePartitioner.close();
+        multiPartitionPartitioner.close();
 
-        List<Object> partitioned = readChannel(outputBuffer.getEnqueuedDeserialized(), 1, type);
-        assertThat(partitioned).containsExactlyInAnyOrderElementsOf(expected); // output of the PagePartitioner can be reordered
+        List<Object> multiPartitionedOutput = readChannel(outputBuffer.getEnqueuedDeserialized(), 1, type);
+        assertThat(multiPartitionedOutput).containsExactlyInAnyOrderElementsOf(expected); // output of the PagePartitioner can be reordered
         outputBuffer.clear();
+
+        // Test single partition output matches input
+        PagePartitioner singlePartitionPartitioner = pagePartitionerBuilder
+                .withPartitionFunction(new SinglePartitionFailIfCalled())
+                .build();
+        OperatorContext operatorContext = operatorContext();
+        singlePartitionPartitioner.partitionPage(input, operatorContext);
+        singlePartitionPartitioner.partitionPage(input, operatorContext);
+        singlePartitionPartitioner.close();
+        List<Object> singlePartitionedOutput = readChannel(outputBuffer.getEnqueuedDeserialized(), 1, type);
+        assertThat(singlePartitionedOutput).isEqualTo(expected);
     }
 
     private static Block createBlockForType(Type type, int positionsPerPage)
@@ -971,6 +1117,22 @@ public class TestPagePartitioner
             }
 
             return toIntExact(Math.abs(value) % partitionCount);
+        }
+    }
+
+    private static final class SinglePartitionFailIfCalled
+            implements PartitionFunction
+    {
+        @Override
+        public int partitionCount()
+        {
+            return 1;
+        }
+
+        @Override
+        public int getPartition(Page page, int position)
+        {
+            throw new UnsupportedOperationException("getPartition should not be called on single partitioned outputs");
         }
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -292,6 +292,15 @@
                                     <new>method io.opentelemetry.api.common.Value&lt;java.util.List&lt;io.opentelemetry.api.common.Value&lt;?&gt;&gt;&gt; io.opentelemetry.api.common.Value&lt;T&gt;::of(io.opentelemetry.api.common.Value&lt;?&gt;[])</new>
                                     <justification>Revapi now detects new API changes to vararg args</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.RowBlock::getRawRowIsNull()</old>
+                                    <new>method boolean[] io.trino.spi.block.RowBlock::getRawRowIsNull()</new>
+                                    <oldVisibility>package</oldVisibility>
+                                    <newVisibility>public</newVisibility>
+                                    <justification>Allow direct access to isNull mask on RowBlock for performance critical sections</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -185,7 +185,7 @@ public final class RowBlock
     }
 
     @Nullable
-    boolean[] getRawRowIsNull()
+    public boolean[] getRawRowIsNull()
     {
         return rowIsNull;
     }


### PR DESCRIPTION
## Description
Adds special case handling for single partition output in `PagePartitioner` such that partition calculations can be skipped when all rows will necessarily go to a single output partition. This improves performance for small queries or when running on small clusters to avoid the work of computing output page partitions.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
