### PR TITLE
Fix preview UI to render catalog properties correctly

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryOverview.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryOverview.tsx
@@ -291,9 +291,13 @@ export const QueryOverview = () => {
                         {key}={value}
                     </div>
                 ))}
-                {Object.entries(session.catalogProperties).map(([key, value]) => (
-                    <div key={key}>
-                        {key}={value}
+                {Object.entries(session.catalogProperties).map(([catalog, catalogProperties]) => (
+                    <div key={catalog}>
+                        {Object.entries(catalogProperties).map(([key, value]) => (
+                            <div key={catalog + key}>
+                                {catalog}.{key}={value}
+                            </div>
+                        ))}
                     </div>
                 ))}
             </>


### PR DESCRIPTION
## Description

The query details page in the Preview UI fails when `catalogProperties` are set for a given query session. For example:

```
{
...
        "systemProperties": {
            "query_max_run_time": "3600000ms"
        },
        "catalogProperties": {
            "data_lake_iceberg": {
                "max_partitions_per_writer": "500",
                "expire_snapshots_min_retention": "2h",
                "remove_orphan_files_min_retention": "2d"
            }
        },
...
```

The react component does not properly handle nested `catalogProperty` objects and throws the following exception:

```
react-dom_client.js?v=2c8e0913:5440 Uncaught Error: Objects are not valid as a React child (found: object with keys {max_partitions_per_writer, expire_snapshots_min_retention, remove_orphan_files_min_retention}). If you meant to render a collection of children, use an array instead.
```

This PR updates the component to correctly render nested session catalog properties.

## Additional context and related issues

After the fix catalog properties are displayed as expected:

<img width="1688" height="982" alt="image" src="https://github.com/user-attachments/assets/f3ba5477-ea0c-4fd0-b87a-4e490f18a7c2" />


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix preview UI to render catalog properties correctly. ({issue}`27327`)
```
