### PR TITLE
docs(elasticsearch): update example timestamp

### DIFF
--- a/docs/src/main/sphinx/connector/elasticsearch.md
+++ b/docs/src/main/sphinx/connector/elasticsearch.md
@@ -239,7 +239,7 @@ For example, you can have an Elasticsearch index that contains documents with th
     "array_string_field": ["trino","the","lean","machine-ohs"],
     "long_field": 314159265359,
     "id_field": "564e6982-88ee-4498-aa98-df9e3f6b6109",
-    "timestamp_field": "1987-09-17T06:22:48.000Z",
+    "timestamp_field": "2025-09-17T06:22:48.000Z",
     "object_field": {
         "array_int_field": [86,75,309],
         "int_field": 2


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Updating the example timestamp in the doc to a more current date in the Elasticsearch connector documentation.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This sounds like a weird PR, but a coworker noticed that Google was assuming the doc was created in 1987 (thanks @skedida!), maybe because it is a too specific timestamp in a structured format:

<img width="662" height="324" alt="image" src="https://github.com/user-attachments/assets/49fa724b-1c19-48af-8ee8-cd1078ffccad" />


To avoid that quirk, I'm bumping the timestamp in the example to a more reasonable one this year (unaware if there's any reason to keep it in 1987).



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

