### PR TITLE
Fix DevelopmentServer plugin.dir configuration

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ClosingBinder.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ClosingBinder.java
@@ -85,6 +85,11 @@ public class ClosingBinder
         closeables.addBinding().toProvider(new ResourceCloser<T>(key, close));
     }
 
+    public void registerCloseable(AutoCloseable instance)
+    {
+        closeables.addBinding().toInstance(instance);
+    }
+
     private static class ResourceCloser<T>
             implements Provider<AutoCloseable>
     {

--- a/testing/trino-server-dev/pom.xml
+++ b/testing/trino-server-dev/pom.xml
@@ -42,6 +42,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 

--- a/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
@@ -18,8 +18,14 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.trino.server.PluginManager.PluginsProvider;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
 
 public final class DevelopmentServer
         extends Server
@@ -29,11 +35,24 @@ public final class DevelopmentServer
     @Override
     protected Iterable<? extends Module> getAdditionalModules()
     {
-        return ImmutableList.of(binder -> {
-            newOptionalBinder(binder, PluginsProvider.class).setBinding()
-                    .to(DevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
-            configBinder(binder).bindConfig(DevelopmentLoaderConfig.class);
-        });
+        try {
+            Path pluginPath = Files.createTempDirectory("plugins");
+
+            return ImmutableList.of(binder -> {
+                newOptionalBinder(binder, PluginsProvider.class).setBinding()
+                        .to(DevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
+                configBinder(binder).bindConfig(DevelopmentLoaderConfig.class);
+
+                // Use a temporary directory to satisfy configuration validation
+                configBinder(binder).bindConfigDefaults(ServerPluginsProviderConfig.class, config ->
+                        config.setInstalledPluginsDirs(ImmutableList.of(pluginPath.toFile())));
+
+                closingBinder(binder).registerCloseable(() -> Files.deleteIfExists(pluginPath));
+            });
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Generate a temporary plugins directory in DevelopmentServer, inject it into ServerPluginsProviderConfig, and ensure it is cleaned up on shutdown; extend ClosingBinder to register arbitrary Closeable instances

Enhancements:
- Create temporary plugin directory in DevelopmentServer and bind it as the default installedPluginsDirs
- Register cleanup of the temporary directory via ClosingBinder
- Wrap plugin directory creation in try/catch and rethrow IOException as UncheckedIOException
- Add registerCloseable method to ClosingBinder to support registering arbitrary Closeable instances for cleanup