### PR TITLE
Randomize role name in BaseHiveConnectorTest

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -794,10 +794,11 @@ public abstract class BaseHiveConnectorTest
         // make sure role-grants only work on existing roles
         assertQueryFails(admin, "ALTER SCHEMA test_schema_authorization_role SET AUTHORIZATION ROLE nonexisting_role", ".*?Role 'nonexisting_role' does not exist in catalog 'hive'");
 
-        assertUpdate(admin, "CREATE ROLE authorized_users IN hive");
-        assertUpdate(admin, "GRANT authorized_users TO user IN hive");
+        String role = "authorized_users" + randomNameSuffix();
+        assertUpdate(admin, "CREATE ROLE " + role + " IN hive");
+        assertUpdate(admin, "GRANT " + role + " TO user IN hive");
 
-        assertUpdate(admin, "ALTER SCHEMA test_schema_authorization_role SET AUTHORIZATION ROLE authorized_users");
+        assertUpdate(admin, "ALTER SCHEMA test_schema_authorization_role SET AUTHORIZATION ROLE " + role);
 
         Session user = testSessionBuilder()
                 .setCatalog(getSession().getCatalog())
@@ -825,7 +826,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(user, "DROP TABLE test_schema_authorization_role.test");
         assertUpdate(user, "DROP SCHEMA test_schema_authorization_role");
 
-        assertUpdate(admin, "DROP ROLE authorized_users IN hive");
+        assertUpdate(admin, "DROP ROLE " + role + " IN hive");
     }
 
     @Test
@@ -908,11 +909,12 @@ public abstract class BaseHiveConnectorTest
                         .build())
                 .build();
 
-        assertUpdate(admin, "CREATE ROLE authorized_users IN hive");
-        assertUpdate(admin, "GRANT authorized_users TO user IN hive");
+        String role = "authorized_users" + randomNameSuffix();
+        assertUpdate(admin, "CREATE ROLE " + role + " IN hive");
+        assertUpdate(admin, "GRANT " + role + " TO user IN hive");
 
         assertQueryFails(admin, "CREATE SCHEMA test_createschema_authorization_role AUTHORIZATION ROLE nonexisting_role", ".*?Role 'nonexisting_role' does not exist in catalog 'hive'");
-        assertUpdate(admin, "CREATE SCHEMA test_createschema_authorization_role AUTHORIZATION ROLE authorized_users");
+        assertUpdate(admin, "CREATE SCHEMA test_createschema_authorization_role AUTHORIZATION ROLE " + role);
         assertUpdate(user, "CREATE TABLE test_createschema_authorization_role.test (x bigint)");
 
         // "user" without the role enabled cannot create new tables
@@ -926,7 +928,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(user, "DROP TABLE test_createschema_authorization_role.test");
         assertUpdate(user, "DROP SCHEMA test_createschema_authorization_role");
 
-        assertUpdate(admin, "DROP ROLE authorized_users IN hive");
+        assertUpdate(admin, "DROP ROLE " + role + " IN hive");
     }
 
     @Test


### PR DESCRIPTION
## Description

The example failure: https://github.com/trinodb/trino/actions/runs/19131497146/job/54673195949

```
2025-11-06T10:08:26.7380760Z [ERROR] io.trino.plugin.hive.TestHiveConnectorTest.testSchemaAuthorizationForRole -- Time elapsed: 0.103 s <<< ERROR!
2025-11-06T10:08:26.7384245Z io.trino.testing.QueryFailedException: line 1:1: Role 'authorized_users' already exists
2025-11-06T10:08:26.7419392Z 	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
2025-11-06T10:08:26.7422409Z 	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:587)
2025-11-06T10:08:26.7425745Z 	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:576)
2025-11-06T10:08:26.7428543Z 	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:106)
2025-11-06T10:08:26.7430034Z 	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:60)
2025-11-06T10:08:26.7432781Z 	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:416)
2025-11-06T10:08:26.7434922Z 	at io.trino.plugin.hive.BaseHiveConnectorTest.testSchemaAuthorizationForRole(BaseHiveConnectorTest.java:797)
2025-11-06T10:08:26.7438022Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
2025-11-06T10:08:26.7440243Z 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
2025-11-06T10:08:26.7441589Z 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
2025-11-06T10:08:26.7452304Z 	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
2025-11-06T10:08:26.7454484Z 	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
2025-11-06T10:08:26.7455628Z 	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:666)
2025-11-06T10:08:26.7456722Z 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
2025-11-06T10:08:26.7458028Z 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
2025-11-06T10:08:26.7459296Z 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
2025-11-06T10:08:26.7460534Z 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
2025-11-06T10:08:26.7461706Z 	Suppressed: java.lang.Exception: SQL: CREATE ROLE authorized_users IN hive
2025-11-06T10:08:26.7462928Z 		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:594)
2025-11-06T10:08:26.7464275Z 		... 15 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
