### PR TITLE
Test Jetty 12.1.3-SNAPSHOT build 6

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -202,7 +202,7 @@ public class ServerMainModule
 
         configBinder(binder).bindConfigDefaults(HttpServerConfig.class, httpServerConfig -> {
             httpServerConfig.setHttp2MaxConcurrentStreams(32 * 1024); // from the default 16K
-            httpServerConfig.setCompressionEnabled(false); // https://github.com/jetty/jetty.project/issues/13679
+            httpServerConfig.setCompressionEnabled(true);
         });
 
         binder.bind(PreparedStatementEncoder.class).in(Scopes.SINGLETON);

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
         <dep.gib.version>4.5.6</dep.gib.version>
         <dep.httpcore5.version>5.3.6</dep.httpcore5.version>
         <dep.iceberg.version>1.10.0</dep.iceberg.version>
+        <dep.jetty.version>12.1.3-SNAPSHOT</dep.jetty.version>
         <dep.jna.version>5.18.1</dep.jna.version>
         <dep.jsonwebtoken.version>0.13.0</dep.jsonwebtoken.version>
         <dep.jts.version>1.20.0</dep.jts.version>
@@ -2425,6 +2426,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <!-- not really but I don't need to configure rrf ;-) -->
+            <id>apache-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
+        </repository>
+    </repositories>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Upgrade Jetty to 12.1.3-SNAPSHOT, add the Sonatype Apache snapshots repository, and re-enable HTTP compression in the HTTP server configuration

Enhancements:
- Re-enable HTTP compression in the server HTTP/2 configuration

Build:
- Bump Jetty version to 12.1.3-SNAPSHOT
- Add Apache snapshots repository for Jetty snapshots