### PR TITLE
Improve overlap percent estimation for low-density ranges in StatisticRange

### DIFF
--- a/core/trino-main/src/test/java/io/trino/cost/TestStatisticRange.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestStatisticRange.java
@@ -60,6 +60,60 @@ public class TestStatisticRange
     }
 
     @Test
+    public void testLowDensityOverlapWithSparseLeftRange()
+    {
+        StatisticRange sparseRange = range(1, 4, NaN);
+        StatisticRange filterRange = range(1, 3662098119.0, 14);
+
+        assertOverlap(sparseRange, filterRange, 1);
+    }
+
+    @Test
+    public void testLowDensityOverlapWithSparseRightRange()
+    {
+        StatisticRange sparseRange = range(1, 3662098119.0, 14);
+        StatisticRange filterRange = range(1, 4, NaN);
+
+        assertOverlap(sparseRange, filterRange, 1);
+    }
+
+    @Test
+    public void testDensityThresholdBoundary()
+    {
+        StatisticRange boundaryRange = range(0, 10000, 10);
+        StatisticRange smallFilter = range(0, 100, 5);
+
+        assertOverlap(boundaryRange, smallFilter, 0.01);
+    }
+
+    @Test
+    public void testHighDensityOverlap()
+    {
+        StatisticRange denseRange = range(0, 100, 50);
+        StatisticRange filterRange = range(20, 30, 5);
+
+        assertOverlap(denseRange, filterRange, 0.1);
+    }
+
+    @Test
+    public void testVeryLowDensity()
+    {
+        StatisticRange verySparse = range(0, 1e9, 10);
+        StatisticRange filterRange = range(100, 200, 5);
+
+        assertOverlap(verySparse, filterRange, 0.5);
+    }
+
+    @Test
+    public void testDensityWithZeroDistinctValues()
+    {
+        StatisticRange zeroDistinct = range(0, 1000, 0);
+        StatisticRange filterRange = range(100, 200, 5);
+
+        assertOverlap(zeroDistinct, filterRange, 0);
+    }
+
+    @Test
     public void testIntersect()
     {
         StatisticRange zeroToTen = range(0, 10, 10);

--- a/testing/trino-tests/src/test/resources/sql/trino/tpcds/iceberg/partitioned/q84.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/trino/tpcds/iceberg/partitioned/q84.plan.txt
@@ -12,15 +12,16 @@ local exchange (GATHER, SINGLE, [])
                                     scan customer_demographics
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                dynamic filter (c_current_addr_sk::EQUAL, c_current_hdemo_sk::EQUAL)
-                                                    scan customer
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan customer_address
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [c_current_hdemo_sk])
+                                                join (INNER, REPLICATED):
+                                                    dynamic filter (c_current_addr_sk::EQUAL, c_current_hdemo_sk::EQUAL)
+                                                        scan customer
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan customer_address
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [hd_demo_sk])
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (hd_income_band_sk::EQUAL)
                                                             scan household_demographics


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Join order can be misestimated due to the uniform distribution assumption in `StatisticRange.overlapPercentWith()`.

When a column has a very wide numeric range but few distinct values `(e.g., distinctValues = 14, low = 1, high = 3.6e9)`, the current overlap estimation becomes extremely small `(e.g., 8.19e-10)`, underestimating join cardinalities.

**Example:**
```
SELECT *
FROM table1 t1
JOIN table2 t2
  ON t1.eid = t2.eid
WHERE CAST(event_date AS DATE) = DATE '2025-09-07'
  AND t1.platform_id IN (1, 2, 3, 4);
```

`table1` is large and `table2` is small.
The column `platform_id` in `table1` has `14` distinct values, with `low = 1` and `high = 3 662 098 119`.
In this case, the method `StatisticRange.overlapPercentWith()` estimates the overlap as
`(4 - 1) / (3,662,098,119 - 1) ≈ 8.19e-10`
which effectively means “all rows are filtered out”.
But in reality, the filter `IN (1,2,3,4)` should keep roughly `4` out of `14` values `(~29%)`.

**Solution:**
Introduce a density check `density = distinctValues / (high - low)` and combine uniform overlap with NDV-based estimate when density is low.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/4107


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
() Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
