### PR TITLE
Fix findOffsetsForTimestampGreaterOrEqual

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -182,8 +182,7 @@ public class KafkaFilterManager
     {
         Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetAndTimestamps = kafkaConsumer.offsetsForTimes(timestamps);
         return topicPartitionOffsetAndTimestamps.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, entry -> Optional.of(entry.getValue())
-                        .map(OffsetAndTimestamp::offset)));
+                .collect(toMap(Map.Entry::getKey, entry -> Optional.ofNullable(entry.getValue()).map(OffsetAndTimestamp::offset)));
     }
 
     private static Map<TopicPartition, Long> overridePartitionBeginOffsets(Map<TopicPartition, Long> partitionBeginOffsets,


### PR DESCRIPTION
According to the Kafka client documentation:

If the message format version in a partition is before 0.10.0, i.e. the messages do not have timestamps, null will be returned for that partition.

Fixes https://github.com/trinodb/trino/issues/26787

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Kafka
* Fix queries failing when filtering partitions by timestamp offset ({issue}`26787`)
```
