### PR TITLE
Fix `select` query when reusing BigQuery `query` table function result

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
@@ -155,7 +155,9 @@ public class BigQuerySplitSource
             String query = buildNativeQuery(bigQueryQueryRelationHandle.getQuery(), filter, limit);
 
             TableId destinationTable = bigQueryQueryRelationHandle.getDestinationTableName().toTableId();
-            TableInfo tableInfo = new ViewMaterializationCache.DestinationTableBuilder(bigQueryClientFactory.create(session), viewExpiration, query, destinationTable).get();
+            BigQueryClient bigQueryClient = bigQueryClientFactory.create(session);
+            Optional<TableInfo> bigQueryTable = bigQueryClient.getTable(destinationTable);
+            TableInfo tableInfo = bigQueryTable.orElseGet(() -> new ViewMaterializationCache.DestinationTableBuilder(bigQueryClient, viewExpiration, query, destinationTable).get());
 
             log.debug("Using Storage API for running query: %s", query);
             remoteTableId = tableInfo.getTableId();

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -1122,6 +1122,13 @@ public abstract class BaseBigQueryConnectorTest
         }
     }
 
+    @Test // regression test for https://github.com/trinodb/trino/issues/27573
+    public void testNativeQueryWhenResultReused()
+    {
+        assertThat(query("WITH t AS (SELECT * FROM TABLE(system.query('SELECT regionkey FROM tpch.region WHERE regionkey = 0'))) SELECT * FROM t, t"))
+                .matches("VALUES (BIGINT '0', BIGINT '0')");
+    }
+
     @Test
     public void testNativeQuerySelectUnsupportedType()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes: https://github.com/trinodb/trino/issues/27573

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
## BigQuery
* Fix query failure when reusing `query` table function result. ({issue}`27573`)
```
