### PR TITLE
Fix handling of dropped base tables for Iceberg MVs

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3928,12 +3928,9 @@ public class IcebergMetadata
                     firstTableChange = firstTableChange
                             .map(epochMilli -> Math.min(epochMilli, snapshot.timestampMillis()));
                 }
-                case UnknownTableChange() -> {
+                case UnknownTableChange(), GoneOrCorruptedTableChange() -> {
                     hasStaleIcebergTables = true;
                     firstTableChange = Optional.empty();
-                }
-                case GoneOrCorruptedTableChange() -> {
-                    return new MaterializedViewFreshness(STALE, Optional.empty());
                 }
             }
         }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1801,9 +1801,14 @@ public abstract class BaseConnectorTest
             assertUpdate("REFRESH MATERIALIZED VIEW " + viewName, 1);
         }
         assertUpdate("DROP TABLE " + baseTable);
-        assertQueryFails(
-                "TABLE " + viewName,
-                "line 1:1: Failed analyzing stored view '%1$s\\.%2$s\\.%3$s': line 3:3: Table '%1$s\\.%2$s\\.%4$s' does not exist".formatted(catalog, schema, viewName, baseTable));
+        if (initialized) {
+            assertQuerySucceeds("TABLE " + viewName);
+        }
+        else {
+            assertQueryFails(
+                    "TABLE " + viewName,
+                    "line 1:1: Failed analyzing stored view '%1$s\\.%2$s\\.%3$s': line 3:3: Table '%1$s\\.%2$s\\.%4$s' does not exist".formatted(catalog, schema, viewName, baseTable));
+        }
         assertUpdate("DROP MATERIALIZED VIEW " + viewName);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Follow-up to 
* https://github.com/trinodb/trino/pull/27551

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Ignore non-existent or corrupted base Iceberg tables when querying materialized views within the grace period ({issue}`27606`)
```
