### PR TITLE
Update `main` syntax to Java 25

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/GenerateTimeZoneIndex.java
+++ b/core/trino-main/src/main/java/io/trino/util/GenerateTimeZoneIndex.java
@@ -32,7 +32,7 @@ public final class GenerateTimeZoneIndex
 {
     private GenerateTimeZoneIndex() {}
 
-    public static void main(String[] args)
+    static void main()
             throws InterruptedException
     {
         //

--- a/core/trino-main/src/test/java/io/trino/BenchmarkBoxedBoolean.java
+++ b/core/trino-main/src/test/java/io/trino/BenchmarkBoxedBoolean.java
@@ -143,7 +143,7 @@ public class BenchmarkBoxedBoolean
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkBoxedBoolean.class)

--- a/core/trino-main/src/test/java/io/trino/BenchmarkPagesIndexPageSorter.java
+++ b/core/trino-main/src/test/java/io/trino/BenchmarkPagesIndexPageSorter.java
@@ -140,7 +140,7 @@ public class BenchmarkPagesIndexPageSorter
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkPagesIndexPageSorter.class).run();

--- a/core/trino-main/src/test/java/io/trino/block/BenchmarkBlockBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/block/BenchmarkBlockBuilder.java
@@ -146,7 +146,7 @@ public class BenchmarkBlockBuilder
         benchmarkAppendRange(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkBlockBuilder.class).run();

--- a/core/trino-main/src/test/java/io/trino/block/BenchmarkMapCopy.java
+++ b/core/trino-main/src/test/java/io/trino/block/BenchmarkMapCopy.java
@@ -101,7 +101,7 @@ public class BenchmarkMapCopy
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/block/BenchmarkRowBlockBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/block/BenchmarkRowBlockBuilder.java
@@ -104,7 +104,7 @@ public class BenchmarkRowBlockBuilder
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkRowBlockBuilder.class)

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -222,7 +222,7 @@ public class BenchmarkNodeScheduler
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkNodeScheduler.class).run();

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkBlockSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkBlockSerde.java
@@ -446,7 +446,7 @@ public class BenchmarkBlockSerde
         deserializeLineitem(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkBlockSerde.class).run();

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkPagesSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkPagesSerde.java
@@ -204,7 +204,7 @@ public class BenchmarkPagesSerde
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         BenchmarkData data = new BenchmarkData();

--- a/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/SplitGenerators.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/SplitGenerators.java
@@ -33,7 +33,7 @@ final class SplitGenerators
 {
     private SplitGenerators() {}
 
-    public static void main(String[] args)
+    static void main()
     {
         Histogram<Long> bins = fromContinuous(ImmutableList.of(
                 MILLISECONDS.toNanos(0),

--- a/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutorSimulation.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutorSimulation.java
@@ -60,7 +60,7 @@ import static java.util.function.Function.identity;
 public class TimeSharingTaskExecutorSimulation
         implements Closeable
 {
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         try (TimeSharingTaskExecutorSimulation simulator = new TimeSharingTaskExecutorSimulation()) {

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/BenchmarkResourceGroup.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/BenchmarkResourceGroup.java
@@ -99,7 +99,7 @@ public class BenchmarkResourceGroup
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkResourceGroup.class).run();

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/BenchmarkBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/BenchmarkBinPackingNodeAllocator.java
@@ -242,7 +242,7 @@ public class BenchmarkBinPackingNodeAllocator
         benchmark.benchmarkProcessPendingAllocations(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkBinPackingNodeAllocator.class)

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -208,7 +208,7 @@ public class BenchmarkDynamicFilterSourceOperator
         context.cleanup();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkDynamicFilterSourceOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -269,7 +269,7 @@ public class BenchmarkGroupByHash
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHashOnSimulatedData.java
@@ -612,7 +612,7 @@ public class BenchmarkGroupByHashOnSimulatedData
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkGroupByHashOnSimulatedData.class)

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
@@ -140,7 +140,7 @@ public class BenchmarkGroupedTopNRankBuilder
         return ImmutableList.copyOf(builder.buildResult());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         BenchmarkData data = new BenchmarkData();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
@@ -128,7 +128,7 @@ public class BenchmarkGroupedTopNRowNumberBuilder
         return ImmutableList.copyOf(topNBuilder.buildResult());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         BenchmarkData data = new BenchmarkData();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -365,7 +365,7 @@ public class BenchmarkHashAndStreamingAggregationOperators
         context.cleanup();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         Benchmarks.benchmark(BenchmarkHashAndStreamingAggregationOperators.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkPagesIndexOrdering.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkPagesIndexOrdering.java
@@ -127,7 +127,7 @@ public class BenchmarkPagesIndexOrdering
         benchmarkQuickSort(context);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkPagesIndexOrdering.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -285,7 +285,7 @@ public class BenchmarkScanFilterAndProjectOperator
         context.cleanup();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkScanFilterAndProjectOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
@@ -201,7 +201,7 @@ public class BenchmarkTopNOperator
         context.cleanup();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         BenchmarkContext data = new BenchmarkContext();

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkWindowOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkWindowOperator.java
@@ -330,7 +330,7 @@ public class BenchmarkWindowOperator
         context.cleanup();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         Benchmarks.benchmark(BenchmarkWindowOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkAggregationMaskBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkAggregationMaskBuilder.java
@@ -219,7 +219,7 @@ public class BenchmarkAggregationMaskBuilder
         return allBlocksBuilderCompiled.buildAggregationMask(arguments, Optional.empty());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Throwable
     {
         BenchmarkAggregationMaskBuilder bench = new BenchmarkAggregationMaskBuilder();

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkArrayAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkArrayAggregation.java
@@ -139,7 +139,7 @@ public class BenchmarkArrayAggregation
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkDecimalAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkDecimalAggregation.java
@@ -203,7 +203,7 @@ public class BenchmarkDecimalAggregation
         new BenchmarkDecimalAggregation().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // ensure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkGroupedTypedHistogram.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkGroupedTypedHistogram.java
@@ -148,7 +148,7 @@ public class BenchmarkGroupedTypedHistogram
         testSharedGroupWithLargeBlocksRunner(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkGroupedTypedHistogram.class)

--- a/core/trino-main/src/test/java/io/trino/operator/join/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/BenchmarkHashBuildAndJoinOperators.java
@@ -464,7 +464,7 @@ public class BenchmarkHashBuildAndJoinOperators
         benchmarkBuildHash(buildContext);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkHashBuildAndJoinOperators.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/BenchmarkHashBuildAndJoinOperators.java
@@ -462,7 +462,7 @@ public class BenchmarkHashBuildAndJoinOperators
         benchmarkBuildHash(buildContext);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkHashBuildAndJoinOperators.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
@@ -570,7 +570,7 @@ public class BenchmarkPartitionedOutputOperator
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkPartitionedOutputOperator.class)

--- a/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/BenchmarkDictionaryBlock.java
@@ -272,7 +272,7 @@ public class BenchmarkDictionaryBlock
         copyPositionsCompactDictionary(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayDistinct.java
@@ -159,7 +159,7 @@ public class BenchmarkArrayDistinct
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayDotProduct.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayDotProduct.java
@@ -140,7 +140,7 @@ public class BenchmarkArrayDotProduct
         new BenchmarkArrayDotProduct().arrayIntersect(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayEqualOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayEqualOperator.java
@@ -127,7 +127,7 @@ public class BenchmarkArrayEqualOperator
         equalOperator(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Throwable
     {
         benchmark(BenchmarkArrayEqualOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayFilter.java
@@ -255,7 +255,7 @@ public class BenchmarkArrayFilter
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayHashCodeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayHashCodeOperator.java
@@ -112,7 +112,7 @@ public class BenchmarkArrayHashCodeOperator
         hashOperator(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Throwable
     {
         benchmark(BenchmarkArrayHashCodeOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayIntersect.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayIntersect.java
@@ -174,7 +174,7 @@ public class BenchmarkArrayIntersect
         new BenchmarkArrayIntersect().arrayIntersect(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayJoin.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayJoin.java
@@ -130,7 +130,7 @@ public class BenchmarkArrayJoin
         new BenchmarkArrayJoin().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySort.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySort.java
@@ -142,7 +142,7 @@ public class BenchmarkArraySort
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySubscript.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraySubscript.java
@@ -223,7 +223,7 @@ public class BenchmarkArraySubscript
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayTransform.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArrayTransform.java
@@ -161,7 +161,7 @@ public class BenchmarkArrayTransform
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraysOverlap.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraysOverlap.java
@@ -154,7 +154,7 @@ public class BenchmarkArraysOverlap
         new BenchmarkArraysOverlap().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkDateTimeFunctions.java
@@ -109,7 +109,7 @@ public class BenchmarkDateTimeFunctions
         getTimestampFieldNew(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkDateTimeFunctions.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkEqualOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkEqualOperator.java
@@ -118,7 +118,7 @@ public class BenchmarkEqualOperator
         equalOperator(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkEqualOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkEqualsConjunctsOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkEqualsConjunctsOperator.java
@@ -153,7 +153,7 @@ public class BenchmarkEqualsConjunctsOperator
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkEqualsConjunctsOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkHashCodeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkHashCodeOperator.java
@@ -106,7 +106,7 @@ public class BenchmarkHashCodeOperator
         hashOperator(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkHashCodeOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkHistogram.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkHistogram.java
@@ -85,7 +85,7 @@ public class BenchmarkHistogram
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonFunctions.java
@@ -342,7 +342,7 @@ public class BenchmarkJsonFunctions
         new BenchmarkJsonFunctions().benchmarkJsonExtractFunction(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkJsonFunctions.class, WarmupMode.BULK_INDI).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonPathBinaryOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonPathBinaryOperators.java
@@ -281,7 +281,7 @@ public class BenchmarkJsonPathBinaryOperators
         new BenchmarkJsonPathBinaryOperators().benchmarkJsonValueFunctionMultipleVaryingTypes(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkJsonPathBinaryOperators.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToArrayCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToArrayCast.java
@@ -179,7 +179,7 @@ public class BenchmarkJsonToArrayCast
         new BenchmarkJsonToArrayCast().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToMapCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonToMapCast.java
@@ -185,7 +185,7 @@ public class BenchmarkJsonToMapCast
         new BenchmarkJsonToMapCast().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkLike.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkLike.java
@@ -253,7 +253,7 @@ public class BenchmarkLike
         checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         Options options = new OptionsBuilder()

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapConcat.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapConcat.java
@@ -192,7 +192,7 @@ public class BenchmarkMapConcat
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapSubscript.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapSubscript.java
@@ -244,7 +244,7 @@ public class BenchmarkMapSubscript
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapToMapCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkMapToMapCast.java
@@ -139,7 +139,7 @@ public class BenchmarkMapToMapCast
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRegexpFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRegexpFunctions.java
@@ -132,7 +132,7 @@ public class BenchmarkRegexpFunctions
         return new Re2JRegexp(Integer.MAX_VALUE, 5, pattern);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkRegexpFunctions.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRoundFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRoundFunction.java
@@ -123,7 +123,7 @@ public class BenchmarkRoundFunction
         return Math.floor(num * factor + 0.5) / factor;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkRoundFunction.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRowEqualOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRowEqualOperator.java
@@ -134,7 +134,7 @@ public class BenchmarkRowEqualOperator
         equalOperator(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkRowEqualOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRowHashCodeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRowHashCodeOperator.java
@@ -119,7 +119,7 @@ public class BenchmarkRowHashCodeOperator
         hashOperator(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkRowHashCodeOperator.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRowToRowCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRowToRowCast.java
@@ -142,7 +142,7 @@ public class BenchmarkRowToRowCast
         new BenchmarkRowToRowCast().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkStringFunctions.java
@@ -250,7 +250,7 @@ public class BenchmarkStringFunctions
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkStringFunctions.class).run();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkTransformKey.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkTransformKey.java
@@ -171,7 +171,7 @@ public class BenchmarkTransformKey
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkTransformValue.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkTransformValue.java
@@ -184,7 +184,7 @@ public class BenchmarkTransformValue
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/operator/unnest/BenchmarkUnnestOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/unnest/BenchmarkUnnestOperator.java
@@ -260,7 +260,7 @@ public class BenchmarkUnnestOperator
         assertThat(block.getPositionCount()).isEqualTo(100);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkUnnestOperator.class)

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -380,7 +380,7 @@ public class TestingHydraIdentityProvider
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging logging = Logging.initialize();

--- a/core/trino-main/src/test/java/io/trino/sql/BenchmarkExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/BenchmarkExpressionInterpreter.java
@@ -86,7 +86,7 @@ public class BenchmarkExpressionInterpreter
         assertThat(benchmark.optimize(data)).hasSize(data.expressions.size());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkExpressionInterpreter.class, WarmupMode.BULK).run();

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkAndColumnarFilterTpchData.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkAndColumnarFilterTpchData.java
@@ -173,7 +173,7 @@ public class BenchmarkAndColumnarFilterTpchData
                 ImmutableList.of());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkAndColumnarFilterTpchData.class).run();

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkColumnarFilter.java
@@ -263,7 +263,7 @@ public class BenchmarkColumnarFilter
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Throwable
     {
         benchmark(BenchmarkColumnarFilter.class)

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkDynamicPageFilter.java
@@ -226,7 +226,7 @@ public class BenchmarkDynamicPageFilter
         return value < chance;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Throwable
     {
         benchmark(BenchmarkDynamicPageFilter.class, WarmupMode.BULK)

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkInCodeGenerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkInCodeGenerator.java
@@ -223,7 +223,7 @@ public class BenchmarkInCodeGenerator
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         Benchmarks.benchmark(BenchmarkInCodeGenerator.class).run();

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor.java
@@ -110,7 +110,7 @@ public class BenchmarkPageProcessor
                         SourcePage.create(inputPage)));
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         new BenchmarkPageProcessor().setup();

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
@@ -204,7 +204,7 @@ public class BenchmarkPageProcessor2
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkPageProcessor2.class).run();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/BenchmarkPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/BenchmarkPlanner.java
@@ -150,7 +150,7 @@ public class BenchmarkPlanner
         }
     }
 
-    public static enum Queries
+    public enum Queries
     {
         TPCH(() -> IntStream.rangeClosed(1, 22)
                 .boxed()
@@ -205,7 +205,7 @@ public class BenchmarkPlanner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/BenchmarkReorderChainedJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/BenchmarkReorderChainedJoins.java
@@ -97,7 +97,7 @@ public class BenchmarkReorderChainedJoins
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkReorderChainedJoins.class).run();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/BenchmarkReorderInterconnectedJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/BenchmarkReorderInterconnectedJoins.java
@@ -108,7 +108,7 @@ public class BenchmarkReorderInterconnectedJoins
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkReorderInterconnectedJoins.class).run();

--- a/core/trino-main/src/test/java/io/trino/type/BenchmarkBigIntOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/BenchmarkBigIntOperators.java
@@ -377,7 +377,7 @@ public class BenchmarkBigIntOperators
         return -x;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkBigIntOperators.class).run();

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkPagesSort.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkPagesSort.java
@@ -265,7 +265,7 @@ public class BenchmarkPagesSort
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkPagesSort.class).run();

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
@@ -65,7 +65,7 @@ public class BenchmarkParseDate
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkParseDate.class).run();

--- a/core/trino-parser/src/main/java/io/trino/sql/ReservedIdentifiers.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ReservedIdentifiers.java
@@ -48,7 +48,7 @@ public final class ReservedIdentifiers
             .collect(toImmutableSet());
 
     @SuppressWarnings("CallToPrintStackTrace")
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         if ((args.length == 2) && args[0].equals("validateDocs")) {
             try {

--- a/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
+++ b/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
@@ -24,7 +24,7 @@ public final class TrinoServer
 {
     private TrinoServer() {}
 
-    public static void main(String[] args)
+    public static void main()
     {
         Runtime.Version javaVersion = Runtime.version();
         int requiredVersion = requiredJavaVersion();

--- a/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkComputePosition.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkComputePosition.java
@@ -78,7 +78,7 @@ public class BenchmarkComputePosition
         return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) / (1L << 32));
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkComputePosition.class).run();

--- a/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkCopyPositions.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkCopyPositions.java
@@ -231,7 +231,7 @@ public class BenchmarkCopyPositions
         new BenchmarkCopyPositions().testCopyPositions();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkCopyPositions.class)

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
@@ -398,7 +398,7 @@ public class BenchmarkSortedRangeSet
         getOrderedRangesLarge(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkSortedRangeSet.class).run();

--- a/core/trino-spi/src/test/java/io/trino/spi/type/BenchmarkInt128.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/BenchmarkInt128.java
@@ -87,7 +87,7 @@ public class BenchmarkInt128
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         Benchmarks.benchmark(BenchmarkInt128.class).run();

--- a/lib/trino-array/src/test/java/io/trino/array/BenchmarkReferenceCountMap.java
+++ b/lib/trino-array/src/test/java/io/trino/array/BenchmarkReferenceCountMap.java
@@ -90,7 +90,7 @@ public class BenchmarkReferenceCountMap
         return map;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkReferenceCountMap.class, WarmupMode.BULK)

--- a/lib/trino-cache/src/test/java/io/trino/cache/BenchmarkEvictableCache.java
+++ b/lib/trino-cache/src/test/java/io/trino/cache/BenchmarkEvictableCache.java
@@ -104,7 +104,7 @@ public class BenchmarkEvictableCache
         public int cacheValueLoadTimeMillis;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkEvictableCache.class).run();

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/serde/BenchmarkGeometrySerde.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/serde/BenchmarkGeometrySerde.java
@@ -378,7 +378,7 @@ public class BenchmarkGeometrySerde
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkGeometrySerde.class).run();

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/serde/BenchmarkJtsGeometrySerde.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/serde/BenchmarkJtsGeometrySerde.java
@@ -310,7 +310,7 @@ public class BenchmarkJtsGeometrySerde
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkJtsGeometrySerde.class).run();

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/BenchmarkGetFileSystem.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/BenchmarkGetFileSystem.java
@@ -95,7 +95,7 @@ public class BenchmarkGetFileSystem
         data.executor.invokeAll(data.callableTasks).forEach(f -> data.blackhole.consume(getFutureValue(f)));
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Benchmarks.benchmark(BenchmarkGetFileSystem.class).run();

--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
@@ -1231,7 +1231,7 @@ public class BenchmarkColumnReaders
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkColumnReaders.class).run();

--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkOrcDecimalReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkOrcDecimalReader.java
@@ -137,7 +137,7 @@ public class BenchmarkOrcDecimalReader
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/lib/trino-orc/src/test/java/io/trino/orc/stream/BenchmarkLongBitPacker.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/stream/BenchmarkLongBitPacker.java
@@ -219,7 +219,7 @@ public class BenchmarkLongBitPacker
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkColumnarFilterParquetData.java
@@ -258,7 +258,7 @@ public class BenchmarkColumnarFilterParquetData
         return outputRows;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkColumnarFilterParquetData.class)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormat.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/BenchmarkParquetFormat.java
@@ -304,7 +304,7 @@ public class BenchmarkParquetFormat
         public abstract TestData createTestData();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Collection<RunResult> results = benchmark(BenchmarkParquetFormat.class)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/BenchmarkTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/BenchmarkTupleDomainParquetPredicate.java
@@ -112,7 +112,7 @@ public class BenchmarkTupleDomainParquetPredicate
         domainFromDictionary(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkTupleDomainParquetPredicate.class).run();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBinaryColumnReader.java
@@ -179,7 +179,7 @@ public class BenchmarkBinaryColumnReader
         return data;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         run(BenchmarkBinaryColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBooleanColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkBooleanColumnReader.java
@@ -83,7 +83,7 @@ public class BenchmarkBooleanColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkBooleanColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkByteColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkByteColumnReader.java
@@ -97,7 +97,7 @@ public class BenchmarkByteColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkByteColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkFixed12ColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkFixed12ColumnReader.java
@@ -83,7 +83,7 @@ public class BenchmarkFixed12ColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkFixed12ColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkInt32ToLongColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkInt32ToLongColumnReader.java
@@ -84,7 +84,7 @@ public class BenchmarkInt32ToLongColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkInt32ToLongColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkIntColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkIntColumnReader.java
@@ -97,7 +97,7 @@ public class BenchmarkIntColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkIntColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongColumnReader.java
@@ -97,7 +97,7 @@ public class BenchmarkLongColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkLongColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongDecimalColumnReader.java
@@ -98,7 +98,7 @@ public class BenchmarkLongDecimalColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkLongDecimalColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadFixedWidthInt.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadFixedWidthInt.java
@@ -95,7 +95,7 @@ public class BenchmarkReadFixedWidthInt
         return result;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkReadFixedWidthInt.class)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Int.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Int.java
@@ -117,7 +117,7 @@ public class BenchmarkReadUleb128Int
         return value | (b << i);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkReadUleb128Int.class)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Long.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkReadUleb128Long.java
@@ -100,7 +100,7 @@ public class BenchmarkReadUleb128Long
         return value | (b << i);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkReadUleb128Long.class)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortColumnReader.java
@@ -97,7 +97,7 @@ public class BenchmarkShortColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkShortColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -90,7 +90,7 @@ public class BenchmarkShortDecimalColumnReader
         writer.writeBytes(binary);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkShortDecimalColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkUuidColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkUuidColumnReader.java
@@ -95,7 +95,7 @@ public class BenchmarkUuidColumnReader
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkUuidColumnReader.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/BenchmarkRleBitPackingDecoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/BenchmarkRleBitPackingDecoder.java
@@ -129,7 +129,7 @@ public class BenchmarkRleBitPackingDecoder
         return Slices.wrappedBuffer(data, Integer.BYTES, data.length - Integer.BYTES);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkRleBitPackingDecoder.class, WarmupMode.BULK)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/BenchmarkFlatDefinitionLevelDecoder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/BenchmarkFlatDefinitionLevelDecoder.java
@@ -161,7 +161,7 @@ public class BenchmarkFlatDefinitionLevelDecoder
         DataGenerator() {}
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkFlatDefinitionLevelDecoder.class)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/BenchmarkBinaryColumnWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/BenchmarkBinaryColumnWriter.java
@@ -110,7 +110,7 @@ public class BenchmarkBinaryColumnWriter
 
     record Range(int from, int to) {}
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         run(BenchmarkBinaryColumnWriter.class);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/BenchmarkLongColumnWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/BenchmarkLongColumnWriter.java
@@ -74,7 +74,7 @@ public class BenchmarkLongColumnWriter
         return batch;
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         run(BenchmarkLongColumnWriter.class);

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/AiQueryRunner.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/AiQueryRunner.java
@@ -24,7 +24,7 @@ public final class AiQueryRunner
 {
     private AiQueryRunner() {}
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build())

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -219,7 +219,7 @@ public final class BigQueryQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = BigQueryQueryRunner.builder()

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/BlackHoleQueryRunner.java
@@ -62,7 +62,7 @@ public final class BlackHoleQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder()

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
@@ -111,7 +111,7 @@ public final class CassandraQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new CassandraServer())

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/ScyllaQueryRunner.java
@@ -103,7 +103,7 @@ public final class ScyllaQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -103,7 +103,7 @@ public final class ClickHouseQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingClickHouseServer())

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -189,7 +189,7 @@ public final class DeltaLakeQueryRunner
     {
         private DefaultDeltaLakeQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             File metastoreDir = createTempDirectory("delta_query_runner").toFile();
@@ -212,7 +212,7 @@ public final class DeltaLakeQueryRunner
     {
         private DeltaLakeExternalQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             // Please set Delta Lake connector properties via VM options. e.g. -Dhive.metastore=glue -D..
@@ -231,7 +231,7 @@ public final class DeltaLakeQueryRunner
     {
         private DeltaLakeSparkQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             String bucketName = "test-bucket";
@@ -254,7 +254,7 @@ public final class DeltaLakeQueryRunner
     {
         private S3DeltaLakeQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             String bucketName = "test-bucket";

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
@@ -141,7 +141,7 @@ public class BenchmarkExtendedStatistics
         benchmark(benchmarkData);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Options options = new OptionsBuilder()

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/DruidQueryRunner.java
@@ -183,7 +183,7 @@ public final class DruidQueryRunner
                 .collect(Collectors.joining("\t"));
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingDruidServer())

--- a/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/DuckDbQueryRunner.java
+++ b/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/DuckDbQueryRunner.java
@@ -90,7 +90,7 @@ public final class DuckDbQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
@@ -162,7 +162,7 @@ public final class ElasticsearchQueryRunner
         LOG.info("Imported %s in %s", table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new ElasticsearchServer(ELASTICSEARCH_7_IMAGE))

--- a/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
+++ b/plugin/trino-example-jdbc/src/test/java/io/trino/plugin/example/ExampleQueryRunner.java
@@ -76,7 +76,7 @@ public final class ExampleQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging logger = Logging.initialize();

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/ExasolQueryRunner.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/ExasolQueryRunner.java
@@ -107,7 +107,7 @@ public final class ExasolQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/FakerQueryRunner.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/FakerQueryRunner.java
@@ -83,7 +83,7 @@ public class FakerQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging logger = Logging.initialize();
@@ -103,7 +103,7 @@ public class FakerQueryRunner
     {
         private FakerQueryRunnerWithTaskRetries() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logger log = Logger.get(FakerQueryRunnerWithTaskRetries.class);

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkBingTilesAround.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkBingTilesAround.java
@@ -61,7 +61,7 @@ public class BenchmarkBingTilesAround
         new BenchmarkBingTilesAround().benchmark(data);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         Benchmarks.benchmark(BenchmarkBingTilesAround.class).run();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkEnvelopeIntersection.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkEnvelopeIntersection.java
@@ -85,7 +85,7 @@ public class BenchmarkEnvelopeIntersection
         assertThat(deserialize(benchmark.envelopes(data))).isEqualTo(deserialize(benchmark.geometries(data)));
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkEnvelopeIntersection.class).run();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkGeometryAggregations.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkGeometryAggregations.java
@@ -133,7 +133,7 @@ public class BenchmarkGeometryAggregations
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         new BenchmarkGeometryAggregations().verify();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkGeometryToBingTiles.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkGeometryToBingTiles.java
@@ -77,7 +77,7 @@ public class BenchmarkGeometryToBingTiles
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTArea.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTArea.java
@@ -90,7 +90,7 @@ public class BenchmarkSTArea
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws IOException, RunnerException
     {
         // assure the benchmarks are valid before running

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTContains.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTContains.java
@@ -153,7 +153,7 @@ public class BenchmarkSTContains
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws IOException, RunnerException
     {
         // assure the benchmarks are valid before running

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTEnvelope.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTEnvelope.java
@@ -69,7 +69,7 @@ public class BenchmarkSTEnvelope
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkSTEnvelope.class).run();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTIntersects.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTIntersects.java
@@ -154,7 +154,7 @@ public class BenchmarkSTIntersects
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkSTIntersects.class).run();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTXMin.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSTXMin.java
@@ -71,7 +71,7 @@ public class BenchmarkSTXMin
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws RunnerException
     {
         benchmark(BenchmarkSTXMin.class).run();

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSpatialJoin.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSpatialJoin.java
@@ -161,7 +161,7 @@ public class BenchmarkSpatialJoin
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/GeoQueryRunner.java
@@ -23,7 +23,7 @@ public final class GeoQueryRunner
 {
     private GeoQueryRunner() {}
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build())

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/SheetsQueryRunner.java
@@ -85,7 +85,7 @@ public final class SheetsQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -389,7 +389,7 @@ public final class HiveQueryRunner
 
     public static final class DefaultHiveQueryRunnerMain
     {
-        public static void main(String[] args)
+        static void main(String[] args)
                 throws Exception
         {
             Optional<Path> baseDataDir = Optional.empty();
@@ -425,7 +425,7 @@ public final class HiveQueryRunner
     {
         private HiveGlueQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             // Requires AWS credentials, which can be provided any way supported by the DefaultProviderChain

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -171,7 +171,7 @@ public final class S3HiveQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Hive3MinioDataLake hiveMinioDataLake = new Hive3MinioDataLake("tpch");
@@ -190,7 +190,7 @@ public final class S3HiveQueryRunner
 
     public static class S3Hive4QueryRunner
     {
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Hive4MinioDataLake hiveMinioDataLake = new Hive4MinioDataLake("tpch");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/BenchmarkGetPartitionsSample.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/BenchmarkGetPartitionsSample.java
@@ -68,7 +68,7 @@ public class BenchmarkGetPartitionsSample
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         benchmark(BenchmarkGetPartitionsSample.class).run();

--- a/plugin/trino-hive/src/test/resources/with_short_zone_id/README.md
+++ b/plugin/trino-hive/src/test/resources/with_short_zone_id/README.md
@@ -9,7 +9,7 @@ import static java.lang.String.format;
 
 public class Main
 {
-    public static void main(String[] args)
+    static void main()
     {
         // Make sure to set default timezone using short timezone id
         TimeZone.setDefault(TimeZone.getTimeZone("EST"));

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -130,7 +130,7 @@ public final class HudiQueryRunner
     {
         private DefaultHudiQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logging.initialize();
@@ -150,7 +150,7 @@ public final class HudiQueryRunner
     {
         private HudiMinioQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logging.initialize();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -191,7 +191,7 @@ public final class IcebergQueryRunner
     {
         private IcebergRestQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Path warehouseLocation = Files.createTempDirectory(null);
@@ -225,7 +225,7 @@ public final class IcebergQueryRunner
     {
         private IcebergPolarisQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Path warehouseLocation = Files.createTempDirectory(null);
@@ -256,7 +256,7 @@ public final class IcebergQueryRunner
     {
         private IcebergUnityQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Path warehouseLocation = Files.createTempDirectory(null);
@@ -289,7 +289,7 @@ public final class IcebergQueryRunner
     {
         private IcebergExternalQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             // Please set Iceberg connector properties via VM options. e.g. -Diceberg.catalog.type=glue -D..
@@ -308,7 +308,7 @@ public final class IcebergQueryRunner
     {
         private IcebergMinioHiveMetastoreQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             String bucketName = "test-bucket";
@@ -347,7 +347,7 @@ public final class IcebergQueryRunner
     {
         private IcebergMinioQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logging.initialize();
@@ -387,7 +387,7 @@ public final class IcebergQueryRunner
     {
         private IcebergAzureQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             String azureContainer = requiredNonEmptySystemProperty("testing.azure-abfs-container");
@@ -436,7 +436,7 @@ public final class IcebergQueryRunner
     {
         private IcebergJdbcQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Path warehouseLocation = Files.createTempDirectory(null);
@@ -468,7 +468,7 @@ public final class IcebergQueryRunner
     {
         private IcebergSnowflakeQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             @SuppressWarnings("resource")
@@ -501,7 +501,7 @@ public final class IcebergQueryRunner
     {
         private IcebergNessieQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             NessieContainer nessieContainer = NessieContainer.builder().build();
@@ -531,7 +531,7 @@ public final class IcebergQueryRunner
     {
         private DefaultIcebergQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logger log = Logger.get(DefaultIcebergQueryRunnerMain.class);
@@ -556,7 +556,7 @@ public final class IcebergQueryRunner
     {
         private IcebergQueryRunnerWithTaskRetries() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logger log = Logger.get(IcebergQueryRunnerWithTaskRetries.class);

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
@@ -95,7 +95,7 @@ public final class IgniteQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -246,7 +246,7 @@ public final class KafkaQueryRunner
     {
         private DefaultKafkaQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logging.initialize();
@@ -266,7 +266,7 @@ public final class KafkaQueryRunner
     {
         private ConfluentSchemaRegistryQueryRunnerMain() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Logging.initialize();

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/LakehouseQueryRunner.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/LakehouseQueryRunner.java
@@ -95,7 +95,7 @@ public final class LakehouseQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         File metastoreDir = createTempDirectory("delta_query_runner").toFile();

--- a/plugin/trino-loki/src/test/java/io/trino/plugin/loki/LokiQueryRunner.java
+++ b/plugin/trino-loki/src/test/java/io/trino/plugin/loki/LokiQueryRunner.java
@@ -73,7 +73,7 @@ public final class LokiQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging logger = Logging.initialize();

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
@@ -103,7 +103,7 @@ public final class MariaDbQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingMariaDbServer())

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
@@ -105,7 +105,7 @@ public final class MemoryQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder()
@@ -124,7 +124,7 @@ public final class MemoryQueryRunner
     {
         private MemoryQueryRunnerWithTaskRetries() {}
 
-        public static void main(String[] args)
+        static void main()
                 throws Exception
         {
             Path exchangeManagerDirectory = createTempDirectory(null);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -109,7 +109,7 @@ public final class MongoQueryRunner
         return MongoClients.create(server.getConnectionString());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new MongoServer())

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -97,7 +97,7 @@ public final class MySqlQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingMySqlServer())

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/OpenLineageListenerQueryRunner.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/OpenLineageListenerQueryRunner.java
@@ -110,7 +110,7 @@ public final class OpenLineageListenerQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         MarquezServer server = new MarquezServer();

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchQueryRunner.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/OpenSearchQueryRunner.java
@@ -145,7 +145,7 @@ public final class OpenSearchQueryRunner
         LOG.info("Imported %s in %s", table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new OpenSearchServer(OPENSEARCH_IMAGE, false, ImmutableMap.of()).getAddress())

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -100,7 +100,7 @@ public final class OracleQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         TestingOracleServer server = new TestingOracleServer();

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -126,7 +126,7 @@ public final class PinotQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         TestingKafka kafka = TestingKafka.createWithSchemaRegistry();

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -108,7 +108,7 @@ public final class PostgreSqlQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingPostgreSqlServer(System.getProperty("testing.postgresql-image-name", DEFAULT_IMAGE_NAME), true))

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/PrometheusQueryRunner.java
@@ -87,7 +87,7 @@ public final class PrometheusQueryRunner
         return new PrometheusClient(config, METRIC_CODEC, TESTING_TYPE_MANAGER);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new PrometheusServer())

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -158,7 +158,7 @@ public final class RedisQueryRunner
         return tableDescriptions.buildOrThrow();
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = RedisQueryRunner.builder(new RedisServer())

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -213,7 +213,7 @@ public final class RedshiftQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/SingleStoreQueryRunner.java
@@ -97,7 +97,7 @@ public final class SingleStoreQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder(new TestingSingleStoreServer())

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
@@ -100,7 +100,7 @@ public final class SnowflakeQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         DistributedQueryRunner queryRunner = builder()

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -107,7 +107,7 @@ public final class SqlServerQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         TestingSqlServer testingSqlServer = new TestingSqlServer();

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftTpchServer.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftTpchServer.java
@@ -38,7 +38,7 @@ public final class ThriftTpchServer
         app.initialize();
     }
 
-    public static void main(String[] args)
+    static void main()
     {
         Logger log = Logger.get(ThriftTpchServer.class);
         try {

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -47,7 +47,7 @@ public final class ThriftQueryRunner
 
     private ThriftQueryRunner() {}
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TpcdsQueryRunner.java
@@ -58,7 +58,7 @@ public final class TpcdsQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         QueryRunner queryRunner = builder()

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/statistics/TpcdsStatisticsRecorder.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/statistics/TpcdsStatisticsRecorder.java
@@ -34,7 +34,7 @@ public class TpcdsStatisticsRecorder
 {
     private static final List<String> SUPPORTED_SCHEMAS = ImmutableList.of("tiny", "sf1");
 
-    public static void main(String[] args)
+    static void main()
     {
         TpcdsStatisticsRecorder tool = new TpcdsStatisticsRecorder(new TableStatisticsRecorder(), new TableStatisticsDataRepository());
 

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/statistics/TpchStatisticsRecorder.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/statistics/TpchStatisticsRecorder.java
@@ -41,7 +41,7 @@ public class TpchStatisticsRecorder
 {
     private static final List<String> SUPPORTED_SCHEMAS = ImmutableList.of("sf0.01", "sf1.0");
 
-    public static void main(String[] args)
+    static void main()
     {
         TpchStatisticsRecorder tool = new TpchStatisticsRecorder(new TableStatisticsRecorder(), new TableStatisticsDataRepository(createObjectMapper()));
 

--- a/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/VerticaQueryRunner.java
+++ b/plugin/trino-vertica/src/test/java/io/trino/plugin/vertica/VerticaQueryRunner.java
@@ -139,7 +139,7 @@ public final class VerticaQueryRunner
         server.execute(sql, "dbadmin", null);
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();

--- a/service/trino-proxy/src/main/java/io/trino/proxy/TrinoProxy.java
+++ b/service/trino-proxy/src/main/java/io/trino/proxy/TrinoProxy.java
@@ -60,7 +60,7 @@ public final class TrinoProxy
         }
     }
 
-    public static void main(String[] args)
+    static void main()
     {
         start();
     }

--- a/service/trino-verifier/src/main/java/io/trino/verifier/TrinoVerifier.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/TrinoVerifier.java
@@ -19,7 +19,7 @@ public final class TrinoVerifier
 {
     private TrinoVerifier() {}
 
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         new CommandLine(new VerifyCommand()).execute(args);
     }

--- a/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginReader.java
+++ b/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginReader.java
@@ -52,7 +52,7 @@ public class PluginReader
     @Option(names = {"-r", "--root-pom"}, description = "Trino root module pom.xml")
     private File rootPom = new File("pom.xml");
 
-    public static void main(String... args)
+    static void main(String... args)
     {
         int exitCode = new CommandLine(new PluginReader()).execute(args);
         System.exit(exitCode);

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/Launcher.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/Launcher.java
@@ -62,7 +62,7 @@ public class Launcher
     @Option(names = "--version", versionHelp = true, description = "Print version information and exit")
     public boolean versionInfoRequested;
 
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         Launcher launcher = new Launcher();
         // write directly to System.out, bypassing logging & io.airlift.log.Logging#rewireStdStreams

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TemptoProductTestRunner.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TemptoProductTestRunner.java
@@ -18,7 +18,7 @@ import io.trino.tempto.runner.TemptoRunnerCommandLineParser;
 
 public final class TemptoProductTestRunner
 {
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         TemptoRunnerCommandLineParser parser = TemptoRunnerCommandLineParser.builder("Trino product tests")
                 .setTestsPackage("io.trino.tests.product.*", false)

--- a/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
@@ -55,7 +55,7 @@ public final class DevelopmentServer
         }
     }
 
-    public static void main(String[] args)
+    static void main()
     {
         new DevelopmentServer().start("dev");
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/WebUiPreviewQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/WebUiPreviewQueryRunner.java
@@ -69,7 +69,7 @@ public class WebUiPreviewQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         DistributedQueryRunner queryRunner = builder()

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/BenchmarkInformationSchema.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/BenchmarkInformationSchema.java
@@ -145,7 +145,7 @@ public class BenchmarkInformationSchema
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         // assure the benchmarks are valid before running

--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/TestPartitionedTpcdsCostBasedPlan.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/TestPartitionedTpcdsCostBasedPlan.java
@@ -59,7 +59,7 @@ public class TestPartitionedTpcdsCostBasedPlan
         return TPCDS_SQL_FILES;
     }
 
-    public static void main(String[] args)
+    static void main()
     {
         new TestPartitionedTpcdsCostBasedPlan().generate();
     }

--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/TestTpchCostBasedPlan.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/TestTpchCostBasedPlan.java
@@ -58,7 +58,7 @@ public class TestTpchCostBasedPlan
         return TPCH_SQL_FILES;
     }
 
-    public static void main(String[] args)
+    static void main()
     {
         new TestTpchCostBasedPlan().generate();
     }

--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/UpdateExpectedPlans.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/UpdateExpectedPlans.java
@@ -27,7 +27,7 @@ public final class UpdateExpectedPlans
 {
     private UpdateExpectedPlans() {}
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         String[] noArgs = new String[0];

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunner.java
@@ -71,7 +71,7 @@ public final class TpchQueryRunner
         }
     }
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         Logging.initialize();


### PR DESCRIPTION
Java no longer requires the main method to be public and have `String[] args` argument. Reduce boilerplate.
