### PR TITLE
Skip testing JDBC 442 in compatibility tests

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -18,8 +18,8 @@ echo "Current version: ${current_version}"
 echo "Testing every ${version_step}. version between ${first_tested_version} and ${previous_released_version}"
 
 # 404 was skipped
-# 422-424 depend on the incompatible version of the open-telemetry semantic conventions used while invoking tests
-tested_versions=$(seq "${first_tested_version}" ${version_step} "${previous_released_version}" | grep -vx '404\|42[234]')
+# 422-424 and 442 depend on the incompatible version of the open-telemetry semantic conventions used while invoking tests
+tested_versions=$(seq "${first_tested_version}" ${version_step} "${previous_released_version}" | grep -vx '404\|42[234]\|442')
 
 if (( (previous_released_version - first_tested_version) % version_step != 0 )); then
     tested_versions="${tested_versions} ${previous_released_version}"


### PR DESCRIPTION
This driver version was incorrectly shaded and is lacking some of the OpenTelemetry semconv classes.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Tests:
- Update the tested_versions filter in run_tests.sh to exclude version 442 alongside existing exclusions.