### PR TITLE
Test timeout consistency for TestQueues

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
@@ -301,7 +301,7 @@ public class TestQueues
     }
 
     @Test
-    @Timeout(10)
+    @Timeout(240)
     public void testQueryTextBasedSelection()
             throws Exception
     {


### PR DESCRIPTION
## Description
This test takes 1.4 seconds on my machine, but takes longer when run in the github checks. Reverted timeout to 240s, for consistency with other test methods. Fixes #27611


## Additional context and related issues
Initial discussion: https://github.com/trinodb/trino/pull/27129#discussion_r2594137872

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
