### PR TITLE
Fix Exchange manager docs

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -414,6 +414,11 @@ the property may be configured for:
     store spooling data.
   -
   - Any
+* - `exchange.max-page-storage-size`
+  - Max storage size of a page written to a sink, including the page itself
+    and its size.
+  - `16MB`
+  - Any
 * - `exchange.sink-buffer-pool-min-size`
   - The minimum buffer pool size for an exchange sink. The larger the buffer
     pool size, the larger the write parallelism and memory usage.
@@ -426,7 +431,7 @@ the property may be configured for:
   - Any
 * - `exchange.sink-max-file-size`
   - Max [data size](prop-type-data-size) of files written by exchange sinks.
-  - ``1GB``
+  - `1GB`
   - Any
 * - `exchange.source-concurrent-readers`
   - Number of concurrent readers to read from spooling storage. The larger the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

I've noticed that `exchange.max-page-storage-size` property exists in the [code](https://github.com/trinodb/trino/blob/b7a6a36b840b2344b62d6722686cfe730245ce57/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeConfig.java#L82) but is not mentioned in the [Exchange manager docs](https://trino.io/docs/current/admin/fault-tolerant-execution.html#id1).
I assume that it's just missing/overlooked. Happy to provide a small fix.

Fixes https://github.com/trinodb/trino/issues/27023

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( x ) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Documentation:
- Add the exchange.max-page-storage-size property to the Exchange manager section with its description and default value