### PR TITLE
Remove deprecated `gcs.use-access-token` from gcs filesystem

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-gcs.md
+++ b/docs/src/main/sphinx/object-storage/file-system-gcs.md
@@ -68,9 +68,6 @@ Cloud Storage:
 
 * - Property
   - Description
-* - `gcs.use-access-token`
-  - Flag to set usage of a client-provided OAuth 2.0 token to access Google
-    Cloud Storage. Defaults to `false`, deprecated to use `gcs.auth-type` instead.
 * - `gcs.auth-type`
   - Authentication type to use for Google Cloud Storage access. Default to `SERVICE_ACCOUNT`.
   Supported values are:

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
@@ -17,13 +17,11 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType;
-import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
@@ -43,7 +41,6 @@ public class TestGcsFileSystemConfig
                 .setWriteBlockSize(DataSize.of(16, MEGABYTE))
                 .setPageSize(100)
                 .setBatchSize(100)
-                .setUseGcsAccessToken(false)
                 .setProjectId(null)
                 .setEndpoint(Optional.empty())
                 .setAuthType(AuthType.SERVICE_ACCOUNT)
@@ -88,44 +85,7 @@ public class TestGcsFileSystemConfig
                 .setMinBackoffDelay(new Duration(20, MILLISECONDS))
                 .setMaxBackoffDelay(new Duration(20, MILLISECONDS))
                 .setApplicationId("application id");
-        assertFullMapping(properties, expected, Set.of("gcs.use-access-token"));
-    }
-
-    // backwards compatibility test, remove if use-access-token is removed
-    @Test
-    void testExplicitPropertyMappingsWithDeprecatedUseAccessToken()
-    {
-        Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("gcs.read-block-size", "51MB")
-                .put("gcs.write-block-size", "52MB")
-                .put("gcs.page-size", "10")
-                .put("gcs.batch-size", "11")
-                .put("gcs.project-id", "project")
-                .put("gcs.endpoint", "http://custom.dns.org:8000")
-                .put("gcs.use-access-token", "true")
-                .put("gcs.client.max-retries", "10")
-                .put("gcs.client.backoff-scale-factor", "4.0")
-                .put("gcs.client.max-retry-time", "10s")
-                .put("gcs.client.min-backoff-delay", "20ms")
-                .put("gcs.client.max-backoff-delay", "20ms")
-                .put("gcs.application-id", "application id")
-                .buildOrThrow();
-
-        GcsFileSystemConfig expected = new GcsFileSystemConfig()
-                .setReadBlockSize(DataSize.of(51, MEGABYTE))
-                .setWriteBlockSize(DataSize.of(52, MEGABYTE))
-                .setPageSize(10)
-                .setBatchSize(11)
-                .setProjectId("project")
-                .setEndpoint(Optional.of("http://custom.dns.org:8000"))
-                .setUseGcsAccessToken(true)
-                .setMaxRetries(10)
-                .setBackoffScaleFactor(4.0)
-                .setMaxRetryTime(new Duration(10, SECONDS))
-                .setMinBackoffDelay(new Duration(20, MILLISECONDS))
-                .setMaxBackoffDelay(new Duration(20, MILLISECONDS))
-                .setApplicationId("application id");
-        assertFullMapping(properties, expected, Set.of("gcs.json-key", "gcs.json-key-file-path", "gcs.auth-type"));
+        assertFullMapping(properties, expected);
     }
 
     @Test
@@ -138,53 +98,5 @@ public class TestGcsFileSystemConfig
                 "retryDelayValid",
                 "gcs.client.min-backoff-delay must be less than or equal to gcs.client.max-backoff-delay",
                 AssertTrue.class);
-
-        assertFailsValidation(
-                new GcsFileSystemConfig()
-                        .setAuthType(AuthType.ACCESS_TOKEN)
-                        .setUseGcsAccessToken(true),
-                "authTypeAndGcsAccessTokenConfigured",
-                "Cannot set both gcs.use-access-token and gcs.auth-type",
-                AssertFalse.class);
-
-        assertFailsValidation(
-                new GcsFileSystemConfig()
-                        .setAuthType(AuthType.ACCESS_TOKEN)
-                        .setUseGcsAccessToken(false),
-                "authTypeAndGcsAccessTokenConfigured",
-                "Cannot set both gcs.use-access-token and gcs.auth-type",
-                AssertFalse.class);
-
-        assertFailsValidation(
-                new GcsFileSystemConfig()
-                        .setUseGcsAccessToken(true)
-                        .setAuthType(AuthType.SERVICE_ACCOUNT),
-                "authTypeAndGcsAccessTokenConfigured",
-                "Cannot set both gcs.use-access-token and gcs.auth-type",
-                AssertFalse.class);
-
-        assertFailsValidation(
-                new GcsFileSystemConfig()
-                        .setUseGcsAccessToken(false)
-                        .setAuthType(AuthType.SERVICE_ACCOUNT),
-                "authTypeAndGcsAccessTokenConfigured",
-                "Cannot set both gcs.use-access-token and gcs.auth-type",
-                AssertFalse.class);
-
-        assertFailsValidation(
-                new GcsFileSystemConfig()
-                        .setUseGcsAccessToken(true)
-                        .setAuthType(AuthType.APPLICATION_DEFAULT),
-                "authTypeAndGcsAccessTokenConfigured",
-                "Cannot set both gcs.use-access-token and gcs.auth-type",
-                AssertFalse.class);
-
-        assertFailsValidation(
-                new GcsFileSystemConfig()
-                        .setUseGcsAccessToken(false)
-                        .setAuthType(AuthType.APPLICATION_DEFAULT),
-                "authTypeAndGcsAccessTokenConfigured",
-                "Cannot set both gcs.use-access-token and gcs.auth-type",
-                AssertFalse.class);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Now we recommend to use the `gcs.auth-type` instead


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://github.com/trinodb/trino/pull/26681


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Delta Lake, Iceberg, Hudi
* {{breaking}} Remove the deprecated `gcs.use-access-token` config property. ({issue}`26941`)
```