### PR TITLE
Parquet reader - avoid redundant dictionary reads

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -16,20 +16,10 @@ package io.trino.parquet.predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.slice.Slice;
-import io.airlift.slice.SliceInput;
-import io.airlift.slice.Slices;
 import io.trino.parquet.BloomFilterStore;
-import io.trino.parquet.DictionaryPage;
 import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
-import io.trino.parquet.ParquetDataSourceId;
-import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.ParquetReaderOptions;
-import io.trino.parquet.crypto.AesCipherUtils;
-import io.trino.parquet.crypto.ColumnDecryptionContext;
-import io.trino.parquet.crypto.FileDecryptionContext;
-import io.trino.parquet.crypto.ModuleType;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ColumnChunkMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
@@ -39,20 +29,12 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.format.BlockCipher;
-import org.apache.parquet.format.DictionaryPageHeader;
-import org.apache.parquet.format.PageHeader;
-import org.apache.parquet.format.PageType;
-import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
-import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.MessageType;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
@@ -61,9 +43,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.parquet.BloomFilterStore.getBloomFilterStore;
-import static io.trino.parquet.ParquetCompressionUtils.decompress;
-import static io.trino.parquet.ParquetReaderUtils.isOnlyDictionaryEncodingPages;
-import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
 import static io.trino.parquet.metadata.PrunedBlockMetadata.createPrunedColumnsMetadata;
 import static io.trino.parquet.reader.TrinoColumnIndexStore.getColumnIndexStore;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -71,20 +50,10 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.format.Util.readPageHeader;
 
 public final class PredicateUtils
 {
-    // Maximum size of dictionary that we will read for row-group pruning.
-    // Reading larger dictionaries is typically not beneficial. Before checking
-    // the dictionary, the row-group, page indexes and bloomfilters have already been checked
-    // and when the dictionary does not eliminate a row-group, the work done to
-    // decode the dictionary and match it with predicates is wasted.
-    private static final int MAX_DICTIONARY_SIZE = 8096;
-
     private PredicateUtils() {}
 
     public static boolean isStatisticsOverflow(Type type, long min, long max)
@@ -139,7 +108,7 @@ public final class PredicateUtils
         return new TupleDomainParquetPredicate(parquetTupleDomain, columnReferences.build(), timeZone);
     }
 
-    public static boolean predicateMatches(
+    private static PredicateMatchResult predicateMatches(
             TupleDomainParquetPredicate parquetPredicate,
             PrunedBlockMetadata columnsMetadata,
             ParquetDataSource dataSource,
@@ -148,21 +117,20 @@ public final class PredicateUtils
             Optional<ColumnIndexStore> columnIndexStore,
             Optional<BloomFilterStore> bloomFilterStore,
             DateTimeZone timeZone,
-            int domainCompactionThreshold,
-            Optional<FileDecryptionContext> decryptionContext)
+            int domainCompactionThreshold)
             throws IOException
     {
         if (columnsMetadata.getRowCount() == 0) {
-            return false;
+            return PredicateMatchResult.FALSE_WITH_DICT_MATCHING_NOT_NEEDED;
         }
         Map<ColumnDescriptor, Statistics<?>> columnStatistics = getStatistics(columnsMetadata, descriptorsByPath);
         Map<ColumnDescriptor, Long> columnValueCounts = getColumnValueCounts(columnsMetadata, descriptorsByPath);
         Optional<List<ColumnDescriptor>> candidateColumns = parquetPredicate.getIndexLookupCandidates(columnValueCounts, columnStatistics, dataSource.getId());
         if (candidateColumns.isEmpty()) {
-            return false;
+            return PredicateMatchResult.FALSE_WITH_DICT_MATCHING_NOT_NEEDED;
         }
         if (candidateColumns.get().isEmpty()) {
-            return true;
+            return PredicateMatchResult.TRUE_WITH_DICT_MATCHING_NOT_NEEDED;
         }
         // Perform column index, bloom filter checks and dictionary lookups only for the subset of columns where it can be useful.
         // This prevents unnecessary filesystem reads and decoding work when the predicate on a column comes from
@@ -171,21 +139,14 @@ public final class PredicateUtils
 
         // Page stats is finer grained but relatively more expensive, so we do the filtering after above block filtering.
         if (columnIndexStore.isPresent() && !indexPredicate.matches(columnValueCounts, columnIndexStore.get(), dataSource.getId())) {
-            return false;
+            return PredicateMatchResult.FALSE_WITH_DICT_MATCHING_NOT_NEEDED;
         }
 
         if (bloomFilterStore.isPresent() && !indexPredicate.matches(bloomFilterStore.get(), domainCompactionThreshold)) {
-            return false;
+            return PredicateMatchResult.FALSE_WITH_DICT_MATCHING_NOT_NEEDED;
         }
 
-        return dictionaryPredicatesMatch(
-                indexPredicate,
-                columnsMetadata,
-                dataSource,
-                descriptorsByPath,
-                ImmutableSet.copyOf(candidateColumns.get()),
-                columnIndexStore,
-                decryptionContext);
+        return new PredicateMatchResult(true, Optional.of(indexPredicate), Optional.of(ImmutableSet.copyOf(candidateColumns.get())));
     }
 
     public static List<RowGroupInfo> getFilteredRowGroups(
@@ -209,7 +170,7 @@ public final class PredicateUtils
                 Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options, parquetMetadata.getDecryptionContext());
                 Optional<BloomFilterStore> bloomFilterStore = getBloomFilterStore(dataSource, block, parquetTupleDomain, options, parquetMetadata.getDecryptionContext());
                 PrunedBlockMetadata columnsMetadata = createPrunedColumnsMetadata(block, dataSource.getId(), descriptorsByPath);
-                if (predicateMatches(
+                PredicateMatchResult predicateMatchResult = predicateMatches(
                         parquetPredicate,
                         columnsMetadata,
                         dataSource,
@@ -218,9 +179,9 @@ public final class PredicateUtils
                         columnIndex,
                         bloomFilterStore,
                         timeZone,
-                        domainCompactionThreshold,
-                        parquetMetadata.getDecryptionContext())) {
-                    rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, block.fileRowCountOffset(), columnIndex));
+                        domainCompactionThreshold);
+                if (predicateMatchResult.matchesWithoutDictionary()) {
+                    rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, block.fileRowCountOffset(), columnIndex, predicateMatchResult.indexPredicate(), predicateMatchResult.candidateColumnsForDictionaryMatching()));
                     break;
                 }
             }
@@ -253,147 +214,9 @@ public final class PredicateUtils
         return columnValueCounts.buildOrThrow();
     }
 
-    private static boolean dictionaryPredicatesMatch(
-            TupleDomainParquetPredicate parquetPredicate,
-            PrunedBlockMetadata columnsMetadata,
-            ParquetDataSource dataSource,
-            Map<List<String>, ColumnDescriptor> descriptorsByPath,
-            Set<ColumnDescriptor> candidateColumns,
-            Optional<ColumnIndexStore> columnIndexStore,
-            Optional<FileDecryptionContext> decryptionContext)
-            throws IOException
+    private record PredicateMatchResult(boolean matchesWithoutDictionary, Optional<TupleDomainParquetPredicate> indexPredicate, Optional<Set<ColumnDescriptor>> candidateColumnsForDictionaryMatching)
     {
-        for (ColumnDescriptor descriptor : descriptorsByPath.values()) {
-            ColumnChunkMetadata columnMetaData = columnsMetadata.getColumnChunkMetaData(descriptor);
-            if (!candidateColumns.contains(descriptor)) {
-                continue;
-            }
-            if (isOnlyDictionaryEncodingPages(columnMetaData)) {
-                Statistics<?> columnStatistics = columnMetaData.getStatistics();
-                boolean nullAllowed = columnStatistics == null || columnStatistics.getNumNulls() != 0;
-                //  Early abort, predicate already filters block so no more dictionaries need be read
-                if (!parquetPredicate.matches(new DictionaryDescriptor(
-                        descriptor,
-                        nullAllowed,
-                        readDictionaryPage(dataSource, columnMetaData, columnIndexStore, decryptionContext)))) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    private static Optional<DictionaryPage> readDictionaryPage(
-            ParquetDataSource dataSource,
-            ColumnChunkMetadata columnMetaData,
-            Optional<ColumnIndexStore> columnIndexStore,
-            Optional<FileDecryptionContext> decryptionContext)
-            throws IOException
-    {
-        int dictionaryPageSize;
-        if (columnMetaData.getDictionaryPageOffset() == 0 || columnMetaData.getFirstDataPageOffset() <= columnMetaData.getDictionaryPageOffset()) {
-            /*
-             * See org.apache.parquet.hadoop.Offsets for reference.
-             * The offsets might not contain the proper values in the below cases:
-             * - The dictionaryPageOffset might not be set; in this case 0 is returned
-             *   (0 cannot be a valid offset because of the MAGIC bytes)
-             * - The firstDataPageOffset might point to the dictionary page
-             *
-             * Such parquet files may have been produced by parquet-mr writers before PARQUET-1977.
-             * We find the dictionary page size from OffsetIndex if that exists,
-             * otherwise fallback to reading the full column chunk.
-             */
-            dictionaryPageSize = columnIndexStore.flatMap(index -> getDictionaryPageSize(index, columnMetaData))
-                    .orElseGet(() -> toIntExact(columnMetaData.getTotalSize()));
-        }
-        else {
-            dictionaryPageSize = toIntExact(columnMetaData.getFirstDataPageOffset() - columnMetaData.getDictionaryPageOffset());
-        }
-        // Get the dictionary page header and the dictionary in single read
-        Slice buffer = dataSource.readFully(columnMetaData.getStartingPos(), dictionaryPageSize);
-        return readPageHeaderWithData(buffer.getInput(), columnMetaData, decryptionContext)
-                .map(data -> decodeDictionaryPage(dataSource.getId(), data, columnMetaData, decryptionContext));
-    }
-
-    private static Optional<Integer> getDictionaryPageSize(ColumnIndexStore columnIndexStore, ColumnChunkMetadata columnMetaData)
-    {
-        OffsetIndex offsetIndex = columnIndexStore.getOffsetIndex(columnMetaData.getPath());
-        if (offsetIndex == null) {
-            return Optional.empty();
-        }
-        long rowGroupOffset = columnMetaData.getStartingPos();
-        long firstPageOffset = offsetIndex.getOffset(0);
-        if (rowGroupOffset < firstPageOffset) {
-            return Optional.of(toIntExact(firstPageOffset - rowGroupOffset));
-        }
-        return Optional.empty();
-    }
-
-    private static Optional<PageHeaderWithData> readPageHeaderWithData(SliceInput inputStream, ColumnChunkMetadata columnMetaData, Optional<FileDecryptionContext> decryptionContext)
-    {
-        Optional<ColumnDecryptionContext> columnContext = decryptionContext.flatMap(context -> context.getColumnDecryptionContext(columnMetaData.getPath()));
-        BlockCipher.Decryptor decryptor = null;
-        byte[] headerAad = null;
-        if (columnContext.isPresent()) {
-            decryptor = columnContext.map(ColumnDecryptionContext::metadataDecryptor).orElse(null);
-            byte[] fileAad = decryptionContext.get().getFileAad();
-            headerAad = AesCipherUtils.createModuleAAD(fileAad, ModuleType.DictionaryPageHeader, columnMetaData.getRowGroupOrdinal(), columnMetaData.getColumnOrdinal(), -1);
-        }
-
-        final PageHeader pageHeader;
-        try {
-            pageHeader = readPageHeader(inputStream, decryptor, headerAad);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
-        if (pageHeader.type != PageType.DICTIONARY_PAGE) {
-            return Optional.empty();
-        }
-        DictionaryPageHeader dictionaryHeader = pageHeader.getDictionary_page_header();
-        if (dictionaryHeader.getNum_values() > MAX_DICTIONARY_SIZE) {
-            return Optional.empty();
-        }
-        return Optional.of(new PageHeaderWithData(
-                pageHeader,
-                inputStream.readSlice(pageHeader.getCompressed_page_size())));
-    }
-
-    private static DictionaryPage decodeDictionaryPage(ParquetDataSourceId dataSourceId, PageHeaderWithData pageHeaderWithData, ColumnChunkMetadata chunkMetaData, Optional<FileDecryptionContext> decryptionContext)
-    {
-        PageHeader pageHeader = pageHeaderWithData.pageHeader();
-        DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
-        ParquetEncoding encoding = getParquetEncoding(Encoding.valueOf(dicHeader.getEncoding().name()));
-        int dictionarySize = dicHeader.getNum_values();
-
-        Slice compressedData = pageHeaderWithData.compressedData();
-        Slice maybeDecrypted = compressedData;
-        Optional<ColumnDecryptionContext> columnContext = decryptionContext.flatMap(context -> context.getColumnDecryptionContext(chunkMetaData.getPath()));
-        if (columnContext.isPresent()) {
-            byte[] aad = AesCipherUtils.createModuleAAD(
-                    columnContext.get().fileAad(),
-                    ModuleType.DictionaryPage,
-                    chunkMetaData.getRowGroupOrdinal(),
-                    chunkMetaData.getColumnOrdinal(),
-                    -1);
-            byte[] plain = columnContext.get().dataDecryptor().decrypt(compressedData.getBytes(), aad);
-            maybeDecrypted = Slices.wrappedBuffer(plain);
-        }
-        try {
-            return new DictionaryPage(decompress(dataSourceId, chunkMetaData.getCodec().getParquetCompressionCodec(), maybeDecrypted, pageHeader.getUncompressed_page_size()), dictionarySize, encoding);
-        }
-        catch (IOException e) {
-            throw new ParquetDecodingException("Could not decode the dictionary for " + chunkMetaData.getPath(), e);
-        }
-    }
-
-    private record PageHeaderWithData(PageHeader pageHeader, Slice compressedData)
-    {
-        private PageHeaderWithData(PageHeader pageHeader, Slice compressedData)
-        {
-            this.pageHeader = requireNonNull(pageHeader, "pageHeader is null");
-            this.compressedData = requireNonNull(compressedData, "compressedData is null");
-        }
+        private static final PredicateMatchResult FALSE_WITH_DICT_MATCHING_NOT_NEEDED = new PredicateMatchResult(false, Optional.empty(), Optional.empty());
+        private static final PredicateMatchResult TRUE_WITH_DICT_MATCHING_NOT_NEEDED = new PredicateMatchResult(true, Optional.empty(), Optional.empty());
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/AbstractColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/AbstractColumnReader.java
@@ -16,8 +16,13 @@ package io.trino.parquet.reader;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
+import io.trino.parquet.metadata.ColumnChunkMetadata;
+import io.trino.parquet.metadata.PrunedBlockMetadata;
+import io.trino.parquet.predicate.DictionaryDescriptor;
+import io.trino.parquet.predicate.TupleDomainParquetPredicate;
 import io.trino.parquet.reader.decoders.ValueDecoder;
 import io.trino.parquet.reader.flat.ColumnAdapter;
 import io.trino.parquet.reader.flat.DictionaryDecoder;
@@ -28,13 +33,18 @@ import io.trino.spi.type.AbstractVariableWidthType;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.io.ParquetDecodingException;
 
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static io.trino.parquet.ParquetReaderUtils.isOnlyDictionaryEncodingPages;
 import static io.trino.parquet.reader.decoders.ValueDecoder.ValueDecodersProvider;
 import static io.trino.parquet.reader.flat.DictionaryDecoder.DictionaryDecoderProvider;
 import static io.trino.parquet.reader.flat.RowRangesIterator.createRowRangesIterator;
@@ -56,6 +66,8 @@ public abstract class AbstractColumnReader<BufferType>
     @Nullable
     protected DictionaryDecoder<BufferType> dictionaryDecoder;
     private boolean produceDictionaryBlock;
+    @Nullable
+    private DictionaryPage dictionaryPage;
 
     public AbstractColumnReader(
             PrimitiveField field,
@@ -77,6 +89,7 @@ public abstract class AbstractColumnReader<BufferType>
         // if it is partly or completely dictionary encoded. At most one dictionary page
         // can be placed in a column chunk.
         DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+        this.dictionaryPage = dictionaryPage;
 
         // For dictionary based encodings - https://github.com/apache/parquet-format/blob/master/Encodings.md
         if (dictionaryPage != null) {
@@ -85,6 +98,29 @@ public abstract class AbstractColumnReader<BufferType>
             produceDictionaryBlock = shouldProduceDictionaryBlock(rowRanges);
         }
         this.rowRanges = createRowRangesIterator(rowRanges);
+    }
+
+    @Override
+    public boolean dictionaryPredicateMatch(RowGroupInfo rowGroupInfo)
+            throws ParquetCorruptionException
+    {
+        checkState(hasPageReader(), "Don't have a pageReader yet, invoke setPageReader() first");
+        Optional<TupleDomainParquetPredicate> indexPredicate = rowGroupInfo.indexPredicate();
+        Optional<Set<ColumnDescriptor>> candidateColumnsForDictionaryMatching = rowGroupInfo.candidateColumnsForDictionaryMatching();
+        if (indexPredicate.isPresent() && candidateColumnsForDictionaryMatching.isPresent()) {
+            ColumnDescriptor descriptor = field.getDescriptor();
+            PrunedBlockMetadata prunedBlockMetadata = rowGroupInfo.prunedBlockMetadata();
+            ColumnChunkMetadata columnMetaData = prunedBlockMetadata.getColumnChunkMetaData(descriptor);
+            if (candidateColumnsForDictionaryMatching.get().contains(descriptor) && isOnlyDictionaryEncodingPages(columnMetaData)) {
+                Statistics<?> columnStatistics = columnMetaData.getStatistics();
+                boolean nullAllowed = columnStatistics == null || columnStatistics.getNumNulls() != 0;
+                return indexPredicate.get().matches(new DictionaryDescriptor(
+                        descriptor,
+                        nullAllowed,
+                        Optional.ofNullable(dictionaryPage)));
+            }
+        }
+        return true;
     }
 
     protected abstract boolean isNonNull();

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReader.java
@@ -13,6 +13,8 @@
  */
 package io.trino.parquet.reader;
 
+import io.trino.parquet.ParquetCorruptionException;
+
 import java.util.Optional;
 
 public interface ColumnReader
@@ -20,6 +22,9 @@ public interface ColumnReader
     boolean hasPageReader();
 
     void setPageReader(PageReader pageReader, Optional<FilteredRowRanges> rowRanges);
+
+    boolean dictionaryPredicateMatch(RowGroupInfo rowGroupInfo)
+            throws ParquetCorruptionException;
 
     void prepareNextRead(int batchSize);
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -109,6 +109,7 @@ public class ParquetReader
     private static final int BATCH_SIZE_GROWTH_FACTOR = 2;
     public static final String PARQUET_CODEC_METRIC_PREFIX = "ParquetReaderCompressionFormat_";
     public static final String COLUMN_INDEX_ROWS_FILTERED = "ParquetColumnIndexRowsFiltered";
+    public static final String PARQUET_READER_DICTIONARY_FILTERED_ROWGROUPS = "ParquetReaderDictionaryFilteredRowGroups";
 
     private final Optional<String> fileCreatedBy;
     private final List<RowGroupInfo> rowGroups;
@@ -151,6 +152,7 @@ public class ParquetReader
     private int currentPageId;
 
     private long columnIndexRowsFiltered = -1;
+    private long dictionaryFilteredRowGroups;
     private final Optional<FileDecryptionContext> decryptionContext;
 
     public ParquetReader(
@@ -467,38 +469,63 @@ public class ParquetReader
     private boolean advanceToNextRowGroup()
             throws IOException
     {
-        currentRowGroupMemoryContext.close();
-        currentRowGroupMemoryContext = memoryContext.newAggregatedMemoryContext();
-        freeCurrentRowGroupBuffers();
+        while (currentRowGroup < rowGroups.size()) {
+            currentRowGroupMemoryContext.close();
+            currentRowGroupMemoryContext = memoryContext.newAggregatedMemoryContext();
+            freeCurrentRowGroupBuffers();
 
-        if (currentRowGroup >= 0 && rowGroupStatisticsValidation.isPresent()) {
-            StatisticsValidation statisticsValidation = rowGroupStatisticsValidation.get();
-            writeValidation.orElseThrow().validateRowGroupStatistics(dataSource.getId(), currentBlockMetadata, statisticsValidation.build());
-            statisticsValidation.reset();
-        }
-
-        currentRowGroup++;
-        if (currentRowGroup == rowGroups.size()) {
-            return false;
-        }
-        RowGroupInfo rowGroupInfo = rowGroups.get(currentRowGroup);
-        currentBlockMetadata = rowGroupInfo.prunedBlockMetadata();
-        firstRowIndexInGroup = rowGroupInfo.fileRowOffset();
-        currentGroupRowCount = currentBlockMetadata.getRowCount();
-        FilteredRowRanges currentGroupRowRanges = blockRowRanges[currentRowGroup];
-        log.debug("advanceToNextRowGroup dataSource %s, currentRowGroup %d, rowRanges %s, currentBlockMetadata %s", dataSource.getId(), currentRowGroup, currentGroupRowRanges, currentBlockMetadata);
-        if (currentGroupRowRanges != null) {
-            long rowCount = currentGroupRowRanges.getRowCount();
-            columnIndexRowsFiltered += currentGroupRowCount - rowCount;
-            if (rowCount == 0) {
-                // Filters on multiple columns with page indexes may yield non-overlapping row ranges and eliminate the entire row group.
-                // Advance to next row group to ensure that we don't return a null Page and close the page source before all row groups are processed
-                return advanceToNextRowGroup();
+            if (currentRowGroup >= 0 && rowGroupStatisticsValidation.isPresent()) {
+                StatisticsValidation statisticsValidation = rowGroupStatisticsValidation.get();
+                writeValidation.orElseThrow().validateRowGroupStatistics(dataSource.getId(), currentBlockMetadata, statisticsValidation.build());
+                statisticsValidation.reset();
             }
-            currentGroupRowCount = rowCount;
+
+            currentRowGroup++;
+            if (currentRowGroup == rowGroups.size()) {
+                return false;
+            }
+            RowGroupInfo rowGroupInfo = rowGroups.get(currentRowGroup);
+            currentBlockMetadata = rowGroupInfo.prunedBlockMetadata();
+            firstRowIndexInGroup = rowGroupInfo.fileRowOffset();
+            currentGroupRowCount = currentBlockMetadata.getRowCount();
+            FilteredRowRanges currentGroupRowRanges = blockRowRanges[currentRowGroup];
+            log.debug("advanceToNextRowGroup dataSource %s, currentRowGroup %d, rowRanges %s, currentBlockMetadata %s", dataSource.getId(), currentRowGroup, currentGroupRowRanges, currentBlockMetadata);
+            if (currentGroupRowRanges != null) {
+                long rowCount = currentGroupRowRanges.getRowCount();
+                columnIndexRowsFiltered += currentGroupRowCount - rowCount;
+                if (rowCount == 0) {
+                    // Filters on multiple columns with page indexes may yield non-overlapping row ranges and eliminate the entire row group.
+                    // Advance to next row group to ensure that we don't return a null Page and close the page source before all row groups are processed
+                    continue;
+                }
+                currentGroupRowCount = rowCount;
+            }
+            nextRowInGroup = 0L;
+            initializeColumnReaders();
+
+            // check dictionary predicate matches, or skip row group
+            if (!dictionaryPredicateMatch(rowGroupInfo)) {
+                dictionaryFilteredRowGroups++;
+                continue;
+            }
+            return true;
         }
-        nextRowInGroup = 0L;
-        initializeColumnReaders();
+        return false;
+    }
+
+    private boolean dictionaryPredicateMatch(RowGroupInfo rowGroupInfo)
+            throws ParquetCorruptionException
+    {
+        for (PrimitiveField field : primitiveFields) {
+            // check presence of indexPredicate and don't eagerly initializePageReader if it's not present
+            if (rowGroupInfo.indexPredicate().isPresent()) {
+                initializePageReader(field);
+                boolean match = columnReaders.get(field.getId()).dictionaryPredicateMatch(rowGroupInfo);
+                if (!match) {
+                    return false;
+                }
+            }
+        }
         return true;
     }
 
@@ -654,29 +681,10 @@ public class ParquetReader
     private ColumnChunk readPrimitive(PrimitiveField field)
             throws IOException
     {
-        ColumnDescriptor columnDescriptor = field.getDescriptor();
         int fieldId = field.getId();
         ColumnReader columnReader = columnReaders.get(fieldId);
         if (!columnReader.hasPageReader()) {
-            validateParquet(currentBlockMetadata.getRowCount() > 0, dataSource.getId(), "Row group has 0 rows");
-            ColumnChunkMetadata metadata = currentBlockMetadata.getColumnChunkMetaData(columnDescriptor);
-            FilteredRowRanges rowRanges = blockRowRanges[currentRowGroup];
-            OffsetIndex offsetIndex = null;
-            if (rowRanges != null) {
-                offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());
-            }
-            ChunkedInputStream columnChunkInputStream = chunkReaders.get(new ChunkKey(fieldId, currentRowGroup));
-            columnReader.setPageReader(
-                    createPageReader(
-                            dataSource.getId(),
-                            columnChunkInputStream,
-                            metadata,
-                            columnDescriptor,
-                            offsetIndex,
-                            fileCreatedBy,
-                            decryptionContext,
-                            options.getMaxPageReadSize().toBytes()),
-                    Optional.ofNullable(rowRanges));
+            initializePageReader(field);
         }
         ColumnChunk columnChunk = columnReader.readPrimitive();
 
@@ -692,6 +700,34 @@ public class ParquetReader
         return columnChunk;
     }
 
+    private void initializePageReader(PrimitiveField field)
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor columnDescriptor = field.getDescriptor();
+        int fieldId = field.getId();
+        ColumnReader columnReader = columnReaders.get(fieldId);
+        checkState(!columnReader.hasPageReader(), "Page reader already initialized");
+        validateParquet(currentBlockMetadata.getRowCount() > 0, dataSource.getId(), "Row group has 0 rows");
+        ColumnChunkMetadata metadata = currentBlockMetadata.getColumnChunkMetaData(columnDescriptor);
+        FilteredRowRanges rowRanges = blockRowRanges[currentRowGroup];
+        OffsetIndex offsetIndex = null;
+        if (rowRanges != null) {
+            offsetIndex = getFilteredOffsetIndex(rowRanges, currentRowGroup, currentBlockMetadata.getRowCount(), metadata.getPath());
+        }
+        ChunkedInputStream columnChunkInputStream = chunkReaders.get(new ChunkKey(fieldId, currentRowGroup));
+        columnReader.setPageReader(
+                createPageReader(
+                        dataSource.getId(),
+                        columnChunkInputStream,
+                        metadata,
+                        columnDescriptor,
+                        offsetIndex,
+                        fileCreatedBy,
+                        decryptionContext,
+                        options.getMaxPageReadSize().toBytes()),
+                Optional.ofNullable(rowRanges));
+    }
+
     public List<Column> getColumnFields()
     {
         return columnFields;
@@ -704,6 +740,7 @@ public class ParquetReader
         if (columnIndexRowsFiltered >= 0) {
             metrics.put(COLUMN_INDEX_ROWS_FILTERED, new LongCount(columnIndexRowsFiltered));
         }
+        metrics.put(PARQUET_READER_DICTIONARY_FILTERED_ROWGROUPS, new LongCount(dictionaryFilteredRowGroups));
         metrics.putAll(dataSource.getMetrics().getMetrics());
 
         return new Metrics(metrics.buildOrThrow());

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/RowGroupInfo.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/RowGroupInfo.java
@@ -14,8 +14,16 @@
 package io.trino.parquet.reader;
 
 import io.trino.parquet.metadata.PrunedBlockMetadata;
+import io.trino.parquet.predicate.TupleDomainParquetPredicate;
+import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
 
 import java.util.Optional;
+import java.util.Set;
 
-public record RowGroupInfo(PrunedBlockMetadata prunedBlockMetadata, long fileRowOffset, Optional<ColumnIndexStore> columnIndexStore) {}
+public record RowGroupInfo(PrunedBlockMetadata prunedBlockMetadata,
+                           long fileRowOffset,
+                           Optional<ColumnIndexStore> columnIndexStore,
+                           Optional<TupleDomainParquetPredicate> indexPredicate,
+                           Optional<Set<ColumnDescriptor>> candidateColumnsForDictionaryMatching)
+{}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -277,7 +277,7 @@ public class ParquetWriter
         long nextStart = 0;
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : parquetMetadata.getBlocks()) {
-            rowGroupInfoBuilder.add(new RowGroupInfo(createPrunedColumnsMetadata(block, input.getId(), descriptorsByPath), nextStart, Optional.empty()));
+            rowGroupInfoBuilder.add(new RowGroupInfo(createPrunedColumnsMetadata(block, input.getId(), descriptorsByPath), nextStart, Optional.empty(), Optional.empty(), Optional.empty()));
             nextStart += block.rowCount();
         }
         return new ParquetReader(

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
@@ -205,6 +205,20 @@ public class ParquetTestUtils
         return pagesBuilder.build();
     }
 
+    public static List<io.trino.spi.Page> generateInputPagesWithBlockData(List<Type> types, List<? extends List<?>> blockData, int pageCount)
+    {
+        checkArgument(blockData.size() == types.size());
+        ImmutableList.Builder<io.trino.spi.Page> pagesBuilder = ImmutableList.builder();
+        for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+            Block[] blocks = new Block[types.size()];
+            for (int i = 0; i < types.size(); i++) {
+                blocks[i] = generateBlock(types.get(i), blockData.get(i));
+            }
+            pagesBuilder.add(new Page(blocks));
+        }
+        return pagesBuilder.build();
+    }
+
     public static List<Integer> generateGroupSizes(int positionsCount)
     {
         int maxGroupSize = 17;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderDictionaryFiltering.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderDictionaryFiltering.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.SliceInput;
+import io.airlift.units.DataSize;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.metadata.BlockMetadata;
+import io.trino.parquet.metadata.ColumnChunkMetadata;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.metrics.Count;
+import io.trino.spi.metrics.Metric;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Type;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.PageType;
+import org.apache.parquet.format.Util;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.BloomFilterStore.hasBloomFilter;
+import static io.trino.parquet.ParquetTestUtils.createParquetReader;
+import static io.trino.parquet.ParquetTestUtils.generateInputPagesWithBlockData;
+import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
+import static io.trino.parquet.reader.ParquetReader.PARQUET_READER_DICTIONARY_FILTERED_ROWGROUPS;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.toIntExact;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetReaderDictionaryFiltering
+{
+    @Test
+    public void testFilteringWithSingleRowGroup()
+            throws Exception
+    {
+        List<String> columnNames = ImmutableList.of("int_col", "bigint_col", "varchar_col");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT, VARCHAR);
+        int totalPositions = 1000;
+        int pageCount = 100;
+        // generate multiples of 5 as distinct values in blocks
+        int[] distinctValues = IntStream.range(1, 21).map(i -> i * 5).toArray();
+        List<Page> inputPages = generatePages(types, distinctValues, totalPositions, pageCount);
+
+        try (ParquetDataSource dataSource = writeParquetAndAssertDictionary(types, columnNames, inputPages, DataSize.of(128, MEGABYTE), 1, distinctValues.length)) {
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+
+            int totalRows = 100000;
+            int totalRowGroups = 1;
+            // TupleDomain.all() --> All rows read, no rowgroups filtered out
+            TupleDomain<String> predicateDomain = TupleDomain.all();
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, totalRows, 0);
+
+            // int_col = 6, not present in dictionary --> No rows read, all rowgroups filtered out
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "int_col", Domain.multipleValues(INTEGER, ImmutableList.of(6L))));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 0, totalRowGroups);
+
+            // 1 < int_col < 5, overlapping range with dictionary values --> All rows read, no rowgroups filtered out
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "int_col", Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 1L), Range.lessThan(INTEGER, 5L)), false)));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, totalRows, 0);
+
+            // varchar_col="varchar-11", not present in dictionary --> No rows read, all rowgroups filtered out
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "varchar_col", Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("varchar-11")))));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 0, totalRowGroups);
+
+            // varchar_col="varchar-5", present in dictionary --> All rows read, no rowgroups filtered out
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "varchar_col", Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("varchar-5")))));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, totalRows, 0);
+
+            // varchar_col in ["varchar-5",varchar-11], overlapping with dictionary values --> All rows read, no rowgroups filtered out
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "varchar_col", Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("varchar-5"), utf8Slice("varchar-11")))));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, totalRows, 0);
+        }
+    }
+
+    @Test
+    public void testFilteringWithMultipleRowGroups()
+            throws Exception
+    {
+        List<String> columnNames = ImmutableList.of("int_col", "bigint_col", "varchar_col");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT, VARCHAR);
+        int totalPositions = 40000;
+        int pageCount = 20;
+        int numDistinctValuesInPage = 20;
+
+        // each column have certain distinct(across rowgroups) values, that are then repeated for all the positions
+        // the combination of current values of totalPositions, pageCount, numDistinctValuesInPage, and MaxBlockSize
+        // give 20 rowgroups
+        // int_col [1000, 1005, 1010...1000, 1005, 1010...] - rowgroup1
+        // int_col [1200, 1205, 1210...1200, 1205, 1210...] - rowgroup2
+        // ...so on
+
+        List<Page> inputPages = new ArrayList<>();
+        for (int i = 0; i < pageCount; i++) {
+            int start = (i + 10) * numDistinctValuesInPage;
+            int end = start + numDistinctValuesInPage;
+            int[] distinctValues = IntStream.range(start, end).map(n -> n * 5).toArray();
+            inputPages.addAll(generatePages(types, distinctValues, totalPositions, 1));
+        }
+
+        try (ParquetDataSource dataSource = writeParquetAndAssertDictionary(types, columnNames, inputPages, DataSize.of(1024, KILOBYTE), pageCount, numDistinctValuesInPage)) {
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+
+            // int_col in [1001, 1101] --> 0 rows read. 2 rowgroups are passed to ParquetReader after min/max filtering, both of them are then filtered by dictionary filter
+            TupleDomain<String> predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of("int_col", Domain.multipleValues(INTEGER, ImmutableList.of(1001L, 1101L), false)));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 0, 2);
+
+            // int_col in [1005] --> 40000 (1 rowgroup) rows read. Others filtered by min/max, not passed to ParquetReader
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of("int_col", Domain.multipleValues(INTEGER, ImmutableList.of(1005L), false)));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 40000, 0);
+
+            // int_col in [1005, 1101, 1201] --> 40000 (1 rowgroup having int_col=1005) rows read. 2 rowgroups filtered by dictionary filter
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of("int_col", Domain.multipleValues(INTEGER, ImmutableList.of(1005L, 1101L, 1201L), false)));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 40000, 2);
+
+            // varchar_col in [varchar-2005, varchar-2101, varchar-2201, varchar-2301] --> 40000 (1 rowgroup having varchar_col=varchar-2005) rows read. 3 rowgroups filtered by dictionary filter
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "varchar_col", Domain.multipleValues(VARCHAR,
+                                    ImmutableList.of(utf8Slice("varchar-2005"), utf8Slice("varchar-2101"), utf8Slice("varchar-2201"), utf8Slice("varchar-2301")))));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 40000, 3);
+
+            // 40000 (1 rowgroup having int_col=1005 and varchar_col=varchar-2005) rows read. 1 rowgroup filtered by dictionary filter (varchar-2101)
+            predicateDomain = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            "int_col", Domain.multipleValues(INTEGER, ImmutableList.of(1005L, 2100L), false),
+                            "varchar_col", Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("varchar-1005"), utf8Slice("varchar-2101")))));
+            assertDictionaryFiltered(dataSource, parquetMetadata, types, columnNames, predicateDomain, 40000, 1);
+        }
+    }
+
+    private static ParquetDataSource writeParquetAndAssertDictionary(List<Type> types, List<String> columnNames, List<Page> inputPages,
+                                                                     DataSize rowGroupMaxSize, int expectedRowGroupCount, int expectedDictionaryValuesCount)
+            throws IOException
+    {
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setMaxBlockSize(rowGroupMaxSize)
+                                .build(),
+                        types,
+                        columnNames,
+                        inputPages),
+                ParquetReaderOptions.defaultOptions());
+
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        assertThat(parquetMetadata.getBlocks().size()).isEqualTo(expectedRowGroupCount);
+        for (BlockMetadata blockMetaData : parquetMetadata.getBlocks()) {
+            assertThat(blockMetaData.columns()).hasSize(columnNames.size());
+            for (ColumnChunkMetadata chunkMetadata : blockMetaData.columns()) {
+                assertThat(chunkMetadata.getDictionaryPageOffset()).isGreaterThan(0);
+                int dictionaryPageSize = toIntExact(chunkMetadata.getFirstDataPageOffset() - chunkMetadata.getDictionaryPageOffset());
+                assertThat(dictionaryPageSize).isGreaterThan(0);
+                assertThat(chunkMetadata.getEncodingStats().hasDictionaryPages()).isTrue();
+                assertThat(chunkMetadata.getEncodingStats().hasDictionaryEncodedPages()).isTrue();
+                assertThat(chunkMetadata.getEncodingStats().hasNonDictionaryEncodedPages()).isFalse();
+                assertThat(hasBloomFilter(chunkMetadata)).isFalse();
+
+                // verify dictionary page
+                SliceInput inputStream = dataSource.readFully(chunkMetadata.getStartingPos(), dictionaryPageSize).getInput();
+                PageHeader pageHeader = Util.readPageHeader(inputStream);
+                assertThat(pageHeader.getType()).isEqualTo(PageType.DICTIONARY_PAGE);
+                assertThat(pageHeader.getDictionary_page_header().getNum_values()).isEqualTo(expectedDictionaryValuesCount);
+            }
+        }
+        return dataSource;
+    }
+
+    private static void assertDictionaryFiltered(ParquetDataSource dataSource, ParquetMetadata parquetMetadata, List<Type> types, List<String> columnNames, TupleDomain<String> predicate, int expectedRowsRead, long expectedDictionaryFilteredRowGroups)
+            throws IOException
+    {
+        try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, ParquetReaderOptions.defaultOptions(), newSimpleAggregatedMemoryContext(), types, columnNames, predicate)) {
+            SourcePage page = reader.nextPage();
+            int rowsRead = 0;
+            while (page != null) {
+                rowsRead += page.getPositionCount();
+                page = reader.nextPage();
+            }
+            assertThat(rowsRead).isEqualTo(expectedRowsRead);
+            Map<String, Metric<?>> metrics = reader.getMetrics().getMetrics();
+            assertThat(metrics).containsKey(PARQUET_READER_DICTIONARY_FILTERED_ROWGROUPS);
+            assertThat(((Count<?>) metrics.get(PARQUET_READER_DICTIONARY_FILTERED_ROWGROUPS)).getTotal())
+                    .isEqualTo(expectedDictionaryFilteredRowGroups);
+        }
+    }
+
+    private List<Page> generatePages(List<Type> types, int[] distinctValues, int totalPositions, int pageCount)
+    {
+        List<? extends List<?>> blockData = types.stream().map(type -> generateBlockValues(type, distinctValues, totalPositions)).toList();
+        return generateInputPagesWithBlockData(types, blockData, pageCount);
+    }
+
+    private List<?> generateBlockValues(Type type, int[] distinctValues, int totalPositions)
+    {
+        IntStream intValues = IntStream.range(0, totalPositions).map(i -> distinctValues[i % distinctValues.length]);
+        if (type == INTEGER || type == BIGINT) {
+            return intValues.asLongStream().boxed().toList();
+        }
+        else if (type == VARCHAR) {
+            return intValues.boxed().map(i -> "varchar-" + i).toList();
+        }
+        throw new IllegalArgumentException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSourceProvider.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSourceProvider.java
@@ -113,7 +113,7 @@ public class RedshiftPageSourceProvider
         long nextStart = 0;
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : parquetMetadata.getBlocks()) {
-            rowGroupInfoBuilder.add(new RowGroupInfo(createPrunedColumnsMetadata(block, dataSource.getId(), descriptorsByPath), nextStart, Optional.empty()));
+            rowGroupInfoBuilder.add(new RowGroupInfo(createPrunedColumnsMetadata(block, dataSource.getId(), descriptorsByPath), nextStart, Optional.empty(), Optional.empty(), Optional.empty()));
             nextStart += block.rowCount();
         }
         return new ParquetReader(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Avoid redundant dictionary reads - earlier the dictionary page is read at the time of rowgroup pruning (`PredicateUtils`) and then again read during the actual file reading(`ParquetReader`). This PR removes this redundant work and moves dictionary based rowgroup pruning logic to `ParquetReader`

Would like to thank @pettyjamesm for his initial suggestions on this.

#### Some numbers with patch

These queries were run on 1TB TPC-DS data(parquet, zstd compressed). 

```
select count(*) from store_sales where ss_store_sk=163;

Without Patch - 26.14 [2.88B rows, 2.08GiB] [110M rows/s, 81.4MiB/s]
With Patch - 21.09 [2.88B rows, 1.09GiB] [137M rows/s, 52.9MiB/s]


select count(*) from store_sales where ss_hdemo_sk < 5226;

Without Patch - 22.23 [2.88B rows, 2.4GiB] [130M rows/s, 111MiB/s]
With Patch - 17.17 [2.88B rows, 1.25GiB] [168M rows/s, 74.6MiB/s]


select count(*) from store_sales where ss_store_sk=163 and ss_hdemo_sk < 5226;

Without Patch - 28.37 [2.88B rows, 5.07GiB] [102M rows/s, 183MiB/s]
With Patch - 18.98 [2.88B rows, 2.94GiB] [152M rows/s, 158MiB/s]


select ss_cdemo_sk, count(*) from store_sales where ss_store_sk=163 and ss_hdemo_sk < 5226 group by ss_cdemo_sk;

Without Patch - 28.87 [2.88B rows, 7.36GiB] [99.8M rows/s, 261MiB/s]
With Patch - 24.23 [2.88B rows, 5.23GiB] [119M rows/s, 221MiB/s]
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
