### PR TITLE
Allow reads to kafka-based tables using manually overridden offsets

### DIFF
--- a/docs/src/main/sphinx/connector/kafka.md
+++ b/docs/src/main/sphinx/connector/kafka.md
@@ -90,7 +90,7 @@ org.apache.kafka=WARN
 The following configuration properties are available:
 
 | Property name                                         | Description                                                                                                                                                                                                                 |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `kafka.default-schema`                                | Default schema name for tables.                                                                                                                                                                                             |
 | `kafka.nodes`                                         | List of nodes in the Kafka cluster.                                                                                                                                                                                         |
 | `kafka.buffer-size`                                   | Kafka read buffer size.                                                                                                                                                                                                     |
@@ -109,6 +109,7 @@ The following configuration properties are available:
 | `kafka.ssl.key.password`                              | Password for the private key in the keystore file.                                                                                                                                                                          |
 | `kafka.ssl.endpoint-identification-algorithm`         | Endpoint identification algorithm used by clients to validate server host name; defaults to `https`.                                                                                                                        |
 | `kafka.config.resources`                              | A comma-separated list of Kafka client configuration files. These files must exist on the machines running Trino. Only specify this if absolutely necessary to access Kafka. Example: `/etc/kafka-configuration.properties` |
+| `kafka.override-topic-partition-offsets`              | Whether to allow overriding offsets to read for a particular kafka partition. Offsets are set with session parameter: `kafka.kafka_topic_partition_offset_overrides`.                                                         |
 
 In addition, you must configure {ref}`table schema and schema registry usage
 <kafka-table-schema-registry>` with the relevant properties.
@@ -217,6 +218,17 @@ The endpoint identification algorithm used by clients to validate server host na
 Kafka uses `https` as default. Use `disabled` to disable server host name validation.
 
 This property is optional; default is `https`.
+
+### `kafka.override-topic-partition-offsets`
+
+If enabled, a user may override the offsets to read for a particular kafka topic-partition to achieve snapshot read semantics.
+
+This property is optional; default is `false`.
+
+The name of the session property to use is `kafka_topic_partition_offset_overrides`.
+
+To read offsets 0 to 10 (exclusive) on partition 0 and 5 to 20 (exclusive) on partition 1 of topic x:
+`SET SESSION kafka.kafka_topic_partition_offset_overrides = 'x-0=0-10,x-1=5-20';`
 
 ## Internal columns
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/CurrentTopicPartitionOffsetProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/CurrentTopicPartitionOffsetProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class CurrentTopicPartitionOffsetProvider
+        implements TopicPartitionOffsetProvider
+{
+    public CurrentTopicPartitionOffsetProvider()
+    {
+    }
+
+    @Override
+    public KafkaPartitionInputs offsetRangesPerPartition(KafkaConsumer<byte[], byte[]> kafkaConsumer, String topicName, ConnectorSession session)
+    {
+        List<PartitionInfo> partitionInfos = kafkaConsumer.partitionsFor(topicName);
+
+        List<TopicPartition> topicPartitions = partitionInfos.stream()
+                .map(KafkaSplitManager::toTopicPartition)
+                .collect(toImmutableList());
+
+        Map<TopicPartition, Long> partitionBeginOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
+        Map<TopicPartition, Long> partitionEndOffsets = kafkaConsumer.endOffsets(topicPartitions);
+        return new KafkaPartitionInputs(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
@@ -49,6 +49,12 @@ public class KafkaConfig
     private String tableDescriptionSupplier = FileTableDescriptionSupplier.NAME;
     private List<File> resourceConfigFiles = ImmutableList.of();
     private String internalFieldPrefix = "_";
+    private boolean overrideTopicPartitionOffsets;
+
+    private static HostAddress toHostAddress(String value)
+    {
+        return HostAddress.fromString(value).withDefaultPort(KAFKA_DEFAULT_PORT);
+    }
 
     @Size(min = 1)
     public Set<HostAddress> getNodes()
@@ -120,11 +126,6 @@ public class KafkaConfig
         return this;
     }
 
-    private static HostAddress toHostAddress(String value)
-    {
-        return HostAddress.fromString(value).withDefaultPort(KAFKA_DEFAULT_PORT);
-    }
-
     @Min(1)
     public int getMessagesPerSplit()
     {
@@ -179,6 +180,19 @@ public class KafkaConfig
     public KafkaConfig setInternalFieldPrefix(String internalFieldPrefix)
     {
         this.internalFieldPrefix = internalFieldPrefix;
+        return this;
+    }
+
+    public boolean isOverrideTopicPartitionOffsets()
+    {
+        return overrideTopicPartitionOffsets;
+    }
+
+    @Config("kafka.override-topic-partition-offsets")
+    @ConfigDescription("Whether a user must specify all topic-partition offsets to query from kafka topic")
+    public KafkaConfig setOverrideTopicPartitionOffsets(boolean overrideTopicPartitionOffsets)
+    {
+        this.overrideTopicPartitionOffsets = overrideTopicPartitionOffsets;
         return this;
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -76,13 +76,14 @@ public class KafkaFilterManager
         this.kafkaInternalFieldManager = requireNonNull(kafkaInternalFieldManager, "kafkaInternalFieldManager is null");
     }
 
-    public KafkaFilteringResult getKafkaFilterResult(
+    public KafkaPartitionInputs getKafkaFilterResult(
             ConnectorSession session,
             KafkaTableHandle kafkaTableHandle,
-            List<PartitionInfo> partitionInfos,
-            Map<TopicPartition, Long> partitionBeginOffsets,
-            Map<TopicPartition, Long> partitionEndOffsets)
+            KafkaPartitionInputs partitionResult)
     {
+        List<PartitionInfo> partitionInfos = partitionResult.partitionInfos();
+        Map<TopicPartition, Long> partitionBeginOffsets = partitionResult.partitionBeginOffsets();
+        Map<TopicPartition, Long> partitionEndOffsets = partitionResult.partitionEndOffsets();
         requireNonNull(session, "session is null");
         requireNonNull(kafkaTableHandle, "kafkaTableHandle is null");
         requireNonNull(partitionInfos, "partitionInfos is null");
@@ -145,9 +146,9 @@ public class KafkaFilterManager
             List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
                     .filter(partitionInfo -> partitionIdsFiltered.contains((long) partitionInfo.partition()))
                     .collect(toImmutableList());
-            return new KafkaFilteringResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
+            return new KafkaPartitionInputs(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
         }
-        return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+        return partitionResult;
     }
 
     private Optional<Domain> getDomain(InternalFieldId internalFieldId, Map<String, Domain> columnNameToDomain)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPartitionInputs.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPartitionInputs.java
@@ -23,12 +23,12 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-public record KafkaFilteringResult(
+public record KafkaPartitionInputs(
         List<PartitionInfo> partitionInfos,
         Map<TopicPartition, Long> partitionBeginOffsets,
         Map<TopicPartition, Long> partitionEndOffsets)
 {
-    public KafkaFilteringResult
+    public KafkaPartitionInputs
     {
         partitionInfos = ImmutableList.copyOf(requireNonNull(partitionInfos, "partitionInfos is null"));
         partitionBeginOffsets = ImmutableMap.copyOf(requireNonNull(partitionBeginOffsets, "partitionBeginOffsets is null"));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSessionProperties.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSessionProperties.java
@@ -24,22 +24,22 @@ import java.util.List;
 public final class KafkaSessionProperties
         implements SessionPropertiesProvider
 {
+    public static final String KAFKA_TOPIC_PARTITION_OFFSET_OVERRIDES = "kafka_topic_partition_offset_overrides";
     private static final String TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED = "timestamp_upper_bound_force_push_down_enabled";
+    private static final String NONE = "";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public KafkaSessionProperties(KafkaConfig kafkaConfig)
     {
         sessionProperties = ImmutableList.of(PropertyMetadata.booleanProperty(
-                TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED,
-                "Enable or disable timestamp upper bound push down for topic createTime mode",
-                kafkaConfig.isTimestampUpperBoundPushDownEnabled(), false));
-    }
-
-    @Override
-    public List<PropertyMetadata<?>> getSessionProperties()
-    {
-        return sessionProperties;
+                        TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED,
+                        "Enable or disable timestamp upper bound push down for topic createTime mode",
+                        kafkaConfig.isTimestampUpperBoundPushDownEnabled(), false),
+                PropertyMetadata.stringProperty(
+                        KAFKA_TOPIC_PARTITION_OFFSET_OVERRIDES,
+                        "Set custom offsets when reading particular kafka topic partitions. Example config: 'topicName-0=0-10,topicName-1=5-20'. Trino will read topicName partition 0 from offsets 0 to 10 (exclusive). If not specified, Trino will fall back to the current partition of a kafka topic.",
+                        NONE, false));
     }
 
     /**
@@ -52,5 +52,11 @@ public final class KafkaSessionProperties
     public static boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED, Boolean.class);
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/OverriddenTopicPartitionOffsetProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/OverriddenTopicPartitionOffsetProvider.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.trino.plugin.kafka.KafkaSessionProperties.KAFKA_TOPIC_PARTITION_OFFSET_OVERRIDES;
+
+public class OverriddenTopicPartitionOffsetProvider
+        implements TopicPartitionOffsetProvider
+{
+    public static final String DELIMITER = "-";
+    public static final String PARTITION_TO_OFFSET_DELIMITER = "=";
+    private final TopicPartitionOffsetProvider offsetProvider;
+
+    public OverriddenTopicPartitionOffsetProvider(TopicPartitionOffsetProvider offsetProvider)
+    {
+        this.offsetProvider = offsetProvider;
+    }
+
+    private static TopicPartitionAndOffsetsString splitTopicPartitionAndOffsets(String topicPartitionAndOffsetString)
+    {
+        String[] parts = topicPartitionAndOffsetString.split(PARTITION_TO_OFFSET_DELIMITER);
+        if (parts.length != 2) {
+            throw new TrinoException(StandardErrorCode.INVALID_SESSION_PROPERTY, "String should be two offsets separated by a '-': " + topicPartitionAndOffsetString);
+        }
+        return new TopicPartitionAndOffsetsString(parts[0], parts[1]);
+    }
+
+    private static TopicPartition parseTopicPartition(String topicPartitionString)
+    {
+        int lastHyphen = topicPartitionString.lastIndexOf(DELIMITER);
+        if (lastHyphen == -1) {
+            throw new TrinoException(StandardErrorCode.INVALID_SESSION_PROPERTY, "No hyphen in topic partition string: " + topicPartitionString);
+        }
+        String topic = topicPartitionString.substring(0, lastHyphen);
+        String partitionString = topicPartitionString.substring(lastHyphen + 1);
+        int partition;
+        try {
+            partition = Integer.parseInt(partitionString);
+        }
+        catch (NumberFormatException exception) {
+            throw new TrinoException(StandardErrorCode.INVALID_SESSION_PROPERTY, "Partition number not parseable as an int: " + partitionString, exception);
+        }
+        return new TopicPartition(topic, partition);
+    }
+
+    private static long parseBeginningOffset(String offsetString)
+    {
+        return parseOffset(offsetString, 0);
+    }
+
+    private static long parseEndOffset(String offsetString)
+    {
+        return parseOffset(offsetString, 1);
+    }
+
+    private static long parseOffset(String offsetRangeString, int rangeIndex)
+    {
+        String[] parts = offsetRangeString.split(DELIMITER);
+        if (parts.length != 2) {
+            throw new TrinoException(StandardErrorCode.INVALID_SESSION_PROPERTY, "String should be two offsets separated by a '-': " + offsetRangeString);
+        }
+        String offsetString = parts[rangeIndex];
+        long offset;
+        try {
+            offset = Long.parseLong(offsetString);
+        }
+        catch (NumberFormatException exception) {
+            throw new TrinoException(StandardErrorCode.INVALID_SESSION_PROPERTY, "Offset number not parseable as a long: " + offsetString, exception);
+        }
+        return offset;
+    }
+
+    public static KafkaPartitionInputs parseOverriddenInputs(String inputString)
+    {
+        List<String> perTopicOffsets = Arrays.stream(inputString.replace(" ", "").split(",")).filter(aEntry -> !aEntry.isEmpty()).toList();
+        Map<TopicPartition, Long> overriddenPartitionBeginOffsets = perTopicOffsets.stream()
+                .map(OverriddenTopicPartitionOffsetProvider::splitTopicPartitionAndOffsets)
+                .collect(Collectors.toMap(aEntry -> parseTopicPartition(aEntry.topicPartition()), aEntry -> parseBeginningOffset(aEntry.offsets())));
+        Map<TopicPartition, Long> overriddenPartitionEndOffsets = perTopicOffsets.stream()
+                .map(OverriddenTopicPartitionOffsetProvider::splitTopicPartitionAndOffsets)
+                .collect(Collectors.toMap(aEntry -> parseTopicPartition(aEntry.topicPartition()), aEntry -> parseEndOffset(aEntry.offsets())));
+        return new KafkaPartitionInputs(List.of(), overriddenPartitionBeginOffsets, overriddenPartitionEndOffsets);
+    }
+
+    @Override
+    public KafkaPartitionInputs offsetRangesPerPartition(KafkaConsumer<byte[], byte[]> kafkaConsumer, String topicName, ConnectorSession session)
+    {
+        KafkaPartitionInputs currentInputs = offsetProvider.offsetRangesPerPartition(kafkaConsumer, topicName, session);
+
+        String offsetOverrideConfig = session.getProperty(KAFKA_TOPIC_PARTITION_OFFSET_OVERRIDES, String.class);
+        KafkaPartitionInputs overriddenOffsets = parseOverriddenInputs(offsetOverrideConfig);
+
+        Map<TopicPartition, Long> mergedBeginningOffsets = new HashMap<>(currentInputs.partitionBeginOffsets());
+        mergedBeginningOffsets.replaceAll((key, value) -> overriddenOffsets.partitionBeginOffsets().getOrDefault(key, value));
+
+        Map<TopicPartition, Long> mergedEndingOffsets = new HashMap<>(currentInputs.partitionEndOffsets());
+        mergedEndingOffsets.replaceAll((key, value) -> overriddenOffsets.partitionEndOffsets().getOrDefault(key, value));
+
+        return new KafkaPartitionInputs(currentInputs.partitionInfos(), mergedBeginningOffsets, mergedEndingOffsets);
+    }
+
+    private record TopicPartitionAndOffsetsString(String topicPartition, String offsets) {}
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/TopicPartitionOffsetProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/TopicPartitionOffsetProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+public interface TopicPartitionOffsetProvider
+{
+    KafkaPartitionInputs offsetRangesPerPartition(KafkaConsumer<byte[], byte[]> kafkaConsumer, String topicName, ConnectorSession session);
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConfig.java
@@ -43,7 +43,8 @@ public class TestKafkaConfig
                 .setMessagesPerSplit(100_000)
                 .setTimestampUpperBoundPushDownEnabled(false)
                 .setResourceConfigFiles(List.of())
-                .setInternalFieldPrefix("_"));
+                .setInternalFieldPrefix("_")
+                .setOverrideTopicPartitionOffsets(false));
     }
 
     @Test
@@ -63,6 +64,7 @@ public class TestKafkaConfig
                 .put("kafka.timestamp-upper-bound-force-push-down-enabled", "true")
                 .put("kafka.config.resources", resource1.toString() + "," + resource2.toString())
                 .put("kafka.internal-column-prefix", "the_most_unexpected_prefix_")
+                .put("kafka.override-topic-partition-offsets", "true")
                 .buildOrThrow();
 
         KafkaConfig expected = new KafkaConfig()
@@ -74,7 +76,8 @@ public class TestKafkaConfig
                 .setMessagesPerSplit(1)
                 .setTimestampUpperBoundPushDownEnabled(true)
                 .setResourceConfigFiles(ImmutableList.of(resource1.toString(), resource2.toString()))
-                .setInternalFieldPrefix("the_most_unexpected_prefix_");
+                .setInternalFieldPrefix("the_most_unexpected_prefix_")
+                .setOverrideTopicPartitionOffsets(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestOverriddenTopicPartitionOffsetProvider.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestOverriddenTopicPartitionOffsetProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.testing.TestingConnectorSession;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.plugin.kafka.KafkaSessionProperties.KAFKA_TOPIC_PARTITION_OFFSET_OVERRIDES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestOverriddenTopicPartitionOffsetProvider
+{
+    @Test
+    public void testCanParseOverriddenOffsets()
+    {
+        KafkaPartitionInputs inputs = OverriddenTopicPartitionOffsetProvider.parseOverriddenInputs("x-0=0-10, y-1=5-20 ");
+        assertThat(inputs.partitionBeginOffsets().get(new TopicPartition("x", 0))).isEqualTo(0);
+        assertThat(inputs.partitionEndOffsets().get(new TopicPartition("x", 0))).isEqualTo(10);
+        assertThat(inputs.partitionBeginOffsets().get(new TopicPartition("y", 1))).isEqualTo(5);
+        assertThat(inputs.partitionEndOffsets().get(new TopicPartition("y", 1))).isEqualTo(20);
+    }
+
+    @Test
+    public void testCanOverrideProvidedOffsets()
+    {
+        String offsetOverrides = "x-0=5-10, y-1=5-20 ";
+        ConnectorSession connectorSession = TestingConnectorSession.builder().setPropertyMetadata(List.of(PropertyMetadata.stringProperty(
+                KAFKA_TOPIC_PARTITION_OFFSET_OVERRIDES,
+                "Test description",
+                offsetOverrides, false))).build();
+        String topicName = StaticTopicPartitionOffsetProvider.TOPIC_PARTITION.topic();
+        OverriddenTopicPartitionOffsetProvider victim = new OverriddenTopicPartitionOffsetProvider(new StaticTopicPartitionOffsetProvider());
+        KafkaPartitionInputs inputs = victim.offsetRangesPerPartition(null, topicName, connectorSession);
+        assertThat(inputs.partitionInfos()).containsOnly(StaticTopicPartitionOffsetProvider.PARTITION_INFO);
+        assertThat(inputs.partitionBeginOffsets()).containsExactlyEntriesOf(Map.of(StaticTopicPartitionOffsetProvider.TOPIC_PARTITION, 5L));
+        assertThat(inputs.partitionEndOffsets()).containsExactlyEntriesOf(Map.of(StaticTopicPartitionOffsetProvider.TOPIC_PARTITION, 10L));
+    }
+
+    @Test
+    public void testThrowsTrinoExceptionOnMalformedTopicPartitionOverrides()
+    {
+        assertThatThrownBy(() -> OverriddenTopicPartitionOffsetProvider.parseOverriddenInputs("x-0?0-10, y-1=5-20 ")).isInstanceOf(TrinoException.class);
+        assertThatThrownBy(() -> OverriddenTopicPartitionOffsetProvider.parseOverriddenInputs("x:0=0-10, y-1=5-20 ")).isInstanceOf(TrinoException.class);
+        assertThatThrownBy(() -> OverriddenTopicPartitionOffsetProvider.parseOverriddenInputs("x-a=0-10, y-1=5-20 ")).isInstanceOf(TrinoException.class);
+        assertThatThrownBy(() -> OverriddenTopicPartitionOffsetProvider.parseOverriddenInputs("x-0=a-10, y-1=5-20 ")).isInstanceOf(TrinoException.class);
+        assertThatThrownBy(() -> OverriddenTopicPartitionOffsetProvider.parseOverriddenInputs("x-0=0-a, y-1=5-20 ")).isInstanceOf(TrinoException.class);
+    }
+
+    private static class StaticTopicPartitionOffsetProvider
+            implements TopicPartitionOffsetProvider
+    {
+        public static final TopicPartition TOPIC_PARTITION = new TopicPartition("x", 0);
+        public static final PartitionInfo PARTITION_INFO = new PartitionInfo(TOPIC_PARTITION.topic(), TOPIC_PARTITION.partition(), Node.noNode(), new Node[0], new Node[0], new Node[0]);
+
+        @Override
+        public KafkaPartitionInputs offsetRangesPerPartition(KafkaConsumer<byte[], byte[]> kafkaConsumer, String topicName, ConnectorSession session)
+        {
+            return new KafkaPartitionInputs(List.of(PARTITION_INFO), Map.of(TOPIC_PARTITION, 0L), Map.of(TOPIC_PARTITION, 20L));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Prior to this change, Trino's Kafka connector reads from dynamically loaded offsets fetched at query time. This is not conducive to snapshot reads, which can only be achieved by specifying a start and end offset per topic partition to read from.

In this change, we enable doing so by setting
kafka.override-topic-partition-offsets to true in the kafka catalog config file.

From there, we can use the session level setting,
kafka_topic_partition_offset_overrides, in order to specify manual overrides for a set of topic partitions. If specified, these will override the existing offsets that the connector loads at runtime.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
() Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Add support for reading user-specified offsets from the kafka connector. See [kafka docs](docs/src/main/sphinx/connector/kafka.md) for details.

## Summary by Sourcery

Enable snapshot-style reads from Kafka by allowing users to specify manual start and end offsets per topic partition via a new catalog flag and session property

New Features:
- Add config property 'kafka.override-topic-partition-offsets' to require explicit offset overrides for Kafka reads
- Introduce session property 'kafka_topic_partition_offset_overrides' to specify custom offset ranges per topic-partition

Enhancements:
- Introduce TopicPartitionOffsetProvider interface with Current and Overridden implementations to centralize offset retrieval
- Refactor KafkaSplitManager and KafkaFilterManager to use unified KafkaPartitionInputs record

Documentation:
- Document the new offset override config and session property in the Kafka connector documentation

Tests:
- Add unit tests for OverriddenTopicPartitionOffsetProvider and update KafkaConfig tests to cover the new catalog setting