### PR TITLE
Update testRestartDuringQuery expected error pattern

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestWorkerRestart.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestWorkerRestart.java
@@ -98,9 +98,9 @@ public class TestWorkerRestart
                 restartWorker(queryRunner);
                 assertThatThrownBy(future::get)
                         .isInstanceOf(ExecutionException.class)
-                        .cause().hasMessageFindingMatch("^Expected response code from \\S+ to be 200, but was 500" +
+                        .cause().hasMessageFindingMatch("^Expected response code from \\S+ to be 200, but was 5\\d\\d" +
                                                         "|Expected response from \\S+ is empty" +
-                                                        "|Error fetching \\S+: Expected response code to be 200, but was 500" +
+                                                        "|Error fetching \\S+: Expected response code to be 200, but was 5\\d\\d" +
                                                         "|Could not communicate with the remote task. The node may have crashed or be under too much load" +
                                                         "|Error fetching \\S+: Content-Type header is not set");
 


### PR DESCRIPTION
It's believed that commit e6cdeb571c2b0172f71011206dd95262cd818fd6 (https://github.com/trinodb/trino/pull/27193) introduced new possible failure that the test may encounter, with HTTP error code 503.

- hopefully fixes https://github.com/trinodb/trino/issues/27435
