### PR TITLE
Fix null pointer exception in UI query resource when URL does not have a query string

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -113,7 +113,8 @@ public class UiQueryResource
             try {
                 checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders), queryInfo.get().getSession().toIdentity(), accessControl);
 
-                if (servletRequest.getQueryString().contains("pretty")) {
+                String queryString = servletRequest.getQueryString();
+                if (queryString != null && queryString.contains("pretty")) {
                     // Use pretty JSON codec that reduces noise
                     return Response.ok(prettyQueryInfoCodec.toJson(queryInfo.get()), APPLICATION_JSON_TYPE).build();
                 }


### PR DESCRIPTION
## Description

After [#26988](https://github.com/trinodb/trino/pull/26988) the Query Details page in the UI is broken and throws an exception when fetching data from `/ui/api/query/{queryId}`:

The server logs show the following error:
```
ava.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because the return value of "jakarta.servlet.http.HttpServletRequest.getQueryString()" is null
	at io.trino.server.ui.UiQueryResource.getQueryInfo(UiQueryResource.java:116)
```

## Additional context and related issues

This happens because both the classic and preview UIs request query information from an endpoint that does not include a query string in the URL. As a result, `HttpServletRequest.getQueryString()` returns null, which is not currently handled and leads to the NPE.

This PR adds null handling when accessing `HttpServletRequest.getQueryString()`.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Bug Fixes:
- Check for null before using getQueryString().contains("pretty") to avoid NPE in UI query endpoint