### PR TITLE
Avoid unnecessary building of TaskStats in SqlTaskManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -252,6 +252,12 @@ public class SqlTask
         return taskStateMachine.getCreatedTime();
     }
 
+    @Nullable
+    public Instant getTaskEndTime()
+    {
+        return taskStateMachine.getEndTime();
+    }
+
     public TaskId getTaskId()
     {
         return taskStateMachine.getTaskId();
@@ -265,6 +271,11 @@ public class SqlTask
     public void recordHeartbeat()
     {
         lastHeartbeat.set(Instant.now());
+    }
+
+    public Instant lastHeartbeat()
+    {
+        return lastHeartbeat.get();
     }
 
     public TaskInfo getTaskInfo()

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -69,7 +69,6 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -656,13 +655,11 @@ public class SqlTaskManager
     void removeOldTasks()
     {
         Instant oldestAllowedTask = Instant.now().minusMillis(infoCacheTime.toMillis());
-        tasks.asMap().values().stream()
-                .map(SqlTask::getTaskInfo)
-                .filter(Objects::nonNull)
-                .forEach(taskInfo -> {
-                    TaskId taskId = taskInfo.taskStatus().getTaskId();
+        tasks.asMap().values()
+                .forEach(sqlTask -> {
+                    TaskId taskId = sqlTask.getTaskId();
                     try {
-                        Instant endTime = taskInfo.stats().getEndTime();
+                        Instant endTime = sqlTask.getTaskEndTime();
                         if (endTime != null && endTime.isBefore(oldestAllowedTask)) {
                             // The removal here is concurrency safe with respect to any concurrent loads: the cache has no expiration,
                             // the taskId is in the cache, so there mustn't be an ongoing load.
@@ -680,20 +677,20 @@ public class SqlTaskManager
         Instant now = Instant.now();
         Instant oldestAllowedHeartbeat = now.minusMillis(clientTimeout.toMillis());
         for (SqlTask sqlTask : tasks.asMap().values()) {
+            TaskId taskId = sqlTask.getTaskId();
             try {
-                TaskInfo taskInfo = sqlTask.getTaskInfo();
-                TaskStatus taskStatus = taskInfo.taskStatus();
-                if (taskStatus.getState().isDone()) {
+                TaskState taskState = sqlTask.getTaskState();
+                if (taskState.isDone()) {
                     continue;
                 }
-                Instant lastHeartbeat = taskInfo.lastHeartbeat();
+                Instant lastHeartbeat = sqlTask.lastHeartbeat();
                 if (lastHeartbeat != null && lastHeartbeat.isBefore(oldestAllowedHeartbeat)) {
-                    log.info("Failing abandoned task %s", taskStatus.getTaskId());
-                    sqlTask.failed(new TrinoException(ABANDONED_TASK, format("Task %s has not been accessed since %s: currentTime %s", taskStatus.getTaskId(), lastHeartbeat, now)));
+                    log.info("Failing abandoned task %s", taskId);
+                    sqlTask.failed(new TrinoException(ABANDONED_TASK, format("Task %s has not been accessed since %s: currentTime %s", taskId, lastHeartbeat, now)));
                 }
             }
             catch (RuntimeException e) {
-                log.warn(e, "Error while inspecting age of task %s", sqlTask.getTaskId());
+                log.warn(e, "Error while inspecting age of task %s", taskId);
             }
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -86,7 +86,6 @@ public class TaskContext
     private final AtomicReference<Instant> executionStartTime = new AtomicReference<>();
     private final AtomicReference<Instant> lastExecutionStartTime = new AtomicReference<>();
     private final AtomicReference<Instant> terminatingStartTime = new AtomicReference<>();
-    private final AtomicReference<Instant> executionEndTime = new AtomicReference<>();
 
     private final List<PipelineContext> pipelineContexts = new CopyOnWriteArrayList<>();
 
@@ -238,9 +237,6 @@ public class TaskContext
             // Only update last start time, if the nothing was started
             lastExecutionStartTime.compareAndSet(null, now);
 
-            // use compare and set from initial value to avoid overwriting if there
-            // were a duplicate notification, which shouldn't happen
-            executionEndTime.compareAndSet(null, now);
             endNanos.compareAndSet(0, nanoTimeNow);
             endFullGcCount.compareAndSet(-1, majorGcCount);
             endFullGcTimeNanos.compareAndSet(-1, majorGcTime);
@@ -585,7 +581,7 @@ public class TaskContext
                 lastExecutionStartTime.get(),
                 terminatingStartTime.get(),
                 lastExecutionEndTime == 0 ? null : Instant.ofEpochMilli(lastExecutionEndTime),
-                executionEndTime.get(),
+                taskStateMachine.getEndTime(),
                 elapsedTime.convertToMostSuccinctTimeUnit(),
                 queuedTime.convertToMostSuccinctTimeUnit(),
                 totalDrivers,


### PR DESCRIPTION
## Description
The information required in removeOldTasks and failAbandonedTasks can be obtained cheaply without contructing TaskStats repeatedly


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
JFR profiles of coordinator often show significant CPU time spent in `io.trino.operator.TaskContext#getTaskStats`
<img width="1344" height="817" alt="Screenshot 2025-10-27 at 11 12 06 PM" src="https://github.com/user-attachments/assets/1dfbbea6-ec24-400c-a849-862691503f6c" />



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Avoid constructing TaskStats repeatedly during task cleanup by querying end time and heartbeat directly and caching the end timestamp in the state machine

Enhancements:
- Simplify removeOldTasks and failAbandonedTasks in SqlTaskManager to use SqlTask.getTaskState, getTaskEndTime, and lastHeartbeat instead of building TaskInfo/TaskStats
- Track execution end time in TaskStateMachine with an AtomicReference and expose it via a new getEndTime method
- Add SqlTask methods getTaskEndTime and lastHeartbeat for direct access to task timestamps