### PR TITLE
Fix `ci` workflow on `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
     steps:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
+        if: github.event_name == 'pull_request'
         with:
+          # Note: `docs` output is currently unused. The docs changes are tested by maven-checks job, leveraging GIB impact analysis.
+          # TODO remove use of non_docs filters and remove `path-filters` job. Use GIB impact analysis to guard job skipping.
           filters: |
             docs: 'docs/**'
             non_docs: '!docs/**'
@@ -100,7 +103,7 @@ jobs:
 
   artifact-checks:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -189,7 +192,7 @@ jobs:
 
   error-prone-checks:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -219,7 +222,7 @@ jobs:
 
   test-jdbc-compatibility:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -261,7 +264,7 @@ jobs:
 
   hive-tests:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -319,7 +322,7 @@ jobs:
 
   test-other-modules:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -408,7 +411,7 @@ jobs:
 
   build-test-matrix:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -833,7 +836,7 @@ jobs:
 
   build-pt:
     needs: path-filters
-    if: needs.path-filters.outputs.non_docs == 'true'
+    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION


The ci workflow got broken in https://github.com/trinodb/trino/commit/3698755cc25d6ae37f2345134878b43453cd247c (https://github.com/trinodb/trino/pull/27070)
because `dorny/paths-filter` action works out of the box on PR runs
only.

It can be made to work on branch push runs too (requires
actions/checkout), but then it's meaningless -- there won't be any
chnages anyway. Or actually can be misleading, as it will compare the
branch against master, so may work surprisingly when the workflow is
enabled on any other branch.