### PR TITLE
Fix query plan default viewport in preview UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryStagePerformance.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryStagePerformance.tsx
@@ -24,13 +24,13 @@ import {
     Select,
     SelectChangeEvent,
 } from '@mui/material'
-import { type Edge, type Node, ReactFlow, useEdgesState, useNodesState } from '@xyflow/react'
+import { type Edge, type Node, ReactFlow, useEdgesState, useNodesState, type Viewport } from '@xyflow/react'
 import { queryStatusApi, QueryStatusInfo, QueryStage } from '../api/webapp/api.ts'
 import { ApiResponse } from '../api/base.ts'
 import { Texts } from '../constant.ts'
 import { QueryProgressBar } from './QueryProgressBar.tsx'
 import { HelpMessage } from './flow/HelpMessage'
-import { nodeTypes, getLayoutedStagePerformanceElements } from './flow/layout'
+import { nodeTypes, getLayoutedStagePerformanceElements, getViewportFocusedOnNode } from './flow/layout'
 import { LayoutDirectionType } from './flow/types'
 import { getStagePerformanceFlowElements } from './flow/flowUtils.ts'
 
@@ -53,6 +53,7 @@ export const QueryStagePerformance = () => {
     const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
     const [layoutDirection, setLayoutDirection] = useState<LayoutDirectionType>('BT')
+    const [viewport, setViewport] = useState<Viewport>()
 
     const [loading, setLoading] = useState<boolean>(true)
     const [error, setError] = useState<string | null>(null)
@@ -135,6 +136,16 @@ export const QueryStagePerformance = () => {
         },
     }
 
+    const focusViewportToFirstPipeline = () => {
+        const viewportTarget = getViewportFocusedOnNode(nodes, {
+            targetNodeId: 'pipeline-0',
+            containerWidth: containerRef.current?.clientWidth ?? 0,
+        })
+        if (viewportTarget) {
+            setViewport(viewportTarget)
+        }
+    }
+
     const handleStageIdChange = (event: SelectChangeEvent) => {
         setStagePlanId(event.target.value as string)
     }
@@ -169,11 +180,14 @@ export const QueryStagePerformance = () => {
                                                         nodeTypes={nodeTypes}
                                                         minZoom={0.1}
                                                         proOptions={{ hideAttribution: true }}
-                                                        defaultViewport={{ x: 200, y: 20, zoom: 0.8 }}
+                                                        viewport={viewport}
+                                                        onViewportChange={setViewport}
+                                                        fitView
                                                     >
                                                         <HelpMessage
                                                             layoutDirection={layoutDirection}
                                                             onLayoutDirectionChange={setLayoutDirection}
+                                                            onOriginClick={focusViewportToFirstPipeline}
                                                             additionalContent={
                                                                 <Box sx={{ mt: 2 }}>
                                                                     <FormControl size="small" sx={{ minWidth: 200 }}>

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/HelpMessage.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/HelpMessage.tsx
@@ -11,21 +11,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Box, Typography, ToggleButtonGroup, ToggleButton } from '@mui/material'
+import { Box, Button, Typography, ToggleButtonGroup, ToggleButton } from '@mui/material'
 import React from 'react'
 import { LayoutDirectionType } from './types'
 
 interface IHelpMessageProps {
     layoutDirection: LayoutDirectionType
     onLayoutDirectionChange: (layoutDirection: LayoutDirectionType) => void
+    onOriginClick: () => void
     additionalContent?: React.ReactNode
 }
 
-export const HelpMessage = ({ layoutDirection, onLayoutDirectionChange, additionalContent }: IHelpMessageProps) => {
+export const HelpMessage = ({
+    layoutDirection,
+    onLayoutDirectionChange,
+    onOriginClick,
+    additionalContent,
+}: IHelpMessageProps) => {
     const handleLayoutChange = (_event: React.MouseEvent<HTMLElement>, newDirection: LayoutDirectionType | null) => {
         if (newDirection !== null) {
             onLayoutDirectionChange(newDirection)
         }
+    }
+
+    const handleOriginClick = () => {
+        onOriginClick()
     }
 
     return (
@@ -47,9 +57,19 @@ export const HelpMessage = ({ layoutDirection, onLayoutDirectionChange, addition
                 alignItems: 'center',
             }}
         >
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 0 }}>
-                Scroll to zoom in/out
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0 }}>
+                    Scroll to zoom in/out
+                </Typography>
+                <Button
+                    onClick={handleOriginClick}
+                    size="small"
+                    variant="text"
+                    sx={{ minWidth: 'auto', px: 1.5, py: 0.25 }}
+                >
+                    Origin
+                </Button>
+            </Box>
 
             <ToggleButtonGroup
                 value={layoutDirection}
@@ -65,7 +85,6 @@ export const HelpMessage = ({ layoutDirection, onLayoutDirectionChange, addition
                     <Typography variant="caption">Horizontal</Typography>
                 </ToggleButton>
             </ToggleButtonGroup>
-
             {additionalContent}
         </Box>
     )

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/layout.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/layout.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 import Dagre from '@dagrejs/dagre'
-import { type Edge, type Node } from '@xyflow/react'
+import { type Edge, type Node, type Viewport } from '@xyflow/react'
 import { RemoteExchangeNode } from './RemoteExchangeNode.tsx'
 import { PlanFragmentNode } from './PlanFragmentNode.tsx'
 import { OperatorNode } from './OperatorNode.tsx'
@@ -182,5 +182,26 @@ export const getLayoutedStagePerformanceElements = (nodes: Node[], edges: Edge[]
     return {
         nodes: [...layoutedPipelineNodes, ...layoutedOperatorNodes],
         edges,
+    }
+}
+
+export const getViewportFocusedOnNode = (
+    nodes: Node[],
+    options?: { targetNodeId?: string; zoom?: number; padding?: number; containerWidth?: number }
+): Viewport | undefined => {
+    if (nodes.length === 0) {
+        return undefined
+    }
+    const { targetNodeId, zoom = 0.8, padding = 20, containerWidth = 0 } = options ?? {}
+    const targetNode = targetNodeId ? nodes.find((node) => node.id === targetNodeId) : undefined
+    const focusNode = targetNode ?? nodes[0]
+    const focusNodeWidth = focusNode.measured?.width ?? focusNode.width ?? 0
+    return {
+        // If width is known then center horizontally in container otherwise align to left
+        x: focusNodeWidth
+            ? containerWidth / 2 - (focusNode.position.x + focusNodeWidth / 2) * zoom
+            : -focusNode.position.x * zoom + padding,
+        y: -focusNode.position.y * zoom + padding,
+        zoom,
     }
 }


### PR DESCRIPTION
## Description

Fix an issue with query live plan in preview UI when complex queries are not visible by default.
Partially addressing https://github.com/trinodb/trino/issues/26724

## Additional context and related issues

The query plan is rendered correctly but the default viewport often falls outside the visible area. This PR addresses the issue by making [fitView ](https://reactflow.dev/api-reference/react-flow#fitview) the default ensuring the entire flow is zoomed and positioned to fit within the window.

In addition it introduces an `Origin` button that dynamically centers on the first node, serving both as a convenient reset and as a default zoom-in option if the full flow initially appears too small.

<img width="1315" height="1012" alt="image" src="https://github.com/user-attachments/assets/8fad5116-fb3c-4551-b135-bd8cf8869d03" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix query plan default viewport in preview UI. ({issue}`26749`)
```
