### PR TITLE
Reapply "Expose /v1/integrations/gateway/metrics for Trino Gateway"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/LocalMemoryManager.java
+++ b/core/trino-main/src/main/java/io/trino/memory/LocalMemoryManager.java
@@ -17,11 +17,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
+import com.sun.management.UnixOperatingSystemMXBean;
 import io.airlift.units.DataSize;
 
+import java.lang.management.ManagementFactory;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Verify.verify;
+import static java.lang.Math.clamp;
 import static java.lang.String.format;
 
 public final class LocalMemoryManager
@@ -30,6 +33,10 @@ public final class LocalMemoryManager
 
     private static final Supplier<Integer> AVAILABLE_PROCESSORS = Suppliers
             .memoizeWithExpiration(Runtime.getRuntime()::availableProcessors, 30, TimeUnit.SECONDS);
+
+    // Clamp value because according to the documentation: if the recent CPU usage is not available, the method returns a negative value.
+    private static final Supplier<Double> SYSTEM_CPU_LOAD = Suppliers
+            .memoizeWithExpiration(() -> clamp(((UnixOperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getCpuLoad(), 0.0, 1.0), 5, TimeUnit.SECONDS);
 
     @Inject
     public LocalMemoryManager(NodeMemoryConfig config)
@@ -63,7 +70,7 @@ public final class LocalMemoryManager
 
     public MemoryInfo getInfo()
     {
-        return new MemoryInfo(AVAILABLE_PROCESSORS.get(), memoryPool.getInfo());
+        return new MemoryInfo(AVAILABLE_PROCESSORS.get(), SYSTEM_CPU_LOAD.get(), memoryPool.getInfo());
     }
 
     public MemoryPool getMemoryPool()

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryInfo.java
@@ -23,14 +23,17 @@ import static java.util.Objects.requireNonNull;
 public class MemoryInfo
 {
     private final int availableProcessors;
+    private final double systemCpuLoad;
     private final MemoryPoolInfo pool;
 
     @JsonCreator
     public MemoryInfo(
             @JsonProperty("availableProcessors") int availableProcessors,
+            @JsonProperty("systemCpuLoad") double systemCpuLoad,
             @JsonProperty("pool") MemoryPoolInfo pool)
     {
         this.availableProcessors = availableProcessors;
+        this.systemCpuLoad = systemCpuLoad;
         this.pool = requireNonNull(pool, "pool is null");
     }
 
@@ -38,6 +41,12 @@ public class MemoryInfo
     public int getAvailableProcessors()
     {
         return availableProcessors;
+    }
+
+    @JsonProperty
+    public double getSystemCpuLoad()
+    {
+        return systemCpuLoad;
     }
 
     @JsonProperty
@@ -51,6 +60,7 @@ public class MemoryInfo
     {
         return toStringHelper(this)
                 .add("availableProcessors", availableProcessors)
+                .add("systemCpuLoad", systemCpuLoad)
                 .add("pool", pool)
                 .toString();
     }

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -242,6 +242,8 @@ public class CoordinatorModule
 
         newExporter(binder).export(ClusterMemoryManager.class).withGeneratedName();
 
+        jaxrsBinder(binder).bind(GatewayResource.class);
+
         // node partitioning manager
         binder.bind(NodePartitioningManager.class).in(Scopes.SINGLETON);
 

--- a/core/trino-main/src/main/java/io/trino/server/GatewayResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/GatewayResource.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.inject.Inject;
+import io.trino.memory.ClusterMemoryManager;
+import io.trino.memory.MemoryInfo;
+import io.trino.server.security.ResourceSecurity;
+import io.trino.spi.memory.MemoryPoolInfo;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_READ;
+import static java.util.Objects.requireNonNull;
+
+@Path("/v1/integrations/gateway")
+@ResourceSecurity(MANAGEMENT_READ)
+public class GatewayResource
+{
+    private final ClusterMemoryManager clusterMemoryManager;
+
+    @Inject
+    public GatewayResource(ClusterMemoryManager clusterMemoryManager)
+    {
+        this.clusterMemoryManager = requireNonNull(clusterMemoryManager, "clusterMemoryManager is null");
+    }
+
+    @GET
+    @Path("metrics")
+    public ClusterMetrics getClusterMetrics()
+    {
+        Map<String, Optional<MemoryInfo>> memoryInfo = clusterMemoryManager.getAllNodesMemoryInfo();
+        long totalFreeBytes = memoryInfo
+                .values()
+                .stream()
+                .flatMap(Optional::stream)
+                .map(MemoryInfo::getPool)
+                .mapToLong(MemoryPoolInfo::getFreeBytes)
+                .sum();
+        double aggregatedSystemLoad = memoryInfo
+                .values()
+                .stream()
+                .flatMap(Optional::stream)
+                .mapToDouble(MemoryInfo::getSystemCpuLoad)
+                .sum();
+        return new ClusterMetrics(memoryInfo.size(), totalFreeBytes, aggregatedSystemLoad);
+    }
+
+    /**
+     * Represents metrics aggregated from all nodes in the Trino cluster
+     */
+    public record ClusterMetrics(long clusterSize, long totalFreeBytes, double aggregatedSystemLoad) {}
+}

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/BenchmarkBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/BenchmarkBinPackingNodeAllocator.java
@@ -179,6 +179,7 @@ public class BenchmarkBinPackingNodeAllocator
         {
             return new MemoryInfo(
                     4,
+                    0,
                     new MemoryPoolInfo(
                             DataSize.of(64, GIGABYTE).toBytes(),
                             usedMemory.toBytes(),

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestBinPackingNodeAllocator.java
@@ -131,6 +131,7 @@ public class TestBinPackingNodeAllocator
     {
         return new MemoryInfo(
                 4,
+                0,
                 new MemoryPoolInfo(
                         DataSize.of(64, GIGABYTE).toBytes(),
                         usedMemory.toBytes(),

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestExponentialGrowthPartitionMemoryEstimator.java
@@ -279,6 +279,7 @@ public class TestExponentialGrowthPartitionMemoryEstimator
     {
         return new MemoryInfo(
                 4,
+                0,
                 new MemoryPoolInfo(
                         DataSize.of(64, GIGABYTE).toBytes(),
                         usedMemory.toBytes(),

--- a/core/trino-main/src/test/java/io/trino/memory/LowMemoryKillerTestingUtils.java
+++ b/core/trino-main/src/test/java/io/trino/memory/LowMemoryKillerTestingUtils.java
@@ -73,7 +73,7 @@ public final class LowMemoryKillerTestingUtils
                     ImmutableMap.of(),
                     tasksMemoryInfoForNode(entry.getKey().getNodeIdentifier(), tasks),
                     ImmutableMap.of());
-            result.add(new MemoryInfo(7, memoryPoolInfo));
+            result.add(new MemoryInfo(7, 0, memoryPoolInfo));
         }
         return result.build();
     }


### PR DESCRIPTION
This reverts commit 9945c9a54d2d4d0a76a49145a4d1de9b218005de and reapplies commit 1ca42b4f1850bc4eeaeae0003c3f656e7055aa12.

## Release notes

This should use the release note from the original PR #26548.

## Summary by Sourcery

Reapply changes to include system CPU load in memory metrics and expose a GatewayResource endpoint for cluster-wide metrics

New Features:
- Add systemCpuLoad field to MemoryInfo and populate it in LocalMemoryManager
- Expose new JAX-RS endpoint GET /v1/integrations/gateway/metrics returning cluster metrics including free memory and aggregated system CPU load

Enhancements:
- Clamp CPU load values between 0 and 1 when retrieving from the operating system
- Register GatewayResource in the coordinator module

Tests:
- Update existing tests to supply the new systemCpuLoad parameter for MemoryInfo instances