### PR TITLE
Retry JDK download in Docker image build

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN \
     echo "Downloading JDK from ${JDK_DOWNLOAD_LINK}" && \
     mkdir -p "${JAVA_HOME}" && \
     curl -#LfS --retry 8 "${JDK_DOWNLOAD_LINK}" -o /jdktarfile && \
-    cat /jdktarfile | tar -zx --strip 1 -C "${JAVA_HOME}" && \
+    tar -zxf /jdktarfile --strip 1 -C "${JAVA_HOME}" && \
     echo "Done"
 
 FROM redhat/ubi10 AS packages


### PR DESCRIPTION
The download can fail, as any other network operation.

- might fix https://github.com/trinodb/trino/issues/27483 