### PR TITLE
Load initial catalogs in TestingTrinoServer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -438,6 +438,10 @@ public class TestingTrinoServer
         spoolingConfiguration.ifPresent(config ->
                 spoolingManagerRegistry.loadSpoolingManager(config.factoryName(), config.configuration()));
 
+        catalogStoreManager.ifPresent(CatalogStoreManager::loadConfiguredCatalogStore);
+        ConnectorServicesProvider connectorServicesProvider = injector.getInstance(ConnectorServicesProvider.class);
+        connectorServicesProvider.loadInitialCatalogs();
+
         EventListenerManager eventListenerManager = injector.getInstance(EventListenerManager.class);
         eventListeners.forEach(eventListenerManager::addEventListener);
 

--- a/testing/trino-tests/src/test/java/io/trino/connector/TestDynamicCatalogs.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/TestDynamicCatalogs.java
@@ -14,12 +14,17 @@
 package io.trino.connector;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Key;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.Session;
 import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.server.ServerConfig;
 import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.catalog.CatalogProperties;
 import io.trino.spi.catalog.CatalogStore;
+import io.trino.spi.catalog.CatalogStoreFactory;
 import io.trino.spi.connector.ConnectorName;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.H2QueryRunner;
@@ -27,9 +32,14 @@ import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static io.trino.connector.FileCatalogStore.computeCatalogVersion;
 import static io.trino.testing.QueryAssertions.assertQuery;
 import static io.trino.testing.QueryAssertions.assertQueryFails;
 import static io.trino.testing.QueryAssertions.assertUpdate;
@@ -40,6 +50,10 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 @Execution(SAME_THREAD)
 public class TestDynamicCatalogs
 {
+    private static final String BROKEN_CATALOG = "broken_catalog";
+    private static final CatalogName BROKEN_CATALOG_NAME = new CatalogName(BROKEN_CATALOG);
+    private static final ConnectorName MEMORY_CONNECTOR_NAME = new ConnectorName("memory");
+
     @Test
     public void testNewHealthyCatalog()
             throws Exception
@@ -51,8 +65,6 @@ public class TestDynamicCatalogs
                 .build();
         queryRunner.installPlugin(new MemoryPlugin());
         queryRunner.createCatalog("healthy_catalog", "memory", ImmutableMap.of("memory.max-data-per-node", "128MB"));
-        ConnectorServicesProvider connectorServicesProvider = queryRunner.getCoordinator().getInstance(new Key<>() {});
-        connectorServicesProvider.loadInitialCatalogs();
         H2QueryRunner h2QueryRunner = new H2QueryRunner();
 
         assertQuery(queryRunner, session, "SHOW CATALOGS", h2QueryRunner, "VALUES 'healthy_catalog', 'system'", false, false);
@@ -72,27 +84,97 @@ public class TestDynamicCatalogs
     public void testNewUnhealthyCatalog()
             throws Exception
     {
-        String catalogName = "new_catalog" + randomNameSuffix();
-        // simulate loading an unhealthy catalog during a startup
         Session session = testSession();
         QueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setAdditionalModule(new TestCatalogStoreModule())
+                .setCoordinatorProperties(ImmutableMap.of("catalog.store", "prepopulated_memory"))
                 .setWorkerCount(0)
                 .build();
         queryRunner.installPlugin(new MemoryPlugin());
         queryRunner.createCatalog("healthy_catalog", "memory", ImmutableMap.of("memory.max-data-per-node", "128MB"));
         H2QueryRunner h2QueryRunner = new H2QueryRunner();
-        CatalogStore catalogStore = queryRunner.getCoordinator().getInstance(new Key<>() {});
-        ConnectorServicesProvider connectorServicesProvider = queryRunner.getCoordinator().getInstance(new Key<>() {});
-        CatalogProperties catalogProperties = catalogStore.createCatalogProperties(new CatalogName(catalogName), new ConnectorName("memory"), ImmutableMap.of("invalid", "128MB"));
-        catalogStore.addOrReplaceCatalog(catalogProperties);
-        connectorServicesProvider.loadInitialCatalogs();
 
-        assertQuery(queryRunner, session, "SHOW CATALOGS", h2QueryRunner, "VALUES 'healthy_catalog', '" + catalogName + "', 'system'", false, false);
-        assertQueryFails(queryRunner, session, "CREATE TABLE %s.default.test_table (age INT)".formatted(catalogName), ".*Catalog '%s' failed to initialize and is disabled.*".formatted(catalogName));
-        assertQueryFails(queryRunner, session, "SELECT * FROM %s.default.test_table".formatted(catalogName), ".*Catalog '%s' failed to initialize and is disabled.*".formatted(catalogName));
-        assertQueryFails(queryRunner, session, "CREATE CATALOG %s USING memory WITH (\"memory.max-data-per-node\" = '128MB')".formatted(catalogName), ".*Catalog '%s' already exists.*".formatted(catalogName));
+        assertQuery(queryRunner, session, "SHOW CATALOGS", h2QueryRunner, "VALUES 'healthy_catalog', '" + BROKEN_CATALOG + "', 'system'", false, false);
+        assertQueryFails(queryRunner, session, "CREATE TABLE %s.default.test_table (age INT)".formatted(BROKEN_CATALOG), ".*Catalog '%s' failed to initialize and is disabled.*".formatted(BROKEN_CATALOG));
+        assertQueryFails(queryRunner, session, "SELECT * FROM %s.default.test_table".formatted(BROKEN_CATALOG), ".*Catalog '%s' failed to initialize and is disabled.*".formatted(BROKEN_CATALOG));
+        assertQueryFails(queryRunner, session, "CREATE CATALOG %s USING memory WITH (\"memory.max-data-per-node\" = '128MB')".formatted(BROKEN_CATALOG), ".*Catalog '%s' already exists.*".formatted(BROKEN_CATALOG));
 
-        assertUpdate(queryRunner, session, "DROP CATALOG " + catalogName, OptionalLong.empty(), Optional.empty());
+        assertUpdate(queryRunner, session, "DROP CATALOG " + BROKEN_CATALOG, OptionalLong.empty(), Optional.empty());
         assertQuery(queryRunner, session, "SHOW CATALOGS", h2QueryRunner, "VALUES 'healthy_catalog', 'system'", false, false);
+    }
+
+    public static class TestCatalogStoreModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            if (buildConfigObject(ServerConfig.class).isCoordinator()) {
+                install(new PrepopulatedInMemoryCatalogStoreModule());
+            }
+        }
+    }
+
+    private static class PrepopulatedInMemoryCatalogStoreModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder) {}
+
+        @Provides
+        @Singleton
+        public PrepopulatedInMemoryCatalogStoreFactory createDbCatalogStoreFactory(CatalogStoreManager catalogStoreManager)
+        {
+            PrepopulatedInMemoryCatalogStoreFactory factory = new PrepopulatedInMemoryCatalogStoreFactory();
+            catalogStoreManager.addCatalogStoreFactory(factory);
+            return factory;
+        }
+    }
+
+    private static class PrepopulatedInMemoryCatalogStoreFactory
+            implements CatalogStoreFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "prepopulated_memory";
+        }
+
+        @Override
+        public CatalogStore create(Map<String, String> config)
+        {
+            return new PrepopulatedInMemoryCatalogStore();
+        }
+    }
+
+    private static class PrepopulatedInMemoryCatalogStore
+            extends InMemoryCatalogStore
+    {
+        @Override
+        public Collection<StoredCatalog> getCatalogs()
+        {
+            Collection<StoredCatalog> catalogs = super.getCatalogs();
+            List<StoredCatalog> catalogsCopy = new ArrayList<>(catalogs);
+            catalogsCopy.add(new StoredCatalog()
+            {
+                @Override
+                public CatalogName name()
+                {
+                    return new CatalogName("broken_catalog");
+                }
+
+                @Override
+                public CatalogProperties loadProperties()
+                {
+                    ImmutableMap<String, String> properties = ImmutableMap.of("non_existing", "false");
+                    return new CatalogProperties(
+                            BROKEN_CATALOG_NAME,
+                            computeCatalogVersion(BROKEN_CATALOG_NAME, MEMORY_CONNECTOR_NAME, properties),
+                            MEMORY_CONNECTOR_NAME,
+                            properties);
+                }
+            });
+            return catalogsCopy;
+        }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/TestSystemMetadataCatalogTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/TestSystemMetadataCatalogTable.java
@@ -14,15 +14,9 @@
 package io.trino.connector.system;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Key;
 import io.trino.Session;
-import io.trino.connector.ConnectorServicesProvider;
-import io.trino.metadata.CatalogManager;
+import io.trino.connector.TestDynamicCatalogs;
 import io.trino.plugin.memory.MemoryPlugin;
-import io.trino.spi.catalog.CatalogName;
-import io.trino.spi.catalog.CatalogProperties;
-import io.trino.spi.catalog.CatalogStore;
-import io.trino.spi.connector.ConnectorName;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -36,23 +30,18 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 public class TestSystemMetadataCatalogTable
         extends AbstractTestQueryFramework
 {
-    private CatalogStore catalogStore;
-    private ConnectorServicesProvider connectorServicesProvider;
-    private CatalogManager catalogManager;
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder().build();
         QueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setAdditionalModule(new TestDynamicCatalogs.TestCatalogStoreModule())
+                .setCoordinatorProperties(ImmutableMap.of("catalog.store", "prepopulated_memory"))
                 .setWorkerCount(0)
                 .build();
         queryRunner.installPlugin(new MemoryPlugin());
         queryRunner.createCatalog("healthy_catalog", "memory", ImmutableMap.of("memory.max-data-per-node", "128MB"));
-        catalogStore = queryRunner.getCoordinator().getInstance(new Key<>() {});
-        connectorServicesProvider = queryRunner.getCoordinator().getInstance(new Key<>() {});
-        catalogManager = queryRunner.getCoordinator().getInstance(new Key<>() {});
         return queryRunner;
     }
 
@@ -61,11 +50,13 @@ public class TestSystemMetadataCatalogTable
     {
         assertQuery("SELECT * FROM system.metadata.catalogs", "VALUES" +
                 "('healthy_catalog', 'healthy_catalog', 'memory', 'OPERATIONAL'), " +
+                "('broken_catalog', 'broken_catalog', 'memory', 'FAILING'), " +
                 "('system', 'system', 'system', 'OPERATIONAL')");
 
         assertUpdate("CREATE CATALOG brain USING memory WITH (\"memory.max-data-per-node\" = '128MB')");
         assertQuery("SELECT * FROM system.metadata.catalogs", "VALUES" +
                 "('healthy_catalog', 'healthy_catalog', 'memory', 'OPERATIONAL'), " +
+                "('broken_catalog', 'broken_catalog', 'memory', 'FAILING'), " +
                 "('brain', 'brain', 'memory', 'OPERATIONAL'), " +
                 "('system', 'system', 'system', 'OPERATIONAL')");
 
@@ -75,14 +66,9 @@ public class TestSystemMetadataCatalogTable
     @Test
     public void testCatalogNotLoadedCorrectly()
     {
-        CatalogProperties catalogProperties = catalogStore.createCatalogProperties(new CatalogName("broken"), new ConnectorName("memory"), ImmutableMap.of("memory.max-data-per-n", "128MB"));
-
-        catalogStore.addOrReplaceCatalog(catalogProperties);
-        connectorServicesProvider.loadInitialCatalogs();
         assertQuery("SELECT * FROM system.metadata.catalogs", "VALUES" +
                 "('healthy_catalog', 'healthy_catalog', 'memory', 'OPERATIONAL'), " +
-                "('broken', 'broken', 'memory', 'FAILING'), " +
+                "('broken_catalog', 'broken_catalog', 'memory', 'FAILING'), " +
                 "('system', 'system', 'system', 'OPERATIONAL')");
-        catalogManager.dropCatalog(new CatalogName("broken"), false);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Previously catalogs were not loaded correctly when TestingTrinoServer /DistributedQueryRunner was used


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Ensure DistributedQueryRunner automatically loads initial catalogs on startup and update tests to configure and verify healthy and failing catalogs via a custom CatalogStore.

Bug Fixes:
- Load initial catalogs correctly when using DistributedQueryRunner.

Enhancements:
- Automatically invoke loadInitialCatalogs after DistributedQueryRunner startup.
- Allow specifying a custom CatalogStore implementation via builder properties and introduce a prepopulated in-memory store module for tests.

Tests:
- Introduce TestCatalogStoreModule and PrepopulatedInMemoryCatalogStore to simulate a broken catalog.
- Update TestDynamicCatalogs to remove manual loading and validate healthy and broken catalog behaviors.
- Update TestSystemMetadataCatalogTable to configure the test catalog store and include the failing catalog in system.metadata.catalogs.