### PR TITLE
[Exasol] Switch off Exasol testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -912,7 +912,7 @@ jobs:
             - suite-delta-lake-databricks154
             - suite-delta-lake-databricks164
             - suite-delta-lake-databricks173
-            - suite-exasol
+            # - suite-exasol
             - suite-ranger
             - suite-gcs
             - suite-hive4


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Turning off Exasol testsuite, for now. 
We were forced to update to 2025.1.8 this morning and it does not seem stable.
2025.1.3 is no longer available.
We will turn off the tests for now so we don't hinder everyone. 
We will turn them back on once we found the issue and have a new stable container to use.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: