### PR TITLE
Rename string0 to separator in  concat_ws documentation

### DIFF
--- a/docs/src/main/sphinx/functions/string.md
+++ b/docs/src/main/sphinx/functions/string.md
@@ -41,10 +41,10 @@ This function provides the same functionality as the
 SQL-standard concatenation operator (`||`).
 :::
 
-:::{function} concat_ws(string0, string1, ..., stringN) -> varchar
+:::{function} concat_ws(separator, string1, ..., stringN) -> varchar
 Returns the concatenation of `string1`, `string2`, `...`, `stringN`
-using `string0` as a separator. If `string0` is null, then the return
-value is null. Any null values provided in the arguments after the
+using `separator` to join the values. If `separator` is null, then the 
+return value is null. Any null values provided in the arguments after the
 separator are skipped.
 :::
 


### PR DESCRIPTION
## Description
The diff says it all, but I renamed `string0` to `separator` in the `concat_ws(separator, string1, ..., stringN)` function documentation

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
