### PR TITLE
Added Ranger and Resource group documentation for `kill_query`

### DIFF
--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -199,7 +199,11 @@ documentation](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java
   - `DATA_DEFINITION`: Queries that affect the data definition. These include
     `CREATE`, `ALTER`, and `DROP` statements for schemas, tables, views, and
     materialized views, as well as statements that manage prepared statements,
-    privileges, sessions, and transactions.
+    privileges, sessions, and transactions. When external clients need 
+    access to the `system.runtime.kill_query()` procedure to stop running or 
+    queued queries, this `queryType` must be used to make sure the
+    `kill_query()` is executed directly and isn't queued to wait for the 
+    initial query to finish.
   - `ALTER_TABLE_EXECUTE`: Queries that execute table procedures with [ALTER
     TABLE EXECUTE](alter-table-execute).
 

--- a/docs/src/main/sphinx/security/ranger-access-control.md
+++ b/docs/src/main/sphinx/security/ranger-access-control.md
@@ -193,3 +193,7 @@ The following table lists the configuration properties for the Ranger access con
   execute any query.
   * To allow this, create a policy in Apache Ranger for a `trinouser` resource
     with value `{USER}` and with the `impersonate` permission for user `{USER}`.
+* External clients can use the `system.runtime.kill_query()` procedure to 
+  kill running queries. Add a policy with Schema `system`, Database
+  `runtime` and Procedure `kill_query` with `execute` permission for user
+  `{USER}`.


### PR DESCRIPTION
## Description
Added some missing documentation about the `system.runtime.kill_query()` procedure in Ranger and Resource group sections.

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

## Summary by Sourcery

Add documentation about the system.runtime.kill_query() procedure in the resource groups guide and the Ranger access control guide

Documentation:
- Explain that the kill_query procedure should use the DATA_DEFINITION queryType to bypass queuing in resource groups
- Add a Ranger policy example for granting execute permission on the system.runtime.kill_query procedure