### PR TITLE
Disable testIcebergTablesSystemTable in S3 Tables

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3TablesConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3TablesConnectorSmokeTest.java
@@ -298,4 +298,9 @@ final class TestIcebergS3TablesConnectorSmokeTest
     @Override
     @Disabled // TODO https://github.com/trinodb/trino/issues/25129 Fix flaky test
     public void testSelectInformationSchemaTables() {}
+
+    @Test
+    @Override
+    @Disabled // TODO https://github.com/trinodb/trino/issues/25129 Fix flaky test
+    public void testIcebergTablesSystemTable() {}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Relates to https://github.com/trinodb/trino/issues/25129


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Tests:
- Disable testIcebergTablesSystemTable due to flakiness (issue #25129)