### PR TITLE
Enable cleanup-node in error-prone job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,7 @@ jobs:
         timeout-minutes: 15
         with:
           cache: restore
+          cleanup-node: true # fix "No space left on device" error
           java-version: 25.0.1
       - name: Maven Install
         run: |


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Hopefully fixes "No space left on device" error https://github.com/trinodb/trino/actions/runs/19975706754/job/57291219289

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.