### PR TITLE
Move gcs-connector to trino-hdfs module

### DIFF
--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -37,7 +37,14 @@
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
+            <version>4.0.0</version>
             <classifier>shaded</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -280,6 +287,34 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <exceptions combine.children="append">
+                        <exception>
+                            <conflictingDependencies>
+                                <dependency>
+                                    <groupId>com.google.cloud.bigdataoss</groupId>
+                                    <artifactId>gcs-connector</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.httpcomponents</groupId>
+                                    <artifactId>httpclient</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.httpcomponents.client5</groupId>
+                                    <artifactId>httpclient5</artifactId>
+                                </dependency>
+                            </conflictingDependencies>
+                            <resources>
+                                <resource>mozilla/public-suffix-list.txt</resource>
+                            </resources>
+                        </exception>
+                    </exceptions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -440,19 +440,6 @@
                 <version>1.11.1</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.google.cloud.bigdataoss</groupId>
-                <artifactId>gcs-connector</artifactId>
-                <version>4.0.0</version>
-                <classifier>shaded</classifier>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <!-- force newer version to be used for dependencies -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -2590,25 +2577,6 @@
                             <exception>
                                 <conflictingDependencies>
                                     <dependency>
-                                        <groupId>com.google.cloud.bigdataoss</groupId>
-                                        <artifactId>gcs-connector</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>org.apache.httpcomponents</groupId>
-                                        <artifactId>httpclient</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>org.apache.httpcomponents.client5</groupId>
-                                        <artifactId>httpclient5</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <resources>
-                                    <resource>mozilla/public-suffix-list.txt</resource>
-                                </resources>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
                                         <groupId>com.github.docker-java</groupId>
                                         <artifactId>docker-java-transport-zerodep</artifactId>
                                     </dependency>
@@ -2619,21 +2587,6 @@
                                 </conflictingDependencies>
                                 <resources>
                                     <resource>org/publicsuffix/list/effective_tld_names.dat</resource>
-                                </resources>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
-                                        <groupId>com.google.api</groupId>
-                                        <artifactId>gax</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>com.google.cloud.bigdataoss</groupId>
-                                        <artifactId>gcs-connector</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <resources>
-                                    <resource>dependencies.properties</resource>
                                 </resources>
                             </exception>
                             <exception>
@@ -2723,28 +2676,6 @@
                                     <package>org.apache.parquet.hadoop.metadata</package>
                                     <package>org.apache.parquet.internal.hadoop.metadata</package>
                                 </packages>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
-                                        <groupId>com.google.cloud.bigdataoss</groupId>
-                                        <artifactId>gcs-connector</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>io.opencensus</groupId>
-                                        <artifactId>opencensus-proto</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <resources>
-                                    <resource>opencensus/proto/agent/common/v1/common.proto</resource>
-                                    <resource>opencensus/proto/agent/metrics/v1/metrics_service.proto</resource>
-                                    <resource>opencensus/proto/agent/trace/v1/trace_service.proto</resource>
-                                    <resource>opencensus/proto/metrics/v1/metrics.proto</resource>
-                                    <resource>opencensus/proto/resource/v1/resource.proto</resource>
-                                    <resource>opencensus/proto/stats/v1/stats.proto</resource>
-                                    <resource>opencensus/proto/trace/v1/trace.proto</resource>
-                                    <resource>opencensus/proto/trace/v1/trace_config.proto</resource>
-                                </resources>
                             </exception>
                             <exception>
                                 <conflictingDependencies>


### PR DESCRIPTION
## Description

We don't declare a dependency in root pom.xml when it's used from single module.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
