### PR TITLE
Disable server-side compression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -202,6 +202,7 @@ public class ServerMainModule
 
         configBinder(binder).bindConfigDefaults(HttpServerConfig.class, httpServerConfig -> {
             httpServerConfig.setHttp2MaxConcurrentStreams(32 * 1024); // from the default 16K
+            httpServerConfig.setCompressionEnabled(false); // https://github.com/jetty/jetty.project/issues/13679
         });
 
         binder.bind(PreparedStatementEncoder.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Some of our tests are spuriously failing:
```
Caused by: java.io.EOFException: \n not found: limit=0 content=…
	at io.trino.jdbc.$internal.okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:339)
	at io.trino.jdbc.$internal.okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:107)
	at io.trino.jdbc.$internal.okhttp3.internal.http1.Http1ExchangeCodec$ChunkedSource.readChunkSize(Http1ExchangeCodec.kt:434)
	at io.trino.jdbc.$internal.okhttp3.internal.http1.Http1ExchangeCodec$ChunkedSource.read(Http1ExchangeCodec.kt:416)
	at io.trino.jdbc.$internal.okhttp3.internal.connection.Exchange$ResponseBodySource.read(Exchange.kt:281)
	at io.trino.jdbc.$internal.okio.RealBufferedSource.read(RealBufferedSource.kt:193)
	at io.trino.jdbc.$internal.okio.RealBufferedSource.exhausted(RealBufferedSource.kt:201)
	at io.trino.jdbc.$internal.okio.InflaterSource.refill(InflaterSource.kt:105)
	at io.trino.jdbc.$internal.okio.InflaterSource.readOrInflate(InflaterSource.kt:69)
	at io.trino.jdbc.$internal.okio.InflaterSource.read(InflaterSource.kt:42)
	at io.trino.jdbc.$internal.okio.GzipSource.read(GzipSource.kt:67)
	at io.trino.jdbc.$internal.okio.Buffer.writeAll(Buffer.kt:1308)
	at io.trino.jdbc.$internal.okio.RealBufferedSource.readString(RealBufferedSource.kt:97)
	at io.trino.jdbc.$internal.okhttp3.ResponseBody.string(ResponseBody.kt:187)
	at io.trino.jdbc.$internal.client.JsonResponse.execute(JsonResponse.java:127)
	... 13 more
```

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```