### PR TITLE
Rename lastFreshTime to lastKnownFreshTime in MaterializedViewFreshness

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
@@ -196,7 +196,7 @@ public class MaterializedViewSystemTable
                             .map(Enum::name)
                             .orElse(null),
                     // last_fresh_time
-                    freshness.flatMap(MaterializedViewFreshness::getLastFreshTime)
+                    freshness.flatMap(MaterializedViewFreshness::getLastKnownFreshTime)
                             .map(instant -> LongTimestampWithTimeZone.fromEpochSecondsAndFraction(
                                     instant.getEpochSecond(),
                                     (long) instant.getNano() * PICOSECONDS_PER_NANOSECOND,

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2388,8 +2388,8 @@ class StatementAnalyzer
             if (freshness == FRESH || freshness == FRESH_WITHIN_GRACE_PERIOD) {
                 return true;
             }
-            Optional<Instant> lastFreshTime = materializedViewFreshness.getLastFreshTime();
-            if (lastFreshTime.isEmpty()) {
+            Optional<Instant> lastKnownFreshTime = materializedViewFreshness.getLastKnownFreshTime();
+            if (lastKnownFreshTime.isEmpty()) {
                 // E.g. never refreshed, or connector not updated to report fresh time
                 return false;
             }
@@ -2399,13 +2399,13 @@ class StatementAnalyzer
             }
             if (gracePeriodZero) {
                 // Consider 0 as a special value meaning "do not accept any staleness". This makes 0 more reliable, and more likely what user wanted,
-                // regardless of lastFreshTime, query time or rounding.
+                // regardless of lastKnownFreshTime, query time or rounding.
                 return false;
             }
 
             Duration gracePeriod = materializedViewDefinition.getGracePeriod().get();
             // Can be negative
-            Duration staleness = Duration.between(lastFreshTime.get(), session.getStart());
+            Duration staleness = Duration.between(lastKnownFreshTime.get(), session.getStart());
             return staleness.compareTo(gracePeriod) <= 0;
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MaterializedViewFreshness.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MaterializedViewFreshness.java
@@ -23,12 +23,12 @@ import static java.util.Objects.requireNonNull;
 public final class MaterializedViewFreshness
 {
     private final Freshness freshness;
-    private final Optional<Instant> lastFreshTime;
+    private final Optional<Instant> lastKnownFreshTime;
 
-    public MaterializedViewFreshness(Freshness freshness, Optional<Instant> lastFreshTime)
+    public MaterializedViewFreshness(Freshness freshness, Optional<Instant> lastKnownFreshTime)
     {
         this.freshness = requireNonNull(freshness, "freshness is null");
-        this.lastFreshTime = requireNonNull(lastFreshTime, "lastFreshTime is null");
+        this.lastKnownFreshTime = requireNonNull(lastKnownFreshTime, "lastKnownFreshTime is null");
     }
 
     public Freshness getFreshness()
@@ -39,9 +39,18 @@ public final class MaterializedViewFreshness
     /**
      * Last time when the materialized view was known to be fresh.
      */
+    public Optional<Instant> getLastKnownFreshTime()
+    {
+        return lastKnownFreshTime;
+    }
+
+    /**
+     * @deprecated Use {@link #getLastKnownFreshTime()} instead.
+     */
+    @Deprecated
     public Optional<Instant> getLastFreshTime()
     {
-        return lastFreshTime;
+        return getLastKnownFreshTime();
     }
 
     @Override
@@ -55,13 +64,13 @@ public final class MaterializedViewFreshness
         }
         MaterializedViewFreshness that = (MaterializedViewFreshness) obj;
         return freshness == that.freshness
-                && Objects.equals(lastFreshTime, that.lastFreshTime);
+                && Objects.equals(lastKnownFreshTime, that.lastKnownFreshTime);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(freshness, lastFreshTime);
+        return Objects.hash(freshness, lastKnownFreshTime);
     }
 
     @Override
@@ -69,7 +78,7 @@ public final class MaterializedViewFreshness
     {
         return new StringJoiner(", ", MaterializedViewFreshness.class.getSimpleName() + "[", "]")
                 .add("freshness=" + freshness)
-                .add("lastFreshTime=" + lastFreshTime.orElse(null))
+                .add("lastKnownFreshTime=" + lastKnownFreshTime.orElse(null))
                 .toString();
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3974,14 +3974,14 @@ public class IcebergMetadata
             }
         }
 
-        Optional<Instant> lastFreshTime = firstTableChange
+        Optional<Instant> lastKnownFreshTime = firstTableChange
                 .map(Instant::ofEpochMilli)
                 .or(() -> refreshTime);
         if (hasStaleIcebergTables) {
-            return new MaterializedViewFreshness(STALE, lastFreshTime);
+            return new MaterializedViewFreshness(STALE, lastKnownFreshTime);
         }
         if (hasUnknownTables) {
-            return new MaterializedViewFreshness(UNKNOWN, lastFreshTime);
+            return new MaterializedViewFreshness(UNKNOWN, lastKnownFreshTime);
         }
         return new MaterializedViewFreshness(FRESH, Optional.empty());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The original commit (b472e09e2676e1de627f16fd9dda4d5ded4cb11a) introducing this field explained it as "last fresh time" to support connectors which "know when view became no longer fresh."

Renaming to `lastKnownFreshTime` makes this emphasis explicit: this field represents the last point in time when the materialized view was confirmed to be fresh, based on the connector's ability to detect base table changes.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Deprecate `MaterializedViewFreshness#getLastFreshTime`. ({issue}`27803`)
```
