### PR TITLE
Retry Redshift queries in tests on timeouts

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
@@ -19,8 +19,10 @@ import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.HandleConsumer;
 import org.jdbi.v3.core.Jdbi;
 
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 
+import static com.google.common.base.Throwables.getCausalChain;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 
 public final class TestingRedshiftServer
@@ -69,6 +71,8 @@ public final class TestingRedshiftServer
                 exception.getMessage().matches(".* concurrent transaction.*")
                         || exception.getMessage().matches(".*deadlock detected.*")
                         || exception.getMessage().matches(".*could not open relation with OID.*")
-                        || exception.getMessage().matches(".*The connection attempt failed.*"));
+                        || exception.getMessage().matches(".*The connection attempt failed.*")
+                        || getCausalChain(exception).stream()
+                        .anyMatch(e -> e instanceof SocketTimeoutException));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Harden additionally the mechanism for running Redshift queries in order to improve CI stability.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
