### PR TITLE
Fix partitioning handle selection for fragments with empty values

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -414,10 +414,16 @@ public class PlanFragmenter
         @Override
         public PlanNode visitValues(ValuesNode node, RewriteContext<FragmentProperties> context)
         {
-            // An empty values node is compatible with any distribution, so
-            // don't attempt to overwrite one's already been chosen
-            if (node.getRowCount() != 0 || !context.get().hasDistribution()) {
+            if (node.getRowCount() != 0) {
+                // A non-empty values node requires single distribution
                 context.get().setSingleNodeDistribution();
+            }
+            else {
+                // An empty values node is compatible with any distribution, so
+                // do not overwrite a distribution if there is one already chosen,
+                // and delay setting the distribution in case the fragment contains
+                // another node with specific distribution requirements
+                context.get().setContainsEmptyValues();
             }
             return context.defaultRewrite(node, context.get());
         }
@@ -594,6 +600,7 @@ public class PlanFragmenter
         private final PartitioningScheme partitioningScheme;
 
         private Optional<PartitioningHandle> partitioningHandle = Optional.empty();
+        private boolean containsEmptyValues;
         private Optional<Integer> partitionCount = Optional.empty();
         private final Set<PlanNodeId> partitionedSources = new HashSet<>();
 
@@ -762,6 +769,11 @@ public class PlanFragmenter
             return this;
         }
 
+        public void setContainsEmptyValues()
+        {
+            this.containsEmptyValues = true;
+        }
+
         public PartitioningScheme getPartitioningScheme()
         {
             return partitioningScheme;
@@ -769,7 +781,9 @@ public class PlanFragmenter
 
         public PartitioningHandle getPartitioningHandle()
         {
-            return partitioningHandle.get();
+            checkState(partitioningHandle.isPresent() || containsEmptyValues, "PartitioningHandle is not set for a fragment that does not contain empty values");
+
+            return partitioningHandle.orElse(SINGLE_DISTRIBUTION);
         }
 
         public Optional<Integer> getPartitionCount()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
fixes: https://github.com/trinodb/trino/issues/21506



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix planning failure of certain queries involving empty VALUES. ({issue}`21506`)
```

## Summary by Sourcery

Fix fragment partitioning logic to defer distribution assignment for fragments containing empty VALUES nodes by tracking them and defaulting to single-node distribution only when necessary, and add tests to ensure correct behavior

Bug Fixes:
- Prevent fragments with only empty VALUES from overwriting existing distribution, fixing planning errors

Enhancements:
- Add containsEmptyValues flag in FragmentProperties to defer distribution assignment for empty VALUES nodes

Tests:
- Add testFragmentPartitioningWithValues to validate query planning with empty VALUES fragments both with and without table scans