### PR TITLE
Use bucket execution for OPTIMIZE on bucketed iceberg tables

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -747,7 +747,15 @@ public class AddExchanges
         {
             // Disable scale writers for partitioned data in case of Optimize since it can lead to small files and
             // not deterministic wrt to user provided min file size configuration.
-            boolean scaleWriters = node.getPartitioningScheme().isEmpty() && isScaleWriters(session);
+            boolean scaleWriters;
+            if (node.getPartitioningScheme().isPresent()) {
+                // Prefer partitioning by the execute node's partitioning scheme to attempt partitioning pushdown into the connector table scan
+                preferredProperties = PreferredProperties.partitioned(node.getPartitioningScheme().get().getPartitioning());
+                scaleWriters = false;
+            }
+            else {
+                scaleWriters = isScaleWriters(session);
+            }
             return visitTableWriter(node, node.getPartitioningScheme(), node.getSource(), preferredProperties, node.getTarget(), scaleWriters);
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -8553,6 +8553,11 @@ public abstract class BaseIcebergConnectorTest
             expectedQuery = "SELECT a.custkey, b.orderkey FROM orders a JOIN orders b on a.orderkey = b.custkey";
             assertQuery(planWithTableNodePartitioning, query, expectedQuery, assertRemoteExchangesCount(1));
             assertQuery(planWithoutTableNodePartitioning, query, expectedQuery, assertRemoteExchangesCount(2));
+
+            // optimize should not require a remote exchange between the scan and the execute nodes
+            query = "ALTER TABLE test_bucketed_select EXECUTE OPTIMIZE";
+            assertUpdate(planWithTableNodePartitioning, query, assertRemoteExchangesCount(1));
+            assertUpdate(planWithoutTableNodePartitioning, query, assertRemoteExchangesCount(2));
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS test_bucketed_select");

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -431,6 +431,11 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertUpdate(queryRunner, session, sql, OptionalLong.of(count), Optional.of(planAssertion));
     }
 
+    protected void assertUpdate(Session session, @Language("SQL") String sql, Consumer<Plan> planAssertion)
+    {
+        QueryAssertions.assertUpdate(queryRunner, session, sql, OptionalLong.empty(), Optional.of(planAssertion));
+    }
+
     protected void assertQuerySucceeds(@Language("SQL") String sql)
     {
         assertQuerySucceeds(getSession(), sql);


### PR DESCRIPTION
## Description
Before
```
Fragment 1 [iceberg:IcebergPartitioningHandle[update=false, partitionFunctions=[IcebergPartitionFunction[transform=BUCKET, dataPath=[0], type=bigint, size=OptionalInt[50]]]]]]                                                                 
     Output layout: [partialrows, fragment]                                                                                                                                                                                                         
     Output partitioning: SINGLE []                                                                                                                                                                                                                 
     TableExecute[]                                                                                                                                                                                                                                 
     │   Layout: [partialrows:bigint, fragment:varbinary]
.....................
     └─ LocalExchange[partitioning = iceberg:IcebergPartitioningHandle[update=false, partitionFunctions=[IcebergPartitionFunction[transform=BUCKET, dataPath=[0], type=bigint, size=OptionalInt[50]]]], arguments = [l_suppkey::bigint]]        
        │   Layout: [l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:integer, l_quantity:decimal(12,2), l_extendedprice:decimal(12,2), l_discount:decimal(12,2), l_tax:decimal(12,2), l_returnflag:varchar, l_linestatus:varchar
        └─ RemoteSource[sourceFragmentIds = [2]]                                                                                                                                                                                                    
               Layout: [l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:integer, l_quantity:decimal(12,2), l_extendedprice:decimal(12,2), l_discount:decimal(12,2), l_tax:decimal(12,2), l_returnflag:varchar, l_linestatus:varchar
                                                                                                                                                                                                                                                    
 Fragment 2 [SOURCE]                                                                                                                                                                                                                                
     Output layout: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment]
     Output partitioning: iceberg:IcebergPartitioningHandle[update=false, partitionFunctions=[IcebergPartitionFunction[transform=IDENTITY, dataPath=[0], type=bigint, size=OptionalInt.empty]]] [l_suppkey]                                         
     TableScan[table = iceberg:default.lineitem$data@1250945765337401983]                                                                                                                                                                           
         Layout: [l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:integer, l_quantity:decimal(12,2), l_extendedprice:decimal(12,2), l_discount:decimal(12,2), l_tax:decimal(12,2), l_returnflag:varchar, l_linestatus:varchar
.....................
```

After
```
Fragment 1 [iceberg:IcebergPartitioningHandle[update=false, partitionFunctions=[IcebergPartitionFunction[transform=BUCKET, dataPath=[0], type=bigint, size=OptionalInt[50]]]]]]                                                                         
     Output layout: [partialrows, fragment]         
     Output partitioning: SINGLE []                                                                                                                                                                                                                 
     TableExecute[]                                                                                                                                                                                                                                 
     │   Layout: [partialrows:bigint, fragment:varbinary]                                                                                                                                                                                           
........................                                                                                                                                                                                                                    
     └─ LocalExchange[partitioning = iceberg:IcebergPartitioningHandle[update=false, partitionFunctions=[IcebergPartitionFunction[transform=BUCKET, dataPath=[0], type=bigint, size=OptionalInt[50]]]], arguments = [l_suppkey::bigint]]        
        │   Layout: [l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:integer, l_quantity:decimal(12,2), l_extendedprice:decimal(12,2), l_discount:decimal(12,2), l_tax:decimal(12,2), l_returnflag:varchar, l_linestatus:varchar
        └─ TableScan[table = iceberg:default.lineitem$data@1250945765337401983]                                                                                                                                                                     
               Layout: [l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:integer, l_quantity:decimal(12,2), l_extendedprice:decimal(12,2), l_discount:decimal(12,2), l_tax:decimal(12,2), l_returnflag:varchar, l_linestatus:varchar
.........................
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Addresses similar problem as https://github.com/trinodb/trino/pull/26632 but without hard-coding the use of table partitioning for the distribution of scan in OPTIMIZE and additionally removing the remote exchange between the execute and scan nodes


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Improve performance of `ALTER TABLE EXECUTE OPTIMIZE` on bucketed tables. ({issue}`27104`)
```