### PR TITLE
Add some more meaningful names to distinct Bootstrap instances

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -236,6 +236,7 @@ public class FileBasedSystemAccessControl
             requireNonNull(config, "config is null");
 
             Bootstrap bootstrap = new Bootstrap(
+                    "io.trino.bootstrap.access." + getName(),
                     binder -> configBinder(binder).bindConfig(FileBasedAccessControlConfig.class),
                     new FileBasedSystemAccessControlModule());
 

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
@@ -44,6 +44,7 @@ public class ExampleConnectorFactory
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.catalog." + catalogName,
                 new JsonModule(),
                 new TypeDeserializerModule(),
                 new ConnectorContextModule(catalogName, context),

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/file/FileAuthenticatorFactory.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/file/FileAuthenticatorFactory.java
@@ -36,6 +36,7 @@ public class FileAuthenticatorFactory
     public PasswordAuthenticator create(Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.auth." + getName(),
                 binder -> {
                     configBinder(binder).bindConfig(FileConfig.class);
                     binder.bind(FileAuthenticator.class).in(Scopes.SINGLETON);

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/file/FileGroupProviderFactory.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/file/FileGroupProviderFactory.java
@@ -36,6 +36,7 @@ public class FileGroupProviderFactory
     public GroupProvider create(Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.groups." + getName(),
                 binder -> {
                     configBinder(binder).bindConfig(FileGroupConfig.class);
                     binder.bind(FileGroupProvider.class).in(Scopes.SINGLETON);

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticatorFactory.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticatorFactory.java
@@ -37,6 +37,7 @@ public class LdapAuthenticatorFactory
     public PasswordAuthenticator create(Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.auth." + getName(),
                 new LdapClientModule(),
                 binder -> {
                     configBinder(binder).bindConfig(LdapAuthenticatorConfig.class);

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/salesforce/SalesforceAuthenticatorFactory.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/salesforce/SalesforceAuthenticatorFactory.java
@@ -37,6 +37,7 @@ public class SalesforceAuthenticatorFactory
     public PasswordAuthenticator create(Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.auth." + getName(),
                 binder -> {
                     configBinder(binder).bindConfig(SalesforceConfig.class);
                     binder.bind(SalesforceBasicAuthenticator.class).in(Scopes.SINGLETON);

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManagerFactory.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/FileResourceGroupConfigurationManagerFactory.java
@@ -36,6 +36,7 @@ public class FileResourceGroupConfigurationManagerFactory
     public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.resource-group." + getName(),
                 new JsonModule(),
                 new FileResourceGroupsModule(),
                 binder -> binder.bind(ClusterMemoryPoolManager.class).toInstance(context.getMemoryPoolManager()));

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -43,6 +43,7 @@ public class DbResourceGroupConfigurationManagerFactory
     {
         FlywayMigration.migrate(new ConfigurationFactory(replaceEnvironmentVariables(config)).build(DbResourceGroupConfig.class));
         Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.resource-group." + getName(),
                 new MBeanModule(),
                 new MBeanServerModule(),
                 new JsonModule(),

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -50,6 +50,7 @@ public class H2ResourceGroupConfigurationManagerFactory
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
+                    "io.trino.bootstrap.resource-group." + getName(),
                     new JsonModule(),
                     new H2ResourceGroupsModule(),
                     new NodeModule(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Follow-up to d01c5ac7918178fc4078b832715746148abf11c5.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This "invents" some more bootstrap name prefixes, specifically `io.trino.bootstrap.auth.` and `io.trino.bootstrap.resource-group.`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```

## Summary by Sourcery

Assign context-specific name prefixes to Bootstrap instances across various plugin factories to improve identification

Enhancements:
- Add io.trino.bootstrap.access.* prefix in FileBasedSystemAccessControl
- Add io.trino.bootstrap.catalog.* prefix in ExampleConnectorFactory
- Add io.trino.bootstrap.auth.* and io.trino.bootstrap.groups.* prefixes in password authenticator and group provider factories
- Add io.trino.bootstrap.resource-group.* prefix in resource group manager factories and tests