### PR TITLE
Avoid Block#getSingleValueBlock copy in WindowAccumulators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctWindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctWindowAccumulator.java
@@ -26,7 +26,6 @@ import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import io.trino.spi.block.ValueBlock;
 import io.trino.spi.function.WindowAccumulator;
 import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.Type;
@@ -118,8 +117,7 @@ public class DistinctWindowAccumulator
                 pageBuilder.reset();
             }
             for (int channel = 0; channel < argumentChannels.size(); channel++) {
-                ValueBlock value = index.getSingleValueBlock(channel, position).getSingleValueBlock(0);
-                pageBuilder.getBlockBuilder(channel).append(value, 0);
+                index.appendTo(channel, position, pageBuilder.getBlockBuilder(channel));
             }
             pageBuilder.declarePosition();
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
@@ -19,7 +19,6 @@ import io.trino.operator.PagesIndexOrdering;
 import io.trino.operator.window.PagesWindowIndex;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.ValueBlock;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.function.WindowAccumulator;
 import io.trino.spi.function.WindowIndex;
@@ -112,8 +111,7 @@ public class OrderedWindowAccumulator
                 indexCurrentPage();
             }
             for (int channel = 0; channel < argumentTypes.size(); channel++) {
-                ValueBlock value = index.getSingleValueBlock(channel, position).getSingleValueBlock(0);
-                pageBuilder.getBlockBuilder(channel).append(value, 0);
+                index.appendTo(channel, position, pageBuilder.getBlockBuilder(channel));
             }
             pageBuilder.declarePosition();
         }


### PR DESCRIPTION
## Description
Avoids awkwardly calling `index.getSingleValueBlock(channel, position).getSingleValueBlock(0)` in both `OrderedWindowAccumulator` and `DistinctWindowAccumulator` by just calling `index.appendTo(...)` instead. This avoid multiple "single value block" copies on the way into the block builder.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
