### PR TITLE
Bump node.js from 22.14.0 to 24.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dep.drift.version>1.24</dep.drift.version>
         <dep.flyway.version>11.19.1</dep.flyway.version>
         <dep.frontend-maven-plugin.version>2.0.0</dep.frontend-maven-plugin.version>
-        <dep.frontend-node.version>v22.14.0</dep.frontend-node.version>
+        <dep.frontend-node.version>v24.12.0</dep.frontend-node.version>
         <dep.frontend-npm.version>11.2.0</dep.frontend-npm.version>
         <dep.httpcore5.version>5.4</dep.httpcore5.version>
         <dep.iceberg.version>1.10.1</dep.iceberg.version>


### PR DESCRIPTION
## Description

bump node.js from 22 to 24.

## Additional context and related issues

Node.js v22 has entered maintenance LTS while v24 is the current active LTS.

Further details:
https://nodejs.org/en/about/previous-releases
https://github.com/nodejs/Release?tab=readme-ov-file#nodejs-release-working-group

**Note**: npm can be upgraded separately or additionally as part of this PR

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
