### PR TITLE
Add binary varying mapping to Redshift connector

### DIFF
--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -625,6 +625,12 @@ public class RedshiftClient
                     RedshiftClient::readTime,
                     RedshiftClient::writeTime));
         }
+        if ("binary varying".equals(type.jdbcTypeName().orElse("")) || type.jdbcType() == Types.LONGVARBINARY) {
+            return Optional.of(ColumnMapping.sliceMapping(
+                    VARBINARY,
+                    varbinaryReadFunction(),
+                    varbinaryWriteFunction()));
+        }
 
         switch (type.jdbcType()) {
             case Types.BIT: // Redshift uses this for booleans
@@ -681,12 +687,6 @@ public class RedshiftClient
                                 : createUnboundedVarcharType(),
                         true));
             }
-
-            case Types.LONGVARBINARY:
-                return Optional.of(ColumnMapping.sliceMapping(
-                        VARBINARY,
-                        varbinaryReadFunction(),
-                        varbinaryWriteFunction()));
 
             case Types.DATE:
                 return Optional.of(ColumnMapping.longMapping(


### PR DESCRIPTION
## Description

Fixes #27403

It seems Redshift is changing their varbinary type mapping recently and it's unstable. 
Adding 2 conditions (`binary varying` & `Types.LONGVARBINARY`) just in case. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
