### PR TITLE
Upgrade Jedis to 7.2.0

### DIFF
--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -81,15 +81,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-pool2</artifactId>
-            <version>2.13.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.1.0</version>
+            <version>7.2.0</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorModule.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorModule.java
@@ -32,7 +32,7 @@ public class RedisConnectorModule
         binder.bind(RedisSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(RedisRecordSetProvider.class).in(Scopes.SINGLETON);
 
-        binder.bind(RedisJedisManager.class).in(Scopes.SINGLETON);
+        binder.bind(RedisClientManager.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(RedisConnectorConfig.class);
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordSet.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordSet.java
@@ -31,7 +31,7 @@ public class RedisRecordSet
         implements RecordSet
 {
     private final RedisSplit split;
-    private final RedisJedisManager jedisManager;
+    private final RedisClientManager clientManager;
 
     private final RowDecoder keyDecoder;
     private final RowDecoder valueDecoder;
@@ -41,14 +41,14 @@ public class RedisRecordSet
 
     RedisRecordSet(
             RedisSplit split,
-            RedisJedisManager jedisManager,
+            RedisClientManager clientManager,
             List<RedisColumnHandle> columnHandles,
             RowDecoder keyDecoder,
             RowDecoder valueDecoder)
     {
         this.split = requireNonNull(split, "split is null");
 
-        this.jedisManager = requireNonNull(jedisManager, "jedisManager is null");
+        this.clientManager = requireNonNull(clientManager, "clientManager is null");
 
         this.keyDecoder = requireNonNull(keyDecoder, "keyDecoder is null");
         this.valueDecoder = requireNonNull(valueDecoder, "valueDecoder is null");
@@ -70,6 +70,6 @@ public class RedisRecordSet
     @Override
     public RecordCursor cursor()
     {
-        return new RedisRecordCursor(keyDecoder, valueDecoder, split, columnHandles, jedisManager);
+        return new RedisRecordCursor(keyDecoder, valueDecoder, split, columnHandles, clientManager);
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordSetProvider.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordSetProvider.java
@@ -39,13 +39,13 @@ public class RedisRecordSetProvider
         implements ConnectorRecordSetProvider
 {
     private final DispatchingRowDecoderFactory decoderFactory;
-    private final RedisJedisManager jedisManager;
+    private final RedisClientManager clientManager;
 
     @Inject
-    public RedisRecordSetProvider(DispatchingRowDecoderFactory decoderFactory, RedisJedisManager jedisManager)
+    public RedisRecordSetProvider(DispatchingRowDecoderFactory decoderFactory, RedisClientManager clientManager)
     {
         this.decoderFactory = requireNonNull(decoderFactory, "decoderFactory is null");
-        this.jedisManager = requireNonNull(jedisManager, "jedisManager is null");
+        this.clientManager = requireNonNull(clientManager, "clientManager is null");
     }
 
     @Override
@@ -77,6 +77,6 @@ public class RedisRecordSetProvider
                                 .filter(col -> !col.isKeyDecoder())
                                 .collect(toImmutableSet())));
 
-        return new RedisRecordSet(redisSplit, jedisManager, redisColumns, keyDecoder, valueDecoder);
+        return new RedisRecordSet(redisSplit, clientManager, redisColumns, keyDecoder, valueDecoder);
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/AbstractTestMinimalFunctionality.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/AbstractTestMinimalFunctionality.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
-import redis.clients.jedis.Jedis;
 
 import java.util.Map;
 import java.util.UUID;
@@ -98,19 +97,18 @@ public abstract class AbstractTestMinimalFunctionality
     {
         JsonEncoder jsonEncoder = new JsonEncoder();
         for (long i = 0; i < count; i++) {
-            Object value = ImmutableMap.of("id", Long.toString(i), "value", UUID.randomUUID().toString());
-            try (Jedis jedis = redisServer.getJedisPool().getResource()) {
-                jedis.set(tableName + ":" + i, jsonEncoder.toString(value));
-                jedis.set(stringValueTableName + ":" + i, jsonEncoder.toString(value));
-                jedis.hmset(hashValueTableName + ":" + i, (Map<String, String>) value);
-            }
+            Map<String, String> value = ImmutableMap.of(
+                    "id", Long.toString(i),
+                    "value", UUID.randomUUID().toString());
+
+            redisServer.getClient().set(tableName + ":" + i, jsonEncoder.toString(value));
+            redisServer.getClient().set(stringValueTableName + ":" + i, jsonEncoder.toString(value));
+            redisServer.getClient().hset(hashValueTableName + ":" + i, value);
         }
     }
 
     protected void clearData()
     {
-        try (Jedis jedis = redisServer.getJedisPool().getResource()) {
-            jedis.flushAll();
-        }
+        redisServer.getClient().flushAll();
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -115,7 +115,7 @@ public final class RedisQueryRunner
                     loadTpchTable(redisServer, trinoClient, table, dataFormat);
                 }
                 log.info("Loading complete in %s", nanosSince(startTime).toString(SECONDS));
-                redisServer.destroyJedisPool();
+                redisServer.closeClient();
                 return queryRunner;
             }
             catch (Throwable e) {

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
@@ -52,7 +52,7 @@ public final class RedisTestUtils
 
     public static void loadTpchTable(RedisServer redisServer, TestingTrinoClient trinoClient, String tableName, QualifiedObjectName tpchTableName, String dataFormat)
     {
-        RedisLoader tpchLoader = new RedisLoader(trinoClient.getServer(), trinoClient.getDefaultSession(), redisServer.getJedisPool(), tableName, dataFormat);
+        RedisLoader tpchLoader = new RedisLoader(trinoClient.getServer(), trinoClient.getDefaultSession(), redisServer.getClient(), tableName, dataFormat);
         tpchLoader.execute(format("SELECT * from %s", tpchTableName));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Migrate deprecated usage of JedisPool and JedisPoolConfig to RedisClient and ConnectionPoolConfig in RedisJedisManager.

Update test utilities to interact with RedisClient directly and ensure resources are closed properly.

Fixes #27784

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
