### PR TITLE
Suppress AccessDeniedException in GlueHiveMetastore.getTablesInternal

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -449,6 +449,10 @@ public class GlueHiveMetastore
             // Database might have been deleted concurrently.
             return ImmutableList.of();
         }
+        catch (AccessDeniedException _) {
+            // permission denied may actually mean "does not exist"
+            return ImmutableList.of();
+        }
         catch (SdkException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
         }


### PR DESCRIPTION
## Description

Glue catalog in Iceberg already suppresses this exception. 
We can apply the same behavior in other connectors.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
