### PR TITLE
Limit column name length in Cassandra connector

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -1827,7 +1827,7 @@ public class TestCassandraConnectorTest
     @Override
     protected void verifyColumnNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageContaining("Attempted serializing to buffer exceeded maximum of 65535 bytes:");
+        assertThat(e).hasMessageContaining("Column name is too long. The maximum supported length is");
     }
 
     @Override


### PR DESCRIPTION
Cassandra server applies column name length limits unreliable. When attempting to create a table with super long column name, it's possible that the server fails creation CQL query, but still creates the table. It's more reliable to apply the limit on our side. The limit is big enough that it doesn't matter.

Deflakes `TestCassandraConnectorTest.testCreateTableWithLongColumnName`.

- fixes https://github.com/trinodb/trino/issues/27474