### PR TITLE
Avoid reading unusually large parquet pages

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -115,6 +115,10 @@ with Parquet files performed by supported object storage connectors:
     This prevents workers from going into full GC or crashing due to poorly
     configured Parquet writers.
   - `15MB`
+* - `parquet.max-page-read-size`
+  - Maximum allowed size of a parquet page during reads. Files with parquet pages
+    larger than this will generate an exception on read.
+  - `500MB`
 :::
 
 [](file-compression) is automatically performed and some details can be

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -27,6 +27,7 @@ public class ParquetReaderOptions
     private static final DataSize DEFAULT_MAX_BUFFER_SIZE = DataSize.of(8, MEGABYTE);
     private static final DataSize DEFAULT_SMALL_FILE_THRESHOLD = DataSize.of(3, MEGABYTE);
     private static final DataSize DEFAULT_MAX_FOOTER_READ_SIZE = DataSize.of(15, MEGABYTE);
+    private static final DataSize DEFAULT_MAX_PAGE_READ_SIZE = DataSize.of(500, MEGABYTE);
 
     private final boolean ignoreStatistics;
     private final DataSize maxReadBlockSize;
@@ -38,6 +39,7 @@ public class ParquetReaderOptions
     private final DataSize smallFileThreshold;
     private final boolean vectorizedDecodingEnabled;
     private final DataSize maxFooterReadSize;
+    private final DataSize maxPageReadSize;
 
     private ParquetReaderOptions()
     {
@@ -51,6 +53,7 @@ public class ParquetReaderOptions
         smallFileThreshold = DEFAULT_SMALL_FILE_THRESHOLD;
         vectorizedDecodingEnabled = true;
         maxFooterReadSize = DEFAULT_MAX_FOOTER_READ_SIZE;
+        maxPageReadSize = DEFAULT_MAX_PAGE_READ_SIZE;
     }
 
     private ParquetReaderOptions(
@@ -63,7 +66,8 @@ public class ParquetReaderOptions
             boolean useBloomFilter,
             DataSize smallFileThreshold,
             boolean vectorizedDecodingEnabled,
-            DataSize maxFooterReadSize)
+            DataSize maxFooterReadSize,
+            DataSize maxPageReadSize)
     {
         this.ignoreStatistics = ignoreStatistics;
         this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxReadBlockSize is null");
@@ -76,6 +80,7 @@ public class ParquetReaderOptions
         this.smallFileThreshold = requireNonNull(smallFileThreshold, "smallFileThreshold is null");
         this.vectorizedDecodingEnabled = vectorizedDecodingEnabled;
         this.maxFooterReadSize = requireNonNull(maxFooterReadSize, "maxFooterReadSize is null");
+        this.maxPageReadSize = requireNonNull(maxPageReadSize, "maxPageReadSize is null");
     }
 
     public static Builder builder()
@@ -143,6 +148,11 @@ public class ParquetReaderOptions
         return maxFooterReadSize;
     }
 
+    public DataSize getMaxPageReadSize()
+    {
+        return maxPageReadSize;
+    }
+
     public static class Builder
     {
         private boolean ignoreStatistics;
@@ -155,6 +165,7 @@ public class ParquetReaderOptions
         private DataSize smallFileThreshold;
         private boolean vectorizedDecodingEnabled;
         private DataSize maxFooterReadSize;
+        private DataSize maxPageReadSize;
 
         private Builder(ParquetReaderOptions parquetReaderOptions)
         {
@@ -169,6 +180,7 @@ public class ParquetReaderOptions
             this.smallFileThreshold = parquetReaderOptions.smallFileThreshold;
             this.vectorizedDecodingEnabled = parquetReaderOptions.vectorizedDecodingEnabled;
             this.maxFooterReadSize = parquetReaderOptions.maxFooterReadSize;
+            this.maxPageReadSize = parquetReaderOptions.maxPageReadSize;
         }
 
         public Builder withIgnoreStatistics(boolean ignoreStatistics)
@@ -231,6 +243,12 @@ public class ParquetReaderOptions
             return this;
         }
 
+        public Builder withMaxPageReadSize(DataSize maxPageReadSize)
+        {
+            this.maxPageReadSize = requireNonNull(maxPageReadSize, "maxPageSize is null");
+            return this;
+        }
+
         public ParquetReaderOptions build()
         {
             return new ParquetReaderOptions(
@@ -243,7 +261,8 @@ public class ParquetReaderOptions
                     useBloomFilter,
                     smallFileThreshold,
                     vectorizedDecodingEnabled,
-                    maxFooterReadSize);
+                    maxFooterReadSize,
+                    maxPageReadSize);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PageReader.java
@@ -70,7 +70,8 @@ public final class PageReader
             ColumnDescriptor columnDescriptor,
             @Nullable OffsetIndex offsetIndex,
             Optional<String> fileCreatedBy,
-            Optional<FileDecryptionContext> decryptionContext)
+            Optional<FileDecryptionContext> decryptionContext,
+            long maxPageSizeInBytes)
     {
         // Parquet schema may specify a column definition as OPTIONAL even though there are no nulls in the actual data.
         // Row-group column statistics can be used to identify such cases and switch to faster non-nullable read
@@ -86,7 +87,8 @@ public final class PageReader
                 metadata,
                 columnChunk,
                 offsetIndex,
-                columnDecryptionContext);
+                columnDecryptionContext,
+                maxPageSizeInBytes);
 
         return new PageReader(
                 dataSourceId,

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -667,7 +667,15 @@ public class ParquetReader
             }
             ChunkedInputStream columnChunkInputStream = chunkReaders.get(new ChunkKey(fieldId, currentRowGroup));
             columnReader.setPageReader(
-                    createPageReader(dataSource.getId(), columnChunkInputStream, metadata, columnDescriptor, offsetIndex, fileCreatedBy, decryptionContext),
+                    createPageReader(
+                            dataSource.getId(),
+                            columnChunkInputStream,
+                            metadata,
+                            columnDescriptor,
+                            offsetIndex,
+                            fileCreatedBy,
+                            decryptionContext,
+                            options.getMaxPageReadSize().toBytes()),
                     Optional.ofNullable(rowRanges));
         }
         ColumnChunk columnChunk = columnReader.readPrimitive();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -146,7 +146,8 @@ public class TestParquetWriter
                 new ColumnDescriptor(new String[] {"columna"}, new PrimitiveType(REQUIRED, INT32, "columna"), 0, 0),
                 null,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Long.MAX_VALUE);
 
         pageReader.readDictionaryPage();
         assertThat(pageReader.hasNext()).isTrue();
@@ -200,7 +201,8 @@ public class TestParquetWriter
                 new ColumnDescriptor(new String[] {"columna"}, new PrimitiveType(REQUIRED, INT32, "columna"), 0, 0),
                 null,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Long.MAX_VALUE);
 
         pageReader.readDictionaryPage();
         assertThat(pageReader.hasNext()).isTrue();
@@ -220,7 +222,8 @@ public class TestParquetWriter
                 new ColumnDescriptor(new String[] {"columnb"}, new PrimitiveType(REQUIRED, INT64, "columnb"), 0, 0),
                 null,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Long.MAX_VALUE);
 
         pageReader.readDictionaryPage();
         assertThat(pageReader.hasNext()).isTrue();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -191,6 +191,23 @@ public class ParquetReaderConfig
         return options.getMaxFooterReadSize();
     }
 
+    @Config("parquet.max-page-read-size")
+    @ConfigDescription("Maximum allowed size of a parquet page during reads. Files with parquet pages larger than this will generate an exception on read")
+    public ParquetReaderConfig setMaxPageReadSize(DataSize maxPageSize)
+    {
+        options = ParquetReaderOptions.builder(options)
+                .withMaxPageReadSize(maxPageSize)
+                .build();
+        return this;
+    }
+
+    @NotNull
+    @MinDataSize("4MB")
+    public DataSize getMaxPageReadSize()
+    {
+        return options.getMaxPageReadSize();
+    }
+
     public ParquetReaderOptions toParquetReaderOptions()
     {
         return options;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -40,7 +40,8 @@ public class TestParquetReaderConfig
                 .setUseBloomFilter(true)
                 .setSmallFileThreshold(DataSize.of(3, MEGABYTE))
                 .setVectorizedDecodingEnabled(true)
-                .setMaxFooterReadSize(DataSize.of(15, MEGABYTE)));
+                .setMaxFooterReadSize(DataSize.of(15, MEGABYTE))
+                .setMaxPageReadSize(DataSize.of(500, MEGABYTE)));
     }
 
     @Test
@@ -57,6 +58,7 @@ public class TestParquetReaderConfig
                 .put("parquet.small-file-threshold", "1kB")
                 .put("parquet.experimental.vectorized-decoding.enabled", "false")
                 .put("parquet.max-footer-read-size", "25MB")
+                .put("parquet.max-page-read-size", "123MB")
                 .buildOrThrow();
 
         ParquetReaderConfig expected = new ParquetReaderConfig()
@@ -69,7 +71,8 @@ public class TestParquetReaderConfig
                 .setUseBloomFilter(false)
                 .setSmallFileThreshold(DataSize.of(1, KILOBYTE))
                 .setVectorizedDecodingEnabled(false)
-                .setMaxFooterReadSize(DataSize.of(25, MEGABYTE));
+                .setMaxFooterReadSize(DataSize.of(25, MEGABYTE))
+                .setMaxPageReadSize(DataSize.of(123, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

  This PR implements page-level size limits for Parquet file reading to prevent
  out-of-memory errors caused by extremely large pages.

  **Background:**
  - Related to issue #27148
  - Page-level validation is more precise and catches issues earlier in the reading
  process

  **Why page-level instead of column-level:**
  - Validation occurs when reading page headers in `ParquetColumnChunkIterator`,
  before page objects are created
  - Applies uniformly to all page types (DataPageV1, DataPageV2, DictionaryPage)
  - Catches oversized pages earlier, preventing memory allocation for invalid data
  - More aligned with Parquet's actual structure where pages are the basic read unit

  **Changes:**
  - Added `maxPageSizeInBytes` parameter to `ParquetColumnChunkIterator` to validate
  uncompressed page size
  - Throws `ParquetCorruptionException` when a page exceeds the configured limit
  - Added ~~session property `parquet_max_page_size` and~~ config property
  `parquet.max-page-read-size` (default: **500MB**) for:
    - Hive connector
    - Iceberg connector
    - Delta Lake connector
  - ~~Added unit test `TestPageReader.testPageSizeLimit()` to verify the validation
  logic~~

  ## Additional context and related issues

  - Relates to #27148: Prevent OOM from extremely large rows
  - The default limit of 500MB balances memory safety with compatibility for
  legitimate large pages
  - Validation happens at ParquetColumnChunkIterator.next() after reading page header
  but before creating page objects

  ## Release notes

  ( ) This is not user-visible or is docs only, and no release notes are required.
  ( ) Release notes are required. Please propose a release note for me.
  (x) Release notes are required, with the following suggested text:

```markdown
## Hive, Delta, Hudi, Iceberg
* Avoid reading unusually large pages from parquet files. The configuration property `parquet.max-page-read-size` can be used to limit the maximum allowed size of a parquet page during reads. Files with parquet pages larger than this will generate an exception on read.
  ({issue}`27148`)
```