### PR TITLE
Update Parquet to 1.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.okhttp.version>5.3.2</dep.okhttp.version>
         <dep.okio.version>3.16.4</dep.okio.version>
-        <dep.parquet.version>1.16.0</dep.parquet.version>
+        <dep.parquet.version>1.17.0</dep.parquet.version>
         <dep.protobuf.version>3.25.8</dep.protobuf.version>
         <dep.swagger.version>2.2.41</dep.swagger.version>
         <dep.takari.version>2.3.2</dep.takari.version>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
