### PR TITLE
Fix SELECT DISTINCT with delimited alias in ORDER BY bug

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -5764,7 +5764,7 @@ class StatementAnalyzer
                 //    SELECT a FROM t ORDER BY a
                 // the "a" in the SELECT clause is bound to the FROM scope, while the "a" in ORDER BY clause is bound
                 // to the "a" from the SELECT clause, so we can't compare by field id / relation id.
-                if (expression instanceof Identifier && aliases.contains(canonicalizationAwareKey(expression))) {
+                if (expression instanceof Identifier && aliases.contains(canonicalizationAwareKey(expression, true))) {
                     continue;
                 }
 
@@ -5787,13 +5787,13 @@ class StatementAnalyzer
                 if (item instanceof SingleColumn column) {
                     Optional<Identifier> alias = column.getAlias();
                     if (alias.isPresent()) {
-                        aliases.add(canonicalizationAwareKey(alias.get()));
+                        aliases.add(canonicalizationAwareKey(alias.get(), true));
                     }
                     else if (column.getExpression() instanceof Identifier identifier) {
-                        aliases.add(canonicalizationAwareKey(identifier));
+                        aliases.add(canonicalizationAwareKey(identifier, true));
                     }
                     else if (column.getExpression() instanceof DereferenceExpression dereferenceExpression) {
-                        aliases.add(canonicalizationAwareKey(dereferenceExpression.getField().orElseThrow()));
+                        aliases.add(canonicalizationAwareKey(dereferenceExpression.getField().orElseThrow(), true));
                     }
                 }
                 else if (item instanceof AllColumns allColumns) {
@@ -5803,10 +5803,10 @@ class StatementAnalyzer
                         Field field = fields.get(i);
 
                         if (!allColumns.getAliases().isEmpty()) {
-                            aliases.add(canonicalizationAwareKey(allColumns.getAliases().get(i)));
+                            aliases.add(canonicalizationAwareKey(allColumns.getAliases().get(i), true));
                         }
                         else if (field.getName().isPresent()) {
-                            aliases.add(canonicalizationAwareKey(new Identifier(field.getName().get())));
+                            aliases.add(canonicalizationAwareKey(new Identifier(field.getName().get()), true));
                         }
                     }
                 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestDistinctWithOrderBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestDistinctWithOrderBy.java
@@ -72,6 +72,52 @@ public class TestDistinctWithOrderBy
         assertThat(assertions.query("SELECT DISTINCT a, b a FROM (VALUES (2, 10), (1, 20), (2, 10)) T(a, b) ORDER BY T.a"))
                 .ordered()
                 .matches("VALUES (1, 20), (2, 10)");
+
+        // tests with delimited and lower case identifiers
+        assertThat(assertions.query("SELECT DISTINCT a as x FROM (VALUES 2, 1, 2) t(a) ORDER BY \"x\""))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"x\" FROM (VALUES 2, 1, 2) t(a) ORDER BY x"))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"x\" FROM (VALUES 2, 1, 2) t(a) ORDER BY \"x\""))
+                .matches("VALUES 1, 2");
+
+        // tests with delimited and upper case identifiers
+        assertThat(assertions.query("SELECT DISTINCT a as X FROM (VALUES 2, 1, 2) t(a) ORDER BY \"X\""))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"X\" FROM (VALUES 2, 1, 2) t(a) ORDER BY X"))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"X\" FROM (VALUES 2, 1, 2) t(a) ORDER BY \"X\""))
+                .matches("VALUES 1, 2");
+
+        // tests with mixed lower (in SELECT DISTINCT) and upper (in ORDER BY) case identifiers
+        assertThat(assertions.query("SELECT DISTINCT a as x FROM (VALUES 2, 1, 2) t(a) ORDER BY X"))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as x FROM (VALUES 2, 1, 2) t(a) ORDER BY \"X\""))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"x\" FROM (VALUES 2, 1, 2) t(a) ORDER BY X"))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"x\" FROM (VALUES 2, 1, 2) t(a) ORDER BY \"X\""))
+                .matches("VALUES 1, 2");
+
+        // tests with mixed upper (in SELECT DISTINCT) and lower (in ORDER BY) case identifiers
+        assertThat(assertions.query("SELECT DISTINCT a as X FROM (VALUES 2, 1, 2) t(a) ORDER BY x"))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as X FROM (VALUES 2, 1, 2) t(a) ORDER BY \"x\""))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"X\" FROM (VALUES 2, 1, 2) t(a) ORDER BY x"))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query("SELECT DISTINCT a as \"X\" FROM (VALUES 2, 1, 2) t(a) ORDER BY \"x\""))
+                .matches("VALUES 1, 2");
     }
 
     @Test

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Identifier.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Identifier.java
@@ -78,10 +78,14 @@ public class Identifier
 
     public String getCanonicalValue()
     {
-        if (isDelimited()) {
+        return getCanonicalValue(false);
+    }
+
+    public String getCanonicalValue(boolean ignoreCase)
+    {
+        if (!ignoreCase && isDelimited()) {
             return value;
         }
-
         return value.toUpperCase(ENGLISH);
     }
 


### PR DESCRIPTION
Fix SELECT DISTINCT with delimited alias in ORDER BY bug

Fixes https://github.com/trinodb/trino/issues/26755

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The canonical value of a non-delimited Identifier was the upper-case value. The canonical value of a delimited Identifier was simply the value. Thus, statements like
SELECT DISTINCT a as x FROM (VALUES 2, 1, 2) t(a) ORDER BY "x"
would fail, as the canonical value of the identifier from SELECT DISTINCT would be "X",
while the canonical value of the identifier from ORDER BY would be "x", and the identifiers would not match.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`26755`)
```

## Summary by Sourcery

Fix SELECT DISTINCT alias matching in ORDER BY to handle delimited and mixed-case identifiers by adding ignore-case canonicalization support and updating alias comparison accordingly.

Bug Fixes:
- Fix failure when ordering by a delimited SELECT DISTINCT alias due to mismatched canonical values.

Enhancements:
- Add ignore-case mode in CanonicalizationAware for identifier equality and hashing.
- Update Identifier to support case-insensitive canonical value retrieval.
- Adjust StatementAnalyzer to use ignore-case canonicalization when resolving DISTINCT aliases.

Tests:
- Add test cases for SELECT DISTINCT with various combinations of delimited and mixed-case aliases in ORDER BY.