### PR TITLE
Extend TestSchedulingUtils with top level union

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSchedulingUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSchedulingUtils.java
@@ -73,6 +73,34 @@ public class TestSchedulingUtils
     }
 
     @Test
+    public void testCanStreamUnion()
+    {
+        /*
+                  parent(union)
+                   /    \    \
+     -------------------------------------- stage boundary
+                  a     b     c
+         */
+        SubPlan aSubPlan = valuesSubPlan("a");
+        RemoteSourceNode remoteSourceA = remoteSource("a");
+
+        SubPlan bSubPlan = valuesSubPlan("b");
+        RemoteSourceNode remoteSourceB = remoteSource("b");
+
+        SubPlan cSubPlan = valuesSubPlan("c");
+        RemoteSourceNode remoteSourceC = remoteSource("c");
+
+        SubPlan parentSubPlan = createSubPlan(
+                "parent",
+                union("union", ImmutableList.of(remoteSourceA, remoteSourceB, remoteSourceC)),
+                ImmutableList.of(aSubPlan, bSubPlan, cSubPlan));
+
+        assertThat(SchedulingUtils.canStream(parentSubPlan, aSubPlan)).isTrue();
+        assertThat(SchedulingUtils.canStream(parentSubPlan, bSubPlan)).isTrue();
+        assertThat(SchedulingUtils.canStream(parentSubPlan, cSubPlan)).isTrue();
+    }
+
+    @Test
     public void testCanStreamJoin()
     {
         /*


### PR DESCRIPTION
Add some missing test coverage

## Summary by Sourcery

Tests:
- Add test for canStream over a union operator with multiple child sources