### PR TITLE
Compile trino-server-main targeting Java 11

### DIFF
--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- allow dependencies with newer bytecode versions -->
         <air.check.skip-enforcer>true</air.check.skip-enforcer>
-        <project.build.targetJdk>8</project.build.targetJdk>
+        <project.build.targetJdk>11</project.build.targetJdk>
     </properties>
 
     <dependencies>

--- a/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
+++ b/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
@@ -13,11 +13,7 @@
  */
 package io.trino.server;
 
-import com.google.common.base.StandardSystemProperty;
-import com.google.common.primitives.Ints;
-
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Strings.nullToEmpty;
 
 public final class TrinoServer
 {
@@ -25,15 +21,13 @@ public final class TrinoServer
 
     public static void main(String[] args)
     {
-        String javaVersion = nullToEmpty(StandardSystemProperty.JAVA_VERSION.value());
-        String majorVersion = javaVersion.split("\\D", 2)[0];
-        Integer major = Ints.tryParse(majorVersion);
-        if (major == null || major < 22) {
+        Runtime.Version javaVersion = Runtime.version();
+        if (javaVersion.feature() < 22) {
             System.err.printf("ERROR: Trino requires Java 22+ (found %s)%n", javaVersion);
             System.exit(100);
         }
 
-        String version = TrinoServer.class.getPackage().getImplementationVersion();
-        new Server().start(firstNonNull(version, "unknown"));
+        String trinoVersion = TrinoServer.class.getPackage().getImplementationVersion();
+        new Server().start(firstNonNull(trinoVersion, "unknown"));
     }
 }


### PR DESCRIPTION
By targeting Java 11 we can eliminate manual Java version string parsing. The downside is that someone trying to run Trino server with JDK 8, 9 or 10 won't get a nice error message anymore. The situation is unlikely given how ancient these versions are.
