### PR TITLE
Add cluster status info to header in preview UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/api/webapp/api.ts
@@ -13,6 +13,14 @@
  */
 import { api, ApiResponse } from '../base.ts'
 
+export interface Cluster {
+    nodeVersion: {
+        version: string
+    }
+    environment: string
+    uptime: string
+}
+
 export interface Stats {
     runningQueries: number
     blockedQueries: number
@@ -352,6 +360,10 @@ export interface QueryStatusInfo extends QueryInfoBase {
 
 export interface WorkerTaskInfo {
     dummy: string
+}
+
+export async function clusterApi(): Promise<ApiResponse<Cluster>> {
+    return await api.get<Cluster>('/ui/api/cluster')
 }
 
 export async function statsApi(): Promise<ApiResponse<Stats>> {


### PR DESCRIPTION
## Description

Cluster status details such as version, environment, and uptime are not currently visible in the preview UI. As in the current UI these should be displayed in the header.

Screenshots:

<img width="1432" height="926" alt="image" src="https://github.com/user-attachments/assets/5b2a8432-581a-403d-905b-ffe186bfb1f0" />

<img width="1428" height="932" alt="image" src="https://github.com/user-attachments/assets/5e8665a2-7b8e-4c1a-b0ab-8f0ac527a27e" />

## Additional context and related issues

-

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Add cluster status info to header in preview UI. ({issue}`27712`)
```
