### PR TITLE
Add support for direct method invocation

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -601,10 +601,8 @@ primaryExpression
         (ON OVERFLOW listAggOverflowBehavior)? ')'
         (WITHIN GROUP '(' orderBy ')')
         filter? over?                                                                     #listagg
-    | processingMode? qualifiedName '(' (label=identifier '.')? ASTERISK ')'
-        filter? over?                                                                     #functionCall
-    | processingMode? qualifiedName '(' (setQuantifier? expression (',' expression)*)?
-        orderBy? ')' filter? (nullTreatment? over)?                                       #functionCall
+    | function                                                                            #functions
+    | left=primaryExpression '.' right=function                                           #directInvocation
     | identifier over                                                                     #measure
     | identifier '->' expression                                                          #lambda
     | '(' (identifier (',' identifier)*)? ')' '->' expression                             #lambda
@@ -667,6 +665,13 @@ primaryExpression
         )?
         (RETURNING type (FORMAT jsonRepresentation)?)?
      ')'                                                                                  #jsonArray
+    ;
+
+function
+    : processingMode? qualifiedName '(' (label=identifier '.')? ASTERISK ')'
+        filter? over?                                                                     #functionCall
+    | processingMode? qualifiedName '(' (setQuantifier? expression (',' expression)*)?
+        orderBy? ')' filter? (nullTreatment? over)?                                       #functionCall
     ;
 
 literal

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestDirectInvocation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestDirectInvocation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestDirectInvocation
+{
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    void testDirectInvocation()
+    {
+        assertThat(assertions.query("SELECT ('hello').upper().concat(' world!')"))
+                .matches("SELECT VARCHAR 'HELLO world!'");
+
+        assertThat(assertions.query("SELECT (-123).abs()"))
+                .matches("SELECT 123");
+    }
+
+    @Test
+    void testQualifiedFunctionName()
+    {
+        assertThat(assertions.query("SELECT (-123).system.builtin.abs()"))
+                .matches("SELECT 123");
+    }
+
+    @Test
+    void testInvalidType()
+    {
+        assertThat(assertions.query("SELECT ('hello').abs()")).failure()
+                .hasMessage("line 1:8: Unexpected parameters (varchar(5)) for function abs. Expected: abs(bigint), abs(decimal(p,s)), abs(double), abs(integer), abs(number), abs(real), abs(smallint), abs(tinyint)");
+    }
+
+    @Test
+    void testInvalidParameter()
+    {
+        assertThat(assertions.query("SELECT (-123).e()")).failure()
+                .hasMessage("line 1:8: Unexpected parameters (integer) for function e. Expected: e()");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -2466,6 +2466,19 @@ class AstBuilder
     }
 
     @Override
+    public Node visitDirectInvocation(SqlBaseParser.DirectInvocationContext context)
+    {
+        FunctionCall functionCall = (FunctionCall) visit(context.right);
+        return new FunctionCall(
+                getLocation(context),
+                functionCall.getName(),
+                ImmutableList.<Expression>builder()
+                        .add((Expression) visit(context.left))
+                        .addAll(functionCall.getArguments())
+                        .build());
+    }
+
+    @Override
     public Node visitAtTimeZone(SqlBaseParser.AtTimeZoneContext context)
     {
         return new AtTimeZone(

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1732,6 +1732,21 @@ public class TestSqlParser
     }
 
     @Test
+    void testDirectInvocation()
+    {
+        assertStatement("SELECT ('hello').concat(' ').concat('world')",
+                simpleQuery(selectList(
+                        new FunctionCall(QualifiedName.of("concat"), Lists.newArrayList(
+                                new FunctionCall(QualifiedName.of("concat"), Lists.newArrayList(new StringLiteral("hello"), new StringLiteral(" "))),
+                                new StringLiteral("world"))))));
+
+        assertStatement("SELECT (-123).abs()",
+                simpleQuery(selectList(
+                        new FunctionCall(QualifiedName.of("abs"), Lists.newArrayList(new LongLiteral("-123"))))));
+
+    }
+
+    @Test
     void testCreateBranch()
     {
         assertThat(statement("CREATE BRANCH b IN TABLE t"))

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -75,7 +75,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("select CAST(-12223222232535343423232435343 AS BIGINT)",
                         "line 1:13: Invalid numeric literal: -12223222232535343423232435343"),
                 Arguments.of("select foo.!",
-                        "line 1:12: mismatched input '!'. Expecting: '*', <identifier>"),
+                        "line 1:12: mismatched input '!'. Expecting: '*', 'FINAL', 'RUNNING', <identifier>"),
                 Arguments.of("select foo(,1)",
                         "line 1:12: mismatched input ','. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>"),
                 Arguments.of("select foo ( ,1)",


### PR DESCRIPTION
## Description

This is a proposal to add support for chained function calls, similar to [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#chained-function-calls), [DuckDB](https://duckdb.org/docs/stable/sql/functions/overview.html#function-chaining-via-the-dot-operator). 
It improves the readability of deeply nested expressions. Also, it eliminates the need to move the cursor backward when writing functions.

```sql
SELECT
  REPLACE(
    REPLACE(
      REPLACE(
        REPLACE(
          REPLACE('one two three four five', 'one', '1'),
          'two', '2'),
        'three', '3'),
      'four', '4'),
    'five', '5');
```
↓
```sql
SELECT
  ('one two three four five')
  .REPLACE('one', '1')
  .REPLACE('two', '2')
  .REPLACE('three', '3')
  .REPLACE('four', '4')
  .REPLACE('five', '5');
```

The corresponding SQL syntax:

**6.17 \<method invocation\>**
```
<method invocation> ::=
    <direct invocation> 
  | <generalized invocation> 

<direct invocation> ::=
  <value expression primary>  <period>  <method name>  [ <SQL argument list>  ]

<generalized invocation> ::=
  <left paren>  <value expression primary>  AS <data type>  <right paren> 
      <period>  <method name>  [ <SQL argument list>  ]

<method selection> ::=
  <routine invocation> 

<constructor method selection> ::=
  <routine invocation> 
```

**6.18 \<static method invocation\>**
```
<static method invocation> ::=
  <path-resolved user-defined type name>  <double colon>  <method name> 
      [ <SQL argument list>  ]

<static method selection> ::=
  <routine invocation> 
```

## Release notes

```markdown
## General
* Add support for chained function calls. ({issue}`26841`)
```
