### PR TITLE
Fix flaky Elasticsearch and OpenSearch docker initialization

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -73,6 +73,7 @@ public class ElasticsearchServer
         container = new ElasticsearchContainer(dockerImageName);
         container.withNetwork(network);
         container.withNetworkAliases("elasticsearch-server");
+        container.withEnv("ES_JAVA_OPTS", "-Des.cgroups.enable=false");
         container.withStartupTimeout(Duration.ofMinutes(5));
 
         configurationPath = createTempDirectory(null);

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchServer.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchServer.java
@@ -48,6 +48,7 @@ public class OpenSearchServer
     {
         container = new OpenSearchContainer<>(image);
         container.withNetwork(network);
+        container.withEnv("OPENSEARCH_JAVA_OPTS", "-Djdk.internal.platform.cgroupv2.disable=true");
         if (secured) {
             container.withSecurityEnabled();
         }


### PR DESCRIPTION
## Description

* https://github.com/trinodb/trino/actions/runs/18620460744/job/53090990880
* https://github.com/trinodb/trino/actions/runs/18620460744/job/53090990926

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Disable cgroupv2 in Elasticsearch and OpenSearch test containers to stabilize Docker initialization

Bug Fixes:
- Add ES_JAVA_OPTS environment variable to disable cgroupv2 in Elasticsearch test container
- Add OPENSEARCH_JAVA_OPTS environment variable to disable cgroupv2 in OpenSearch test container