### PR TITLE
Allow multiple input files for execution in CLI

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -226,8 +226,8 @@ public class ClientOptions
     @Option(names = "--path", paramLabel = "<catalog.schema>", description = "Default SQL path", arity = "0..*")
     public List<String> path = ImmutableList.of();
 
-    @Option(names = {"-f", "--file"}, paramLabel = "<file>", description = "Execute statements from file and exit")
-    public String file;
+    @Option(names = {"-f", "--file"}, paramLabel = "<file>", description = "Execute statements from file and exit (can be used multiple times)")
+    public List<String> files = new ArrayList<>();
 
     @Option(names = DEBUG_OPTION_NAME, paramLabel = "<debug>", description = "Enable debug information")
     public boolean debug;

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -136,17 +136,18 @@ public class Console
             if (hasQuery) {
                 throw new RuntimeException("both --execute and --file specified");
             }
-            try {
-                StringBuilder fileContents = new StringBuilder();
-                for (String file : clientOptions.files) {
+
+            StringBuilder fileContents = new StringBuilder();
+            for (String file : clientOptions.files) {
+                try {
                     fileContents.append(asCharSource(new File(file), UTF_8).read());
                     fileContents.append("\n");
                 }
+                catch (IOException e) {
+                    throw new RuntimeException(format("Error reading from file '%s': %s",file ,e.getMessage()));
+                }
                 query = fileContents.toString();
                 hasQuery = true;
-            }
-            catch (IOException e) {
-                throw new RuntimeException(format("Error reading from file: %s", e.getMessage()));
             }
         }
 

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -125,7 +125,7 @@ public class Console
         TrinoUri uri = clientOptions.getTrinoUri(restrictedOptions);
         ClientSession session = clientOptions.toClientSession(uri);
         boolean hasQuery = clientOptions.execute != null;
-        boolean isFromFile = !isNullOrEmpty(clientOptions.file);
+        boolean isFromFile = !clientOptions.files.isEmpty();
 
         String query = clientOptions.execute;
         if (hasQuery) {
@@ -137,11 +137,16 @@ public class Console
                 throw new RuntimeException("both --execute and --file specified");
             }
             try {
-                query = asCharSource(new File(clientOptions.file), UTF_8).read();
+                StringBuilder fileContents = new StringBuilder();
+                for (String file : clientOptions.files) {
+                    fileContents.append(asCharSource(new File(file), UTF_8).read());
+                    fileContents.append("\n");
+                }
+                query = fileContents.toString();
                 hasQuery = true;
             }
             catch (IOException e) {
-                throw new RuntimeException(format("Error reading from file %s: %s", clientOptions.file, e.getMessage()));
+                throw new RuntimeException(format("Error reading from file: %s", e.getMessage()));
             }
         }
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -376,6 +376,22 @@ public class TestClientOptions
     }
 
     @Test
+    public void testMultipleFilesOrder()
+    {
+        Console console = createConsole("--file", "file1.sql", "--file", "file3.sql", "--file", "file2.sql");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.files).isEqualTo(ImmutableList.of("file1.sql", "file3.sql", "file2.sql"));
+    }
+
+    @Test
+    public void testRepeatedFiles()
+    {
+        Console console = createConsole("--file", "file1.sql", "--file", "file1.sql");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.files).isEqualTo(ImmutableList.of("file1.sql", "file1.sql"));
+    }
+
+    @Test
     public void testAllClientOptionsHaveMappingToAConnectionProperty()
     {
         Set<String> fieldsWithoutMapping = Arrays.stream(ClientOptions.class.getDeclaredFields())

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -368,6 +368,14 @@ public class TestClientOptions
     }
 
     @Test
+    public void testMultipleFiles()
+    {
+        Console console = createConsole("--file", "file1.sql", "--file", "file2.sql", "--file", "file3.sql");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.files).isEqualTo(ImmutableList.of("file1.sql", "file2.sql", "file3.sql"));
+    }
+
+    @Test
     public void testAllClientOptionsHaveMappingToAConnectionProperty()
     {
         Set<String> fieldsWithoutMapping = Arrays.stream(ClientOptions.class.getDeclaredFields())
@@ -385,7 +393,7 @@ public class TestClientOptions
         switch (name) {
             case "url":
             case "server":
-            case "file":
+            case "files":
             case "debug":
             case "historyFile":
             case "progress":

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -536,7 +536,8 @@ mode:
 * - `--execute=<execute>`
   - Execute specified statements and exit.
 * - `-f`, `--file=<file>`
-  - Execute statements from file and exit.
+  - Execute statements from file and exit. Can be specified multiple times to
+    execute multiple files sequentially in the specified order.
 * - `--ignore-errors`
   - Continue processing in batch mode when an error occurs. Default is to exit
     immediately.
@@ -610,6 +611,19 @@ and displays an error message (which is unaffected by the output format):
 Query 20200707_170726_00030_2iup9 failed: line 1:25: Column 'region' cannot be resolved
 SELECT nationkey, name, region FROM tpch.sf1.nation LIMIT 3
 ```
+
+You can use the `--file` option multiple times to execute multiple SQL files
+sequentially. Files are executed in the order they are specified:
+
+```text
+trino --catalog iceberg --schema default --file ddls.sql --file inserts.sql
+```
+
+This executes all statements in `ddls.sql` first, followed by all statements
+in `inserts.sql`. If an error occurs during execution, the CLI exits
+immediately unless the `--ignore-errors` option is specified. The specific
+file name is included in any error messages to help identify which file
+caused the problem.
 
 (cli-spooling-protocol)=
 ## Spooling protocol


### PR DESCRIPTION
Fixes : #27532
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
I've successfully implemented the feature to accept repeated --file options in the Trino CLI to run all files sequentially, as requested in issue.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


`trino --catalog iceberg --schema default --file ddls.sql --file inserts.sql`

The CLI will:
Read the contents of ddls.sql
Read the contents of inserts.sql
Concatenate them with newlines
Execute all statements sequentially

The files are processed in the order they are specified on the command line, which is exactly what was requested in the issue.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


