### PR TITLE
Disable Exasol product tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -912,7 +912,7 @@ jobs:
             - suite-delta-lake-databricks154
             - suite-delta-lake-databricks164
             - suite-delta-lake-databricks173
-            - suite-exasol
+            #- suite-exasol
             - suite-ranger
             - suite-gcs
             - suite-hive4


### PR DESCRIPTION
The product test environment fails to start quite deterministically, failing all builds. This needs to be urgently investigated.

Stop gap workaround for https://github.com/trinodb/trino/issues/27339, just to limit blast radius.
We should not merge this, if the result color of CI jobs is unimportant (but it believe it does matter).
