### PR TITLE
Fix recording of query completion event for query failures before execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -183,6 +183,7 @@ public class QueryMonitor
 
     public void queryImmediateFailureEvent(BasicQueryInfo queryInfo, ExecutionFailureInfo failure)
     {
+        BasicQueryStats queryStats = queryInfo.getQueryStats();
         eventListenerManager.queryCompleted(requiresAnonymizedPlan -> new QueryCompletedEvent(
                 new QueryMetadata(
                         queryInfo.getQueryId().toString(),
@@ -201,16 +202,16 @@ public class QueryMonitor
                 new QueryStatistics(
                         Duration.ZERO,
                         Duration.ZERO,
-                        Duration.ZERO,
-                        queryInfo.getQueryStats().getQueuedTime().toJavaTime(),
+                        queryStats.getElapsedTime().toJavaTime(),
+                        queryStats.getQueuedTime().toJavaTime(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.of(queryStats.getResourceWaitingTime().toJavaTime()),
+                        Optional.of(queryStats.getAnalysisTime().toJavaTime()),
+                        Optional.of(queryStats.getPlanningTime().toJavaTime()),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
+                        Optional.of(queryStats.getExecutionTime().toJavaTime()),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),


### PR DESCRIPTION
## Description
queryImmediateFailureEvent can be called for queries which fail during analysis, resource waiting or planning
It is updated to populate the relevant metrics


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
