### PR TITLE
Add connection properties for Druid connector

### DIFF
--- a/docs/src/main/sphinx/connector/druid.md
+++ b/docs/src/main/sphinx/connector/druid.md
@@ -53,6 +53,21 @@ determine the user credentials for the connection, often a service user. You can
 use {doc}`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+Additionally, the following configuration properties can be set depending
+on the use-case:
+
+:::{list-table} Druid Configuration Properties
+:widths: 30, 35, 35
+:header-rows: 1
+
+* - Property Name
+  - Description
+  - Default
+* - `druid.execution-timeout`
+  - Query timeout for Druid queries, beyond which unfinished queries will be cancelled. Example: `10s`, `1m`, and `1000ms`.
+  - `None`
+:::
+
 ```{include} jdbc-authentication.fragment
 ```
 

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -27,6 +27,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-base-jdbc</artifactId>
         </dependency>
@@ -105,6 +115,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>
         </dependency>
@@ -124,12 +140,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>units</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidConfig.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+
+import java.util.Optional;
+
+public class DruidConfig
+{
+    private Duration executionTimeout;
+
+    public Optional<Duration> getExecutionTimeout()
+    {
+        return Optional.ofNullable(executionTimeout);
+    }
+
+    @Config("druid.execution-timeout")
+    @ConfigDescription("Maximum time to wait for a Druid query to complete before timing out")
+    public DruidConfig setExecutionTimeout(Duration executionTimeout)
+    {
+        this.executionTimeout = executionTimeout;
+        return this;
+    }
+}

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClientModule.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClientModule.java
@@ -32,6 +32,7 @@ import org.apache.calcite.avatica.remote.Driver;
 import java.util.Properties;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class DruidJdbcClientModule
         implements Module
@@ -40,19 +41,28 @@ public class DruidJdbcClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(DruidJdbcClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(DruidConfig.class);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
     }
 
     @Provides
     @Singleton
     @ForBaseJdbc
-    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
+    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, DruidConfig druidConfig, OpenTelemetry openTelemetry)
     {
         Properties connectionProperties = new Properties();
 
         // Druid can be configured to approximate `count_distinct()` function calls.
         // This behavior could be confusing - we can force Druid to never approximate.
         connectionProperties.setProperty("useApproximateCountDistinct", "false");
+        // According to Druid documentation, Druid does not support passing connection context parameters from the
+        // JDBC connection string to Druid. These context parameters must be passed using a Properties object instead
+        // https://druid.apache.org/docs/latest/api-reference/sql-jdbc/
+        if (druidConfig.getExecutionTimeout().isPresent()) {
+            // Query timeout in millis, beyond which unfinished queries will be cancelled
+            // https://druid.apache.org/docs/latest/querying/query-context-reference/
+            connectionProperties.setProperty("timeout", String.valueOf(druidConfig.getExecutionTimeout().get().toMillis()));
+        }
         return DriverConnectionFactory.builder(new Driver(), config.getConnectionUrl(), credentialProvider)
                 .setOpenTelemetry(openTelemetry)
                 .setConnectionProperties(connectionProperties)

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConfig.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+final class TestDruidConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DruidConfig.class)
+                .setExecutionTimeout(null));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("druid.execution-timeout", "10s")
+                .buildOrThrow();
+
+        DruidConfig expected = new DruidConfig()
+                .setExecutionTimeout(new Duration(10, SECONDS));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR adds support for configuring additional Druid connector properties, specifically timeout.
The motivation is to provide client-side safeguards: poorly written SQL queries can trigger full table scans in Druid, putting significant pressure on the Druid cluster. By allowing these properties to be set on the client side, we can limit query execution time and control time zone interpretation, mitigating potential cluster impact.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
`druid.execution-timeout` allows users to limit the maximum execution time of a query.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Druid
* Add support for configuring `druid.execution-timeout` config property. ({issue}`27150`)
```
