### PR TITLE
Configure internal communication for ANNOUNCE discovery mode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/node/AirliftNodeInventoryModule.java
+++ b/core/trino-main/src/main/java/io/trino/node/AirliftNodeInventoryModule.java
@@ -17,6 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.client.DiscoveryModule;
+import io.airlift.discovery.client.ForDiscoveryClient;
 import io.airlift.discovery.server.DynamicAnnouncementResource;
 import io.airlift.discovery.server.EmbeddedDiscoveryModule;
 import io.airlift.discovery.server.ServiceResource;
@@ -75,6 +76,6 @@ public class AirliftNodeInventoryModule
                 .addProperty("coordinator", String.valueOf(coordinator));
 
         // internal communication setup for discovery http client
-        install(new InternalCommunicationForDiscoveryModule());
+        install(new InternalCommunicationForDiscoveryModule(ForDiscoveryClient.class));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/node/AnnounceNodeInventoryModule.java
+++ b/core/trino-main/src/main/java/io/trino/node/AnnounceNodeInventoryModule.java
@@ -46,5 +46,8 @@ public class AnnounceNodeInventoryModule
                     config.setIdleTimeout(new Duration(3, SECONDS));
                     config.setRequestTimeout(new Duration(3, SECONDS));
                 }).build());
+
+        // internal communication setup for discovery http client
+        install(new InternalCommunicationForDiscoveryModule(ForAnnouncer.class));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/node/InternalCommunicationForDiscoveryModule.java
+++ b/core/trino-main/src/main/java/io/trino/node/InternalCommunicationForDiscoveryModule.java
@@ -16,7 +16,6 @@ package io.trino.node;
 import com.google.inject.Binder;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.airlift.discovery.client.ForDiscoveryClient;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.Request;
@@ -24,6 +23,7 @@ import io.trino.server.InternalAuthenticationManager;
 import io.trino.server.InternalCommunicationConfig;
 
 import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -33,19 +33,27 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.node.AddressToHostname.encodeAddressAsHostname;
 import static io.trino.server.InternalCommunicationHttpClientModule.configureClient;
+import static java.util.Objects.requireNonNull;
 
 public class InternalCommunicationForDiscoveryModule
         extends AbstractConfigurationAwareModule
 {
+    private final Class<? extends Annotation> httpClientQualifier;
+
+    public InternalCommunicationForDiscoveryModule(Class<? extends Annotation> httpClientQualifier)
+    {
+        this.httpClientQualifier = requireNonNull(httpClientQualifier, "httpClientQualifier is null");
+    }
+
     @Override
     protected void setup(Binder binder)
     {
         InternalCommunicationConfig internalCommunicationConfig = buildConfigObject(InternalCommunicationConfig.class);
-        Multibinder<HttpRequestFilter> discoveryFilterBinder = newSetBinder(binder, HttpRequestFilter.class, ForDiscoveryClient.class);
+        Multibinder<HttpRequestFilter> discoveryFilterBinder = newSetBinder(binder, HttpRequestFilter.class, httpClientQualifier);
         if (internalCommunicationConfig.isHttpsRequired() && internalCommunicationConfig.getKeyStorePath() == null && internalCommunicationConfig.getTrustStorePath() == null) {
             discoveryFilterBinder.addBinding().to(DiscoveryEncodeAddressAsHostname.class);
         }
-        configBinder(binder).bindConfigDefaults(HttpClientConfig.class, ForDiscoveryClient.class, config -> configureClient(config, internalCommunicationConfig));
+        configBinder(binder).bindConfigDefaults(HttpClientConfig.class, httpClientQualifier, config -> configureClient(config, internalCommunicationConfig));
         discoveryFilterBinder.addBinding().to(InternalAuthenticationManager.class);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This includes automatic generation of TLS certificates for internal communication when the certificate is not configured explicitly in the `ANNOUNCE` node discovery mode.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This follows up on the node inventory refactoring in #26083.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Enabled automatic TLS certificate generation in the `ANNOUNCE` node discovery mode. ({issue}`issuenumber`)
```

## Summary by Sourcery

Enable automatic TLS setup for internal communications in both node discovery and announce modes by extracting and applying the configuration logic into a reusable module.

New Features:
- Enable automatic TLS certificate generation in the ANNOUNCE node discovery mode when certificates are not explicitly configured.

Enhancements:
- Extract internal communication HTTP client configuration into a new InternalCommunicationForDiscoveryModule.
- Refactor AirliftNodeInventoryModule and AnnounceNodeInventoryModule to install the new reusable module instead of duplicating setup logic.