### PR TITLE
Only warn about DockerContainer log paths when configured

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/DockerContainer.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/DockerContainer.java
@@ -157,7 +157,6 @@ public class DockerContainer
 
     public DockerContainer withExposedLogPaths(String... logPaths)
     {
-        requireNonNull(this.logPaths, "log paths are already exposed");
         this.logPaths.addAll(Arrays.asList(logPaths));
         return this;
     }
@@ -292,6 +291,10 @@ public class DockerContainer
 
     public void copyLogsToHostPath(Path hostPath)
     {
+        if (logPaths.isEmpty()) {
+            return;
+        }
+
         if (!isRunning()) {
             log.warn("Could not copy files from stopped container %s", logicalName);
             return;


### PR DESCRIPTION
Fix spurious warnings from `DockerContainer` in product tests when log paths are not configured.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Refine DockerContainer log handling to suppress unnecessary warnings and clean up outdated null checks.

Bug Fixes:
- Only warn about missing DockerContainer log files when log paths are configured to avoid spurious warnings.

Enhancements:
- Remove redundant null check in DockerContainer.withExposedLogPaths.