### PR TITLE
Use random table name even for fail scenarios in create smoke tests

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -140,12 +140,12 @@ public abstract class BaseConnectorSmokeTest
     @Test
     public void testCreateTable()
     {
+        String tableName = "test_create_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_TABLE)) {
-            assertQueryFails("CREATE TABLE xxxx (a bigint, b double)", "This connector does not support creating tables");
+            assertQueryFails("CREATE TABLE %s (a bigint, b double)".formatted(tableName), "This connector does not support creating tables");
             return;
         }
 
-        String tableName = "test_create_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " " + getCreateTableDefaultDefinition());
         assertThat(query("SELECT a, b FROM " + tableName))
                 .returnsEmptyResult();
@@ -170,12 +170,12 @@ public abstract class BaseConnectorSmokeTest
     @Test
     public void testCreateTableAsSelect()
     {
+        String tableName = "test_create_" + randomNameSuffix();
         if (!hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA)) {
-            assertQueryFails("CREATE TABLE xxxx AS SELECT BIGINT '42' a, DOUBLE '-38.5' b", "This connector does not support creating tables with data");
+            assertQueryFails("CREATE TABLE %s AS SELECT BIGINT '42' a, DOUBLE '-38.5' b".formatted(tableName), "This connector does not support creating tables with data");
             return;
         }
 
-        String tableName = "test_create_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT BIGINT '42' a, DOUBLE '-38.5' b", 1);
         assertThat(query("SELECT CAST(a AS bigint), b FROM " + tableName))
                 .matches("VALUES (BIGINT '42', -385e-1)");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

In trino engine, it could be situation that some checks could be executed on different levels (Metastore e.t.c)
So we can fall in situation, that with static table name (if for example it mimics some bucket storage), some location checks could potentially be executed before engine checks (and test could fail not because of some logic, but just because preexisting bucket). 
To omit such situation - let's use random naming even for fail scenarious.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
