### PR TITLE
Make concurrent insert timeout adjustable for testInsertRowConcurrently

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -5471,12 +5471,13 @@ public abstract class BaseConnectorTest
         int threads = 4;
         CyclicBarrier barrier = new CyclicBarrier(threads);
         ExecutorService executor = newFixedThreadPool(threads);
+        long insertTimeoutMillis = getConcurrentInsertTimeout().toMillis();
         try (TestTable table = createTableWithOneIntegerColumn("test_insert")) {
             String tableName = table.getName();
 
             List<Future<OptionalInt>> futures = IntStream.range(0, threads)
                     .mapToObj(threadNumber -> executor.submit(() -> {
-                        barrier.await(10, SECONDS);
+                        barrier.await(insertTimeoutMillis, MILLISECONDS);
                         try {
                             getQueryRunner().execute("INSERT INTO " + tableName + " VALUES (" + threadNumber + ")");
                             return OptionalInt.of(threadNumber);
@@ -5498,7 +5499,7 @@ public abstract class BaseConnectorTest
                     .collect(toImmutableList());
 
             List<Integer> values = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 10, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .map(future -> tryGetFutureValue(future, (int) insertTimeoutMillis, MILLISECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
                     .filter(OptionalInt::isPresent)
                     .map(OptionalInt::getAsInt)
                     .collect(toImmutableList());
@@ -5516,7 +5517,7 @@ public abstract class BaseConnectorTest
         }
         finally {
             executor.shutdownNow();
-            executor.awaitTermination(10, SECONDS);
+            executor.awaitTermination(insertTimeoutMillis, MILLISECONDS);
         }
     }
 
@@ -5524,6 +5525,14 @@ public abstract class BaseConnectorTest
     {
         // By default, do not expect INSERT to fail in case of concurrent inserts
         throw new AssertionError("Unexpected concurrent insert failure", e);
+    }
+
+    protected Duration getConcurrentInsertTimeout()
+    {
+        // most often we experienced this test failing due to timeout waiting on the barrier,
+        // the reason behind this for pooled connectors is connection timeout,
+        // making this timeout adjustable according to connection timeout settings
+        return new Duration(10, SECONDS);
     }
 
     // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Most often we experienced this test failing due to timeout waiting on the barrier,
the reason behind this for pooled connectors is connection timeout,
making this timeout adjustable according to connection timeout settings

```
.testInsertRowConcurrently()[2] -- Time elapsed: 30.63 s <<< ERROR!
2025-11-28T18:46:32.1530648Z java.lang.RuntimeException: Wait timed out
2025-11-28T18:46:32.1532348Z 	at io.trino.testing.BaseConnectorTest.lambda$testInsertRowConcurrently$3(BaseConnectorTest.java:5500)
2025-11-28T18:46:32.1533985Z 	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
2025-11-28T18:46:32.1535456Z 	at io.trino.testing.BaseConnectorTest.lambda$testInsertRowConcurrently$2(BaseConnectorTest.java:5500)
2025-11-28T18:46:32.1537311Z 	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
2025-11-28T18:46:32.1539043Z 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
2025-11-28T18:46:32.1540712Z 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
2025-11-28T18:46:32.1542454Z 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
2025-11-28T18:46:32.1544144Z 	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
2025-11-28T18:46:32.1545724Z 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
2025-11-28T18:46:32.1547371Z 	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
2025-11-28T18:46:32.1549131Z 	at io.trino.testing.BaseConnectorTest.testInsertRowConcurrently(BaseConnectorTest.java:5503)
2025-11-28T18:46:32.1550727Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
2025-11-28T18:46:32.1552289Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
2025-11-28T18:46:32.1553921Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
2025-11-28T18:46:32.1555708Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
2025-11-28T18:46:32.1557191Z 	at java.base/java.lang.Thread.run(Thread.java:1474)
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
