### PR TITLE
Disable Airbase dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
       exclude:
         - io.airlift:*
         - io.trino:*
+    ignore:
+      # Airbase and Airlift are best updated together. Update Airbase only when updating Airlift.
+      - dependency-name: "io.airlift:airbase"


### PR DESCRIPTION
Airbase and Airlift are best updated together. Instruct dependabot not to issue separate Airbase updates. We will update Airbase when updating Airlift.

Examples of independent updates that run into issues
- https://github.com/trinodb/trino/pull/27752
- https://github.com/trinodb/trino/pull/27750

Example combined update
- https://github.com/trinodb/trino/pull/27822