### PR TITLE
Downgrade com.amazon.redshift:redshift-jdbc42 to 2.1.0.30

### DIFF
--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -18,7 +18,8 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.2.1</version>
+            <!-- TODO upgrade once https://github.com/aws/amazon-redshift-jdbc-driver/issues/148 has been addressed -->
+            <version>2.1.0.30</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The version 2.2.0 and 2.2.1 of the driver are introducing a
regression in coping with long table names.
The regression has been documented in the issue
https://github.com/aws/amazon-redshift-jdbc-driver/issues/148


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/aws/amazon-redshift-jdbc-driver/issues/148

https://github.com/trinodb/trino/pull/27445


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
