### PR TITLE
Apache DataSketches plugin for Trino

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -40,6 +40,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/datasketches">
+        <artifact id="${project.groupId}:trino-datasketches:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/delta-lake">
         <artifact id="${project.groupId}:trino-delta-lake:zip:${project.version}">
             <unpack />

--- a/docs/src/main/sphinx/functions.md
+++ b/docs/src/main/sphinx/functions.md
@@ -40,6 +40,7 @@ Color               <functions/color>
 Comparison          <functions/comparison>
 Conditional         <functions/conditional>
 Conversion          <functions/conversion>
+DataSketches        <functions/datasketches>
 Date and time       <functions/datetime>
 Decimal             <functions/decimal>
 Geospatial          <functions/geospatial>

--- a/docs/src/main/sphinx/functions/datasketches.md
+++ b/docs/src/main/sphinx/functions/datasketches.md
@@ -1,0 +1,100 @@
+# DataSketches functions
+
+[Apache DataSketches](https://datasketches.apache.org) is a high-performance
+library of stochastic streaming algorithms (sketch algorithms) that produce
+compact probabilistic summaries called sketches. A sketch is a small, stateful
+data structure that processes massive data as a stream and can provide
+approximate answers with mathematical guarantees much faster than traditional
+exact methods. DataSketches functions allow querying these serialized sketches
+from Trino. Support for the
+[Theta Sketch framework](https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html)
+is available through {func}`theta_sketch_union` and
+{func}`theta_sketch_cardinality`, typically used to replace expensive
+`COUNT(DISTINCT ...)` aggregations when sketches are precomputed and stored.
+
+## Configuration
+
+Because the DataSketches functions are provided by a connector, they are not
+available by default. To enable them, you must configure a
+[catalog properties file](catalog-properties) to register the functions with
+the specified catalog name.
+
+Create a catalog properties file `etc/catalog/datasketches.properties` that
+references the `datasketches` connector:
+
+```properties
+connector.name=datasketches
+```
+
+The DataSketches functions are available with the `theta` schema name. For the
+preceding example, the functions use the `datasketches.theta` catalog and
+schema prefix.
+
+To avoid needing to reference the functions with their fully qualified name,
+configure the `sql.path` [SQL environment
+property](/admin/properties-sql-environment) in the `config.properties` file to
+include the catalog and schema prefix:
+
+```properties
+sql.path=datasketches.theta
+```
+
+Configure multiple catalogs to use the same functions with different
+DataSketches configurations. In this case, the functions must be referenced
+using their fully qualified name, rather than relying on the SQL path.
+
+:::{note}
+Trino does not create new sketches. Build Theta sketches upstream (for example,
+in Spark, Hive, or Pig using the Apache DataSketches Theta APIs) and store the
+serialized sketch bytes as a ``VARBINARY`` column. The Trino functions operate
+on serialized Theta sketches only; other sketch families are not supported.
+:::
+
+## Functions
+
+:::{function} theta_sketch_union(sketch [, nominal_entries, seed]) -> varbinary
+Returns a serialized sketch as `varbinary`, which is a merged collection of
+sketches. The optional `nominal_entries` and `seed` parameters let you specify
+non-default sketch size and seed when merging sketches created with custom
+settings.
+:::
+
+:::{function} theta_sketch_cardinality(sketch) -> double
+Returns the estimated value of the sketch.
+:::
+
+::: {function} theta_sketch_cardinality(sketch, seed) -> double
+:noindex: true
+
+Returns the estimated value of the sketch using the supplied `seed`. Use this
+when the sketch was created with a non-default seed.
+:::
+
+## Examples
+
+The following query reads precomputed customer sketches from
+`tpch.sf100000.orders`, unions them per order date, and produces an approximate
+distinct customer count alongside exact spend. Using sketches avoids a heavy
+`COUNT(DISTINCT ...)` over billions of rows while retaining predictable error
+bounds.
+
+```sql
+SELECT
+  o_orderdate AS date,
+  theta_sketch_cardinality(theta_sketch_union(o_custkey_sketch)) AS unique_user_count,
+  SUM(o_totalprice) AS user_spent
+FROM tpch.sf100000.orders
+GROUP BY o_orderdate;
+```
+
+For comparison, the exact equivalent requires the raw keys and a costly distinct
+aggregation:
+
+```sql
+SELECT
+  o_orderdate AS date,
+  COUNT(DISTINCT o_custkey) AS unique_user_count,
+  SUM(o_totalprice) AS user_spent
+FROM tpch.sf100000.orders_raw_keys
+GROUP BY o_orderdate;
+```

--- a/docs/src/main/sphinx/functions/list-by-topic.md
+++ b/docs/src/main/sphinx/functions/list-by-topic.md
@@ -176,6 +176,13 @@ For more details, see {doc}`conversion`
 - {func}`try_cast`
 - {func}`typeof`
 
+## DataSketches
+
+For more details, see {doc}`datasketches`
+
+- {func}`theta_sketch_cardinality`
+- {func}`theta_sketch_union`
+
 ## Date and time
 
 For more details, see {doc}`datetime`

--- a/docs/src/main/sphinx/functions/list.md
+++ b/docs/src/main/sphinx/functions/list.md
@@ -464,6 +464,8 @@
 - {func}`tan`
 - {func}`tanh`
 - {func}`tdigest_agg`
+- {func}`theta_sketch_cardinality`
+- {func}`theta_sketch_union`
 - {func}`timestamp_objectid`
 - {func}`timezone`
 - {func}`timezone_hour`

--- a/plugin/trino-datasketches/pom.xml
+++ b/plugin/trino-datasketches/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>480-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-datasketches</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - DataSketches functions</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-array</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.datasketches</groupId>
+            <artifactId>datasketches-java</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Trino SPI -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/state/SketchState.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/state/SketchState.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.state;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.AccumulatorState;
+import io.trino.spi.function.AccumulatorStateMetadata;
+
+/**
+ * State object to keep track of sketch aggregations.
+ */
+@AccumulatorStateMetadata(stateSerializerClass = SketchStateSerializer.class, stateFactoryClass = SketchStateFactory.class)
+public interface SketchState
+        extends AccumulatorState
+{
+    Slice getSketch();
+
+    int getNominalEntries();
+
+    long getSeed();
+
+    void addSketch(Slice value);
+
+    void setNominalEntries(int value);
+
+    void setSeed(long value);
+
+    void merge(SketchState state);
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/state/SketchStateFactory.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/state/SketchStateFactory.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.state;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.array.ObjectBigArray;
+import io.trino.spi.function.AccumulatorStateFactory;
+import io.trino.spi.function.GroupedAccumulatorState;
+import org.apache.datasketches.theta.ThetaSetOperation;
+import org.apache.datasketches.theta.ThetaSketch;
+import org.apache.datasketches.theta.ThetaUnion;
+
+import java.lang.foreign.MemorySegment;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.instanceSize;
+
+public class SketchStateFactory
+        implements AccumulatorStateFactory<SketchState>
+{
+    @Override
+    public SketchState createSingleState()
+    {
+        return new SingleSketchState();
+    }
+
+    @Override
+    public SketchState createGroupedState()
+    {
+        return new GroupedSketchState();
+    }
+
+    public static class GroupedSketchState
+            implements GroupedAccumulatorState, SketchState
+    {
+        private static final long INSTANCE_SIZE = instanceSize(GroupedSketchState.class);
+        private int nominalEntries;
+        private long seed;
+        private long groupId;
+        private final ObjectBigArray<ThetaUnion> unions = new ObjectBigArray<>();
+        private long totalUnionSize;
+
+        @Override
+        public void ensureCapacity(int size)
+        {
+            unions.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return INSTANCE_SIZE + totalUnionSize + unions.sizeOf();
+        }
+
+        @Override
+        public Slice getSketch()
+        {
+            ThetaUnion union = getUnion();
+            if (union == null) {
+                return null;
+            }
+            return Slices.wrappedBuffer(union.getResult().toByteArray());
+        }
+
+        @Override
+        public int getNominalEntries()
+        {
+            return nominalEntries;
+        }
+
+        @Override
+        public long getSeed()
+        {
+            return seed;
+        }
+
+        public ThetaUnion getUnion()
+        {
+            return unions.get(groupId);
+        }
+
+        @Override
+        public void setGroupId(int groupId)
+        {
+            this.groupId = groupId;
+        }
+
+        @Override
+        public void setNominalEntries(int value)
+        {
+            nominalEntries = value;
+        }
+
+        @Override
+        public void setSeed(long value)
+        {
+            seed = value;
+        }
+
+        @Override
+        public void addSketch(Slice value)
+        {
+            if (value == null) {
+                return;
+            }
+
+            checkState(nominalEntries > 0, "nominalEntries is not set");
+            checkState(seed != 0, "seed is not set");
+            addSketchToUnion(value, nominalEntries);
+        }
+
+        @Override
+        public void merge(SketchState otherState)
+        {
+            if (otherState.getSketch() == null) {
+                return;
+            }
+            addSketchToUnion(otherState.getSketch(), otherState.getNominalEntries());
+        }
+
+        private void addSketchToUnion(Slice value, int nominalEntries)
+        {
+            checkState(value != null, "sketch is null");
+            checkState(nominalEntries > 0, "nominalEntries is not set");
+            ThetaSketch sketch = ThetaSketch.wrap(MemorySegment.ofArray(value.getBytes()), seed);
+            ThetaUnion groupedUnion = getUnion();
+            int previousSize = groupedUnion == null ? 0 : groupedUnion.getCurrentBytes();
+            if (groupedUnion == null) {
+                groupedUnion = ThetaSetOperation.builder()
+                        .setSeed(seed)
+                        .setNominalEntries(nominalEntries)
+                        .buildUnion();
+                groupedUnion.union(sketch);
+                unions.set(groupId, groupedUnion);
+            }
+            else {
+                groupedUnion.union(sketch);
+            }
+            updateMemoryUsage(groupedUnion, previousSize);
+        }
+
+        private void updateMemoryUsage(ThetaUnion union, int previousSize)
+        {
+            int newSize = union.getCurrentBytes();
+            totalUnionSize += newSize - previousSize;
+        }
+    }
+
+    public static class SingleSketchState
+            implements SketchState
+    {
+        private static final long INSTANCE_SIZE = instanceSize(SingleSketchState.class);
+        private ThetaUnion union;
+        private int nominalEntries;
+        private long seed;
+
+        @Override
+        public Slice getSketch()
+        {
+            if (union == null) {
+                return null;
+            }
+            ThetaSketch result = union.getResult();
+            return Slices.wrappedBuffer(result.toByteArray());
+        }
+
+        @Override
+        public int getNominalEntries()
+        {
+            return nominalEntries;
+        }
+
+        @Override
+        public long getSeed()
+        {
+            return seed;
+        }
+
+        @Override
+        public void addSketch(Slice value)
+        {
+            if (value == null) {
+                return;
+            }
+
+            checkState(nominalEntries > 0, "nominalEntries is not set");
+            checkState(seed != 0, "seed is not set");
+            addSketchToUnion(value, nominalEntries);
+        }
+
+        @Override
+        public void setNominalEntries(int value)
+        {
+            nominalEntries = value;
+        }
+
+        @Override
+        public void setSeed(long value)
+        {
+            seed = value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            int sketchSize = union == null ? 0 : union.getCurrentBytes();
+            return INSTANCE_SIZE + sketchSize;
+        }
+
+        @Override
+        public void merge(SketchState otherState)
+        {
+            if (otherState.getSketch() == null) {
+                return;
+            }
+
+            addSketchToUnion(otherState.getSketch(), otherState.getNominalEntries());
+        }
+
+        private void addSketchToUnion(Slice value, int nominalEntries)
+        {
+            checkState(value != null, "sketch is null");
+            checkState(nominalEntries > 0, "nominalEntries is not set");
+            ThetaSketch sketch = ThetaSketch.wrap(MemorySegment.ofArray(value.getBytes()), seed);
+            if (union == null) {
+                union = ThetaSetOperation.builder()
+                        .setSeed(seed)
+                        .setNominalEntries(nominalEntries)
+                        .buildUnion();
+                union.union(sketch);
+                return;
+            }
+            union.union(sketch);
+        }
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/state/SketchStateSerializer.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/state/SketchStateSerializer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.state;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorStateSerializer;
+import io.trino.spi.type.Type;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+
+public class SketchStateSerializer
+        implements AccumulatorStateSerializer<SketchState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(SketchState state, BlockBuilder out)
+    {
+        if (state.getSketch() == null) {
+            out.appendNull();
+        }
+        else {
+            Slice slice = state.getSketch();
+
+            Slice serialized = Slices.allocate(SIZE_OF_LONG + SIZE_OF_INT + SIZE_OF_INT + slice.length());
+            SliceOutput sliceOutput = serialized.getOutput();
+            sliceOutput.appendInt(state.getNominalEntries());
+            sliceOutput.appendLong(state.getSeed());
+
+            sliceOutput.appendInt(slice.length());
+            sliceOutput.appendBytes(slice);
+
+            VARBINARY.writeSlice(out, sliceOutput.slice());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, SketchState state)
+    {
+        Slice slice = VARBINARY.getSlice(block, index);
+        SliceInput input = slice.getInput();
+
+        state.setNominalEntries(input.readInt());
+        state.setSeed(input.readLong());
+
+        int sketchLength = input.readInt();
+        state.addSketch(input.readSlice(sketchLength));
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/Estimate.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/Estimate.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.apache.datasketches.theta.ThetaSketch;
+
+import java.lang.foreign.MemorySegment;
+
+import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
+
+public class Estimate
+{
+    private Estimate() {}
+
+    @ScalarFunction("theta_sketch_cardinality")
+    @Description("Converts sketch bytearrays to double estimate")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double estimate(@SqlType(StandardTypes.VARBINARY) Slice inputValue)
+    {
+        return estimate(inputValue, DEFAULT_UPDATE_SEED);
+    }
+
+    @ScalarFunction("theta_sketch_cardinality")
+    @Description("Converts sketch bytearrays to double estimate")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double estimate(@SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.BIGINT) long seed)
+    {
+        if (inputValue.getBytes().length == 0) {
+            return 0;
+        }
+        return ThetaSketch.wrap(MemorySegment.ofArray(inputValue.getBytes()), seed).getEstimate();
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctions.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctions.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.spi.function.AggregationFunctionMetadata;
+import io.trino.spi.function.AggregationImplementation;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+
+import java.util.List;
+
+public class SketchFunctions
+        implements FunctionProvider
+{
+    private static final InternalFunctionBundle FUNCTION_BUNDLE = InternalFunctionBundle.builder()
+            .functions(Estimate.class)
+            .functions(Union.class)
+            .functions(UnionWithParams.class)
+            .build();
+
+    public List<FunctionMetadata> getFunctions()
+    {
+        return ImmutableList.copyOf(FUNCTION_BUNDLE.getFunctions());
+    }
+
+    public AggregationFunctionMetadata getAggregationFunctionMetadata(FunctionId functionId)
+    {
+        return FUNCTION_BUNDLE.getAggregationFunctionMetadata(functionId);
+    }
+
+    public FunctionDependencyDeclaration getFunctionDependencies(FunctionId functionId, BoundSignature boundSignature)
+    {
+        return FUNCTION_BUNDLE.getFunctionDependencies(functionId, boundSignature);
+    }
+
+    @Override
+    public ScalarFunctionImplementation getScalarFunctionImplementation(
+            FunctionId functionId,
+            BoundSignature boundSignature,
+            FunctionDependencies functionDependencies,
+            InvocationConvention invocationConvention)
+    {
+        return FUNCTION_BUNDLE.getScalarFunctionImplementation(functionId, boundSignature, functionDependencies, invocationConvention);
+    }
+
+    @Override
+    public AggregationImplementation getAggregationImplementation(FunctionId functionId, BoundSignature boundSignature, FunctionDependencies functionDependencies)
+    {
+        return FUNCTION_BUNDLE.getAggregationImplementation(functionId, boundSignature, functionDependencies);
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnector.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnector.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class SketchFunctionsConnector
+        implements Connector
+{
+    private final SketchMetadata metadata;
+    private final SketchFunctions functionProvider;
+
+    public SketchFunctionsConnector(SketchMetadata metadata, SketchFunctions functionProvider)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return SketchTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transaction)
+    {
+        return metadata;
+    }
+
+    @Override
+    public Optional<FunctionProvider> getFunctionProvider()
+    {
+        return Optional.of(functionProvider);
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+
+public class SketchFunctionsConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "datasketches";
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        SketchFunctions functions = new SketchFunctions();
+        SketchMetadata metadata = new SketchMetadata(functions.getFunctions(), functions);
+
+        return new SketchFunctionsConnector(metadata, functions);
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsPlugin.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class SketchFunctionsPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableSet.of(new SketchFunctionsConnectorFactory());
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchMetadata.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.AggregationFunctionMetadata;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.SchemaFunctionName;
+
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class SketchMetadata
+        implements ConnectorMetadata
+{
+    private static final String SCHEMA_NAME = "theta";
+
+    private final List<FunctionMetadata> functions;
+    private final SketchFunctions functionProvider;
+
+    public SketchMetadata(List<FunctionMetadata> functions, SketchFunctions functionProvider)
+    {
+        this.functions = ImmutableList.copyOf(requireNonNull(functions, "functions is null"));
+        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+    }
+
+    @Override
+    public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName)
+    {
+        return schemaName.equals(SCHEMA_NAME) ? functions : List.of();
+    }
+
+    @Override
+    public Collection<FunctionMetadata> getFunctions(ConnectorSession session, SchemaFunctionName name)
+    {
+        if (!name.schemaName().equals(SCHEMA_NAME)) {
+            return List.of();
+        }
+
+        return functions.stream()
+                .filter(function -> function.getCanonicalName().equals(name.functionName()))
+                .toList();
+    }
+
+    @Override
+    public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId)
+    {
+        return functions.stream()
+                .filter(function -> function.getFunctionId().equals(functionId))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Override
+    public AggregationFunctionMetadata getAggregationFunctionMetadata(ConnectorSession session, FunctionId functionId)
+    {
+        return functionProvider.getAggregationFunctionMetadata(functionId);
+    }
+
+    @Override
+    public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
+    {
+        return functionProvider.getFunctionDependencies(functionId, boundSignature);
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchTransactionHandle.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+public enum SketchTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/Union.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/Union.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.airlift.slice.Slice;
+import io.trino.plugin.datasketches.state.SketchState;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AggregationFunction;
+import io.trino.spi.function.AggregationState;
+import io.trino.spi.function.CombineFunction;
+import io.trino.spi.function.InputFunction;
+import io.trino.spi.function.OutputFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
+import static org.apache.datasketches.thetacommon.ThetaUtil.DEFAULT_NOMINAL_ENTRIES;
+
+@AggregationFunction("theta_sketch_union")
+public final class Union
+{
+    private Union() {}
+
+    @InputFunction
+    public static void input(@AggregationState SketchState state, @SqlType(StandardTypes.VARBINARY) Slice inputValue)
+    {
+        state.setNominalEntries(DEFAULT_NOMINAL_ENTRIES);
+        state.setSeed(DEFAULT_UPDATE_SEED);
+        state.addSketch(inputValue);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState SketchState state, SketchState otherState)
+    {
+        UnionWithParams.combine(state, otherState);
+    }
+
+    @OutputFunction(StandardTypes.VARBINARY)
+    public static void output(@AggregationState SketchState state, BlockBuilder out)
+    {
+        UnionWithParams.output(state, out);
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/UnionWithParams.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/UnionWithParams.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.airlift.slice.Slice;
+import io.trino.plugin.datasketches.state.SketchState;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import io.trino.spi.function.AggregationFunction;
+import io.trino.spi.function.AggregationState;
+import io.trino.spi.function.CombineFunction;
+import io.trino.spi.function.InputFunction;
+import io.trino.spi.function.OutputFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+@AggregationFunction("theta_sketch_union")
+public final class UnionWithParams
+{
+    private UnionWithParams() {}
+
+    @InputFunction
+    public static void input(@AggregationState SketchState state, @SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) Integer nominalEntries, @SqlType(StandardTypes.BIGINT) Long seed)
+    {
+        state.setNominalEntries(nominalEntries);
+        state.setSeed(seed);
+        state.addSketch(inputValue);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState SketchState state, SketchState otherState)
+    {
+        if (otherState.getSketch() == null) {
+            return;
+        }
+
+        if (state.getSketch() == null) {
+            state.setSeed(otherState.getSeed());
+            state.setNominalEntries(otherState.getNominalEntries());
+            state.addSketch(otherState.getSketch());
+            return;
+        }
+
+        state.merge(otherState);
+    }
+
+    @OutputFunction(StandardTypes.VARBINARY)
+    public static void output(@AggregationState SketchState state, BlockBuilder out)
+    {
+        Slice sketch = state.getSketch();
+        if (sketch == null) {
+            out.appendNull();
+            return;
+        }
+
+        VariableWidthBlockBuilder blockBuilder = (VariableWidthBlockBuilder) out;
+        blockBuilder.writeEntry(sketch, 0, sketch.length());
+    }
+}

--- a/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
+++ b/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.Session;
+import io.trino.plugin.datasketches.state.SketchState;
+import io.trino.plugin.datasketches.state.SketchStateFactory;
+import io.trino.plugin.datasketches.theta.Estimate;
+import io.trino.plugin.datasketches.theta.SketchFunctionsPlugin;
+import io.trino.plugin.datasketches.theta.Union;
+import io.trino.plugin.datasketches.theta.UnionWithParams;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import org.apache.datasketches.theta.ThetaSetOperation;
+import org.apache.datasketches.theta.ThetaSketch;
+import org.apache.datasketches.theta.ThetaUnion;
+import org.apache.datasketches.theta.UpdatableThetaSketch;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.google.common.io.BaseEncoding.base16;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.SqlPath.buildPath;
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
+import static org.apache.datasketches.thetacommon.ThetaUtil.DEFAULT_NOMINAL_ENTRIES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDataSketches
+        extends AbstractTestQueryFramework
+{
+    private static final long TEST_SEED = 95869L;
+    private static final int TEST_ENTRIES = 2048;
+    private static final int DEFAULT_ENTRIES = DEFAULT_NOMINAL_ENTRIES;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .setPath(buildPath("datasketches.theta", Optional.empty()))
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+        queryRunner.installPlugin(new SketchFunctionsPlugin());
+        queryRunner.createCatalog("datasketches", "datasketches");
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+        return queryRunner;
+    }
+
+    @Test
+    public void testSimpleMerge()
+    {
+        SketchStateFactory factory = new SketchStateFactory();
+        SketchState state1 = factory.createSingleState();
+        SketchState state2 = factory.createSingleState();
+
+        // 1000 unique keys
+        UpdatableThetaSketch sketch1 = UpdatableThetaSketch.builder()
+                .setSeed(TEST_SEED)
+                .setNominalEntries(TEST_ENTRIES)
+                .build();
+        for (int key = 0; key < 1000; key++) {
+            sketch1.update(key);
+        }
+
+        // 1000 unique keys
+        // the first 500 unique keys overlap with sketch1
+        UpdatableThetaSketch sketch2 = UpdatableThetaSketch.builder()
+                .setSeed(TEST_SEED)
+                .setNominalEntries(TEST_ENTRIES)
+                .build();
+        for (int key = 500; key < 1500; key++) {
+            sketch2.update(key);
+        }
+
+        UnionWithParams.input(state1, Slices.wrappedBuffer(sketch1.compact().toByteArray()), TEST_ENTRIES, TEST_SEED);
+        UnionWithParams.input(state2, Slices.wrappedBuffer(sketch2.compact().toByteArray()), TEST_ENTRIES, TEST_SEED);
+        Union.combine(state1, state2);
+        double estimate = Estimate.estimate(state1.getSketch(), TEST_SEED);
+
+        ThetaUnion union = ThetaSetOperation.builder().setSeed(TEST_SEED).setNominalEntries(TEST_ENTRIES).buildUnion();
+        union.union(sketch1);
+        union.union(sketch2);
+        ThetaSketch unionResult = union.getResult();
+
+        assertThat(estimate).isEqualTo(unionResult.getEstimate());
+    }
+
+    @Test
+    public void testMergeAndEstimate()
+    {
+        int[] idACategory = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        int[] idBCategory = {6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+        String sketchA = toHexSketch(idACategory);
+        String sketchB = toHexSketch(idBCategory);
+
+        MaterializedResult actualEstimateResult = computeActual("""
+                SELECT category, theta_sketch_cardinality(sketch)
+                FROM (VALUES
+                        ('a', X'%s'),
+                        ('b', X'%s')) t(category, sketch)
+                ORDER BY category
+                """.formatted(sketchA, sketchB));
+        assertThat(actualEstimateResult.getRowCount()).isEqualTo(2);
+        MaterializedResult expectedEstimateResult = resultBuilder(getSession(), VARCHAR, DOUBLE)
+                .row("a", 10d)
+                .row("b", 10d)
+                .build();
+        assertThat(actualEstimateResult.getMaterializedRows())
+                .isEqualTo(expectedEstimateResult.getMaterializedRows());
+
+        double mergeEstimateResult = (double) computeScalar("""
+                SELECT theta_sketch_cardinality(theta_sketch_union(sketch))
+                FROM (VALUES
+                        (X'%s'),
+                        (X'%s')) t(sketch)
+                """.formatted(sketchA, sketchB));
+        assertThat(mergeEstimateResult).isEqualTo(15d);
+    }
+
+    @Test
+    public void testMergeDoesNotDoubleCount()
+    {
+        SketchStateFactory factory = new SketchStateFactory();
+        SketchState left = factory.createSingleState();
+        left.setNominalEntries(DEFAULT_ENTRIES);
+        left.setSeed(DEFAULT_UPDATE_SEED);
+        left.addSketch(toSketchSlice(new int[] {1, 2, 3}, DEFAULT_UPDATE_SEED, DEFAULT_ENTRIES));
+
+        SketchState right = factory.createSingleState();
+        right.setNominalEntries(DEFAULT_ENTRIES);
+        right.setSeed(DEFAULT_UPDATE_SEED);
+        right.addSketch(toSketchSlice(new int[] {3, 4, 5}, DEFAULT_UPDATE_SEED, DEFAULT_ENTRIES));
+
+        left.merge(right);
+
+        double estimate = ThetaSketch.wrap(toMemory(left.getSketch()), DEFAULT_UPDATE_SEED).getEstimate();
+        assertThat(estimate).isEqualTo(5d);
+    }
+
+    @Test
+    public void testMergeWithEmptyStateDoesNotFail()
+    {
+        SketchStateFactory factory = new SketchStateFactory();
+        SketchState empty = factory.createSingleState();
+        empty.setNominalEntries(DEFAULT_ENTRIES);
+        empty.setSeed(DEFAULT_UPDATE_SEED);
+
+        SketchState populated = factory.createSingleState();
+        populated.setNominalEntries(DEFAULT_ENTRIES);
+        populated.setSeed(DEFAULT_UPDATE_SEED);
+        populated.addSketch(toSketchSlice(new int[] {1, 2, 3, 4}, DEFAULT_UPDATE_SEED, DEFAULT_ENTRIES));
+
+        empty.merge(populated);
+
+        double estimate = ThetaSketch.wrap(toMemory(empty.getSketch()), DEFAULT_UPDATE_SEED).getEstimate();
+        assertThat(estimate).isEqualTo(4d);
+    }
+
+    @Test
+    public void testUnionIgnoresNullInputs()
+    {
+        String sketch = toHexSketch(new int[] {1, 2, 3});
+
+        double estimate = (double) computeScalar("""
+                SELECT theta_sketch_cardinality(theta_sketch_union(sketch))
+                FROM (VALUES
+                        (CAST(NULL AS VARBINARY)),
+                        (X'%s'),
+                        (CAST(NULL AS VARBINARY))) t(sketch)
+                """.formatted(sketch));
+
+        assertThat(estimate).isEqualTo(3d);
+    }
+
+    private String toHexSketch(int[] data)
+    {
+        UpdatableThetaSketch sketch = UpdatableThetaSketch.builder()
+                .setNominalEntries(DEFAULT_NOMINAL_ENTRIES)
+                .setSeed(DEFAULT_UPDATE_SEED)
+                .build();
+        Arrays.stream(data).forEach(sketch::update);
+
+        return base16().lowerCase().encode(sketch.compact().toByteArray());
+    }
+
+    private static Slice toSketchSlice(int[] data, long seed, int nominalEntries)
+    {
+        UpdatableThetaSketch sketch = UpdatableThetaSketch.builder()
+                .setNominalEntries(nominalEntries)
+                .setSeed(seed)
+                .build();
+        Arrays.stream(data).forEach(sketch::update);
+        return Slices.wrappedBuffer(sketch.compact().toByteArray());
+    }
+
+    private static java.lang.foreign.MemorySegment toMemory(Slice slice)
+    {
+        return java.lang.foreign.MemorySegment.ofArray(slice.getBytes());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <module>plugin/trino-blackhole</module>
         <module>plugin/trino-cassandra</module>
         <module>plugin/trino-clickhouse</module>
+        <module>plugin/trino-datasketches</module>
         <module>plugin/trino-delta-lake</module>
         <module>plugin/trino-druid</module>
         <module>plugin/trino-duckdb</module>


### PR DESCRIPTION
Plugin to query Apache DataSketches (https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html). This includes merge and estimate function for theta sketch.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add DataSketches functions. ({issue}`issuenumber`)
```

Supercedes https://github.com/trinodb/trino/pull/6643