### PR TITLE
Use --raw-streams for Maven 4.0.0 compatibility

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get milestone from pom.xml
         run: |
           .github/bin/retry ./mvnw -v
-          MILESTONE_NUMBER="$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | cut -d- -f1)"
+          MILESTONE_NUMBER="$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout --raw-streams | cut -d- -f1)"
           echo "Setting PR milestone to ${MILESTONE_NUMBER}"
           echo "MILESTONE_NUMBER=${MILESTONE_NUMBER}" >> $GITHUB_ENV
       - name: Set milestone to PR

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -104,12 +104,12 @@ if [ -n "$TRINO_VERSION" ]; then
     for artifactId in "io.trino:${SERVER_ARTIFACT}:${TRINO_VERSION}:tar.gz" io.trino:trino-cli:"${TRINO_VERSION}":jar:executable; do
         "${SOURCE_DIR}/mvnw" -C dependency:get -Dtransitive=false -Dartifact="$artifactId"
     done
-    local_repo=$("${SOURCE_DIR}/mvnw" -B help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
+    local_repo=$("${SOURCE_DIR}/mvnw" -B help:evaluate -Dexpression=settings.localRepository -q -DforceStdout --raw-streams)
     trino_server="$local_repo/io/trino/${SERVER_ARTIFACT}/${TRINO_VERSION}/${SERVER_ARTIFACT}-${TRINO_VERSION}.tar.gz"
     trino_client="$local_repo/io/trino/trino-cli/${TRINO_VERSION}/trino-cli-${TRINO_VERSION}-executable.jar"
     chmod +x "$trino_client"
 else
-    TRINO_VERSION=$("${SOURCE_DIR}/mvnw" -f "${SOURCE_DIR}/pom.xml" --quiet help:evaluate -Dexpression=project.version -DforceStdout)
+    TRINO_VERSION=$("${SOURCE_DIR}/mvnw" -f "${SOURCE_DIR}/pom.xml" --quiet help:evaluate -Dexpression=project.version -DforceStdout --raw-streams)
     echo "🎯 Using currently built artifacts from the core/${SERVER_ARTIFACT} and client/trino-cli modules and version ${TRINO_VERSION}"
     trino_server="${SOURCE_DIR}/core/${SERVER_ARTIFACT}/target/${SERVER_ARTIFACT}-${TRINO_VERSION}.tar.gz"
     trino_client="${SOURCE_DIR}/client/trino-cli/target/trino-cli-${TRINO_VERSION}-executable.jar"

--- a/testing/trino-product-tests-launcher/bin/run-launcher
+++ b/testing/trino-product-tests-launcher/bin/run-launcher
@@ -9,7 +9,7 @@ if command -v mvnd >/dev/null; then
     trino_version=$(mvnd -B help:evaluate -Dexpression=pom.version -q -DforceStdout --raw-streams -Dmvnd.logPurgePeriod=999999d)
     mvn="mvnd"
 else
-    trino_version=$(./mvnw -B help:evaluate -Dexpression=pom.version -q -DforceStdout)
+    trino_version=$(./mvnw -B help:evaluate -Dexpression=pom.version -q -DforceStdout --raw-streams)
     mvn="./mvnw"
 fi
 launcher_jar="${target}/trino-product-tests-launcher-${trino_version}-executable.jar"

--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -8,7 +8,7 @@ maven_run_tests="${maven} clean test ${MAVEN_TEST:--B} -pl :trino-test-jdbc-comp
 
 "${maven}" -version
 
-current_version=$(${maven} help:evaluate -Dexpression=project.version -q -DforceStdout)
+current_version=$(${maven} help:evaluate -Dexpression=project.version -q -DforceStdout --raw-streams)
 previous_released_version=$((${current_version%-SNAPSHOT}-1))
 first_tested_version=352
 # test n-th version only


### PR DESCRIPTION
This is no-op on Maven 3.9.x but is required for Maven 4.0.0 support

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Enhancements:
- Add --raw-streams flag to maven help:evaluate invocations in build scripts, CI workflows, and test runners to enable Maven 4.0.0 compatibility