### PR TITLE
Remove redundant spaces from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -965,7 +965,7 @@ jobs:
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
             - suite: suite-delta-lake-databricks173
               ignore exclusion if: >-
-                ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}          
+                ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
             - suite: suite-snowflake
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.SNOWFLAKE_PASSWORD != '' }}


### PR DESCRIPTION
## Description

`suite-delta-lake-databricks173` runs on PR from forked repositories like https://github.com/trinodb/trino/actions/runs/19276621494/job/55118493393?pr=27278

This change prevents such PRs from running the job. 
(I'm not sure why spaces cause such behavior 😕)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
