### PR TITLE
Wait longer to reduce flakiness of TestNodeStateManager

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/TestNodeStateManager.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestNodeStateManager.java
@@ -60,7 +60,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 class TestNodeStateManager
 {
-    public static final int GRACE_PERIOD_MILLIS = 200;
+    public static final int GRACE_PERIOD_MILLIS = 1000;
     private FakeScheduledExecutorService executor;
     private NodeStateManager nodeStateManager;
     private TestingTicker ticker;
@@ -94,7 +94,7 @@ class TestNodeStateManager
         ticker.increment(1, SECONDS);
         executor.run();
 
-        await().atMost(1, SECONDS).untilAsserted(() -> assertThat(nodeStateManager.getServerState()).isEqualTo(DRAINED));
+        await().atMost(5, SECONDS).untilAsserted(() -> assertThat(nodeStateManager.getServerState()).isEqualTo(DRAINED));
     }
 
     @Test
@@ -105,8 +105,8 @@ class TestNodeStateManager
         nodeStateManager.transitionState(NodeState.SHUTTING_DOWN);
         assertThat(nodeStateManager.getServerState()).isEqualTo(NodeState.SHUTTING_DOWN);
 
-        // here wait for at least 2 grace periods, and add some slack to reduce test flakiness
-        await().atMost(4 * GRACE_PERIOD_MILLIS + 100, MILLISECONDS).until(() -> shutdownAction.isShuttingDown());
+        // here wait for at least 4 grace periods, and add some slack to reduce test flakiness
+        await().atMost(4 * GRACE_PERIOD_MILLIS + 1000, MILLISECONDS).until(() -> shutdownAction.isShuttingDown());
     }
 
     @Test
@@ -117,7 +117,7 @@ class TestNodeStateManager
         nodeStateManager.transitionState(NodeState.SHUTTING_DOWN);
         assertThat(nodeStateManager.getServerState()).isEqualTo(NodeState.SHUTTING_DOWN);
 
-        // here wait for at least 2 grace periods, and add some slack to reduce test flakiness
+        // here wait for at least 4 grace periods, and add some slack to reduce test flakiness
         await().atMost(4 * GRACE_PERIOD_MILLIS, MILLISECONDS).until(() -> shutdownAction.isShuttingDown());
 
         assertThatThrownBy(() -> nodeStateManager.transitionState(ACTIVE))
@@ -144,9 +144,8 @@ class TestNodeStateManager
         nodeStateManager.transitionState(NodeState.SHUTTING_DOWN);
         assertThat(nodeStateManager.getServerState()).isEqualTo(NodeState.SHUTTING_DOWN);
 
-        // here only wait for minimal amount of time, as shutdown should be immediate
         await().pollInterval(1, MILLISECONDS)
-                .atMost(100, MILLISECONDS).until(() -> shutdownAction.isShuttingDown());
+                .atMost(1, SECONDS).until(() -> shutdownAction.isShuttingDown());
     }
 
     @Test
@@ -171,7 +170,7 @@ class TestNodeStateManager
         // make sure that nodeStateManager registered a listener for tasks to finish
         ticker.increment(1, SECONDS);
         executor.run();
-        await().atMost(1, SECONDS).until(() -> sqlTasksObservable.getTasks().size() == 1);
+        await().atMost(5, SECONDS).until(() -> sqlTasksObservable.getTasks().size() == 1);
 
         // simulate task completion after some time
         tasks.set(Collections.emptyList());
@@ -213,7 +212,7 @@ class TestNodeStateManager
                 .stateChanged(TaskState.FINISHED);
 
         // when NodeStateManager sees task finished - it will drain after another drain period
-        await().atMost(1, SECONDS)
+        await().atMost(5, SECONDS)
                 .untilAsserted(() -> assertThat(nodeStateManager.getServerState()).isEqualTo(DRAINED));
     }
 


### PR DESCRIPTION
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

## Summary by Sourcery

Adjust test timing in TestNodeStateManager to reduce flakiness by increasing the grace period and extending await timeouts

Tests:
- Increase GRACE_PERIOD_MILLIS from 200ms to 1000ms in TestNodeStateManager
- Extend await timeouts and slack for shutdown transitions to accommodate the longer grace period
- Update comments in tests to reflect waiting for four grace periods and use longer time units for clarity