### PR TITLE
Defer broadcast join probe leaf splits

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorFactory.java
@@ -13,6 +13,10 @@
  */
 package io.trino.operator;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+
 public interface OperatorFactory
 {
     Operator createOperator(DriverContext driverContext);
@@ -27,4 +31,14 @@ public interface OperatorFactory
     void noMoreOperators();
 
     OperatorFactory duplicate();
+
+    /**
+     * Returns a future indicating that any dependencies operators have on other pipelines has been satisfied and that leaf splits
+     * should be allowed to start for this operator. This is used to prevent join probe splits from starting before the build side
+     * of a join is ready when the two are in the same stage (i.e.: broadcast join on top of a table scan).
+     */
+    default ListenableFuture<Void> pipelineDependenciesSatisfied()
+    {
+        return immediateVoidFuture();
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
@@ -14,6 +14,7 @@
 package io.trino.operator;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.operator.join.JoinOperatorFactory;
@@ -84,6 +85,21 @@ public class WorkProcessorOperatorAdapter
             }
 
             return lookupJoin.createOuterOperatorFactory();
+        }
+
+        @Override
+        public ListenableFuture<Void> buildPipelineReady()
+        {
+            if (!(operatorFactory instanceof JoinOperatorFactory lookupJoin)) {
+                return Futures.immediateVoidFuture();
+            }
+            return lookupJoin.buildPipelineReady();
+        }
+
+        @Override
+        public ListenableFuture<Void> pipelineDependenciesSatisfied()
+        {
+            return buildPipelineReady();
         }
 
         @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.join;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.operator.OperatorFactory;
 
 import java.util.Optional;
@@ -20,4 +21,10 @@ import java.util.Optional;
 public interface JoinOperatorFactory
 {
     Optional<OperatorFactory> createOuterOperatorFactory();
+
+    /**
+     * Future that indicates when the build side of the join has been completed and probe processing
+     * can begin. Used by {@link OperatorFactory#pipelineDependenciesSatisfied()}.
+     */
+    ListenableFuture<Void> buildPipelineReady();
 }

--- a/core/trino-main/src/main/java/io/trino/operator/join/LookupJoinOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/LookupJoinOperatorFactory.java
@@ -15,6 +15,7 @@ package io.trino.operator.join;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.operator.HashGenerator;
 import io.trino.operator.JoinOperatorType;
 import io.trino.operator.OperatorFactory;
@@ -162,6 +163,12 @@ public class LookupJoinOperatorFactory
     public String getOperatorType()
     {
         return LookupJoinOperator.class.getSimpleName();
+    }
+
+    @Override
+    public ListenableFuture<Void> buildPipelineReady()
+    {
+        return joinBridgeManager.getBuildFinishedFuture();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/unspilled/LookupJoinOperatorFactory.java
@@ -14,6 +14,7 @@
 package io.trino.operator.join.unspilled;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.operator.JoinOperatorType;
 import io.trino.operator.OperatorFactory;
 import io.trino.operator.ProcessorContext;
@@ -131,6 +132,12 @@ public class LookupJoinOperatorFactory
     public String getOperatorType()
     {
         return LookupJoinOperator.class.getSimpleName();
+    }
+
+    @Override
+    public ListenableFuture<Void> buildPipelineReady()
+    {
+        return joinBridgeManager.getBuildFinishedFuture();
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Avoids starting join probe leaf splits for tasks that are awaiting the build side completion. Otherwise, build side leaf split concurrency will be starved by probe side splits that start and then immediately block.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Relates to https://github.com/trinodb/trino/issues/27121


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Defer broadcast join probe-side split scheduling until build pipelines complete to avoid starving build-side split concurrency

Enhancements:
- Track pipeline dependency readiness in DriverFactory and OperatorFactory to expose a pipelineDependenciesSatisfied future
- Buffer and batch pending splits in SqlTaskExecution, scheduling them only when pipeline dependencies are satisfied
- Extend WorkProcessorOperatorAdapter, JoinBridgeManager, and join operator factories to expose buildPipelineReady futures and register listeners