### PR TITLE
Support sending user principal to OPA

### DIFF
--- a/docs/src/main/sphinx/security/opa-access-control.md
+++ b/docs/src/main/sphinx/security/opa-access-control.md
@@ -61,6 +61,8 @@ The following table lists the configuration properties for the OPA access contro
 * - `opa.allow-permission-management-operations`
   - Configure if permission management operations are allowed. Find more details in
     [](opa-permission-management). Defaults to `false`.
+* - `opa.include-user-principal`
+  - Whether to include the user's principal when sending authorization requests to OPA. Defaults to `false`.
 * - `opa.http-client.*`
   - Optional HTTP client configurations for the connection from Trino to OPA,
     for example `opa.http-client.http-proxy` for configuring the HTTP proxy.

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaBatchAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaBatchAccessControl.java
@@ -74,7 +74,7 @@ public final class OpaBatchAccessControl
                 "FilterViewQueryOwnedBy",
                 queryOwners,
                 queryOwner -> OpaQueryInputResource.builder()
-                        .user(new TrinoUser(queryOwner))
+                        .user(new TrinoUser(queryOwner, this.allowPermissionManagementOperations()))
                         .build());
     }
 

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -28,6 +28,7 @@ public class OpaConfig
     private boolean logRequests;
     private boolean logResponses;
     private boolean allowPermissionManagementOperations;
+    private boolean includeUserPrincipal;
     private Optional<URI> opaRowFiltersUri = Optional.empty();
     private Optional<URI> opaColumnMaskingUri = Optional.empty();
     private Optional<URI> opaBatchColumnMaskingUri = Optional.empty();
@@ -96,6 +97,19 @@ public class OpaConfig
     public OpaConfig setAllowPermissionManagementOperations(boolean allowPermissionManagementOperations)
     {
         this.allowPermissionManagementOperations = allowPermissionManagementOperations;
+        return this;
+    }
+
+    public boolean getIncludeUserPrincipal()
+    {
+        return this.includeUserPrincipal;
+    }
+
+    @Config("opa.include-user-principal")
+    @ConfigDescription("Whether to include the user's principal when sending authorization requests to OPA")
+    public OpaConfig setIncludeUserPrincipal(boolean includeUserPrincipal)
+    {
+        this.includeUserPrincipal = includeUserPrincipal;
         return this;
     }
 

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
@@ -16,24 +16,29 @@ package io.trino.plugin.opa.schema;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.security.Identity;
 
+import java.security.Principal;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
 public record TrinoIdentity(
         String user,
-        Set<String> groups)
+        Set<String> groups,
+        Optional<Principal> principal)
 {
-    public static TrinoIdentity fromTrinoIdentity(Identity identity)
+    public static TrinoIdentity fromTrinoIdentity(Identity identity, boolean includeUserPrincipal)
     {
         return new TrinoIdentity(
                 identity.getUser(),
-                identity.getGroups());
+                identity.getGroups(),
+                includeUserPrincipal ? identity.getPrincipal() : Optional.empty());
     }
 
     public TrinoIdentity
     {
         requireNonNull(user, "user is null");
         groups = ImmutableSet.copyOf(requireNonNull(groups, "groups is null"));
+        requireNonNull(principal, "principal is null");
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoUser.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoUser.java
@@ -38,8 +38,8 @@ public record TrinoUser(String user, @JsonUnwrapped TrinoIdentity identity)
         this(name, null);
     }
 
-    public TrinoUser(Identity identity)
+    public TrinoUser(Identity identity, boolean includeUserPrincipal)
     {
-        this(null, TrinoIdentity.fromTrinoIdentity(identity));
+        this(null, TrinoIdentity.fromTrinoIdentity(identity, includeUserPrincipal));
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/SerializableTestPrincipal.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/SerializableTestPrincipal.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.opa;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.security.Principal;
+
+// A Principal for tests that can be serialized using Jackson
+@JsonSerialize
+public class SerializableTestPrincipal
+        implements Principal
+{
+    private String name;
+
+    public SerializableTestPrincipal(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
@@ -36,7 +36,8 @@ final class TestOpaConfig
                 .setOpaBatchColumnMaskingUri(null)
                 .setLogRequests(false)
                 .setLogResponses(false)
-                .setAllowPermissionManagementOperations(false));
+                .setAllowPermissionManagementOperations(false)
+                .setIncludeUserPrincipal(false));
     }
 
     @Test
@@ -51,6 +52,7 @@ final class TestOpaConfig
                 .put("opa.log-requests", "true")
                 .put("opa.log-responses", "true")
                 .put("opa.allow-permission-management-operations", "true")
+                .put("opa.include-user-principal", "true")
                 .buildOrThrow();
 
         OpaConfig expected = new OpaConfig()
@@ -61,7 +63,8 @@ final class TestOpaConfig
                 .setOpaBatchColumnMaskingUri(URI.create("https://opa-column-masking.example.com"))
                 .setLogRequests(true)
                 .setLogResponses(true)
-                .setAllowPermissionManagementOperations(true);
+                .setAllowPermissionManagementOperations(true)
+                .setIncludeUserPrincipal(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description


Sometimes more context than the username and/or groups is helpful to make an authorization decision.
This PR adds support to additionally send the users principal to the OPA server.
As this increases the payload size for every OPA request, we made this opt-in using the configuration property `opa.include-user-principal`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->




<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Added
* Support sending user principal to open policy agent 
```

## Summary by Sourcery

Add optional support for including the user principal in OPA authorization requests based on a new configuration property.

New Features:
- Add opa.include-user-principal configuration option to opt in to sending the user principal in OPA requests

Enhancements:
- Extend TrinoIdentity and TrinoUser to carry an optional Principal when includeUserPrincipal is enabled
- Update OpaAccessControl and OpaBatchAccessControl to pass the includeUserPrincipal flag when building OPA input

Documentation:
- Document the new opa.include-user-principal property in the OPA access control documentation

Tests:
- Add OpaConfig tests for default and explicit includeUserPrincipal mappings
- Add end-to-end test verifying the OPA request payload includes the user principal when enabled and include a SerializableTestPrincipal helper

Chores:
- Introduce SerializableTestPrincipal class for testing principal serialization