### PR TITLE
Fix transactional table alter to include thrift catalog name

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -754,7 +754,7 @@ public class ThriftHiveMetastoreClient
                 },
                 () -> {
                     table.setWriteId(originalWriteId);
-                    client.alterTableWithEnvironmentContext(table.getDbName(), table.getTableName(), table, environmentContext);
+                    client.alterTableWithEnvironmentContext(prependCatalogToDbName(catalogName, table.getDbName()), table.getTableName(), table, environmentContext);
                     return null;
                 });
     }


### PR DESCRIPTION
The HMS image we use by default in the tests is not reproducing the issue, so tested manually with enforcing chosenAlterTransactionalTableAlternative to 1, to trigger the alternate call. This was an alternate call we missed in the original implementation. 

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## Hive
* Fix potential failure when updating or deleting Hive transactional tables and the
  `hive.metastore.thrift.catalog-name` property was configured. ({issue}`27032`)
```

## Summary by Sourcery

Bug Fixes:
- Include the catalog name when calling alterTableWithEnvironmentContext in the alternate alterTransactionalTable path.