### PR TITLE
fix(iceberg): fix table creation without namespace location

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1281,10 +1281,13 @@ public class IcebergMetadata
                     .orElseGet(() -> catalog.defaultTableLocation(session, tableMetadata.getTable()));
         }
         transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties);
+
         Location location = Location.of(transaction.table().location());
         try {
             // S3 Tables internally assigns a unique location for each table
-            if (!isS3Tables(location.toString())) {
+            // we create a non-staged table if tableLocation.isEmpty(), in that case, the table location will not be
+            // empty
+            if (!isS3Tables(location.toString()) && !(tableLocation != null && tableLocation.isEmpty())) {
                 TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), transaction.table().io().properties());
                 if (!replace && fileSystem.listFiles(location).hasNext()) {
                     throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, format("" +

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1281,7 +1281,6 @@ public class IcebergMetadata
                     .orElseGet(() -> catalog.defaultTableLocation(session, tableMetadata.getTable()));
         }
         transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties);
-
         Location location = Location.of(transaction.table().location());
         try {
             // S3 Tables internally assigns a unique location for each table


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This should fix #26742 where it's impossible to create a table on non-s3tables REST catalogs that don't return a namespace location.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

There are two separate conditions being used to determine if a table should be non-staged and if its location has to be empty. If the table is being created as non-staged, then the location won't be empty. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

