### PR TITLE
Avoid constant from deprecated PostgreSQLContainer

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestingIcebergJdbcServer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestingIcebergJdbcServer.java
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import static java.lang.String.format;
-import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
+import static org.testcontainers.postgresql.PostgreSQLContainer.POSTGRESQL_PORT;
 
 public class TestingIcebergJdbcServer
         implements Closeable


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Enhancements:
- Replace import of POSTGRESQL_PORT from deprecated org.testcontainers.containers.PostgreSQLContainer with org.testcontainers.postgresql.PostgreSQLContainer