### PR TITLE
Remove special casing for explicit row in VALUES

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -227,7 +227,6 @@ import io.trino.sql.tree.ResetSession;
 import io.trino.sql.tree.ResetSessionAuthorization;
 import io.trino.sql.tree.Revoke;
 import io.trino.sql.tree.Rollback;
-import io.trino.sql.tree.Row;
 import io.trino.sql.tree.RowPattern;
 import io.trino.sql.tree.SampledRelation;
 import io.trino.sql.tree.SecurityCharacteristic;
@@ -4082,31 +4081,15 @@ class StatementAnalyzer
             // add coercions
             for (Expression row : node.getRows()) {
                 Type actualType = analysis.getType(row);
-                if (row instanceof Row value) {
-                    // coerce Row by fields to preserve Row structure and enable optimizations based on this structure, e.g. pruning, predicate extraction
-                    // TODO coerce the whole Row and add an Optimizer rule that converts CAST(ROW(...) AS ...) into ROW(CAST(...), CAST(...), ...).
-                    //  The rule would also handle Row-type expressions that were specified as CAST(ROW). It should support multiple casts over a ROW.
-                    for (int i = 0; i < actualType.getTypeParameters().size(); i++) {
-                        Expression item = value.getFields().get(i).getExpression();
-                        Type actualItemType = actualType.getTypeParameters().get(i);
-                        Type expectedItemType = commonSuperType.getTypeParameters().get(i);
-                        if (!actualItemType.equals(expectedItemType)) {
-                            analysis.addCoercion(item, expectedItemType);
-                        }
-                    }
-                }
-                else if (actualType instanceof RowType) {
-                    // coerce row-type expression as a whole
-                    if (!actualType.equals(commonSuperType)) {
-                        analysis.addCoercion(row, commonSuperType);
-                    }
-                }
-                else {
+
+                Type targetType = commonSuperType;
+                if (!(actualType instanceof RowType)) {
                     // coerce field. it will be wrapped in Row by Planner
-                    Type superType = getOnlyElement(commonSuperType.getTypeParameters());
-                    if (!actualType.equals(superType)) {
-                        analysis.addCoercion(row, superType);
-                    }
+                    targetType = getOnlyElement(commonSuperType.getTypeParameters());
+                }
+
+                if (!actualType.equals(targetType)) {
+                    analysis.addCoercion(row, targetType);
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/MergeProjectWithValues.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/MergeProjectWithValues.java
@@ -20,6 +20,10 @@ import io.trino.Session;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.spi.block.SqlRow;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
@@ -40,6 +44,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.isMergeProjectWithValues;
 import static io.trino.matching.Capture.newCapture;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.ExpressionNodeInliner.replaceExpression;
 import static io.trino.sql.planner.plan.Patterns.project;
@@ -129,10 +134,12 @@ public class MergeProjectWithValues
         // do not proceed if ValuesNode contains a non-deterministic expression and it is referenced more than once by the projection
         Set<Symbol> nonDeterministicValuesOutputs = new HashSet<>();
         for (Expression rowExpression : valuesNode.getRows().get()) {
-            Row row = (Row) rowExpression;
-            for (int i = 0; i < valuesNode.getOutputSymbols().size(); i++) {
-                if (!isDeterministic(row.items().get(i))) {
-                    nonDeterministicValuesOutputs.add(valuesNode.getOutputSymbols().get(i));
+            if (!(rowExpression instanceof Constant)) {
+                Row row = (Row) rowExpression;
+                for (int i = 0; i < valuesNode.getOutputSymbols().size(); i++) {
+                    if (!isDeterministic(row.items().get(i))) {
+                        nonDeterministicValuesOutputs.add(valuesNode.getOutputSymbols().get(i));
+                    }
                 }
             }
         }
@@ -150,7 +157,12 @@ public class MergeProjectWithValues
         // inline values expressions into projection's assignments
         ImmutableList.Builder<Expression> projectedRows = ImmutableList.builder();
         for (Expression rowExpression : valuesNode.getRows().get()) {
-            Map<Reference, Expression> mapping = buildMappings(valuesNode.getOutputSymbols(), (Row) rowExpression);
+            Map<Reference, Expression> mapping = switch (rowExpression) {
+                case Row row -> buildMappings(valuesNode.getOutputSymbols(), row);
+                case Constant constant -> buildMappings(valuesNode.getOutputSymbols(), constant);
+                default -> throw new IllegalStateException("Unexpected expression type in ValuesNode: " + rowExpression.getClass().getName());
+            };
+
             Row projectedRow = new Row(expressions.stream()
                     .map(expression -> replaceExpression(expression, mapping))
                     .collect(toImmutableList()));
@@ -161,7 +173,8 @@ public class MergeProjectWithValues
 
     private static boolean isSupportedValues(ValuesNode valuesNode)
     {
-        return valuesNode.getRows().isEmpty() || valuesNode.getRows().get().stream().allMatch(Row.class::isInstance);
+        return valuesNode.getRows().isEmpty() ||
+                valuesNode.getRows().get().stream().allMatch(row -> row instanceof Row || row instanceof Constant);
     }
 
     private Map<Reference, Expression> buildMappings(List<Symbol> symbols, Row row)
@@ -170,6 +183,23 @@ public class MergeProjectWithValues
         for (int i = 0; i < row.items().size(); i++) {
             mappingBuilder.put(symbols.get(i).toSymbolReference(), row.items().get(i));
         }
+        return mappingBuilder.buildOrThrow();
+    }
+
+    private Map<Reference, Expression> buildMappings(List<Symbol> symbols, Constant row)
+    {
+        ImmutableMap.Builder<Reference, Expression> mappingBuilder = ImmutableMap.builder();
+
+        RowType type = (RowType) row.type();
+        SqlRow rowValue = (SqlRow) row.value();
+        for (int field = 0; field < type.getFields().size(); field++) {
+            Type fieldType = type.getFields().get(field).getType();
+
+            mappingBuilder.put(symbols.get(field).toSymbolReference(), new Constant(
+                    fieldType,
+                    readNativeValue(fieldType, rowValue.getRawFieldBlock(field), rowValue.getRawIndex())));
+        }
+
         return mappingBuilder.buildOrThrow();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -162,6 +162,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.topN;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.topNRanking;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.unnest;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.valuesOf;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.windowFunction;
 import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
@@ -2290,11 +2291,15 @@ public class TestLogicalPlanner
         assertPlan("VALUES (TINYINT '1', REAL '1'), (DOUBLE '2', SMALLINT '2')",
                 CREATED,
                 anyTree(
-                        values(
+                        valuesOf(
                                 ImmutableList.of("field", "field0"),
                                 ImmutableList.of(
-                                        ImmutableList.of(new Cast(new Constant(TINYINT, 1L), DOUBLE), new Constant(REAL, Reals.toReal(1f))),
-                                        ImmutableList.of(new Constant(DOUBLE, 2.0), new Cast(new Constant(SMALLINT, 2L), REAL))))));
+                                        new Cast(
+                                                new Row(ImmutableList.of(new Constant(TINYINT, 1L), new Constant(REAL, Reals.toReal(1f)))),
+                                                RowType.anonymousRow(DOUBLE, REAL)),
+                                        new Cast(
+                                                new Row(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(SMALLINT, 2L))),
+                                                RowType.anonymousRow(DOUBLE, REAL))))));
 
         // entry of type other than Row coerced as a whole
         assertPlan("VALUES DOUBLE '1', CAST(ROW(2) AS row(bigint))",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -793,6 +793,14 @@ public final class PlanMatchPattern
         return values(ImmutableList.of(), nCopies(rowCount, ImmutableList.of()));
     }
 
+    public static PlanMatchPattern valuesOf(List<String> aliases, List<Expression> expectedRows)
+    {
+        return values(
+                aliasToIndex(aliases),
+                Optional.of(aliases.size()),
+                Optional.of(expectedRows));
+    }
+
     public static PlanMatchPattern values(List<String> aliases, List<List<Expression>> expectedRows)
     {
         return values(aliases, Optional.of(expectedRows));


### PR DESCRIPTION
Injecting coerciones field by field is no longer needed. This is now handled by PushCastIntoRow.



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
