### PR TITLE
Improve RepeatFunction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RepeatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RepeatFunction.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar;
 
+import io.airlift.units.DataSize;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.function.Description;
@@ -23,6 +24,7 @@ import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.util.Failures.checkCondition;
@@ -32,8 +34,8 @@ import static java.lang.Math.toIntExact;
 @Description("Repeat an element for a given number of times")
 public final class RepeatFunction
 {
-    private static final long MAX_RESULT_ENTRIES = 10_000;
-    private static final long MAX_SIZE_IN_BYTES = 1_000_000;
+    private static final long MAX_RESULT_ENTRIES = 100_000;
+    private static final long MAX_SIZE_IN_BYTES = DataSize.of(4, MEGABYTE).toBytes();
 
     private RepeatFunction() {}
 
@@ -100,7 +102,7 @@ public final class RepeatFunction
 
     private static void checkCountConditions(long count)
     {
-        checkCondition(count <= MAX_RESULT_ENTRIES, INVALID_FUNCTION_ARGUMENT, "count argument of repeat function must be less than or equal to 10000");
+        checkCondition(count <= MAX_RESULT_ENTRIES, INVALID_FUNCTION_ARGUMENT, "count argument of repeat function must be less than or equal to %s", MAX_RESULT_ENTRIES);
         checkCondition(count >= 0, INVALID_FUNCTION_ARGUMENT, "count argument of repeat function must be greater than or equal to 0");
     }
 
@@ -114,6 +116,7 @@ public final class RepeatFunction
         checkCondition(
                 block.getSizeInBytes() <= MAX_SIZE_IN_BYTES,
                 INVALID_FUNCTION_ARGUMENT,
-                "result of repeat function must not take more than 1000000 bytes");
+                "result of repeat function must not take more than %s bytes",
+                MAX_SIZE_IN_BYTES);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -4231,10 +4231,10 @@ public class TestArrayOperators
         assertTrinoExceptionThrownBy(assertions.function("repeat", "1", "1000000")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(assertions.function("repeat", "'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongvarchar'", "9999")::evaluate)
+        assertTrinoExceptionThrownBy(assertions.function("repeat", "'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongvarchar'", "99999")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(assertions.function("repeat", "array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]", "9999")::evaluate)
+        assertTrinoExceptionThrownBy(assertions.function("repeat", "array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]", "99999")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 


### PR DESCRIPTION
## Description
Improve performance of RepeatFunction by using RunLengthEncodedBlock directly
instead of going through BlockBuilder

Expand the max size limits on the function


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of `repeat` function. ({issue}`27369`)
```
