### PR TITLE
Fixes formatting issue for negated SQL subqueries

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -572,8 +572,8 @@ public final class ExpressionFormatter
 
             return switch (node.getSign()) {
                 // Unary is ambiguous with respect to negative numbers. "-1" parses as a number, but "-(1)" parses as "unaryMinus(number)"
-                // The parentheses are needed to ensure the parsing roundtrips properly.
-                case MINUS -> "-(" + value + ")";
+                // When parentheses are not present, adding them is necessary to ensure the parsing round trips properly.
+                case MINUS -> value.startsWith("(") ? "-" + value : "-(" + value + ")";
                 case PLUS -> "+" + value;
             };
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes #19695 . Addresses issues with round-trips for negated subqueries. Specifically, the formatter adds parentheses around negative unary arithmetic expressions, even if the value being negated already has parentheses around it (i.e. for SQL subqueries). 

This change just checks whether the value being negated is already wrapped in parentheses.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
