### PR TITLE
Add table procedures support for Lakehouse

### DIFF
--- a/docs/src/main/sphinx/connector/lakehouse.md
+++ b/docs/src/main/sphinx/connector/lakehouse.md
@@ -67,6 +67,21 @@ The connector supports accessing the following file systems:
 
 You must enable and configure the specific file system access. 
 
+(lakehouse-sql-support)=
+## SQL support
+
+(lakehouse-schema-and-table-management)=
+### Schema and table management
+
+(lakehouse-alter-table-execute)=
+#### ALTER TABLE EXECUTE
+
+The connector supports the following commands for use with {ref}`ALTER TABLE
+EXECUTE <alter-table-execute>`:
+* for the {ref}`Iceberg connector <iceberg-alter-table-execute>`
+* for the {ref}`Delta Lake connector <delta-lake-alter-table-execute>`
+* for the {ref}`Hive connector <hive-alter-table-execute>`
+
 ## Examples
 
 Create an Iceberg table:

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseConnector.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.lakehouse;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.hive.HiveSchemaProperties;
@@ -26,6 +27,7 @@ import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
@@ -52,6 +54,7 @@ public class LakehouseConnector
     private final LakehouseSessionProperties sessionProperties;
     private final LakehouseTableProperties tableProperties;
     private final IcebergMaterializedViewProperties materializedViewProperties;
+    private final Set<TableProcedureMetadata> tableProcedures;
 
     @Inject
     public LakehouseConnector(
@@ -63,7 +66,8 @@ public class LakehouseConnector
             LakehouseNodePartitioningProvider nodePartitioningProvider,
             LakehouseSessionProperties sessionProperties,
             LakehouseTableProperties tableProperties,
-            IcebergMaterializedViewProperties materializedViewProperties)
+            IcebergMaterializedViewProperties materializedViewProperties,
+            Set<TableProcedureMetadata> tableProcedures)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -74,6 +78,7 @@ public class LakehouseConnector
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
         this.materializedViewProperties = requireNonNull(materializedViewProperties, "materializedViewProperties is null");
+        this.tableProcedures = ImmutableSet.copyOf(requireNonNull(tableProcedures, "tableProcedures is null"));
     }
 
     @Override
@@ -147,6 +152,12 @@ public class LakehouseConnector
     public List<PropertyMetadata<?>> getMaterializedViewProperties()
     {
         return materializedViewProperties.getMaterializedViewProperties();
+    }
+
+    @Override
+    public Set<TableProcedureMetadata> getTableProcedures()
+    {
+        return tableProcedures;
     }
 
     @Override

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
@@ -62,6 +62,7 @@ public abstract class BaseLakehouseConnectorSmokeTest
                 .addLakehouseProperty("s3.endpoint", hiveMinio.getMinio().getMinioAddress())
                 .addLakehouseProperty("s3.path-style-access", "true")
                 .addLakehouseProperty("s3.streaming.part-size", "5MB")
+                .addLakehouseProperty("iceberg.add-files-procedure.enabled", "true")
                 .build();
     }
 

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseDeltaConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseDeltaConnectorSmokeTest.java
@@ -21,6 +21,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableType.PARTITIONS;
 import static io.trino.plugin.deltalake.DeltaLakeTableType.PROPERTIES;
 import static io.trino.plugin.deltalake.DeltaLakeTableType.TRANSACTIONS;
 import static io.trino.plugin.lakehouse.TableType.DELTA;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -86,5 +87,18 @@ public class TestLakehouseDeltaConnectorSmokeTest
                 .failure().hasMessageMatching(".* Table .* does not exist");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$timeline\""))
                 .failure().hasMessageMatching(".* Table .* does not exist");
+    }
+
+    @Test
+    public void testTableProcedures()
+    {
+        String tableName = "test_table_procedures_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar)");
+        try {
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE optimize(file_size_threshold => '10kB')")).succeeds();
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
     }
 }

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -29,6 +29,7 @@ import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.REFS;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
 import static io.trino.plugin.lakehouse.TableType.ICEBERG;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLakehouseIcebergConnectorSmokeTest
@@ -92,5 +93,47 @@ public class TestLakehouseIcebergConnectorSmokeTest
 
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$timeline\""))
                 .failure().hasMessageMatching(".* Table .* does not exist");
+    }
+
+    @Test
+    public void testTableProcedures()
+    {
+        String tableName = "test_table_procedures_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar)");
+        try {
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE optimize(file_size_threshold => '10kB')")).succeeds();
+
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE optimize_manifests")).succeeds();
+
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE drop_extended_stats")).succeeds();
+
+            long currentSnapshotId = getCurrentSnapshotId(tableName);
+            assertThat(currentSnapshotId).isGreaterThan(0);
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE rollback_to_snapshot(" + currentSnapshotId + ")")).succeeds();
+
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE expire_snapshots(retention_threshold => '7d')")).succeeds();
+
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE remove_orphan_files(retention_threshold => '7d')")).succeeds();
+
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE add_files(" +
+                    " location => 's3://my-bucket/a/path'," +
+                    " format => 'ORC')"))
+                    .failure().hasMessage("Failed to add files: Failed to list location: s3://my-bucket/a/path");
+
+            String tableName2 = "test_optimize2_" + randomNameSuffix();
+            assertUpdate("CREATE TABLE " + tableName2 + " (key integer, value varchar)");
+            assertThat(query("ALTER TABLE " + tableName + " EXECUTE add_files_from_table(" +
+                    " schema_name => CURRENT_SCHEMA," +
+                    " table_name => '" + tableName2 + "')"))
+                    .failure().hasMessage("Adding files from non-Hive tables is unsupported");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    private long getCurrentSnapshotId(String tableName)
+    {
+        return (long) computeScalar("SELECT snapshot_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES");
     }
 }


### PR DESCRIPTION
Add table procedures support for Lakehouse

Fixes https://github.com/trinodb/trino/issues/26754

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Iceberg module has several table procedures.
Hive and DeltaLake modules have only the "optimize" table procedure.
The code for the "optimize" table procedure is identical in all 3 modules. 
So, the code from Iceberg module is used.

We could redeclare the table procedure in the Lakehouse module, or maybe there could be a refactoring so that the identical code for the "optimize" table procedure is placed in a common place and reused from there.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`26754`)
```

## Summary by Sourcery

Introduce support for Iceberg-style table procedures in the Lakehouse connector by registering and exposing procedure metadata, and add smoke tests validating these procedures in Iceberg, Hive, and Delta modules.

New Features:
- Expose Iceberg table procedures in the Lakehouse connector
- Support procedures: optimize, optimize_manifests, drop_extended_stats, rollback_to_snapshot, expire_snapshots, remove_orphan_files, add_files, and add_files_from_table

Enhancements:
- Register TableProcedureMetadata bindings in LakehouseModule
- Implement getTableProcedures in LakehouseConnector
- Enable add-files procedure via iceberg.add-files-procedure.enabled property in smoke tests

Tests:
- Add smoke tests for table procedures in Lakehouse Iceberg connector covering various procedure operations
- Add smoke tests for optimize procedure in Hive connector including session property enforcement
- Add smoke test for optimize procedure in Delta connector
- Add tests verifying failure scenarios for add_files and add_files_from_table procedures