### PR TITLE
Show time based on locale to support 12 hour and 24 hour notation in UI.

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
@@ -319,9 +319,7 @@ export function parseDuration(value: string): number | null {
 }
 
 export function formatShortTime(date: Date): string {
-    const hours = date.getHours() % 12 || 12
-    const minutes = (date.getMinutes() < 10 ? '0' : '') + date.getMinutes()
-    return hours + ':' + minutes + (date.getHours() >= 12 ? 'pm' : 'am')
+    return date.toLocaleTimeString([], { timeStyle: 'short' })
 }
 
 export function formatShortDateTime(date: Date): string {

--- a/core/trino-web-ui/src/main/resources/webapp/src/utils.js
+++ b/core/trino-web-ui/src/main/resources/webapp/src/utils.js
@@ -501,9 +501,7 @@ export function parseDuration(value: string): ?number {
 }
 
 export function formatShortTime(date: Date): string {
-    const hours = date.getHours() % 12 || 12
-    const minutes = (date.getMinutes() < 10 ? '0' : '') + date.getMinutes()
-    return hours + ':' + minutes + (date.getHours() >= 12 ? 'pm' : 'am')
+    return date.toLocaleTimeString([], { timeStyle: 'short' }).replace(' ', '').toLowerCase()
 }
 
 export function formatShortDateTime(date: Date): string {


### PR DESCRIPTION
## Description
Show either 12-hour or 24-hour notation in the coordinator UI, based on locale.

## Additional context and related issues
Note that the offical time format has uppercase `AM` and `PM`, whereas the original Trino code uses `am` and `pm`.
~~If we want to stick to that, I could add `.toLowerCase()`, but I don't think lowercase is needed.~~
In the old (current) UI, the removed space and lowercase `pm` is needed because otherwise the text will be too long for the bootstraps `xs-2` class. In the preview UI the header is different, so in that case we can stick to the default `.toLocaleTimeString`


**UI**
<img width="185" height="140" alt="Screenshot 2025-11-07 at 14-39-55 Cluster Overview - Trino" src="https://github.com/user-attachments/assets/eec0f39c-62f1-47d4-9315-f8d3009e8a26" />

<img width="331" height="240" alt="Screenshot 2025-11-07 at 14-36-58 Cluster Overview - Trino" src="https://github.com/user-attachments/assets/3286687e-ef8e-4448-915a-4bcdf6f5ce5f" />

**Preview UI**
<img width="277" height="161" alt="Screenshot 2025-11-07 at 14-39-40 Trino - Preview UI" src="https://github.com/user-attachments/assets/ca920b93-6598-4d13-b646-0329637e2444" />

<img width="294" height="194" alt="Screenshot 2025-11-07 at 14-37-12 Trino - Preview UI" src="https://github.com/user-attachments/assets/5f3f9070-9b3d-4b4b-9a06-ff79340a80d9" />


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## User interface
* Use browser locale to format time
```


## Summary by Sourcery

Format short times in the coordinator UI using the browser's locale to automatically support 12-hour or 24-hour notation.

New Features:
- Support displaying times in 12-hour or 24-hour notation based on the user's locale

Enhancements:
- Replace manual formatShortTime implementation with toLocaleTimeString in both utils.ts and utils.js

Documentation:
- Add release note for user interface to use browser locale to format time