### PR TITLE
Deprecate join-pushdown.with-expressions config property

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -71,12 +71,14 @@ public class JdbcMetadataConfig
         return this;
     }
 
+    @Deprecated
     public boolean isComplexJoinPushdownEnabled()
     {
         return complexJoinPushdownEnabled;
     }
 
-    @Config("join-pushdown.with-expressions")
+    @Deprecated
+    @Config("deprecated.join-pushdown.with-expressions")
     @ConfigDescription("Enable join pushdown with complex expressions")
     public JdbcMetadataConfig setComplexJoinPushdownEnabled(boolean complexJoinPushdownEnabled)
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
@@ -33,6 +33,7 @@ public class JdbcMetadataSessionProperties
 {
     public static final String COMPLEX_EXPRESSION_PUSHDOWN = "complex_expression_pushdown";
     public static final String JOIN_PUSHDOWN_ENABLED = "join_pushdown_enabled";
+    @Deprecated
     public static final String COMPLEX_JOIN_PUSHDOWN_ENABLED = "complex_join_pushdown_enabled";
     public static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
     public static final String TOPN_PUSHDOWN_ENABLED = "topn_pushdown_enabled";
@@ -102,6 +103,7 @@ public class JdbcMetadataSessionProperties
         return session.getProperty(JOIN_PUSHDOWN_ENABLED, Boolean.class);
     }
 
+    @Deprecated
     public static boolean isComplexJoinPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(COMPLEX_JOIN_PUSHDOWN_ENABLED, Boolean.class);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -43,7 +43,7 @@ public class TestJdbcMetadataConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("complex-expression-pushdown.enabled", "false")
                 .put("join-pushdown.enabled", "true")
-                .put("join-pushdown.with-expressions", "false")
+                .put("deprecated.join-pushdown.with-expressions", "false")
                 .put("aggregation-pushdown.enabled", "false")
                 .put("jdbc.bulk-list-columns.enabled", "true")
                 .put("domain-compaction-threshold", "42")


### PR DESCRIPTION
Deprecate `join-pushdown.with-expressions` config property and associated `complex_join_pushdown_enabled` session property. It was added for transition period when join pushdown behavior was being build out.  Removing it will allow simplifying code.


### Release notes

```markdown
## SQL Server, PosgreSQL, Snowflake, Oracle, MySQL, Ignit Druid, Exasol, DuckDB, SingleStore, ClickHouse, MariaDB, Vertica, Redshift

Replace `join-pushdown.with-expressions` configuration property with `deprecated.join-pushdown.with-expressions`. The new property will be removed in a future version.
```