### PR TITLE
Update limit pushdown for Oracle

### DIFF
--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -620,7 +620,7 @@ public class OracleClient
     @Override
     protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return Optional.of((sql, limit) -> format("SELECT * FROM (%s) WHERE ROWNUM <= %s", sql, limit));
+        return Optional.of((sql, limit) -> format("%s FETCH FIRST %s ROWS ONLY", sql, limit));
     }
 
     @Override


### PR DESCRIPTION
Update limit pushdown for Oracle

Change appeared after discussion on PR https://github.com/trinodb/trino/pull/26688
which is a fix for issue: Support TopN pushdown for Oracle connector https://github.com/trinodb/trino/issues/26566

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

As Trino no longer supports Oracle version 11,
update limit pushdown from the older Oracle version (<=11) "ROWNUM <= number" syntax to the newer (>=12) "FETCH FIRST number ROWS ONLY" syntax.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Enhancements:
- Replace ROWNUM <= n syntax with FETCH FIRST n ROWS ONLY in the Oracle connector’s limit pushdown