### PR TITLE
Revert "Bump com.github.docker-java:docker-java-api from 3.6.0 to 3.7.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-api</artifactId>
-                <version>3.7.0</version>
+                <version>3.6.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Reverts trinodb/trino#27301

This bump might cause #27339
