### PR TITLE
Remove unnecessary use of PageBuilder in PositionDeleteWriter

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
@@ -24,8 +24,8 @@ import io.trino.plugin.iceberg.IcebergFileWriterFactory;
 import io.trino.plugin.iceberg.MetricsWrapper;
 import io.trino.plugin.iceberg.PartitionData;
 import io.trino.spi.Page;
-import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorSession;
 import org.apache.iceberg.FileContent;
@@ -42,7 +42,6 @@ import java.util.Optional;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -112,26 +111,69 @@ public class PositionDeleteWriter
 
     private void writeDeletes(ImmutableLongBitmapDataProvider rowsToDelete)
     {
-        PageBuilder pageBuilder = new PageBuilder(List.of(BIGINT));
-
+        PositionsList deletedPositions = new PositionsList(4 * 1024);
         rowsToDelete.forEach(rowPosition -> {
-            pageBuilder.declarePosition();
-            BIGINT.writeLong(pageBuilder.getBlockBuilder(0), rowPosition);
-            if (pageBuilder.isFull()) {
-                writePage(pageBuilder.build());
-                pageBuilder.reset();
+            deletedPositions.add(rowPosition);
+            if (deletedPositions.isFull()) {
+                writePage(deletedPositions);
+                deletedPositions.reset();
             }
         });
 
-        if (!pageBuilder.isEmpty()) {
-            writePage(pageBuilder.build());
+        if (!deletedPositions.isEmpty()) {
+            writePage(deletedPositions);
         }
     }
 
-    private void writePage(Page page)
+    private void writePage(PositionsList deletedPositions)
     {
         writer.appendRows(new Page(
-                RunLengthEncodedBlock.create(dataFilePathBlock, page.getPositionCount()),
-                page.getBlock(0)));
+                deletedPositions.size(),
+                RunLengthEncodedBlock.create(dataFilePathBlock, deletedPositions.size()),
+                new LongArrayBlock(deletedPositions.size(), Optional.empty(), deletedPositions.elements())));
+    }
+
+    // Wrapper around a long[] to provide an effectively final variable for lambda use
+    private static class PositionsList
+    {
+        private long[] positions;
+        private int size;
+
+        PositionsList(int initialCapacity)
+        {
+            this.positions = new long[initialCapacity];
+            this.size = 0;
+        }
+
+        void add(long position)
+        {
+            positions[size++] = position;
+        }
+
+        boolean isEmpty()
+        {
+            return size == 0;
+        }
+
+        boolean isFull()
+        {
+            return size == positions.length;
+        }
+
+        long[] elements()
+        {
+            return positions;
+        }
+
+        int size()
+        {
+            return size;
+        }
+
+        void reset()
+        {
+            size = 0;
+            positions = new long[positions.length];
+        }
     }
 }


### PR DESCRIPTION
## Description
We can use pre-sized arrays instead of going through PageBuilder/BlockBuilder


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
