### PR TITLE
Add variant type to type mapping section in Delta Lake

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -299,6 +299,8 @@ this table:
   - `TIMESTAMP(6)`
 * - `TIMESTAMP`
   - `TIMESTAMP(3) WITH TIME ZONE`
+* - `VARIANT`
+  - `JSON`
 * - `ARRAY`
   - `ARRAY`
 * - `MAP`


### PR DESCRIPTION
Currently, reading `variant` type is supported in Delta Lake to Trino mapping.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Documentation:
- Include VARIANT to JSON type mapping in the Delta Lake connector documentation