### PR TITLE
Remove dependency group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      dependency-updates:
-        applies-to: version-updates
-        update-types:
-        - major
-        - minor
-        - patch
-      security-updates:
-        applies-to: security-updates
-        dependency-type: production
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -21,13 +11,3 @@ updates:
     assignees:
       - wendigo
     open-pull-requests-limit: 10
-    groups:
-      dependency-updates:
-        applies-to: version-updates
-        update-types:
-        - major
-        - minor
-        - patch
-      security-updates:
-        applies-to: security-updates
-        dependency-type: production


### PR DESCRIPTION
It's not really useful as usually you need to resolve conflicts one by one so having updates batched makes more work then merging individual conflict-free updates.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
