### PR TITLE
Fix trino-parquet  lib can't read a list-inner-list column

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetColumnIOConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetColumnIOConverter.java
@@ -93,7 +93,7 @@ public final class IcebergParquetColumnIOConverter
             checkArgument(subColumns.size() == 1, "Not an array: %s", context);
             ColumnIdentity elementIdentity = getOnlyElement(subColumns);
             // TODO validate column ID
-            Optional<Field> field = constructField(new FieldContext(arrayType.getElementType(), elementIdentity), getArrayElementColumn(groupColumnIO.getChild(0)));
+            Optional<Field> field = constructField(new FieldContext(arrayType.getElementType(), elementIdentity), getArrayElementColumn(arrayType.getElementType(), groupColumnIO.getChild(0)));
             return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
         }
         PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;


### PR DESCRIPTION
* Fix trino-parquet  lib can't read a list-inner-list column array(array(varchar)) fixes #27766


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
