### PR TITLE
Fix typo in file-system-access-control.md

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.md
+++ b/docs/src/main/sphinx/security/file-system-access-control.md
@@ -906,7 +906,7 @@ These table functions can be used to access or modify the underlying data of
 the catalog.
 
 The following example allows the `admin` user to execute `system.query` table function from
-any catalog, and all users to create, drop, and execute functions (including from views)
+this catalog, and all users to create, drop, and execute functions (including from views)
 in the `function` schema of this catalog:
 
 ```json


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR just contains a small typo fix in the catalog-level section of the file-based access control documentation


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
