### PR TITLE
Update Exasol image to 2025.1.8

### DIFF
--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
@@ -47,7 +47,7 @@ public class TestingExasolServer
 
     public TestingExasolServer()
     {
-        container = new ExasolContainer<>("2025.1.3")
+        container = new ExasolContainer<>("2025.1.8")
                 .withExposedPorts(8563)
                 .withRequiredServices(ExasolService.JDBC)
                 .withEnv("COSLWD_ENABLED", "1"); //Disables rsyslogd, cleans up log clutter and speeds up database startup

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeExasol.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeExasol.java
@@ -56,7 +56,7 @@ public class EnvMultinodeExasol
 
     private DockerContainer createExasol()
     {
-        DockerContainer container = new DockerContainer("exasol/docker-db:2025.1.3", "exasol")
+        DockerContainer container = new DockerContainer("exasol/docker-db:2025.1.8", "exasol")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(forSelectedPorts(EXASOL_PORT))
                 .withEnv("COSLWD_ENABLED", "1"); //Disables rsyslogd, cleans up log clutter and speeds up database startup


### PR DESCRIPTION
## Description

It seems `2025.1.3` has been removed from dockerhub.
https://hub.docker.com/r/exasol/docker-db/tags?name=2025.1.3

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
