### PR TITLE
Wrap storage descriptor errors in TrinoExceptions

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveGlueMetadataListing.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveGlueMetadataListing.java
@@ -25,7 +25,6 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -125,17 +124,8 @@ public class TestHiveGlueMetadataListing
         assertQueryReturnsEmptyResult(format("SELECT table_name FROM hive.information_schema.tables WHERE table_name = '%s' AND table_schema='%s'", FAILING_TABLE_WITH_BAD_HIVE_TYPE, tpchSchema));
         assertQueryReturnsEmptyResult(format("SELECT table_name FROM hive.information_schema.tables WHERE table_name = '%s' AND table_schema='%s'", FAILING_TABLE_WITH_NULL_SERDE, tpchSchema));
 
-        @Language("RegExp") String tableMetadataRegex = format(
-                "Error listing table columns for catalog hive: Failed to construct table metadata for table (%s.%s|%s.%s)",
-                tpchSchema,
-                FAILING_TABLE_WITH_BAD_HIVE_TYPE,
-                tpchSchema,
-                FAILING_TABLE_WITH_NULL_SERDE);
-        assertQueryFails("SELECT table_name, column_name from hive.information_schema.columns WHERE table_schema = '" + tpchSchema + "'", tableMetadataRegex);
-        /* Now broken by these new broken tables. To restore once fixed.
         assertQuery("SELECT table_name, column_name from hive.information_schema.columns WHERE table_schema = '" + tpchSchema + "'",
                 "VALUES ('region', 'regionkey'), ('region', 'name'), ('region', 'comment'), ('nation', 'nationkey'), ('nation', 'name'), ('nation', 'regionkey'), ('nation', 'comment')");
-        */
         assertQuery("SELECT table_name, column_name from hive.information_schema.columns WHERE table_name = 'region' AND table_schema='" + tpchSchema + "'",
                 "VALUES ('region', 'regionkey'), ('region', 'name'), ('region', 'comment')");
         assertQueryReturnsEmptyResult(format("SELECT table_name FROM hive.information_schema.columns WHERE table_name = '%s' AND table_schema='%s'", FAILING_TABLE_WITH_NULL_STORAGE_DESCRIPTOR_NAME, tpchSchema));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueConverter.java
@@ -23,10 +23,8 @@ import io.trino.metastore.Partition;
 import io.trino.metastore.Storage;
 import io.trino.metastore.StorageFormat;
 import io.trino.metastore.Table;
-import io.trino.plugin.hive.HiveViewNotSupportedException;
 import io.trino.plugin.hive.TableType;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.security.PrincipalType;
 import org.junit.jupiter.api.Test;
@@ -358,10 +356,8 @@ class TestGlueConverter
                 .build();
 
         assertThatThrownBy(() -> GlueConverter.fromGlueTable(table, table.databaseName()))
-                .isNotInstanceOfAny(
-                        HiveViewNotSupportedException.class,
-                        TableNotFoundException.class,
-                        TrinoException.class);
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Column badhivetype has invalid type: notarealtype");
     }
 
     @Test
@@ -379,10 +375,8 @@ class TestGlueConverter
                 .build();
 
         assertThatThrownBy(() -> GlueConverter.fromGlueTable(table, table.databaseName()))
-                .isNotInstanceOfAny(
-                        HiveViewNotSupportedException.class,
-                        TableNotFoundException.class,
-                        TrinoException.class);
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Column emptyhivetype has invalid type: ");
     }
 
     @Test
@@ -393,10 +387,8 @@ class TestGlueConverter
                 .build();
 
         assertThatThrownBy(() -> GlueConverter.fromGlueTable(table, table.databaseName()))
-                .isNotInstanceOfAny(
-                        HiveViewNotSupportedException.class,
-                        TableNotFoundException.class,
-                        TrinoException.class);
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("StorageDescriptor SerDeInfo is null: %s.%s".formatted(glueTable.databaseName(), glueTable.name()));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

There's a lot of leeway in just what can go into tables in AWS Glue. For example, here I create 3 different tables, one with a column with a type that isn't [a proper hive type](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types) and [won't parse](https://github.com/trinodb/trino/blob/772a84b28a307b09d799d14759c8d36cf952d288/lib/trino-metastore/src/main/java/io/trino/metastore/HiveType.java#L118), one with a null `SerdeInfo`, and one that is "legit" (though not backed by real files).

```
aws glue create-table --region [SOME_REGION] --catalog-id [SOME_CATALOG_ID] --database-name [SOME_DB_NAME] --table-input '{"Name":"nothive", "StorageDescriptor":{ "Columns": [ { "Name": "badtype", "Type": "notrealtype" } ], "SerdeInfo": { "SerializationLibrary": "org.openx.data.jsonserde.JsonSerDe" } }}'

aws glue create-table --region [SOME_REGION] --catalog-id [SOME_CATALOG_ID] --database-name [SOME_DB_NAME] --table-input '{"Name":"noserde", "StorageDescriptor": { "Columns": [ { "Name": "goodtype", "Type": "string" } ] } }'

aws glue create-table --region [SOME_REGION] --catalog-id [SOME_CATALOG_ID] --database-name [SOME_DB_NAME] --table-input '{"Name":"goodtable", "StorageDescriptor": { "Columns": [ { "Name": "goodtype", "Type": "string" } ], "SerdeInfo": { "SerializationLibrary" : "org.openx.data.jsonserde.JsonSerDe" }, "Location": "s3://notreal" } }'
```

I expect to be able to list valid columns from the information_schema. For example ...
```
SELECT * FROM glue.information_schema.columns WHERE table_schema='[SOME_DB_NAME]'
```

But this query fails from trying to parse the metadata of my malformed tables.

```
Query 20251201_195347_00009_8y8j7 failed: Error listing table columns for catalog glue: Failed to construct table metadata for table [SOME_DB_NAME].noserde
io.trino.spi.TrinoException: Error listing table columns for catalog glue: Failed to construct table metadata for table [SOME_DB_NAME].noserde
```

After these changes this looks like ...
```
trino> SELECT * FROM glue.information_schema.columns WHERE table_schema='[SOME_DB_NAME]';
 table_catalog | table_schema | table_name | column_name | ordinal_position | column_default | is_nullable | data_type
[....]
 hive                  | SOME_DB_NAME  | goodtable  | goodtype    |                1 | NULL           | YES         | varchar
(1 row)
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

[I found in the source code there is this try-catch to skip malformed tables](https://github.com/trinodb/trino/blob/772a84b28a307b09d799d14759c8d36cf952d288/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java#L924-L928). But it only catches known exception types. In these changes I wrap two sources of exceptions I found for malformed metadata in `TrinoException`s. I tried to follow [existing precedent in GlueConverters](https://github.com/trinodb/trino/blob/772a84b28a307b09d799d14759c8d36cf952d288/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueConverter.java#L312). 

There [also appears to be an existing, though now stale, discussion about how to handle errors while listing metadata](https://github.com/trinodb/trino/issues/6551).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix failure when listing tables with invalid table metadata in AWS Glue. ({issue}`27525`)
```
