### PR TITLE
Fix rollback failure message in `DefaultJdbcMetadata`

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -1275,7 +1275,7 @@ public class DefaultJdbcMetadata
             }
         }
         if (!exceptions.isEmpty()) {
-            TrinoException trinoException = new TrinoException(JDBC_ERROR, "Error rollback for merge");
+            TrinoException trinoException = new TrinoException(JDBC_ERROR, "Error rollback");
             exceptions.forEach(trinoException::addSuppressed);
             throw trinoException;
         }


### PR DESCRIPTION
The rollback is not only used by `MERGE`

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
