### PR TITLE
Validate CatalogName is lowercase

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/catalog/CatalogName.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/catalog/CatalogName.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Locale.ENGLISH;
 
 public final class CatalogName
 {
@@ -32,6 +33,10 @@ public final class CatalogName
     {
         if (catalogName.isEmpty()) {
             throw new IllegalArgumentException("catalogName is empty");
+        }
+        // Currently, catalog names must be lowercase.
+        if (!catalogName.equals(catalogName.toLowerCase(ENGLISH))) {
+            throw new IllegalArgumentException("catalogName is not lowercase: " + catalogName);
         }
         this.catalogName = catalogName;
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcPlugin.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcPlugin.java
@@ -104,8 +104,8 @@ public class TestJdbcPlugin
     private static class TestingJdbcModule
             extends AbstractConfigurationAwareModule
     {
-        public static final String CATALOG_WITH_PUSH_DOWN_ENABLED = "catalogWithPushDownEnabled";
-        public static final String CATALOG_WITH_PUSH_DOWN_DISABLED = "catalogWithPushDownDisabled";
+        public static final String CATALOG_WITH_PUSH_DOWN_ENABLED = "catalog_with_pushdown_enabled";
+        public static final String CATALOG_WITH_PUSH_DOWN_DISABLED = "catalog_with_pushdown_disabled";
 
         @Override
         protected void setup(Binder binder)


### PR DESCRIPTION
Currently all objects in Trino are lowercase. However, the catalog store does not validate this. It's possible to create
`etc/catalog/TPCH.properties` which will create `TPCH` catalog. The system starts, but the catalog is not usable.

The upcoming case-sensitivity changes target, at least in near term, non-lowercase schema, tables and column names. Eventually it may be extended to support non-lowercase catalog names, but that's not a near term goal. However, this work will require removal of lowercasing in `Identifier` and `QualifiedName` (https://github.com/trinodb/trino/pull/26339). Expecting `CatalogName` to be lowercase may prevent a class of issues while case-sensitivity story evolves.

- relates to #17 
