### PR TITLE
Bump npm from 11.2.0 to 11.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <dep.flyway.version>11.19.1</dep.flyway.version>
         <dep.frontend-maven-plugin.version>2.0.0</dep.frontend-maven-plugin.version>
         <dep.frontend-node.version>v24.12.0</dep.frontend-node.version>
-        <dep.frontend-npm.version>11.2.0</dep.frontend-npm.version>
+        <dep.frontend-npm.version>11.7.0</dep.frontend-npm.version>
         <dep.httpcore5.version>5.4</dep.httpcore5.version>
         <dep.iceberg.version>1.10.1</dep.iceberg.version>
         <dep.jna.version>5.18.1</dep.jna.version>


### PR DESCRIPTION
## Description

Upgrade npm from version 11.2.0 to 11.7.0 to align with the recent node.js 24 update.

## Additional context and related issues

node.js has been bumped to version 24 and updating npm ensures compatibility, access to the latest fixes, and improved stability.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
