### PR TITLE
Add support for PostgreSQL-style shorthand casts

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -109,6 +109,7 @@ import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SimpleCaseExpression;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.Trim;
@@ -316,6 +317,7 @@ public class TranslationMap
                 case io.trino.sql.tree.FieldReference expression -> translate(expression);
                 case Identifier expression -> translate(expression);
                 case FunctionCall expression -> translate(expression);
+                case StaticMethodCall expression -> translate(expression);
                 case DereferenceExpression expression -> translate(expression);
                 case Array expression -> translate(expression);
                 case CurrentCatalog expression -> translate(expression);
@@ -661,6 +663,14 @@ public class TranslationMap
                 expression.getArguments().stream()
                         .map(this::translateExpression)
                         .collect(toImmutableList()));
+    }
+
+    private io.trino.sql.ir.Expression translate(StaticMethodCall expression)
+    {
+        // Currently, only PostgreSQL-style cast shorthand expressions are supported
+        return new io.trino.sql.ir.Cast(
+                translateExpression(expression.getTarget()),
+                analysis.getType(expression));
     }
 
     private io.trino.sql.ir.Expression translate(DereferenceExpression expression)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestStaticMethodCall
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    void testPostgreSqlStyleCast()
+    {
+        assertThat(assertions.expression("1::double"))
+                .hasType(DoubleType.DOUBLE)
+                .isEqualTo(1.0);
+
+        assertThat(assertions.expression("1::varchar"))
+                .hasType(VarcharType.VARCHAR)
+                .isEqualTo("1");
+
+        assertThatThrownBy(() -> assertions.expression("1::varchar(100)").evaluate())
+                .hasMessage("line 1:13: Static method calls are not supported");
+
+        assertThat(assertions.expression("(a + b)::double")
+                .binding("a", "1")
+                .binding("b", "2"))
+                .hasType(DoubleType.DOUBLE)
+                .isEqualTo(3.0);
+
+        assertThatThrownBy(() -> assertions.expression("1::decimal(3, 2)").evaluate())
+                .hasMessage("line 1:13: Static method calls are not supported");
+    }
+
+    @Test
+    void testCall()
+    {
+        assertThatThrownBy(() -> assertions.expression("1::double(2)").evaluate())
+                .hasMessage("line 1:13: Static method calls are not supported");
+
+        assertThatThrownBy(() -> assertions.expression("1::foo").evaluate())
+                .hasMessage("line 1:13: Static method calls are not supported");
+
+        assertThatThrownBy(() -> assertions.expression("integer::foo").evaluate())
+                .hasMessage("line 1:19: Static method calls are not supported");
+
+        assertThatThrownBy(() -> assertions.expression("integer::foo(1, 2)").evaluate())
+                .hasMessage("line 1:19: Static method calls are not supported");
+
+        assertThat(assertions.query("SELECT bigint::real FROM (VALUES 1) AS t(bigint)"))
+                .failure()
+                .hasMessage("line 1:14: Static method calls are not supported");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -91,6 +91,7 @@ import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.SimpleGroupBy;
 import io.trino.sql.tree.SkipTo;
 import io.trino.sql.tree.SortItem;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -462,6 +463,24 @@ public final class ExpressionFormatter
 
             if (node.getWindow().isPresent()) {
                 builder.append(" OVER ").append(formatWindow(node.getWindow().get()));
+            }
+
+            return builder.toString();
+        }
+
+        @Override
+        protected String visitStaticMethodCall(StaticMethodCall node, Void context)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            builder.append(process(node.getTarget(), context))
+                    .append("::")
+                    .append(process(node.getMethod(), context));
+
+            if (!node.getArguments().isEmpty()) {
+                builder.append('(')
+                        .append(joinExpressions(node.getArguments()))
+                        .append(')');
             }
 
             return builder.toString();

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -278,6 +278,7 @@ import io.trino.sql.tree.SkipTo;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -3102,6 +3103,16 @@ class AstBuilder
                 nulls,
                 mode,
                 arguments);
+    }
+
+    @Override
+    public Node visitStaticMethodCall(SqlBaseParser.StaticMethodCallContext context)
+    {
+        return new StaticMethodCall(
+                getLocation(context.DOUBLE_COLON()),
+                (Expression) visit(context.primaryExpression()),
+                (Identifier) visit(context.identifier()),
+                visit(context.expression(), Expression.class));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -322,6 +322,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitStaticMethodCall(StaticMethodCall node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitProcessingMode(ProcessingMode node, C context)
     {
         return visitNode(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/StaticMethodCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/StaticMethodCall.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+public class StaticMethodCall
+        extends Expression
+{
+    private final Expression target;
+    private final Identifier method;
+    private final List<Expression> arguments;
+
+    public StaticMethodCall(NodeLocation location, Expression target, Identifier method, List<Expression> arguments)
+    {
+        super(location);
+        this.target = target;
+        this.method = method;
+        this.arguments = arguments;
+    }
+
+    public Expression getTarget()
+    {
+        return target;
+    }
+
+    public Identifier getMethod()
+    {
+        return method;
+    }
+
+    public List<Expression> getArguments()
+    {
+        return arguments;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitStaticMethodCall(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.<Node>builder()
+                .add(target)
+                .add(method)
+                .addAll(arguments)
+                .build();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof StaticMethodCall that)) {
+            return false;
+        }
+        return Objects.equals(target, that.target) && Objects.equals(method, that.method) && Objects.equals(arguments, that.arguments);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(target, method, arguments);
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -33,7 +33,7 @@ public class TestSqlParserErrorHandling
     {
         return Stream.of(
                 Arguments.of("", "line 1:1: mismatched input '<EOF>'. Expecting: <expression>"),
-                Arguments.of("1 + 1 x", "line 1:7: mismatched input 'x'. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'OR', '[', '||', <EOF>, <predicate>"));
+                Arguments.of("1 + 1 x", "line 1:7: mismatched input 'x'. Expecting: '%', '*', '+', '-', '.', '/', '::', 'AND', 'AT', 'OR', '[', '||', <EOF>, <predicate>"));
     }
 
     private static Stream<Arguments> statements()
@@ -67,7 +67,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("select 1x from dual",
                         "line 1:8: identifiers must not start with a digit; surround the identifier with double quotes"),
                 Arguments.of("select fuu from dual order by fuu order by fuu",
-                        "line 1:35: mismatched input 'order'. Expecting: '%', '*', '+', ',', '-', '.', '/', 'AND', 'ASC', 'AT', 'DESC', 'FETCH', 'LIMIT', 'NULLS', 'OFFSET', 'OR', '[', '||', <EOF>, <predicate>"),
+                        "line 1:35: mismatched input 'order'. Expecting: '%', '*', '+', ',', '-', '.', '/', '::', 'AND', 'ASC', 'AT', 'DESC', 'FETCH', 'LIMIT', 'NULLS', 'OFFSET', 'OR', '[', '||', <EOF>, <predicate>"),
                 Arguments.of("select fuu from dual limit 10 order by fuu",
                         "line 1:31: mismatched input 'order'. Expecting: <EOF>"),
                 Arguments.of("select CAST(12223222232535343423232435343 AS BIGINT)",
@@ -99,7 +99,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT x() over (ROWS select) FROM t",
                         "line 1:23: mismatched input 'select'. Expecting: ')', 'BETWEEN', 'CURRENT', 'GROUPS', 'MEASURES', 'ORDER', 'PARTITION', 'RANGE', 'ROWS', 'UNBOUNDED', <expression>"),
                 Arguments.of("SELECT X() OVER (ROWS UNBOUNDED) FROM T",
-                        "line 1:32: mismatched input ')'. Expecting: '%', '(', '*', '+', '-', '->', '.', '/', 'AND', 'AT', 'FOLLOWING', 'OR', 'OVER', 'PRECEDING', '[', '||', <predicate>, <string>"),
+                        "line 1:32: mismatched input ')'. Expecting: '%', '(', '*', '+', '-', '->', '.', '/', '::', 'AND', 'AT', 'FOLLOWING', 'OR', 'OVER', 'PRECEDING', '[', '||', <predicate>, <string>"),
                 Arguments.of("SELECT a FROM x ORDER BY (SELECT b FROM t WHERE ",
                         "line 1:49: mismatched input '<EOF>'. Expecting: <expression>"),
                 Arguments.of("SELECT a FROM a AS x TABLESAMPLE x ",
@@ -134,7 +134,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT a FROM \"\".s.t",
                         "line 1:15: Zero-length delimited identifier not allowed"),
                 Arguments.of("WITH t AS (SELECT 1 SELECT t.* FROM t",
-                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
+                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', '::', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
                                 "'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WHERE', 'WINDOW', '[', '||', " +
                                 "<identifier>, <predicate>"),
                 Arguments.of("SHOW CATALOGS LIKE '%$_%' ESCAPE",
@@ -160,9 +160,9 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT * FROM t FOR VERSION AS OF TIMESTAMP WHERE",
                         "line 1:50: mismatched input '<EOF>'. Expecting: <expression>"),
                 Arguments.of("SELECT ROW(DATE '2022-10-10', DOUBLE 12.0)",
-                        "line 1:38: mismatched input '12.0'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', 'AND', 'AT', 'OR', 'ORDER', 'OVER', 'PRECISION', '[', '||', <predicate>, <string>"),
+                        "line 1:38: mismatched input '12.0'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'ORDER', 'OVER', 'PRECISION', '[', '||', <predicate>, <string>"),
                 Arguments.of("VALUES(DATE 2)",
-                        "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
+                        "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
                 Arguments.of("SELECT count(DISTINCT *) FROM (VALUES 1)",
                         "line 1:23: mismatched input '*'. Expecting: <expression>"));
     }
@@ -182,7 +182,7 @@ public class TestSqlParserErrorHandling
                         "1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * " +
                         "1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * " +
                         "1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9",
-                "line 1:375: mismatched input '<EOF>'. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'OR', 'THEN', '[', '||', <predicate>");
+                "line 1:375: mismatched input '<EOF>'. Expecting: '%', '*', '+', '-', '.', '/', '::', 'AND', 'AT', 'OR', 'THEN', '[', '||', <predicate>");
     }
 
     @Test
@@ -212,7 +212,7 @@ public class TestSqlParserErrorHandling
                         "OR (f()\n" +
                         "OR (f()\n" +
                         "GROUP BY id",
-                "line 24:1: mismatched input 'GROUP'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AT', 'FILTER', 'IGNORE', 'OR', 'OVER', 'RESPECT', '[', '||', <predicate>");
+                "line 24:1: mismatched input 'GROUP'. Expecting: '%', ')', '*', '+', ',', '-', '.', '/', '::', 'AND', 'AT', 'FILTER', 'IGNORE', 'OR', 'OVER', 'RESPECT', '[', '||', <predicate>");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Standard SQL supports static method calls on types via the :: operator. While this syntax is generally incompatible with PostgreSQL shorthand cast syntax, there's a subset of that can be safely repurposed to support that functionality.

The SQL specification defines static method calls as:

```
   <static method invocation> ::=
      <path-resolved user-defined type name> <double colon> <method name>
      [ <SQL argument list> ]
```

where `<path-resolved user-defined type name> `translates to:

```
   <user-defined type name> ::=
      [ <schema name> <period> ] <qualified identifier>
```

To support casts, we need to extend the rule to support arbitrary expressions as the target of the invocation. To disambiguate a static method call from a cast, we distinguish between type-producing expressions and expressions that produce regular values. For the latter, if the method matches the name of a well-known type, we treat it as a cast. Otherwise, the expression assumed to be a static method call and fail the evaluation with a "not yet supported" error.

One limitation is that casts are only supported for simple types. Parametric types are not yet supported, but it wouldn't be too hard to add. Types whose name don't match the syntax of SQL function calls are not supported either and will be harder to support. That will require introducing type-producing expressions into the language and making types first-class expressions.

Fixes https://github.com/trinodb/trino/issues/23795

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support to simplified cast expressions with the `::` operator. ({issue}`23795`)
```
