### PR TITLE
Correctly remove position delete files on optimize

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -348,7 +348,7 @@ public class IcebergSplitSource
                 // OPTIMIZE supports only enforced predicates which select whole partitions, so if there is no path or fileModifiedTime predicate, then we can clean up position deletes
                 List<org.apache.iceberg.DeleteFile> fullyAppliedDeletes = wholeFileTask.deletes().stream()
                         .filter(deleteFile -> switch (deleteFile.content()) {
-                            case POSITION_DELETES -> partitionDomain.isAll() && pathDomain.isAll() && fileModifiedTimeDomain.isAll();
+                            case POSITION_DELETES -> pathDomain.isAll() && fileModifiedTimeDomain.isAll();
                             case EQUALITY_DELETES -> tableHandle.getEnforcedPredicate().isAll();
                             case DATA -> throw new IllegalStateException("Unexpected delete file: " + deleteFile);
                         })

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5612,57 +5612,40 @@ public abstract class BaseIcebergConnectorTest
             throws IOException
     {
         String tableName = "test_optimize_" + randomNameSuffix();
-        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM nation", 25);
 
-        List<String> allDataFilesInitially = getAllDataFilesFromTableDirectory(tableName);
-        assertThat(allDataFilesInitially).hasSize(5);
+        // There are 5 distinct region keys, so we expect 5 data files. A 'content' value of 0 corresponds to a data file, and a value of 1
+        // corresponds to a delete file
+        assertQuery(
+                "SELECT content, count(*) FROM \"" + tableName + "$files\" GROUP BY content",
+                "VALUES (0, 5)");
 
+        // Test that OPTIMIZE filtered on the partition column rewrites the corresponding data file and removes the delete file
         assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 7", 1);
+        assertQuery(
+                "SELECT content, count(*) FROM \"" + tableName + "$files\" GROUP BY content",
+                "VALUES (0, 5), (1, 1)");
+
+        Session session = withSingleWriterPerTask(getSession());
+        computeActual(session, "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE WHERE regionkey = 3");
+        assertQuery(
+                "SELECT content, count(*) FROM \"" + tableName + "$files\" GROUP BY content",
+                "VALUES (0, 5)");
+
+        // Test that OPTIMIZE using the $partition column rewrites the corresponding data file and removes the delete file
+        assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 8", 1);
+        assertQuery(
+                "SELECT content, count(*) FROM \"" + tableName + "$files\" GROUP BY content",
+                "VALUES (0, 5), (1, 1)");
+
+        computeActual(session, "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE WHERE \"$partition\" = 'regionkey=2'");
+        assertQuery(
+                "SELECT content, count(*) FROM \"" + tableName + "$files\" GROUP BY content",
+                "VALUES (0, 5)");
 
         assertQuery(
-                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
-                "VALUES '1'");
-
-        List<String> allDataFilesAfterDelete = getAllDataFilesFromTableDirectory(tableName);
-        assertThat(allDataFilesAfterDelete).hasSize(6);
-
-        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
-        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE WHERE regionkey = 3");
-        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
-        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
-
-        assertQuery(
-                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
-                "VALUES '0'");
-        List<String> allDataFilesAfterOptimizeWithWhere = getAllDataFilesFromTableDirectory(tableName);
-        assertThat(allDataFilesAfterOptimizeWithWhere)
-                .hasSize(5)
-                .doesNotContain(allDataFilesInitially.stream().filter(file -> file.contains("regionkey=3"))
-                        .toArray(String[]::new))
-                .contains(allDataFilesInitially.stream().filter(file -> !file.contains("regionkey=3"))
-                        .toArray(String[]::new));
-
-        assertThat(query("SELECT * FROM " + tableName))
-                .matches("SELECT * FROM nation WHERE nationkey != 7");
-
-        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
-        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
-        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
-        computeActual(sessionWithShortRetentionUnlocked, "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
-
-        assertQuery(
-                "SELECT summary['total-delete-files'] FROM \"" + tableName + "$snapshots\" WHERE snapshot_id = " + getCurrentSnapshotId(tableName),
-                "VALUES '0'");
-        List<String> allDataFilesAfterFullOptimize = getAllDataFilesFromTableDirectory(tableName);
-        assertThat(allDataFilesAfterFullOptimize)
-                .hasSize(5)
-                // All files skipped from OPTIMIZE as they have no deletes and there's only one file per partition
-                .contains(allDataFilesAfterOptimizeWithWhere.toArray(new String[0]));
-
-        assertThat(query("SELECT * FROM " + tableName))
-                .matches("SELECT * FROM nation WHERE nationkey != 7");
-
+                "SELECT * FROM " + tableName,
+                "SELECT * FROM nation WHERE nationkey NOT IN (7, 8)");
         assertUpdate("DROP TABLE " + tableName);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes #27732 . Corrects an underlying bug that only affected predicates using the `$partition` column.

I updated an existing test to verify this behavior, as the test previously obscured this bug by using `EXECUTE REMOVE_ORPHAN_FILES`, which removes the dangling deletes that should've been removed by `OPTIMIZE`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

I believe the logic used to determine whether a position delete is fully applied is faulty, but **I could use a careful review here to verify my understanding.**

From the comment on line 348: `OPTIMIZE supports only enforced predicates which select whole partitions, so if there is no path or fileModifiedTime predicate, then we can clean up position deletes`

This seems to contradict the logic on line 351: `case POSITION_DELETES -> partitionDomain.isAll() && pathDomain.isAll() && fileModifiedTimeDomain.isAll();`

As I understand this, `partitionDomain.isAll()` just checks whether there is any filter on the `$partition` column. As position delete files are only granular to the partition level, just checking the path and fileModifiedTime domains should be sufficient, as that would mean we're fully covering the partition. 

For predicates on the filter column (i.e. not using `$partition`), `partitionDomain.isAll()` is true, because we are not explicitly filtering on the `$partition` column. This is why the bug doesn't surface for these predicates.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
