### PR TITLE
Fix query splits timeline in preview UI to prevent blank screen

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QuerySplitsTimeline.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QuerySplitsTimeline.tsx
@@ -177,8 +177,11 @@ export const QuerySplitsTimeline = () => {
             return <Alert severity="info">No split timeline data available.</Alert>
         }
 
-        const timelineStartTime = items.reduce((min, item) => Math.min(min, item.start_time), items[0].start_time)
-        const timelineEndTime = items.reduce((max, item) => Math.max(max, item.end_time), items[0].end_time)
+        const startTimes = items.map((i) => i.start_time).filter(Number.isFinite)
+        const endTimes = items.map((i) => i.end_time).filter(Number.isFinite)
+
+        const timelineStartTime = startTimes.length ? Math.min(...startTimes) : null
+        const timelineEndTime = endTimes.length ? Math.max(...endTimes) : null
 
         const itemRenderer: TimelineItemRenderer = ({ item, itemContext, getItemProps }: TimelineItemRendererProps) => {
             const splitItem = item as SplitTimelineItem
@@ -286,20 +289,28 @@ export const QuerySplitsTimeline = () => {
                     ))}
                 </Box>
 
-                <Timeline
-                    groups={groups}
-                    items={items}
-                    defaultTimeStart={timelineStartTime}
-                    defaultTimeEnd={timelineEndTime}
-                    itemRenderer={itemRenderer}
-                    minZoom={60 * 1000}
-                    itemHeightRatio={0.65}
-                    itemTouchSendsClick={false}
-                    canMove={false}
-                    canResize={false}
-                    stackItems
-                    // traditionalZoom
-                />
+                {timelineStartTime && timelineEndTime ? (
+                    <Timeline
+                        groups={groups}
+                        items={items}
+                        defaultTimeStart={timelineStartTime}
+                        defaultTimeEnd={timelineEndTime}
+                        itemRenderer={itemRenderer}
+                        minZoom={60 * 1000}
+                        itemHeightRatio={0.65}
+                        itemTouchSendsClick={false}
+                        canMove={false}
+                        canResize={false}
+                        stackItems
+                        // traditionalZoom
+                    />
+                ) : (
+                    <Box sx={{ width: '100%', mt: 1 }}>
+                        <Alert severity="info">
+                            Splits timeline will appear automatically when at least one query task starts running
+                        </Alert>
+                    </Box>
+                )}
             </Box>
         )
     }


### PR DESCRIPTION
## Description

Fix an issue when blank screen appears in the preview UI **Query Splits Timeline** when split task hasn’t started.

## Additional context and related issues

Sometimes this happens because the `<Timeline>` component requires valid `defaultTimeStart` and `defaultTimeEnd` values, but `NaN` is being selected as min/max when some tasks don’t have a start/end time.

To fix:
- Filter out `NaN` values when calculating min/max task times.  
- Add a validation check to ensure both `defaultTimeStart` and `defaultTimeEnd` are available before rendering the timeline.  
- Show an `Alert` if the required time values are missing, instead of rendering an empty timeline that results a blank screen

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix query splits timeline in preview UI to prevent blank screen ({issue}`26920`)
```
