### PR TITLE
Avoid nullptr exceptions in ConnectorAwareSplitSource#close

### DIFF
--- a/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
  * Thread-safety: the implementations is not thread-safe
  *
  * Note: The implementation is internally not thread-safe but also {@link ConnectorSplitSource} is
- * not required to be thread-safe.
+ * not required to be thread-safe, except the close() method which may be called concurrently.
  */
 @NotThreadSafe
 public class ConnectorAwareSplitSource
@@ -95,7 +95,7 @@ public class ConnectorAwareSplitSource
         closeSource();
     }
 
-    private void closeSource()
+    private synchronized void closeSource()
     {
         if (source != null) {
             try {


### PR DESCRIPTION
## Description

```
java.lang.NullPointerException: Cannot invoke "io.trino.spi.connector.ConnectorSplitSource.getMetrics()" because "this.source" is null
	at io.trino.split.ConnectorAwareSplitSource.closeSource(ConnectorAwareSplitSource.java:103)
	at io.trino.split.ConnectorAwareSplitSource.close(ConnectorAwareSplitSource.java:95)
	at io.trino.split.TracingSplitSource.close(TracingSplitSource.java:96)
	at io.trino.split.BufferingSplitSource.close(BufferingSplitSource.java:68)
	at io.trino.split.TracingSplitSource.close(TracingSplitSource.java:96)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.closeSplitSources(PipelinedQueryScheduler.java:1361)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler$1.stateChanged(PipelinedQueryScheduler.java:1190)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler$1.stateChanged(PipelinedQueryScheduler.java:1180)
	at io.trino.execution.StateMachine.fireStateChangedListener(StateMachine.java:240)
	at io.trino.execution.StateMachine.lambda$fireStateChanged$0(StateMachine.java:232)
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
