### PR TITLE
Update ignored properties in GCS config test

### DIFF
--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
@@ -88,7 +88,7 @@ public class TestGcsFileSystemConfig
                 .setMinBackoffDelay(new Duration(20, MILLISECONDS))
                 .setMaxBackoffDelay(new Duration(20, MILLISECONDS))
                 .setApplicationId("application id");
-        assertFullMapping(properties, expected, Set.of("gcs.json-key", "gcs.json-key-file-path", "gcs.use-access-token"));
+        assertFullMapping(properties, expected, Set.of("gcs.use-access-token"));
     }
 
     // backwards compatibility test, remove if use-access-token is removed


### PR DESCRIPTION
Removed 'gcs.json-key' and 'gcs.json-key-file-path' from the set of ignored properties in the `assertFullMapping` call.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The `gcs.json-key` and `gcs.json-key-file-path` properties were moved to `GcsServiceAccountAuthConfig` in #27106, so there is no need to keep them in `TestGcsFileSystemConfig` anymore.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
