### PR TITLE
Re-throw StorageException as IOException

### DIFF
--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsOutputStream.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsOutputStream.java
@@ -141,6 +141,7 @@ public class GcsOutputStream
                 if (e.getCode() == HTTP_PRECON_FAILED) {
                     throw new FileAlreadyExistsException(location.toString());
                 }
+                throw new IOException(e);
             }
             catch (IOException e) {
                 throw new IOException("Error closing file: " + location, e);


### PR DESCRIPTION
## Description
Updates the close method GcsOutputStream to re-throw StorageException as IOException to avoid silently swallowing them.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Currently when a StorageException is thrown, it is silently swallowed except if it's an HTTP 412.  Therefore it's possible that a file was never written to GCS because of some other transient networking error, but the stream is marked as closed.

I checked the S3 implementation and see that [it similarly re-throws these types of exceptions as `IOException`](https://github.com/trinodb/trino/blob/4da16d9597ecc4750f3d499f3975c4f1337c76c7/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java#L164-L166) so this is consistent with other filesystem behavior.

I came across this code while investigating an issue we encountered in one of our Iceberg tables.  We can see files tracked in the Iceberg metadata that do not exist in the GCS bucket so it makes me suspect this is the root cause.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Bug Fixes:
- Re-throw StorageException as IOException instead of swallowing it in GcsOutputStream.close to surface failures