### PR TITLE
Fix typo in test

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/TestNodeStateManager.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestNodeStateManager.java
@@ -137,7 +137,7 @@ class TestNodeStateManager
         ticker.increment(1, SECONDS);
         executor.run();
         // 2 gracePeriods or more
-        await().atMost(2 * GRACE_PERIOD_MILLIS + 100, SECONDS)
+        await().atMost(2 * GRACE_PERIOD_MILLIS + 100, MILLISECONDS)
                 .untilAsserted(() -> assertThat(nodeStateManager.getServerState()).isEqualTo(DRAINED));
 
         // now test the shutdown from the DRAINED state


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

## Summary by Sourcery

Fix a typo in the TestNodeStateManager unit test by changing the await() timeout unit from SECONDS to MILLISECONDS

Bug Fixes:
- Correct the timeout unit in TestNodeStateManager to use MILLISECONDS instead of SECONDS

Tests:
- Fix a typo in the await() timeout unit in TestNodeStateManager