### PR TITLE
Disallow dropping sort column explicitly in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2619,6 +2619,11 @@ public class IcebergMetadata
         if (isPartitionColumn) {
             throw new TrinoException(NOT_SUPPORTED, "Cannot drop partition field: " + name);
         }
+        boolean isSortColumn = icebergTable.sortOrder().fields().stream()
+                .anyMatch(field -> field.sourceId() == fieldId);
+        if (isSortColumn) {
+            throw new TrinoException(NOT_SUPPORTED, "Cannot drop sort field: " + name);
+        }
         int currentSpecId = icebergTable.spec().specId();
         boolean columnUsedInOlderPartitionSpecs = icebergTable.specs().entrySet().stream()
                 .filter(spec -> spec.getValue().specId() != currentSpecId)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1631,7 +1631,7 @@ public abstract class BaseIcebergConnectorTest
                 "WITH (sorted_by = ARRAY['comment']) AS SELECT * FROM nation WITH NO DATA")) {
             assertUpdate(withSmallRowGroups, "INSERT INTO " + table.getName() + " SELECT * FROM nation", 25);
             assertThat(query("ALTER TABLE " + table.getName() + " DROP COLUMN comment"))
-                    .failure().hasMessageContaining("Cannot find source column for sort field");
+                    .failure().hasMessageContaining("Cannot drop sort field: comment");
         }
     }
 


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Disallow explicitly dropping sort fields in Iceberg tables and adjust the test to verify the updated exception message.

Enhancements:
- Prevent dropping sort columns by throwing a NOT_SUPPORTED exception when attempting to drop a sort field in IcebergMetadata

Tests:
- Update test assertion to expect the new error message 'Cannot drop sort field: comment' when dropping a sort column