### PR TITLE
Fix typo in FTE doc

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -625,7 +625,7 @@ The following `exchange-manager.properties` configuration example specifies Allu
 as the spooling storage destination.
 
 ```properties
-exchange-manager.name=alluxio
+exchange-manager.name=filesystem
 exchange.base-directories=alluxio://alluxio-master:19998/exchange-spooling-directory
 exchange.alluxio.site-file-path=/path/to/alluxio-site.properties
 ```


### PR DESCRIPTION
## Description
`exchange-manager.name` should be `filesystem` when exchange spooling on `Alluxio` in FTE

## Additional context and related issues

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
