### PR TITLE
Skip underlying query analysis if MV is fresh

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2610,19 +2610,6 @@ class StatementAnalyzer
                 throw semanticException(VIEW_IS_RECURSIVE, table, "View is recursive");
             }
 
-            Query query = parseView(originalSql, name, table);
-
-            if (!query.getFunctions().isEmpty()) {
-                throw semanticException(NOT_SUPPORTED, table, "View contains inline function: %s", name);
-            }
-
-            analysis.registerTableForView(table, name, isMaterializedView);
-            RelationType descriptor = analyzeView(query, name, catalog, schema, owner, path, table);
-            analysis.unregisterTableForView();
-
-            checkViewStaleness(columns, descriptor.getVisibleFields(), name, table)
-                    .ifPresent(explanation -> { throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, explanation); });
-
             // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
             // This is needed in case the underlying table(s) changed and the query in the view now produces types that
             // are implicitly coercible to the declared view types.
@@ -2642,6 +2629,19 @@ class StatementAnalyzer
                 analysis.setMaterializedViewStorageTableFields(table, storageTableFields);
             }
             else {
+                Query query = parseView(originalSql, name, table);
+
+                if (!query.getFunctions().isEmpty()) {
+                    throw semanticException(NOT_SUPPORTED, table, "View contains inline function: %s", name);
+                }
+
+                analysis.registerTableForView(table, name, isMaterializedView);
+                RelationType descriptor = analyzeView(query, name, catalog, schema, owner, path, table);
+                analysis.unregisterTableForView();
+
+                checkViewStaleness(columns, descriptor.getVisibleFields(), name, table)
+                        .ifPresent(explanation -> { throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, explanation); });
+
                 analysis.registerNamedQuery(table, query);
             }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -554,17 +554,8 @@ public class TestEventListenerBasic
         QueryCompletedEvent event = queryEvents.getQueryCompletedEvent();
 
         List<TableInfo> tables = event.getMetadata().getTables();
-        assertThat(tables).hasSize(2);
-        TableInfo table = tables.get(0);
-        assertThat(table)
-                .hasCatalogSchemaTable("tpch", "tiny", "nation")
-                .hasAuthorization("alice")
-                .isNotDirectlyReferenced()
-                .hasColumnsWithoutMasking("nationkey", "regionkey", "name", "comment")
-                .hasNoRowFilters()
-                .hasTableReferencesSatisfying(tableRef -> assertThat(tableRef).asMaterializedViewInfo().hasCatalogSchemaView("mock", "default", "test_materialized_view_fresh"));
-
-        table = tables.get(1);
+        assertThat(tables).hasSize(1);
+        TableInfo table = tables.getFirst();
         assertThat(table)
                 .hasCatalogSchemaTable("mock", "default", "test_materialized_view_fresh")
                 .hasAuthorization("user")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Analyzing the underlying query can be costly in some scenarios, especially when it references many tables. An additional benefit of skipping this analysis is improved availability - MV data sources don’t need to be reachable when accessing the MV.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

We are working on adding a `WHEN STALE` clause to `CREATE MATERIALIZED VIEW`. Relevant PRs:
* https://github.com/trinodb/trino/pull/27356
* https://github.com/trinodb/trino/pull/27502

The change proposed in this PR makes the definitions of the behaviors controlled by the new clause simpler and more symmetric; see this comment: https://github.com/trinodb/trino/pull/27356#discussion_r2537145553.

Additionally, it brings the current MV implementation closer to resolving https://github.com/trinodb/trino/discussions/23387#discussioncomment-10640385 and https://github.com/trinodb/trino/issues/23747.

- fixes https://github.com/trinodb/trino/issues/23747

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Improve performance of queries referencing fresh materialized views. ({issue}`27551`)
```
