### PR TITLE
Fix incorrect results when reading migrated Iceberg Avro files

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -574,7 +574,8 @@ public class IcebergPageSourceProvider
                     fileSchema,
                     nameMapping,
                     partition,
-                    dataColumns);
+                    dataColumns,
+                    partitionKeys);
         };
     }
 
@@ -1113,7 +1114,8 @@ public class IcebergPageSourceProvider
             Schema fileSchema,
             Optional<NameMapping> nameMapping,
             String partition,
-            List<IcebergColumnHandle> columns)
+            List<IcebergColumnHandle> columns,
+            Map<Integer, Optional<String>> partitionKeys)
     {
         InputFile file = new ForwardingInputFile(inputFile);
         OptionalLong fileModifiedTime = OptionalLong.empty();
@@ -1146,7 +1148,13 @@ public class IcebergPageSourceProvider
 
             int nextOrdinal = 0;
             for (IcebergColumnHandle column : columns) {
-                if (column.isPartitionColumn()) {
+                if (partitionKeys.containsKey(column.getId())) {
+                    Type trinoType = column.getType();
+                    transforms.constantValue(nativeValueToBlock(
+                            trinoType,
+                            deserializePartitionValue(trinoType, partitionKeys.get(column.getId()).orElse(null), column.getName())));
+                }
+                else if (column.isPartitionColumn()) {
                     transforms.constantValue(nativeValueToBlock(PARTITION.getType(), utf8Slice(partition)));
                 }
                 else if (column.isPathColumn()) {


### PR DESCRIPTION
## Description

Fixes #26863

## Release notes

```markdown
## Iceberg
* Fix incorrect results when reading Avro files migrated from Hive. ({issue}`26863`)
```

## Summary by Sourcery

Fix partition key handling in Avro page source for migrated Iceberg files and extend migration tests to cover Avro and ORC formats

Bug Fixes:
- Correct partition column resolution in the Avro page source by passing and applying explicit partition keys

Tests:
- Parameterize TestIcebergMigrateProcedure to run partitioned table migration tests for AVRO and ORC and include file format in CREATE TABLE