### PR TITLE
Document nullability of map type

### DIFF
--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -332,7 +332,8 @@ More information in [](/functions/array).
 ### `MAP`
 
 A map between the given component types. A map is a collection of key-value
-pairs, where each key is associated with a single value.
+pairs, where each key is associated with a single value. Map keys are required,
+while map values can be null.
 
 Example: `MAP(ARRAY['foo', 'bar'], ARRAY[1, 2])`
 


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Documentation:
- Specify that map keys are required and map values can be null in the MAP type description