### PR TITLE
Disable CGroups for Elastic/OpenSearch docker

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -54,7 +54,7 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public class ElasticsearchServer
         implements Closeable
 {
-    public static final String ELASTICSEARCH_7_IMAGE = "elasticsearch:7.16.2";
+    public static final String ELASTICSEARCH_7_IMAGE = "elasticsearch:7.17.28";
     public static final String ELASTICSEARCH_8_IMAGE = "elasticsearch:8.11.3";
 
     private final Path configurationPath;
@@ -74,6 +74,7 @@ public class ElasticsearchServer
         container.withNetwork(network);
         container.withNetworkAliases("elasticsearch-server");
         container.withStartupTimeout(Duration.ofMinutes(5));
+        container.withEnv("ES_JAVA_OPTS", "-Xmx256m -Xms256m -Dlog4j2.disableJmx=true -Dlog4j2.disable.jmx=true -XX:-UseContainerSupport"); // Disable CGroups
 
         configurationPath = createTempDirectory(null);
         Map<String, String> configurationFiles = ImmutableMap.<String, String>builder()

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchServer.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchServer.java
@@ -48,6 +48,7 @@ public class OpenSearchServer
     {
         container = new OpenSearchContainer<>(image);
         container.withNetwork(network);
+        container.withEnv("OPENSEARCH_JAVA_OPTS", "-XX:-UseContainerSupport"); // Disable CGroups
         if (secured) {
             container.withSecurityEnabled();
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Disable container-level resource detection for Elasticsearch and OpenSearch Docker test containers by adding the respective Java option to disable UseContainerSupport.

Enhancements:
- Disable CGroups support in Elasticsearch test container by setting ES_JAVA_OPTS to -XX:-UseContainerSupport
- Disable CGroups support in OpenSearch test container by setting OPENSEARCH_JAVA_OPTS to -XX:-UseContainerSupport