### PR TITLE
Harden pre-signed URI tests

### DIFF
--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -1053,12 +1053,13 @@ public abstract class AbstractTestTrinoFileSystem
                     .preSignedUri(location, new Duration(1, SECONDS));
 
             assertThat(directLocation).isPresent();
-            assertThat(retrieveUri(directLocation.get()))
-                    .isEqualTo(TEST_BLOB_CONTENT_PREFIX + location);
+
+            assertEventually(new Duration(5, SECONDS), () -> assertThat(retrieveUri(directLocation.get()))
+                    .isEqualTo(TEST_BLOB_CONTENT_PREFIX + location));
 
             // Check if it can be retrieved more than once
-            assertThat(retrieveUri(directLocation.get()))
-                    .isEqualTo(TEST_BLOB_CONTENT_PREFIX + location);
+            assertEventually(new Duration(5, SECONDS), () -> assertThat(retrieveUri(directLocation.get()))
+                    .isEqualTo(TEST_BLOB_CONTENT_PREFIX + location));
 
             // Check if after a timeout the pre-signed URI is no longer valid
             assertEventually(new Duration(5, SECONDS), new Duration(1, SECONDS), () -> assertThatThrownBy(() -> retrieveUri(expiredDirectLocation.get()))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Harden pre-signed URI tests by extending valid duration, introducing an expired URI scenario, and using eventual assertions to account for retrieval delays.

Tests:
- Increase pre-signed URI validity from 3 to 30 seconds and generate a separate 1-second URI to test expiration
- Replace direct retrieval assertions with assertEventually calls to handle potential delays
- Assert that expired URIs throw an IOException containing "Failed to retrieve"