### PR TITLE
Avoid deprecated TableMetadataParser.read method in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -240,7 +240,7 @@ public abstract class AbstractIcebergTableOperations
     {
         refreshFromMetadataLocation(
                 newLocation,
-                metadataLocation -> TableMetadataParser.read(fileIo, fileIo.newInputFile(metadataLocation)));
+                metadataLocation -> TableMetadataParser.read(fileIo.newInputFile(metadataLocation)));
     }
 
     protected void refreshFromMetadataLocation(String newLocation, Function<String, TableMetadata> metadataLoader)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -819,7 +819,7 @@ public class TrinoGlueCatalog
             if (metadataLocation == null) {
                 throw new TrinoException(ICEBERG_INVALID_METADATA, format("Table %s is missing [%s] property", from, METADATA_LOCATION_PROP));
             }
-            TableMetadata metadata = TableMetadataParser.read(io, io.newInputFile(metadataLocation));
+            TableMetadata metadata = TableMetadataParser.read(io.newInputFile(metadataLocation));
             TableInput tableInput = getTableInput(
                     typeManager,
                     to.getTableName(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -257,7 +257,7 @@ public final class IcebergTestUtils
         while (fileIterator.hasNext()) {
             FileEntry entry = fileIterator.next();
             if (fromFilePath(entry.location().path()) == METADATA_JSON) {
-                TableMetadata tableMetadata = TableMetadataParser.read(null, new ForwardingInputFile(trinoFileSystem.newInputFile(entry.location())));
+                TableMetadata tableMetadata = TableMetadataParser.read(new ForwardingInputFile(trinoFileSystem.newInputFile(entry.location())));
                 metadataFiles.put(entry.location().path(), tableMetadata.lastUpdatedMillis());
             }
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
@@ -120,7 +120,7 @@ public class TestIcebergGlueCatalogSkipArchive
             Map<String, String> tableParameters = new HashMap<>(glueTable.parameters());
             String metadataLocation = tableParameters.remove(METADATA_LOCATION_PROP);
             FileIO io = FILE_IO_FACTORY.create(getFileSystemFactory(getDistributedQueryRunner()).create(SESSION));
-            TableMetadata metadata = TableMetadataParser.read(io, io.newInputFile(metadataLocation));
+            TableMetadata metadata = TableMetadataParser.read(io.newInputFile(metadataLocation));
             boolean cacheTableMetadata = new IcebergGlueCatalogConfig().isCacheTableMetadata();
             TableInput tableInput = getTableInput(TESTING_TYPE_MANAGER, table.getName(), Optional.empty(), metadata, metadata.location(), metadataLocation, tableParameters, cacheTableMetadata);
             glueClient.updateTable(builder -> builder.databaseName(schemaName).tableInput(tableInput));


### PR DESCRIPTION
## Description

Use `TableMetadataParser.read(InputFile)` instead of the `deprecated read(FileIO, InputFile)` signature.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
