### PR TITLE
Disable Redshift Cloud tests to fix master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,8 +509,8 @@ jobs:
             - { modules: plugin/trino-postgresql }
             - { modules: plugin/trino-redis }
             - { modules: plugin/trino-redshift }
-            - { modules: plugin/trino-redshift, profile: cloud-tests }
-            - { modules: plugin/trino-redshift, profile: fte-tests }
+            #- { modules: plugin/trino-redshift, profile: cloud-tests }
+            #- { modules: plugin/trino-redshift, profile: fte-tests }
             - { modules: plugin/trino-resource-group-managers }
             - { modules: plugin/trino-singlestore }
             - { modules: plugin/trino-snowflake }


### PR DESCRIPTION
Master is red due to resource provisioning issue. The tests will be re-enabled once the issue is solved.

https://github.com/trinodb/trino/commits/master/

<img width="614" height="1258" alt="image" src="https://github.com/user-attachments/assets/2da1993d-8326-45b1-89e2-063d0859ecac" />

