### PR TITLE
Add support for `write.object-storage.partitioned-paths` Iceberg table property

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ObjectStoreLocationProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ObjectStoreLocationProvider.java
@@ -25,7 +25,10 @@ import java.util.Map;
 
 import static com.google.common.hash.Hashing.murmur3_32_fixed;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.iceberg.TableProperties.WRITE_OBJECT_STORE_PARTITIONED_PATHS;
+import static org.apache.iceberg.TableProperties.WRITE_OBJECT_STORE_PARTITIONED_PATHS_DEFAULT;
 import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
+import static org.apache.iceberg.util.PropertyUtil.propertyAsBoolean;
 
 // based on org.apache.iceberg.LocationProviders.ObjectStoreLocationProvider
 public class ObjectStoreLocationProvider
@@ -35,12 +38,14 @@ public class ObjectStoreLocationProvider
     private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
     private final String storageLocation;
     private final String context;
+    private final boolean includePartitionPaths;
 
     public ObjectStoreLocationProvider(String tableLocation, Map<String, String> properties)
     {
         this.storageLocation = stripTrailingSlash(dataLocation(properties, tableLocation));
         // if the storage location is within the table prefix, don't add table and database name context
         this.context = storageLocation.startsWith(stripTrailingSlash(tableLocation)) ? null : pathContext(tableLocation);
+        this.includePartitionPaths = propertyAsBoolean(properties, WRITE_OBJECT_STORE_PARTITIONED_PATHS, WRITE_OBJECT_STORE_PARTITIONED_PATHS_DEFAULT);
     }
 
     @SuppressWarnings("deprecation")
@@ -62,7 +67,10 @@ public class ObjectStoreLocationProvider
     @Override
     public String newDataLocation(PartitionSpec spec, StructLike partitionData, String filename)
     {
-        return newDataLocation("%s/%s".formatted(spec.partitionToPath(partitionData), filename));
+        if (includePartitionPaths) {
+            return newDataLocation("%s/%s".formatted(spec.partitionToPath(partitionData), filename));
+        }
+        return newDataLocation(filename);
     }
 
     @Override
@@ -72,7 +80,12 @@ public class ObjectStoreLocationProvider
         if (context != null) {
             return "%s/%s/%s/%s".formatted(storageLocation, hash, context, filename);
         }
-        return "%s/%s/%s".formatted(storageLocation, hash, filename);
+        if (includePartitionPaths) {
+            // if partition paths are included, add last part of entropy as dir before partition names
+            return "%s/%s/%s".formatted(storageLocation, hash, filename);
+        }
+        // if partition paths are not included, append last part of entropy with `-` to file name
+        return "%s/%s-%s".formatted(storageLocation, hash, filename);
     }
 
     private static String pathContext(String tableLocation)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -9309,7 +9309,7 @@ public abstract class BaseIcebergConnectorTest
         String filePath = (String) computeScalar("SELECT file_path FROM \"" + tableName + "$files\"");
         Location dataFileLocation = Location.of(filePath);
         assertThat(fileSystem.newInputFile(dataFileLocation).exists()).isTrue();
-        assertThat(filePath).matches("local:///data-location/xyz/.{6}/tpch/%s.*".formatted(tableName));
+        assertThat(filePath).matches("local:///data-location/xyz/[01]{4}/[01]{4}/[01]{4}/[01]{8}/tpch/%s.*".formatted(tableName));
 
         assertUpdate("DROP TABLE " + tableName);
         assertThat(fileSystem.newInputFile(dataFileLocation).exists()).isFalse();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithObjectStoreLayout.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithObjectStoreLayout.java
@@ -62,7 +62,7 @@ final class TestIcebergTableWithObjectStoreLayout
         String filePath = (String) computeScalar("SELECT file_path FROM \"test_create_table_with_different_location$files\"");
         Location dataFileLocation = Location.of(filePath);
         assertThat(fileSystem.newInputFile(dataFileLocation).exists()).isTrue();
-        assertThat(filePath).matches("local:///table-location/abc/.{6}/tpch/test_create_table_with_different_location-.*/.*\\.parquet");
+        assertThat(filePath).matches("local:///table-location/abc/[01]{4}/[01]{4}/[01]{4}/[01]{8}/tpch/test_create_table_with_different_location-.*/.*\\.parquet");
 
         assertQuerySucceeds("DROP TABLE test_create_table_with_different_location");
         assertThat(metastore.getTable("tpch", "test_create_table_with_different_location")).isEmpty();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithObjectStoreLayout.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithObjectStoreLayout.java
@@ -19,6 +19,8 @@ import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.Table;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.apache.iceberg.BaseTable;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
@@ -68,5 +70,27 @@ final class TestIcebergTableWithObjectStoreLayout
         assertThat(metastore.getTable("tpch", "test_create_table_with_different_location")).isEmpty();
         assertThat(fileSystem.newInputFile(dataFileLocation).exists()).isFalse();
         assertThat(fileSystem.newInputFile(tableLocation).exists()).isFalse();
+    }
+
+    @Test
+    void testPartitionedPathsDisabled()
+    {
+        try (TestTable table = newTrinoTable("test_partitioned_paths_disabled", "(id INT, part INT) WITH (partitioning = ARRAY['part'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 10)", 1);
+            assertThat((String) computeScalar("SELECT \"$path\" FROM " + table.getName() + " WHERE id = 1"))
+                    .contains("part=10");
+
+            loadTable(table.getName()).updateProperties()
+                    .set("write.object-storage.partitioned-paths", "false")
+                    .commit();
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 20)", 1);
+            assertThat((String) computeScalar("SELECT \"$path\" FROM " + table.getName() + " WHERE id = 2"))
+                    .doesNotContain("part=20");
+        }
+    }
+
+    private BaseTable loadTable(String tableName)
+    {
+        return IcebergTestUtils.loadTable(tableName, metastore, getFileSystemFactory(getQueryRunner()), "iceberg", "tpch");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithObjectStoreLayout.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithObjectStoreLayout.java
@@ -19,6 +19,9 @@ import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.Table;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.apache.iceberg.BaseTable;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
@@ -37,15 +40,16 @@ final class TestIcebergTableWithObjectStoreLayout
     protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
+        return IcebergQueryRunner.builder()
                 .addIcebergProperty("iceberg.object-store-layout.enabled", "true")
                 .build();
+    }
 
-        metastore = getHiveMetastore(queryRunner);
-
-        fileSystem = getFileSystemFactory(queryRunner).create(SESSION);
-
-        return queryRunner;
+    @BeforeAll
+    public void setUp()
+    {
+        metastore = getHiveMetastore(getQueryRunner());
+        fileSystem = getFileSystemFactory(getQueryRunner()).create(SESSION);
     }
 
     @Test
@@ -68,5 +72,27 @@ final class TestIcebergTableWithObjectStoreLayout
         assertThat(metastore.getTable("tpch", "test_create_table_with_different_location")).isEmpty();
         assertThat(fileSystem.newInputFile(dataFileLocation).exists()).isFalse();
         assertThat(fileSystem.newInputFile(tableLocation).exists()).isFalse();
+    }
+
+    @Test
+    void testPartitionedPathsDisabled()
+    {
+        try (TestTable table = newTrinoTable("test_partitioned_paths_disabled", "(id INT, part INT) WITH (partitioning = ARRAY['part'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 10)", 1);
+            assertThat((String) computeScalar("SELECT \"$path\" FROM " + table.getName() + " WHERE id = 1"))
+                    .contains("part=10");
+
+            loadTable(table.getName()).updateProperties()
+                    .set("write.object-storage.partitioned-paths", "false")
+                    .commit();
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 20)", 1);
+            assertThat((String) computeScalar("SELECT \"$path\" FROM " + table.getName() + " WHERE id = 2"))
+                    .doesNotContain("part=20");
+        }
+    }
+
+    private BaseTable loadTable(String tableName)
+    {
+        return IcebergTestUtils.loadTable(tableName, metastore, getFileSystemFactory(getQueryRunner()), "iceberg", "tpch");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestObjectStoreLocationProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestObjectStoreLocationProvider.java
@@ -13,12 +13,18 @@
  */
 package io.trino.plugin.iceberg.util;
 
+import io.trino.plugin.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.apache.iceberg.TableProperties.WRITE_OBJECT_STORE_PARTITIONED_PATHS;
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestObjectStoreLocationProvider
@@ -100,5 +106,43 @@ class TestObjectStoreLocationProvider
 
         assertThat(provider.newDataLocation("test"))
                 .isEqualTo("s3://data-location/xyz/1011/1101/0010/00010011/test");
+    }
+
+    @Test
+    void testObjectStoragePartitionedPathsEnabled()
+    {
+        Schema schema = new Schema(optional(1, "part", Types.IntegerType.get()));
+        PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("part").build();
+
+        ObjectStoreLocationProvider provider = new ObjectStoreLocationProvider("s3://table-location/", Map.of(WRITE_OBJECT_STORE_PARTITIONED_PATHS, "true"));
+
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {1}), "test"))
+                .isEqualTo("s3://table-location/data/1001/1001/1101/10011000/part=1/test");
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {2}), "test"))
+                .isEqualTo("s3://table-location/data/1101/1101/0101/10100010/part=2/test");
+
+        assertThat(provider.newDataLocation("test-a"))
+                .isEqualTo("s3://table-location/data/0000/1000/1101/10101100/test-a");
+        assertThat(provider.newDataLocation("test-b"))
+                .isEqualTo("s3://table-location/data/0110/1101/0101/00010111/test-b");
+    }
+
+    @Test
+    void testObjectStoragePartitionedPathsDisabled()
+    {
+        Schema schema = new Schema(optional(1, "part", Types.IntegerType.get()));
+        PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("part").build();
+
+        LocationProvider provider = new ObjectStoreLocationProvider("s3://table-location/", Map.of(WRITE_OBJECT_STORE_PARTITIONED_PATHS, "false"));
+
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {1}), "test"))
+                .isEqualTo("s3://table-location/data/1011/1101/0010/00010011-test");
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {2}), "test"))
+                .isEqualTo("s3://table-location/data/1011/1101/0010/00010011-test");
+
+        assertThat(provider.newDataLocation("test-a"))
+                .isEqualTo("s3://table-location/data/0000/1000/1101/10101100-test-a");
+        assertThat(provider.newDataLocation("test-b"))
+                .isEqualTo("s3://table-location/data/0110/1101/0101/00010111-test-b");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestObjectStoreLocationProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestObjectStoreLocationProvider.java
@@ -29,7 +29,7 @@ class TestObjectStoreLocationProvider
         LocationProvider provider = new ObjectStoreLocationProvider("s3://table-location/xyz", Map.of());
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://table-location/xyz/data/E9Jrug/test");
+                .isEqualTo("s3://table-location/xyz/data/1011/1101/0010/00010011/test");
     }
 
     @Test
@@ -40,7 +40,7 @@ class TestObjectStoreLocationProvider
                 Map.of(TableProperties.WRITE_DATA_LOCATION, "s3://data-location/write/"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://data-location/write/E9Jrug/test");
+                .isEqualTo("s3://data-location/write/1011/1101/0010/00010011/test");
     }
 
     @Test
@@ -51,7 +51,7 @@ class TestObjectStoreLocationProvider
                 Map.of(TableProperties.WRITE_DATA_LOCATION, "s3://data-location/write/"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://data-location/write/E9Jrug/xyz/test");
+                .isEqualTo("s3://data-location/write/1011/1101/0010/00010011/xyz/test");
     }
 
     @Test
@@ -62,7 +62,7 @@ class TestObjectStoreLocationProvider
                 Map.of(TableProperties.WRITE_DATA_LOCATION, "s3://data-location/write/"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://data-location/write/E9Jrug/abc/xyz/test");
+                .isEqualTo("s3://data-location/write/1011/1101/0010/00010011/abc/xyz/test");
     }
 
     @Test
@@ -73,7 +73,7 @@ class TestObjectStoreLocationProvider
                 Map.of(TableProperties.WRITE_DATA_LOCATION, "s3://data-location/write/"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://data-location/write/E9Jrug/abc/xyz/test");
+                .isEqualTo("s3://data-location/write/1011/1101/0010/00010011/abc/xyz/test");
     }
 
     @SuppressWarnings("deprecation")
@@ -84,14 +84,14 @@ class TestObjectStoreLocationProvider
                 TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://folder-location/xyz"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://folder-location/xyz/E9Jrug/test");
+                .isEqualTo("s3://folder-location/xyz/1011/1101/0010/00010011/test");
 
         provider = new ObjectStoreLocationProvider("s3://table-location/", Map.of(
                 TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://folder-location/abc",
                 TableProperties.OBJECT_STORE_PATH, "s3://object-location/xyz"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://object-location/xyz/E9Jrug/test");
+                .isEqualTo("s3://object-location/xyz/1011/1101/0010/00010011/test");
 
         provider = new ObjectStoreLocationProvider("s3://table-location/", Map.of(
                 TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://folder-location/abc",
@@ -99,6 +99,6 @@ class TestObjectStoreLocationProvider
                 TableProperties.WRITE_DATA_LOCATION, "s3://data-location/xyz"));
 
         assertThat(provider.newDataLocation("test"))
-                .isEqualTo("s3://data-location/xyz/E9Jrug/test");
+                .isEqualTo("s3://data-location/xyz/1011/1101/0010/00010011/test");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestObjectStoreLocationProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestObjectStoreLocationProvider.java
@@ -13,12 +13,18 @@
  */
 package io.trino.plugin.iceberg.util;
 
+import io.trino.plugin.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.apache.iceberg.TableProperties.WRITE_OBJECT_STORE_PARTITIONED_PATHS;
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestObjectStoreLocationProvider
@@ -100,5 +106,43 @@ class TestObjectStoreLocationProvider
 
         assertThat(provider.newDataLocation("test"))
                 .isEqualTo("s3://data-location/xyz/E9Jrug/test");
+    }
+
+    @Test
+    void testObjectStoragePartitionedPathsEnabled()
+    {
+        Schema schema = new Schema(optional(1, "part", Types.IntegerType.get()));
+        PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("part").build();
+
+        ObjectStoreLocationProvider provider = new ObjectStoreLocationProvider("s3://table-location/", Map.of(WRITE_OBJECT_STORE_PARTITIONED_PATHS, "true"));
+
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {1}), "test"))
+                .isEqualTo("s3://table-location/data/mJ158A/part=1/test");
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {2}), "test"))
+                .isEqualTo("s3://table-location/data/otWd0w/part=2/test");
+
+        assertThat(provider.newDataLocation("test-a"))
+                .isEqualTo("s3://table-location/data/rI2Q2Q/test-a");
+        assertThat(provider.newDataLocation("test-b"))
+                .isEqualTo("s3://table-location/data/F9UWCA/test-b");
+    }
+
+    @Test
+    void testObjectStoragePartitionedPathsDisabled()
+    {
+        Schema schema = new Schema(optional(1, "part", Types.IntegerType.get()));
+        PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("part").build();
+
+        LocationProvider provider = new ObjectStoreLocationProvider("s3://table-location/", Map.of(WRITE_OBJECT_STORE_PARTITIONED_PATHS, "false"));
+
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {1}), "test"))
+                .isEqualTo("s3://table-location/data/E9Jrug-test");
+        assertThat(provider.newDataLocation(partitionSpec, new PartitionData(new Integer[] {2}), "test"))
+                .isEqualTo("s3://table-location/data/E9Jrug-test");
+
+        assertThat(provider.newDataLocation("test-a"))
+                .isEqualTo("s3://table-location/data/rI2Q2Q-test-a");
+        assertThat(provider.newDataLocation("test-b"))
+                .isEqualTo("s3://table-location/data/F9UWCA-test-b");
     }
 }


### PR DESCRIPTION
## Description

The PR adds support for `write.object-storage.partitioned-paths` table property. 
The property avoids including partition values in the location if it's disabled.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## Iceberg
* Add support for `write.object-storage.partitioned-paths` Iceberg table property. ({issue}`27633`)
```
