### PR TITLE
Fix failure when reading Iceberg `$files` table in Lakehouse connector

### DIFF
--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehousePageSourceProviderFactory.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehousePageSourceProviderFactory.java
@@ -22,8 +22,10 @@ import io.trino.plugin.hudi.HudiPageSourceProvider;
 import io.trino.plugin.hudi.HudiTableHandle;
 import io.trino.plugin.iceberg.IcebergPageSourceProviderFactory;
 import io.trino.plugin.iceberg.IcebergTableHandle;
+import io.trino.plugin.iceberg.system.files.FilesTableSplit;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
+import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorTableHandle;
 
 import static java.util.Objects.requireNonNull;
@@ -53,17 +55,21 @@ public class LakehousePageSourceProviderFactory
     public ConnectorPageSourceProvider createPageSourceProvider()
     {
         return (transaction, session, split, table, columns, dynamicFilter) ->
-                forHandle(table).createPageSource(transaction, session, split, table, columns, dynamicFilter);
+                forHandle(split, table).createPageSource(transaction, session, split, table, columns, dynamicFilter);
     }
 
-    private ConnectorPageSourceProvider forHandle(ConnectorTableHandle handle)
+    private ConnectorPageSourceProvider forHandle(ConnectorSplit split, ConnectorTableHandle handle)
     {
+        if (split instanceof FilesTableSplit) {
+            return icebergPageSourceProviderFactory.createPageSourceProvider();
+        }
+
         return switch (handle) {
             case HiveTableHandle _ -> hivePageSourceProvider;
             case IcebergTableHandle _ -> icebergPageSourceProviderFactory.createPageSourceProvider();
             case DeltaLakeTableHandle _ -> deltaLakePageSourceProvider;
             case HudiTableHandle _ -> hudiPageSourceProvider;
-            default -> throw new UnsupportedOperationException("Unsupported table handle " + handle.getClass());
+            default -> throw new UnsupportedOperationException("Unsupported table handle " + handle.getClass() + " with split " + split.getClass());
         };
     }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseHiveConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseHiveConnectorSmokeTest.java
@@ -66,4 +66,13 @@ public class TestLakehouseHiveConnectorSmokeTest
                    type = 'HIVE'
                 )""");
     }
+
+    @Test
+    void testSelectMetadataTable()
+    {
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$history\""))
+                .failure().hasMessageMatching(".* Table .* does not exist");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$files\""))
+                .failure().hasMessageMatching(".* Table .* does not exist");
+    }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -15,6 +15,19 @@ package io.trino.plugin.lakehouse;
 
 import org.junit.jupiter.api.Test;
 
+import static io.trino.plugin.iceberg.TableType.ALL_ENTRIES;
+import static io.trino.plugin.iceberg.TableType.ALL_MANIFESTS;
+import static io.trino.plugin.iceberg.TableType.DATA;
+import static io.trino.plugin.iceberg.TableType.ENTRIES;
+import static io.trino.plugin.iceberg.TableType.FILES;
+import static io.trino.plugin.iceberg.TableType.HISTORY;
+import static io.trino.plugin.iceberg.TableType.MANIFESTS;
+import static io.trino.plugin.iceberg.TableType.MATERIALIZED_VIEW_STORAGE;
+import static io.trino.plugin.iceberg.TableType.METADATA_LOG_ENTRIES;
+import static io.trino.plugin.iceberg.TableType.PARTITIONS;
+import static io.trino.plugin.iceberg.TableType.PROPERTIES;
+import static io.trino.plugin.iceberg.TableType.REFS;
+import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
 import static io.trino.plugin.lakehouse.TableType.ICEBERG;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,5 +56,41 @@ public class TestLakehouseIcebergConnectorSmokeTest
                    location = \\E's3://test-bucket-.*/tpch/region-.*'\\Q,
                    type = 'ICEBERG'
                 )\\E""");
+    }
+
+    @Test
+    void testSelectMetadataTable()
+    {
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$history\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$metadata_log_entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$snapshots\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$all_manifests\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$manifests\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$partitions\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$files\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$all_entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(6 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$refs\"")).matches("VALUES (CAST(1 AS BIGINT))");
+
+        // This test should get updated if a new system table is added
+        assertThat(io.trino.plugin.iceberg.TableType.values())
+                .containsExactly(
+                        DATA,
+                        HISTORY,
+                        METADATA_LOG_ENTRIES,
+                        SNAPSHOTS,
+                        ALL_MANIFESTS,
+                        MANIFESTS,
+                        PARTITIONS,
+                        FILES,
+                        ALL_ENTRIES,
+                        ENTRIES,
+                        PROPERTIES,
+                        REFS,
+                        MATERIALIZED_VIEW_STORAGE);
+
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$timeline\""))
+                .failure().hasMessageMatching(".* Table .* does not exist");
     }
 }


### PR DESCRIPTION
Fix support for system tables for Lakehouse.
The $files and $history system tables for Iceberg tables are not handled properly.

Fixes https://github.com/trinodb/trino/issues/26751

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

For system tables, the handle will be an instance of io.trino.connector.system.SystemTableHandle.
Some Iceberg system tables ($files and $history) use special splits (FilesTableSplit).

io.trino.connector.system.SystemTableHandle is part of trino-main, which is a test dependency for trino-lakehouse.
The dependency to trino-main is not changed.

## Release notes

```markdown
## Lakehouse
* Fix failure when reading Iceberg `$files` table. ({issue}`26751`)
```
