### PR TITLE
Add method to provide Identity from Authenticator's in SPI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/UserMapping.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/UserMapping.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.security.Identity;
 import io.trino.util.Case;
 
 import java.io.File;
@@ -67,6 +68,14 @@ public final class UserMapping
         }
 
         throw new UserMappingException("No user mapping patterns match the principal");
+    }
+
+    public Identity mapIdentity(Identity identity)
+            throws UserMappingException
+    {
+        return Identity.from(identity)
+                .withUser(mapUser(identity.getUser()))
+                .build();
     }
 
     public static final class UserMappingRules

--- a/core/trino-spi/src/main/java/io/trino/spi/security/CertificateAuthenticator.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/CertificateAuthenticator.java
@@ -16,6 +16,7 @@ package io.trino.spi.security;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Optional;
 
 public interface CertificateAuthenticator
 {
@@ -28,5 +29,20 @@ public interface CertificateAuthenticator
      * @return the authenticated entity
      * @throws AccessDeniedException if not allowed
      */
+    @Deprecated
     Principal authenticate(List<X509Certificate> certificates);
+
+    /**
+     * If implemented and authenticated; extract principal from client certificate and
+     * provide an {@link Identity}.
+     *
+     * @param certificates This client certificate chain, in ascending order of trust.
+     * The first certificate in the chain is the one set by the client, the next is the
+     * one used to authenticate the first, and so on.
+     * @return the authenticated {@link Identity}
+     */
+    default Optional<Identity> createAuthenticatedIdentity(List<X509Certificate> certificates)
+    {
+        return Optional.empty();
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/HeaderAuthenticator.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/HeaderAuthenticator.java
@@ -15,6 +15,7 @@ package io.trino.spi.security;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Optional;
 
 public interface HeaderAuthenticator
 {
@@ -29,7 +30,18 @@ public interface HeaderAuthenticator
      *
      * @return the authenticated entity
      * @throws AccessDeniedException if not allowed
-
      */
+    @Deprecated
     Principal createAuthenticatedPrincipal(Headers headers);
+
+    /**
+     * If implemented and authenticated; provide an {@link Identity}.
+     *
+     * @param headers headers used to authenticate
+     * @return the authenticated {@link Identity}
+     */
+    default Optional<Identity> createAuthenticatedIdentity(Headers headers)
+    {
+        return Optional.empty();
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/PasswordAuthenticator.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/PasswordAuthenticator.java
@@ -14,6 +14,7 @@
 package io.trino.spi.security;
 
 import java.security.Principal;
+import java.util.Optional;
 
 public interface PasswordAuthenticator
 {
@@ -23,5 +24,16 @@ public interface PasswordAuthenticator
      * @return the authenticated entity
      * @throws AccessDeniedException if not allowed
      */
+    @Deprecated
     Principal createAuthenticatedPrincipal(String user, String password);
+
+    /**
+     * If implemented and authenticated; provide an {@link Identity}.
+     *
+     * @return the authenticated {@link Identity}
+     */
+    default Optional<Identity> createAuthenticatedIdentity(String user, String password)
+    {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
## Description
Introduce additional methods to the SPI authenticators to directly provide an `Identity`.

### Problem
Some authentication methods can also have authorization information (i.e. - `Identity.groups` population using `JWT claims`.. also see [comments](https://github.com/trinodb/trino/pull/22944#issuecomment-2483047829)) but there is no way to provide that information to the `Identity` given the current implementation (only accepts a `Principal`).

### Solution
Allow implementing classes to provide an `Identity` directly. This allows significantly more flexibility in shaping what properties an `Identity` has and better decoupling from main.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
