### PR TITLE
Fix TrinoInputStream.available implementations

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -27,7 +27,6 @@ import java.io.EOFException;
 import java.io.IOException;
 
 import static com.google.common.base.Verify.verify;
-import static com.google.common.primitives.Ints.saturatedCast;
 import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
 import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_POSITION;
 import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_SIZE;
@@ -70,9 +69,10 @@ public class AlluxioInputStream
     public int available()
             throws IOException
     {
+        // Not needed per contract, but complies with AbstractTestTrinoFileSystem expectations easier.
+        // It's easer to just check "is open?" in available() than refactor that test.
         ensureOpen();
-
-        return saturatedCast(fileLength - position);
+        return super.available();
     }
 
     @Override

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInputStream.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInputStream.java
@@ -15,7 +15,6 @@ package io.trino.filesystem.gcs;
 
 import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
-import com.google.common.primitives.Ints;
 import io.trino.filesystem.TrinoInputStream;
 import io.trino.filesystem.encryption.EncryptionKey;
 
@@ -63,9 +62,10 @@ public class GcsInputStream
     public int available()
             throws IOException
     {
+        // Not needed per contract, but complies with AbstractTestTrinoFileSystem expectations easier.
+        // It's easer to just check "is open?" in available() than refactor that test.
         ensureOpen();
-        repositionStream();
-        return Ints.saturatedCast(fileSize - currentPosition);
+        return super.available();
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalInputStream.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalInputStream.java
@@ -13,7 +13,6 @@
  */
 package io.trino.filesystem.local;
 
-import com.google.common.primitives.Ints;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInputStream;
 
@@ -53,7 +52,7 @@ class LocalInputStream
             throws IOException
     {
         ensureOpen();
-        return Ints.saturatedCast(fileLength - position);
+        return input.available();
     }
 
     @Override


### PR DESCRIPTION
The contract for this method is

> Returns an estimate of the number of bytes that can be read (or
> skipped over) from this input stream without blocking

only the in-memory buffered bytes are available in that sense.
