### PR TITLE
Remove duplicate binding of TypeManager in trino-kafka

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
@@ -59,7 +59,7 @@ public class KafkaConnectorFactory
                 ImmutableList.<Module>builder()
                         .add(new JsonModule())
                         .add(new TypeDeserializerModule())
-                        .add(new KafkaConnectorModule(context.getTypeManager()))
+                        .add(new KafkaConnectorModule())
                         .add(new KafkaClientsModule())
                         .add(new KafkaSecurityModule())
                         .add(new ConnectorContextModule(catalogName, context))

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
@@ -31,24 +31,15 @@ import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
-import io.trino.spi.type.TypeManager;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
-import static java.util.Objects.requireNonNull;
 
 public class KafkaConnectorModule
         extends AbstractConfigurationAwareModule
 {
-    private final TypeManager typeManager;
-
-    public KafkaConnectorModule(TypeManager typeManager)
-    {
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
-    }
-
     @Override
     public void setup(Binder binder)
     {
@@ -67,7 +58,7 @@ public class KafkaConnectorModule
 
         configBinder(binder).bindConfig(KafkaConfig.class);
         bindTopicSchemaProviderModule(FileTableDescriptionSupplier.NAME, new FileTableDescriptionSupplierModule());
-        bindTopicSchemaProviderModule(ConfluentSchemaRegistryTableDescriptionSupplier.NAME, new ConfluentModule(typeManager));
+        bindTopicSchemaProviderModule(ConfluentSchemaRegistryTableDescriptionSupplier.NAME, new ConfluentModule());
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(KafkaSessionProperties.class).in(Scopes.SINGLETON);
         jsonCodecBinder(binder).bindJsonCodec(KafkaTopicDescription.class);
     }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -79,18 +79,9 @@ import static java.util.Objects.requireNonNull;
 public class ConfluentModule
         extends AbstractConfigurationAwareModule
 {
-    private final TypeManager typeManager;
-
-    public ConfluentModule(TypeManager typeManager)
-    {
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
-    }
-
     @Override
     protected void setup(Binder binder)
     {
-        binder.bind(TypeManager.class).toInstance(typeManager);
-
         configBinder(binder).bindConfig(ConfluentSchemaRegistryConfig.class);
         install(new ConfluentDecoderModule());
         install(new ConfluentEncoderModule());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This binding is already provided by `ConnectorContextModule`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

`ConnectorContextModule` was added in #27054.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Remove redundant TypeManager constructor injections and manual bindings in the trino-kafka plugin modules and delegate TypeManager binding to ConnectorContextModule

Enhancements:
- Drop TypeManager parameter and field from KafkaConnectorModule and ConfluentModule
- Remove manual binding of TypeManager in ConfluentModule
- Simplify KafkaConnectorFactory to use KafkaConnectorModule without passing TypeManager