### PR TITLE
Add support for token exchange in Iceberg REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -509,6 +509,9 @@ following properties:
 * - `iceberg.rest-catalog.oauth2.token-refresh-enabled`
   - Controls whether a token should be refreshed if information about its expiration time is available.
     Defaults to `true`
+* - `iceberg.rest-catalog.oauth2.token-exchange-enabled`
+  - Controls whether to use the token exchange flow to acquire new tokens.
+    Defaults to `true` 
 * - `iceberg.rest-catalog.vended-credentials-enabled`
   - Use credentials provided by the REST backend for file system access.
     Defaults to `false`.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityConfig.java
@@ -29,6 +29,7 @@ public class OAuth2SecurityConfig
     private String token;
     private URI serverUri;
     private boolean tokenRefreshEnabled = OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT;
+    private boolean tokenExchangeEnabled = OAuth2Properties.TOKEN_EXCHANGE_ENABLED_DEFAULT;
 
     public Optional<String> getCredential()
     {
@@ -94,6 +95,19 @@ public class OAuth2SecurityConfig
     public OAuth2SecurityConfig setTokenRefreshEnabled(boolean tokenRefreshEnabled)
     {
         this.tokenRefreshEnabled = tokenRefreshEnabled;
+        return this;
+    }
+
+    public boolean isTokenExchangeEnabled()
+    {
+        return tokenExchangeEnabled;
+    }
+
+    @Config("iceberg.rest-catalog.oauth2.token-exchange-enabled")
+    @ConfigDescription("Controls whether to use the token exchange flow to acquire new tokens")
+    public OAuth2SecurityConfig setTokenExchangeEnabled(boolean tokenExchangeEnabled)
+    {
+        this.tokenExchangeEnabled = tokenExchangeEnabled;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
@@ -45,6 +45,7 @@ public class OAuth2SecurityProperties
         securityConfig.getServerUri().ifPresent(
                 value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
         propertiesBuilder.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, String.valueOf(securityConfig.isTokenRefreshEnabled()));
+        propertiesBuilder.put(OAuth2Properties.TOKEN_EXCHANGE_ENABLED, String.valueOf(securityConfig.isTokenExchangeEnabled()));
 
         this.securityProperties = propertiesBuilder.buildOrThrow();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2SecurityConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2SecurityConfig.java
@@ -35,7 +35,8 @@ public class TestOAuth2SecurityConfig
                 .setToken(null)
                 .setScope(null)
                 .setServerUri(null)
-                .setTokenRefreshEnabled(OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT));
+                .setTokenRefreshEnabled(OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT)
+                .setTokenExchangeEnabled(OAuth2Properties.TOKEN_EXCHANGE_ENABLED_DEFAULT));
     }
 
     @Test
@@ -47,6 +48,7 @@ public class TestOAuth2SecurityConfig
                 .put("iceberg.rest-catalog.oauth2.scope", "scope")
                 .put("iceberg.rest-catalog.oauth2.server-uri", "http://localhost:8080/realms/iceberg/protocol/openid-connect/token")
                 .put("iceberg.rest-catalog.oauth2.token-refresh-enabled", "false")
+                .put("iceberg.rest-catalog.oauth2.token-exchange-enabled", "false")
                 .buildOrThrow();
 
         OAuth2SecurityConfig expected = new OAuth2SecurityConfig()
@@ -54,7 +56,8 @@ public class TestOAuth2SecurityConfig
                 .setToken("token")
                 .setScope("scope")
                 .setServerUri(URI.create("http://localhost:8080/realms/iceberg/protocol/openid-connect/token"))
-                .setTokenRefreshEnabled(false);
+                .setTokenRefreshEnabled(false)
+                .setTokenExchangeEnabled(false);
         assertThat(expected.credentialOrTokenPresent()).isTrue();
         assertThat(expected.scopePresentOnlyWithCredential()).isFalse();
         assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description

With https://github.com/apache/iceberg/pull/13809, there is an option users can use to enable/disable token exchange as refresh. As not all iceberg REST catalog support token exchange, it is beneficial to have this control available on Trino when dealing with iceberg REST catalogs.

## Release notes

```markdown
## Iceberg
* Add support for disabling token exchange via the `iceberg.rest-catalog.oauth2.token-exchange-enabled` config property. ({issue}`27174`)
```
