### PR TITLE
Check synchronization in FileHiveMetastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -1408,7 +1408,7 @@ public class FileHiveMetastore
             if (getCausalChain(e).stream().anyMatch(FileNotFoundException.class::isInstance)) {
                 return Optional.empty();
             }
-            throw new TrinoException(HIVE_METASTORE_ERROR, "Could not read " + type, e);
+            throw new TrinoException(HIVE_METASTORE_ERROR, "Could not read %s from %s".formatted(type, file), e);
         }
     }
 


### PR DESCRIPTION
Enforce proper synchronization in `FileHiveMetastore` with static code check.
Add more diagnostic information.

- relates to https://github.com/trinodb/trino/issues/21121