### PR TITLE
Delete all objects from testing GCS bucket

### DIFF
--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
@@ -13,8 +13,10 @@
  */
 package io.trino.filesystem.gcs;
 
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
@@ -71,7 +73,11 @@ public abstract class AbstractTestGcsFileSystem
     void tearDown()
     {
         try {
-            storage.delete(rootLocation.host().get());
+            Bucket bucket = storage.get(new GcsLocation(rootLocation).bucket());
+            for (Blob blob : bucket.list().iterateAll()) {
+                storage.delete(blob.getBlobId());
+            }
+            bucket.delete();
         }
         finally {
             fileSystem = null;


### PR DESCRIPTION
## Description

Adding extra removal logic though we already have `cleanupFiles` with `@AfterEach`

* Hopefully fixes https://github.com/trinodb/trino/issues/27386

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
