### PR TITLE
Enable RedundantNullCheck errorprone rule

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
@@ -61,10 +61,6 @@ public class OkHttpSegmentLoader
                 .build();
 
         Response response = callFactory.newCall(request).execute();
-        if (response.body() == null) {
-            throw new IOException("Could not open segment for streaming, got empty body");
-        }
-
         if (response.isSuccessful()) {
             return response.body().byteStream();
         }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -184,9 +184,7 @@ public class FunctionManager
             return globalFunctionCatalog;
         }
 
-        FunctionProvider functionProvider = functionProviders.getService(resolvedFunction.catalogHandle());
-        checkArgument(functionProvider != null, "No function provider for catalog: '%s' (function '%s')", resolvedFunction.catalogHandle(), resolvedFunction.signature().getName());
-        return functionProvider;
+        return functionProviders.getService(resolvedFunction.catalogHandle());
     }
 
     private static void verifyMethodHandleSignature(BoundSignature boundSignature, ScalarFunctionImplementation scalarFunctionImplementation, InvocationConvention convention)

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusClient.java
@@ -174,7 +174,7 @@ public class PrometheusClient
         Request.Builder requestBuilder = new Request.Builder().url(uri.toString());
         try {
             Response response = httpClient.newCall(requestBuilder.build()).execute();
-            if (response.isSuccessful() && response.body() != null) {
+            if (response.isSuccessful()) {
                 return response.body();
             }
             throw new TrinoException(PROMETHEUS_UNKNOWN_ERROR, "Bad response " + response.code() + " " + response.message());

--- a/pom.xml
+++ b/pom.xml
@@ -3009,6 +3009,7 @@
                                     <!-- flags List fields even if initialized with ImmutableList -->
                                     -Xep:PreferredInterfaceType:OFF \
                                     -Xep:PrimitiveArrayPassedToVarargsMethod:ERROR \
+                                    -Xep:RedundantNullCheck:ERROR \
                                     -Xep:RethrowReflectiveOperationExceptionAsLinkageError:OFF \
                                     -Xep:StaticAssignmentOfThrowable:ERROR \
                                     -Xep:StaticGuardedByInstance:ERROR \


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Enforce the RedundantNullCheck rule by configuring it as an error and cleaning up existing redundant null checks across the codebase

Enhancements:
- Enable the RedundantNullCheck ErrorProne rule in the build configuration

Chores:
- Remove redundant null-check code in OkHttpSegmentLoader, FunctionManager, and PrometheusClient