### PR TITLE
Configure Oracle UCP wait connection timeout

### DIFF
--- a/docs/src/main/sphinx/connector/oracle.md
+++ b/docs/src/main/sphinx/connector/oracle.md
@@ -66,6 +66,7 @@ them, change the properties in the catalog configuration file:
 oracle.connection-pool.max-size=30
 oracle.connection-pool.min-size=1
 oracle.connection-pool.inactive-timeout=20m
+oracle.connection-pool.wait-duration=3s
 ```
 
 To disable connection pooling, update properties to include the following:

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
@@ -86,6 +86,7 @@ public class OracleClientModule
                     oracleConfig.getConnectionPoolMinSize(),
                     oracleConfig.getConnectionPoolMaxSize(),
                     oracleConfig.getInactiveConnectionTimeout(),
+                    oracleConfig.getConnectionPoolWaitDuration(),
                     openTelemetry);
         }
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
@@ -26,6 +26,7 @@ import java.math.RoundingMode;
 import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig("oracle.disable-automatic-fetch-size")
 public class OracleConfig
@@ -38,6 +39,7 @@ public class OracleConfig
     private int connectionPoolMinSize = 1;
     private int connectionPoolMaxSize = 30;
     private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
+    private Duration connectionPoolWaitDuration = new Duration(3, SECONDS);
     private Integer fetchSize;
 
     public boolean isSynonymsEnabled()
@@ -139,6 +141,20 @@ public class OracleConfig
     public OracleConfig setInactiveConnectionTimeout(Duration inactiveConnectionTimeout)
     {
         this.inactiveConnectionTimeout = inactiveConnectionTimeout;
+        return this;
+    }
+
+    @NotNull
+    public Duration getConnectionPoolWaitDuration()
+    {
+        return connectionPoolWaitDuration;
+    }
+
+    @Config("oracle.connection-pool.wait-duration")
+    @ConfigDescription("Maximum amount of time a request will wait to obtain an available connection from the pool if all connections are currently in use")
+    public OracleConfig setConnectionPoolWaitDuration(Duration connectionPoolWaitDuration)
+    {
+        this.connectionPoolWaitDuration = connectionPoolWaitDuration;
         return this;
     }
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OraclePoolConnectionFactory.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OraclePoolConnectionFactory.java
@@ -43,6 +43,7 @@ public class OraclePoolConnectionFactory
             int connectionPoolMinSize,
             int connectionPoolMaxSize,
             Duration inactiveConnectionTimeout,
+            Duration connectionPoolWaitDuration,
             OpenTelemetry openTelemetry)
             throws SQLException
     {
@@ -59,6 +60,7 @@ public class OraclePoolConnectionFactory
         dataSource.setValidateConnectionOnBorrow(true);
         dataSource.setConnectionProperties(connectionProperties);
         dataSource.setInactiveConnectionTimeout(toIntExact(inactiveConnectionTimeout.roundTo(SECONDS)));
+        dataSource.setConnectionWaitDuration(connectionPoolWaitDuration.toJavaTime());
         credentialProvider.getConnectionUser(Optional.empty())
                 .ifPresent(user -> {
                     try {

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
@@ -43,6 +43,7 @@ public class TestOracleConfig
                 .setConnectionPoolMinSize(1)
                 .setConnectionPoolMaxSize(30)
                 .setInactiveConnectionTimeout(new Duration(20, MINUTES))
+                .setConnectionPoolWaitDuration(new Duration(3, SECONDS))
                 .setFetchSize(null));
     }
 
@@ -58,6 +59,7 @@ public class TestOracleConfig
                 .put("oracle.connection-pool.min-size", "10")
                 .put("oracle.connection-pool.max-size", "20")
                 .put("oracle.connection-pool.inactive-timeout", "30s")
+                .put("oracle.connection-pool.wait-duration", "10s")
                 .put("oracle.fetch-size", "2000")
                 .buildOrThrow();
 
@@ -70,6 +72,7 @@ public class TestOracleConfig
                 .setConnectionPoolMinSize(10)
                 .setConnectionPoolMaxSize(20)
                 .setInactiveConnectionTimeout(new Duration(30, SECONDS))
+                .setConnectionPoolWaitDuration(new Duration(10, SECONDS))
                 .setFetchSize(2000);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This change adds support for configuring a connection wait timeout for the Oracle connector’s connection pool.

When all connections in the pool are borrowed, connection requests can fail with UCP-45064 during bursts of queries where connections would become available shortly after. This can cause otherwise healthy workloads to fail unnecessarily.

The new catalog property, oracle.connection-pool.wait-timeout, allows connection requests to wait for a free connection for a configurable amount of time. By setting a higher wait timeout, queries can be serviced during brief bursts of high concurrency instead of occasionally failing.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is particularly useful for bursty workloads with many short-running queries, where brief contention on the pool can lead to query failures despite sufficient database capacity and a high maximum connection pool size, because the pool cannot always scale fast enough to handle sudden bursts.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## Oracle
* Add support for configuring a connection wait timeout via the `oracle.connection-pool.wait-timeout` catalog property. ({issue}`27744`)
```
