### PR TITLE
Temp fix for broken download link

### DIFF
--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -27,7 +27,10 @@ Versions before 350 are not supported.
 (jdbc-installation)=
 ## Installation
 
-Download {download_mc}`jdbc` and add it to the classpath of your Java application.
+<!-- Download {download_mc}`jdbc` and add it to the classpath of your Java application. -->
+Download
+[trino-jdbc-477.jar](https://repo1.maven.org/maven2/io/trino/trino-jdbc/477/trino-jdbc-477.jar)
+and add it to the classpath of your Java application.
 
 The driver is also available from Maven Central:
 


### PR DESCRIPTION
## Description

The download link for trino-jdbc-477.jar was broken. I tried to debug the {download_mc} macro, but it all looked right to me. As a stopgap, I just hardcoded the actual download link. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Documentation:
- Replace the {download_mc}`jdbc` macro with a hardcoded hyperlink to trino-jdbc-477.jar on Maven Central