### PR TITLE
Upgrade Hudi version to 1.1.0

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.hudi.version>1.0.2</dep.hudi.version>
+        <dep.hudi.version>1.1.0</dep.hudi.version>
     </properties>
 
     <dependencies>
@@ -425,6 +425,10 @@
                         <ignoredResourcePattern>log4j.properties</ignoredResourcePattern>
                         <ignoredResourcePattern>log4j-surefire.properties</ignoredResourcePattern>
                     </ignoredResourcePatterns>
+
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>org.apache.parquet.conf.ParquetConfiguration</ignoredClassPattern>
+                    </ignoredClassPatterns>
                 </configuration>
             </plugin>
         </plugins>

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/io/TrinoHudiFileReaderFactory.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/io/TrinoHudiFileReaderFactory.java
@@ -17,6 +17,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.io.storage.HFileReaderFactory;
 import org.apache.hudi.io.storage.HoodieAvroBootstrapFileReader;
 import org.apache.hudi.io.storage.HoodieFileReader;
 import org.apache.hudi.io.storage.HoodieFileReaderFactory;
@@ -52,7 +53,13 @@ public class TrinoHudiFileReaderFactory
             Option<Schema> schemaOption)
             throws IOException
     {
-        return new HoodieNativeAvroHFileReader(storage, path, schemaOption);
+        return HoodieNativeAvroHFileReader.builder()
+                .readerFactory(HFileReaderFactory.builder()
+                        .withStorage(storage)
+                        .build())
+                .path(path)
+                .schema(schemaOption)
+                .build();
     }
 
     @Override
@@ -64,7 +71,13 @@ public class TrinoHudiFileReaderFactory
             Option<Schema> schemaOption)
             throws IOException
     {
-        return new HoodieNativeAvroHFileReader(this.storage, content, schemaOption);
+        return HoodieNativeAvroHFileReader.builder()
+                .readerFactory(HFileReaderFactory.builder()
+                        .withStorage(storage)
+                        .withContent(content)
+                        .build())
+                .schema(schemaOption)
+                .build();
     }
 
     @Override

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/TpchHudiTablesInitializer.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/TpchHudiTablesInitializer.java
@@ -44,6 +44,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieJavaEngineContext;
 import org.apache.hudi.common.bootstrap.index.NoOpBootstrapIndex;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
@@ -166,9 +167,9 @@ public class TpchHudiTablesInitializer
                     .map(MaterializedRow::getFields)
                     .map(recordConverter::toRecord)
                     .collect(Collectors.toList());
-            String timestamp = "0";
-            writeClient.startCommitWithTime(timestamp);
-            writeClient.insert(records, timestamp);
+            String newCommitTime = writeClient.startCommit();
+            List<WriteStatus> statuses = writeClient.insert(records, newCommitTime);
+            writeClient.commit(newCommitTime, statuses);
         }
     }
 


### PR DESCRIPTION
## Description

This PR upgrades Hudi version to 1.1.0 for Hudi connector.

## Additional context and related issues

Hudi release 1.1.0 is out: https://hudi.apache.org/releases/release-1.1.0

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
