### PR TITLE
Replace deprecated NestedField.of with NestedField.optional in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -1494,7 +1494,7 @@ public class TestIcebergV2
         catalog.newCreateTableTransaction(
                         SESSION,
                         schemaTableName,
-                        new Schema(Types.NestedField.of(1, true, "x", Types.LongType.get())),
+                        new Schema(Types.NestedField.optional(1, "x", Types.LongType.get())),
                         PartitionSpec.unpartitioned(),
                         SortOrder.unsorted(),
                         Optional.ofNullable(catalog.defaultTableLocation(SESSION, schemaTableName)),


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
