### PR TITLE
Fix misleading error message in ParquetFileWriter

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -147,13 +147,14 @@ public final class ParquetFileWriter
             parquetWriter.close();
         }
         catch (IOException | UncheckedIOException e) {
+            TrinoException trinoException = new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Parquet file", e);
             try {
                 rollbackAction.close();
             }
-            catch (Exception _) {
-                // ignore
+            catch (Exception rollbackException) {
+                trinoException.addSuppressed(rollbackException);
             }
-            throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Parquet file", e);
+            throw trinoException;
         }
 
         if (validationInputFactory.isPresent()) {


### PR DESCRIPTION
It mentions Hive, but the code is used in contexts outside of Hive too (Iceberg, Delta Lake connectors).
