### PR TITLE
docs(opensearch): update example timestamp

### DIFF
--- a/docs/src/main/sphinx/connector/opensearch.md
+++ b/docs/src/main/sphinx/connector/opensearch.md
@@ -243,7 +243,7 @@ following structure:
     "array_string_field": ["trino","the","lean","machine-ohs"],
     "long_field": 314159265359,
     "id_field": "564e6982-88ee-4498-aa98-df9e3f6b6109",
-    "timestamp_field": "1987-09-17T06:22:48.000Z",
+    "timestamp_field": "2025-09-17T06:22:48.000Z",
     "object_field": {
         "array_int_field": [86,75,309],
         "int_field": 2


### PR DESCRIPTION
Update the example timestamp in the OpenSearch connector docs to a recent date so search engines don\'t infer the page was created in 1987, aligning with the Elasticsearch doc change.\n\nNotable changes:\n- refresh the sample document timestamp in the OpenSearch connector guide\n- keep the rest of the example unchanged\n\nTesting:\n- not run (docs-only change)