### PR TITLE
Add `retain_last` and `clean_expired_metadata` options to Iceberg `expire_snapshots` table procedure

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -906,6 +906,10 @@ The command accepts an optional `retain_last` parameter to specify the minimum
 number of ancestor snapshots to preserve (defaults to 1), regardless of the
 `retention_threshold` value.
 
+The command accepts an optional `clean_expired_metadata` parameter (defaults to false).
+When true, cleans up metadata such as partition specs and schemas that are no
+longer referenced by snapshots.
+
 (iceberg-remove-orphan-files)=
 ##### remove_orphan_files
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1641,11 +1641,12 @@ public class IcebergMetadata
         int retainLast = firstNonNull(
                 (Integer) executeProperties.get("retain_last"),
                 propertyAsInt(icebergTable.properties(), MIN_SNAPSHOTS_TO_KEEP, MIN_SNAPSHOTS_TO_KEEP_DEFAULT));
+        boolean cleanExpiredMetadata = (boolean) executeProperties.get("clean_expired_metadata");
 
         return Optional.of(new IcebergTableExecuteHandle(
                 tableHandle.getSchemaTableName(),
                 EXPIRE_SNAPSHOTS,
-                new IcebergExpireSnapshotsHandle(retentionThreshold, retainLast),
+                new IcebergExpireSnapshotsHandle(retentionThreshold, retainLast, cleanExpiredMetadata),
                 icebergTable.location(),
                 icebergTable.io().properties()));
     }
@@ -2095,6 +2096,7 @@ public class IcebergMetadata
             table.expireSnapshots()
                     .expireOlderThan(session.getStart().toEpochMilli() - retention.toMillis())
                     .retainLast(expireSnapshotsHandle.retainLast())
+                    .cleanExpiredMetadata(expireSnapshotsHandle.cleanExpiredMetadata())
                     .planWith(icebergScanExecutor)
                     .commit();
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/ExpireSnapshotsTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/ExpireSnapshotsTableProcedure.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.EXPIRE_SNAPSHOTS;
 import static io.trino.spi.connector.TableProcedureExecutionMode.coordinatorOnly;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 
 public class ExpireSnapshotsTableProcedure
@@ -44,6 +45,11 @@ public class ExpireSnapshotsTableProcedure
                                 "Number of snapshots to retain",
                                 null,
                                 value -> checkArgument(value == null || value >= 1, "Number of snapshots to retain must be at least 1"),
+                                false),
+                        booleanProperty(
+                                "clean_expired_metadata",
+                                "When true, cleans up metadata such as partition specs and schemas that are no longer referenced by snapshots",
+                                false, // Same default as cleanExpiredMetadata field in org.apache.iceberg.RemoveSnapshots
                                 false)));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergExpireSnapshotsHandle.java
@@ -18,7 +18,7 @@ import io.airlift.units.Duration;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-public record IcebergExpireSnapshotsHandle(Duration retentionThreshold, int retainLast)
+public record IcebergExpireSnapshotsHandle(Duration retentionThreshold, int retainLast, boolean cleanExpiredMetadata)
         implements IcebergProcedureHandle
 {
     public IcebergExpireSnapshotsHandle

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -31,6 +31,7 @@ import io.trino.execution.StagesInfo;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputStream;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
@@ -6625,6 +6626,66 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testExpireSnapshotsCleanExpiredMetadata()
+            throws Exception
+    {
+        String tableName = "test_expiring_snapshots_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN value");
+        assertUpdate("INSERT INTO " + tableName + " VALUES 'two'", 1);
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("VALUES VARCHAR 'one', 'two'");
+
+        List<Long> initialSnapshots = getSnapshotIds(tableName);
+        String tableLocation = getTableLocation(tableName);
+        List<String> initialFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS(retention_threshold => '0s', clean_expired_metadata => true)");
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("VALUES VARCHAR 'one', 'two'");
+        List<String> updatedFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        List<Long> updatedSnapshots = getSnapshotIds(tableName);
+        assertThat(updatedFiles).hasSize(initialFiles.size() - 2);
+        assertThat(updatedSnapshots.size()).isLessThan(initialSnapshots.size());
+        assertThat(updatedSnapshots).hasSize(1);
+        assertThat(initialSnapshots).containsAll(updatedSnapshots);
+
+        for (String updateFile : updatedFiles) {
+            if (!updateFile.endsWith(".metadata.json")) {
+                continue;
+            }
+
+            String fileName = updateFile.substring(updateFile.lastIndexOf('/') + 1);
+            String metadata = readFile(updateFile);
+            if (fileName.startsWith("00000") || fileName.startsWith("00001")) {
+                // CREATE TABLE and first INSERT only have schema-id 0
+                assertThat(metadata).contains("\"schema-id\":0").doesNotContain("\"schema-id\":1");
+            }
+            else if (fileName.startsWith("00002") || fileName.startsWith("00003")) {
+                // DROP COLUMN and second INSERT have both schema-id 0 and 1
+                assertThat(metadata).contains("\"schema-id\":0", "\"schema-id\":1");
+            }
+            else if (fileName.startsWith("00004")) {
+                // Final metadata only has schema-id 1 after cleaning expired metadata
+                assertThat(metadata).contains("\"schema-id\":1").doesNotContain("\"schema-id\":0");
+            }
+            else {
+                throw new IllegalStateException("Unexpected metadata file: " + updateFile);
+            }
+        }
+    }
+
+    private String readFile(String location)
+            throws IOException
+    {
+        try (TrinoInputStream inputStream = fileSystem.newInputFile(Location.of(location)).newStream()) {
+            return new String(inputStream.readAllBytes(), UTF_8);
+        }
+    }
+
+    @Test
     public void testExpireSnapshotsOnSnapshot()
     {
         String tableName = "test_expire_snapshots_on_snapshot_" + randomNameSuffix();
@@ -6658,7 +6719,7 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
 
         assertExplain("EXPLAIN ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')",
-                "SimpleTableExecute\\[table = iceberg:schemaTableName:tpch.test_expiring_snapshots.*\\[retentionThreshold=0\\.00s, retainLast=1].*");
+                "SimpleTableExecute\\[table = iceberg:schemaTableName:tpch.test_expiring_snapshots.*\\[retentionThreshold=0\\.00s, retainLast=1, cleanExpiredMetadata=false].*");
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #27357

## Release notes

```markdown
## Iceberg
* Add `retain_last` and `clean_expired_metadata` options to `expire_snapshots` command. ({issue}`27357`)
```
