### PR TITLE
[Exasol] Update Exasol docker container used in integration tests

### DIFF
--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestingExasolServer.java
@@ -47,7 +47,7 @@ public class TestingExasolServer
 
     public TestingExasolServer()
     {
-        container = new ExasolContainer<>("2025.1.3")
+        container = new ExasolContainer<>("2025.1.8")
                 .withExposedPorts(8563)
                 .withRequiredServices(ExasolService.JDBC)
                 .withEnv("COSLWD_ENABLED", "1"); //Disables rsyslogd, cleans up log clutter and speeds up database startup

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeExasol.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeExasol.java
@@ -56,7 +56,7 @@ public class EnvMultinodeExasol
 
     private DockerContainer createExasol()
     {
-        DockerContainer container = new DockerContainer("exasol/docker-db:2025.1.3", "exasol")
+        DockerContainer container = new DockerContainer("exasol/docker-db:2025.1.8", "exasol")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(forSelectedPorts(EXASOL_PORT))
                 .withEnv("COSLWD_ENABLED", "1"); //Disables rsyslogd, cleans up log clutter and speeds up database startup


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

A critical issue was found in Exasol container 2025.1.3 and we are now urgently updating to 2025.1.8
2025.1.3 became unavailable overnight and this might break the CI. We are updating to 2025.1.8, the latest stable version of Exasol docker-db.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This piece of code instruments what Exasol docker container to use for the integration tests. We've just updated the version number.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
