### PR TITLE
Throw a correct exception from SqlServerClient#listSchemas

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -394,7 +394,7 @@ public class SqlServerClient
             return schemaNames.build();
         }
         catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new TrinoException(JDBC_ERROR, e);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Do not throw a generic `RuntimeException`, but a correct `TrinoException` with the `JDBC_ERROR` error code. This is, among other things, what the test framework requires.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Introduced by ba4d205127946ccfe11c7f24308aad090bb0b213 (#26553).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Bug Fixes:
- Replace generic RuntimeException with a TrinoException(JDBC_ERROR) in SqlServerClient#listSchemas to satisfy test framework requirements