### PR TITLE
Make `whenStaleBehavior` non-optional in `MaterializedViewDefinition`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -26,13 +26,16 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior.INLINE;
 import static java.util.Objects.requireNonNull;
 
 public class MaterializedViewDefinition
         extends ViewDefinition
 {
+    public static final WhenStaleBehavior DEFAULT_WHEN_STALE_BEHAVIOR = INLINE;
+
     private final Optional<Duration> gracePeriod;
-    private final Optional<WhenStaleBehavior> whenStaleBehavior;
+    private final WhenStaleBehavior whenStaleBehavior;
     private final Optional<CatalogSchemaTableName> storageTable;
 
     public MaterializedViewDefinition(
@@ -41,7 +44,7 @@ public class MaterializedViewDefinition
             Optional<String> schema,
             List<ViewColumn> columns,
             Optional<Duration> gracePeriod,
-            Optional<WhenStaleBehavior> whenStaleBehavior,
+            WhenStaleBehavior whenStaleBehavior,
             Optional<String> comment,
             Identity owner,
             List<CatalogSchemaName> path,
@@ -59,7 +62,7 @@ public class MaterializedViewDefinition
         return gracePeriod;
     }
 
-    public Optional<WhenStaleBehavior> getWhenStaleBehavior()
+    public WhenStaleBehavior getWhenStaleBehavior()
     {
         return whenStaleBehavior;
     }
@@ -80,7 +83,7 @@ public class MaterializedViewDefinition
                         .map(column -> new ConnectorMaterializedViewDefinition.Column(column.name(), column.type(), column.comment()))
                         .collect(toImmutableList()),
                 getGracePeriod(),
-                whenStaleBehavior,
+                Optional.of(whenStaleBehavior),
                 getComment(),
                 getRunAsIdentity().map(Identity::getUser),
                 getPath());
@@ -95,7 +98,7 @@ public class MaterializedViewDefinition
                 .add("schema", getSchema().orElse(null))
                 .add("columns", getColumns())
                 .add("gracePeriod", gracePeriod.orElse(null))
-                .add("whenStaleBehavior", whenStaleBehavior.orElse(null))
+                .add("whenStaleBehavior", whenStaleBehavior)
                 .add("comment", getComment().orElse(null))
                 .add("runAsIdentity", getRunAsIdentity())
                 .add("path", getPath())

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -160,6 +160,7 @@ import static io.trino.metadata.CatalogStatus.OPERATIONAL;
 import static io.trino.metadata.GlobalFunctionCatalog.BUILTIN_SCHEMA;
 import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
 import static io.trino.metadata.LanguageFunctionManager.isTrinoSqlLanguageFunction;
+import static io.trino.metadata.MaterializedViewDefinition.DEFAULT_WHEN_STALE_BEHAVIOR;
 import static io.trino.metadata.QualifiedObjectName.convertFromSchemaTableName;
 import static io.trino.metadata.RedirectionAwareTableHandle.noRedirection;
 import static io.trino.metadata.RedirectionAwareTableHandle.withRedirectionTo;
@@ -1827,7 +1828,7 @@ public final class MetadataManager
                         .map(column -> new ViewColumn(column.getName(), column.getType(), Optional.empty()))
                         .collect(toImmutableList()),
                 view.getGracePeriod(),
-                view.getWhenStaleBehavior(),
+                view.getWhenStaleBehavior().orElse(DEFAULT_WHEN_STALE_BEHAVIOR),
                 view.getComment(),
                 runAsIdentity,
                 view.getPath(),

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2415,7 +2415,7 @@ class StatementAnalyzer
 
         private static boolean shouldFailWhenStale(MaterializedViewDefinition materializedViewDefinition)
         {
-            WhenStaleBehavior whenStale = materializedViewDefinition.getWhenStaleBehavior().orElse(WhenStaleBehavior.INLINE);
+            WhenStaleBehavior whenStale = materializedViewDefinition.getWhenStaleBehavior();
             return switch (whenStale) {
                 case WhenStaleBehavior.INLINE -> false;
                 case WhenStaleBehavior.FAIL -> true;

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -139,7 +139,6 @@ import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
-import static io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior.INLINE;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.QueryUtil.aliased;
@@ -567,7 +566,7 @@ public final class ShowQueriesRewrite
                     false,
                     viewDefinition.get().getGracePeriod()
                             .map(DateTimeUtils::formatDayTimeInterval),
-                    Optional.of(toSqlWhenStaleBehavior(viewDefinition.get().getWhenStaleBehavior().orElse(INLINE))),
+                    Optional.of(toSqlWhenStaleBehavior(viewDefinition.get().getWhenStaleBehavior())),
                     propertyNodes,
                     viewDefinition.get().getComment())).trim();
             return singleValueQuery("Create Materialized View", sql);

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -90,6 +90,7 @@ import static io.trino.metadata.TestMetadataManager.createTestMetadataManager;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.BRANCH_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior.INLINE;
 import static io.trino.spi.connector.SaveMode.IGNORE;
 import static io.trino.spi.connector.SaveMode.REPLACE;
 import static io.trino.spi.security.PrincipalType.ROLE;
@@ -204,7 +205,7 @@ public abstract class BaseDataDefinitionTaskTest
                 Optional.empty(),
                 columns,
                 Optional.empty(),
-                Optional.empty(),
+                INLINE,
                 Optional.empty(),
                 Identity.ofUser("owner"),
                 ImmutableList.of(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -63,6 +63,7 @@ import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createP
 import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.spi.RefreshType.FULL;
 import static io.trino.spi.RefreshType.INCREMENTAL;
+import static io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior.INLINE;
 import static io.trino.spi.connector.SaveMode.FAIL;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampWithTimeZoneParametricType.TIMESTAMP_WITH_TIME_ZONE;
@@ -182,8 +183,8 @@ public class TestMaterializedViews
             return null;
         });
 
-        createFreshAndStaleMaterializedViews("fresh_materialized_view", planTester, metadata, Optional.empty());
-        createFreshAndStaleMaterializedViews("fresh_materialized_view_when_stale_fail", planTester, metadata, Optional.of(WhenStaleBehavior.FAIL));
+        createFreshAndStaleMaterializedViews("fresh_materialized_view", planTester, metadata, INLINE);
+        createFreshAndStaleMaterializedViews("fresh_materialized_view_when_stale_fail", planTester, metadata, WhenStaleBehavior.FAIL);
 
         MaterializedViewDefinition materializedViewDefinitionWithCasts = new MaterializedViewDefinition(
                 "SELECT a, b FROM test_table",
@@ -191,7 +192,7 @@ public class TestMaterializedViews
                 Optional.of(SCHEMA),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty()), new ViewColumn("b", BIGINT.getTypeId(), Optional.empty())),
                 Optional.empty(),
-                Optional.empty(),
+                INLINE,
                 Optional.empty(),
                 Identity.ofUser("some user"),
                 ImmutableList.of(),
@@ -226,7 +227,7 @@ public class TestMaterializedViews
                 Optional.of(SCHEMA),
                 ImmutableList.of(new ViewColumn("id", BIGINT.getTypeId(), Optional.empty()), new ViewColumn("ts", timestampWithTimezone3.getTypeId(), Optional.empty())),
                 Optional.empty(),
-                Optional.empty(),
+                INLINE,
                 Optional.empty(),
                 Identity.ofUser("some user"),
                 ImmutableList.of(),
@@ -248,7 +249,7 @@ public class TestMaterializedViews
         return planTester;
     }
 
-    private void createFreshAndStaleMaterializedViews(String name, PlanTester planTester, Metadata metadata, Optional<WhenStaleBehavior> whenStaleBehavior)
+    private void createFreshAndStaleMaterializedViews(String name, PlanTester planTester, Metadata metadata, WhenStaleBehavior whenStaleBehavior)
     {
         QualifiedObjectName freshMaterializedView = new QualifiedObjectName(TEST_CATALOG_NAME, SCHEMA, name);
         MaterializedViewDefinition materializedViewDefinition = new MaterializedViewDefinition(
@@ -297,7 +298,7 @@ public class TestMaterializedViews
                 Optional.of(SCHEMA),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty()), new ViewColumn("b", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of(STALE_MV_STALENESS.plusHours(1)),
-                Optional.empty(),
+                INLINE,
                 Optional.empty(),
                 Identity.ofUser("some user"),
                 ImmutableList.of(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Addresses:
* https://github.com/trinodb/trino/pull/27502#discussion_r2655414258.

I didn’t address the second part regarding `ConnectorMaterializedViewDefinition`, because that would require connectors to know what the default value is. See the mapping from `IcebergMaterializedViewDefinition` to `ConnectorMaterializedViewDefinition` in `AbstractTrinoCatalog#getMaterializedViewDefinition`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
