### PR TITLE
Fix case typo in `NativeLogicalTypesAvroTypeManager#validateLogicalType`

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/NativeLogicalTypesAvroTypeManager.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/NativeLogicalTypesAvroTypeManager.java
@@ -256,7 +256,7 @@ public class NativeLogicalTypesAvroTypeManager
             case DATE, DECIMAL, TIME_MILLIS, TIME_MICROS, TIMESTAMP_MILLIS, TIMESTAMP_MICROS, UUID:
                 logicalType = fromSchemaIgnoreInvalid(schema);
                 break;
-            case LOCAL_TIMESTAMP_MICROS + LOCAL_TIMESTAMP_MILLIS:
+            case LOCAL_TIMESTAMP_MICROS, LOCAL_TIMESTAMP_MILLIS:
                 log.debug("Logical type %s not currently supported by by Trino", typeName);
                 // fall through
             default:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Bug Fixes:
- Correct switch-case syntax to separate LOCAL_TIMESTAMP_MICROS and LOCAL_TIMESTAMP_MILLIS cases in NativeLogicalTypesAvroTypeManager