### PR TITLE
 Rename castToVarchar to render in ValuePrinter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
@@ -783,7 +783,7 @@ public class IoPlanPrinter
                                     .collect(toImmutableSet())),
                     discreteValues -> formattedRanges.addAll(
                             discreteValues.getValues().stream()
-                                    .map(value -> valuePrinter.castToVarchar(type, value))
+                                    .map(value -> valuePrinter.render(type, value))
                                     .map(value -> new FormattedMarker(Optional.of(value), Bound.EXACTLY))
                                     .map(marker -> new FormattedRange(marker, marker))
                                     .collect(toImmutableSet())),
@@ -799,13 +799,13 @@ public class IoPlanPrinter
             FormattedMarker low = range.isLowUnbounded()
                     ? new FormattedMarker(Optional.empty(), Bound.ABOVE)
                     : new FormattedMarker(
-                    Optional.of(valuePrinter.castToVarchar(range.getType(), range.getLowBoundedValue())),
+                    Optional.of(valuePrinter.render(range.getType(), range.getLowBoundedValue())),
                     range.isLowInclusive() ? Bound.EXACTLY : Bound.ABOVE);
 
             FormattedMarker high = range.isHighUnbounded()
                     ? new FormattedMarker(Optional.empty(), Bound.BELOW)
                     : new FormattedMarker(
-                    Optional.of(valuePrinter.castToVarchar(range.getType(), range.getHighBoundedValue())),
+                    Optional.of(valuePrinter.render(range.getType(), range.getHighBoundedValue())),
                     range.isHighInclusive() ? Bound.EXACTLY : Bound.BELOW);
 
             return new FormattedRange(low, high);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -597,7 +597,7 @@ public class PlanPrinter
                 .map(argument -> {
                     if (argument.isConstant()) {
                         NullableValue constant = argument.getConstant();
-                        String printableValue = valuePrinter.castToVarchar(constant.getType(), constant.getValue());
+                        String printableValue = valuePrinter.render(constant.getType(), constant.getValue());
                         return constant.getType().getDisplayName() + "(" + anonymizer.anonymize(constant.getType(), printableValue) + ")";
                     }
                     return anonymizer.anonymize(argument.getColumn());
@@ -1905,7 +1905,7 @@ public class PlanPrinter
                     argument.getType().getDisplayName(),
                     anonymizer.anonymize(
                             argument.getType(),
-                            valuePrinter.castToVarchar(argument.getType(), argument.getValue())));
+                            valuePrinter.render(argument.getType(), argument.getValue())));
         }
 
         private String formatDescriptorArgument(String argumentName, DescriptorArgument argument)
@@ -2065,7 +2065,7 @@ public class PlanPrinter
                         for (Range range : ranges.getOrderedRanges()) {
                             StringBuilder builder = new StringBuilder();
                             if (range.isSingleValue()) {
-                                String value = anonymizer.anonymize(type, valuePrinter.castToVarchar(type, range.getSingleValue()));
+                                String value = anonymizer.anonymize(type, valuePrinter.render(type, range.getSingleValue()));
                                 builder.append('[').append(value).append(']');
                             }
                             else {
@@ -2075,7 +2075,7 @@ public class PlanPrinter
                                     builder.append("<min>");
                                 }
                                 else {
-                                    builder.append(anonymizer.anonymize(type, valuePrinter.castToVarchar(type, range.getLowBoundedValue())));
+                                    builder.append(anonymizer.anonymize(type, valuePrinter.render(type, range.getLowBoundedValue())));
                                 }
 
                                 builder.append(", ");
@@ -2084,7 +2084,7 @@ public class PlanPrinter
                                     builder.append("<max>");
                                 }
                                 else {
-                                    builder.append(anonymizer.anonymize(type, valuePrinter.castToVarchar(type, range.getHighBoundedValue())));
+                                    builder.append(anonymizer.anonymize(type, valuePrinter.render(type, range.getHighBoundedValue())));
                                 }
 
                                 builder.append(range.isHighInclusive() ? ']' : ')');
@@ -2093,7 +2093,7 @@ public class PlanPrinter
                         }
                     },
                     discreteValues -> discreteValues.getValues().stream()
-                            .map(value -> anonymizer.anonymize(type, valuePrinter.castToVarchar(type, value)))
+                            .map(value -> anonymizer.anonymize(type, valuePrinter.render(type, value)))
                             .sorted() // Sort so the values will be printed in predictable order
                             .forEach(parts::add),
                     allOrNone -> {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/ValuePrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/ValuePrinter.java
@@ -38,7 +38,7 @@ public final class ValuePrinter
         this.session = requireNonNull(session, "session is null");
     }
 
-    public String castToVarchar(Type type, Object value)
+    public String render(Type type, Object value)
     {
         try {
             if (value == null) {


### PR DESCRIPTION
## Description
Remove unused method castToVarcharOrFail  and rename castToVarchar to render in ValuePrinter 
## Release notes
(X) This is not user-visible or is docs only, and no release notes are required.
