### PR TITLE
Fix dynamic catalogs in tests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -438,10 +438,6 @@ public class TestingTrinoServer
         spoolingConfiguration.ifPresent(config ->
                 spoolingManagerRegistry.loadSpoolingManager(config.factoryName(), config.configuration()));
 
-        catalogStoreManager.ifPresent(CatalogStoreManager::loadConfiguredCatalogStore);
-        ConnectorServicesProvider connectorServicesProvider = injector.getInstance(ConnectorServicesProvider.class);
-        connectorServicesProvider.loadInitialCatalogs();
-
         EventListenerManager eventListenerManager = injector.getInstance(EventListenerManager.class);
         eventListeners.forEach(eventListenerManager::addEventListener);
 

--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.trino.Session;
+import io.trino.connector.ConnectorServicesProvider;
 import io.trino.cost.StatsCalculator;
 import io.trino.execution.FailureInjector.InjectedFailureType;
 import io.trino.execution.QueryManagerConfig;
@@ -88,6 +89,7 @@ public final class StandaloneQueryRunner
                         .buildOrThrow());
         serverProcessor.accept(builder);
         this.server = builder.build();
+        server.getInstance(Key.get(ConnectorServicesProvider.class)).loadInitialCatalogs();
 
         this.trinoClient = new TestingDirectTrinoClient(
                 server.getDispatchManager(),

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -30,6 +30,7 @@ import io.trino.Session;
 import io.trino.Session.SessionBuilder;
 import io.trino.client.ClientSession;
 import io.trino.client.StatementClient;
+import io.trino.connector.ConnectorServicesProvider;
 import io.trino.connector.CoordinatorDynamicCatalogManager;
 import io.trino.cost.StatsCalculator;
 import io.trino.execution.FailureInjector.InjectedFailureType;
@@ -997,6 +998,7 @@ public final class DistributedQueryRunner
                 closeAllSuppress(e, queryRunner);
                 throw e;
             }
+            queryRunner.getCoordinator().getInstance(Key.get(ConnectorServicesProvider.class)).loadInitialCatalogs();
 
             return queryRunner;
         }

--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -470,7 +470,7 @@ public final class QueryAssertions
         }
     }
 
-    protected static void assertQueryReturnsEmptyResult(QueryRunner queryRunner, Session session, @Language("SQL") String sql)
+    public static void assertQueryReturnsEmptyResult(QueryRunner queryRunner, Session session, @Language("SQL") String sql)
     {
         QueryId queryId = null;
         try {

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/TestSystemMetadataCatalogTable.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/TestSystemMetadataCatalogTable.java
@@ -17,6 +17,10 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.connector.TestDynamicCatalogs;
 import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.catalog.CatalogProperties;
+import io.trino.spi.connector.CatalogVersion;
+import io.trino.spi.connector.ConnectorName;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -30,13 +34,20 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 public class TestSystemMetadataCatalogTable
         extends AbstractTestQueryFramework
 {
+    private static final String BROKEN_CATALOG = "broken_catalog";
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
         Session session = testSessionBuilder().build();
+        ImmutableMap<String, String> properties = ImmutableMap.of("non_existing", "false");
         QueryRunner queryRunner = DistributedQueryRunner.builder(session)
-                .setAdditionalModule(new TestDynamicCatalogs.TestCatalogStoreModule())
+                .setAdditionalModule(new TestDynamicCatalogs.TestCatalogStoreModule(ImmutableMap.of(new CatalogName(BROKEN_CATALOG), new CatalogProperties(
+                        new CatalogName(BROKEN_CATALOG),
+                        new CatalogVersion("abc123"),
+                        new ConnectorName("memory"),
+                        properties))))
                 .setCoordinatorProperties(ImmutableMap.of("catalog.store", "prepopulated_memory"))
                 .setWorkerCount(0)
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`io.trino.connector.ConnectorServicesProvider#loadInitialCatalogs` needs to have connector plugins available.
When it was called from `TestingTrinoServer` connector factories defined via `io.trino.testing.QueryRunner#installPlugin` were not available and thus catalog initialization failed for a wrong reason - missing connector factory instead of expected invalid configuration of a catalog. 
Additionaly this PR adds a test that validates that catalogs are correctly initialized when necessary. 



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Fix the initialization of dynamic catalogs in test setups by deferring initial catalog loading until after connector plugins are installed, refactoring the catalog store modules to accept arbitrary prepopulated catalogs, and adding tests to validate correct catalog behavior.

New Features:
- Add testPrepopulatedHealthyCatalog in TestDynamicCatalogs to verify creation, use, and removal of a prepopulated catalog

Bug Fixes:
- Defer ConnectorServicesProvider.loadInitialCatalogs call until after plugins are installed in DistributedQueryRunner to ensure connector factories are available

Enhancements:
- Refactor TestCatalogStoreModule, PrepopulatedInMemoryCatalogStoreModule, factory, and store to accept a map of prepopulated catalogs instead of a hardcoded entry
- Expose assertQueryReturnsEmptyResult as a public assertion helper

Tests:
- Update TestDynamicCatalogs to rename and adjust the unhealthy catalog test and add a healthy prepopulated catalog test
- Update TestSystemMetadataCatalogTable to configure its catalog store with a custom prepopulated catalog