### PR TITLE
Allow time travel reads to Hudi Tables

### DIFF
--- a/docs/src/main/sphinx/connector/hudi.md
+++ b/docs/src/main/sphinx/connector/hudi.md
@@ -170,6 +170,21 @@ GROUP BY dt;
 (1 rows)
 ```
 
+### Time travel queries
+
+The connector offers the ability to query historical data. This allows viewing
+the state of the table at a previous snapshot.
+
+The historical data of the table can be retrieved by specifying the last valid
+commit timestamp:
+```sql
+SELECT * FROM  hudi.default.table_name FOR VERSION AS OF '20251027183851494';
+```
+Note: Hudi stores its table versions as a yyyyMMddHHmmssSSS representation of
+the commit time in the table's time zone, though any string can be used. Hudi
+will perform a string comparison between the passed in string and the commit
+time.
+
 ### Schema and table management
 
 Hudi supports [two types of tables](https://hudi.apache.org/docs/table_types)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiTableHandle.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiTableHandle.java
@@ -24,6 +24,7 @@ import io.trino.spi.predicate.TupleDomain;
 import org.apache.hudi.common.model.HoodieTableType;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
@@ -41,6 +42,7 @@ public class HudiTableHandle
     private final Set<HiveColumnHandle> constraintColumns;
     private final TupleDomain<HiveColumnHandle> partitionPredicates;
     private final TupleDomain<HiveColumnHandle> regularPredicates;
+    private final Optional<String> readVersion;
 
     @JsonCreator
     public HudiTableHandle(
@@ -50,9 +52,10 @@ public class HudiTableHandle
             @JsonProperty("tableType") HoodieTableType tableType,
             @JsonProperty("partitionColumns") List<HiveColumnHandle> partitionColumns,
             @JsonProperty("partitionPredicates") TupleDomain<HiveColumnHandle> partitionPredicates,
-            @JsonProperty("regularPredicates") TupleDomain<HiveColumnHandle> regularPredicates)
+            @JsonProperty("regularPredicates") TupleDomain<HiveColumnHandle> regularPredicates,
+            @JsonProperty("readVersion") Optional<String> readVersion)
     {
-        this(schemaName, tableName, basePath, tableType, partitionColumns, ImmutableSet.of(), partitionPredicates, regularPredicates);
+        this(schemaName, tableName, basePath, tableType, partitionColumns, ImmutableSet.of(), partitionPredicates, regularPredicates, readVersion);
     }
 
     public HudiTableHandle(
@@ -63,7 +66,8 @@ public class HudiTableHandle
             List<HiveColumnHandle> partitionColumns,
             Set<HiveColumnHandle> constraintColumns,
             TupleDomain<HiveColumnHandle> partitionPredicates,
-            TupleDomain<HiveColumnHandle> regularPredicates)
+            TupleDomain<HiveColumnHandle> regularPredicates,
+            Optional<String> readVersion)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -73,6 +77,7 @@ public class HudiTableHandle
         this.constraintColumns = requireNonNull(constraintColumns, "constraintColumns is null");
         this.partitionPredicates = requireNonNull(partitionPredicates, "partitionPredicates is null");
         this.regularPredicates = requireNonNull(regularPredicates, "regularPredicates is null");
+        this.readVersion = requireNonNull(readVersion, "readVersion is null");
     }
 
     @JsonProperty
@@ -124,6 +129,12 @@ public class HudiTableHandle
         return regularPredicates;
     }
 
+    @JsonProperty
+    public Optional<String> getReadVersion()
+    {
+        return readVersion;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return schemaTableName(schemaName, tableName);
@@ -142,7 +153,8 @@ public class HudiTableHandle
                 partitionColumns,
                 constraintColumns,
                 partitionPredicates.intersect(partitionTupleDomain),
-                regularPredicates.intersect(regularTupleDomain));
+                regularPredicates.intersect(regularTupleDomain),
+                readVersion);
     }
 
     @Override

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -160,7 +160,7 @@ public final class HudiQueryRunner
             hiveMinioDataLake.start();
             QueryRunner queryRunner = builder(hiveMinioDataLake)
                     .addCoordinatorProperty("http-server.http.port", "8080")
-                    .setDataLoader(new TpchHudiTablesInitializer(TpchTable.getTables()))
+                    .setDataLoader(new TpchHudiTablesInitializer(TpchTable.getTables(), "0"))
                     .build();
 
             log.info("======== SERVER STARTED ========");

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMinioConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMinioConnectorSmokeTest.java
@@ -35,7 +35,7 @@ public class TestHudiMinioConnectorSmokeTest
 
         return HudiQueryRunner.builder(hiveMinioDataLake)
                 .addConnectorProperty("hudi.columns-to-hide", COLUMNS_TO_HIDE)
-                .setDataLoader(new TpchHudiTablesInitializer(REQUIRED_TPCH_TABLES))
+                .setDataLoader(new TpchHudiTablesInitializer(REQUIRED_TPCH_TABLES, "0"))
                 .build();
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSharedMetastore.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSharedMetastore.java
@@ -70,7 +70,7 @@ final class TestHudiSharedMetastore
 
         queryRunner.execute("CREATE SCHEMA hive.default");
 
-        TpchHudiTablesInitializer tpchHudiTablesInitializer = new TpchHudiTablesInitializer(List.of(NATION));
+        TpchHudiTablesInitializer tpchHudiTablesInitializer = new TpchHudiTablesInitializer(List.of(NATION), "0");
         tpchHudiTablesInitializer.initializeTables(queryRunner, Location.of(dataDirectory.toString()), "default");
 
         copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, hiveSession, ImmutableList.of(TpchTable.REGION));

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/TpchHudiTablesInitializer.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/TpchHudiTablesInitializer.java
@@ -113,10 +113,12 @@ public class TpchHudiTablesInitializer
     private static final HdfsContext CONTEXT = new HdfsContext(SESSION);
 
     private final List<TpchTable<?>> tpchTables;
+    private final String commitTimestamp;
 
-    public TpchHudiTablesInitializer(List<TpchTable<?>> tpchTables)
+    public TpchHudiTablesInitializer(List<TpchTable<?>> tpchTables, String commitTimestamp)
     {
         this.tpchTables = requireNonNull(tpchTables, "tpchTables is null");
+        this.commitTimestamp = requireNonNull(commitTimestamp, "commitTimestamp is null");
     }
 
     @Override
@@ -166,9 +168,8 @@ public class TpchHudiTablesInitializer
                     .map(MaterializedRow::getFields)
                     .map(recordConverter::toRecord)
                     .collect(Collectors.toList());
-            String timestamp = "0";
-            writeClient.startCommitWithTime(timestamp);
-            writeClient.insert(records, timestamp);
+            writeClient.startCommitWithTime(commitTimestamp);
+            writeClient.insert(records, commitTimestamp);
         }
     }
 


### PR DESCRIPTION
This commit handles simple "FOR VERSION AS OF X" syntax in
the Hudi connector order to ensure that we can read previous
table state.

Previously, all reads to Hudi tables would occur at the latest
commit timestamp. While a user could technically filter down
the data using a predicate on the _hoodie_commit_time column,
there is no functionality that pushes this down into the Hudi
API to minimize file reads.

Timestamps are provided as strings..

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Added time travel reads in Hudi connector.
