### PR TITLE
Avoid null pointer exceptions from empty tables without snapshot

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3423,6 +3423,9 @@ public class IcebergMetadata
 
     private static List<ManifestFile> loadAllManifestsFromSnapshot(Table icebergTable, Snapshot snapshot)
     {
+        if (snapshot == null) {
+            return ImmutableList.of();
+        }
         try {
             return snapshot.allManifests(icebergTable.io());
         }


### PR DESCRIPTION
## Description
It is possible for optimize_manifests to fail
```
{"type":"java.lang.NullPointerException","message":"Cannot invoke \"org.apache.iceberg.Snapshot.allManifests(org.apache.iceberg.io.FileIO)\" because \"snapshot\" is null","suppressed":[],"stack":["io.trino.plugin.iceberg.IcebergMetadata.loadAllManifestsFromSnapshot(IcebergMetadata.java:4183)","io.trino.plugin.iceberg.IcebergMetadata.executeOptimizeManifests
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix failure in `optimize_manifests` for empty tables. ({issue}`26970`)
```
