### PR TITLE
Add active worker count and active coordinator count JMX metrics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/node/CoordinatorNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/node/CoordinatorNodeManager.java
@@ -291,7 +291,7 @@ public final class CoordinatorNodeManager
     }
 
     @Managed
-    public long getActiveWorkerCount()
+    public int getActiveWorkerCount()
     {
         AllNodes allNodes = getAllNodes();
         return allNodes.activeNodes().size() - allNodes.activeCoordinators().size();


### PR DESCRIPTION
## Description
The `/metrics` endpoint lists active nodes, but not all nodes are workers and # of workers is not always equal to # nodes - # coordinators as coordinators can be workers as well.

This PR adds `CoordinatorNodeManager_ActiveCoordinatorCount` and `CoordinatorNodeManager_ActiveWorkerCount`  metrics. I can't find any tests for the current metrics in the `CoordinatorNodeManager`, so I'm not sure they should be added.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( X ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Metrics
* Added coordinator and worker counts to the metrics endpoint
```
