### PR TITLE
Add documentation for Delta Lake connector configuration properties

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -90,6 +90,10 @@ values. Typical usage does not require you to configure them.
     specified in [](prop-type-data-size) values such as `64MB`. Default is
     calculated to 5% of the maximum memory allocated to the JVM.
   - 
+* - `delta.transaction-log.max-cached-file-size`
+  - Maximum size of delta transaction log file that will be cached in memory
+    for the table metadata cache.
+  - `16MB` 
 * - `delta.compression-codec`
   - The compression codec to be used when writing new data files. Possible
     values are:
@@ -104,6 +108,11 @@ values. Typical usage does not require you to configure them.
 * - `delta.max-partitions-per-writer`
   - Maximum number of partitions per writer.
   - `100`
+* - `delta.idle-writer-min-file-size`
+  - Minimum data written by a single partition writer before it can
+    be considered as idle and can be closed by the engine. The equivalent
+    catalog session property is `idle_writer_min_file_size`.
+  - `16MB`
 * - `delta.hide-non-delta-lake-tables`
   - Hide information about tables that are not managed by Delta Lake. Hiding
     only applies to tables with the metadata managed in a Glue catalog, and does

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -475,7 +475,7 @@ public class DeltaLakeConfig
     }
 
     @Config("delta.idle-writer-min-file-size")
-    @ConfigDescription("Minimum data written by a single partition writer before it can be consider as 'idle' and could be closed by the engine")
+    @ConfigDescription("Minimum data written by a single partition writer before it can be considered as 'idle' and could be closed by the engine")
     public DeltaLakeConfig setIdleWriterMinFileSize(DataSize idleWriterMinFileSize)
     {
         this.idleWriterMinFileSize = idleWriterMinFileSize;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The following configuration properties from `DeltaLakeConfig` were missing from `delta-lake.md`:

- `delta.transaction-log.max-cached-file-size`
- `delta.idle-writer-min-file-size`

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
