### PR TITLE
Avoid calling TypeConverters when injecting a header

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ExternalUriInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ExternalUriInfo.java
@@ -13,9 +13,9 @@
  */
 package io.trino.server;
 
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriBuilderException;
 import jakarta.ws.rs.core.UriInfo;
@@ -23,8 +23,8 @@ import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElse;
 
 /**
  * Provides external URI information for the current request. The external URI may have a path prefix when behind a reverse proxy.
@@ -37,10 +37,15 @@ public class ExternalUriInfo
     private final UriInfo uriInfo;
     private final String forwardedPrefix;
 
-    public ExternalUriInfo(@Context UriInfo uriInfo, @HeaderParam(X_FORWARDED_PREFIX) String forwardedPrefix)
+    public ExternalUriInfo(@Context UriInfo uriInfo, @Context HttpHeaders httpHeaders)
+    {
+        this(uriInfo, requireNonNull(httpHeaders, "httpHeaders is null").getHeaderString(X_FORWARDED_PREFIX));
+    }
+
+    ExternalUriInfo(UriInfo uriInfo, String forwardedPrefix)
     {
         this.uriInfo = requireNonNull(uriInfo, "uriInfo is null");
-        this.forwardedPrefix = requireNonNullElse(forwardedPrefix, "");
+        this.forwardedPrefix = firstNonNull(forwardedPrefix, "");
     }
 
     public static ExternalUriInfo from(ContainerRequestContext requestContext)


### PR DESCRIPTION
Injecting header as a String directly into the Jakarta's managed bean will use reflection to convert to desired type. Injecting managed HttpHeaders avoid that kind of a conversion.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
