### PR TITLE
Fix totalOperatorsCount mismatch in duplicated LookupJoinOperatorFactory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -99,6 +99,8 @@ import io.trino.operator.TopNRankingOperator;
 import io.trino.operator.ValuesOperator.ValuesOperatorFactory;
 import io.trino.operator.WindowFunctionDefinition;
 import io.trino.operator.WindowOperator.WindowOperatorFactory;
+import io.trino.operator.WorkProcessorOperatorAdapter;
+import io.trino.operator.WorkProcessorOperatorFactory;
 import io.trino.operator.aggregation.AccumulatorFactory;
 import io.trino.operator.aggregation.AggregatorFactory;
 import io.trino.operator.aggregation.DistinctAccumulatorFactory;
@@ -123,6 +125,7 @@ import io.trino.operator.index.IndexSourceOperator;
 import io.trino.operator.join.HashBuilderOperator.HashBuilderOperatorFactory;
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.JoinOperatorFactory;
+import io.trino.operator.join.LookupJoinOperatorFactory;
 import io.trino.operator.join.LookupSourceFactory;
 import io.trino.operator.join.NestedLoopJoinBridge;
 import io.trino.operator.join.NestedLoopJoinPagesSupplier;
@@ -718,34 +721,82 @@ public class LocalExecutionPlanner
             boolean inputDriver = context.isInputDriver();
             OptionalInt driverInstances = context.getDriverInstanceCount();
             List<OperatorFactory> operatorFactories = physicalOperation.getOperatorFactories();
-            addLookupOuterDrivers(outputDriver, operatorFactories);
-            addDriverFactory(inputDriver, outputDriver, operatorFactories, driverInstances);
+
+            // addLookupOuterDrivers may adjust LookupJoinOperatorFactory's totalOperatorsCount
+            // to account for additional operators created by duplicating factories
+            List<OperatorFactory> adjustedFactories = addLookupOuterDrivers(outputDriver, operatorFactories);
+            addDriverFactory(inputDriver, outputDriver, adjustedFactories, driverInstances);
         }
 
-        private void addLookupOuterDrivers(boolean isOutputDriver, List<OperatorFactory> operatorFactories)
+        /**
+         * For an outer join on the lookup side (RIGHT or FULL), adds an additional driver
+         * to output the unused rows in the lookup source.
+         *
+         * When duplicating factories, this method also adjusts the totalOperatorsCount of
+         * LookupJoinOperatorFactory to account for the additional operators that will be
+         * created by the duplicated factories.
+         *
+         * @return the adjusted list of operator factories (with updated totalOperatorsCount)
+         */
+        private List<OperatorFactory> addLookupOuterDrivers(boolean isOutputDriver, List<OperatorFactory> operatorFactories)
         {
-            // For an outer join on the lookup side (RIGHT or FULL) add an additional
-            // driver to output the unused rows in the lookup source
-            for (int i = 0; i < operatorFactories.size(); i++) {
-                OperatorFactory operatorFactory = operatorFactories.get(i);
+            // Use ArrayList to allow in-place modifications
+            List<OperatorFactory> adjustedFactories = new ArrayList<>(operatorFactories);
+
+            for (int i = 0; i < adjustedFactories.size(); i++) {
+                OperatorFactory operatorFactory = adjustedFactories.get(i);
                 if (!(operatorFactory instanceof JoinOperatorFactory lookupJoin)) {
                     continue;
                 }
 
                 Optional<OperatorFactory> outerOperatorFactoryResult = lookupJoin.createOuterOperatorFactory();
                 if (outerOperatorFactoryResult.isPresent()) {
+                    // Before duplicating, adjust the totalOperatorsCount of LookupJoinOperatorFactory
+                    // in the original list. Each outer driver creates 1 additional operator instance
+                    // (outerDriverInstances = 1), so we increment by 1.
+                    for (int j = i + 1; j < adjustedFactories.size(); j++) {
+                        OperatorFactory original = adjustedFactories.get(j);
+                        OperatorFactory adjusted = adjustFactoryIfLookupJoin(original, 1);
+                        if (adjusted != original) {
+                            adjustedFactories.set(j, adjusted);
+                        }
+                    }
+
                     // Add a new driver to output the unmatched rows in an outer join.
                     // We duplicate all of the factories above the JoinOperator (the ones reading from the joins),
                     // and replace the JoinOperator with the OuterOperator (the one that produces unmatched rows).
                     ImmutableList.Builder<OperatorFactory> newOperators = ImmutableList.builder();
                     newOperators.add(outerOperatorFactoryResult.get());
-                    operatorFactories.subList(i + 1, operatorFactories.size()).stream()
+                    adjustedFactories.subList(i + 1, adjustedFactories.size()).stream()
                             .map(OperatorFactory::duplicate)
                             .forEach(newOperators::add);
 
                     addDriverFactory(false, isOutputDriver, newOperators.build(), OptionalInt.of(1));
                 }
             }
+
+            return adjustedFactories;
+        }
+
+        /**
+         * If the factory is a LookupJoinOperatorFactory (directly or wrapped in WorkProcessorOperatorAdapter),
+         * returns a new factory with adjusted totalOperatorsCount.
+         */
+        private static OperatorFactory adjustFactoryIfLookupJoin(OperatorFactory factory, int additionalOperators)
+        {
+            if (factory instanceof LookupJoinOperatorFactory lookupJoin) {
+                return (OperatorFactory) lookupJoin.withAdjustedTotalOperatorsCount(additionalOperators);
+            }
+            if (factory instanceof WorkProcessorOperatorAdapter.Factory adapterFactory) {
+                WorkProcessorOperatorFactory innerFactory = adapterFactory.getWorkProcessorOperatorFactory();
+                if (innerFactory instanceof LookupJoinOperatorFactory lookupJoin) {
+                    LookupJoinOperatorFactory adjusted = lookupJoin.withAdjustedTotalOperatorsCount(additionalOperators);
+                    if (adjusted != lookupJoin) {
+                        return WorkProcessorOperatorAdapter.createAdapterOperatorFactory(adjusted);
+                    }
+                }
+            }
+            return factory;
         }
 
         private void addDriverFactory(boolean inputDriver, boolean outputDriver, List<OperatorFactory> operatorFactories, OptionalInt driverInstances)

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinOperatorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinOperatorFactory.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.join;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import io.trino.operator.NullSafeHashCompiler;
+import io.trino.operator.OperatorFactory;
+import io.trino.operator.WorkProcessorOperatorAdapter;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spiller.GenericPartitioningSpillerFactory;
+import io.trino.spiller.PartitioningSpillerFactory;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.trino.operator.JoinOperatorType.innerJoin;
+import static io.trino.operator.JoinOperatorType.lookupOuterJoin;
+import static io.trino.operator.OperatorFactories.spillingJoin;
+import static io.trino.operator.join.JoinTestUtils.DummySpillerFactory;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestLookupJoinOperatorFactory
+{
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+    private static final NullSafeHashCompiler HASH_COMPILER = new NullSafeHashCompiler(TYPE_OPERATORS);
+    private static final PartitioningSpillerFactory PARTITIONING_SPILLER_FACTORY =
+            new GenericPartitioningSpillerFactory(new DummySpillerFactory());
+
+    @Test
+    public void testWithAdjustedTotalOperatorsCountReturnsNewInstance()
+    {
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.of(8));
+
+        LookupJoinOperatorFactory adjusted = factory.withAdjustedTotalOperatorsCount(1);
+
+        // should return a new instance with adjusted count
+        assertThat(adjusted).isNotSameAs(factory);
+        assertThat(getTotalOperatorsCount(adjusted)).isEqualTo(OptionalInt.of(9));
+        // original should be unchanged
+        assertThat(getTotalOperatorsCount(factory)).isEqualTo(OptionalInt.of(8));
+    }
+
+    @Test
+    public void testWithAdjustedTotalOperatorsCountMultipleAdjustments()
+    {
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.of(8));
+
+        // simulate multiple outer drivers adjusting the same factory
+        LookupJoinOperatorFactory adjusted1 = factory.withAdjustedTotalOperatorsCount(1);
+        LookupJoinOperatorFactory adjusted2 = adjusted1.withAdjustedTotalOperatorsCount(1);
+
+        assertThat(getTotalOperatorsCount(adjusted1)).isEqualTo(OptionalInt.of(9));
+        assertThat(getTotalOperatorsCount(adjusted2)).isEqualTo(OptionalInt.of(10));
+    }
+
+    @Test
+    public void testWithAdjustedTotalOperatorsCountZeroReturnsThis()
+    {
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.of(8));
+
+        LookupJoinOperatorFactory same = factory.withAdjustedTotalOperatorsCount(0);
+
+        // should return the same instance when additionalOperators is 0
+        assertThat(same).isSameAs(factory);
+    }
+
+    @Test
+    public void testWithAdjustedTotalOperatorsCountEmptyReturnsThis()
+    {
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.empty());
+
+        LookupJoinOperatorFactory same = factory.withAdjustedTotalOperatorsCount(1);
+
+        // should return the same instance when totalOperatorsCount is empty
+        assertThat(same).isSameAs(factory);
+    }
+
+    @Test
+    public void testDuplicatePreservesTotalOperatorsCount()
+    {
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.of(8));
+
+        LookupJoinOperatorFactory duplicated = factory.duplicate();
+
+        assertThat(duplicated).isNotSameAs(factory);
+        assertThat(getTotalOperatorsCount(duplicated)).isEqualTo(OptionalInt.of(8));
+    }
+
+    @Test
+    public void testDuplicateAfterAdjustmentPreservesAdjustedCount()
+    {
+        // this is the core scenario that caused the bug:
+        // factory is adjusted before duplication, duplicated factory should have the adjusted count
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.of(8));
+
+        LookupJoinOperatorFactory adjusted = factory.withAdjustedTotalOperatorsCount(1);
+        LookupJoinOperatorFactory duplicated = adjusted.duplicate();
+
+        assertThat(getTotalOperatorsCount(adjusted)).isEqualTo(OptionalInt.of(9));
+        assertThat(getTotalOperatorsCount(duplicated)).isEqualTo(OptionalInt.of(9));
+    }
+
+    @Test
+    public void testOuterOperatorFactoryPresenceForLookupOuterJoin()
+    {
+        LookupJoinOperatorFactory factory = createLookupOuterFactory(OptionalInt.of(8));
+
+        Optional<OperatorFactory> outerFactory = factory.createOuterOperatorFactory();
+
+        // LOOKUP_OUTER join should have an outer operator factory
+        assertThat(outerFactory).isPresent();
+    }
+
+    @Test
+    public void testOuterOperatorFactoryAbsenceForInnerJoin()
+    {
+        LookupJoinOperatorFactory factory = createFactory(OptionalInt.of(8));
+
+        Optional<OperatorFactory> outerFactory = factory.createOuterOperatorFactory();
+
+        // INNER join should not have an outer operator factory
+        assertThat(outerFactory).isEmpty();
+    }
+
+    @Test
+    public void testAddLookupOuterDriversScenario()
+    {
+        // simulate: [OuterJoin1, InnerJoin2] pipeline
+        // when OuterJoin1 creates outer driver, InnerJoin2 gets duplicated
+        // InnerJoin2's totalOperatorsCount should be adjusted from 8 to 9
+        LookupJoinOperatorFactory join1 = createLookupOuterFactory(OptionalInt.of(8));
+        LookupJoinOperatorFactory join2 = createFactory(OptionalInt.of(8));
+
+        assertThat(join1.createOuterOperatorFactory()).isPresent();
+
+        // adjust join2 (simulating what addLookupOuterDrivers does)
+        LookupJoinOperatorFactory adjustedJoin2 = join2.withAdjustedTotalOperatorsCount(1);
+        // duplicate the adjusted factory (for the outer driver)
+        LookupJoinOperatorFactory duplicatedJoin2 = adjustedJoin2.duplicate();
+
+        // both the adjusted and duplicated factories should have correct count
+        assertThat(getTotalOperatorsCount(adjustedJoin2)).isEqualTo(OptionalInt.of(9));
+        assertThat(getTotalOperatorsCount(duplicatedJoin2)).isEqualTo(OptionalInt.of(9));
+        // original join2 should be unchanged
+        assertThat(getTotalOperatorsCount(join2)).isEqualTo(OptionalInt.of(8));
+    }
+
+    @Test
+    public void testAdjustmentWithWorkProcessorOperatorAdapter()
+    {
+        OperatorFactory wrappedFactory = createWrappedFactory(OptionalInt.of(8));
+
+        assertThat(wrappedFactory).isInstanceOf(WorkProcessorOperatorAdapter.Factory.class);
+
+        WorkProcessorOperatorAdapter.Factory adapterFactory = (WorkProcessorOperatorAdapter.Factory) wrappedFactory;
+        LookupJoinOperatorFactory innerFactory = (LookupJoinOperatorFactory) adapterFactory.getWorkProcessorOperatorFactory();
+
+        LookupJoinOperatorFactory adjustedInner = innerFactory.withAdjustedTotalOperatorsCount(1);
+        assertThat(getTotalOperatorsCount(adjustedInner)).isEqualTo(OptionalInt.of(9));
+
+        // create new wrapped factory with adjusted inner
+        OperatorFactory adjustedWrapped = WorkProcessorOperatorAdapter.createAdapterOperatorFactory(adjustedInner);
+        assertThat(adjustedWrapped).isInstanceOf(WorkProcessorOperatorAdapter.Factory.class);
+
+        LookupJoinOperatorFactory newInner = (LookupJoinOperatorFactory)
+                ((WorkProcessorOperatorAdapter.Factory) adjustedWrapped).getWorkProcessorOperatorFactory();
+        assertThat(getTotalOperatorsCount(newInner)).isEqualTo(OptionalInt.of(9));
+    }
+
+    @Test
+    public void testMultipleOuterJoinsInPipeline()
+    {
+        // simulate: [OuterJoin1, OuterJoin2, InnerJoin3]
+        // OuterJoin1 adjusts OuterJoin2 and InnerJoin3
+        // OuterJoin2 adjusts InnerJoin3
+        // so InnerJoin3 should be adjusted twice (from 8 to 10)
+        LookupJoinOperatorFactory join3 = createFactory(OptionalInt.of(8));
+
+        // first adjustment (from OuterJoin1)
+        LookupJoinOperatorFactory adjustedOnce = join3.withAdjustedTotalOperatorsCount(1);
+        assertThat(getTotalOperatorsCount(adjustedOnce)).isEqualTo(OptionalInt.of(9));
+
+        // second adjustment (from OuterJoin2)
+        LookupJoinOperatorFactory adjustedTwice = adjustedOnce.withAdjustedTotalOperatorsCount(1);
+        assertThat(getTotalOperatorsCount(adjustedTwice)).isEqualTo(OptionalInt.of(10));
+    }
+
+    private LookupJoinOperatorFactory createFactory(OptionalInt totalOperatorsCount)
+    {
+        return createFactoryWithType(innerJoin(false, false), totalOperatorsCount);
+    }
+
+    private LookupJoinOperatorFactory createLookupOuterFactory(OptionalInt totalOperatorsCount)
+    {
+        return createFactoryWithType(lookupOuterJoin(false), totalOperatorsCount);
+    }
+
+    private LookupJoinOperatorFactory createFactoryWithType(
+            io.trino.operator.JoinOperatorType joinType,
+            OptionalInt totalOperatorsCount)
+    {
+        List<Type> probeTypes = ImmutableList.of(BIGINT);
+        List<Integer> probeJoinChannels = ImmutableList.of(0);
+        List<Type> hashChannelTypes = probeJoinChannels.stream()
+                .map(probeTypes::get)
+                .toList();
+
+        JoinBridgeManager<PartitionedLookupSourceFactory> bridgeManager = JoinBridgeManager.lookupAllAtOnce(
+                new PartitionedLookupSourceFactory(
+                        probeTypes,
+                        probeTypes,
+                        hashChannelTypes,
+                        1,
+                        false,
+                        HASH_COMPILER));
+
+        return new LookupJoinOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                bridgeManager,
+                probeTypes,
+                probeTypes,
+                probeTypes,
+                joinType,
+                new JoinProbe.JoinProbeFactory(Ints.toArray(ImmutableList.of(0)), probeJoinChannels),
+                HASH_COMPILER,
+                totalOperatorsCount,
+                probeJoinChannels,
+                PARTITIONING_SPILLER_FACTORY);
+    }
+
+    private OperatorFactory createWrappedFactory(OptionalInt totalOperatorsCount)
+    {
+        List<Type> probeTypes = ImmutableList.of(BIGINT);
+        List<Integer> probeJoinChannels = ImmutableList.of(0);
+        List<Type> hashChannelTypes = probeJoinChannels.stream()
+                .map(probeTypes::get)
+                .toList();
+
+        JoinBridgeManager<PartitionedLookupSourceFactory> bridgeManager = JoinBridgeManager.lookupAllAtOnce(
+                new PartitionedLookupSourceFactory(
+                        probeTypes,
+                        probeTypes,
+                        hashChannelTypes,
+                        1,
+                        false,
+                        HASH_COMPILER));
+
+        return spillingJoin(
+                innerJoin(false, false),
+                0,
+                new PlanNodeId("test"),
+                bridgeManager,
+                probeTypes,
+                probeJoinChannels,
+                Optional.empty(),
+                totalOperatorsCount,
+                PARTITIONING_SPILLER_FACTORY,
+                HASH_COMPILER);
+    }
+
+    private OptionalInt getTotalOperatorsCount(LookupJoinOperatorFactory factory)
+    {
+        try {
+            var field = LookupJoinOperatorFactory.class.getDeclaredField("totalOperatorsCount");
+            field.setAccessible(true);
+            return (OptionalInt) field.get(factory);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes a checkState failure in `PartitionedLookupSourceFactory` when multiple LEFT JOINs are executed with Fault-Tolerant Execution (FTE), Spilling and Adaptive Join Reordering enabled.

### Root Cause:
When `AdaptiveReorderPartitionedJoin` transforms a LEFT JOIN to RIGHT JOIN based on runtime statistics, `addLookupOuterDrivers` creates an outer driver and duplicates subsequent `LookupJoinOperatorFactory` instances. The duplicated factories shared the original `totalOperatorsCount`, but the actual number of operators increased due to the outer driver. During spilling, `finishedProbeOperators` exceeded `lookupJoinsCount`, causing a checkState failure.

### Solution:
- Added `LookupJoinOperatorFactory.withAdjustedTotalOperatorsCount()` to create a new factory with an incremented totalOperatorsCount
- Modified `LocalExecutionPlanner.addLookupOuterDrivers()` to adjust totalOperatorsCount of subsequent `LookupJoinOperatorFactory` instances before duplication
- Added helper method `adjustFactoryIfLookupJoin()` to handle both direct and `WorkProcessorOperatorAdapter`-wrapped factories
- Ensures both original and duplicated factories have the correct expected operator count

### Testing:
Added `TestLookupJoinOperatorFactory` with 11 unit and integration tests covering core scenarios


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Reproduction Requirements:
- At least two LEFT JOINs in the query
- First LEFT JOIN gets transformed to RIGHT JOIN by AdaptiveReorderPartitionedJoin (when runtime stats show probeDataSize > buildDataSize)
- FTE mode enabled (retry-policy=TASK)
- Adaptive query planning enabled
- Spilling enabled

Example Query:
```
SELECT order_item_ext_info.datachange_lasttimeFROM baseLEFT JOIN order_item_info ON base.orderid = order_item_info.orderidLEFT JOIN order_item_ext_info ON order_item_info.orderitemid = order_item_ext_info.orderitemidLEFT JOIN order_item_viewspot ON order_item_info.orderitemid = order_item_viewspot.orderitemid
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Query Execution
* Fix `checkState` failure when multiple LEFT JOINs are executed with Fault-Tolerant Execution and Adaptive Join Reordering enabled. The issue occurred when `AdaptiveReorderPartitionedJoin` transformed a LEFT JOIN to RIGHT JOIN, causing subsequent join operator factories to have incorrect `totalOperatorsCount` after duplication.
```
