### PR TITLE
Remove use of deprecated ObjectMapper::createParser

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/JsonUtils.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/JsonUtils.java
@@ -31,7 +31,6 @@ import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -95,16 +94,6 @@ public final class JsonUtils
     public static <T> T parseJson(ObjectMapper mapper, InputStream inputStream, Class<T> javaType)
     {
         return parseJson(mapper, ObjectMapper::createParser, inputStream, javaType);
-    }
-
-    public static <T> T parseJson(URL url, Class<T> javaType)
-    {
-        return parseJson(OBJECT_MAPPER, url, javaType);
-    }
-
-    public static <T> T parseJson(ObjectMapper mapper, URL url, Class<T> javaType)
-    {
-        return parseJson(mapper, ObjectMapper::createParser, url, javaType);
     }
 
     private static <I, T> T parseJson(ObjectMapper mapper, ParserConstructor<I> parserConstructor, I input, Class<T> javaType)

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/statistics/TableStatisticsDataRepository.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/statistics/TableStatisticsDataRepository.java
@@ -16,11 +16,13 @@ package io.trino.plugin.tpcds.statistics;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.io.Resources;
 import io.trino.tpcds.Table;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -84,7 +86,9 @@ public class TableStatisticsDataRepository
             return Optional.empty();
         }
         try {
-            return Optional.of(parseJson(objectMapper, resource, TableStatisticsData.class));
+            try (InputStream inputStream = Resources.asByteSource(resource).openStream()) {
+                return Optional.of(parseJson(objectMapper, inputStream, TableStatisticsData.class));
+            }
         }
         catch (Exception e) {
             throw new RuntimeException(format("Failed to parse stats from resource [%s]", resourcePath), e);

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/statistics/TableStatisticsDataRepository.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/statistics/TableStatisticsDataRepository.java
@@ -14,12 +14,14 @@
 package io.trino.plugin.tpch.statistics;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
 import io.trino.tpch.TpchColumn;
 import io.trino.tpch.TpchTable;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -78,7 +80,9 @@ public class TableStatisticsDataRepository
             return Optional.empty();
         }
         try {
-            return Optional.of(parseJson(objectMapper, resource, TableStatisticsData.class));
+            try (InputStream inputStream = Resources.asByteSource(resource).openStream()) {
+                return Optional.of(parseJson(objectMapper, inputStream, TableStatisticsData.class));
+            }
         }
         catch (Exception e) {
             throw new RuntimeException(format("Failed to parse stats from resource [%s]", resourcePath), e);


### PR DESCRIPTION
The `createParser` variant that takes `URL` is deprecated. The caller is expected to provide a stream. This removes usages from `JsonUtils` and updates the call sites.
