### PR TITLE
Enable MisleadingEscapedSpace error-prone check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2922,7 +2922,6 @@
                                     -Xep:InconsistentHashCode:ERROR \
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR \
                                     -Xep:InvalidInlineTag:ERROR \
-                                    -Xep:MisleadingEscapedSpace:OFF \
                                     -Xep:MissingCasesInEnumSwitch:ERROR \
                                     -Xep:MissingOverride:ERROR \
                                     <!-- Sometimes our javadoc contains just a @see directive -->

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -162,7 +162,7 @@ public class TestHiveCoercionOnUnpartitionedTable
                             binary_to_string                   BINARY,
                             binary_to_smaller_varchar          BINARY,
                             id                                 BIGINT)
-                        STORED AS\s\
+                        STORED AS \
                         """ + fileFormat);
     }
 
@@ -180,7 +180,7 @@ public class TestHiveCoercionOnUnpartitionedTable
                             string_to_timestamp        STRING,
                             timestamp_to_date          TIMESTAMP,
                             id                         BIGINT)
-                        STORED AS\s\
+                        STORED AS \
                         """ + fileFormat);
     }
 


### PR DESCRIPTION
It was disabled in 898e53e19f408505dfd8ac33dab439307a39d608 commit that updated airbase, perhaps it was a new check added by error-prone update? It's an ERROR by default in error-prone and there is no strong reason to keep it disabled.
