### PR TITLE
Fix Jdk 25 release notes entry

### DIFF
--- a/docs/src/main/sphinx/release/release-479.md
+++ b/docs/src/main/sphinx/release/release-479.md
@@ -11,7 +11,7 @@
 * Add `GRACE PERIOD` to `SHOW CREATE MATERIALIZED VIEW` output. ({issue}`27529`)
 * Allow field name declaration in row literals. For example, `row(1 as a, 2 as b)` is now legal. ({issue}`25261`)
 * Add `queryText` as a regular expression in resource group selector. ({issue}`27129`)
-* Require JDK 25 to build and run Trino. ({issue}`27153`)
+* {{breaking}} Require JDK 25 to build and run Trino. ({issue}`27171`)
 * {{breaking}} The configuration property `task.statistics-cpu-timer-enabled` is now defunct and must be removed. ({issue}`27504`)
 * Deprecate `EXPLAIN` type `LOGICAL` and `DISTRIBUTED`. Use `EXPLAIN` without a type clause, instead. ({issue}`27434`)
 * Remove `prefer_streaming_operators` session property. ({issue}`27506`)


### PR DESCRIPTION
## Description

Its breaking change just like it was in prior releases such as 476 with JDK 24. PR link was wrong.

Found during recording https://youtube.com/live/7clvlAxGFOI

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
