### PR TITLE
Remove prefer_streaming_operators property

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -68,7 +68,6 @@ public final class SystemSessionProperties
     public static final String MAX_HASH_PARTITION_COUNT = "max_hash_partition_count";
     public static final String MIN_HASH_PARTITION_COUNT = "min_hash_partition_count";
     public static final String MIN_HASH_PARTITION_COUNT_FOR_WRITE = "min_hash_partition_count_for_write";
-    public static final String PREFER_STREAMING_OPERATORS = "prefer_streaming_operators";
     public static final String TASK_MIN_WRITER_COUNT = "task_min_writer_count";
     public static final String TASK_MAX_WRITER_COUNT = "task_max_writer_count";
     public static final String TASK_CONCURRENCY = "task_concurrency";
@@ -299,11 +298,6 @@ public final class SystemSessionProperties
                         "Minimum number of partitions for distributed joins and aggregations in write queries",
                         queryManagerConfig.getMinHashPartitionCountForWrite(),
                         value -> validateIntegerValue(value, MIN_HASH_PARTITION_COUNT_FOR_WRITE, 1, false),
-                        false),
-                booleanProperty(
-                        PREFER_STREAMING_OPERATORS,
-                        "Prefer source table layouts that produce streaming operators",
-                        false,
                         false),
                 integerProperty(
                         TASK_MIN_WRITER_COUNT,
@@ -1200,11 +1194,6 @@ public final class SystemSessionProperties
     public static int getMinHashPartitionCountForWrite(Session session)
     {
         return session.getSystemProperty(MIN_HASH_PARTITION_COUNT_FOR_WRITE, Integer.class);
-    }
-
-    public static boolean preferStreamingOperators(Session session)
-    {
-        return session.getSystemProperty(PREFER_STREAMING_OPERATORS, Boolean.class);
     }
 
     public static int getTaskMinWriterCount(Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPreferredProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPreferredProperties.java
@@ -31,7 +31,6 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SystemSessionProperties.getTaskConcurrency;
-import static io.trino.SystemSessionProperties.preferStreamingOperators;
 import static io.trino.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.FIXED;
 import static io.trino.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.MULTIPLE;
 import static io.trino.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.SINGLE;
@@ -82,7 +81,7 @@ public class StreamPreferredProperties
 
     public static StreamPreferredProperties defaultParallelism(Session session)
     {
-        if (getTaskConcurrency(session) > 1 && !preferStreamingOperators(session)) {
+        if (getTaskConcurrency(session) > 1) {
             return new StreamPreferredProperties(Optional.of(MULTIPLE), Optional.empty(), false);
         }
         return any();
@@ -159,7 +158,7 @@ public class StreamPreferredProperties
 
     public StreamPreferredProperties withDefaultParallelism(Session session)
     {
-        if (getTaskConcurrency(session) > 1 && !preferStreamingOperators(session)) {
+        if (getTaskConcurrency(session) > 1) {
             return withParallelism();
         }
         return this;


### PR DESCRIPTION
## Description
This is an old undocumented property that doesn't have a clear use case. It's effect can be achieved by setting task_concurrency to 1 as well


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Removed `prefer_streaming_operators` session property. `SET SESSION task_concurrency=1` can be used to achieve the same behaviour as `prefer_streaming_operators`. ({issue}`27506`)
```
