### PR TITLE
Reenable HTTP/2 for internal communication

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationConfig.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class InternalCommunicationConfig
 {
     private String sharedSecret;
-    private boolean http2Enabled;
+    private boolean http2Enabled = true;
     private boolean httpsRequired;
     private String keyStorePath;
     private String keyStorePassword;

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -333,6 +333,7 @@ public class ServerMainModule
                     config.setMaxResponseContentLength(DataSize.of(64, MEGABYTE));
                     config.setMaxRequestsQueuedPerDestination(65536);
                     if (internalCommunicationConfig.isHttp2Enabled()) {
+                        // HTTP/2 requires fewer connections thanks to multiplexing
                         config.setMaxConnectionsPerServer(64);
                     }
                     else {

--- a/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestInternalCommunicationConfig.java
@@ -32,7 +32,7 @@ public class TestInternalCommunicationConfig
     {
         assertRecordedDefaults(recordDefaults(InternalCommunicationConfig.class)
                 .setSharedSecret(null)
-                .setHttp2Enabled(false)
+                .setHttp2Enabled(true)
                 .setHttpsRequired(false)
                 .setKeyStorePath(null)
                 .setKeyStorePassword(null)
@@ -50,7 +50,7 @@ public class TestInternalCommunicationConfig
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("internal-communication.shared-secret", "secret")
-                .put("internal-communication.http2.enabled", "true")
+                .put("internal-communication.http2.enabled", "false")
                 .put("internal-communication.https.required", "true")
                 .put("internal-communication.https.keystore.path", keystoreFile.toString())
                 .put("internal-communication.https.keystore.key", "key-key")
@@ -61,7 +61,7 @@ public class TestInternalCommunicationConfig
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
                 .setSharedSecret("secret")
-                .setHttp2Enabled(true)
+                .setHttp2Enabled(false)
                 .setHttpsRequired(true)
                 .setKeyStorePath(keystoreFile.toString())
                 .setKeyStorePassword("key-key")


### PR DESCRIPTION
Lower number of TCP/IP connections for HTTP/2

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
*  Enable HTTP/2 for internal communication ({issue}`issuenumber`)
```

## Summary by Sourcery

Enable HTTP/2 for internal Trino communication by default and adjust connection limits accordingly

Enhancements:
- Enable HTTP/2 for internal communication by default
- Reduce default max connections per server from 250 to 64 when HTTP/2 is enabled
- Add http2Enabled default value to InternalCommunicationConfig
- Update tests to expect the new HTTP/2 default and explicit configuration mappings