### PR TITLE
Explain tested version skipping in comment

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteCompatibility.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteCompatibility.java
@@ -82,7 +82,7 @@ public class SuiteCompatibility
             int testVersion = currentVersion - 1; // always test last release version
             for (int i = 0; i < NUMBER_OF_TESTED_VERSIONS; i++) {
                 if (testVersion == 456) {
-                    // 456 release was skipped.
+                    // 456 is invalid - release process errors resulted in invalid artifacts.
                     testVersion--;
                 }
                 if (testVersion < FIRST_TRINO_VERSION) {

--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
@@ -74,7 +74,7 @@ public class TestJdbcResultSetCompatibilityOldServer
             int testVersion = currentVersion - 1; // last release version
             for (int i = 0; i < NUMBER_OF_TESTED_VERSIONS; i++) {
                 if (testVersion == 456) {
-                    // 456 release was skipped.
+                    // 456 is invalid - release process errors resulted in invalid artifacts.
                     testVersion--;
                 }
                 if (testVersion < FIRST_VERSION) {


### PR DESCRIPTION
Neither code comment, commit message nor PR explained why 456 is skipped, so it's worth adding some more visibility.

follows
- https://github.com/trinodb/trino/pull/23577

source of truth
- https://trino.io/docs/current/release/release-456.html