### PR TITLE
Relax the recoverable exception matching for concurrent transactions

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
@@ -66,7 +66,7 @@ public final class TestingRedshiftServer
     public static boolean isExceptionRecoverable(Throwable exception)
     {
         return exception != null && (
-                exception.getMessage().matches(".* concurrent transaction .*")
+                exception.getMessage().matches(".* concurrent transaction.*")
                         || exception.getMessage().matches(".*deadlock detected.*")
                         || exception.getMessage().matches(".*could not open relation with OID.*")
                         || exception.getMessage().matches(".*The connection attempt failed.*"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
**Testing scaffolding change.**

Make sure to retry as well on exceptions with the following message

```
Caused by: com.amazon.redshift.util.RedshiftException: ERROR: could not complete because of conflict with concurrent transaction
```

Apparently, the previous matching for concurrent transactions exceptions relied on an exception message that did not end with "concurrent transaction" phrase.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Stacktrace

```
io.trino.testing.QueryFailedException: ERROR: could not complete because of conflict with concurrent transaction
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:645)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:621)
	at io.trino.plugin.redshift.TrinoSqlExecutorWithRetries.lambda$execute$1(TrinoSqlExecutorWithRetries.java:52)
	at dev.failsafe.Functions.lambda$toCtxSupplier$9(Functions.java:228)
	at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
	at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
	at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
	at dev.failsafe.FailsafeExecutor.run(FailsafeExecutor.java:220)
	at io.trino.plugin.redshift.TrinoSqlExecutorWithRetries.execute(TrinoSqlExecutorWithRetries.java:52)
	at io.trino.testing.sql.TestTable.createAndInsert(TestTable.java:52)
	at io.trino.testing.sql.TestTable.<init>(TestTable.java:47)
	at io.trino.plugin.redshift.TestRedshiftConnectorSmokeTest.newTrinoTable(TestRedshiftConnectorSmokeTest.java:47)
	at io.trino.testing.AbstractTestQueryFramework.newTrinoTable(AbstractTestQueryFramework.java:700)
	at io.trino.testing.BaseConnectorSmokeTest.testDeleteAllDataFromTable(BaseConnectorSmokeTest.java:280)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: CREATE TABLE test_delete_all_dataqc8nrjj2wv AS SELECT * FROM region
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:652)
		... 19 more
Caused by: io.trino.spi.TrinoException: ERROR: could not complete because of conflict with concurrent transaction
	at io.trino.plugin.jdbc.BaseJdbcClient.finishInsertTable(BaseJdbcClient.java:1198)
	at io.trino.plugin.jdbc.BaseJdbcClient.commitCreateTable(BaseJdbcClient.java:1063)
	at io.trino.plugin.jdbc.ForwardingJdbcClient.commitCreateTable(ForwardingJdbcClient.java:275)
	at io.trino.plugin.jdbc.jmx.StatisticsAwareJdbcClient.lambda$commitCreateTable$0(StatisticsAwareJdbcClient.java:363)
	at io.trino.plugin.jdbc.jmx.JdbcApiStats.wrap(JdbcApiStats.java:46)
	at io.trino.plugin.jdbc.jmx.StatisticsAwareJdbcClient.commitCreateTable(StatisticsAwareJdbcClient.java:363)
	at io.trino.plugin.jdbc.RetryingJdbcClient.commitCreateTable(RetryingJdbcClient.java:380)
	at io.trino.plugin.jdbc.CachingJdbcClient.commitCreateTable(CachingJdbcClient.java:405)
	at io.trino.plugin.jdbc.CachingJdbcClient.commitCreateTable(CachingJdbcClient.java:405)
	at io.trino.plugin.jdbc.DefaultJdbcMetadata.finishCreateTable(DefaultJdbcMetadata.java:1205)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.finishCreateTable(ClassLoaderSafeConnectorMetadata.java:582)
	at io.trino.tracing.TracingConnectorMetadata.finishCreateTable(TracingConnectorMetadata.java:653)
	at io.trino.metadata.MetadataManager.finishCreateTable(MetadataManager.java:1218)
	at io.trino.tracing.TracingMetadata.finishCreateTable(TracingMetadata.java:647)
	at io.trino.sql.planner.LocalExecutionPlanner.lambda$createTableFinisher$0(LocalExecutionPlanner.java:4434)
	at io.trino.operator.TableFinishOperator.getOutput(TableFinishOperator.java:316)
	at io.trino.operator.Driver.processInternal(Driver.java:400)
	at io.trino.operator.Driver.lambda$process$0(Driver.java:303)
	at io.trino.operator.Driver.tryWithLock(Driver.java:706)
	at io.trino.operator.Driver.process(Driver.java:295)
	at io.trino.operator.Driver.processForDuration(Driver.java:266)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:853)
	at io.trino.execution.executor.timesharing.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:189)
	at io.trino.execution.executor.timesharing.TimeSharingTaskExecutor$TaskRunner.run(TimeSharingTaskExecutor.java:651)
	at io.trino.$gen.Trino_testversion____20251128_135252_1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: com.amazon.redshift.util.RedshiftException: ERROR: could not complete because of conflict with concurrent transaction
	at com.amazon.redshift.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2648)
	at com.amazon.redshift.core.v3.QueryExecutorImpl.processResultsOnThread(QueryExecutorImpl.java:2295)
	at com.amazon.redshift.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1886)
	at com.amazon.redshift.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1878)
	at com.amazon.redshift.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:375)
	at com.amazon.redshift.jdbc.RedshiftStatementImpl.executeInternal(RedshiftStatementImpl.java:519)
	at com.amazon.redshift.jdbc.RedshiftStatementImpl.execute(RedshiftStatementImpl.java:440)
	at com.amazon.redshift.jdbc.RedshiftStatementImpl.executeWithFlags(RedshiftStatementImpl.java:381)
	at com.amazon.redshift.jdbc.RedshiftStatementImpl.executeCachedSql(RedshiftStatementImpl.java:367)
	at com.amazon.redshift.jdbc.RedshiftStatementImpl.executeWithFlags(RedshiftStatementImpl.java:344)
	at com.amazon.redshift.jdbc.RedshiftStatementImpl.execute(RedshiftStatementImpl.java:334)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.lambda$execute$5(OpenTelemetryStatement.java:110)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.wrapCall(OpenTelemetryStatement.java:402)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.wrapCall(OpenTelemetryStatement.java:388)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.execute(OpenTelemetryStatement.java:110)
	at io.trino.plugin.jdbc.BaseJdbcClient.execute(BaseJdbcClient.java:1629)
	at io.trino.plugin.jdbc.BaseJdbcClient.finishInsertTable(BaseJdbcClient.java:1195)
	... 27 more
	Suppressed: java.lang.RuntimeException: Query: INSERT INTO "***"."test_schema"."test_delete_all_dataqc8nrjj2wv" ("regionkey", "name", "comment") SELECT "regionkey", "name", "comment" FROM "***"."test_schema"."tmp_trino_ff92a8fd_dfb0527c" temp_table WHERE EXISTS (SELECT 1 FROM "***"."test_schema"."tmp_trino_ff92a8fd_66e5a04a" page_sink_table WHERE page_sink_table.trino_page_sink_id = temp_table.trino_page_sink_id)
		at io.trino.plugin.jdbc.BaseJdbcClient.execute(BaseJdbcClient.java:1632)
		... 28 more
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
