### PR TITLE
Use AdaptiveBlockSplitBloomFilter in parquet writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -45,7 +45,7 @@ import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.ValuesWriter;
-import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
+import org.apache.parquet.column.values.bloomfilter.AdaptiveBlockSplitBloomFilter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.schema.GroupType;
@@ -90,7 +90,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 final class ParquetWriters
 {
     private static final int DEFAULT_DICTIONARY_PAGE_SIZE = 1024 * 1024;
-    static final int BLOOM_FILTER_EXPECTED_ENTRIES = 100_000;
+    private static final int BLOOM_FILTER_CANDIDATES_NUMBER = 5;
 
     private ParquetWriters() {}
 
@@ -294,11 +294,9 @@ final class ParquetWriters
             if (!SUPPORTED_BLOOM_FILTER_TYPES.contains(colummType)) {
                 return Optional.empty();
             }
-            // TODO: Enable use of AdaptiveBlockSplitBloomFilter once parquet-mr 1.14.0 is released
             String dotPath = Joiner.on('.').join(columnDescriptor.getPath());
             if (bloomFilterColumns.contains(dotPath)) {
-                int optimalNumOfBits = BlockSplitBloomFilter.optimalNumOfBits(BLOOM_FILTER_EXPECTED_ENTRIES, bloomFilterFpp);
-                return Optional.of(new BlockSplitBloomFilter(optimalNumOfBits / 8, maxBloomFilterSize));
+                return Optional.of(new AdaptiveBlockSplitBloomFilter(maxBloomFilterSize, BLOOM_FILTER_CANDIDATES_NUMBER, bloomFilterFpp, columnDescriptor));
             }
             return Optional.empty();
         }


### PR DESCRIPTION
## Description
Avoids hard-coding of expected ndv in writing of bloom filter.
This helps to improve effectiveness of bloom filters for high cardinality columns



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Delta Lake, Iceberg, Hudi
* Improve effectiveness of bloom filters written in parquet files for high cardinality columns. ({issue}`27656`)
```
