### PR TITLE
Remove unnecessary DROP TABLE statement in TestIgniteTypeMapping

### DIFF
--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -335,7 +335,6 @@ public class TestIgniteTypeMapping
                 .build();
 
         assertQueryFails("CREATE TABLE test_unsupported_date_range_ctas (data) AS SELECT DATE '1582-10-05'", "Date must be between 1970-01-01 and 9999-12-31 in Ignite.*");
-        assertUpdate("DROP TABLE IF EXISTS test_unsupported_date_range_ctas");
 
         List<String> unsupportedDateValues = ImmutableList.of("-0001-01-01", "0001-01-01", "1000-01-01", "1969-12-31", "10000-01-01");
         try (TestTable table = new TestTable(igniteServer::execute, "test_unsupported_date_range", "(id int primary key, data date)")) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

After the changes from https://github.com/trinodb/trino/pull/27702 there have been spotted signs of flakiness in the test

`io.trino.plugin.ignite.TestIgniteTypeMapping#testUnsupportedDateRange()`


```
io.trino.testing.QueryFailedException: Table doesn't exist: TEST_UNSUPPORTED_DATE_RANGE_CTAS
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:621)
	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:603)
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:107)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:61)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:419)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:414)
	at io.trino.plugin.ignite.TestIgniteTypeMapping.testUnsupportedDateRange(TestIgniteTypeMapping.java:338)
	at io.trino.plugin.ignite.TestIgniteTypeMapping.testUnsupportedDateRange(TestIgniteTypeMapping.java:327)
	Suppressed: java.lang.Exception: SQL: DROP TABLE IF EXISTS test_unsupported_date_range_ctas
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:628)
		... 7 more
Caused by: io.trino.spi.TrinoException: Table doesn't exist: TEST_UNSUPPORTED_DATE_RANGE_CTAS
	at io.trino.plugin.jdbc.BaseJdbcClient.execute(BaseJdbcClient.java:1626)
	at io.trino.plugin.jdbc.BaseJdbcClient.dropTable(BaseJdbcClient.java:1459)
	at io.trino.plugin.jdbc.BaseJdbcClient.dropTable(BaseJdbcClient.java:1453)
	at io.trino.plugin.jdbc.ForwardingJdbcClient.dropTable(ForwardingJdbcClient.java:311)
	at io.trino.plugin.jdbc.jmx.StatisticsAwareJdbcClient.lambda$dropTable$0(StatisticsAwareJdbcClient.java:399)
	at io.trino.plugin.jdbc.jmx.JdbcApiStats.wrap(JdbcApiStats.java:46)
	at io.trino.plugin.jdbc.jmx.StatisticsAwareJdbcClient.dropTable(StatisticsAwareJdbcClient.java:399)
	at io.trino.plugin.jdbc.RetryingJdbcClient.dropTable(RetryingJdbcClient.java:421)
	at io.trino.plugin.jdbc.CachingJdbcClient.dropTable(CachingJdbcClient.java:446)
	at io.trino.plugin.jdbc.CachingJdbcClient.dropTable(CachingJdbcClient.java:446)
	at io.trino.plugin.jdbc.DefaultJdbcMetadata.dropTable(DefaultJdbcMetadata.java:1151)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.dropTable(ClassLoaderSafeConnectorMetadata.java:486)
	at io.trino.tracing.TracingConnectorMetadata.dropTable(TracingConnectorMetadata.java:398)
	at io.trino.metadata.MetadataManager.dropTable(MetadataManager.java:1071)
	at io.trino.tracing.TracingMetadata.dropTable(TracingMetadata.java:599)
	at io.trino.execution.DropTableTask.execute(DropTableTask.java:88)
	at io.trino.execution.DropTableTask.execute(DropTableTask.java:36)
	at io.trino.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:152)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:297)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:150)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$1(LocalDispatchQuery.java:134)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$0(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at io.trino.$gen.Trino_testversion____20251224_102123_37.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.sql.SQLException: Table doesn't exist: TEST_UNSUPPORTED_DATE_RANGE_CTAS
	at org.apache.ignite.internal.jdbc.thin.JdbcThinConnection.sendRequest(JdbcThinConnection.java:1138)
	at org.apache.ignite.internal.jdbc.thin.JdbcThinStatement.execute0(JdbcThinStatement.java:245)
	at org.apache.ignite.internal.jdbc.thin.JdbcThinStatement.execute(JdbcThinStatement.java:577)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.lambda$execute$5(OpenTelemetryStatement.java:110)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.wrapCall(OpenTelemetryStatement.java:402)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.wrapCall(OpenTelemetryStatement.java:388)
	at io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement.execute(OpenTelemetryStatement.java:110)
	at io.trino.plugin.jdbc.BaseJdbcClient.execute(BaseJdbcClient.java:1636)
	at io.trino.plugin.jdbc.BaseJdbcClient.execute(BaseJdbcClient.java:1623)
	... 27 more
	Suppressed: java.lang.RuntimeException: Query: DROP TABLE `PUBLIC`.`TEST_UNSUPPORTED_DATE_RANGE_CTAS`
		at io.trino.plugin.jdbc.BaseJdbcClient.execute(BaseJdbcClient.java:1639)
		... 28 more
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This flakiness has been highlighted by the changes in https://github.com/trinodb/trino/pull/27702


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
