### PR TITLE
Make task outputDataSize track network bytes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -881,5 +881,10 @@ public class SqlTaskManager
         {
             return resultsFuture;
         }
+
+        public void recordNetworkOutput(long bytesSent)
+        {
+            task.getTaskContext().ifPresent(taskContext -> taskContext.recordNetworkOutput(bytesSent));
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -550,6 +550,7 @@ public class TaskResource
             return response.build();
         }
 
+        taskWithResults.recordNetworkOutput(serializedPages.stream().mapToLong(Slice::length).sum());
         return response
                 .type(TRINO_PAGES)
                 .entity((StreamingOutput) output ->


### PR DESCRIPTION
Previously, `outputDataSize` for tasks and stages was equal to the memory retained by the pages sent to the output operator, and not the actual number of bytes sent over the network. The latter is more useful, as it can be used to discover internal network bottlenecks.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
## Section
* Make the stage output in the explain analyze, display the actual size of data sent over the network
```
