### PR TITLE
Add support for DateTime64(precision[, timezone]) in ClickHouse

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.md
+++ b/docs/src/main/sphinx/connector/clickhouse.md
@@ -233,6 +233,9 @@ to the following table:
 * - `DateTime[(timezone)]`
   - `TIMESTAMP(0) [WITH TIME ZONE]`
   -
+* - `DateTime64(p[, timezone])`
+  - `TIMESTAMP(p) [WITH TIME ZONE]`
+  -
 * - `IPv4`
   - `IPADDRESS`
   -
@@ -303,6 +306,9 @@ to the following table:
   -
 * - `TIMESTAMP(0)`
   - `DateTime`
+  -
+* - `TIMESTAMP(p)`
+  - `DateTime64(p)`
   -
 * - `UUID`
   - `UUID`

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/TrinoToClickHouseWriteChecker.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/TrinoToClickHouseWriteChecker.java
@@ -36,16 +36,18 @@ public class TrinoToClickHouseWriteChecker<T>
     // Different versions of ClickHouse may support different min/max values for the
     // same data type, you can refer to the table below:
     //
-    // | version | column type | min value           | max value            |
-    // |---------|-------------|---------------------|----------------------|
-    // | any     | UInt8       | 0                   | 255                  |
-    // | any     | UInt16      | 0                   | 65535                |
-    // | any     | UInt32      | 0                   | 4294967295           |
-    // | any     | UInt64      | 0                   | 18446744073709551615 |
-    // | < 21.4  | Date        | 1970-01-01          | 2106-02-07           |
-    // | < 21.4  | DateTime    | 1970-01-01 00:00:00 | 2106-02-06 06:28:15  |
-    // | >= 21.4 | Date        | 1970-01-01          | 2149-06-06           |
-    // | >= 21.4 | DateTime    | 1970-01-01 00:00:00 | 2106-02-07 06:28:15  |
+    // | version | column type | min value           | max value                     |
+    // |---------+-------------+---------------------+-------------------------------|
+    // | any     | UInt8       | 0                   | 255                           |
+    // | any     | UInt16      | 0                   | 65535                         |
+    // | any     | UInt32      | 0                   | 4294967295                    |
+    // | any     | UInt64      | 0                   | 18446744073709551615          |
+    // | < 21.4  | Date        | 1970-01-01          | 2106-02-07                    |
+    // | < 21.4  | DateTime    | 1970-01-01 00:00:00 | 2106-02-06 06:28:15           |
+    // | < 21.4  | DateTime64  | 1970-01-01 00:00:00 | 2106-02-06 06:28:15.999999999 |
+    // | >= 21.4 | Date        | 1970-01-01          | 2149-06-06                    |
+    // | >= 21.4 | DateTime    | 1970-01-01 00:00:00 | 2106-02-07 06:28:15           |
+    // | >= 21.4 | DateTime64  | 1925-01-01 00:00:00 | 2283-11-11 23:59:59.99999999  |
     //
     // And when the value written to ClickHouse is out of range, ClickHouse will store
     // the incorrect result, so we need to check the range of the written value to
@@ -68,6 +70,14 @@ public class TrinoToClickHouseWriteChecker<T>
                     new TimestampWriteValueChecker(
                             version -> version.isNewerOrEqualTo("21.4"),
                             new Range<>(LocalDateTime.parse("1970-01-01T00:00:00"), LocalDateTime.parse("2106-02-07T06:28:15")))));
+    public static final TrinoToClickHouseWriteChecker<LocalDateTime> DATETIME64 = new TrinoToClickHouseWriteChecker<>(
+            ImmutableList.of(
+                    new TimestampWriteValueChecker(
+                            version -> version.isOlderThan("21.4"),
+                            new Range<>(LocalDateTime.parse("1900-01-01T00:00:00"), LocalDateTime.parse("2262-04-11T23:47:16"))),
+                    new TimestampWriteValueChecker(
+                            version -> version.isNewerOrEqualTo("21.4"),
+                            new Range<>(LocalDateTime.parse("1900-01-01T00:00:00"), LocalDateTime.parse("2262-04-11T23:47:16")))));
 
     private final List<Checker<T>> checkers;
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -599,8 +599,6 @@ public class TestClickHouseConnectorTest
 
             case "time":
             case "time(6)":
-            case "timestamp":
-            case "timestamp(6)":
             case "timestamp(3) with time zone":
             case "timestamp(6) with time zone":
                 return Optional.of(dataMappingTestSetup.asUnsupported());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This commit supports reading `DateTime64(precision, timezone)` from ClickHouse.

In addition to this, previously Trino `Timestamp(0)` was mapped to ClickHouse `DateTime`, this commit extends this behavior by mapping Trino `Timestamp(p)` to ClickHouse `DateTime64(p)`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Re-opening an old issue and PR @tangjiangling was working on some time ago:
https://github.com/trinodb/trino/issues/10537
https://github.com/trinodb/trino/pull/15040 

Besides resolving some merge conflicts and a few tweaks this is all his work.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Add full support for ClickHouse DateTime64 types by mapping Trino TIMESTAMP(p) to DateTime64(p), implementing read/write logic with precision handling and range checks, and updating tests and documentation accordingly

New Features:
- Support ClickHouse DateTime64(p[, timezone]) type for both TIMESTAMP and TIMESTAMP WITH TIME ZONE
- Map Trino TIMESTAMP(p) to ClickHouse DateTime64(p) on write and vice versa on read

Enhancements:
- Introduce dedicated read/write functions and range validation for DateTime64 with up to 9 digits of fractional precision
- Refactor ClickHouseClient to handle DateTime64 mappings and add helper methods for short and long timestamp handling

Documentation:
- Update ClickHouse connector documentation to include DateTime64(p[, timezone]) mappings

Tests:
- Add SQLDataTypeTest cases and connector tests covering DateTime64 precision range, time zones, and min/max bounds
- Extend BaseClickHouseTypeMapping with DateTime64 type factory and value limits