### PR TITLE
Add regex support for query partition filter required schemas

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -273,9 +273,11 @@ Hive connector documentation.
     catalog specific use.
   - `false`
 * - `hive.query-partition-filter-required-schemas`
-  - Allow specifying the list of schemas for which Trino will enforce that
-    queries use a filter on partition keys for source tables. The list can be
-    specified using the `hive.query-partition-filter-required-schemas`,
+  - Allow specifying the list of schema names or regex patterns for which Trino
+    will enforce that queries use a filter on partition keys for source tables.
+    Each entry can be an exact schema name (e.g., `schema1`) or a regular
+    expression pattern (e.g., `schema.*` to match all schemas starting with "schema").
+    The list can be specified using the `hive.query-partition-filter-required-schemas`,
     or the `query_partition_filter_required_schemas` session property. The list
     is taken into consideration only if the `hive.query-partition-filter-required`
     configuration property or the `query_partition_filter_required` session

--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -173,8 +173,10 @@ implementation is used:
     catalog session property is `query_partition_filter_required`.
   - `false`
 * - `iceberg.query-partition-filter-required-schemas`
-  - Specify the list of schemas for which Trino can enforce that queries use a
-    filter on partition keys for source tables. Equivalent session property is
+  - Specify the list of schema names or regex patterns for which Trino can enforce
+    that queries use a filter on partition keys for source tables. Each entry can be
+    an exact schema name (e.g., `schema1`) or a regular expression pattern (e.g., `schema.*`
+    to match all schemas starting with "schema"). Equivalent session property is
     `query_partition_filter_required_schemas`. The list is used if the
     `iceberg.query-partition-filter-required` configuration property or the
     `query_partition_filter_required` catalog session property is set to `true`.

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -1134,7 +1134,7 @@ public class HiveConfig
     }
 
     @Config("hive.query-partition-filter-required-schemas")
-    @ConfigDescription("List of schemas for which filter on partition column is enforced")
+    @ConfigDescription("List of schema names or regex patterns for which filter on partition column is enforced")
     public HiveConfig setQueryPartitionFilterRequiredSchemas(List<String> queryPartitionFilterRequiredSchemas)
     {
         this.queryPartitionFilterRequiredSchemas = queryPartitionFilterRequiredSchemas.stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -4071,6 +4071,7 @@ public class HiveMetadata
         Set<String> requiredSchemas = getQueryPartitionFilterRequiredSchemas(session);
         // If query_partition_filter_required_schemas is empty, then we would apply partition filter for all tables.
         return isQueryPartitionFilterRequired(session) &&
-                (requiredSchemas.isEmpty() || requiredSchemas.contains(schemaTableName.getSchemaName()));
+                (requiredSchemas.isEmpty() || requiredSchemas.contains(schemaTableName.getSchemaName()) ||
+                        requiredSchemas.stream().anyMatch(pattern -> schemaTableName.getSchemaName().matches(pattern)));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -482,7 +482,7 @@ public final class HiveSessionProperties
                         false),
                 new PropertyMetadata<>(
                         QUERY_PARTITION_FILTER_REQUIRED_SCHEMAS,
-                        "List of schemas for which filter on partition column is enforced.",
+                        "List of schema names or regex patterns for which filter on partition column is enforced.",
                         new ArrayType(VARCHAR),
                         Set.class,
                         hiveConfig.getQueryPartitionFilterRequiredSchemas(),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -501,7 +501,7 @@ public class IcebergConfig
     }
 
     @Config("iceberg.query-partition-filter-required-schemas")
-    @ConfigDescription("List of schemas for which filter on partition column is enforced")
+    @ConfigDescription("List of schemas (or regex patterns) for which filter on partition column is enforced")
     public IcebergConfig setQueryPartitionFilterRequiredSchemas(Set<String> queryPartitionFilterRequiredSchemas)
     {
         this.queryPartitionFilterRequiredSchemas = queryPartitionFilterRequiredSchemas.stream()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1048,7 +1048,8 @@ public class IcebergMetadata
         Set<String> requiredSchemas = getQueryPartitionFilterRequiredSchemas(session);
         // If query_partition_filter_required_schemas is empty then we would apply partition filter for all tables.
         return isQueryPartitionFilterRequired(session) &&
-                (requiredSchemas.isEmpty() || requiredSchemas.contains(table.getSchemaName()));
+                (requiredSchemas.isEmpty() || requiredSchemas.contains(table.getSchemaName()) ||
+                        requiredSchemas.stream().anyMatch(pattern -> table.getSchemaName().matches(pattern)));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -367,7 +367,7 @@ public final class IcebergSessionProperties
                         false))
                 .add(new PropertyMetadata<>(
                         QUERY_PARTITION_FILTER_REQUIRED_SCHEMAS,
-                        "List of schemas for which filter on partition column is enforced.",
+                        "List of schema names or regex patterns for which filter on partition column is enforced.",
                         new ArrayType(VARCHAR),
                         Set.class,
                         icebergConfig.getQueryPartitionFilterRequiredSchemas(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Add regex support for query partition filter required schemas (Hive & Iceberg)


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Add regex support for query partition filter required schemas
```
