### PR TITLE
Fix SHOW CREATE SCHEMA failure due to unsupported properties

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSchemaProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSchemaProperties.java
@@ -14,16 +14,22 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.trino.spi.session.PropertyMetadata;
 
 import java.util.List;
+import java.util.Set;
 
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 
 public final class IcebergSchemaProperties
 {
     public static final String LOCATION_PROPERTY = "location";
+
+    public static final Set<String> SUPPORTED_SCHEMA_PROPERTIES = ImmutableSet.<String>builder()
+            .add(LOCATION_PROPERTY)
+            .build();
 
     public final List<PropertyMetadata<?>> schemaProperties;
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -292,9 +292,6 @@ public class TrinoGlueCatalog
             if (database.locationUri() != null) {
                 metadata.put(LOCATION_PROPERTY, database.locationUri());
             }
-            if (database.parameters() != null) {
-                metadata.putAll(database.parameters());
-            }
             return metadata.buildOrThrow();
         }
         catch (EntityNotFoundException e) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -59,9 +59,11 @@ import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.Locations.appendPath;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergSchemaProperties.SUPPORTED_SCHEMA_PROPERTIES;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.quotedTableName;
 import static io.trino.plugin.iceberg.catalog.nessie.IcebergNessieUtil.toIdentifier;
@@ -125,7 +127,9 @@ public class TrinoNessieCatalog
     public Map<String, Object> loadNamespaceMetadata(ConnectorSession session, String namespace)
     {
         try {
-            return ImmutableMap.copyOf(nessieClient.loadNamespaceMetadata(Namespace.of(namespace)));
+            return nessieClient.loadNamespaceMetadata(Namespace.of(namespace)).entrySet().stream()
+                    .filter(metadata -> SUPPORTED_SCHEMA_PROPERTIES.contains(metadata.getKey()))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
         catch (NoSuchNamespaceException e) {
             throw new SchemaNotFoundException(namespace);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
@@ -19,6 +19,7 @@ import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.local.LocalFileSystemFactory;
+import io.trino.metastore.Database;
 import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.cache.CachingHiveMetastore;
 import io.trino.plugin.hive.TrinoViewHiveMetastore;
@@ -43,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -87,6 +89,17 @@ public class TestTrinoHiveCatalogWithFileMetastore
             throws IOException
     {
         deleteRecursively(tempDir, ALLOW_INSECURE);
+    }
+
+    @Override
+    protected void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties)
+    {
+        metastore.createDatabase(Database.builder()
+                .setDatabaseName(namespace)
+                .setOwnerName(Optional.of("test"))
+                .setOwnerType(Optional.of(PrincipalType.USER))
+                .setParameters(properties)
+                .build());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -74,6 +74,15 @@ public class TestTrinoGlueCatalog
         return createGlueTrinoCatalog(useUniqueTableLocations, false);
     }
 
+    @Override
+    protected void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties)
+    {
+        try (GlueClient glueClient = GlueClient.create()) {
+            glueClient.createDatabase(database -> database
+                    .databaseInput(input -> input.name(namespace).parameters(properties)));
+        }
+    }
+
     private TrinoCatalog createGlueTrinoCatalog(boolean useUniqueTableLocations, boolean useSystemSecurity)
     {
         GlueClient glueClient = GlueClient.create();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TestingTypeManager;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.nessie.NessieIcebergClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,6 +83,18 @@ public class TestTrinoNessieCatalog
         if (nessieContainer != null) {
             nessieContainer.close();
         }
+    }
+
+    @Override
+    protected void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties)
+    {
+        IcebergNessieCatalogConfig icebergNessieCatalogConfig = new IcebergNessieCatalogConfig()
+                .setServerUri(URI.create(nessieContainer.getRestApiUri()));
+        NessieApiV2 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
+                .withUri(nessieContainer.getRestApiUri())
+                .build(NessieApiV2.class);
+        NessieIcebergClient nessieClient = new NessieIcebergClient(nessieApi, icebergNessieCatalogConfig.getDefaultReferenceName(), null, ImmutableMap.of());
+        nessieClient.createNamespace(Namespace.of(namespace), properties);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.json.JsonCodec.jsonCodec;
@@ -60,6 +61,17 @@ public class TestTrinoRestCatalog
             throws IOException
     {
         return createTrinoRestCatalog(useUniqueTableLocations, ImmutableMap.of());
+    }
+
+    @Override
+    protected void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties)
+    {
+        catalog.createNamespace(
+                SESSION,
+                namespace,
+                properties.entrySet().stream()
+                        .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)),
+                new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
     }
 
     private static TrinoRestCatalog createTrinoRestCatalog(boolean useUniqueTableLocations, Map<String, String> properties)

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.jdbc.JdbcClientPool;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -146,6 +147,12 @@ public class TestTrinoSnowflakeCatalog
             throws SQLException
     {
         server.execute(SNOWFLAKE_TEST_SCHEMA, sql);
+    }
+
+    @Override
+    protected void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> namespaceProperties)
+    {
+        Assumptions.abort("Snowflake catalog does not support creating namespaces");
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes #24744

## Release notes

```markdown
## Iceberg
* Fix failure when executing `SHOW CREATE SCHEMA` on a schema with unsupported properties with
  REST, Glue or Nessie catalog. ({issue}`24744`)
```

## Summary by Sourcery

Filter out unsupported namespace properties to avoid failures in SHOW CREATE SCHEMA and ensure only the LOCATION property is retained when loading namespace metadata across Iceberg catalogs.

Bug Fixes:
- Filter out non-LOCATION namespace properties in REST and Nessie catalogs during loadNamespaceMetadata
- Remove propagation of Glue catalog database parameters so only LOCATION_PROPERTY is returned

Enhancements:
- Introduce abstract createNamespaceWithProperties helper in BaseTrinoCatalogTest and implement it in each catalog test

Tests:
- Add testSchemaWithInvalidProperties to verify unsupported namespace properties are ignored