### PR TITLE
Run path-filters only on pull requests CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ concurrency:
 
 jobs:
   path-filters:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       docs: ${{ steps.filter.outputs.docs }}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Path-filters CI job allows us to identify if the change is on docs or actual code change - Ref : https://github.com/trinodb/trino/pull/27070 and we would like to run the job only when for PR.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

CI:
- Add an if condition to run the path-filters job only on pull_request events