### PR TITLE
[WIP] Add dynamic client registration URL to Oauth2 config

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServerConfigProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServerConfigProvider.java
@@ -22,7 +22,14 @@ public interface OAuth2ServerConfigProvider
 {
     OAuth2ServerConfig get();
 
-    record OAuth2ServerConfig(Optional<String> accessTokenIssuer, URI authUrl, URI tokenUrl, URI jwksUrl, Optional<URI> userinfoUrl, Optional<URI> endSessionUrl)
+    record OAuth2ServerConfig(
+            Optional<String> accessTokenIssuer,
+            URI authUrl,
+            URI tokenUrl,
+            URI jwksUrl,
+            Optional<URI> userinfoUrl,
+            Optional<URI> endSessionUrl,
+            Optional<URI> dynamicClientRegistrationUrl)
     {
         public OAuth2ServerConfig
         {
@@ -32,6 +39,7 @@ public interface OAuth2ServerConfigProvider
             requireNonNull(jwksUrl, "jwksUrl is null");
             requireNonNull(userinfoUrl, "userinfoUrl is null");
             requireNonNull(endSessionUrl, "endSessionUrl is null");
+            requireNonNull(dynamicClientRegistrationUrl, "dynamicClientRegistrationUrl is null");
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -115,6 +115,7 @@ public class OidcDiscovery
                 userinfoEndpoint = Optional.empty();
             }
             Optional<URI> endSessionEndpoint = Optional.ofNullable(metadata.getEndSessionEndpointURI());
+            Optional<URI> clientRegistrationUri = Optional.ofNullable(metadata.getRegistrationEndpointURI());
             return new OAuth2ServerConfig(
                     // AD FS server can include "access_token_issuer" field in OpenID Provider Metadata.
                     // It's not a part of the OIDC standard thus have to be handled separately.
@@ -124,7 +125,8 @@ public class OidcDiscovery
                     getRequiredField("token_endpoint", metadata.getTokenEndpointURI(), TOKEN_URL, tokenUrl),
                     getRequiredField("jwks_uri", metadata.getJWKSetURI(), JWKS_URL, jwksUrl),
                     userinfoEndpoint.map(URI::create),
-                    endSessionEndpoint);
+                    endSessionEndpoint,
+                    clientRegistrationUri);
         }
         catch (JsonProcessingException e) {
             throw new ParseException("Invalid JSON value", e);

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticConfigurationProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticConfigurationProvider.java
@@ -29,7 +29,8 @@ public class StaticConfigurationProvider
                 config.getTokenUrl(),
                 config.getJwksUrl(),
                 config.getUserinfoUrl(),
-                config.getEndSessionUrl());
+                config.getEndSessionUrl(),
+                config.getDynamicClientRegistrationUrl());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticOAuth2ServerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticOAuth2ServerConfig.java
@@ -28,6 +28,7 @@ public class StaticOAuth2ServerConfig
     public static final String JWKS_URL = "http-server.authentication.oauth2.jwks-url";
     public static final String USERINFO_URL = "http-server.authentication.oauth2.userinfo-url";
     public static final String END_SESSION_URL = "http-server.authentication.oauth2.end-session-url";
+    public static final String DYNAMIC_CLIENT_REGISTRATION_URL = "http-server.authentication.oauth2.dynamic-client-registration-url";
 
     private Optional<String> accessTokenIssuer = Optional.empty();
     private URI authUrl;
@@ -35,6 +36,7 @@ public class StaticOAuth2ServerConfig
     private URI jwksUrl;
     private Optional<URI> userinfoUrl = Optional.empty();
     private Optional<URI> endSessionUrl = Optional.empty();
+    private Optional<URI> dynamicClientRegistrationUrl = Optional.empty();
 
     @NotNull
     public Optional<String> getAccessTokenIssuer()
@@ -115,6 +117,19 @@ public class StaticOAuth2ServerConfig
     public StaticOAuth2ServerConfig setEndSessionUrl(URI endSessionUrl)
     {
         this.endSessionUrl = Optional.ofNullable(endSessionUrl);
+        return this;
+    }
+
+    public Optional<URI> getDynamicClientRegistrationUrl()
+    {
+        return dynamicClientRegistrationUrl;
+    }
+
+    @Config(DYNAMIC_CLIENT_REGISTRATION_URL)
+    @ConfigDescription("URL of the dynamic client registration endpoint")
+    public StaticOAuth2ServerConfig setDynamicClientRegistrationUrl(URI dynamicClientRegistrationUrl)
+    {
+        this.dynamicClientRegistrationUrl = Optional.ofNullable(dynamicClientRegistrationUrl);
         return this;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This commit adds the [optional `registration_endpoint` property](https://openid.net/specs/openid-connect-discovery-1_0.html) as pulled from OIDC metadata endpoint, or optionally from static config, for retrieval by the `Oauth2ServerConfigProvider`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

New Features:
- Add support for optional dynamic client registration URL in OAuth2 server configuration