### PR TITLE
Use correct kilobyte unit in docs

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-kafka.md
+++ b/docs/src/main/sphinx/admin/event-listeners-kafka.md
@@ -102,7 +102,7 @@ Use the following properties for further configuration.
   - `5MB`
 * - `kafka-event-listener.batch-size`
   - [Size value](prop-type-data-size) that specifies the size to batch before sending records to Kafka.
-  - `16KB`
+  - `16kB`
 * - `kafka-event-listener.publish-created-event`
   - [Boolean](prop-type-boolean) switch to control publishing of query creation
     events.

--- a/docs/src/main/sphinx/admin/properties-client-protocol.md
+++ b/docs/src/main/sphinx/admin/properties-client-protocol.md
@@ -75,8 +75,8 @@ segments.
 ### `protocol.spooling.encoding.compression.threshold`
 
 - **Type:** [](prop-type-data-size)
-- **Default value:** `8KB`
-- **Minimum value:** `1KB`
+- **Default value:** `8kB`
+- **Minimum value:** `1kB`
 - **Maximum value:** `4MB`
 
 Threshold for enabling compression with larger segments.
@@ -85,7 +85,7 @@ Threshold for enabling compression with larger segments.
 
 - **Type:** [](prop-type-data-size)
 - **Default value:** `8MB`
-- **Minimum value:** `1KB`
+- **Minimum value:** `1kB`
 - **Maximum value:** `128MB`
 - **Session property:** `spooling_initial_segment_size`
 
@@ -95,7 +95,7 @@ Initial size of the spooled segments.
 
 - **Type:** [](prop-type-data-size)
 - **Default value:** `16MB`
-- **Minimum value:** `1KB`
+- **Minimum value:** `1kB`
 - **Maximum value:** `128MB`
 - **Session property:** `spooling_max_segment_size`
 
@@ -124,7 +124,7 @@ Maximum number of rows to inline per worker.
 
 - **Type:** [](prop-type-data-size)
 - **Default value:** `128kB`
-- **Minimum value:** `1KB`
+- **Minimum value:** `1kB`
 - **Maximum value:** `1MB`
 - **Session property:** `spooling_inlining_max_size`
 

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -152,7 +152,7 @@ mode:
     [](cli-troubleshooting). Displays more information about query
     processing statistics.
 * - `--decimal-data-size`
-  - Show data size and rate in base 10 (KB, MB, etc.) rather than the default 
+  - Show data size and rate in base 10 (kB, MB, etc.) rather than the default
     base 2 (KiB, MiB, etc.).
 * - `--disable-auto-suggestion`
   - Disables autocomplete suggestions.


### PR DESCRIPTION
DataSize accepts only kB as a unit, not KB
which makes documentation incorrect.

Closes https://github.com/trinodb/trino/issues/27597

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
