### PR TITLE
Fail internal communication gracefully during intialization

### DIFF
--- a/core/trino-main/src/test/java/io/trino/node/TestAnnounceNodeInventory.java
+++ b/core/trino-main/src/test/java/io/trino/node/TestAnnounceNodeInventory.java
@@ -16,6 +16,7 @@ package io.trino.node;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.http.client.HttpClient;
@@ -26,6 +27,7 @@ import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
 import io.airlift.node.testing.TestingNodeModule;
 import io.trino.client.NodeVersion;
+import io.trino.server.StartupStatus;
 import io.trino.server.security.SecurityConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -172,6 +174,7 @@ class TestAnnounceNodeInventory
                             URI.create("https://example.com:1234"),
                             new NodeVersion("test-version"),
                             true));
+                    binder.bind(StartupStatus.class).in(Scopes.SINGLETON);
                 });
         Injector injector = new Bootstrap(modules.build())
                 .doNotInitializeLogging()
@@ -180,6 +183,8 @@ class TestAnnounceNodeInventory
 
         AnnounceNodeInventory nodeInventory = injector.getInstance(AnnounceNodeInventory.class);
         URI serverUri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+        StartupStatus startupStatus = injector.getInstance(StartupStatus.class);
+        startupStatus.startupComplete();
         return new AnnouncementServer(
                 nodeInventory,
                 serverUri,


### PR DESCRIPTION
Internal resources are not expected to be called while server is still initializing. It can result to spurious errors like not being able to parse JSON requests as some Jackson serializers are only installd during plugins initialization.

Situation is cleaner with explicit check.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Inject StartupStatus into InternalAuthenticationManager and leverage it to gracefully reject internal requests during server startup.

Enhancements:
- Inject StartupStatus into InternalAuthenticationManager to track initialization state
- Abort internal communication requests with HTTP 503 Service Unavailable while server initialization is in progress