### PR TITLE
Fix typo in null check message

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
@@ -181,7 +181,7 @@ public class ConnectorServices
         this.accessControl = Optional.ofNullable(accessControl);
 
         List<PropertyMetadata<?>> sessionProperties = connector.getSessionProperties();
-        requireNonNull(sessionProperties, format("Connector '%s' returned a null system properties set", catalogHandle));
+        requireNonNull(sessionProperties, format("Connector '%s' returned a null session properties set", catalogHandle));
         this.sessionProperties = Maps.uniqueIndex(sessionProperties, PropertyMetadata::getName);
 
         List<PropertyMetadata<?>> tableProperties = connector.getTableProperties();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct null check error message to reference session properties instead of system properties in ConnectorServices