### PR TITLE
Fix expected error message of BigQuery wildcard table

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -969,7 +969,7 @@ public abstract class BaseBigQueryConnectorTest
             assertQuery("DESCRIBE test.\"" + wildcardTable + "\"", "VALUES ('value', 'varchar', '', '')");
 
             assertThat(query("SELECT * FROM test.\"" + wildcardTable + "\""))
-                    .failure().hasMessageContaining("Cannot read field of type INT64 as STRING Field: value");
+                    .failure().hasMessageContaining("Cannot read field of type INT64 as STRING");
         }
         finally {
             onBigQuery("DROP TABLE IF EXISTS test." + firstTable);


### PR DESCRIPTION
## Description

BigQuery changed an error message for wildcard tables with different column types:

```
Error:    TestBigQueryAvroConnectorTest>BaseBigQueryConnectorTest.testWildcardTableWithDifferentColumnDefinition:972 
Expecting throwable message:
  "Failed to run the query: Cannot read field of type INT64 as STRING"
to contain:
  "Cannot read field of type INT64 as STRING Field: value"
```

https://github.com/trinodb/trino/actions/runs/18574518715/job/52956589032

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Tests:
- Update expected exception message in testWildcardTableWithDifferentColumnDefinition to remove deprecated suffix and align with BigQuery's new error message