### PR TITLE
Replace deprecated TrinoContainer

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import io.trino.jdbc.BaseTestJdbcResultSet;
 import org.testcontainers.DockerClientFactory;
-import org.testcontainers.containers.TrinoContainer;
+import org.testcontainers.trino.TrinoContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Tests:
- Switch to using a generic Testcontainers container instead of the deprecated TrinoContainer in the old-server JDBC compatibility test