### PR TITLE
Increase timeout for github/actions/setup to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: ${{ matrix.cache }}
           java-version: ${{ matrix.java-version }}
@@ -100,7 +100,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: 'restore'
           cleanup-node: true
@@ -186,7 +186,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
           java-version: 25
@@ -214,7 +214,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
       - name: Maven Install
@@ -259,7 +259,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
       - name: Install Hive Module
@@ -309,7 +309,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
           cleanup-node: true
@@ -397,7 +397,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
       - name: Update PR check
@@ -517,7 +517,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
           cleanup-node: ${{ format('{0}', matrix.modules == 'plugin/trino-singlestore' || matrix.modules == 'plugin/trino-exasol' || matrix.modules == 'plugin/trino-oracle') }}
@@ -821,7 +821,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           cache: restore
           cleanup-node: true
@@ -1020,7 +1020,7 @@ jobs:
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
         with:
           # The job doesn't build anything, so the ~/.m2/repository cache isn't useful
           cache: 'false'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -78,7 +78,7 @@ jobs:
         with:
           fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-        timeout-minutes: 10
+        timeout-minutes: 15
       - name: Get milestone from pom.xml
         run: |
           .github/bin/retry ./mvnw -v


### PR DESCRIPTION
## Description
Timeout of setup at 10 minutes seems to be somewhat frequent occurance
e.g. https://github.com/trinodb/trino/actions/runs/18583781049/job/52983702292

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

CI:
- Bump timeout-minutes for ./.github/actions/setup from 10 to 15 in ci.yml, docs.yml, and milestone.yml