### PR TITLE
Validate JVM version in TrinoServer with built-time requirement

### DIFF
--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -48,4 +48,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>io/trino/server/build.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>io/trino/server/build.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/core/trino-server-main/src/main/resources/io/trino/server/build.properties
+++ b/core/trino-server-main/src/main/resources/io/trino/server/build.properties
@@ -1,0 +1,1 @@
+target.jdk=${project.build.targetJdk}


### PR DESCRIPTION
`TrinoServer` compares current runtime Java version with the one required to run Trino. Previously it used hard-coded knowledge about what's required, not it takes it from the build.
