### PR TITLE
Support anonymous S3 access via the s3.auth-type property

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -104,12 +104,6 @@ support:
 * - `s3.max-error-retries`
   - Specifies maximum number of retries the client will make on errors.
     Defaults to `20`.
-* - `s3.use-web-identity-token-credentials-provider`
-  - Set to `true` to only use the web identity token credentials provider,
-    instead of the default providers chain. This can be useful when running
-    Trino on Amazon EKS and using [IAM roles for service accounts
-    (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
-    Defaults to `false`.
 * - `s3.application-id`
   - Specify the application identifier appended to the `User-Agent` header 
     for all requests sent to S3. Defaults to `Trino`.
@@ -118,7 +112,10 @@ support:
 ## Authentication
 
 Use the following properties to configure the authentication to S3 with access
-and secret keys, STS, or an IAM role:
+and secret keys, STS, or an IAM role. The access key, secret key, STS, and
+external ID properties are only used by the `DEFAULT` and `IAM_ROLE`
+authentication modes; setting any of them for `ANONYMOUS` or `WEB_IDENTITY`
+fails at startup.
 
 :::{list-table}
 :widths: 40, 60
@@ -136,12 +133,24 @@ and secret keys, STS, or an IAM role:
 * - `s3.sts.region`
   - AWS region of the STS service.
 * - `s3.iam-role`
-  - ARN of an IAM role to assume when connecting to S3.
+  - ARN of an IAM role to assume when connecting to S3. Requires
+    `s3.auth-type=IAM_ROLE`.
 * - `s3.role-session-name`
   - Role session name to use when connecting to S3. Defaults to
     `trino-filesystem`.
 * - `s3.external-id`
   - External ID for the IAM role trust policy when connecting to S3.
+* - `s3.auth-type`
+  - Authentication mode for accessing S3, one of:
+
+    - `ANONYMOUS`: sends no credentials, for reading public buckets.
+    - `DEFAULT` (default): uses the static access keys when set, otherwise the
+      AWS default credentials chain. Security mapping roles are still honored.
+    - `IAM_ROLE`: assumes the IAM role configured in `s3.iam-role`.
+    - `WEB_IDENTITY`: uses the web identity token file credentials provider
+      instead of the default credentials chain. Useful when running Trino on
+      Amazon EKS with [IAM roles for service accounts
+      (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 :::
 
 ## Security mapping

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -42,7 +42,10 @@ import static software.amazon.awssdk.awscore.retry.AwsRetryStrategy.adaptiveRetr
 import static software.amazon.awssdk.awscore.retry.AwsRetryStrategy.legacyRetryStrategy;
 import static software.amazon.awssdk.awscore.retry.AwsRetryStrategy.standardRetryStrategy;
 
-@DefunctConfig("s3.exclusive-create")
+@DefunctConfig({
+        "s3.exclusive-create",
+        "s3.use-web-identity-token-credentials-provider",
+})
 public class S3FileSystemConfig
 {
     public enum S3SseType
@@ -115,6 +118,14 @@ public class S3FileSystemConfig
         }
     }
 
+    public enum S3AuthType
+    {
+        DEFAULT,
+        IAM_ROLE,
+        WEB_IDENTITY,
+        ANONYMOUS,
+    }
+
     public enum RetryMode
     {
         STANDARD,
@@ -145,7 +156,7 @@ public class S3FileSystemConfig
     private S3SseType sseType = S3SseType.NONE;
     private String sseKmsKeyId;
     private String sseCustomerKey;
-    private boolean useWebIdentityTokenCredentialsProvider;
+    private S3AuthType authType = S3AuthType.DEFAULT;
     private SignerType signerType;
     private DataSize streamingPartSize = DataSize.of(32, MEGABYTE);
     private boolean requesterPays;
@@ -372,15 +383,16 @@ public class S3FileSystemConfig
         return this;
     }
 
-    public boolean isUseWebIdentityTokenCredentialsProvider()
+    public S3AuthType getAuthType()
     {
-        return useWebIdentityTokenCredentialsProvider;
+        return authType;
     }
 
-    @Config("s3.use-web-identity-token-credentials-provider")
-    public S3FileSystemConfig setUseWebIdentityTokenCredentialsProvider(boolean useWebIdentityTokenCredentialsProvider)
+    @Config("s3.auth-type")
+    @ConfigDescription("Authentication mode for accessing S3")
+    public S3FileSystemConfig setAuthType(S3AuthType authType)
     {
-        this.useWebIdentityTokenCredentialsProvider = useWebIdentityTokenCredentialsProvider;
+        this.authType = authType;
         return this;
     }
 
@@ -403,6 +415,26 @@ public class S3FileSystemConfig
     {
         if (sseType == S3SseType.CUSTOMER) {
             return sseCustomerKey != null;
+        }
+        return true;
+    }
+
+    @AssertTrue(message = "s3.iam-role must be set when, and only when, s3.auth-type=IAM_ROLE")
+    public boolean isIamRolePresenceValid()
+    {
+        return (authType == S3AuthType.IAM_ROLE) == (iamRole != null);
+    }
+
+    @AssertTrue(message = "s3.auth-type=ANONYMOUS and s3.auth-type=WEB_IDENTITY cannot be used with other authentication properties (s3.aws-access-key, s3.aws-secret-key, s3.external-id, s3.sts.endpoint, s3.sts.region)")
+    public boolean isCredentialFreeAuthTypeValid()
+    {
+        // s3.external-id and s3.sts.* remain allowed under DEFAULT for security-mapping roles.
+        if (authType == S3AuthType.ANONYMOUS || authType == S3AuthType.WEB_IDENTITY) {
+            return awsAccessKey == null &&
+                    awsSecretKey == null &&
+                    externalId == null &&
+                    stsEndpoint == null &&
+                    stsRegion == null;
         }
         return true;
     }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -20,8 +20,10 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.s3.S3Context.S3SseContext;
+import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
 import io.trino.filesystem.s3.S3FileSystemConfig.SignerType;
 import jakarta.annotation.PreDestroy;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
@@ -161,7 +163,7 @@ final class S3FileSystemLoader
         Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
         Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
         boolean pathStyleAccess = config.isPathStyleAccess();
-        boolean useWebIdentityTokenCredentialsProvider = config.isUseWebIdentityTokenCredentialsProvider();
+        S3AuthType authType = config.getAuthType();
         Optional<String> staticIamRole = Optional.ofNullable(config.getIamRole());
         String staticRoleSessionName = config.getRoleSessionName();
         String externalId = config.getExternalId();
@@ -191,23 +193,27 @@ final class S3FileSystemLoader
             endpoint.map(URI::create).ifPresent(s3::endpointOverride);
             s3.forcePathStyle(pathStyleAccess);
 
-            if (useWebIdentityTokenCredentialsProvider) {
-                s3.credentialsProvider(WebIdentityTokenFileCredentialsProvider.builder()
+            switch (authType) {
+                case ANONYMOUS -> s3.credentialsProvider(AnonymousCredentialsProvider.create());
+                case WEB_IDENTITY -> s3.credentialsProvider(WebIdentityTokenFileCredentialsProvider.builder()
                         .asyncCredentialUpdateEnabled(true)
                         .build());
-            }
-            else if (iamRole.isPresent()) {
-                s3.credentialsProvider(StsAssumeRoleCredentialsProvider.builder()
-                        .refreshRequest(request -> request
-                                .roleArn(iamRole.get())
-                                .roleSessionName(roleSessionName)
-                                .externalId(externalId))
-                        .stsClient(createStsClient(config, credentialsProvider))
-                        .asyncCredentialUpdateEnabled(true)
-                        .build());
-            }
-            else {
-                credentialsProvider.ifPresent(s3::credentialsProvider);
+                case IAM_ROLE, DEFAULT -> {
+                    // A security mapping may supply a per-request IAM role even when the static auth type is DEFAULT.
+                    if (iamRole.isPresent()) {
+                        s3.credentialsProvider(StsAssumeRoleCredentialsProvider.builder()
+                                .refreshRequest(request -> request
+                                        .roleArn(iamRole.get())
+                                        .roleSessionName(roleSessionName)
+                                        .externalId(externalId))
+                                .stsClient(createStsClient(config, credentialsProvider))
+                                .asyncCredentialUpdateEnabled(true)
+                                .build());
+                    }
+                    else {
+                        credentialsProvider.ifPresent(s3::credentialsProvider);
+                    }
+                }
             }
 
             return s3.build();

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
@@ -13,6 +13,8 @@
  */
 package io.trino.filesystem.s3;
 
+import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -38,7 +40,7 @@ final class S3FileSystemUtils
         Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
         Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
         boolean pathStyleAccess = config.isPathStyleAccess();
-        boolean useWebIdentityTokenCredentialsProvider = config.isUseWebIdentityTokenCredentialsProvider();
+        S3AuthType authType = config.getAuthType();
         Optional<String> staticIamRole = Optional.ofNullable(config.getIamRole());
         String staticRoleSessionName = config.getRoleSessionName();
         String externalId = config.getExternalId();
@@ -52,23 +54,20 @@ final class S3FileSystemUtils
                 .pathStyleAccessEnabled(pathStyleAccess)
                 .build());
 
-        if (useWebIdentityTokenCredentialsProvider) {
-            s3.credentialsProvider(WebIdentityTokenFileCredentialsProvider.builder()
+        switch (authType) {
+            case ANONYMOUS -> s3.credentialsProvider(AnonymousCredentialsProvider.create());
+            case WEB_IDENTITY -> s3.credentialsProvider(WebIdentityTokenFileCredentialsProvider.builder()
                     .asyncCredentialUpdateEnabled(true)
                     .build());
-        }
-        else if (staticIamRole.isPresent()) {
-            s3.credentialsProvider(StsAssumeRoleCredentialsProvider.builder()
+            case IAM_ROLE -> s3.credentialsProvider(StsAssumeRoleCredentialsProvider.builder()
                     .refreshRequest(request -> request
-                            .roleArn(staticIamRole.get())
+                            .roleArn(staticIamRole.orElseThrow())
                             .roleSessionName(staticRoleSessionName)
                             .externalId(externalId))
                     .stsClient(createStsClient(config, staticCredentialsProvider))
                     .asyncCredentialUpdateEnabled(true)
                     .build());
-        }
-        else {
-            staticCredentialsProvider.ifPresent(s3::credentialsProvider);
+            case DEFAULT -> staticCredentialsProvider.ifPresent(s3::credentialsProvider);
         }
 
         return s3.build();

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAnonymous.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemAnonymous.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.containers.Minio;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Exercises {@code s3.auth-type=ANONYMOUS} against MinIO, which enforces auth.
+ * Anonymous reads succeed only against a bucket with a public-read policy, so this
+ * verifies the request is genuinely unsigned rather than falling back to credentials.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestS3FileSystemAnonymous
+{
+    private static final String PUBLIC_BUCKET = "public-bucket";
+    private static final String PRIVATE_BUCKET = "private-bucket";
+    private static final String KNOWN_KEY = "directory/known-file.txt";
+    private static final byte[] KNOWN_CONTENT = "anonymous read works".getBytes(StandardCharsets.UTF_8);
+
+    private Minio minio;
+    private S3FileSystemFactory fileSystemFactory;
+    private TrinoFileSystem fileSystem;
+
+    @BeforeAll
+    void init()
+    {
+        minio = Minio.builder().build();
+        minio.start();
+        try (S3Client s3Client = createAdminClient()) {
+            s3Client.createBucket(builder -> builder.bucket(PUBLIC_BUCKET));
+            s3Client.putBucketPolicy(builder -> builder.bucket(PUBLIC_BUCKET).policy(publicReadPolicy(PUBLIC_BUCKET)));
+            s3Client.putObject(builder -> builder.bucket(PUBLIC_BUCKET).key(KNOWN_KEY), RequestBody.fromBytes(KNOWN_CONTENT));
+
+            s3Client.createBucket(builder -> builder.bucket(PRIVATE_BUCKET));
+            s3Client.putObject(builder -> builder.bucket(PRIVATE_BUCKET).key(KNOWN_KEY), RequestBody.fromBytes(KNOWN_CONTENT));
+        }
+
+        fileSystemFactory = new S3FileSystemFactory(
+                OpenTelemetry.noop(),
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setEndpoint(minio.getMinioAddress())
+                        .setRegion(Minio.MINIO_REGION)
+                        .setPathStyleAccess(true),
+                new S3FileSystemStats());
+        fileSystem = fileSystemFactory.create(ConnectorIdentity.ofUser("test"));
+    }
+
+    @AfterAll
+    void cleanup()
+    {
+        fileSystem = null;
+        if (fileSystemFactory != null) {
+            fileSystemFactory.destroy();
+            fileSystemFactory = null;
+        }
+        if (minio != null) {
+            minio.close();
+            minio = null;
+        }
+    }
+
+    @Test
+    void testAnonymousRead()
+            throws IOException
+    {
+        TrinoInputFile inputFile = fileSystem.newInputFile(Location.of("s3://%s/%s".formatted(PUBLIC_BUCKET, KNOWN_KEY)));
+        assertThat(inputFile.exists()).isTrue();
+        assertThat(inputFile.length()).isEqualTo(KNOWN_CONTENT.length);
+        try (TrinoInputStream inputStream = inputFile.newStream()) {
+            assertThat(inputStream.readAllBytes()).isEqualTo(KNOWN_CONTENT);
+        }
+    }
+
+    @Test
+    void testAnonymousListDirectories()
+            throws IOException
+    {
+        assertThat(fileSystem.listDirectories(Location.of("s3://%s/".formatted(PUBLIC_BUCKET))))
+                .contains(Location.of("s3://%s/directory/".formatted(PUBLIC_BUCKET)));
+    }
+
+    @Test
+    void testAnonymousReadDeniedOnPrivateBucket()
+    {
+        // Object exists in the bucket, so a 403 proves the request was genuinely anonymous rather than falling back to credentials.
+        TrinoInputFile inputFile = fileSystem.newInputFile(Location.of("s3://%s/%s".formatted(PRIVATE_BUCKET, KNOWN_KEY)));
+        assertThatThrownBy(() -> {
+            try (TrinoInputStream inputStream = inputFile.newStream()) {
+                inputStream.readAllBytes();
+            }
+        })
+                .isInstanceOf(IOException.class)
+                .cause()
+                .isInstanceOf(SdkServiceException.class)
+                .extracting(cause -> ((SdkServiceException) cause).statusCode())
+                .isEqualTo(403);
+    }
+
+    @Test
+    void testAnonymousListDirectoriesDeniedOnPrivateBucket()
+    {
+        assertThatThrownBy(() -> fileSystem.listDirectories(Location.of("s3://%s/".formatted(PRIVATE_BUCKET))))
+                .isInstanceOf(IOException.class)
+                .cause()
+                .isInstanceOf(SdkServiceException.class)
+                .extracting(cause -> ((SdkServiceException) cause).statusCode())
+                .isEqualTo(403);
+    }
+
+    private S3Client createAdminClient()
+    {
+        return S3Client.builder()
+                .endpointOverride(URI.create(minio.getMinioAddress()))
+                .region(Region.of(Minio.MINIO_REGION))
+                .forcePathStyle(true)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(Minio.MINIO_ROOT_USER, Minio.MINIO_ROOT_PASSWORD)))
+                .build();
+    }
+
+    private static String publicReadPolicy(String bucket)
+    {
+        return """
+               {
+                   "Version": "2012-10-17",
+                   "Statement": [{
+                       "Effect": "Allow",
+                       "Principal": {"AWS": ["*"]},
+                       "Action": ["s3:GetObject", "s3:ListBucket"],
+                       "Resource": ["arn:aws:s3:::%s/*", "arn:aws:s3:::%s"]
+                   }]
+               }""".formatted(bucket, bucket);
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -18,17 +18,20 @@ import com.google.common.net.HostAndPort;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.filesystem.s3.S3FileSystemConfig.ObjectCannedAcl;
+import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
 import io.trino.filesystem.s3.S3FileSystemConfig.S3SseType;
 import io.trino.filesystem.s3.S3FileSystemConfig.StorageClassType;
 import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static io.airlift.testing.ValidationAssertions.assertValidates;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.LEGACY;
 import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.STANDARD;
@@ -59,7 +62,7 @@ public class TestS3FileSystemConfig
                 .setRetryMode(LEGACY)
                 .setMaxErrorRetries(20)
                 .setSseKmsKeyId(null)
-                .setUseWebIdentityTokenCredentialsProvider(false)
+                .setAuthType(S3AuthType.DEFAULT)
                 .setSseCustomerKey(null)
                 .setStreamingPartSize(DataSize.of(32, MEGABYTE))
                 .setRequesterPays(false)
@@ -79,20 +82,12 @@ public class TestS3FileSystemConfig
                 .setApplicationId("Trino"));
     }
 
-    @Test
-    public void testExplicitPropertyMappings()
+    private static void addCommonProperties(ImmutableMap.Builder<String, String> builder)
     {
-        Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("s3.aws-access-key", "abc123")
-                .put("s3.aws-secret-key", "secret")
-                .put("s3.endpoint", "endpoint.example.com")
+        builder.put("s3.endpoint", "endpoint.example.com")
                 .put("s3.region", "eu-central-1")
                 .put("s3.path-style-access", "true")
-                .put("s3.iam-role", "myrole")
                 .put("s3.role-session-name", "mysession")
-                .put("s3.external-id", "myid")
-                .put("s3.sts.endpoint", "sts.example.com")
-                .put("s3.sts.region", "us-west-2")
                 .put("s3.storage-class", "STANDARD_IA")
                 .put("s3.signer-type", "Aws4Signer")
                 .put("s3.canned-acl", "BUCKET_OWNER_FULL_CONTROL")
@@ -101,7 +96,6 @@ public class TestS3FileSystemConfig
                 .put("s3.sse.type", "KMS")
                 .put("s3.sse.kms-key-id", "mykey")
                 .put("s3.sse.customer-key", "customerKey")
-                .put("s3.use-web-identity-token-credentials-provider", "true")
                 .put("s3.streaming.part-size", "42MB")
                 .put("s3.requester-pays", "true")
                 .put("s3.max-connections", "42")
@@ -117,20 +111,16 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.password", "test")
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .put("s3.application-id", "application id")
-                .put("s3.cross-region-access", "true")
-                .buildOrThrow();
+                .put("s3.cross-region-access", "true");
+    }
 
-        S3FileSystemConfig expected = new S3FileSystemConfig()
-                .setAwsAccessKey("abc123")
-                .setAwsSecretKey("secret")
+    private static S3FileSystemConfig setCommonConfig(S3FileSystemConfig config)
+    {
+        return config
                 .setEndpoint("endpoint.example.com")
                 .setRegion("eu-central-1")
                 .setPathStyleAccess(true)
-                .setIamRole("myrole")
                 .setRoleSessionName("mysession")
-                .setExternalId("myid")
-                .setStsEndpoint("sts.example.com")
-                .setStsRegion("us-west-2")
                 .setStorageClass(STANDARD_IA)
                 .setSignerType(Aws4Signer)
                 .setCannedAcl(ObjectCannedAcl.BUCKET_OWNER_FULL_CONTROL)
@@ -139,7 +129,6 @@ public class TestS3FileSystemConfig
                 .setMaxErrorRetries(12)
                 .setSseType(S3SseType.KMS)
                 .setSseKmsKeyId("mykey")
-                .setUseWebIdentityTokenCredentialsProvider(true)
                 .setSseCustomerKey("customerKey")
                 .setRequesterPays(true)
                 .setMaxConnections(42)
@@ -156,8 +145,52 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPreemptiveBasicProxyAuth(true)
                 .setCrossRegionAccessEnabled(true)
                 .setApplicationId("application id");
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
+                .put("s3.auth-type", "IAM_ROLE")
+                .put("s3.aws-access-key", "abc123")
+                .put("s3.aws-secret-key", "secret")
+                .put("s3.iam-role", "myrole")
+                .put("s3.external-id", "myid")
+                .put("s3.sts.endpoint", "sts.example.com")
+                .put("s3.sts.region", "us-west-2");
+        addCommonProperties(builder);
+        Map<String, String> properties = builder.buildOrThrow();
+
+        S3FileSystemConfig expected = setCommonConfig(new S3FileSystemConfig()
+                .setAuthType(S3AuthType.IAM_ROLE)
+                .setAwsAccessKey("abc123")
+                .setAwsSecretKey("secret")
+                .setIamRole("myrole")
+                .setExternalId("myid")
+                .setStsEndpoint("sts.example.com")
+                .setStsRegion("us-west-2"));
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testAnonymousAuthTypeMapping()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
+                .put("s3.auth-type", "ANONYMOUS");
+        addCommonProperties(builder);
+        Map<String, String> properties = builder.buildOrThrow();
+
+        S3FileSystemConfig expected = setCommonConfig(new S3FileSystemConfig()
+                .setAuthType(S3AuthType.ANONYMOUS));
+
+        assertFullMapping(properties, expected, Set.of(
+                "s3.aws-access-key",
+                "s3.aws-secret-key",
+                "s3.iam-role",
+                "s3.external-id",
+                "s3.sts.endpoint",
+                "s3.sts.region"));
     }
 
     @Test
@@ -168,5 +201,127 @@ public class TestS3FileSystemConfig
                 "sseWithCustomerKeyConfigValid",
                 "s3.sse.customer-key has to be set for server-side encryption with customer-provided key",
                 AssertTrue.class);
+    }
+
+    private static final String CREDENTIAL_FREE_MESSAGE = "s3.auth-type=ANONYMOUS and s3.auth-type=WEB_IDENTITY cannot be used with other authentication properties (s3.aws-access-key, s3.aws-secret-key, s3.external-id, s3.sts.endpoint, s3.sts.region)";
+    private static final String IAM_ROLE_MESSAGE = "s3.iam-role must be set when, and only when, s3.auth-type=IAM_ROLE";
+
+    @Test
+    public void testAnonymousAuthTypeWithAccessKey()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setAwsAccessKey("test-key"),
+                "credentialFreeAuthTypeValid",
+                CREDENTIAL_FREE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testAnonymousAuthTypeWithSecretKey()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setAwsSecretKey("test-secret"),
+                "credentialFreeAuthTypeValid",
+                CREDENTIAL_FREE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testAnonymousAuthTypeWithExternalId()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setExternalId("external-id"),
+                "credentialFreeAuthTypeValid",
+                CREDENTIAL_FREE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testAnonymousAuthTypeWithStsEndpoint()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setStsEndpoint("sts.example.com"),
+                "credentialFreeAuthTypeValid",
+                CREDENTIAL_FREE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testAnonymousAuthTypeWithStsRegion()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setStsRegion("us-west-2"),
+                "credentialFreeAuthTypeValid",
+                CREDENTIAL_FREE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testWebIdentityAuthTypeWithAccessKey()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.WEB_IDENTITY)
+                        .setAwsAccessKey("test-key"),
+                "credentialFreeAuthTypeValid",
+                CREDENTIAL_FREE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testAnonymousAuthTypeWithIamRole()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.ANONYMOUS)
+                        .setIamRole("arn:aws:iam::123456789012:role/test"),
+                "iamRolePresenceValid",
+                IAM_ROLE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testIamRoleAuthTypeWithoutIamRole()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.IAM_ROLE),
+                "iamRolePresenceValid",
+                IAM_ROLE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testDefaultAuthTypeWithIamRole()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.DEFAULT)
+                        .setIamRole("arn:aws:iam::123456789012:role/test"),
+                "iamRolePresenceValid",
+                IAM_ROLE_MESSAGE,
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testDefaultAuthTypeAllowsStsOverridesForMappedRoles()
+    {
+        // s3.external-id and s3.sts.* support security-mapping roles in the DEFAULT branch.
+        assertValidates(
+                new S3FileSystemConfig()
+                        .setAuthType(S3AuthType.DEFAULT)
+                        .setExternalId("external-id")
+                        .setStsEndpoint("sts.example.com")
+                        .setStsRegion("us-west-2"));
     }
 }


### PR DESCRIPTION
## Description
Adds support for accessing public S3 buckets anonymously, and generalizes S3 authentication selection into a single `s3.auth-type` configuration property.

Previously the native S3 file system always used the AWS credential provider chain, which fails to initialize when no credentials are present, blocking access to public datasets that require no authentication.

`s3.auth-type` accepts:
- `DEFAULT` (default): static access key when configured, otherwise the AWS default credential provider chain.
- `IAM_ROLE`: assume the role configured in `s3.iam-role`.
- `WEB_IDENTITY`: web identity token file credentials.
- `ANONYMOUS`: unsigned requests against public buckets via `AnonymousCredentialsProvider`.

`s3.auth-type` is the single source of truth and defaults to `DEFAULT`. The available authentication properties depend on the chosen mode: `s3.iam-role` requires `IAM_ROLE`, and each mode rejects properties that belong to another, so a misconfiguration fails validation rather than silently picking a credential source.

Backward-incompatible changes:
- `s3.iam-role` now requires `s3.auth-type=IAM_ROLE`; configs that set `s3.iam-role` without an auth type must add it.
- `s3.use-web-identity-token-credentials-provider` is removed (defunct); use `s3.auth-type=WEB_IDENTITY`.

## Additional context and related issues
Fixes: https://github.com/trinodb/trino/issues/27512

- Adds the `S3AuthType` enum and the `s3.auth-type` property to `S3FileSystemConfig`, with per-mode validation of the allowed authentication properties.
- Routes credential selection in `S3FileSystemLoader` and the presigner in `S3FileSystemUtils` through `s3.auth-type`.
- Makes `s3.use-web-identity-token-credentials-provider` defunct in favor of `s3.auth-type=WEB_IDENTITY`.
- Documents the property and its modes.
- Adds configuration mapping and validation tests, plus `TestS3FileSystemAnonymous`, which uses a MinIO container with a public-read bucket policy to exercise the anonymous path (a read of a private bucket returns 403, proving the request is genuinely unsigned).

Verified against a Hive catalog configured with `s3.auth-type=ANONYMOUS` reading the public NOAA bucket:
```
trino:default> CREATE CATALOG hive USING hive
               WITH (
                   "hive.metastore" = 'file',
                   "fs.s3.enabled" = 'true',
                   "s3.region" = 'us-east-1',
                   "s3.auth-type" = 'ANONYMOUS'
               );

trino:default> CREATE TABLE hive.default.noaa_test (
            ->       id VARCHAR,
            ->       date VARCHAR,
            ->       element VARCHAR,
            ->       data_value INTEGER
            ->   )
            ->   WITH (
            ->       format = 'PARQUET',
            ->       external_location = 's3://noaa-ghcn-pds/parquet/by_year/YEAR=2024/ELEMENT=TMAX/'
            ->   );
CREATE TABLE

trino:default> SELECT * FROM hive.default.noaa_test LIMIT 5;
     id      |   date   | element | data_value
-------------+----------+---------+------------
 USC00307383 | 20241222 | NULL    |        -11
 AE000041196 | 20240101 | NULL    |        278
 AEM00041218 | 20240101 | NULL    |        275
 AGE00147716 | 20240101 | NULL    |        203
 AEM00041194 | 20240101 | NULL    |        277
(5 rows)
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Object Storage
* Add the `s3.auth-type` configuration property to select the S3 authentication mode, including `ANONYMOUS` for accessing public buckets. ({issue}`27512`)
* {{breaking}} Require `s3.auth-type=IAM_ROLE` when `s3.iam-role` is set.
* {{breaking}} Remove the `s3.use-web-identity-token-credentials-provider` configuration property. Use `s3.auth-type=WEB_IDENTITY` instead.
```



