### PR TITLE
Add logic to cleanup dangling AWS Redshift ephemeral CI clusters

### DIFF
--- a/.github/bin/redshift/cleanup/README.md
+++ b/.github/bin/redshift/cleanup/README.md
@@ -1,0 +1,71 @@
+# Redshift Cluster Cleanup Script
+
+This script allows you to delete AWS Redshift clusters that contain a specific substring in their name and are older than the specified number of hours.
+
+## Requirements
+
+- **AWS CLI**: The AWS Command Line Interface must be installed and configured with appropriate credentials. [Installation guide](https://aws.amazon.com/cli/)
+- **jq**: A lightweight command-line JSON processor. [Installation guide](https://stedolan.github.io/jq/download/)
+- **Bash**: Version 4.0 or higher
+
+## Usage Examples
+
+### Basic usage (dry run)
+```bash
+./cleanup-redshift.sh --name-substring "test-cluster" --age-hours 24
+```
+
+### Actually delete clusters (with confirmation)
+```bash
+./cleanup-redshift.sh --name-substring "test-cluster" --age-hours 24 --delete
+```
+
+### Delete clusters automatically without confirmation (DANGEROUS!)
+```bash
+./cleanup-redshift.sh --name-substring "test-cluster" --age-hours 48 --delete --auto-confirm
+```
+
+### Specify region and batch limit
+```bash
+./cleanup-redshift.sh --name-substring "ci-" --age-hours 72 --region "us-west-2" --delete-batch-limit 5 --delete
+```
+
+## Parameters
+
+- `--name-substring` (required): Substring that must be present in cluster name to qualify for deletion
+- `--age-hours` (optional, default: 24): Minimum age in hours for clusters to qualify for deletion
+- `--region` (optional, default: us-east-1): AWS region to operate in
+- `--delete-batch-limit` (optional, default: 10): Maximum number of clusters to delete at once
+- `--delete` (optional): Actually perform deletion (without this, it's a dry run)
+- `--auto-confirm` (optional): Skip user confirmation prompt (DANGEROUS!)
+- `--output-file` (optional): Output file to save cluster identifiers
+
+## Safety Features
+
+1. **Dry run by default**: The script won't delete anything unless `--delete` flag is provided
+2. **Required substring**: Clusters must contain the specified substring to qualify
+3. **Age requirement**: Clusters must be older than specified hours
+4. **User confirmation**: Prompts for confirmation before deletion (unless `--auto-confirm`)
+5. **Batch limits**: Limits number of clusters processed in single run
+
+## Example Output
+
+```
+Cleaning Redshift clusters...
+region: us-east-1
+name-substring: test-
+age-hours: 48
+
+[2025-09-09 09:00:00] AWS API call redshift describe-clusters
+[2025-09-09 09:00:01] Cluster test-cluster-old qualified for deletion (age: 72 hours)
+[2025-09-09 09:00:01] Cluster test-another-cluster qualified for deletion (age: 96 hours)
+[2025-09-09 09:00:01] Found 2 Redshift clusters eligible for deletion
+
+List of Redshift clusters to be deleted:
+test-cluster-old
+test-another-cluster
+
+You are about to delete 2 Redshift clusters shown above!
+This action is IRREVERSIBLE and will permanently delete the clusters and their data!
+Are you sure (enter strict 'yes' to proceed)? 
+```

--- a/.github/bin/redshift/cleanup/cleanup-redshift.sh
+++ b/.github/bin/redshift/cleanup/cleanup-redshift.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+    printf "[%s] %s\n" "$(date +%F" "%T)" "$1" >&2
+}
+
+err_exit() {
+    log "$@"
+    exit 1
+}
+
+elapsed_hours_from_aws_time() {
+    local awsDateTime=$1
+    local epoch
+
+    # Handle empty input
+    [ -n "${awsDateTime}" ] || err_exit "Empty AWS date time provided"
+
+    # Handle different AWS date formats using case and grep for POSIX compatibility
+    # Format 1: 2025-01-08T10:30:00+00:00 (timezone offset)
+    # Format 2: 2025-01-08T10:30:00.000+00:00 (timezone offset with fractional seconds)
+    # Format 3: 2025-01-08T10:30:00.000Z (UTC with milliseconds)
+    # Format 4: 2025-01-08T10:30:00Z (UTC without milliseconds)
+
+    if echo "${awsDateTime}" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?[+-][0-9]{2}:[0-9]{2}$'; then
+        # Format with timezone offset like +00:00, with optional fractional seconds
+        local cleanDateTime
+        # Remove fractional seconds if present for better compatibility: 2025-01-08T10:30:00.947000+00:00 -> 2025-01-08T10:30:00+00:00
+        case "${awsDateTime}" in
+            *.*+*)
+                # Extract parts: date.fractional+timezone
+                local before_plus="${awsDateTime%+*}"
+                local after_plus="${awsDateTime##*+}"
+                local date_part="${before_plus%.*}"
+                cleanDateTime="${date_part}+${after_plus}"
+                ;;
+            *.*-*)
+                # Extract parts: date.fractional-timezone
+                local before_minus="${awsDateTime%-*}"
+                local after_minus="${awsDateTime##*-}"
+                local date_part="${before_minus%.*}"
+                cleanDateTime="${date_part}-${after_minus}"
+                ;;
+            *) cleanDateTime="${awsDateTime}" ;;
+        esac
+        # first call is for Linux, the following one for Mac
+        epoch=$(date --date "${cleanDateTime}" +%s 2>/dev/null) ||
+            epoch=$(date -j -f "%FT%T%z" "${cleanDateTime}" +%s 2>/dev/null)
+    elif echo "${awsDateTime}" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$'; then
+        # Format with Z suffix (UTC), with or without fractional seconds
+        local cleanDateTime
+        # Remove fractional seconds if present: 2025-01-08T10:30:00.000Z -> 2025-01-08T10:30:00Z
+        case "${awsDateTime}" in
+            *.*Z) cleanDateTime="${awsDateTime%.*}Z" ;;
+            *) cleanDateTime="${awsDateTime}" ;;
+        esac
+        # Convert Z to +0000 for better compatibility
+        cleanDateTime="${cleanDateTime%Z}+0000"
+        # first call is for Linux, the following one for Mac
+        epoch=$(date --date "${cleanDateTime}" +%s 2>/dev/null) ||
+            epoch=$(date -j -f "%FT%T%z" "${cleanDateTime}" +%s 2>/dev/null)
+    else
+        err_exit "Unexpected AWS date time format ${awsDateTime}"
+    fi
+
+    # Validate that we got a valid epoch time
+    if [ -n "${epoch}" ] && echo "${epoch}" | grep -qE '^[0-9]+$'; then
+        echo $((($(date +%s) - epoch) / 3600))
+    else
+        err_exit "Failed to parse AWS date time ${awsDateTime}"
+    fi
+}
+
+elapsed_hours_from_millis_timestamp() {
+    local millisTimestamp=$1
+
+    [[ "${millisTimestamp}" =~ ^[0-9]+$ ]] || err_exit "Unexpected timestamp arg ${millisTimestamp}"
+    echo $((($(date +%s) - (millisTimestamp / 1000)) / 3600))
+}
+
+get_user_confirmation() {
+    read -p "Are you sure (enter strict 'yes' to proceed)? " -r
+    [[ $REPLY =~ ^yes$ ]]
+}
+
+check_required_tools() {
+    if ! command -v aws >/dev/null 2>&1; then
+        err_exit "AWS CLI is required but not installed."
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        err_exit "jq is required but not installed."
+    fi
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage:
+    $0 [--delete] [--auto-confirm] [--output-file <file>] [--delete-batch-limit <int>] [--name-substring <string>] [--age-hours <int>] [--region <string>]
+Where options are:
+    --delete - perform deletion
+    --auto-confirm - automatic confirmation of deletion
+    --output-file - output file with cluster identifiers qualified to delete. If given, it won't be deleted on exit
+    --delete-batch-limit - limit number of clusters to be deleted at once
+    --name-substring - substring that must be present in cluster name to qualify for deletion
+    --age-hours - minimum age in hours for clusters to qualify for deletion
+    --region - aws region
+Description
+    This script allows to delete AWS Redshift clusters that contain a specific substring in their name
+    and are older than the specified number of hours.
+    It is safe to run this script manually - it will analyze AWS Redshift and output results. It won't delete
+    anything without strict user confirmation (with exception when run with --auto-confirm option!)
+EOF
+}
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -h | --help)
+            usage
+            exit
+            ;;
+        --delete)
+            delete=true
+            shift
+            ;;
+        --auto-confirm)
+            autoConfirm=true
+            shift
+            ;;
+        --output-file)
+            outputFile=$2
+            shift 2
+            ;;
+        --delete-batch-limit)
+            deleteBatchLimit=$2
+            [[ "${deleteBatchLimit}" =~ ^[0-9]+$ && "${deleteBatchLimit}" -gt 0 ]] ||
+                err_exit "Invalid --delete-batch-limit value ${deleteBatchLimit}"
+            shift 2
+            ;;
+        --name-substring)
+            nameSubstring=$2
+            shift 2
+            ;;
+        --age-hours)
+            ageHours=$2
+            [[ "${ageHours}" =~ ^[0-9]+$ && "${ageHours}" -gt 0 ]] ||
+                err_exit "Invalid --age-hours value ${ageHours}"
+            shift 2
+            ;;
+        --region)
+            region=$2
+            shift 2
+            ;;
+        *)
+            err_exit "Unknown argument given $1"
+            ;;
+        esac
+    done
+
+    # defaults if not provided
+    delete=${delete:-false}
+    autoConfirm=${autoConfirm:-false}
+    deleteBatchLimit=${deleteBatchLimit:-10}
+    nameSubstring=${nameSubstring:-""}
+    ageHours=${ageHours:-24}
+    region=${region:-"us-east-1"}
+
+    # Validate required parameters
+    [ -n "${nameSubstring}" ] || err_exit "Parameter --name-substring is required"
+
+    # Check for required tools
+    check_required_tools
+
+    echo "Cleaning Redshift clusters..."
+    echo "region: $region"
+    echo "name-substring: $nameSubstring"
+    echo "age-hours: $ageHours"
+
+    find_redshift_clusters_to_delete
+    [ "${clustersToDeleteCount}" -gt 0 ] || {
+        log "Nothing to delete, exiting"
+        exit 0
+    }
+
+    echo -e "\nList of Redshift clusters to be deleted:"
+    cat "${outputFile}"
+
+    "${delete}" || exit 0
+
+    echo -e "\nYou are about to delete ${clustersToDeleteCount} Redshift clusters shown above!"
+    echo "This action is IRREVERSIBLE and will permanently delete the clusters and their data!"
+
+    if "${autoConfirm}" || get_user_confirmation; then
+        delete_redshift_clusters "${outputFile}"
+    else
+        log "Deletion of Redshift clusters skipped"
+    fi
+}
+
+qualify_for_deletion() {
+    local inputClusters=$1
+    local clusters
+    local cluster
+    local clusterIdentifier
+    local clusterCreateTime
+    local ageInHours
+
+    readarray -t clusters < <(jq --compact-output '.[]' <<<"${inputClusters}")
+
+    for cluster in "${clusters[@]}"; do
+        clusterIdentifier=$(jq --raw-output '.ClusterIdentifier' <<<"${cluster}")
+        clusterCreateTime=$(jq --raw-output '.ClusterCreateTime' <<<"${cluster}")
+
+        # Check if cluster name contains the required substring
+        if [[ "${clusterIdentifier}" != *"${nameSubstring}"* ]]; then
+            log "Cluster ${clusterIdentifier} does not contain substring '${nameSubstring}', skipping"
+            continue
+        fi
+
+        # Calculate age in hours
+        ageInHours=$(elapsed_hours_from_aws_time "${clusterCreateTime}") || {
+            log "Failed to calculate age for cluster ${clusterIdentifier}, skipping"
+            continue
+        }
+
+        # Validate that ageInHours is a valid integer
+        if [ -z "${ageInHours}" ] || ! echo "${ageInHours}" | grep -qE '^[0-9]+$'; then
+            log "Invalid age calculation for cluster ${clusterIdentifier} (got: '${ageInHours}'), skipping"
+            continue
+        fi
+
+        if [ "${ageInHours}" -lt "${ageHours}" ]; then
+            log "Cluster ${clusterIdentifier} is only ${ageInHours} hours old, requires ${ageHours} hours minimum age"
+            continue
+        fi
+
+        log "Cluster ${clusterIdentifier} qualified for deletion (age: ${ageInHours} hours)"
+        echo "${clusterIdentifier}" >>"${outputFile}"
+        ((clustersToDeleteCount += 1))
+
+        [ "${clustersToDeleteCount}" -lt "${deleteBatchLimit}" ] || break
+    done
+}
+
+find_redshift_clusters_to_delete() {
+    local response
+    local marker
+
+    if [ -z ${outputFile+x} ]; then
+        outputFile=$(mktemp)
+        trap 'log "Clean up temp file" ; rm -f "${outputFile}"' EXIT
+    fi
+
+    [ -f "${outputFile}" ] && rm -f "${outputFile}"
+    clustersToDeleteCount=0
+
+    marker=""
+    log "AWS API call redshift describe-clusters"
+    while true; do
+        # shellcheck disable=SC2046
+        response=$(aws redshift describe-clusters \
+            --tag-keys "project" \
+            --tag-values "trino-redshift" \
+            --region "$region" \
+            --output json \
+            $([ -n "${marker}" ] && echo --marker "${marker}")) ||
+            err_exit "API call redshift describe-clusters failed"
+
+        qualify_for_deletion "$(jq '.Clusters' <<<"${response}")" ||
+            err_exit "Unexpected error while qualifying clusters for deletion"
+
+        [ "${clustersToDeleteCount}" -lt "${deleteBatchLimit}" ] || break
+
+        marker=$(jq '.Marker // empty' -r <<<"${response}")
+        [ -n "${marker}" ] || break
+        log "AWS API call redshift describe-clusters (next page)"
+    done
+
+    log "Found ${clustersToDeleteCount} Redshift clusters eligible for deletion"
+}
+
+delete_redshift_clusters() {
+    local file=$1
+    declare -a clustersToDelete
+
+    [ -f "${file}" ] || err_exit "File not found ${file}"
+
+    mapfile -t clustersToDelete < "${file}"
+
+    log "Starting deletion of ${#clustersToDelete[@]} Redshift clusters"
+
+    for clusterIdentifier in "${clustersToDelete[@]}"; do
+        log "Deleting Redshift cluster: ${clusterIdentifier}"
+        aws redshift delete-cluster \
+            --cluster-identifier "${clusterIdentifier}" \
+            --skip-final-cluster-snapshot \
+            --region "$region" ||
+            err_exit "Failed to delete cluster ${clusterIdentifier}"
+        log "Successfully initiated deletion of cluster: ${clusterIdentifier}"
+    done
+}
+
+main "$@"

--- a/.github/workflows/aws-cleanup.yml
+++ b/.github/workflows/aws-cleanup.yml
@@ -1,0 +1,30 @@
+name: AWS CICD resources cleanup
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+jobs:
+  cleanup-redshift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execution environment
+        uses: hmarr/debug-action@v3
+
+      - name: git checkout
+        uses: actions/checkout@v4
+
+      - name: Cleanup danging ephemeral AWS Redshift CI clusters
+        continue-on-error: true
+        env:
+          AWS_REGION: ${{ vars.REDSHIFT_AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ vars.REDSHIFT_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.REDSHIFT_AWS_SECRET_ACCESS_KEY }}
+          MAX_REDSHIFT_AGE_HOURS: 4
+        run: |
+          .github/bin/redshift/cleanup/cleanup-redshift.sh --name-substring "trino-redshift-ci-cluster" --age-hours "${MAX_REDSHIFT_AGE_HOURS}" --region "${AWS_REGION}" --delete --auto-confirm


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

These changes are adding a routine to remove eventually dangling ephemeral Redshift clusters used for CI purposes.
The new workflow is set to run several times a day.

NOTE that on the AWS permissions side, the AWS CI user used to interact with AWS Redshift receives extra permissions in order to be able to list/describe the active clusters

```
        {
            "Sid": "RedshiftDescribeClusters",
            "Effect": "Allow",
            "Action": [
                "redshift:DescribeClusters"
            ],
            "Resource": "arn:aws:redshift:xx-xxxx-x:xxxxx:cluster:*"
        }
```



With regards to dangling ephemeral Redshift clusters it is worth adding that through the existing logic in `ci.yml` even though a CI run is being interrupted, the ephemeral Redshift cluster still gets deleted:

https://github.com/trinodb/trino/blob/21c5a6d3cfd45c295b9397d8c2befefbcb38a72a/.github/workflows/ci.yml#L786-L793

For the rare cases though, when the deletion of the Redshift cluster does not succeed, we're adding here safety logic to remove dangling ephemeral Redshift resources.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
