### PR TITLE
Avoid legacy tracing config properties in DistributedQueryRunner

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -955,8 +955,8 @@ public final class DistributedQueryRunner
                 extraCloseables.add(collector);
                 addExtraProperties(Map.of(
                         "tracing.enabled", "true",
-                        "tracing.exporter.endpoint", collector.getExporterEndpoint().toString(),
-                        "tracing.exporter.protocol", "http/protobuf"));
+                        "otel.exporter.endpoint", collector.getExporterEndpoint().toString(),
+                        "otel.exporter.protocol", "http/protobuf"));
                 checkState(eventListeners.isEmpty(), "eventListeners already set");
                 setEventListener(new EventListener()
                 {


### PR DESCRIPTION
## Description

Follow-up of https://github.com/airlift/airlift/pull/1608

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
