### PR TITLE
Retry on deadlock in SqlServerClient.getTableHandle

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -444,6 +444,12 @@ public class SqlServerClient
     }
 
     @Override
+    public Optional<JdbcTableHandle> getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        return retryOnDeadlock(() -> super.getTableHandle(session, schemaTableName), "error when getting table handle for '%s'".formatted(schemaTableName));
+    }
+
+    @Override
     public List<JdbcColumnHandle> getColumns(ConnectorSession session, SchemaTableName schemaTableName, RemoteTableName remoteTableName)
     {
         return retryOnDeadlock(() -> super.getColumns(session, schemaTableName, remoteTableName), "error when getting columns for table '%s'".formatted(remoteTableName));


### PR DESCRIPTION
## Description

Fixes a flaky `TestSqlServerConnectorTest.testSelectInformationSchemaColumns` on mater branch. 
https://github.com/trinodb/trino/actions/runs/19442491907/job/55629014545

* Follow-up of #27259 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
