### PR TITLE
Add the monaco editor to the Preview UI distribution

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/App.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/App.tsx
@@ -34,10 +34,13 @@ import { darkTheme, lightTheme } from './theme'
 import trinoLogo from './assets/trino.svg'
 import { QueryDetails } from './components/QueryDetails'
 import { WorkerStatus } from './components/WorkerStatus'
+import { loader } from '@monaco-editor/react'
+import * as monaco from 'monaco-editor'
 
 const App = () => {
     const config = useConfigStore()
     const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+    loader.config({ monaco })
 
     const themeToUse = () => {
         if (config.theme === ThemeStore.Auto) {


### PR DESCRIPTION
## Description
The Preview UI uses the monaco editor to display queries. This uses https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js to load the npm module. With this fix, the npm module is added and used to the dist via vite. This fix is useful for air gapped networks.

## Before
<img width="1175" height="212" alt="Screenshot 2025-12-23 at 22-29-48 Trino - Preview UI" src="https://github.com/user-attachments/assets/9fe63fe1-593e-4bd5-bd7d-8cc797f2a045" />
(Fails to load sql view)

##  After
<img width="1174" height="272" alt="Screenshot 2025-12-23 at 22-19-20 Trino - Preview UI" src="https://github.com/user-attachments/assets/dd8f390f-cd5f-4a00-8981-45038c3518e7" />

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

