### PR TITLE
Mark Deprecated with removal for `join-pushdown.with-expressions`

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -77,8 +77,8 @@ public class JdbcMetadataConfig
         return complexJoinPushdownEnabled;
     }
 
-    @Deprecated
-    @Config("deprecated.join-pushdown.with-expressions")
+    @Deprecated(forRemoval = true)
+    @Config("join-pushdown.with-expressions")
     @ConfigDescription("Enable join pushdown with complex expressions")
     public JdbcMetadataConfig setComplexJoinPushdownEnabled(boolean complexJoinPushdownEnabled)
     {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -43,7 +43,7 @@ public class TestJdbcMetadataConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("complex-expression-pushdown.enabled", "false")
                 .put("join-pushdown.enabled", "true")
-                .put("deprecated.join-pushdown.with-expressions", "false")
+                .put("join-pushdown.with-expressions", "false")
                 .put("aggregation-pushdown.enabled", "false")
                 .put("jdbc.bulk-list-columns.enabled", "true")
                 .put("domain-compaction-threshold", "42")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

We should following below steps to retire or remove config.
**Removing a configuration property**
When a configuration is being fully removed, the following steps should be applied:

1. Mark the configuration as deprecated using `@Deprecated(forRemoval = true)`.
2. Remove the configuration code + add the removed configuration key to `@DefunctConfig` (if applicable)

**Renaming a configuration property**
When a configuration is renamed (with or without a future removal plan), apply the following steps:

1. Mark the old configuration with `@Deprecated` and `@LegacyConfig` for old configuration key. If the old name is expected to be removed eventually, set `forRemoval = true` in `@Deprecated`.
2. if with removal old configuration: 
  * Add `@LegacyConfig` on the old configuration with `replacedBy` pointing to the new name.(also we could revert `@Deprecated(forRemoval = true)` back to `@Deprecated` or even remove `@Deprecated` fully)
  * Add the removed configuration key to `@DefunctConfig` (if applicable)

The `join-pushdown.with-expressions` original in https://github.com/trinodb/trino/pull/27498 was renamed but actually is going to be removed, thus we follow the removed instructions.
in pr: revert the rename(removed the prefix "deprecated.") and mark `@Deprecated(forRemoval = true)` at current.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/27153#discussion_r2609218042


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
