### PR TITLE
Initialize PREFERRED_BIT_WIDTH before detect simd support

### DIFF
--- a/core/trino-main/src/main/java/io/trino/simd/BlockEncodingSimdSupport.java
+++ b/core/trino-main/src/main/java/io/trino/simd/BlockEncodingSimdSupport.java
@@ -46,8 +46,8 @@ public final class BlockEncodingSimdSupport
     }
 
     private static final int MINIMUM_SIMD_LENGTH = 256;
-    private static final SimdSupport AUTO_DETECTED_SUPPORT = detectSimd();
     private static final int PREFERRED_BIT_WIDTH = VectorShape.preferredShape().vectorBitSize();
+    private static final SimdSupport AUTO_DETECTED_SUPPORT = detectSimd();
 
     private final SimdSupport simdSupport;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Otherwise, PREFERRED_BIT_WIDTH will be uninitialized and equal to the default value of 0, causing detectSimd() to always return SimdSupport.NONE.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


No release notes required because this fixes hardware detection for SIMD support that has not yet shipped in a release.
