### PR TITLE
Add indentation parameter to json_format function

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonFunctions.java
@@ -700,6 +700,42 @@ public class TestJsonFunctions
     }
 
     @Test
+    public void testJsonFormatWithIndentation()
+    {
+        assertThat(assertions.function("json_format", "JSON '{\"a\":1,\"b\":2}'", "2"))
+                .hasType(VARCHAR)
+                .isEqualTo("{\n  \"a\" : 1,\n  \"b\" : 2\n}");
+
+        assertThat(assertions.function("json_format", "JSON '{\"a\":1,\"b\":2}'", "4"))
+                .hasType(VARCHAR)
+                .isEqualTo("{\n    \"a\" : 1,\n    \"b\" : 2\n}");
+
+        assertThat(assertions.function("json_format", "JSON '{\"a\":1,\"b\":2}'", "0"))
+                .hasType(VARCHAR)
+                .isEqualTo("{\"a\":1,\"b\":2}");
+
+        assertThat(assertions.function("json_format", "JSON '{\"a\":{\"x\":1},\"b\":[1,2]}'", "2"))
+                .hasType(VARCHAR)
+                .isEqualTo("{\n  \"a\" : {\n    \"x\" : 1\n  },\n  \"b\" : [\n    1,\n    2\n  ]\n}");
+
+        assertThat(assertions.function("json_format", "JSON '[1,2,3]'", "2"))
+                .hasType(VARCHAR)
+                .isEqualTo("[\n  1,\n  2,\n  3\n]");
+
+        assertThat(assertions.function("json_format", "JSON '{\"id\":9223372036854775807}'", "2"))
+                .hasType(VARCHAR)
+                .isEqualTo("{\n  \"id\" : 9223372036854775807\n}");
+    }
+
+    @Test
+    public void testJsonFormatWithIndentationInvalid()
+    {
+        assertTrinoExceptionThrownBy(assertions.function("json_format", "JSON '{\"a\":1}'", "-1")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Indentation spaces must be non-negative");
+    }
+
+    @Test
     public void testJsonSize()
     {
         assertThat(assertions.function("json_size", "'{\"x\": {\"a\" : 1, \"b\" : 2} }'", "'$'"))

--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -1894,6 +1894,32 @@ SELECT json_format(JSON '[1, 2, 3]'); -- '[1,2,3]'
 SELECT json_format(JSON '"a"');       -- '"a"'
 ```
 
+:::{function} json_format(json, indent_spaces) -> varchar
+:no-index:
+Returns the JSON text serialized from the input JSON value with specified
+indentation. The `indent_spaces` parameter specifies the number of spaces to use
+for indentation. This is useful for formatting JSON output in a human-readable
+format, especially when working with clients that cannot handle large integers
+in compact JSON strings.
+
+```
+SELECT json_format(JSON '{"a": 1, "b": 2}', 2);
+-- '{
+--   "a" : 1,
+--   "b" : 2
+-- }'
+
+SELECT json_format(JSON '{"id": 9223372036854775807}', 2);
+-- '{
+--   "id" : 9223372036854775807
+-- }'
+```
+
+When `indent_spaces` is 0, the function returns the compact format (same as
+the single-argument version). The `indent_spaces` parameter must be
+non-negative.
+:::
+
 :::{note}
 {func}`json_format` and `CAST(json AS VARCHAR)` have completely
 different semantics.


### PR DESCRIPTION
## Description
Adds additional formatting options for JSON by overloading the existing `json_format` function with a `indentSpaces` parameter to add formatting without impacting precision. 

## Additional context and related issues
`json_format` currently outputs compact JSON, which is hard to read in tools that display raw strings. Adding optional pretty-printing improves readability without losing precision, especially for clients like Grafana that mishandle large integers when parsing JSON. This feature is fully backward-compatible and opt-in.
Related to #27113


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
