### PR TITLE
Avoid String.format in S3Input read

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Input.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Input.java
@@ -58,7 +58,7 @@ final class S3Input
             return;
         }
 
-        String range = "bytes=%s-%s".formatted(position, (position + length) - 1);
+        String range = "bytes=" + position + "-" + ((position + length) - 1);
         GetObjectRequest rangeRequest = request.toBuilder().range(range).build();
 
         int n = read(buffer, offset, length, rangeRequest);
@@ -77,7 +77,7 @@ final class S3Input
             return 0;
         }
 
-        String range = "bytes=-%s".formatted(length);
+        String range = "bytes=-" + length;
         GetObjectRequest rangeRequest = request.toBuilder().range(range).build();
 
         return read(buffer, offset, length, rangeRequest);


### PR DESCRIPTION
## Description
Minor cleanup to prefer string concatenation instead of `String.format` in a relatively frequently called codepath.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

