### PR TITLE
Simplify io.trino.spi.PageSorter interface

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndexPageSorter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndexPageSorter.java
@@ -19,10 +19,9 @@ import io.trino.spi.PageSorter;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 
+import java.util.Iterator;
 import java.util.List;
 
-import static io.trino.operator.SyntheticAddress.decodePosition;
-import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
 import static java.util.Objects.requireNonNull;
 
 public class PagesIndexPageSorter
@@ -37,24 +36,12 @@ public class PagesIndexPageSorter
     }
 
     @Override
-    public long[] sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
+    public Iterator<Page> sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
     {
         PagesIndex pagesIndex = pagesIndexFactory.newPagesIndex(types, expectedPositions);
         pages.forEach(pagesIndex::addPage);
         pagesIndex.sort(sortChannels, sortOrders);
 
-        return pagesIndex.getValueAddresses().toLongArray();
-    }
-
-    @Override
-    public int decodePageIndex(long address)
-    {
-        return decodeSliceIndex(address);
-    }
-
-    @Override
-    public int decodePositionIndex(long address)
-    {
-        return decodePosition(address);
+        return pagesIndex.getSortedPages();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/BenchmarkPagesIndexPageSorter.java
+++ b/core/trino-main/src/test/java/io/trino/BenchmarkPagesIndexPageSorter.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.RunnerException;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -55,8 +56,13 @@ public class BenchmarkPagesIndexPageSorter
     public int runBenchmark(BenchmarkData data)
     {
         PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
-        long[] addresses = pageSorter.sort(data.types, data.pages, data.sortChannels, nCopies(data.sortChannels.size(), ASC_NULLS_FIRST), 10_000);
-        return addresses.length;
+        Iterator<Page> outputPages = pageSorter.sort(data.types, data.pages, data.sortChannels, nCopies(data.sortChannels.size(), ASC_NULLS_FIRST), 10_000);
+        int totalPositions = 0;
+        while (outputPages.hasNext()) {
+            Page page = outputPages.next();
+            totalPositions += page.getPositionCount();
+        }
+        return totalPositions;
     }
 
     private static List<Page> createPages(int pageCount, int channelCount, Type type)

--- a/core/trino-main/src/test/java/io/trino/TestPagesIndexPageSorter.java
+++ b/core/trino-main/src/test/java/io/trino/TestPagesIndexPageSorter.java
@@ -18,8 +18,6 @@ import com.google.common.primitives.Ints;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexPageSorter;
 import io.trino.spi.Page;
-import io.trino.spi.PageBuilder;
-import io.trino.spi.block.Block;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.testing.MaterializedResult;
@@ -150,29 +148,10 @@ public class TestPagesIndexPageSorter
 
     private static void assertSorted(List<Page> inputPages, List<Page> expectedPages, List<Type> types, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
     {
-        long[] sortedAddresses = sorter.sort(types, inputPages, sortChannels, sortOrders, expectedPositions);
-        List<Page> outputPages = createOutputPages(types, inputPages, sortedAddresses);
+        List<Page> outputPages = ImmutableList.copyOf(sorter.sort(types, inputPages, sortChannels, sortOrders, expectedPositions));
 
         MaterializedResult expected = toMaterializedResult(TEST_SESSION, types, expectedPages);
         MaterializedResult actual = toMaterializedResult(TEST_SESSION, types, outputPages);
         assertThat(actual.getMaterializedRows()).isEqualTo(expected.getMaterializedRows());
-    }
-
-    private static List<Page> createOutputPages(List<Type> types, List<Page> inputPages, long[] sortedAddresses)
-    {
-        PageBuilder pageBuilder = new PageBuilder(types);
-        pageBuilder.reset();
-        for (long address : sortedAddresses) {
-            int index = sorter.decodePageIndex(address);
-            int position = sorter.decodePositionIndex(address);
-
-            Page page = inputPages.get(index);
-            for (int i = 0; i < types.size(); i++) {
-                Block block = page.getBlock(i);
-                pageBuilder.getBlockBuilder(i).append(block.getUnderlyingValueBlock(), block.getUnderlyingValuePosition(position));
-            }
-            pageBuilder.declarePosition();
-        }
-        return ImmutableList.of(pageBuilder.build());
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -306,6 +306,19 @@
                                     <old>method void io.trino.spi.connector.ConnectorMetadata::executeTableExecute(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableExecuteHandle)</old>
                                     <new>method java.util.Map&lt;java.lang.String, java.lang.Long&gt; io.trino.spi.connector.ConnectorMetadata::executeTableExecute(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableExecuteHandle)</new>
                                 </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.PageSorter::decodePageIndex(long)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method int io.trino.spi.PageSorter::decodePositionIndex(long)</old>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method long[] io.trino.spi.PageSorter::sort(java.util.List&lt;io.trino.spi.type.Type&gt;, java.util.List&lt;io.trino.spi.Page&gt;, java.util.List&lt;java.lang.Integer&gt;, java.util.List&lt;io.trino.spi.connector.SortOrder&gt;, int)</old>
+                                    <new>method java.util.Iterator&lt;io.trino.spi.Page&gt; io.trino.spi.PageSorter::sort(java.util.List&lt;io.trino.spi.type.Type&gt;, java.util.List&lt;io.trino.spi.Page&gt;, java.util.List&lt;java.lang.Integer&gt;, java.util.List&lt;io.trino.spi.connector.SortOrder&gt;, int)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/PageSorter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageSorter.java
@@ -16,17 +16,13 @@ package io.trino.spi;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 
+import java.util.Iterator;
 import java.util.List;
 
 public interface PageSorter
 {
     /**
-     * @return Sorted synthetic addresses for pages. A synthetic address is encoded as a long with
-     * the high 32 bits containing the page index and the low 32 bits containing position index
+     * @return Iterator of sorted pages.
      */
-    long[] sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions);
-
-    int decodePageIndex(long address);
-
-    int decodePositionIndex(long address);
+    Iterator<Page> sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions);
 }


### PR DESCRIPTION
## Description
Engine can provide the sorted Pages directly to the connector. 
This avoids code duplication in connector and lets the engine avoid exposing internal details around PagesIndex#sort output


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Simplify the PageSorter SPI to return an iterator of sorted pages directly and eliminate synthetic address manipulation across the engine and connectors.

Enhancements:
- Modify PageSorter to return Iterator<Page> and remove decodePageIndex and decodePositionIndex methods.
- Refactor SortBuffer to use the new sorted pages iterator instead of manual PageBuilder merging.
- Update PagesIndexPageSorter to yield sorted pages via iterator rather than address arrays.

Build:
- Update revapi configuration in trino-spi pom to remove deprecated PageSorter methods and reflect the signature change.

Tests:
- Adapt TestPagesIndexPageSorter and BenchmarkPagesIndexPageSorter to consume Iterator<Page> and drop synthetic address decoding logic.