### PR TITLE
Minor cleanup on free-disk-space.sh

### DIFF
--- a/.github/bin/free-disk-space.sh
+++ b/.github/bin/free-disk-space.sh
@@ -23,16 +23,29 @@ function free_up_disk_space_ubuntu()
     sudo apt-get autoclean -y
 
     echo  "Removing toolchains"
-    sudo rm -rf \
-      /usr/local/graalvm \
-      /usr/local/lib/android/ \
-      /usr/share/dotnet/ \
-      /opt/ghc/ \
-      /usr/local/share/boost/ \
-      "${AGENT_TOOLSDIRECTORY}"
+    directories_to_be_removed=(
+      "/usr/local/graalvm/"
+      "/usr/local/lib/android/"
+      "/usr/share/dotnet/"
+      "/opt/ghc/"
+      "/usr/local/share/boost/"
+      "${AGENT_TOOLSDIRECTORY}")
 
-      echo "Prune docker images"
-      sudo docker system prune --all -f
+    delete_directories_with_rsync "${directories_to_be_removed[@]}"
+
+    echo "Prune docker images"
+    sudo docker system prune --all -f
+}
+
+function delete_directories_with_rsync()
+{
+    sudo mkdir /tmp/empty
+    for dir in "$@"; do
+        echo "Deleting contents of $dir using rsync"
+        sudo rsync --delete -a /tmp/empty/ "$dir"
+        sudo rmdir "$dir"
+    done
+    sudo rmdir /tmp/empty
 }
 
 echo "Disk space usage before cleaning:"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR attempts to speed up the `free-disk-space.sh` which takes more than 15mins to execute. We first remove`man-db` as updating it takes some time - Even official runners from Nov 10th would have them removed - https://github.com/actions/runner-images/issues/13213

Additionally we try to use `rsync` to drop the files instead of `rm -rf`.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Enhancements:
- Add logging of disk usage before cleaning in free-disk-space script

## Summary by Sourcery

Optimize disk cleanup script by excluding man-db, introducing rsync-based deletion for directories, and logging pre-cleanup disk usage.

Enhancements:
- Exclude man-db from the list of Ubuntu package removals to speed up updates
- Add delete_directories_with_rsync function to use rsync for faster purging of toolchain directories
- Replace bulk rm -rf directory removal with rsync-based deletion
- Log disk usage before running cleanup steps to provide pre-cleanup metrics