### PR TITLE
Restrict logical navigations to the running match in running semantics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/LogicalIndexNavigation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/LogicalIndexNavigation.java
@@ -76,26 +76,20 @@ public class LogicalIndexNavigation
         checkArgument(currentRow >= patternStart && currentRow < patternStart + matchedLabels.length(), "current row is out of bounds of the match");
 
         int relativePosition;
+        int patternEndInclusive = running ? currentRow - patternStart : matchedLabels.length() - 1;
         if (last) {
-            int start;
-            if (running) {
-                start = currentRow - patternStart;
-            }
-            else {
-                start = matchedLabels.length() - 1;
-            }
-            relativePosition = findLastAndBackwards(start, matchedLabels);
+            relativePosition = findLastAndBackwards(patternEndInclusive, matchedLabels);
         }
         else {
-            relativePosition = findFirstAndForward(matchedLabels);
+            relativePosition = findFirstAndForward(patternEndInclusive, matchedLabels);
         }
         return adjustPosition(relativePosition, patternStart, searchStart, searchEnd);
     }
 
     // LAST(A.price, 3): find the last occurrence of label "A" and go 3 occurrences backwards
-    private int findLastAndBackwards(int searchStart, ArrayView matchedLabels)
+    private int findLastAndBackwards(int patternEndInclusive, ArrayView matchedLabels)
     {
-        int position = searchStart + 1;
+        int position = patternEndInclusive + 1;
         int found = 0;
         while (found <= logicalOffset && position > 0) {
             position--;
@@ -110,11 +104,11 @@ public class LogicalIndexNavigation
     }
 
     // FIRST(A.price, 3): find the first occurrence of label "A" and go 3 occurrences forward
-    private int findFirstAndForward(ArrayView matchedLabels)
+    private int findFirstAndForward(int patternEndInclusive, ArrayView matchedLabels)
     {
         int position = -1;
         int found = 0;
-        while (found <= logicalOffset && position < matchedLabels.length() - 1) {
+        while (found <= logicalOffset && position < patternEndInclusive) {
             position++;
             if (labels.isEmpty() || labels.contains(matchedLabels.get(position))) {
                 found++;

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
@@ -1020,8 +1020,8 @@ public class TestRowPatternMatching
 
         assertThat(assertions.query(format(query, "FIRST(value, 2)")))
                 .matches("VALUES " +
-                        "     (1, 30), " +
-                        "     (2, 30), " +
+                        "     (1, null), " +
+                        "     (2, null), " +
                         "     (3, 30) ");
 
         assertThat(assertions.query(format(query, "LAST(value, 10)")))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Before this change, the logical navigation function `FIRST` could return position out of bounds of the current match in the `running` semantics. Now it is restricted to the current match.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes: https://github.com/trinodb/trino/issues/26981


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## General
* In row pattern matching, restrict logical navigations to current match in running semantics. ({issue}`26981`)
```

## Summary by Sourcery

Restrict logical navigation functions to the current match bounds in running semantics and update tests accordingly.

Bug Fixes:
- Prevent FIRST and LAST navigations from returning positions outside the current match in running semantics

Tests:
- Adjust expected results for FIRST navigation to null when the match is not yet complete in running semantics