### PR TITLE
Cleanup S3FileSystemExchangeStorage

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/s3/S3FileSystemExchangeStorage.java
@@ -56,8 +56,6 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
@@ -395,7 +393,6 @@ public class S3FileSystemExchangeStorage
             DeleteObjectsRequest request = DeleteObjectsRequest.builder()
                     .bucket(bucketName)
                     .delete(Delete.builder().objects(list.stream().map(key -> ObjectIdentifier.builder().key(key).build()).collect(toImmutableList())).build())
-                    .overrideConfiguration(disableStrongIntegrityChecksums())
                     .build();
             return toListenableFuture(s3Clients.getUnchecked(bucketName).deleteObjects(request));
         }).collect(toImmutableList())));
@@ -926,15 +923,5 @@ public class S3FileSystemExchangeStorage
                     .build();
             return stats.getAbortMultipartUpload().record(toListenableFuture(s3AsyncClient.abortMultipartUpload(abortMultipartUploadRequest)));
         }
-    }
-
-    // TODO (https://github.com/trinodb/trino/issues/24955):
-    // remove me once all of the S3-compatible storage support strong integrity checks
-    @SuppressWarnings("deprecation")
-    static AwsRequestOverrideConfiguration disableStrongIntegrityChecksums()
-    {
-        return AwsRequestOverrideConfiguration.builder()
-                .signer(AwsS3V4Signer.create())
-                .build();
     }
 }


### PR DESCRIPTION
We use LegacyMd5Plugin which makes other settings redundant

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Clean up S3FileSystemExchangeStorage by removing the legacy override that disables strong integrity checks and deleting the associated helper method.

Enhancements:
- Remove the disableStrongIntegrityChecksums request override from deleteObjects
- Delete the deprecated disableStrongIntegrityChecksums helper method