### PR TITLE
Run TestBigQueryCaseInsensitiveMappingWithCache with single thread

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMappingWithCache.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMappingWithCache.java
@@ -15,7 +15,11 @@ package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.parallel.Execution;
 
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Execution(SAME_THREAD) // run single-threaded to avoid interference with other tests
 final class TestBigQueryCaseInsensitiveMappingWithCache
         extends BaseBigQueryCaseInsensitiveMapping
 {


### PR DESCRIPTION
## Description

Fixes #23779

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Summary by Sourcery

Force TestBigQueryCaseInsensitiveMappingWithCache to run in a single thread to prevent interference with other tests.

Bug Fixes:
- Annotate TestBigQueryCaseInsensitiveMappingWithCache with @Execution(SAME_THREAD) to avoid concurrent test interference.

Tests:
- Add JUnit parallel execution imports and @Execution(SAME_THREAD) annotation to enforce single-threaded test execution.