### PR TITLE
Add support for Zstd, Brotli, Gzip compression to client

### DIFF
--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -56,12 +56,22 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-brotli</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-urlconnection</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-zstd</artifactId>
         </dependency>
 
         <dependency>

--- a/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
@@ -21,7 +21,11 @@ import io.trino.client.auth.external.ExternalAuthenticator;
 import io.trino.client.auth.external.HttpTokenPoller;
 import io.trino.client.auth.external.RedirectHandler;
 import io.trino.client.auth.external.TokenPoller;
+import okhttp3.CompressionInterceptor;
+import okhttp3.Gzip;
 import okhttp3.OkHttpClient;
+import okhttp3.brotli.Brotli;
+import okhttp3.zstd.Zstd;
 
 import java.io.File;
 import java.time.Duration;
@@ -126,6 +130,10 @@ public class HttpClientFactory
         setupTimeouts(builder, toIntExact(uri.getTimeout().toMillis()), TimeUnit.MILLISECONDS);
         setupHttpLogging(builder, uri.getHttpLoggingLevel());
 
+        if (!uri.isCompressionDisabled()) {
+            setupCompression(builder);
+        }
+
         if (uri.isLocalRedirectDisallowed()) {
             builder.addNetworkInterceptor(new DisallowLocalRedirectInterceptor());
         }
@@ -164,6 +172,11 @@ public class HttpClientFactory
         uri.getDnsResolver().ifPresent(resolverClass -> builder.dns(instantiateDnsResolver(resolverClass, uri.getDnsResolverContext())::lookup));
 
         return builder;
+    }
+
+    private static void setupCompression(OkHttpClient.Builder builder)
+    {
+        builder.addInterceptor(new CompressionInterceptor(Zstd.INSTANCE, Brotli.INSTANCE, Gzip.INSTANCE));
     }
 
     protected static void setupUserAgent(OkHttpClient.Builder builder, String userAgent)

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -477,6 +477,10 @@
                                     <shadedPattern>${shadeBase}.guava</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.squareup</pattern>
+                                    <shadedPattern>${shadeBase}.squareup</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>io.airlift</pattern>
                                     <shadedPattern>${shadeBase}.airlift</shadedPattern>
                                 </relocation>
@@ -487,6 +491,10 @@
                                 <relocation>
                                     <pattern>net.bytebuddy</pattern>
                                     <shadedPattern>${shadeBase}.net.bytebuddy</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.brotli</pattern>
+                                    <shadedPattern>${shadeBase}.brotli</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.joda.time</pattern>

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/JdbcDriverIT.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/JdbcDriverIT.java
@@ -75,6 +75,6 @@ public class JdbcDriverIT
 
     public static boolean isExpectedFile(String filename)
     {
-        return MANIFEST_FILES.contains(filename) || filename.startsWith("io/trino/jdbc") || filename.startsWith("aircompressor/");
+        return MANIFEST_FILES.contains(filename) || filename.startsWith("io/trino/jdbc") || filename.startsWith("aircompressor/") || filename.startsWith("jni/");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## CLI/JDBC/Client
* Negotiate zstd, brotli and gzip compression ({issue}`issuenumber`)
```

## Summary by Sourcery

Enable optional Brotli, Zstd, and Gzip compression in the Trino client by adding the necessary dependencies, configuring a CompressionInterceptor in the HTTP client factory, and adjusting package relocation rules in the JDBC client

New Features:
- Add support for Brotli, Zstd, and Gzip compression in the HTTP client

Enhancements:
- Add okhttp-brotli and okhttp-zstd dependencies and configure a CompressionInterceptor in HttpClientFactory
- Relocate com.squareup and org.brotli packages in the JDBC client to prevent classpath conflicts

Tests:
- Update JdbcDriverIT to recognize jni/ directory entries in the shaded file manifest