### PR TITLE
Add support for table_changes function for Lakehouse

### DIFF
--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseConnector.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.lakehouse;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.hive.HiveSchemaProperties;
@@ -26,10 +27,13 @@ import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.immutableEnumSet;
@@ -52,6 +56,8 @@ public class LakehouseConnector
     private final LakehouseSessionProperties sessionProperties;
     private final LakehouseTableProperties tableProperties;
     private final IcebergMaterializedViewProperties materializedViewProperties;
+    private final Set<ConnectorTableFunction> tableFunctions;
+    private final FunctionProvider functionProvider;
 
     @Inject
     public LakehouseConnector(
@@ -63,7 +69,9 @@ public class LakehouseConnector
             LakehouseNodePartitioningProvider nodePartitioningProvider,
             LakehouseSessionProperties sessionProperties,
             LakehouseTableProperties tableProperties,
-            IcebergMaterializedViewProperties materializedViewProperties)
+            IcebergMaterializedViewProperties materializedViewProperties,
+            Set<ConnectorTableFunction> tableFunctions,
+            FunctionProvider functionProvider)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -74,6 +82,8 @@ public class LakehouseConnector
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
         this.materializedViewProperties = requireNonNull(materializedViewProperties, "materializedViewProperties is null");
+        this.tableFunctions = ImmutableSet.copyOf(requireNonNull(tableFunctions, "tableFunctions is null"));
+        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
     }
 
     @Override
@@ -159,5 +169,17 @@ public class LakehouseConnector
     public Set<ConnectorCapabilities> getCapabilities()
     {
         return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT, MATERIALIZED_VIEW_GRACE_PERIOD, MATERIALIZED_VIEW_WHEN_STALE_BEHAVIOR);
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return tableFunctions;
+    }
+
+    @Override
+    public Optional<FunctionProvider> getFunctionProvider()
+    {
+        return Optional.of(functionProvider);
     }
 }

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseDeltaModule.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseDeltaModule.java
@@ -21,6 +21,7 @@ import io.trino.plugin.deltalake.DefaultDeltaLakeFileSystemFactory;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.DeltaLakeExecutorModule;
 import io.trino.plugin.deltalake.DeltaLakeFileSystemFactory;
+import io.trino.plugin.deltalake.DeltaLakeFunctionProvider;
 import io.trino.plugin.deltalake.DeltaLakeMergeResult;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.DeltaLakeNodePartitioningProvider;
@@ -32,6 +33,7 @@ import io.trino.plugin.deltalake.DeltaLakeSynchronizerModule;
 import io.trino.plugin.deltalake.DeltaLakeTableProperties;
 import io.trino.plugin.deltalake.DeltaLakeTransactionManager;
 import io.trino.plugin.deltalake.DeltaLakeWriterStats;
+import io.trino.plugin.deltalake.functions.tablechanges.TableChangesProcessorProvider;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastoreModule;
 import io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler;
 import io.trino.plugin.deltalake.metastore.NoOpVendedCredentialsProvider;
@@ -102,6 +104,9 @@ public class LakehouseDeltaModule
 
         binder.bind(DeltaLakeTableMetadataScheduler.class).in(Scopes.SINGLETON);
         newExporter(binder).export(DeltaLakeTableMetadataScheduler.class).withGeneratedName();
+
+        binder.bind(TableChangesProcessorProvider.class).in(Scopes.SINGLETON);
+        binder.bind(DeltaLakeFunctionProvider.class).in(Scopes.SINGLETON);
 
         jsonCodecBinder(binder).bindJsonCodec(DataFileInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(DeltaLakeMergeResult.class);

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseFunctionProvider.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseFunctionProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lakehouse;
+
+import com.google.inject.Inject;
+import io.trino.plugin.deltalake.DeltaLakeFunctionProvider;
+import io.trino.plugin.deltalake.functions.tablechanges.TableChangesTableFunctionHandle;
+import io.trino.plugin.iceberg.functions.IcebergFunctionProvider;
+import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionHandle;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.TableFunctionProcessorProviderFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class LakehouseFunctionProvider
+        implements FunctionProvider
+{
+    private final DeltaLakeFunctionProvider deltaLakeFunctionProvider;
+    private final IcebergFunctionProvider icebergFunctionProvider;
+
+    @Inject
+    public LakehouseFunctionProvider(
+            DeltaLakeFunctionProvider deltaLakeFunctionProvider,
+            IcebergFunctionProvider icebergFunctionProvider)
+    {
+        this.deltaLakeFunctionProvider = requireNonNull(deltaLakeFunctionProvider, "deltaLakeFunctionProvider is null");
+        this.icebergFunctionProvider = requireNonNull(icebergFunctionProvider, "icebergFunctionProvider is null");
+    }
+
+    @Override
+    public TableFunctionProcessorProviderFactory getTableFunctionProcessorProviderFactory(ConnectorTableFunctionHandle functionHandle)
+    {
+        if (functionHandle instanceof TableChangesTableFunctionHandle) {
+            return deltaLakeFunctionProvider.getTableFunctionProcessorProviderFactory(functionHandle);
+        }
+        if (functionHandle instanceof TableChangesFunctionHandle) {
+            return icebergFunctionProvider.getTableFunctionProcessorProviderFactory(functionHandle);
+        }
+        throw new UnsupportedOperationException("Unsupported function: " + functionHandle);
+    }
+}

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseIcebergModule.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseIcebergModule.java
@@ -43,6 +43,7 @@ import io.trino.plugin.iceberg.catalog.hms.IcebergHiveMetastoreCatalogModule;
 import io.trino.plugin.iceberg.delete.DefaultDeletionVectorWriter;
 import io.trino.plugin.iceberg.delete.DeletionVectorWriter;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIoFactory;
+import io.trino.plugin.iceberg.functions.IcebergFunctionProvider;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -77,6 +78,8 @@ public class LakehouseIcebergModule
         jsonCodecBinder(binder).bindJsonCodec(CommitTaskData.class);
 
         binder.bind(ForwardingFileIoFactory.class).in(Scopes.SINGLETON);
+
+        binder.bind(IcebergFunctionProvider.class).in(Scopes.SINGLETON);
 
         install(switch (buildConfigObject(MetastoreTypeConfig.class).getMetastoreType()) {
             case THRIFT -> new IcebergHiveMetastoreCatalogModule();

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseModule.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseModule.java
@@ -24,7 +24,12 @@ import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionProcessorProviderFactory;
+import io.trino.plugin.lakehouse.functions.tablechanges.TableChangesFunctionProvider;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
@@ -52,6 +57,10 @@ class LakehouseModule
 
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
+
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(TableChangesFunctionProvider.class).in(Scopes.SINGLETON);
+        binder.bind(FunctionProvider.class).to(LakehouseFunctionProvider.class).in(Scopes.SINGLETON);
+        binder.bind(TableChangesFunctionProcessorProviderFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(Key.get(boolean.class, HideDeltaLakeTables.class)).toInstance(false);
     }

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/functions/tablechanges/TableChangesFunction.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/functions/tablechanges/TableChangesFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lakehouse.functions.tablechanges;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.deltalake.metastore.NotADeltaLakeTableException;
+import io.trino.plugin.iceberg.UnknownTableTypeException;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+
+import java.util.Map;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class TableChangesFunction
+        extends AbstractConnectorTableFunction
+{
+    private static final String FUNCTION_NAME = "table_changes";
+    private static final String SCHEMA_NAME = "system";
+    private static final String NAME = "table_changes";
+    public static final String SCHEMA_NAME_ARGUMENT = "SCHEMA_NAME";
+    private static final String TABLE_NAME_ARGUMENT = "TABLE_NAME";
+    private static final String START_SNAPSHOT_VAR_NAME = "START_SNAPSHOT_ID";
+    private static final String END_SNAPSHOT_VAR_NAME = "END_SNAPSHOT_ID";
+    private static final String SINCE_VERSION_ARGUMENT = "SINCE_VERSION";
+
+    private final io.trino.plugin.deltalake.functions.tablechanges.TableChangesFunction deltaLakeTableChangesFunction;
+    private final io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunction icebergTableChangesFunction;
+
+    public TableChangesFunction(
+            io.trino.plugin.deltalake.functions.tablechanges.TableChangesFunction deltaLakeTableChangesFunction,
+            io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunction icebergTableChangesFunction)
+    {
+        super(
+                SCHEMA_NAME,
+                NAME,
+                ImmutableList.of(
+                        ScalarArgumentSpecification.builder().name(SCHEMA_NAME_ARGUMENT).type(VARCHAR).build(),
+                        ScalarArgumentSpecification.builder().name(TABLE_NAME_ARGUMENT).type(VARCHAR).build(),
+                        ScalarArgumentSpecification.builder().name(START_SNAPSHOT_VAR_NAME).type(BIGINT).defaultValue(null).build(),
+                        ScalarArgumentSpecification.builder().name(END_SNAPSHOT_VAR_NAME).type(BIGINT).defaultValue(null).build(),
+                        ScalarArgumentSpecification.builder().name(SINCE_VERSION_ARGUMENT).type(BIGINT).defaultValue(null).build()),
+                GENERIC_TABLE);
+        this.deltaLakeTableChangesFunction = deltaLakeTableChangesFunction;
+        this.icebergTableChangesFunction = icebergTableChangesFunction;
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(
+            ConnectorSession session,
+            ConnectorTransactionHandle transaction,
+            Map<String, Argument> arguments,
+            ConnectorAccessControl accessControl)
+    {
+        try {
+            return deltaLakeTableChangesFunction.analyze(session, transaction, arguments, accessControl);
+        }
+        catch (NotADeltaLakeTableException _) {
+            checkNonNull(arguments.get(START_SNAPSHOT_VAR_NAME), START_SNAPSHOT_VAR_NAME);
+            checkNonNull(arguments.get(END_SNAPSHOT_VAR_NAME), END_SNAPSHOT_VAR_NAME);
+            try {
+                return icebergTableChangesFunction.analyze(session, transaction, arguments, accessControl);
+            }
+            catch (UnknownTableTypeException e) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "table_changes function is not supported for the given table type");
+            }
+        }
+    }
+
+    private void checkNonNull(Object argumentValue, String argumentName)
+    {
+        if (argumentValue == null) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, FUNCTION_NAME + " argument " + argumentName + " may not be null");
+        }
+    }
+}

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/functions/tablechanges/TableChangesFunctionProvider.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/functions/tablechanges/TableChangesFunctionProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.lakehouse.functions.tablechanges;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
+import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.type.TypeManager;
+
+import static java.util.Objects.requireNonNull;
+
+public class TableChangesFunctionProvider
+        implements Provider<ConnectorTableFunction>
+{
+    private final DeltaLakeMetadataFactory deltaLakeMetadataFactory;
+
+    private final TrinoCatalogFactory trinoCatalogFactory;
+    private final TypeManager typeManager;
+
+    @Inject
+    public TableChangesFunctionProvider(
+            DeltaLakeMetadataFactory deltaLakeMetadataFactory,
+            TrinoCatalogFactory trinoCatalogFactory,
+            TypeManager typeManager)
+    {
+        this.deltaLakeMetadataFactory = requireNonNull(deltaLakeMetadataFactory, "deltaLakeMetadataFactory is null");
+        this.trinoCatalogFactory = requireNonNull(trinoCatalogFactory, "trinoCatalogFactory is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        io.trino.plugin.deltalake.functions.tablechanges.TableChangesFunction deltaLakeTableChangesFunction =
+                new io.trino.plugin.deltalake.functions.tablechanges.TableChangesFunction(deltaLakeMetadataFactory);
+        io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunction icebergTableChangesFunction =
+                new io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunction(trinoCatalogFactory, typeManager);
+        return new ClassLoaderSafeConnectorTableFunction(new TableChangesFunction(deltaLakeTableChangesFunction, icebergTableChangesFunction), getClass().getClassLoader());
+    }
+}

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseDeltaConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseDeltaConnectorSmokeTest.java
@@ -21,6 +21,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableType.PARTITIONS;
 import static io.trino.plugin.deltalake.DeltaLakeTableType.PROPERTIES;
 import static io.trino.plugin.deltalake.DeltaLakeTableType.TRANSACTIONS;
 import static io.trino.plugin.lakehouse.TableType.DELTA;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -86,5 +87,99 @@ public class TestLakehouseDeltaConnectorSmokeTest
                 .failure().hasMessageMatching(".* Table .* does not exist");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$timeline\""))
                 .failure().hasMessageMatching(".* Table .* does not exist");
+    }
+
+    @Test
+    void testTableChangesFunction()
+    {
+        String tableName = "test_table_changes_function_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (page_url VARCHAR, domain VARCHAR, views INTEGER) WITH (change_data_feed_enabled = true)");
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES('url1', 'domain1', 1), ('url2', 'domain2', 2), ('url3', 'domain3', 3)", 3);
+        assertUpdate("INSERT INTO " + tableName + " VALUES('url4', 'domain4', 4), ('url5', 'domain5', 2), ('url6', 'domain6', 6)", 3);
+
+        assertUpdate("UPDATE " + tableName + " SET page_url = 'url22' WHERE views = 2", 2);
+        assertTableChangesQuery("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "'))",
+                """
+                        VALUES
+                            ('url1', 'domain1', 1, 'insert', BIGINT '1'),
+                            ('url2', 'domain2', 2, 'insert', BIGINT '1'),
+                            ('url3', 'domain3', 3, 'insert', BIGINT '1'),
+                            ('url4', 'domain4', 4, 'insert', BIGINT '2'),
+                            ('url5', 'domain5', 2, 'insert', BIGINT '2'),
+                            ('url6', 'domain6', 6, 'insert', BIGINT '2'),
+                            ('url2', 'domain2', 2, 'update_preimage', BIGINT '3'),
+                            ('url22', 'domain2', 2, 'update_postimage', BIGINT '3'),
+                            ('url5', 'domain5', 2, 'update_preimage', BIGINT '3'),
+                            ('url22', 'domain5', 2, 'update_postimage', BIGINT '3')
+                        """);
+
+        assertUpdate("DELETE FROM " + tableName + " WHERE views = 2", 2);
+        assertTableChangesQuery("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "', null, null, 3))",
+                """
+                        VALUES
+                            ('url22', 'domain2', 2, 'delete', BIGINT '4'),
+                            ('url22', 'domain5', 2, 'delete', BIGINT '4')
+                        """);
+
+        assertTableChangesQuery("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "')) ORDER BY _commit_version, _change_type, domain",
+                """
+                        VALUES
+                            ('url1', 'domain1', 1, 'insert', BIGINT '1'),
+                            ('url2', 'domain2', 2, 'insert', BIGINT '1'),
+                            ('url3', 'domain3', 3, 'insert', BIGINT '1'),
+                            ('url4', 'domain4', 4, 'insert', BIGINT '2'),
+                            ('url5', 'domain5', 2, 'insert', BIGINT '2'),
+                            ('url6', 'domain6', 6, 'insert', BIGINT '2'),
+                            ('url22', 'domain2', 2, 'update_postimage', BIGINT '3'),
+                            ('url22', 'domain5', 2, 'update_postimage', BIGINT '3'),
+                            ('url2', 'domain2', 2, 'update_preimage', BIGINT '3'),
+                            ('url5', 'domain5', 2, 'update_preimage', BIGINT '3'),
+                            ('url22', 'domain2', 2, 'delete', BIGINT '4'),
+                            ('url22', 'domain5', 2, 'delete', BIGINT '4')
+                        """);
+    }
+
+    private void assertTableChangesQuery(String sql, String expectedResult)
+    {
+        assertThat(query(sql))
+                .result()
+                .exceptColumns("_commit_timestamp")
+                .skippingTypesCheck()
+                .matches(expectedResult);
+    }
+
+    @Test
+    void testTableChangesFunctionFailures()
+    {
+        String tableName = "test_table_changes_function_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (page_url VARCHAR, domain VARCHAR, views INTEGER) WITH (change_data_feed_enabled = true)");
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES('url1', 'domain1', 1), ('url2', 'domain2', 2), ('url3', 'domain3', 3)", 3);
+        assertUpdate("INSERT INTO " + tableName + " VALUES('url4', 'domain4', 4), ('url5', 'domain5', 2), ('url6', 'domain6', 6)", 3);
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes())"))
+                .failure().hasMessage("line 1:21: Missing argument: SCHEMA_NAME");
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(NOSCHEMA))"))
+                .failure().hasMessage("line 1:42: Column 'noschema' cannot be resolved");
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA))"))
+                .failure().hasMessage("line 1:42: Missing argument: TABLE_NAME");
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "'))"))
+                .succeeds();
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "', 'not-a-number', null, null))"))
+                .failure().hasMessage("line 1:100: Cannot cast type varchar(12) to bigint");
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "', null, 'not-a-number', null))"))
+                .failure().hasMessage("line 1:106: Cannot cast type varchar(12) to bigint");
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "', null, null, 'not-a-number'))"))
+                .failure().hasMessage("line 1:112: Cannot cast type varchar(12) to bigint");
+
+        assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "', null, null, 1))"))
+                .succeeds();
     }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -13,7 +13,12 @@
  */
 package io.trino.plugin.lakehouse;
 
+import com.google.common.collect.Iterables;
+import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static io.trino.plugin.iceberg.TableType.ALL_ENTRIES;
 import static io.trino.plugin.iceberg.TableType.ALL_MANIFESTS;
@@ -29,6 +34,8 @@ import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.REFS;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
 import static io.trino.plugin.lakehouse.TableType.ICEBERG;
+import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLakehouseIcebergConnectorSmokeTest
@@ -92,5 +99,96 @@ public class TestLakehouseIcebergConnectorSmokeTest
 
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$timeline\""))
                 .failure().hasMessageMatching(".* Table .* does not exist");
+    }
+
+    @Test
+    void testTableChangesFunction()
+    {
+        DateTimeFormatter instantMillisFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSVV").withZone(UTC);
+
+        try (TestTable table = newTrinoTable(
+                "test_table_changes_function_",
+                "AS SELECT nationkey, name FROM tpch.tiny.nation WITH NO DATA")) {
+            long initialSnapshot = getMostRecentSnapshotId(table.getName());
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, name FROM nation", 25);
+            long snapshotAfterInsert = getMostRecentSnapshotId(table.getName());
+            String snapshotAfterInsertTime = getSnapshotTime(table.getName(), snapshotAfterInsert).format(instantMillisFormatter);
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
+                    "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation".formatted(snapshotAfterInsert, snapshotAfterInsertTime));
+
+            // Run with named arguments
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes(schema_name => CURRENT_SCHEMA, table_name => '%s', start_snapshot_id => %s, end_snapshot_id => %s))"
+                                    .formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
+                    "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation".formatted(snapshotAfterInsert, snapshotAfterInsertTime));
+
+            assertUpdate("DELETE FROM " + table.getName(), 25);
+            long snapshotAfterDelete = getMostRecentSnapshotId(table.getName());
+            String snapshotAfterDeleteTime = getSnapshotTime(table.getName(), snapshotAfterDelete).format(instantMillisFormatter);
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), snapshotAfterInsert, snapshotAfterDelete),
+                    "SELECT nationkey, name, 'delete', %s, '%s', 0 FROM nation".formatted(snapshotAfterDelete, snapshotAfterDeleteTime));
+
+            assertQuery(
+                    "SELECT nationkey, name, _change_type, _change_version_id, to_iso8601(_change_timestamp), _change_ordinal " +
+                            "FROM TABLE(system.table_changes(CURRENT_SCHEMA, '%s', %s, %s))".formatted(table.getName(), initialSnapshot, snapshotAfterDelete),
+                    "SELECT nationkey, name, 'insert', %s, '%s', 0 FROM nation UNION SELECT nationkey, name, 'delete', %s, '%s', 1 FROM nation".formatted(
+                            snapshotAfterInsert, snapshotAfterInsertTime, snapshotAfterDelete, snapshotAfterDeleteTime));
+        }
+    }
+
+    private long getMostRecentSnapshotId(String tableName)
+    {
+        return (long) Iterables.getOnlyElement(getQueryRunner().execute(format("SELECT snapshot_id FROM \"%s$snapshots\" ORDER BY committed_at DESC LIMIT 1", tableName))
+                .getOnlyColumnAsSet());
+    }
+
+    private ZonedDateTime getSnapshotTime(String tableName, long snapshotId)
+    {
+        return (ZonedDateTime) Iterables.getOnlyElement(getQueryRunner().execute(format("SELECT committed_at FROM \"%s$snapshots\" WHERE snapshot_id = %s", tableName, snapshotId))
+                .getOnlyColumnAsSet());
+    }
+
+    @Test
+    void testTableChangesFunctionFailures()
+    {
+        try (TestTable table = newTrinoTable(
+                "test_table_changes_function_",
+                "AS SELECT nationkey, name FROM tpch.tiny.nation WITH NO DATA")) {
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT nationkey, name FROM nation", 25);
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes())"))
+                    .failure().hasMessageMatching("line 1:21: Missing argument: SCHEMA_NAME");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(NOSCHEMA))"))
+                    .failure().hasMessageMatching("line 1:42: Column 'noschema' cannot be resolved");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA))"))
+                    .failure().hasMessageMatching("line 1:42: Missing argument: TABLE_NAME");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "'))"))
+                    .failure().hasMessageMatching("table_changes arguments may not be null");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "', 'not-a-number', null, null))"))
+                    .failure().hasMessage("line 1:100: Cannot cast type varchar(12) to bigint");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "', null, 'not-a-number', null))"))
+                    .failure().hasMessage("line 1:106: Cannot cast type varchar(12) to bigint");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "', null, null, 'not-a-number'))"))
+                    .failure().hasMessage("line 1:112: Cannot cast type varchar(12) to bigint");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "', 100))"))
+                    .failure().hasMessageMatching("table_changes arguments may not be null");
+
+            assertThat(query("SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "', 100, 200))"))
+                    .failure().hasMessageMatching("Snapshot not found in Iceberg table history: 100");
+        }
     }
 }


### PR DESCRIPTION
Add support for table_changes function for Lakehouse

Fixes https://github.com/trinodb/trino/issues/26756

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The table_changes function is supported by DeltaLake and Iceberg modules.

The TableChangesFunction does the initial analysis.
The Lakehouse TableChangesFunction will delegate to the DeltaLake TableChangesFunction, or, if the table is not found, to the Iceberg TableChangesFunction.

The LakehouseFunctionProvider returns the TableFunctionProcessorProviderFactory from DeltaLake or Iceberg, depending on the previously functionHandle generated by the TableChangesFunction.

The function for DeltaLake has 3 parameters:
schema_name, table_name, since_version (optional)

The function for Iceberg has 4 parameters (all required):
schema_name, table_name, start_snapshot_id, end_snapshot_id

The function for Lakehouse will have 5 parameters:
schema_name, table_name, start_snapshot_id, end_snapshot_id, since_version (optional)

start_snapshot_id and end_snapshot_id are optional for DeltaLake, but required for Iceberg module

For DeltaLake, the function is called like this:
```
system.table_changes(
  schema_name => 'tpch',
  table_name => 'region',
  since_version => 0
)
```
or
```
system.table_changes('tpch', 'region', null, null, 0)
```
For Iceberg, the function is called like this:
```
system.table_changes(
  schema_name => 'tpch',
  table_name => 'region',
  start_snapshot_id => 12345,
  end_snapshot_id => 67890
)
```
or
```
system.table_changes('tpch', 'region', 12345, 678909)
```
<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`26756`)
```

## Summary by Sourcery

Add support for the system.table_changes function to the Lakehouse connector by delegating SQL analysis and execution to the DeltaLake or Iceberg implementations.

New Features:
- Expose a table_changes table function in the Lakehouse connector that routes to DeltaLake or Iceberg based on the target table.

Enhancements:
- Extend LakehouseConnector to register table functions and provide a FunctionProvider for delegation.
- Configure dependency injection in LakehouseModule, LakehouseDeltaModule, and LakehouseIcebergModule to bind function providers and processor factories.

Tests:
- Add integration smoke tests for table_changes in both Iceberg and DeltaLake connectors to validate insert, update, and delete change streams.