### PR TITLE
Implement ASOF join

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -365,6 +365,7 @@ selectItem
 relation
     : left=relation
       ( CROSS JOIN right=sampledRelation
+      | ASOF JOIN rightRelation=relation joinCriteria
       | joinType JOIN rightRelation=relation joinCriteria
       | NATURAL joinType JOIN right=sampledRelation
       )                                                     #joinRelation
@@ -1070,6 +1071,7 @@ AND: 'AND';
 ANY: 'ANY';
 ARRAY: 'ARRAY';
 AS: 'AS';
+ASOF: 'ASOF';
 ASC: 'ASC';
 AT: 'AT';
 AUTHORIZATION: 'AUTHORIZATION';

--- a/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
+++ b/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
@@ -38,6 +38,7 @@ public class TestSqlKeywords
                         "ARRAY",
                         "AS",
                         "ASC",
+                        "ASOF",
                         "AT",
                         "AUTHORIZATION",
                         "AUTO",

--- a/core/trino-main/src/main/java/io/trino/cost/JoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/JoinStatsRule.java
@@ -85,7 +85,7 @@ public class JoinStatsRule
 
         return switch (node.getType()) {
             case INNER -> Optional.of(computeInnerJoinStats(node, crossJoinStats, context.session()));
-            case LEFT -> Optional.of(computeLeftJoinStats(node, leftStats, rightStats, crossJoinStats, context.session()));
+            case LEFT, ASOF -> Optional.of(computeLeftJoinStats(node, leftStats, rightStats, crossJoinStats, context.session()));
             case RIGHT -> Optional.of(computeRightJoinStats(node, leftStats, rightStats, crossJoinStats, context.session()));
             case FULL -> Optional.of(computeFullJoinStats(node, leftStats, rightStats, crossJoinStats, context.session()));
         };

--- a/core/trino-main/src/main/java/io/trino/cost/SpatialJoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SpatialJoinStatsRule.java
@@ -44,7 +44,7 @@ public class SpatialJoinStatsRule
 
         return switch (node.getType()) {
             case INNER -> Optional.of(statsCalculator.filterStats(crossJoinStats, node.getFilter(), context.session()));
-            case LEFT -> Optional.of(PlanNodeStatsEstimate.unknown());
+            case LEFT, ASOF -> Optional.of(PlanNodeStatsEstimate.unknown());
         };
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/JoinOperatorType.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinOperatorType.java
@@ -32,7 +32,7 @@ public class JoinOperatorType
     {
         return switch (joinNodeType) {
             case INNER -> innerJoin(outputSingleMatch, waitForBuild);
-            case LEFT -> probeOuterJoin(outputSingleMatch);
+            case LEFT, ASOF -> probeOuterJoin(outputSingleMatch);
             case RIGHT -> lookupOuterJoin(waitForBuild);
             case FULL -> fullOuterJoin();
         };

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -302,7 +302,7 @@ public class EffectivePredicateExtractor
         public Expression visitUnnest(UnnestNode node, Void context)
         {
             return switch (node.getJoinType()) {
-                case INNER, LEFT -> pullExpressionThroughSymbols(node.getSource().accept(this, context), node.getOutputSymbols());
+                case INNER, LEFT, ASOF -> pullExpressionThroughSymbols(node.getSource().accept(this, context), node.getOutputSymbols());
                 case RIGHT, FULL -> TRUE;
             };
         }
@@ -324,7 +324,7 @@ public class EffectivePredicateExtractor
                         .add(combineConjuncts(joinConjuncts))
                         .add(node.getFilter().orElse(TRUE))
                         .build()), node.getOutputSymbols());
-                case LEFT -> combineConjuncts(ImmutableList.<Expression>builder()
+                case LEFT, ASOF -> combineConjuncts(ImmutableList.<Expression>builder()
                         .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
                         .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
                         .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
@@ -536,7 +536,7 @@ public class EffectivePredicateExtractor
                         .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
                         .add(pullExpressionThroughSymbols(rightPredicate, node.getOutputSymbols()))
                         .build());
-                case LEFT -> combineConjuncts(ImmutableList.<Expression>builder()
+                case LEFT, ASOF -> combineConjuncts(ImmutableList.<Expression>builder()
                         .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
                         .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
                         .build());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2563,7 +2563,7 @@ public class LocalExecutionPlanner
             List<Symbol> rightSymbols = Lists.transform(clauses, JoinNode.EquiJoinClause::getRight);
 
             return switch (node.getType()) {
-                case INNER, LEFT, RIGHT, FULL ->
+                case INNER, LEFT, RIGHT, FULL, ASOF ->
                         createLookupJoin(node, node.getLeft(), leftSymbols, node.getRight(), rightSymbols, localDynamicFilters, context);
             };
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
@@ -253,6 +253,7 @@ public class PushJoinIntoTableScan
         return switch (joinNode.getType()) {
             case INNER -> JoinType.INNER;
             case LEFT -> JoinType.LEFT_OUTER;
+            case ASOF -> JoinType.ASOF;
             case RIGHT -> JoinType.RIGHT_OUTER;
             case FULL -> JoinType.FULL_OUTER;
         };

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantJoin.java
@@ -51,7 +51,7 @@ public class RemoveRedundantJoin
         PlanNode right = joinNode.getRight();
         return switch (joinNode.getType()) {
             case INNER -> isEmpty(left, lookup) || isEmpty(right, lookup);
-            case LEFT -> isEmpty(left, lookup);
+            case LEFT, ASOF -> isEmpty(left, lookup);
             case RIGHT -> isEmpty(right, lookup);
             case FULL -> isEmpty(left, lookup) && isEmpty(right, lookup);
         };

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceJoinOverConstantWithProject.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceJoinOverConstantWithProject.java
@@ -114,7 +114,7 @@ public class ReplaceJoinOverConstantWithProject
                 }
                 yield Result.empty();
             }
-            case LEFT -> {
+            case LEFT, ASOF -> {
                 if (canInlineLeftSource && rightCardinality.isAtLeastScalar()) {
                     yield Result.ofPlanNode(appendProjection(right, node.getRightOutputSymbols(), left, node.getLeftOutputSymbols(), context.getIdAllocator()));
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceRedundantJoinWithProject.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceRedundantJoinWithProject.java
@@ -56,7 +56,7 @@ public class ReplaceRedundantJoinWithProject
 
         return switch (node.getType()) {
             case INNER -> Result.empty();
-            case LEFT -> !isEmpty(left, lookup) && isEmpty(right, lookup) ?
+            case LEFT, ASOF -> !isEmpty(left, lookup) && isEmpty(right, lookup) ?
                     Result.ofPlanNode(appendNulls(
                             left,
                             node.getLeftOutputSymbols(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceRedundantJoinWithSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceRedundantJoinWithSource.java
@@ -89,7 +89,7 @@ public class ReplaceRedundantJoinWithSource
                 }
                 yield Result.ofPlanNode(restrictOutputs(context.getIdAllocator(), source, ImmutableSet.copyOf(sourceOutputs)).orElse(source));
             }
-            case LEFT -> rightSourceScalarWithNoOutputs ?
+            case LEFT, ASOF -> rightSourceScalarWithNoOutputs ?
                     Result.ofPlanNode(restrictOutputs(context.getIdAllocator(), node.getLeft(), ImmutableSet.copyOf(node.getLeftOutputSymbols()))
                             .orElse(node.getLeft())) :
                     Result.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteAsofJoinToLeftJoinWithTop1.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RewriteAsofJoinToLeftJoinWithTop1.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrUtils;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.AssignUniqueId;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.WindowNode;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.ir.Comparison.Operator.LESS_THAN;
+import static io.trino.sql.ir.Comparison.Operator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.planner.plan.JoinType.ASOF;
+import static io.trino.sql.planner.plan.JoinType.LEFT;
+import static io.trino.sql.planner.plan.Patterns.Join.type;
+import static io.trino.sql.planner.plan.Patterns.join;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Rewrites an ASOF join into:
+ * AssignUniqueId(left) -> AssignUniqueId(right) -> LEFT JOIN (with original equi-criteria and inequality)
+ * -> Window(row_number() PARTITION BY left_uid ORDER BY right_ts DESC NULLS LAST, right_uid DESC NULLS LAST)
+ * -> Filter(row_number = 1)
+ * -> Project(original outputs)
+ */
+public class RewriteAsofJoinToLeftJoinWithTop1
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = join().with(type().equalTo(ASOF));
+
+    private final PlannerContext plannerContext;
+
+    public RewriteAsofJoinToLeftJoinWithTop1(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        // Validate equi-criteria
+        if (node.getCriteria().isEmpty()) {
+            throw new TrinoException(NOT_SUPPORTED, "ASOF join requires at least one equi-join criterion");
+        }
+
+        // Extract and validate non-equi inequality predicate
+        Comparison inequality = extractSupportedInequality(node)
+                .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "ASOF join requires a single supported inequality predicate"));
+
+        // Determine which side provides the right-side timestamp symbol and ensure orderable
+        RightOrderingColumns orderingColumns = resolveOrderingColumns(node, inequality);
+        if (!orderingColumns.rightTs.type().isOrderable()) {
+            throw new TrinoException(NOT_SUPPORTED, "ASOF join inequality requires an orderable type on the build side");
+        }
+
+        // Assign unique ids for partitioning and deterministic tie-breaking
+        Symbol leftUid = context.getSymbolAllocator().newSymbol("asof_left_uid", BIGINT);
+        PlanNode leftWithUid = new AssignUniqueId(context.getIdAllocator().getNextId(), node.getLeft(), leftUid);
+
+        Symbol rightUid = context.getSymbolAllocator().newSymbol("asof_right_uid", BIGINT);
+        PlanNode rightWithUid = new AssignUniqueId(context.getIdAllocator().getNextId(), node.getRight(), rightUid);
+
+        // Build LEFT join preserving original equi-criteria and filter
+        List<Symbol> newLeftOutputs = ImmutableList.<Symbol>builder()
+                .addAll(node.getLeftOutputSymbols())
+                .add(leftUid)
+                .build();
+
+        // Ensure right outputs include the timestamp used for ordering and right uid
+        ImmutableList.Builder<Symbol> rightOutputsBuilder = ImmutableList.<Symbol>builder()
+                .addAll(node.getRightOutputSymbols());
+        if (!node.getRightOutputSymbols().contains(orderingColumns.rightTs)) {
+            rightOutputsBuilder.add(orderingColumns.rightTs);
+        }
+        rightOutputsBuilder.add(rightUid);
+        List<Symbol> newRightOutputs = rightOutputsBuilder.build();
+
+        JoinNode leftJoin = new JoinNode(
+                node.getId(),
+                LEFT,
+                leftWithUid,
+                rightWithUid,
+                node.getCriteria(),
+                newLeftOutputs,
+                newRightOutputs,
+                node.isMaySkipOutputDuplicates(),
+                node.getFilter(), // keep original inequality filter as-is
+                node.getDistributionType(),
+                node.isSpillable(),
+                node.getDynamicFilters(),
+                node.getReorderJoinStatsAndCost());
+
+        // Window: row_number over partition by leftUid ordered by rightTs desc nulls last, rightUid desc nulls last
+        Symbol rankSymbol = context.getSymbolAllocator().newSymbol("asof_rank", BIGINT);
+        WindowNode.Function rowNumber = new WindowNode.Function(
+                plannerContext.getMetadata().resolveBuiltinFunction("row_number", ImmutableList.of()),
+                ImmutableList.of(),
+                Optional.empty(),
+                WindowNode.Frame.DEFAULT_FRAME,
+                false,
+                false);
+
+        OrderingScheme orderingScheme = new OrderingScheme(
+                ImmutableList.of(orderingColumns.rightTs, rightUid),
+                ImmutableMap.of(orderingColumns.rightTs, SortOrder.DESC_NULLS_LAST, rightUid, SortOrder.DESC_NULLS_LAST));
+
+        WindowNode windowNode = new WindowNode(
+                context.getIdAllocator().getNextId(),
+                leftJoin,
+                new DataOrganizationSpecification(ImmutableList.of(leftUid), Optional.of(orderingScheme)),
+                ImmutableMap.of(rankSymbol, rowNumber),
+                ImmutableSet.of(),
+                0);
+
+        // Filter: rank = 1
+        FilterNode filterNode = new FilterNode(
+                context.getIdAllocator().getNextId(),
+                windowNode,
+                new Comparison(LESS_THAN_OR_EQUAL, rankSymbol.toSymbolReference(), new Constant(BIGINT, 1L)));
+
+        // Project back to original outputs (drop helper symbols)
+        List<Symbol> finalOutputs = ImmutableList.<Symbol>builder()
+                .addAll(node.getLeftOutputSymbols())
+                .addAll(node.getRightOutputSymbols())
+                .build();
+        ProjectNode projectNode = new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                filterNode,
+                Assignments.identity(finalOutputs));
+
+        return Result.ofPlanNode(projectNode);
+    }
+
+    private Optional<Comparison> extractSupportedInequality(JoinNode node)
+    {
+        Optional<Expression> filter = node.getFilter();
+        if (filter.isEmpty()) {
+            return Optional.empty();
+        }
+        List<Expression> conjuncts = IrUtils.extractConjuncts(filter.get());
+        List<Comparison> comparisons = conjuncts.stream()
+                .filter(Comparison.class::isInstance)
+                .map(Comparison.class::cast)
+                .filter(c -> c.operator() == LESS_THAN || c.operator() == LESS_THAN_OR_EQUAL || c.operator() == GREATER_THAN || c.operator() == GREATER_THAN_OR_EQUAL)
+                .collect(Collectors.toList());
+        if (comparisons.size() != 1) {
+            return Optional.empty();
+        }
+        return Optional.of(comparisons.get(0));
+    }
+
+    private RightOrderingColumns resolveOrderingColumns(JoinNode node, Comparison inequality)
+    {
+        Set<Symbol> leftSymbols = ImmutableSet.copyOf(node.getLeft().getOutputSymbols());
+        Set<Symbol> rightSymbols = ImmutableSet.copyOf(node.getRight().getOutputSymbols());
+
+        Expression leftExpr = inequality.left();
+        Expression rightExpr = inequality.right();
+
+        boolean leftExprFromRight = referencesOnly(leftExpr, rightSymbols);
+        boolean rightExprFromLeft = referencesOnly(rightExpr, leftSymbols);
+        boolean leftExprFromLeft = referencesOnly(leftExpr, leftSymbols);
+        boolean rightExprFromRight = referencesOnly(rightExpr, rightSymbols);
+
+        // Supported forms:
+        // 1) right.ts <= left.ts  (or <)
+        if ((inequality.operator() == LESS_THAN || inequality.operator() == LESS_THAN_OR_EQUAL) && leftExprFromRight && rightExprFromLeft) {
+            Symbol rightTs = symbolFromReference(leftExpr);
+            return new RightOrderingColumns(rightTs);
+        }
+        // 2) left.ts >= right.ts  (or >)
+        if ((inequality.operator() == GREATER_THAN || inequality.operator() == GREATER_THAN_OR_EQUAL) && leftExprFromLeft && rightExprFromRight) {
+            Symbol rightTs = symbolFromReference(rightExpr);
+            return new RightOrderingColumns(rightTs);
+        }
+
+        throw new TrinoException(NOT_SUPPORTED, "ASOF join inequality must compare build-side timestamp to probe-side timestamp with <=/< or >=/>");
+    }
+
+    private boolean referencesOnly(Expression expression, Set<Symbol> allowed)
+    {
+        return io.trino.sql.planner.SymbolsExtractor.extractUnique(expression).stream().allMatch(allowed::contains);
+    }
+
+    private Symbol symbolFromReference(Expression expression)
+    {
+        checkArgument(expression instanceof Reference, "Expected symbol reference, got: %s", expression);
+        return Symbol.from(expression);
+    }
+
+    private record RightOrderingColumns(Symbol rightTs) {}
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -160,7 +160,7 @@ public class IndexJoinOptimizer
                         }
                         break;
 
-                    case LEFT:
+                    case LEFT, ASOF:
                         // We cannot use indices for outer joins until index join supports in-line filtering
                         if (node.getFilter().isEmpty() && rightIndexCandidate.isPresent()) {
                             return createIndexJoinWithExpectedOutputs(node.getOutputSymbols(), IndexJoinNode.Type.SOURCE_OUTER, leftRewritten, rightIndexCandidate.get(), createEquiJoinClause(leftJoinSymbols, rightJoinSymbols), idAllocator);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -567,7 +567,7 @@ public final class PropertyDerivations
                             .unordered(unordered)
                             .build();
                 }
-                case LEFT -> ActualProperties.builderFrom(probeProperties.translate(column -> filterIfMissing(node.getOutputSymbols(), column)))
+                case LEFT, ASOF -> ActualProperties.builderFrom(probeProperties.translate(column -> filterIfMissing(node.getOutputSymbols(), column)))
                         .unordered(unordered)
                         .build();
                 case RIGHT -> ActualProperties.builderFrom(buildProperties.translate(column -> filterIfMissing(node.getOutputSymbols(), column)))
@@ -608,7 +608,7 @@ public final class PropertyDerivations
                             .constants(constants)
                             .build();
                 }
-                case LEFT -> ActualProperties.builderFrom(probeProperties.translate(column -> filterIfMissing(node.getOutputSymbols(), column)))
+                case LEFT, ASOF -> ActualProperties.builderFrom(probeProperties.translate(column -> filterIfMissing(node.getOutputSymbols(), column)))
                         .build();
             };
         }
@@ -843,7 +843,7 @@ public final class PropertyDerivations
             });
 
             return switch (node.getJoinType()) {
-                case INNER, LEFT -> translatedProperties;
+                case INNER, LEFT, ASOF -> translatedProperties;
                 case RIGHT, FULL -> ActualProperties.builderFrom(translatedProperties)
                         .local(ImmutableList.of())
                         .build();
@@ -926,7 +926,7 @@ public final class PropertyDerivations
             return false;
         }
         return switch (joinType) {
-            case INNER, LEFT -> true;
+            case INNER, LEFT, ASOF -> true;
             // Even though join might not have "spillable" property set yet
             // it might still be set as spillable later on by AddLocalExchanges.
             case RIGHT, FULL -> false; // Currently there is no spill support for outer on the build side.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -239,7 +239,7 @@ public final class StreamPropertyDerivations
                 case INNER -> leftProperties
                         .translate(column -> PropertyDerivations.filterOrRewrite(node.getOutputSymbols(), node.getCriteria(), column))
                         .unordered(unordered);
-                case LEFT -> leftProperties
+                case LEFT, ASOF -> leftProperties
                         .translate(column -> PropertyDerivations.filterIfMissing(node.getOutputSymbols(), column))
                         .unordered(unordered);
                 case RIGHT ->
@@ -272,7 +272,7 @@ public final class StreamPropertyDerivations
             StreamProperties leftProperties = inputProperties.get(0);
 
             return switch (node.getType()) {
-                case INNER, LEFT -> leftProperties.translate(column -> PropertyDerivations.filterIfMissing(node.getOutputSymbols(), column));
+                case INNER, LEFT, ASOF -> leftProperties.translate(column -> PropertyDerivations.filterIfMissing(node.getOutputSymbols(), column));
             };
         }
 
@@ -537,7 +537,7 @@ public final class StreamPropertyDerivations
             });
 
             return switch (node.getJoinType()) {
-                case INNER, LEFT -> translatedProperties;
+                case INNER, LEFT, ASOF -> translatedProperties;
                 case RIGHT, FULL -> translatedProperties.unordered(true);
             };
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static io.trino.sql.planner.plan.JoinType.ASOF;
 import static io.trino.sql.planner.plan.JoinType.FULL;
 import static io.trino.sql.planner.plan.JoinType.INNER;
 import static io.trino.sql.planner.plan.JoinType.LEFT;
@@ -165,6 +166,7 @@ public class JoinNode
         return switch (type) {
             case INNER -> INNER;
             case FULL -> FULL;
+            case ASOF -> ASOF;
             case LEFT -> RIGHT;
             case RIGHT -> LEFT;
         };

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinType.java
@@ -18,7 +18,8 @@ public enum JoinType
     INNER("InnerJoin"),
     LEFT("LeftJoin"),
     RIGHT("RightJoin"),
-    FULL("FullJoin");
+    FULL("FullJoin"),
+    ASOF("AsofJoin");
 
     private final String joinLabel;
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SpatialJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SpatialJoinNode.java
@@ -36,7 +36,8 @@ public class SpatialJoinNode
     public enum Type
     {
         INNER("SpatialInnerJoin"),
-        LEFT("SpatialLeftJoin");
+        LEFT("SpatialLeftJoin"),
+        ASOF("SpatialAsofJoin");
 
         private final String joinLabel;
 
@@ -55,6 +56,7 @@ public class SpatialJoinNode
             return switch (joinNodeType) {
                 case INNER -> Type.INNER;
                 case LEFT -> Type.LEFT;
+                case ASOF -> Type.ASOF;
                 default -> throw new IllegalArgumentException("Unsupported spatial join type: " + joinNodeType);
             };
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
@@ -626,6 +626,7 @@ public class TestPushJoinIntoTableScan
     {
         return switch (joinType) {
             case INNER -> JoinType.INNER;
+            case ASOF -> JoinType.ASOF;
             case LEFT -> JoinType.LEFT_OUTER;
             case RIGHT -> JoinType.RIGHT_OUTER;
             case FULL -> JoinType.FULL_OUTER;

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -1963,7 +1963,10 @@ class AstBuilder
         }
 
         Join.Type joinType;
-        if (context.joinType().LEFT() != null) {
+        if (context.ASOF() != null) {
+            joinType = Join.Type.ASOF;
+        }
+        else if (context.joinType().LEFT() != null) {
             joinType = Join.Type.LEFT;
         }
         else if (context.joinType().RIGHT() != null) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Join.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Join.java
@@ -28,7 +28,7 @@ public class Join
 {
     public enum Type
     {
-        CROSS, INNER, LEFT, RIGHT, FULL, IMPLICIT
+        CROSS, INNER, LEFT, RIGHT, FULL, IMPLICIT, ASOF
     }
 
     public Join(Type type, Relation left, Relation right, Optional<JoinCriteria> criteria)

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestAsofJoin.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestAsofJoin.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.parser;
+
+import io.trino.sql.tree.AllColumns;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Join;
+import io.trino.sql.tree.JoinOn;
+import io.trino.sql.tree.JoinUsing;
+import io.trino.sql.tree.LogicalExpression;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Table;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.sql.QueryUtil.equal;
+import static io.trino.sql.QueryUtil.nameReference;
+import static io.trino.sql.QueryUtil.selectList;
+import static io.trino.sql.QueryUtil.simpleQuery;
+import static io.trino.sql.parser.ParserAssert.statement;
+import static io.trino.sql.parser.TreeNodes.location;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for ASOF JOIN syntax.
+ * These tests are disabled until the ASOF JOIN feature is implemented.
+ */
+public class TestAsofJoin
+{
+    @Test
+    public void testAsofJoinWithExplicitCondition()
+    {
+        assertThat(statement("SELECT * FROM a ASOF JOIN b ON a.key = b.key AND a.ts >= b.ts"))
+                .ignoringLocation()
+                .isEqualTo(simpleQuery(
+                        selectList(new AllColumns()),
+                        new Join(
+                                Join.Type.ASOF,
+                                new Table(QualifiedName.of("a")),
+                                new Table(QualifiedName.of("b")),
+                                Optional.of(new JoinOn(
+                                        new LogicalExpression(
+                                                location(1, 32),
+                                                LogicalExpression.Operator.AND,
+                                                List.of(
+                                                        equal(nameReference("a", "key"), nameReference("b", "key")),
+                                                        new ComparisonExpression(
+                                                                ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL,
+                                                                nameReference("a", "ts"),
+                                                                nameReference("b", "ts")))))))));
+    }
+
+    @Test
+    public void testAsofJoinWithUsingClause()
+    {
+        assertThat(statement("SELECT * FROM a ASOF JOIN b USING (key, ts)"))
+                .ignoringLocation()
+                .isEqualTo(simpleQuery(
+                        selectList(new AllColumns()),
+                        new Join(
+                                Join.Type.ASOF,
+                                new Table(QualifiedName.of("a")),
+                                new Table(QualifiedName.of("b")),
+                                Optional.of(new JoinUsing(
+                                        List.of(
+                                                new Identifier("key"),
+                                                new Identifier("ts")))))));
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -50,7 +50,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("select * from 'oops",
                         "line 1:15: mismatched input '''. Expecting: '(', 'JSON_TABLE', 'LATERAL', 'TABLE', 'UNNEST', <identifier>"),
                 Arguments.of("select *\nfrom x\nfrom",
-                        "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'CROSS', 'EXCEPT', 'FETCH', 'FOR', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', " +
+                        "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'ASOF', 'CROSS', 'EXCEPT', 'FETCH', 'FOR', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', " +
                                 "'LIMIT', 'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>, <identifier>"),
                 Arguments.of("select *\nfrom x\nwhere from",
                         "line 3:7: mismatched input 'from'. Expecting: <expression>"),
@@ -121,7 +121,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT foo(*) filter (",
                         "line 1:23: mismatched input '<EOF>'. Expecting: 'WHERE'"),
                 Arguments.of("SELECT * FROM t t x",
-                        "line 1:19: mismatched input 'x'. Expecting: '(', ',', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', " +
+                        "line 1:19: mismatched input 'x'. Expecting: '(', ',', 'ASOF', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', " +
                                 "'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>"),
                 Arguments.of("SELECT * FROM t WHERE EXISTS (",
                         "line 1:31: mismatched input '<EOF>'. Expecting: <query>"),

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/JoinType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/JoinType.java
@@ -19,4 +19,5 @@ public enum JoinType
     LEFT_OUTER,
     RIGHT_OUTER,
     FULL_OUTER,
+    ASOF,
 }

--- a/docs/src/main/sphinx/language/reserved.md
+++ b/docs/src/main/sphinx/language/reserved.md
@@ -12,6 +12,7 @@ be quoted (using double quotes) in order to be used as an identifier.
 | `ALTER`             | reserved | reserved |
 | `AND`               | reserved | reserved |
 | `AS`                | reserved | reserved |
+| `ASOF`              |          |          |
 | `AUTO`              |          |          |
 | `BETWEEN`           | reserved | reserved |
 | `BY`                | reserved | reserved |

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -375,6 +375,7 @@ public class DefaultQueryBuilder
         return switch (joinType) {
             case INNER -> "INNER JOIN";
             case LEFT_OUTER -> "LEFT JOIN";
+            case ASOF -> "ASOF JOIN";
             case RIGHT_OUTER -> "RIGHT JOIN";
             case FULL_OUTER -> "FULL JOIN";
         };

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1542,7 +1542,7 @@ public class TestEventListenerBasic
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 90., 0., 0.)),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "173",
+                                        "175",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "[connectorHandleType = SystemPartitioningHandle, partitioning = SINGLE, function = SINGLE]",
@@ -1552,7 +1552,7 @@ public class TestEventListenerBasic
                                         ImmutableList.of(),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                                         ImmutableList.of(new JsonRenderedNode(
-                                                "140",
+                                                "142",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
                                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
@@ -1560,7 +1560,7 @@ public class TestEventListenerBasic
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
                 "1", new JsonRenderedNode(
-                        "139",
+                        "141",
                         "LimitPartial",
                         ImmutableMap.of(
                                 "count", "10",

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestAsofJoinQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestAsofJoinQueries.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.NONE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestAsofJoinQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        QueryRunner queryRunner = new io.trino.testing.StandaloneQueryRunner(testSessionBuilder()
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.toString())
+                .build());
+
+        queryRunner.installPlugin(new io.trino.plugin.tpch.TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch", com.google.common.collect.ImmutableMap.of("tpch.splits-per-node", "1"));
+
+        return queryRunner;
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testRightLteLeft()
+    {
+        assertQuery(
+                """
+                WITH
+                  left_t(k, ts, v) AS (
+                    VALUES
+                      (1, DATE '1992-01-01', 10),
+                      (1, DATE '1992-01-03', 20),
+                      (2, DATE '1992-01-02', 30),
+                      (3, DATE '1992-01-01', 40)  -- no match case
+                  ),
+                  right_t(k, ts, x) AS (
+                    VALUES
+                      (1, DATE '1992-01-01', 100),
+                      (1, DATE '1992-01-02', 200),
+                      (2, DATE '1992-01-01', 300)
+                  )
+                SELECT l.k, l.ts, r.x
+                FROM left_t l ASOF JOIN right_t r
+                  ON l.k = r.k AND r.ts <= l.ts
+                ORDER BY l.k, l.ts""",
+                """
+                VALUES
+                  (1, DATE '1992-01-01', 100),
+                  (1, DATE '1992-01-03', 200),
+                  (2, DATE '1992-01-02', 300),
+                  (3, DATE '1992-01-01', CAST(NULL AS INTEGER))
+                """);
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testLeftGteRight()
+    {
+        assertQuery(
+                """
+                WITH
+                  left_t(k, ts, v) AS (
+                    VALUES
+                      (1, DATE '1992-01-01', 10),
+                      (1, DATE '1992-01-03', 20),
+                      (2, DATE '1992-01-02', 30),
+                      (3, DATE '1992-01-01', 40)  -- no match case
+                  ),
+                  right_t(k, ts, x) AS (
+                    VALUES
+                      (1, DATE '1992-01-01', 100),
+                      (1, DATE '1992-01-02', 200),
+                      (2, DATE '1992-01-01', 300)
+                  )
+                SELECT l.k, l.ts, r.x
+                FROM left_t l ASOF JOIN right_t r
+                  ON l.k = r.k AND l.ts >= r.ts
+                ORDER BY l.k, l.ts""",
+                """
+                VALUES
+                  (1, DATE '1992-01-01', 100),
+                  (1, DATE '1992-01-03', 200),
+                  (2, DATE '1992-01-02', 300),
+                  (3, DATE '1992-01-01', CAST(NULL AS INTEGER))
+                """);
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testRightLtLeft()
+    {
+        assertQuery(
+                """
+                WITH
+                  left_t(k, ts, v) AS (
+                    VALUES
+                      (1, DATE '1992-01-01', 10), -- no match case
+                      (1, DATE '1992-01-03', 20),
+                      (2, DATE '1992-01-02', 30),
+                      (3, DATE '1992-01-01', 40)  -- no match case
+                  ),
+                  right_t(k, ts, x) AS (
+                    VALUES
+                      (1, DATE '1992-01-01', 100),
+                      (1, DATE '1992-01-02', 200),
+                      (2, DATE '1992-01-01', 300)
+                  )
+                SELECT l.k, l.ts, r.x
+                FROM left_t l ASOF JOIN right_t r
+                  ON l.k = r.k AND r.ts < l.ts
+                ORDER BY l.k, l.ts""",
+                """
+                VALUES
+                  (1, DATE '1992-01-01', CAST(NULL AS INTEGER)),
+                  (1, DATE '1992-01-03', 200),
+                  (2, DATE '1992-01-02', 300),
+                  (3, DATE '1992-01-01', CAST(NULL AS INTEGER))
+                """);
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testCompositeEquiKeys()
+    {
+        assertQuery(
+                """
+                WITH
+                  left_t(k1, k2, ts, v) AS (
+                    VALUES
+                      (1, 10, DATE '1992-01-01', 10), -- no match case
+                      (1, 10, DATE '1992-01-03', 20),
+                      (2, 20, DATE '1992-01-02', 30),
+                      (3, 30, DATE '1992-01-01', 40)  -- no match case
+                  ),
+                  right_t(k1, k2, ts, x) AS (
+                    VALUES
+                      (1, 10, DATE '1992-01-01', 100),
+                      (1, 10, DATE '1992-01-02', 200),
+                      (2, 20, DATE '1992-01-01', 300)
+                  )
+                SELECT l.k1, l.k2, l.ts, r.x
+                FROM left_t l ASOF JOIN right_t r
+                  ON l.k1 = r.k1 AND l.k2 = r.k2 AND r.ts < l.ts
+                ORDER BY l.k1, l.k2, l.ts""",
+                """
+                VALUES
+                  (1, 10, DATE '1992-01-01', CAST(NULL AS INTEGER)),
+                  (1, 10, DATE '1992-01-03', 200),
+                  (2, 20, DATE '1992-01-02', 300),
+                  (3, 30, DATE '1992-01-01', CAST(NULL AS INTEGER))
+                """);
+    }
+}


### PR DESCRIPTION
## Description

This implementation adds basic ASOF join support to Trino (requested in https://github.com/trinodb/trino/issues/21759). ASOF joins are useful for time-series data where you want to join rows based on equality on some columns plus finding the "closest" match on a time/ordering column.

## Supported Syntax

Trino now supports two ASOF join syntaxes:

### 1. Explicit ON clause with inequality
```sql
SELECT a.time, a.key, b.value 
FROM table_expr1 a 
ASOF JOIN table_expr2 b 
  ON a.key = b.key AND a.time >= b.time
```

### 2. USING clause (last column treated as inequality)
```sql
SELECT time, key, value
FROM table_expr1 
ASOF JOIN table_expr2 USING (key, time)
```

In the USING form, all columns except the last are treated as equality criteria, and the last column is treated as an inequality (`right.column <= left.column`).

## Implementation Details

The planner rewrites ASOF joins into a combination of standard SQL operations:

1. **AssignUniqueId** on left side (for partitioning)
2. **AssignUniqueId** on right side (for deterministic tie-breaking)
3. **LEFT JOIN** with original equi-criteria and inequality filter
4. **Window function** computing `row_number()` over:
   - PARTITION BY left_unique_id
   - ORDER BY right_timestamp DESC NULLS LAST, right_unique_id DESC NULLS LAST
5. **Filter** where row_number = 1
6. **Project** to return only the original output columns

### Example rewrite:

**Original query:**
```sql
SELECT a.key, a.ts, b.value
FROM left_table l
ASOF JOIN right_table r
  ON l.key = r.key AND l.ts >= r.ts
```

**Rewritten as (conceptually):**
```sql
WITH left_with_uid AS (
  SELECT *, ROW_NUMBER() OVER () as left_uid FROM left_table
),
right_with_uid AS (
  SELECT *, ROW_NUMBER() OVER () as right_uid FROM right_table
),
joined AS (
  SELECT l.*, r.*
  FROM left_with_uid l
  LEFT JOIN right_with_uid r
    ON l.key = r.key AND r.ts <= l.ts
),
ranked AS (
  SELECT *,
    ROW_NUMBER() OVER (
      PARTITION BY left_uid 
      ORDER BY r.ts DESC NULLS LAST, right_uid DESC NULLS LAST
    ) as rn
  FROM joined
)
SELECT a_key, a_ts, b_value
FROM ranked
WHERE rn = 1
```

## Semantics

- **Equi-criteria**: At least one equality condition is required (e.g., `a.key = b.key`)
- **Inequality condition**: Exactly one inequality comparing a column from each side is required
- **Supported inequalities**: `<=`, `<`, `>=`, `>`
- **Match selection**: For each left row, selects the right row with the greatest timestamp that satisfies the inequality
- **Outer semantics**: If no matching right row exists, NULL values are returned for right columns (like LEFT JOIN)
- **Tie-breaking**: When multiple right rows have the same timestamp, selection is deterministic but unspecified

## Limitations

1. **Performance**: The current implementation is not optimized for large tables on the right side because:
   - All potentially matching rows from the right table are fetched via LEFT JOIN
   - A window function processes all these rows to find the top-1 per left row
   - No specialized ASOF join operator exists yet

2. **No connector pushdown**: ASOF joins are not pushed down to connectors; they are always executed in the Trino engine

3. **Type requirements**: The inequality column must have an orderable type (e.g., DATE, TIMESTAMP, numeric types)

4. **Single inequality**: Only one inequality condition is supported; multiple inequality predicates will fail with an error

5. **No pure temporal joins**: At least one equi-join criterion is required; pure ASOF joins on time alone are not supported

## Future Optimization Opportunities

To improve performance, the following optimizations could be implemented:

1. **Sort-merge ASOF join operator**: Instead of LEFT JOIN + window function, implement a dedicated operator that:
   - Sorts both inputs by equi-keys + timestamp
   - Performs a merge-join-like scan
   - For each left row, scans right rows until the inequality fails
   - Complexity: `O(n log n + m log m)` instead of `O(n × m)` in worst case

2. **Index-based lookups**: For connectors supporting indexed seeks:
   - Use equi-keys to locate candidate rows
   - Binary search on timestamp to find the latest match
   - Complexity: `O(n log m)` per left row

3. **Predicate pushdown**: Push down equi-criteria and timestamp range filters to connectors to reduce data volume

4. **Partitioned execution**: When equi-keys are already partitioned/bucketed, process partitions independently in parallel

5. **Connector-specific ASOF join**: Some databases (e.g., ClickHouse, QuestDB) have native ASOF join support; push down when possible

6. **Bloom filters / dynamic filtering**: Use left-side timestamp ranges to filter right-side data earlier

## Error Messages

- `ASOF join requires at least one equi-join criterion`: No equality conditions found in ON clause
- `ASOF join requires a single supported inequality predicate`: Either no inequality, multiple inequalities, or unsupported inequality form
- `ASOF join inequality requires an orderable type on the build side`: The right-side timestamp column type cannot be ordered

## Testing

The implementation includes:
- Parser tests for both ON and USING syntax (`TestAsofJoin`)
- Logical planner tests verifying ASOF join nodes are created (`TestLogicalPlanner.testAsofJoin`)
- Optimized plan tests verifying rewrite to LEFT JOIN + window (`TestLogicalPlanner.testAsofJoinOptimizedPlan`)
- USING clause tests (`TestLogicalPlanner.testAsofJoinUsing*`)
- Negative tests for error conditions
- Integration tests with actual execution (`TestAsofJoinQueries`)

## Conclusion

While this implementation is intentionally simple and not optimized for production workloads with large datasets, it provides correct ASOF join semantics and establishes a foundation for future optimization. The rewrite-based approach leverages existing, well-tested operators (LEFT JOIN, window functions) and can be improved incrementally without changing the user-facing API.


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
