### PR TITLE
Remove unused ConnectorSplit.getSplitInfo method

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
@@ -13,12 +13,10 @@
  */
 package io.trino.spi.connector;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 
 import java.util.List;
-import java.util.Map;
 
 public interface ConnectorSplit
 {
@@ -40,16 +38,6 @@ public interface ConnectorSplit
             throw new IllegalStateException("getAddresses must be implemented when for splits with isRemotelyAccessible=false");
         }
         return List.of();
-    }
-
-    /**
-     * @deprecated Use {@link Object#toString()} for printing debugging information, or {@link ConnectorSplitSource#getMetrics()} for recording metrics
-     */
-    @Deprecated(forRemoval = true)
-    @JsonIgnore // ConnectorSplit is json-serializable, but we don't want to repeat information in that field
-    default Map<String, String> getSplitInfo()
-    {
-        throw new UnsupportedOperationException();
     }
 
     default SplitWeight getSplitWeight()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

() This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Remove the deprecated `ConnectorSplit.getSplitInfo` method. ({issue}`27063`)
```

## Summary by Sourcery

Remove the deprecated getSplitInfo method and related unused imports from ConnectorSplit interface

Enhancements:
- Remove deprecated getSplitInfo method from ConnectorSplit interface

Chores:
- Remove unused imports of JsonIgnore and Map in ConnectorSplit