### PR TITLE
Fix prop-type typo for http-client max-content-length

### DIFF
--- a/docs/src/main/sphinx/admin/properties-http-client.md
+++ b/docs/src/main/sphinx/admin/properties-http-client.md
@@ -32,7 +32,7 @@ Timeout value for establishing the connection to the external service.
 
 ### `max-content-length`
 
-- **Type:** [](prop-type-duration)
+- **Type:** [](prop-type-data-size)
 - **Default value:** `16MB`
 
 Maximum content size for each HTTP request and response.


### PR DESCRIPTION
## Description
Wrong prop type, fixed

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: