### PR TITLE
Deprecate EXPLAIN (TYPE DISTRIBUTED)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainer.java
@@ -60,8 +60,8 @@ import static java.util.Objects.requireNonNull;
 public class QueryExplainer
 {
     public static final String DEPRECATED_TYPE_LOGICAL_WARNING = """
-                                                                 WARNING: EXPLAIN TYPE LOGICAL is no longer supported and will be removed in a future release.
-                                                                 Below is the output for EXPLAIN TYPE DISTRIBUTED. Please update your query.
+                                                                 WARNING: EXPLAIN [TYPE LOGICAL | TYPE DISTRIBUTED] is no longer supported and will be removed in a future release.
+                                                                 Below is the output for EXPLAIN <query>. Please update your query.
 
                                                                  """;
     private final List<PlanOptimizer> planOptimizers;
@@ -103,11 +103,10 @@ public class QueryExplainer
         }
 
         return switch (planType) {
-            case LOGICAL -> {
+            case LOGICAL, DISTRIBUTED -> {
                 setDeprecatedTypeLogicalWarning(warningCollector);
                 yield DEPRECATED_TYPE_LOGICAL_WARNING + textDistributedPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector);
             }
-            case DISTRIBUTED -> textDistributedPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector);
             case IO -> textIoPlan(getLogicalPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector), plannerContext, session);
             default -> throw new IllegalArgumentException("Unhandled plan type: " + planType);
         };
@@ -133,11 +132,10 @@ public class QueryExplainer
         }
 
         return switch (planType) {
-            case LOGICAL -> {
+            case LOGICAL, DISTRIBUTED -> {
                 setDeprecatedTypeLogicalWarning(warningCollector);
                 yield PlanPrinter.graphvizDistributedPlan(getDistributedPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector));
             }
-            case DISTRIBUTED -> PlanPrinter.graphvizDistributedPlan(getDistributedPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector));
             default -> throw new IllegalArgumentException("Unhandled plan type: " + planType);
         };
     }
@@ -152,11 +150,10 @@ public class QueryExplainer
 
         return switch (planType) {
             case IO -> textIoPlan(getLogicalPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector), plannerContext, session);
-            case LOGICAL -> {
+            case LOGICAL, DISTRIBUTED -> {
                 setDeprecatedTypeLogicalWarning(warningCollector);
                 yield jsonDistributedPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector);
             }
-            case DISTRIBUTED -> jsonDistributedPlan(session, statement, parameters, warningCollector, planOptimizersStatsCollector);
             default -> throw new TrinoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         };
     }
@@ -172,7 +169,7 @@ public class QueryExplainer
 
     private void setDeprecatedTypeLogicalWarning(WarningCollector warningCollector)
     {
-        warningCollector.add(new TrinoWarning(DEPRECATED_SYNTAX, "EXPLAIN TYPE LOGICAL is deprecated. Please use EXPLAIN TYPE DISTRIBUTED instead."));
+        warningCollector.add(new TrinoWarning(DEPRECATED_SYNTAX, "EXPLAIN [TYPE LOGICAL | TYPE DISTRIBUTED] is deprecated. Please use EXPLAIN <query> instead."));
     }
 
     public Plan getLogicalPlan(Session session, Statement statement, List<Expression> parameters, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -60,7 +60,6 @@ import static io.trino.SystemSessionProperties.IGNORE_DOWNSTREAM_PREFERENCES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.sql.analyzer.QueryExplainer.DEPRECATED_TYPE_LOGICAL_WARNING;
 import static io.trino.sql.tree.ExplainType.Type.DISTRIBUTED;
 import static io.trino.sql.tree.ExplainType.Type.IO;
 import static io.trino.sql.tree.ExplainType.Type.LOGICAL;
@@ -6013,7 +6012,7 @@ public abstract class AbstractTestEngineOnlyQueries
         String query = "SELECT * FROM orders";
         MaterializedResult result = computeActual("EXPLAIN (TYPE LOGICAL, FORMAT TEXT) " + query);
         assertThat(getOnlyElement(result.getOnlyColumnAsSet())).isEqualTo(getExplainPlan(query, LOGICAL));
-        assertThat(getOnlyElement(result.getOnlyColumnAsSet())).isEqualTo(DEPRECATED_TYPE_LOGICAL_WARNING + getExplainPlan(query, DISTRIBUTED));
+        assertThat(getOnlyElement(result.getOnlyColumnAsSet())).isEqualTo(getExplainPlan(query, DISTRIBUTED));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

follow up of https://github.com/trinodb/trino/pull/27434
Going to deprecate the EXPLAIN (TYPE DISTRIBUTED) 

https://github.com/trinodb/trino/pull/27153#discussion_r2609180198

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Deprecate EXPLAIN type LOGICAL and DISTRIBUTED. Use EXPLAIN without a type clause, instead
```
