### PR TITLE
[WIP] feature: Make filesystem cache table aware

### DIFF
--- a/lib/trino-filesystem-manager/pom.xml
+++ b/lib/trino-filesystem-manager/pom.xml
@@ -103,6 +103,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/lib/trino-filesystem-manager/pom.xml
+++ b/lib/trino-filesystem-manager/pom.xml
@@ -80,6 +80,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration-testing</artifactId>
             <scope>test</scope>
@@ -88,6 +93,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -13,8 +13,11 @@
  */
 package io.trino.filesystem.manager;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+
+import java.util.List;
 
 import static java.lang.System.getenv;
 
@@ -27,6 +30,7 @@ public class FileSystemConfig
     private boolean nativeGcsEnabled;
     private boolean nativeLocalEnabled;
     private boolean cacheEnabled;
+    private List<String> cacheIncludeTables = ImmutableList.of();
 
     // Enable leak detection if configured or if running in a CI environment
     private boolean trackingEnabled = getenv("CONTINUOUS_INTEGRATION") != null;
@@ -112,6 +116,19 @@ public class FileSystemConfig
     public FileSystemConfig setCacheEnabled(boolean enabled)
     {
         this.cacheEnabled = enabled;
+        return this;
+    }
+
+    public List<String> getCacheIncludeTables()
+    {
+        return cacheIncludeTables;
+    }
+
+    @Config("fs.cache.include-tables")
+    @ConfigDescription("List of tables to include in file system cache (schema.table format, supports wildcards like schema.* or *)")
+    public FileSystemConfig setCacheIncludeTables(List<String> tables)
+    {
+        this.cacheIncludeTables = ImmutableList.copyOf(tables);
         return this;
     }
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -125,7 +125,7 @@ public class FileSystemConfig
     }
 
     @Config("fs.cache.include-tables")
-    @ConfigDescription("List of tables to include in file system cache (schema.table format, supports wildcards like schema.* or *)")
+    @ConfigDescription("List of tables to include in file system cache, use * to cache listings for all tables in all schemas")
     public FileSystemConfig setCacheIncludeTables(List<String> tables)
     {
         this.cacheIncludeTables = ImmutableList.copyOf(tables);

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.manager;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
@@ -30,7 +31,7 @@ public class FileSystemConfig
     private boolean nativeGcsEnabled;
     private boolean nativeLocalEnabled;
     private boolean cacheEnabled;
-    private List<String> cacheIncludeTables = ImmutableList.of();
+    private List<String> cacheIncludeTables = ImmutableList.of("*");
 
     // Enable leak detection if configured or if running in a CI environment
     private boolean trackingEnabled = getenv("CONTINUOUS_INTEGRATION") != null;
@@ -119,6 +120,7 @@ public class FileSystemConfig
         return this;
     }
 
+    @NotEmpty
     public List<String> getCacheIncludeTables()
     {
         return cacheIncludeTables;

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.manager;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
@@ -127,11 +128,17 @@ public class FileSystemConfig
     }
 
     @Config("fs.cache.include-tables")
-    @ConfigDescription("List of tables to include in file system cache, use * to cache listings for all tables in all schemas")
+    @ConfigDescription("List of tables to include in file system cache, use * to cache all tables in all schemas")
     public FileSystemConfig setCacheIncludeTables(List<String> tables)
     {
         this.cacheIncludeTables = ImmutableList.copyOf(tables);
         return this;
+    }
+
+    @AssertTrue(message = "fs.cache.enabled must be true when fs.cache.include-tables is explicitly configured")
+    public boolean isCacheIncludeTablesConfigValid()
+    {
+        return cacheEnabled || cacheIncludeTables.equals(ImmutableList.of("*"));
     }
 
     public boolean isTrackingEnabled()

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -130,6 +130,8 @@ public class FileSystemModule
         newOptionalBinder(binder, CachingHostAddressProvider.class).setDefault().to(DefaultCachingHostAddressProvider.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, CacheKeyProvider.class).setDefault().to(DefaultCacheKeyProvider.class).in(Scopes.SINGLETON);
 
+        binder.bind(TableCachingPredicate.class).in(Scopes.SINGLETON);
+
         newOptionalBinder(binder, TrinoFileSystemCache.class);
         newOptionalBinder(binder, MemoryFileSystemCache.class);
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
@@ -40,13 +40,7 @@ public class TableCachingPredicate
     public TableCachingPredicate(List<String> includeTables)
     {
         requireNonNull(includeTables, "includeTables is null");
-
-        if (includeTables.isEmpty()) {
-            this.predicate = _ -> true;
-        }
-        else {
-            this.predicate = matches(includeTables);
-        }
+        this.predicate = buildPredicate(includeTables);
     }
 
     public boolean test(SchemaTableName table)
@@ -54,7 +48,7 @@ public class TableCachingPredicate
         return predicate.test(table);
     }
 
-    private static Predicate<SchemaTableName> matches(List<String> tables)
+    private static Predicate<SchemaTableName> buildPredicate(List<String> tables)
     {
         return tables.stream()
                 .map(TableCachingPredicate::parseTableName)

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
@@ -13,6 +13,7 @@
  */
 package io.trino.filesystem.manager;
 
+import com.google.inject.Inject;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 
@@ -29,6 +30,12 @@ import static java.util.Objects.requireNonNull;
 public class TableCachingPredicate
 {
     private final Predicate<SchemaTableName> predicate;
+
+    @Inject
+    public TableCachingPredicate(FileSystemConfig config)
+    {
+        this(config.getCacheIncludeTables());
+    }
 
     public TableCachingPredicate(List<String> includeTables)
     {

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Predicate to determine if a table should be cached based on configured include list.
- * Supports wildcards: schema.table, schema.*, or use * to cache listings for all tables in all schemas
+ * Supports wildcards: schema.table, schema.*, or use * to cache all tables in all schemas
  */
 public class TableCachingPredicate
 {

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Predicate to determine if a table should be cached based on configured include list.
- * Supports wildcards: schema.table, schema.*, or *
+ * Supports wildcards: schema.table, schema.*, or use * to cache listings for all tables in all schemas
  */
 public class TableCachingPredicate
 {

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/TableCachingPredicate.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.manager;
+
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Predicate to determine if a table should be cached based on configured include list.
+ * Supports wildcards: schema.table, schema.*, or *
+ */
+public class TableCachingPredicate
+{
+    private final Predicate<SchemaTableName> predicate;
+
+    public TableCachingPredicate(List<String> includeTables)
+    {
+        requireNonNull(includeTables, "includeTables is null");
+
+        if (includeTables.isEmpty()) {
+            this.predicate = _ -> true;
+        }
+        else {
+            this.predicate = matches(includeTables);
+        }
+    }
+
+    public boolean test(SchemaTableName table)
+    {
+        return predicate.test(table);
+    }
+
+    private static Predicate<SchemaTableName> matches(List<String> tables)
+    {
+        return tables.stream()
+                .map(TableCachingPredicate::parseTableName)
+                .map(prefix -> (Predicate<SchemaTableName>) prefix::matches)
+                .reduce(Predicate::or)
+                .orElse(_ -> false);
+    }
+
+    private static SchemaTablePrefix parseTableName(String tableName)
+    {
+        if (tableName.equals("*")) {
+            return new SchemaTablePrefix();
+        }
+        String[] parts = tableName.split("\\.");
+        checkArgument(parts.length == 2, "Invalid schemaTableName: %s", tableName);
+        String schema = parts[0];
+        String table = parts[1];
+        if (table.equals("*")) {
+            return new SchemaTablePrefix(schema);
+        }
+        return new SchemaTablePrefix(schema, table);
+    }
+}

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -15,6 +15,7 @@ package io.trino.filesystem.manager;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import org.junit.jupiter.api.Test;
 
@@ -83,5 +84,16 @@ public class TestFileSystemConfig
                 "cacheIncludeTables",
                 "must not be empty",
                 NotEmpty.class);
+    }
+
+    @Test
+    public void testCacheIncludeTablesRequiresCacheEnabled()
+    {
+        assertFailsValidation(
+                new FileSystemConfig()
+                        .setCacheIncludeTables(ImmutableList.of("schema1.table1")),
+                "cacheIncludeTablesConfigValid",
+                "fs.cache.enabled must be true when fs.cache.include-tables is explicitly configured",
+                AssertTrue.class);
     }
 }

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -15,6 +15,7 @@ package io.trino.filesystem.manager;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import jakarta.validation.constraints.NotEmpty;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -22,6 +23,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static java.lang.System.getenv;
 
 public class TestFileSystemConfig
@@ -39,7 +41,7 @@ public class TestFileSystemConfig
                 .setNativeGcsEnabled(false)
                 .setNativeLocalEnabled(false)
                 .setCacheEnabled(false)
-                .setCacheIncludeTables(ImmutableList.of())
+                .setCacheIncludeTables(ImmutableList.of("*"))
                 .setTrackingEnabled(RUNNING_IN_CI));
     }
 
@@ -70,5 +72,16 @@ public class TestFileSystemConfig
                 .setTrackingEnabled(!RUNNING_IN_CI);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testValidation()
+    {
+        assertFailsValidation(
+                new FileSystemConfig()
+                        .setCacheIncludeTables(ImmutableList.of()),
+                "cacheIncludeTables",
+                "must not be empty",
+                NotEmpty.class);
     }
 }

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.filesystem.manager;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,7 @@ public class TestFileSystemConfig
                 .setNativeGcsEnabled(false)
                 .setNativeLocalEnabled(false)
                 .setCacheEnabled(false)
+                .setCacheIncludeTables(ImmutableList.of())
                 .setTrackingEnabled(RUNNING_IN_CI));
     }
 
@@ -52,6 +54,7 @@ public class TestFileSystemConfig
                 .put("fs.native-gcs.enabled", "true")
                 .put("fs.native-local.enabled", "true")
                 .put("fs.cache.enabled", "true")
+                .put("fs.cache.include-tables", "schema1.table1,schema2.*,*")
                 .put("fs.tracking.enabled", Boolean.toString(!RUNNING_IN_CI))
                 .buildOrThrow();
 
@@ -63,6 +66,7 @@ public class TestFileSystemConfig
                 .setNativeGcsEnabled(true)
                 .setNativeLocalEnabled(true)
                 .setCacheEnabled(true)
+                .setCacheIncludeTables(ImmutableList.of("schema1.table1", "schema2.*", "*"))
                 .setTrackingEnabled(!RUNNING_IN_CI);
 
         assertFullMapping(properties, expected);

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestTableCachingPredicate.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestTableCachingPredicate.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.manager;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestTableCachingPredicate
+{
+    @Test
+    public void testWildcardMatchesAll()
+    {
+        TableCachingPredicate predicate = new TableCachingPredicate(ImmutableList.of("*"));
+
+        assertThat(predicate.test(new SchemaTableName("schema1", "table1"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema2", "table2"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("any_schema", "any_table"))).isTrue();
+    }
+
+    @Test
+    public void testSchemaWildcard()
+    {
+        TableCachingPredicate predicate = new TableCachingPredicate(ImmutableList.of("schema1.*"));
+
+        assertThat(predicate.test(new SchemaTableName("schema1", "table1"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema1", "table2"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema1", "any_table"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema2", "table1"))).isFalse();
+        assertThat(predicate.test(new SchemaTableName("other", "table1"))).isFalse();
+    }
+
+    @Test
+    public void testExactTableMatch()
+    {
+        TableCachingPredicate predicate = new TableCachingPredicate(ImmutableList.of("schema1.table1"));
+
+        assertThat(predicate.test(new SchemaTableName("schema1", "table1"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema1", "table2"))).isFalse();
+        assertThat(predicate.test(new SchemaTableName("schema2", "table1"))).isFalse();
+    }
+
+    @Test
+    public void testMultiplePatterns()
+    {
+        TableCachingPredicate predicate = new TableCachingPredicate(ImmutableList.of("schema1.table1", "schema2.*"));
+
+        assertThat(predicate.test(new SchemaTableName("schema1", "table1"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema1", "table2"))).isFalse();
+        assertThat(predicate.test(new SchemaTableName("schema2", "any_table"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("schema3", "table1"))).isFalse();
+    }
+
+    @Test
+    public void testEmptyListMatchesNone()
+    {
+        TableCachingPredicate predicate = new TableCachingPredicate(ImmutableList.of());
+
+        assertThat(predicate.test(new SchemaTableName("schema1", "table1"))).isFalse();
+        assertThat(predicate.test(new SchemaTableName("any", "table"))).isFalse();
+    }
+
+    @Test
+    public void testInvalidPatternWithoutSchema()
+    {
+        assertThatThrownBy(() -> new TableCachingPredicate(ImmutableList.of("table_only")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid schemaTableName");
+    }
+
+    @Test
+    public void testInvalidPatternTooManyParts()
+    {
+        assertThatThrownBy(() -> new TableCachingPredicate(ImmutableList.of("catalog.schema.table")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid schemaTableName");
+    }
+
+    @Test
+    public void testMixedPatternsWithGlobalWildcard()
+    {
+        TableCachingPredicate predicate = new TableCachingPredicate(ImmutableList.of("schema1.table1", "*"));
+
+        assertThat(predicate.test(new SchemaTableName("schema1", "table1"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("any_schema", "any_table"))).isTrue();
+    }
+
+    @Test
+    public void testFromConfig()
+    {
+        FileSystemConfig config = new FileSystemConfig()
+                .setCacheIncludeTables(ImmutableList.of("myschema.*"));
+
+        TableCachingPredicate predicate = new TableCachingPredicate(config);
+
+        assertThat(predicate.test(new SchemaTableName("myschema", "table1"))).isTrue();
+        assertThat(predicate.test(new SchemaTableName("other", "table1"))).isFalse();
+    }
+
+    @Test
+    public void testDefaultConfigMatchesAll()
+    {
+        FileSystemConfig config = new FileSystemConfig();
+
+        TableCachingPredicate predicate = new TableCachingPredicate(config);
+
+        assertThat(predicate.test(new SchemaTableName("any_schema", "any_table"))).isTrue();
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystemFactory.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystemFactory.java
@@ -25,11 +25,21 @@ public interface TrinoFileSystemFactory
         return create(session.getIdentity());
     }
 
+    /**
+     * Creates a file system for the given session with explicit caching control.
+     * The default implementation ignores the cachingEnabled parameter and delegates to {@link #create(ConnectorSession)}.
+     * Implementations that support caching control should override this method.
+     */
     default TrinoFileSystem create(ConnectorSession session, boolean cachingEnabled)
     {
         return create(session);
     }
 
+    /**
+     * Creates a file system for the given identity with explicit caching control.
+     * The default implementation ignores the cachingEnabled parameter and delegates to {@link #create(ConnectorIdentity)}.
+     * Implementations that support caching control should override this method.
+     */
     default TrinoFileSystem create(ConnectorIdentity identity, boolean cachingEnabled)
     {
         return create(identity);

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystemFactory.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystemFactory.java
@@ -24,4 +24,14 @@ public interface TrinoFileSystemFactory
     {
         return create(session.getIdentity());
     }
+
+    default TrinoFileSystem create(ConnectorSession session, boolean cachingEnabled)
+    {
+        return create(session);
+    }
+
+    default TrinoFileSystem create(ConnectorIdentity identity, boolean cachingEnabled)
+    {
+        return create(identity);
+    }
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
@@ -35,30 +35,37 @@ public final class CacheFileSystem
     private final TrinoFileSystem delegate;
     private final TrinoFileSystemCache cache;
     private final CacheKeyProvider keyProvider;
+    private final boolean cachingEnabled;
 
     public CacheFileSystem(TrinoFileSystem delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider)
+    {
+        this(delegate, cache, keyProvider, true);
+    }
+
+    public CacheFileSystem(TrinoFileSystem delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider, boolean cachingEnabled)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.cache = requireNonNull(cache, "cache is null");
         this.keyProvider = requireNonNull(keyProvider, "keyProvider is null");
+        this.cachingEnabled = cachingEnabled;
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location)
     {
-        return new CacheInputFile(delegate.newInputFile(location), cache, keyProvider, OptionalLong.empty(), Optional.empty());
+        return new CacheInputFile(delegate.newInputFile(location), cache, keyProvider, OptionalLong.empty(), Optional.empty(), cachingEnabled);
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length)
     {
-        return new CacheInputFile(delegate.newInputFile(location, length), cache, keyProvider, OptionalLong.of(length), Optional.empty());
+        return new CacheInputFile(delegate.newInputFile(location, length), cache, keyProvider, OptionalLong.of(length), Optional.empty(), cachingEnabled);
     }
 
     @Override
     public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
     {
-        return new CacheInputFile(delegate.newInputFile(location, length, lastModified), cache, keyProvider, OptionalLong.of(length), Optional.of(lastModified));
+        return new CacheInputFile(delegate.newInputFile(location, length, lastModified), cache, keyProvider, OptionalLong.of(length), Optional.of(lastModified), cachingEnabled);
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystemFactory.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystemFactory.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.tracing.TracingFileSystemCache;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.security.ConnectorIdentity;
 
 import static java.util.Objects.requireNonNull;
@@ -41,5 +42,17 @@ public final class CacheFileSystemFactory
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
         return new CacheFileSystem(delegate.create(identity), new TracingFileSystemCache(tracer, cache), keyProvider);
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorSession session, boolean cachingEnabled)
+    {
+        return new CacheFileSystem(delegate.create(session), new TracingFileSystemCache(tracer, cache), keyProvider, cachingEnabled);
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity, boolean cachingEnabled)
+    {
+        return new CacheFileSystem(delegate.create(identity), new TracingFileSystemCache(tracer, cache), keyProvider, cachingEnabled);
     }
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystemFactory.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystemFactory.java
@@ -40,8 +40,20 @@ public final class TracingFileSystemFactory
     }
 
     @Override
+    public TrinoFileSystem create(ConnectorIdentity identity, boolean cachingEnabled)
+    {
+        return new TracingFileSystem(tracer, delegate.create(identity, cachingEnabled));
+    }
+
+    @Override
     public TrinoFileSystem create(ConnectorSession session)
     {
         return new TracingFileSystem(tracer, delegate.create(session));
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorSession session, boolean cachingEnabled)
+    {
+        return new TracingFileSystem(tracer, delegate.create(session, cachingEnabled));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.security.ConnectorIdentity;
 
 import java.util.Map;
@@ -37,5 +38,11 @@ public class DefaultIcebergFileSystemFactory
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
         return fileSystemFactory.create(identity);
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorSession session, Map<String, String> fileIoProperties, boolean cachingEnabled)
+    {
+        return fileSystemFactory.create(session, cachingEnabled);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileSystemFactory.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.security.ConnectorIdentity;
 
 import java.util.Map;
@@ -21,4 +22,17 @@ import java.util.Map;
 public interface IcebergFileSystemFactory
 {
     TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties);
+
+    /**
+     * Create a file system with explicit caching control.
+     *
+     * @param session the connector session
+     * @param fileIoProperties file I/O properties
+     * @param cachingEnabled whether file system caching should be enabled
+     * @return a TrinoFileSystem instance
+     */
+    default TrinoFileSystem create(ConnectorSession session, Map<String, String> fileIoProperties, boolean cachingEnabled)
+    {
+        return create(session.getIdentity(), fileIoProperties);
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -24,6 +24,7 @@ import io.airlift.slice.Slice;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.manager.TableCachingPredicate;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.orc.OrcColumn;
 import io.trino.orc.OrcCorruptionException;
@@ -75,6 +76,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.EmptyPageSource;
 import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.connector.SystemColumnHandle;
 import io.trino.spi.predicate.Domain;
@@ -213,6 +215,7 @@ public class IcebergPageSourceProvider
     private final OrcReaderOptions orcReaderOptions;
     private final ParquetReaderOptions parquetReaderOptions;
     private final TypeManager typeManager;
+    private final TableCachingPredicate tableCachingPredicate;
     private final DeleteManager unpartitionedTableDeleteManager;
     private final Map<Integer, Function<PartitionData, PartitionKey>> partitionKeyFactories = new ConcurrentHashMap<>();
     private final Map<PartitionKey, DeleteManager> partitionedDeleteManagers = new ConcurrentHashMap<>();
@@ -223,7 +226,8 @@ public class IcebergPageSourceProvider
             FileFormatDataSourceStats fileFormatDataSourceStats,
             OrcReaderOptions orcReaderOptions,
             ParquetReaderOptions parquetReaderOptions,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            TableCachingPredicate tableCachingPredicate)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileIoFactory = requireNonNull(fileIoFactory, "fileIoFactory is null");
@@ -231,6 +235,7 @@ public class IcebergPageSourceProvider
         this.orcReaderOptions = requireNonNull(orcReaderOptions, "orcReaderOptions is null");
         this.parquetReaderOptions = requireNonNull(parquetReaderOptions, "parquetReaderOptions is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.tableCachingPredicate = requireNonNull(tableCachingPredicate, "tableCachingPredicate is null");
         this.unpartitionedTableDeleteManager = new DeleteManager(typeManager);
     }
 
@@ -263,8 +268,11 @@ public class IcebergPageSourceProvider
                 .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
                 .toArray(org.apache.iceberg.types.Type[]::new);
 
+        SchemaTableName schemaTableName = new SchemaTableName(tableHandle.getSchemaName(), tableHandle.getTableName());
+
         return createPageSource(
                 session,
+                schemaTableName,
                 icebergColumns,
                 schema,
                 partitionSpec,
@@ -287,6 +295,7 @@ public class IcebergPageSourceProvider
 
     public ConnectorPageSource createPageSource(
             ConnectorSession session,
+            SchemaTableName schemaTableName,
             List<IcebergColumnHandle> icebergColumns,
             Schema tableSchema,
             PartitionSpec partitionSpec,
@@ -316,10 +325,11 @@ public class IcebergPageSourceProvider
         if (effectivePredicate.isNone()) {
             return new EmptyPageSource();
         }
+        boolean shouldCache = tableCachingPredicate.test(schemaTableName);
 
         // exit early when only reading partition keys from a simple split
         String partition = partitionSpec.partitionToPath(partitionData);
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), fileIoProperties);
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session, fileIoProperties, shouldCache);
         TrinoInputFile inputFile = isUseFileSizeFromMetadata(session)
                 ? fileSystem.newInputFile(Location.of(path), fileSize)
                 : fileSystem.newInputFile(Location.of(path));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProviderFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProviderFactory.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.inject.Inject;
+import io.trino.filesystem.manager.TableCachingPredicate;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
@@ -35,6 +36,7 @@ public class IcebergPageSourceProviderFactory
     private final OrcReaderOptions orcReaderOptions;
     private final ParquetReaderOptions parquetReaderOptions;
     private final TypeManager typeManager;
+    private final TableCachingPredicate tableCachingPredicate;
 
     @Inject
     public IcebergPageSourceProviderFactory(
@@ -43,7 +45,8 @@ public class IcebergPageSourceProviderFactory
             FileFormatDataSourceStats fileFormatDataSourceStats,
             OrcReaderConfig orcReaderConfig,
             ParquetReaderConfig parquetReaderConfig,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            TableCachingPredicate tableCachingPredicate)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileIoFactory = requireNonNull(fileIoFactory, "fileIoFactory is null");
@@ -51,11 +54,12 @@ public class IcebergPageSourceProviderFactory
         this.orcReaderOptions = orcReaderConfig.toOrcReaderOptions();
         this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.tableCachingPredicate = requireNonNull(tableCachingPredicate, "tableCachingPredicate is null");
     }
 
     @Override
     public ConnectorPageSourceProvider createPageSourceProvider()
     {
-        return new IcebergPageSourceProvider(fileSystemFactory, fileIoFactory, fileFormatDataSourceStats, orcReaderOptions, parquetReaderOptions, typeManager);
+        return new IcebergPageSourceProvider(fileSystemFactory, fileIoFactory, fileFormatDataSourceStats, orcReaderOptions, parquetReaderOptions, typeManager, tableCachingPredicate);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -48,38 +48,25 @@ public class IcebergRestCatalogFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
-        if (vendedCredentialsEnabled &&
-                fileIoProperties.containsKey(VENDED_S3_ACCESS_KEY) &&
-                fileIoProperties.containsKey(VENDED_S3_SECRET_KEY) &&
-                fileIoProperties.containsKey(VENDED_S3_SESSION_TOKEN)) {
-            // Do not include original credentials as they should not be used in vended mode
-            ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
-                    .withGroups(identity.getGroups())
-                    .withPrincipal(identity.getPrincipal())
-                    .withEnabledSystemRoles(identity.getEnabledSystemRoles())
-                    .withConnectorRole(identity.getConnectorRole())
-                    .withExtraCredentials(ImmutableMap.<String, String>builder()
-                            .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, fileIoProperties.get(VENDED_S3_ACCESS_KEY))
-                            .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, fileIoProperties.get(VENDED_S3_SECRET_KEY))
-                            .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, fileIoProperties.get(VENDED_S3_SESSION_TOKEN))
-                            .buildOrThrow())
-                    .build();
-            return fileSystemFactory.create(identityWithExtraCredentials);
-        }
-
-        return fileSystemFactory.create(identity);
+        ConnectorIdentity effectiveIdentity = getEffectiveIdentity(identity, fileIoProperties);
+        return fileSystemFactory.create(effectiveIdentity);
     }
 
     @Override
     public TrinoFileSystem create(ConnectorSession session, Map<String, String> fileIoProperties, boolean cachingEnabled)
     {
-        ConnectorIdentity identity = session.getIdentity();
+        ConnectorIdentity effectiveIdentity = getEffectiveIdentity(session.getIdentity(), fileIoProperties);
+        return fileSystemFactory.create(effectiveIdentity, cachingEnabled);
+    }
+
+    private ConnectorIdentity getEffectiveIdentity(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    {
         if (vendedCredentialsEnabled &&
                 fileIoProperties.containsKey(VENDED_S3_ACCESS_KEY) &&
                 fileIoProperties.containsKey(VENDED_S3_SECRET_KEY) &&
                 fileIoProperties.containsKey(VENDED_S3_SESSION_TOKEN)) {
             // Do not include original credentials as they should not be used in vended mode
-            ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
+            return ConnectorIdentity.forUser(identity.getUser())
                     .withGroups(identity.getGroups())
                     .withPrincipal(identity.getPrincipal())
                     .withEnabledSystemRoles(identity.getEnabledSystemRoles())
@@ -90,9 +77,8 @@ public class IcebergRestCatalogFileSystemFactory
                             .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, fileIoProperties.get(VENDED_S3_SESSION_TOKEN))
                             .buildOrThrow())
                     .build();
-            return fileSystemFactory.create(identityWithExtraCredentials, cachingEnabled);
         }
 
-        return fileSystemFactory.create(session, cachingEnabled);
+        return identity;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -115,6 +115,7 @@ public class TableChangesFunctionProcessor
 
         this.pageSource = icebergPageSourceProvider.createPageSource(
                 session,
+                functionHandle.schemaTableName(),
                 functionHandle.columns(),
                 tableSchema,
                 partitionSpec,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -572,8 +572,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
             DynamicFilter dynamicFilter)
     {
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
-        // Create a TableCachingPredicate that caches all tables (empty list means cache all)
-        TableCachingPredicate tableCachingPredicate = new TableCachingPredicate(ImmutableList.of());
+        TableCachingPredicate tableCachingPredicate = new TableCachingPredicate(ImmutableList.of("*"));
         IcebergPageSourceProviderFactory factory = new IcebergPageSourceProviderFactory(
                 new DefaultIcebergFileSystemFactory(new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS)),
                 FILE_IO_FACTORY,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -22,6 +22,7 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.filesystem.local.LocalInputFile;
 import io.trino.filesystem.local.LocalOutputFile;
+import io.trino.filesystem.manager.TableCachingPredicate;
 import io.trino.metadata.TableHandle;
 import io.trino.orc.OrcWriteValidation;
 import io.trino.orc.OrcWriter;
@@ -571,13 +572,16 @@ public class TestIcebergNodeLocalDynamicSplitPruning
             DynamicFilter dynamicFilter)
     {
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
+        // Create a TableCachingPredicate that caches all tables (empty list means cache all)
+        TableCachingPredicate tableCachingPredicate = new TableCachingPredicate(ImmutableList.of());
         IcebergPageSourceProviderFactory factory = new IcebergPageSourceProviderFactory(
                 new DefaultIcebergFileSystemFactory(new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS)),
                 FILE_IO_FACTORY,
                 stats,
                 ORC_READER_CONFIG,
                 PARQUET_READER_CONFIG,
-                TESTING_TYPE_MANAGER);
+                TESTING_TYPE_MANAGER,
+                tableCachingPredicate);
         return factory.createPageSourceProvider().createPageSource(
                 transaction,
                 getSession(icebergConfig),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestTableCachingIntegration.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestTableCachingIntegration.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.manager.TableCachingPredicate;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTableCachingIntegration
+        extends AbstractTestQueryFramework
+{
+    private static final String CACHED_SCHEMA = "cached_schema";
+    private static final String NON_CACHED_SCHEMA = "non_cached_schema";
+    private TableCachingPredicate cachingPredicate;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        cachingPredicate = new TableCachingPredicate(ImmutableList.of("cached_schema.*", "prod.orders"));
+
+        Path cacheDirectory = Files.createTempDirectory("cache");
+        closeAfterClass(() -> deleteRecursively(cacheDirectory, ALLOW_INSECURE));
+        Path metastoreDirectory = Files.createTempDirectory(ICEBERG_CATALOG);
+        closeAfterClass(() -> deleteRecursively(metastoreDirectory, ALLOW_INSECURE));
+
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .put("fs.cache.enabled", "true")
+                .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
+                .put("fs.cache.max-sizes", "100MB")
+                .put("fs.cache.include-tables", "cached_schema.*,prod.orders")
+                .put("hive.metastore.catalog.dir", metastoreDirectory.toUri().toString())
+                .buildOrThrow();
+
+        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
+                .setSchemaInitializer(SchemaInitializer.builder()
+                        .withSchemaName(CACHED_SCHEMA)
+                        .build())
+                .setIcebergProperties(icebergProperties)
+                .setWorkerCount(0)
+                .build();
+        queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + CACHED_SCHEMA);
+        queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + NON_CACHED_SCHEMA);
+        queryRunner.execute("CREATE SCHEMA IF NOT EXISTS prod");
+        return queryRunner;
+    }
+
+    @Test
+    public void testCachingPredicateMatchesSchemaWildcard()
+    {
+        assertThat(cachingPredicate.test(new SchemaTableName("cached_schema", "any_table"))).isTrue();
+        assertThat(cachingPredicate.test(new SchemaTableName("cached_schema", "orders"))).isTrue();
+        assertThat(cachingPredicate.test(new SchemaTableName("cached_schema", "customers"))).isTrue();
+    }
+
+    @Test
+    public void testCachingPredicateMatchesExactTable()
+    {
+        assertThat(cachingPredicate.test(new SchemaTableName("prod", "orders"))).isTrue();
+        assertThat(cachingPredicate.test(new SchemaTableName("prod", "customers"))).isFalse();
+    }
+
+    @Test
+    public void testCachingPredicateDoesNotMatchNonCachedSchema()
+    {
+        assertThat(cachingPredicate.test(new SchemaTableName("non_cached_schema", "orders"))).isFalse();
+        assertThat(cachingPredicate.test(new SchemaTableName("dev", "some_table"))).isFalse();
+    }
+
+    @Test
+    public void testCreateAndQueryTableInCachedSchema()
+    {
+        assertUpdate("CREATE TABLE cached_schema.test_orders (id BIGINT, name VARCHAR)");
+        assertUpdate("INSERT INTO cached_schema.test_orders VALUES (1, 'order1'), (2, 'order2')", 2);
+
+        assertQuery("SELECT * FROM cached_schema.test_orders ORDER BY id", "VALUES (1, 'order1'), (2, 'order2')");
+        assertQuery("SELECT count(*) FROM cached_schema.test_orders", "VALUES 2");
+
+        assertThat(cachingPredicate.test(new SchemaTableName("cached_schema", "test_orders"))).isTrue();
+
+        assertUpdate("DROP TABLE cached_schema.test_orders");
+    }
+
+    @Test
+    public void testCreateAndQueryTableInNonCachedSchema()
+    {
+        assertUpdate("CREATE TABLE non_cached_schema.temp_data (id BIGINT, value VARCHAR)");
+        assertUpdate("INSERT INTO non_cached_schema.temp_data VALUES (10, 'value1'), (20, 'value2')", 2);
+
+        assertQuery("SELECT * FROM non_cached_schema.temp_data ORDER BY id", "VALUES (10, 'value1'), (20, 'value2')");
+        assertQuery("SELECT count(*) FROM non_cached_schema.temp_data", "VALUES 2");
+
+        assertThat(cachingPredicate.test(new SchemaTableName("non_cached_schema", "temp_data"))).isFalse();
+
+        assertUpdate("DROP TABLE non_cached_schema.temp_data");
+    }
+
+    @Test
+    public void testQueryTablesAcrossSchemas()
+    {
+        assertUpdate("CREATE TABLE cached_schema.data_a (id BIGINT)");
+        assertUpdate("CREATE TABLE non_cached_schema.data_b (id BIGINT)");
+
+        assertUpdate("INSERT INTO cached_schema.data_a VALUES (1), (2), (3)", 3);
+        assertUpdate("INSERT INTO non_cached_schema.data_b VALUES (4), (5)", 2);
+
+        assertQuery("SELECT * FROM cached_schema.data_a ORDER BY id", "VALUES 1, 2, 3");
+        assertQuery("SELECT * FROM non_cached_schema.data_b ORDER BY id", "VALUES 4, 5");
+
+        assertThat(cachingPredicate.test(new SchemaTableName("cached_schema", "data_a"))).isTrue();
+        assertThat(cachingPredicate.test(new SchemaTableName("non_cached_schema", "data_b"))).isFalse();
+
+        assertUpdate("DROP TABLE cached_schema.data_a");
+        assertUpdate("DROP TABLE non_cached_schema.data_b");
+    }
+}


### PR DESCRIPTION
Related Issue : https://github.com/trinodb/trino/issues/27276 


Earlier there was no provision for selective table caching, all the queried files from all the tables competed for LRU eviction, this PR introduces ability to cache specific tables by passing the table names in description. 
Setting this property for a particular table will led to Filesystem caching being enabled for that table itself, users can then check their S3 API logs to optimize their API call cost / performance as they will have business context around what tables contribute most to the API cost. 
Example - A `fact` table can be a highly queried fast changing table, while a `dim` table will be equally highly queried slowly changing table, so it will be more beneficial to cache the `dim` table, rather than the `fact` table. 

Introduces `fs.cache.include-tables` configuration property that accepts a list of table patterns to include in caching
   - Supports wildcards: `schema.table`, `schema.*`, or `*` to cache all tables
   - Default value is `['*']` (cache all tables) to maintain backward compatibility



Testing 
- [ ]  Tested locally only using minio. Will further test on production workload too. 
