### PR TITLE
Increase retry count and timeout values for `npm clean install` in `trino-web-ui` config

### DIFF
--- a/core/trino-web-ui/pom.xml
+++ b/core/trino-web-ui/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <frontend.package.goal>package</frontend.package.goal>
         <frontend.check.goal>check</frontend.check.goal>
+        <frontend.npm.retries>--fetch-retries=4 --fetch-retry-mintimeout=10000 --fetch-retry-maxtimeout=120000</frontend.npm.retries>
     </properties>
 
     <dependencies>
@@ -100,7 +101,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>run ${frontend.package.goal}</arguments>
+                            <arguments>run ${frontend.package.goal} ${frontend.npm.retries}</arguments>
                             <workingDirectory>src/main/resources/webapp/src</workingDirectory>
                         </configuration>
                     </execution>
@@ -133,7 +134,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>run ${frontend.package.goal}</arguments>
+                            <arguments>run ${frontend.package.goal} ${frontend.npm.retries}</arguments>
                             <workingDirectory>src/main/resources/webapp-preview</workingDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

(Possibly) fixes #27458 .

The flakiness of `trino-web-ui` builds seem to be due to transient network failures during `npm clean install`. Adding additional retries (and longer timeouts) may reduce the chances of this happening.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Note that npm already has some retries enabled [by default](https://docs.npmjs.com/cli/v11/using-npm/config#fetch-retries):
- fetch-retries: 2
- fetch-retry-mintimeout: 10000 ms
- fetch-retry-maxtimeout: 60000 ms

If this does not resolve the issue, we could use an external retry mechanism.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
