### PR TITLE
Remove the query field in the URI before reconstructing to avoid duplicated query field in new URI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusAirliftHttpClient.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusAirliftHttpClient.java
@@ -79,7 +79,7 @@ public class NimbusAirliftHttpClient
                 .setMethod(method.name())
                 .setFollowRedirects(httpRequest.getFollowRedirects());
 
-        UriBuilder url = UriBuilder.fromUri(httpRequest.getURI());
+        UriBuilder url = UriBuilder.fromUri(httpRequest.getURI()).replaceQuery(null);
         if (method.equals(GET) || method.equals(DELETE)) {
             httpRequest.getQueryStringParameters().forEach((key, value) -> url.queryParam(key, value.toArray()));
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
When querying a non-standard userinfo endpoint (not the Microsoft one found in https://login.microsoftonline.com/<TENANT_ID>/v2.0/.well-known/openid-configuration), and instead, using UserInfo endpoint querying method (https://learn.microsoft.com/en-us/entra/identity-platform/userinfo) , the Trino code identifies the URL with the query params, however, during the original parsing, rather than starting a URL builder from scratch, it's taking the original URL and re-appending the query string to itself, resulting in duplicate query param.
E.g. `https://graph.microsoft.com/v1.0/me?select=id,userPrincipalName,displayName,email,onPremisesSamAccountName&select=id,userPrincipalName,displayName,email,onPremisesSamAccountName` instead of the expected `https://graph.microsoft.com/v1.0/me?select=id,userPrincipalName,displayName,email,onPremisesSamAccountName`. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
<img width="1172" height="495" alt="487552600-c3a5e755-7f02-467b-8e76-c1ab1e2ba626" src="https://github.com/user-attachments/assets/9f28ed38-4019-42ed-a0d1-47778976df8e" />



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Bug Fixes:
- Strip the original query field in UriBuilder to avoid appending duplicate query parameters