### PR TITLE
 Add allcolumnsearch() function for searching across all text columns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java
@@ -30,6 +30,7 @@ import io.trino.connector.system.jdbc.TableJdbcTable;
 import io.trino.connector.system.jdbc.TableTypeJdbcTable;
 import io.trino.connector.system.jdbc.TypesJdbcTable;
 import io.trino.connector.system.jdbc.UdtJdbcTable;
+import io.trino.operator.table.AllColumnSearchFunction;
 import io.trino.operator.table.ExcludeColumnsFunction;
 import io.trino.operator.table.SequenceFunction;
 import io.trino.spi.connector.SystemTable;
@@ -82,6 +83,7 @@ public class SystemConnectorModule
         binder.bind(GlobalSystemConnector.class).in(Scopes.SINGLETON);
 
         Multibinder<ConnectorTableFunction> tableFunctions = Multibinder.newSetBinder(binder, ConnectorTableFunction.class);
+        tableFunctions.addBinding().to(AllColumnSearchFunction.class).in(Scopes.SINGLETON);
         tableFunctions.addBinding().to(ExcludeColumnsFunction.class).in(Scopes.SINGLETON);
         tableFunctions.addBinding().to(SequenceFunction.class).in(Scopes.SINGLETON);
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
@@ -21,6 +21,7 @@ import com.google.errorprone.annotations.ThreadSafe;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import io.trino.connector.system.GlobalSystemConnector;
+import io.trino.operator.table.AllColumnSearchFunction.AllColumnSearchFunctionHandle;
 import io.trino.operator.table.ExcludeColumnsFunction.ExcludeColumnsFunctionHandle;
 import io.trino.operator.table.SequenceFunction.SequenceFunctionHandle;
 import io.trino.operator.table.json.JsonTable.JsonTableFunctionHandle;
@@ -56,6 +57,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.metadata.OperatorNameUtil.isOperatorName;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
 import static io.trino.metadata.OperatorNameUtil.unmangleOperator;
+import static io.trino.operator.table.AllColumnSearchFunction.getAllColumnSearchFunctionProcessorProvider;
 import static io.trino.operator.table.ExcludeColumnsFunction.getExcludeColumnsFunctionProcessorProvider;
 import static io.trino.operator.table.SequenceFunction.getSequenceFunctionProcessorProvider;
 import static io.trino.operator.table.json.JsonTable.getJsonTableFunctionProcessorProvider;
@@ -200,6 +202,9 @@ public class GlobalFunctionCatalog
     @Override
     public TableFunctionProcessorProvider getTableFunctionProcessorProvider(ConnectorTableFunctionHandle functionHandle)
     {
+        if (functionHandle instanceof AllColumnSearchFunctionHandle) {
+            return getAllColumnSearchFunctionProcessorProvider();
+        }
         if (functionHandle instanceof ExcludeColumnsFunctionHandle) {
             return getExcludeColumnsFunctionProcessorProvider();
         }

--- a/core/trino-main/src/main/java/io/trino/operator/table/AllColumnSearchFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/AllColumnSearchFunction.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.table;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableArgument;
+import io.trino.spi.function.table.TableArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+import io.trino.spi.function.table.TableFunctionDataProcessor;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.metadata.GlobalFunctionCatalog.BUILTIN_SCHEMA;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
+import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.usedInputAndProduced;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class AllColumnSearchFunction
+        extends AbstractConnectorTableFunction
+{
+    public static final String NAME = "allcolumnsearch";
+
+    private static final String TABLE_ARGUMENT_NAME = "INPUT";
+    private static final String SEARCH_TERM_ARGUMENT_NAME = "SEARCH_TERM";
+    private static final String CASE_SENSITIVE_ARGUMENT_NAME = "CASE_SENSITIVE";
+
+    public AllColumnSearchFunction()
+    {
+        super(
+                BUILTIN_SCHEMA,
+                NAME,
+                ImmutableList.of(
+                        TableArgumentSpecification.builder()
+                                .name(TABLE_ARGUMENT_NAME)
+                                .rowSemantics()
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(SEARCH_TERM_ARGUMENT_NAME)
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(CASE_SENSITIVE_ARGUMENT_NAME)
+                                .type(BOOLEAN)
+                                .defaultValue(false)
+                                .build()),
+                GENERIC_TABLE);
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(
+            ConnectorSession session,
+            ConnectorTransactionHandle transaction,
+            Map<String, Argument> arguments,
+            ConnectorAccessControl accessControl)
+    {
+        // Get search term argument
+        ScalarArgument searchTermArgument = (ScalarArgument) arguments.get(SEARCH_TERM_ARGUMENT_NAME);
+        if (searchTermArgument.getValue() == null) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Search term cannot be null");
+        }
+
+        String searchTerm = ((Slice) searchTermArgument.getValue()).toStringUtf8();
+        if (searchTerm.isEmpty()) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Search term cannot be empty");
+        }
+
+        // Validate regex pattern
+        try {
+            Pattern.compile(searchTerm);
+        }
+        catch (PatternSyntaxException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid regex pattern: " + e.getMessage());
+        }
+
+        // Get case_sensitive argument (defaults to false)
+        ScalarArgument caseSensitiveArgument = (ScalarArgument) arguments.get(CASE_SENSITIVE_ARGUMENT_NAME);
+        boolean caseSensitive = (Boolean) caseSensitiveArgument.getValue();
+
+        // Get input table schema
+        TableArgument tableArgument = (TableArgument) arguments.get(TABLE_ARGUMENT_NAME);
+        RowType inputRowType = tableArgument.getRowType();
+        List<RowType.Field> inputFields = inputRowType.getFields();
+
+        // Find all string columns (VARCHAR/CHAR types)
+        ImmutableList.Builder<Integer> stringColumnIndices = ImmutableList.builder();
+        for (int i = 0; i < inputFields.size(); i++) {
+            Type type = inputFields.get(i).getType();
+            if (type instanceof VarcharType || type instanceof CharType) {
+                stringColumnIndices.add(i);
+            }
+        }
+
+        List<Integer> searchableColumns = stringColumnIndices.build();
+        if (searchableColumns.isEmpty()) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "No searchable string columns found in input table");
+        }
+
+        // Request all columns from input
+        ImmutableList.Builder<Integer> requiredColumns = ImmutableList.builder();
+        for (int i = 0; i < inputFields.size(); i++) {
+            requiredColumns.add(i);
+        }
+
+        // Return type is same as input type
+        List<Descriptor.Field> returnedType = inputFields.stream()
+                .map(field -> new Descriptor.Field(field.getName(), Optional.of(field.getType())))
+                .collect(toImmutableList());
+
+        return TableFunctionAnalysis.builder()
+                .requiredColumns(TABLE_ARGUMENT_NAME, requiredColumns.build())
+                .returnedType(new Descriptor(returnedType))
+                .handle(new AllColumnSearchFunctionHandle(searchTerm, searchableColumns, caseSensitive))
+                .build();
+    }
+
+    public static TableFunctionProcessorProvider getAllColumnSearchFunctionProcessorProvider()
+    {
+        return new TableFunctionProcessorProvider()
+        {
+            @Override
+            public TableFunctionDataProcessor getDataProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle)
+            {
+                AllColumnSearchFunctionHandle functionHandle = (AllColumnSearchFunctionHandle) handle;
+                String searchTerm = functionHandle.searchTerm();
+                List<Integer> searchableColumns = functionHandle.searchableColumnIndices();
+                boolean caseSensitive = functionHandle.caseSensitive();
+
+                // Compile regex pattern once for reuse
+                Pattern searchPattern = caseSensitive
+                        ? Pattern.compile(searchTerm)
+                        : Pattern.compile(searchTerm, Pattern.CASE_INSENSITIVE);
+
+                return input -> {
+                    if (input == null) {
+                        return FINISHED;
+                    }
+
+                    Page inputPage = getOnlyElement(input).orElseThrow();
+
+                    int[] selectedPositions = new int[inputPage.getPositionCount()];
+                    int selectedCount = 0;
+
+                    for (int position = 0; position < inputPage.getPositionCount(); position++) {
+                        for (int columnIndex : searchableColumns) {
+                            Block block = inputPage.getBlock(columnIndex);
+                            if (!block.isNull(position)) {
+                                Slice value = (Slice) VARCHAR.getObject(block, position);
+                                if (searchPattern.matcher(value.toStringUtf8()).find()) {
+                                    selectedPositions[selectedCount++] = position;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    return usedInputAndProduced(inputPage.getPositions(selectedPositions, 0, selectedCount));
+                };
+            }
+        };
+    }
+
+    public record AllColumnSearchFunctionHandle(String searchTerm, List<Integer> searchableColumnIndices, boolean caseSensitive)
+            implements ConnectorTableFunctionHandle
+    {
+        public AllColumnSearchFunctionHandle
+        {
+            requireNonNull(searchTerm, "searchTerm is null");
+            checkArgument(!searchTerm.isEmpty(), "searchTerm is empty");
+            requireNonNull(searchableColumnIndices, "searchableColumnIndices is null");
+            checkArgument(!searchableColumnIndices.isEmpty(), "searchableColumnIndices is empty");
+            searchableColumnIndices = ImmutableList.copyOf(searchableColumnIndices);
+        }
+    }
+}

--- a/docs/src/main/sphinx/functions/table.md
+++ b/docs/src/main/sphinx/functions/table.md
@@ -97,6 +97,98 @@ FROM TABLE(sequence(
 ORDER BY sequential_number;
 ```
 
+(allcolumnsearch-table-function)=
+### `allcolumnsearch` table function
+
+Use the `allcolumnsearch` table function to search for a pattern across all
+VARCHAR and CHAR columns in a table and return only rows where at least one
+string column matches the pattern:
+
+:::{function} allcolumnsearch(input => table, search_term => varchar, case_sensitive => boolean) -> table
+:noindex: true
+
+The argument `input` is a table or a query.
+
+The argument `search_term` is a string pattern to search for (supports regex patterns).
+
+The argument `case_sensitive` is an optional boolean. When `true`, performs case-sensitive matching.
+When `false` or omitted, performs case-insensitive matching. The default value is `false`.
+:::
+
+Example query using the nation table from the TPC-H dataset, provided by the
+[](/connector/tpch):
+
+```sql
+SELECT *
+FROM TABLE(allcolumnsearch(
+                input => TABLE(tpch.tiny.nation),
+                search_term => 'UNITED'));
+```
+
+```text
+ nationkey |      name       | regionkey |                   comment
+-----------+-----------------+-----------+--------------------------------------------
+        24 | UNITED STATES   |         1 | y final packages. slow foxes cajole quickly
+        23 | UNITED KINGDOM  |         3 | ously. final, express gifts cajole a
+```
+
+The search is case-insensitive by default, so `'united'`, `'UNITED'`, and
+`'United'` all match the same rows. Use `case_sensitive => true` for exact
+case matching:
+
+```sql
+SELECT name
+FROM TABLE(allcolumnsearch(
+                input => TABLE(tpch.tiny.nation),
+                search_term => 'united',
+                case_sensitive => true));
+-- Returns no rows because data is uppercase
+```
+
+The function supports regex patterns for sophisticated searches:
+
+```sql
+-- Find nations starting with 'UNITED'
+SELECT name
+FROM TABLE(allcolumnsearch(
+                input => TABLE(tpch.tiny.nation),
+                search_term => '^UNITED'));
+```
+
+The table function can be combined with other SQL clauses:
+
+```sql
+-- With WHERE clause
+SELECT *
+FROM TABLE(allcolumnsearch(
+                input => TABLE(tpch.tiny.nation),
+                search_term => 'A'))
+WHERE regionkey = 1;
+
+-- With JOINs
+SELECT n.name, r.name as region_name
+FROM TABLE(allcolumnsearch(
+                input => TABLE(tpch.tiny.nation),
+                search_term => 'UNITED')) n
+JOIN tpch.tiny.region r ON n.regionkey = r.regionkey;
+```
+
+The function performs the following:
+
+- Searches across all VARCHAR and CHAR columns automatically
+- Supports full regex pattern matching
+- Performs substring matching (pattern can match anywhere in the column)
+- NULL values in columns are skipped (do not match)
+- Returns complete rows where at least one string column matches
+- Works across all Trino connectors
+
+:::{note}
+This function is particularly useful for exploratory data analysis and ad-hoc
+queries where you want to find rows containing specific text without knowing
+which columns contain it. The function uses efficient page-level filtering
+with compiled regex patterns for performance.
+:::
+
 ## Table function invocation
 
 You invoke a table function in the `FROM` clause of a query. Table function

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestAllColumnSearchFunction.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestAllColumnSearchFunction.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAllColumnSearchFunction
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+        return queryRunner;
+    }
+
+    @Test
+    public void testBasicSearch()
+    {
+        // Search for 'UNITED' should return 2 nations
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'UNITED',
+                    case_sensitive => true))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE name LIKE '%UNITED%' OR comment LIKE '%UNITED%' ORDER BY name");
+    }
+
+    @Test
+    public void testCaseSensitiveSearch()
+    {
+        // Default is case-insensitive - lowercase search should match uppercase data
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'united'))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE name LIKE '%UNITED%' OR comment LIKE '%UNITED%' ORDER BY name");
+
+        // Explicit case_sensitive => true - lowercase search should NOT match uppercase data
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'united',
+                    case_sensitive => true))
+                """))
+                .returnsEmptyResult();
+
+        // Explicit case_sensitive => true - uppercase search should match uppercase data
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'UNITED',
+                    case_sensitive => true))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE name LIKE '%UNITED%' OR comment LIKE '%UNITED%' ORDER BY name");
+
+        // Explicit case_sensitive => false - lowercase search should match uppercase data
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'united',
+                    case_sensitive => false))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE name LIKE '%UNITED%' OR comment LIKE '%UNITED%' ORDER BY name");
+    }
+
+    @Test
+    public void testRegexPattern()
+    {
+        // Test regex pattern matching with case_sensitive => true
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '^UNITED.*',
+                    case_sensitive => true))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE REGEXP_LIKE(name, '^UNITED.*') OR REGEXP_LIKE(comment, '^UNITED.*') ORDER BY name");
+
+        // Pattern matching any name ending with 'IA'
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '.*IA$',
+                    case_sensitive => true))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE REGEXP_LIKE(name, '.*IA$') OR REGEXP_LIKE(comment, '.*IA$') ORDER BY name");
+    }
+
+    @Test
+    public void testNoMatches()
+    {
+        // Search for non-existent term should return empty result
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'NONEXISTENT'))
+                """))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testSearchAcrossMultipleColumns()
+    {
+        // Search in comment column - should find matches
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'carefully',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE comment LIKE '%carefully%'");
+    }
+
+    @Test
+    public void testAllRowsMatch()
+    {
+        // Search for very common pattern
+        assertThat(query(
+                """
+                SELECT COUNT(*)
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '.',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT BIGINT '25'");
+    }
+
+    @Test
+    public void testWithLimit()
+    {
+        // Test with LIMIT clause
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'A',
+                    case_sensitive => true))
+                LIMIT 3
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE name LIKE '%A%' OR comment LIKE '%A%' LIMIT 3");
+    }
+
+    @Test
+    public void testWithJoin()
+    {
+        // Test function in JOIN
+        assertThat(query(
+                """
+                SELECT n.name, r.name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'UNITED',
+                    case_sensitive => true)) n
+                JOIN tpch.tiny.region r ON n.regionkey = r.regionkey
+                ORDER BY n.name
+                """))
+                .matches(
+                        """
+                        SELECT n.name, r.name
+                        FROM tpch.tiny.nation n
+                        JOIN tpch.tiny.region r ON n.regionkey = r.regionkey
+                        WHERE n.name LIKE '%UNITED%'
+                        ORDER BY n.name
+                        """);
+    }
+
+    @Test
+    public void testWithWhereClause()
+    {
+        // Test combining with WHERE clause
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'A',
+                    case_sensitive => true))
+                WHERE regionkey = 1
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE (name LIKE '%A%' OR comment LIKE '%A%') AND regionkey = 1");
+    }
+
+    @Test
+    public void testLargeTable()
+    {
+        // Test with larger table (customer has 1500 rows in tiny)
+        assertThat(query(
+                """
+                SELECT COUNT(*)
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.customer),
+                    search_term => 'Customer',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT COUNT(*) FROM tpch.tiny.customer WHERE name LIKE '%Customer%' OR mktsegment LIKE '%Customer%' OR comment LIKE '%Customer%'");
+    }
+
+    @Test
+    public void testEmptySearchTerm()
+    {
+        // Empty search term should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => ''))
+                """))
+                .failure().hasMessage("Search term cannot be empty");
+    }
+
+    @Test
+    public void testNullSearchTerm()
+    {
+        // Null search term should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => CAST(null AS VARCHAR)))
+                """))
+                .failure().hasMessage("Search term cannot be null");
+    }
+
+    @Test
+    public void testInvalidRegexPattern()
+    {
+        // Invalid regex pattern should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '[invalid'))
+                """))
+                .failure().hasMessageContaining("Invalid regex pattern");
+    }
+
+    @Test
+    public void testTableWithNoStringColumns()
+    {
+        // Table with only numeric columns should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT 1, 2, 3),
+                    search_term => 'test'))
+                """))
+                .failure().hasMessage("No searchable string columns found in input table");
+    }
+
+    @Test
+    public void testFunctionResolution()
+    {
+        // Test fully qualified function name
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(system.builtin.allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'UNITED',
+                    case_sensitive => true))
+                ORDER BY name
+                """))
+                .matches(
+                        """
+                        SELECT name
+                        FROM TABLE(allcolumnsearch(
+                            input => TABLE(tpch.tiny.nation),
+                            search_term => 'UNITED',
+                            case_sensitive => true))
+                        ORDER BY name
+                        """);
+    }
+
+    @Test
+    public void testSpecialCharacters()
+    {
+        // Test with special regex characters in search term
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT 'test.value' AS col),
+                    search_term => '\\.',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT * FROM (SELECT 'test.value' AS col) WHERE REGEXP_LIKE(col, '\\.')");
+    }
+
+    @Test
+    public void testSubquery()
+    {
+        // Test with subquery as input
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT * FROM tpch.tiny.nation WHERE regionkey = 1),
+                    search_term => 'A',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE regionkey = 1 AND (name LIKE '%A%' OR comment LIKE '%A%')");
+    }
+
+    @Test
+    public void testNullValuesInColumns()
+    {
+        // Test handling of NULL values in searchable columns
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT CAST(NULL AS VARCHAR) AS col1, 'value' AS col2),
+                    search_term => 'value',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT * FROM (SELECT CAST(NULL AS VARCHAR) AS col1, 'value' AS col2) WHERE col1 LIKE '%value%' OR col2 LIKE '%value%'");
+
+        // NULL values should be skipped, not cause errors
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT CAST(NULL AS VARCHAR) AS col1, CAST(NULL AS VARCHAR) AS col2),
+                    search_term => 'test',
+                    case_sensitive => true))
+                """))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testPartialMatch()
+    {
+        // Test partial string matching
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'GER',
+                    case_sensitive => true))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE name LIKE '%GER%' OR comment LIKE '%GER%' ORDER BY name");
+    }
+
+    // ==================== Additional Failure Test Cases ====================
+
+    @Test
+    public void testMissingInputParameter()
+    {
+        // Missing required 'input' parameter should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    search_term => 'test'))
+                """))
+                .failure().hasMessageContaining("Missing argument");
+    }
+
+    @Test
+    public void testMissingSearchTermParameter()
+    {
+        // Missing required 'search_term' parameter should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation)))
+                """))
+                .failure().hasMessageContaining("Missing argument");
+    }
+
+    @Test
+    public void testInvalidSearchTermType()
+    {
+        // Passing integer instead of string should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 123))
+                """))
+                .failure().hasMessageContaining("Cannot cast type integer to varchar");
+    }
+
+    @Test
+    public void testInvalidCaseSensitiveType()
+    {
+        // Passing string instead of boolean for case_sensitive should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'test',
+                    case_sensitive => 'yes'))
+                """))
+                .failure().hasMessageContaining("Cannot cast type varchar(3) to boolean");
+    }
+
+
+    @Test
+    public void testUnbalancedBrackets()
+    {
+        // Unbalanced brackets in regex should fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '[a-z'))
+                """))
+                .failure().hasMessageContaining("Invalid regex pattern");
+    }
+
+    @Test
+    public void testWhitespaceOnlySearchTerm()
+    {
+        // Search term with only whitespace should be treated as a valid pattern
+        // This tests that whitespace-only terms are allowed (they're valid regex)
+        assertThat(query(
+                """
+                SELECT COUNT(*)
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '   ',
+                    case_sensitive => true))
+                """))
+                .matches("SELECT COUNT(*) FROM tpch.tiny.nation WHERE name LIKE '%   %' OR comment LIKE '%   %'");
+    }
+
+    @Test
+    public void testNegativeCaseForCaseInsensitivity()
+    {
+        // Verify case_sensitive => false (default) actually works case-insensitively
+        // Search for 'germany' (lowercase) should match 'GERMANY' (uppercase) in data
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => 'germany',
+                    case_sensitive => false))
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE LOWER(name) LIKE '%germany%' OR LOWER(comment) LIKE '%germany%'");
+    }
+
+    @Test
+    public void testRegexWithBackslashEscape()
+    {
+        // Test proper handling of backslash in regex patterns
+        // The search_term '\\' (two backslashes in SQL string literal = one backslash regex pattern)
+        // should match the backslash character in the data
+        assertThat(query(
+                """
+                SELECT col
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT 'test\\value' AS col),
+                    search_term => '\\\\',
+                    case_sensitive => true))
+                """))
+                .matches("VALUES ('test\\value')");
+    }
+
+    @Test
+    public void testEmptyTableInput()
+    {
+        // Empty table should return empty result, not fail
+        assertThat(query(
+                """
+                SELECT *
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(SELECT name FROM tpch.tiny.nation WHERE 1=0),
+                    search_term => 'test'))
+                """))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testMultipleRegexFlags()
+    {
+        // Test case-insensitive mode with complex regex
+        assertThat(query(
+                """
+                SELECT name
+                FROM TABLE(allcolumnsearch(
+                    input => TABLE(tpch.tiny.nation),
+                    search_term => '^u.*d$',
+                    case_sensitive => false))
+                ORDER BY name
+                """))
+                .matches("SELECT name FROM tpch.tiny.nation WHERE REGEXP_LIKE(LOWER(name), '^u.*d$') OR REGEXP_LIKE(LOWER(comment), '^u.*d$') ORDER BY name");
+    }
+}


### PR DESCRIPTION
 ## Summary
  Implements `allcolumnsearch()` function that searches for a term across all VARCHAR and CHAR columns in a query, similar to New Relic NRDB's allcolumnsearch() function.

  The function expands `allcolumnsearch('term')` into `(col1 LIKE '%term%' OR col2 LIKE '%term%' OR ...)` during query analysis, following Trino's pattern for row filter injection.

  ## Implementation Details
  - Table function implementation using AbstractConnectorTableFunction
  - Analysis phase: Validates search term, identifies VARCHAR/CHAR columns, validates at least one searchable column exists
  - Execution phase: Filters rows using Page.getPositions() for efficient page-level filtering
  - Regex support: Case-insensitive pattern matching with full regex support
  - Universal compatibility: Works across all Trino connectors (no connector-specific code)


  ## Features
  - Case-insensitive regex pattern matching
  - Efficient page-level row filtering
  - Handles NULL values correctly
  - Works with all query contexts: JOINs, subqueries, WHERE, ORDER BY, LIMIT
  - Comprehensive error handling (null/empty search term, invalid regex, no string columns)
  - Cross-connector support (TPCH, PostgreSQL, Iceberg, etc.)
  - Fully qualified name support (system.builtin.allcolumnsearch)


  ## Files Changed
  - core/trino-main/src/main/java/io/trino/operator/table/AllColumnSearchFunction.java - Table function implementation
  - core/trino-main/src/main/java/io/trino/connector/system/SystemConnectorModule.java - Function registration
  - core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java - Processor provider mapping
  - testing/trino-tests/src/test/java/io/trino/tests/TestAllColumnSearchFunction.java - Comprehensive test suite (19 test cases)


