### PR TITLE
Refactor: Optimize regex usage by precompiling Patterns

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/MarkdownTablePrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/MarkdownTablePrinter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -39,6 +40,7 @@ public class MarkdownTablePrinter
         implements OutputPrinter
 {
     private static final Set<String> NUMERIC_TYPES = ImmutableSet.of(TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, DECIMAL);
+    private static final Pattern SPECIAL_CHARS = Pattern.compile("([\\\\`*_{}\\[\\]<>()#+!|])");
     private final List<String> fieldNames;
     private final List<Align> alignments;
     private final Writer writer;
@@ -111,8 +113,8 @@ public class MarkdownTablePrinter
 
     static String formatValue(Object o)
     {
-        return FormatUtils.formatValue(o)
-                .replaceAll("([\\\\`*_{}\\[\\]<>()#+!|])", "\\\\$1")
+        return SPECIAL_CHARS.matcher(FormatUtils.formatValue(o))
+                .replaceAll("\\\\$1")
                 .replace("\n", "<br>");
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/UserAgentBuilder.java
+++ b/client/trino-client/src/main/java/io/trino/client/UserAgentBuilder.java
@@ -20,12 +20,14 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class UserAgentBuilder
 {
     private static final Joiner.MapJoiner MAP_JOINER = Joiner.on(" ").withKeyValueSeparator("=");
+    private static final Pattern SANITIZE_PATTERN = Pattern.compile("[^a-zA-Z0-9_.-]+");
     private static final String LANGUAGE = "lang/java";
     private static final String OS_NAME = "os";
     private static final String OS_VERSION = "os/version";
@@ -69,7 +71,7 @@ public class UserAgentBuilder
     @VisibleForTesting
     static String sanitize(String value)
     {
-        return value.replaceAll("[^a-zA-Z0-9_.-]+", "_");
+        return SANITIZE_PATTERN.matcher(value).replaceAll("_");
     }
 
     private static String getProductVersion()

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/SpnegoHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/SpnegoHandler.java
@@ -30,6 +30,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Base64;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.CharMatcher.whitespace;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
@@ -42,6 +43,8 @@ public class SpnegoHandler
         implements Interceptor, Authenticator
 {
     private static final String NEGOTIATE = "Negotiate";
+    private static final Pattern SERVICE_PATTERN = Pattern.compile("\\$\\{SERVICE}");
+    private static final Pattern HOST_PATTERN = Pattern.compile("\\$\\{HOST}");
     private final String servicePrincipalPattern;
     private final String remoteServiceName;
     private final boolean useCanonicalHostname;
@@ -132,7 +135,7 @@ public class SpnegoHandler
         if (useCanonicalHostname) {
             serviceHostName = canonicalizeServiceHostName(hostName);
         }
-        return servicePrincipalPattern.replaceAll("\\$\\{SERVICE}", serviceName).replaceAll("\\$\\{HOST}", serviceHostName.toLowerCase(Locale.US));
+        return SERVICE_PATTERN.matcher(HOST_PATTERN.matcher(servicePrincipalPattern).replaceAll(serviceHostName.toLowerCase(Locale.US))).replaceAll(serviceName);
     }
 
     private static String canonicalizeServiceHostName(String hostName)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -46,6 +46,7 @@ import java.time.LocalTime;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -82,6 +83,7 @@ public final class FormatFunction
     public static final FormatFunction FORMAT_FUNCTION = new FormatFunction();
     private static final MethodHandle METHOD_HANDLE = methodHandle(FormatFunction.class, "sqlFormat", List.class, ConnectorSession.class, Slice.class, SqlRow.class);
     private static final CatalogSchemaFunctionName JSON_FORMAT_NAME = builtinFunctionName("json_format");
+    private static final Pattern JAVA_UTIL_EXCEPTION_PATTERN = Pattern.compile("^java\\.util\\.(\\w+)Exception");
 
     private FormatFunction()
     {
@@ -167,7 +169,7 @@ public final class FormatFunction
             return utf8Slice(format(session.getLocale(), format, args));
         }
         catch (IllegalFormatException e) {
-            String message = e.toString().replaceFirst("^java\\.util\\.(\\w+)Exception", "$1");
+            String message = JAVA_UTIL_EXCEPTION_PATTERN.matcher(e.toString()).replaceFirst("$1");
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Invalid format string: %s (%s)", format, message), e);
         }
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -93,6 +94,7 @@ public class TrinoJdbcCatalog
         extends AbstractTrinoCatalog
 {
     private static final Logger LOG = Logger.get(TrinoJdbcCatalog.class);
+    private static final Pattern METADATA_SUFFIX_PATTERN = Pattern.compile("/metadata/[^/]*$");
 
     private static final int PER_QUERY_CACHE_SIZE = 1000;
 
@@ -362,7 +364,7 @@ public class TrinoJdbcCatalog
         if (metadataLocation.isEmpty()) {
             throw new TrinoException(ICEBERG_INVALID_METADATA, format("Could not find metadata_location for table %s", schemaTableName));
         }
-        String tableLocation = metadataLocation.get().replaceFirst("/metadata/[^/]*$", "");
+        String tableLocation = METADATA_SUFFIX_PATTERN.matcher(metadataLocation.get()).replaceFirst("");
         deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, tableLocation);
         invalidateTableCache(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
@@ -65,6 +66,7 @@ public class RegisterTableProcedure
     private static final String TABLE_NAME = "TABLE_NAME";
     private static final String TABLE_LOCATION = "TABLE_LOCATION";
     private static final String METADATA_FILE_NAME = "METADATA_FILE_NAME";
+    private static final Pattern S3_SCHEMA_PATTERN = Pattern.compile("^s3[an]://");
 
     static {
         try {
@@ -211,7 +213,7 @@ public class RegisterTableProcedure
     {
         // Normalize e.g. s3a to s3, so that table can be registered using s3:// location
         // even if internally it uses s3a:// paths.
-        String normalizedSchema = tableLocation.replaceFirst("^s3[an]://", "s3://");
+        String normalizedSchema = S3_SCHEMA_PATTERN.matcher(tableLocation).replaceFirst("s3://");
         // Remove trailing slashes so that test_dir is equal to test_dir/
         return stripTrailingSlash(normalizedSchema);
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/Configurations.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/Configurations.java
@@ -24,6 +24,7 @@ import io.trino.tests.product.launcher.suite.Suite;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -31,6 +32,9 @@ import static java.lang.reflect.Modifier.isAbstract;
 
 public final class Configurations
 {
+    private static final Pattern ENV_PREFIX_PATTERN = Pattern.compile("^Env");
+    private static final Pattern SUITE_PREFIX_PATTERN = Pattern.compile("^Suite");
+
     private Configurations() {}
 
     public static List<Class<? extends EnvironmentProvider>> findEnvironmentsByBasePackage(String packageName)
@@ -118,7 +122,7 @@ public final class Configurations
         String className = clazz.getSimpleName();
         checkArgument(className.matches("^Suite[A-Z0-9].*"), "Name of %s should start with 'Suite'", clazz);
         // For a suite "Suite1", the UPPER_CAMEL to LOWER_HYPHEN conversion won't insert a hyphen after "Suite"
-        return "suite-" + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, className.replaceFirst("^Suite", ""));
+        return "suite-" + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, SUITE_PREFIX_PATTERN.matcher(className).replaceFirst(""));
     }
 
     public static String nameForJdkProviderName(Class<? extends JdkProvider> clazz)
@@ -129,7 +133,7 @@ public final class Configurations
     public static String canonicalEnvironmentName(String name)
     {
         if (name.matches("^Env[A-Z].*")) {
-            name = name.replaceFirst("^Env", "");
+            name = ENV_PREFIX_PATTERN.matcher(name).replaceFirst("");
         }
         return canonicalName(name);
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/OptionsPrinter.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/OptionsPrinter.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
@@ -33,6 +34,7 @@ public final class OptionsPrinter
 {
     private static final Joiner JOINER = Joiner.on(" \\\n")
             .skipNulls();
+    private static final Pattern NO_PREFIX_PATTERN = Pattern.compile("--no-");
 
     private OptionsPrinter() {}
 
@@ -82,7 +84,7 @@ public final class OptionsPrinter
 
         if (value instanceof Boolean) {
             if ((boolean) value) {
-                return annotation.names()[0].replaceFirst("--no-", "--");
+                return NO_PREFIX_PATTERN.matcher(annotation.names()[0]).replaceFirst("--");
             }
             if (annotation.negatable()) {
                 return annotation.names()[0];

--- a/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
@@ -29,6 +29,7 @@ import io.trino.tracing.TracingConnectorMetadata;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -43,6 +44,7 @@ import static java.util.stream.Collectors.joining;
 public class CountingMockConnector
         implements AutoCloseable
 {
+    private static final Pattern TRINO_PREFIX = Pattern.compile("^trino\\.");
     private final Object lock = new Object();
 
     private final Set<String> tablesTestSchema1 = IntStream.range(0, 1000)
@@ -110,7 +112,7 @@ public class CountingMockConnector
                         String attributes = span.getAttributes().asMap().entrySet().stream()
                                 .map(entry -> entry(entry.getKey().getKey(), entry.getValue()))
                                 .filter(entry -> !entry.getKey().equals("trino.catalog"))
-                                .map(entry -> "%s=%s".formatted(entry.getKey().replaceFirst("^trino\\.", ""), entry.getValue()))
+                                .map(entry -> "%s=%s".formatted(TRINO_PREFIX.matcher(entry.getKey()).replaceFirst(""), entry.getValue()))
                                 .sorted()
                                 .collect(joining(", "));
                         if (attributes.isEmpty()) {


### PR DESCRIPTION
Fixed #26914

Replace inline regex in String#replaceAll and String#replaceFirst calls with precompiled Pattern objects to avoid recompiling the regex on every call.

Slight performance improvement and cleaner, reusable code.