### PR TITLE
Use Path instead of a File for plugin.dir

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerPluginsProviderConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerPluginsProviderConfig.java
@@ -18,21 +18,21 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 public class ServerPluginsProviderConfig
 {
-    private List<File> installedPluginsDirs = ImmutableList.of(new File("plugin"));
+    private List<Path> installedPluginsDirs = ImmutableList.of(Path.of("plugin"));
 
-    public List<@FileExists File> getInstalledPluginsDirs()
+    public List<@FileExists Path> getInstalledPluginsDirs()
     {
         return installedPluginsDirs;
     }
 
     @Config("plugin.dir")
     @ConfigDescription("Comma separated list of root directories where the plugins are located")
-    public ServerPluginsProviderConfig setInstalledPluginsDirs(List<File> installedPluginsDirs)
+    public ServerPluginsProviderConfig setInstalledPluginsDirs(List<Path> installedPluginsDirs)
     {
         this.installedPluginsDirs = ImmutableList.copyOf(installedPluginsDirs);
         return this;

--- a/core/trino-main/src/test/java/io/trino/server/TestServerPluginsProviderConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestServerPluginsProviderConfig.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,7 @@ public class TestServerPluginsProviderConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ServerPluginsProviderConfig.class)
-                .setInstalledPluginsDirs(List.of(new File("plugin"))));
+                .setInstalledPluginsDirs(List.of(Path.of("plugin"))));
     }
 
     @Test
@@ -41,7 +40,7 @@ public class TestServerPluginsProviderConfig
         Map<String, String> properties = ImmutableMap.of("plugin.dir", tempDir.toString());
 
         ServerPluginsProviderConfig expected = new ServerPluginsProviderConfig()
-                .setInstalledPluginsDirs(List.of(tempDir.toFile()));
+                .setInstalledPluginsDirs(List.of(tempDir));
 
         assertFullMapping(properties, expected);
     }
@@ -52,7 +51,7 @@ public class TestServerPluginsProviderConfig
         Map<String, String> properties = ImmutableMap.of("plugin.dir", tempDir1.toString() + "," + tempDir2.toString());
 
         ServerPluginsProviderConfig expected = new ServerPluginsProviderConfig()
-                .setInstalledPluginsDirs(List.of(tempDir1.toFile(), tempDir2.toFile()));
+                .setInstalledPluginsDirs(List.of(tempDir1, tempDir2));
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginLoader.java
+++ b/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginLoader.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.Plugin;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
@@ -67,7 +67,7 @@ public class PluginLoader
         plugin.getExchangeManagerFactories().forEach(factory -> System.out.println(EXCHANGE_MANAGER + factory.getName()));
     }
 
-    public static List<Plugin> loadPlugins(List<File> path)
+    public static List<Plugin> loadPlugins(List<Path> path)
     {
         ServerPluginsProviderConfig config = new ServerPluginsProviderConfig();
         config.setInstalledPluginsDirs(path);

--- a/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginReader.java
+++ b/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginReader.java
@@ -22,6 +22,7 @@ import picocli.CommandLine.Option;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +47,7 @@ public class PluginReader
     private Optional<File> impactedModulesFile;
 
     @Option(names = {"-p", "--plugin-dir"}, description = "Trino plugin directories", arity = "1..*")
-    private List<File> pluginDirs = List.of(new File("plugin"));
+    private List<Path> pluginDirs = List.of(Path.of("plugin"));
 
     @Option(names = {"-r", "--root-pom"}, description = "Trino root module pom.xml")
     private File rootPom = new File("pom.xml");


### PR DESCRIPTION
Just a cleanup

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Refactor plugin directory handling to use java.nio.file.Path instead of java.io.File across core and testing modules.

Enhancements:
- Use Path in ServerPluginsProvider and update directory listing, classpath building, and URL conversion methods accordingly
- Change ServerPluginsProviderConfig to accept Path lists for installedPluginsDirs instead of File
- Adjust PluginLoader and PluginReader to use Path for plugin directory inputs

Tests:
- Update TestServerPluginsProviderConfig to assert Path-based defaults and explicit plugin directory mappings