### PR TITLE
Improve performance when parsing invalid queries

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionMappingParser.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ExpressionMappingParser.java
@@ -15,13 +15,16 @@ package io.trino.plugin.jdbc.expression;
 
 import com.google.common.collect.ImmutableMap;
 import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 import java.util.Map;
 import java.util.Set;
@@ -69,20 +72,20 @@ public class ExpressionMappingParser
             lexer.addErrorListener(ERROR_LISTENER);
 
             parser.removeErrorListeners();
-            parser.addErrorListener(ERROR_LISTENER);
 
             ParserRuleContext tree;
             try {
                 // first, try parsing with potentially faster SLL mode
                 parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+                parser.setErrorHandler(new BailErrorStrategy());
                 tree = parseFunction.apply(parser);
             }
-            catch (IllegalArgumentException ex) {
+            catch (ParseCancellationException e) {
                 // if we fail, parse with LL mode
-                tokenStream.seek(0); // rewind input stream
                 parser.reset();
-
                 parser.getInterpreter().setPredictionMode(PredictionMode.LL);
+                parser.setErrorHandler(new DefaultErrorStrategy());
+                parser.addErrorListener(ERROR_LISTENER);
                 tree = parseFunction.apply(parser);
             }
             return new ExpressionPatternBuilder(typeClasses).visit(tree);


### PR DESCRIPTION
Use `BailErrorStrategy` as recommended by the ANTLR team in https://github.com/antlr/antlr4/issues/192

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
