### PR TITLE
Update tableReplace javadoc of ConnectorMetadata#getStatisticsCollectionMetadataForWrite method

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -685,7 +685,7 @@ public interface ConnectorMetadata
     /**
      * Describes statistics that must be collected during a write.
      *
-     * @param tableReplace if true, replace old statistics
+     * @param tableReplace indicates whether this is for table replace operation and statistics of an existing table (if any) should be ignored
      */
     default TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean tableReplace)
     {


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Documentation:
- Update Javadoc to explain that tableReplace indicates a table replace operation and that existing table statistics should be ignored