### PR TITLE
Change to use Chainguard MinIO container

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
@@ -39,7 +39,7 @@ public class Minio
 
     private static final String MINIO_ACCESS_KEY = "minio-access-key";
     private static final String MINIO_SECRET_KEY = "minio-secret-key";
-    private static final String MINIO_RELEASE = "RELEASE.2025-01-20T14-49-07Z";
+    private static final String MINIO_RELEASE = "latest";
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop
     private static final int MINIO_CONSOLE_PORT = 9001;
@@ -69,7 +69,7 @@ public class Minio
 
     private DockerContainer createMinioContainer()
     {
-        DockerContainer container = new DockerContainer("minio/minio:" + MINIO_RELEASE, MINIO_CONTAINER_NAME)
+        DockerContainer container = new DockerContainer("cgr.dev/chainguard/minio:" + MINIO_RELEASE, MINIO_CONTAINER_NAME)
                 .withEnv(ImmutableMap.<String, String>builder()
                         .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
                         .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
@@ -47,7 +47,7 @@ public class SpoolingMinio
     private static final String MINIO_SPOOLING_CONTAINER_NAME = "spooling-minio";
     private static final String MINIO_ACCESS_KEY = "minio-access-key";
     private static final String MINIO_SECRET_KEY = "minio-secret-key";
-    private static final String MINIO_RELEASE = "RELEASE.2025-01-20T14-49-07Z";
+    private static final String MINIO_RELEASE = "latest";
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop
     private static final int MINIO_CONSOLE_PORT = 9001;
@@ -95,7 +95,7 @@ public class SpoolingMinio
             throw new UncheckedIOException(e);
         }
 
-        DockerContainer container = new DockerContainer("minio/minio:" + MINIO_RELEASE, MINIO_SPOOLING_CONTAINER_NAME)
+        DockerContainer container = new DockerContainer("cgr.dev/chainguard/minio:" + MINIO_RELEASE, MINIO_SPOOLING_CONTAINER_NAME)
                 .withEnv(ImmutableMap.<String, String>builder()
                         .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
                         .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -41,7 +41,7 @@ public class Minio
 {
     private static final Logger log = Logger.get(Minio.class);
 
-    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2024-12-18T13-15-44Z";
+    public static final String DEFAULT_IMAGE = "cgr.dev/chainguard/minio";
     public static final String DEFAULT_HOST_NAME = "minio";
 
     public static final int MINIO_API_PORT = 4566;


### PR DESCRIPTION
## Description

Change to use the MinIO container image from Chainguard Containers. Only "latest" is available so I am trying with that.

This PR is just an initial test for now. 

## Additional context and related issues

MinIO no longer publishes updated to their container images and even the latest one has CVEs reported against it.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
