### PR TITLE
Enable Kafka Transport for OpenLineage Event Listener 

### DIFF
--- a/plugin/trino-openlineage/pom.xml
+++ b/plugin/trino-openlineage/pom.xml
@@ -78,12 +78,32 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-kafka</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.confluent</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
 
         <dependency>
@@ -179,6 +199,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>
@@ -231,4 +257,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredResourcePatterns combine.children="append">
+                            <!-- com.google.protobuf:protobuf-java and com.squareup.wire:wire-schema proto file duplicate -->
+                            <ignoredResourcePattern>google/protobuf/.*\.proto$</ignoredResourcePattern>
+                        </ignoredResourcePatterns>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListenerModule.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListenerModule.java
@@ -19,15 +19,21 @@ import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
+import io.trino.plugin.kafka.KafkaSecurityConfig;
+import io.trino.plugin.kafka.security.KafkaSslConfig;
 import io.trino.plugin.openlineage.transport.OpenLineageTransportConfig;
 import io.trino.plugin.openlineage.transport.OpenLineageTransportCreator;
 import io.trino.plugin.openlineage.transport.console.OpenLineageConsoleTransport;
 import io.trino.plugin.openlineage.transport.http.OpenLineageHttpTransport;
 import io.trino.plugin.openlineage.transport.http.OpenLineageHttpTransportConfig;
+import io.trino.plugin.openlineage.transport.kafka.OpenLineageKafkaTransport;
+import io.trino.plugin.openlineage.transport.kafka.OpenLineageKafkaTransportConfig;
 import io.trino.spi.eventlistener.EventListener;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 
 import java.net.URI;
 
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class OpenLineageListenerModule
@@ -49,6 +55,7 @@ public class OpenLineageListenerModule
         install(switch (buildConfigObject(OpenLineageTransportConfig.class).getTransport()) {
             case CONSOLE -> new ConsoleTransportModule();
             case HTTP -> new HttpTransportModule();
+            case KAFKA -> new KafkaTransportModule();
         });
     }
 
@@ -70,6 +77,25 @@ public class OpenLineageListenerModule
         {
             configBinder(binder).bindConfig(OpenLineageHttpTransportConfig.class);
             binder.bind(OpenLineageTransportCreator.class).to(OpenLineageHttpTransport.class);
+        }
+    }
+
+    private static class KafkaTransportModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            configBinder(binder).bindConfig(OpenLineageKafkaTransportConfig.class);
+            configBinder(binder).bindConfig(KafkaSecurityConfig.class);
+            newOptionalBinder(binder, KafkaSslConfig.class);
+            SecurityProtocol securityProtocol = buildConfigObject(KafkaSecurityConfig.class)
+                    .getSecurityProtocol()
+                    .orElse(SecurityProtocol.PLAINTEXT);
+            if (securityProtocol == SecurityProtocol.SSL) {
+                configBinder(binder).bindConfig(KafkaSslConfig.class);
+            }
+            binder.bind(OpenLineageTransportCreator.class).to(OpenLineageKafkaTransport.class);
         }
     }
 }

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageTransport.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageTransport.java
@@ -17,5 +17,6 @@ public enum OpenLineageTransport
 {
     CONSOLE,
     HTTP,
+    KAFKA,
     /**/
 }

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/kafka/OpenLineageKafkaTransport.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/kafka/OpenLineageKafkaTransport.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.openlineage.transport.kafka;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.openlineage.client.transports.KafkaConfig;
+import io.openlineage.client.transports.KafkaTransport;
+import io.trino.plugin.kafka.KafkaSecurityConfig;
+import io.trino.plugin.kafka.security.KafkaSslConfig;
+import io.trino.plugin.openlineage.transport.OpenLineageTransportCreator;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static io.trino.plugin.kafka.utils.PropertiesUtils.readProperties;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SSL;
+
+public class OpenLineageKafkaTransport
+        implements OpenLineageTransportCreator
+{
+    private static final Logger log = Logger.get(OpenLineageKafkaTransport.class);
+
+    private final String topicName;
+    private final Properties kafkaProperties;
+    private final Optional<String> messageKey;
+
+    @Inject
+    public OpenLineageKafkaTransport(
+            OpenLineageKafkaTransportConfig config,
+            KafkaSecurityConfig securityConfig,
+            Optional<KafkaSslConfig> sslConfig)
+            throws Exception
+    {
+        this.topicName = config.getTopicName();
+        this.messageKey = config.getMessageKey();
+        this.kafkaProperties = buildKafkaProperties(config, securityConfig, sslConfig);
+
+        log.info("Initializing OpenLineage Kafka transport: brokers=%s, topic=%s, protocol=%s, messageKey=%s",
+                config.getBrokerEndpoints(),
+                topicName,
+                securityConfig.getSecurityProtocol().orElse(PLAINTEXT),
+                messageKey);
+    }
+
+    @Override
+    public KafkaTransport buildTransport()
+    {
+        KafkaConfig kafkaConfig = new KafkaConfig(
+                topicName,
+                messageKey.orElse(null),
+                kafkaProperties);
+        KafkaTransport transport = new KafkaTransport(kafkaConfig);
+        log.info("Created OpenLineage Kafka transport: topic=%s", topicName);
+        return transport;
+    }
+
+    private Properties buildKafkaProperties(
+            OpenLineageKafkaTransportConfig config,
+            KafkaSecurityConfig securityConfig,
+            Optional<KafkaSslConfig> sslConfig)
+            throws Exception
+    {
+        Properties properties = new Properties();
+
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBrokerEndpoints());
+        config.getClientId().ifPresent(id -> properties.put(ProducerConfig.CLIENT_ID_CONFIG, id));
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "zstd");
+        properties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, Long.toString(config.getRequestTimeout().toMillis()));
+
+        SecurityProtocol protocol = securityConfig.getSecurityProtocol().orElse(PLAINTEXT);
+        if (protocol == SSL) {
+            KafkaSslConfig kafkaSslConfig = sslConfig.orElseThrow(() ->
+                    new IllegalStateException("SSL security protocol specified but SSL configuration is not provided"));
+            properties.putAll(kafkaSslConfig.getKafkaClientProperties());
+        }
+        else {
+            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, protocol.name());
+        }
+
+        Map<String, String> configOverrides = readProperties(config.getResourceConfigFiles());
+        properties.putAll(configOverrides);
+        return properties;
+    }
+}

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/kafka/OpenLineageKafkaTransportConfig.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/kafka/OpenLineageKafkaTransportConfig.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.openlineage.transport.kafka;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.validation.FileExists;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class OpenLineageKafkaTransportConfig
+{
+    private String brokerEndpoints;
+    private String topicName;
+    private Optional<String> clientId = Optional.empty();
+    private Duration requestTimeout = new Duration(10, TimeUnit.SECONDS);
+    private List<File> resourceConfigFiles = ImmutableList.of();
+    private Optional<String> messageKey = Optional.empty();
+
+    @NotEmpty
+    public String getBrokerEndpoints()
+    {
+        return brokerEndpoints;
+    }
+
+    @Config("openlineage-event-listener.kafka-transport.broker-endpoints")
+    @ConfigDescription("Comma-separated list of Kafka broker addresses (host:port)")
+    public OpenLineageKafkaTransportConfig setBrokerEndpoints(String brokerEndpoints)
+    {
+        this.brokerEndpoints = brokerEndpoints;
+        return this;
+    }
+
+    @NotEmpty
+    public String getTopicName()
+    {
+        return topicName;
+    }
+
+    @Config("openlineage-event-listener.kafka-transport.topic-name")
+    @ConfigDescription("Kafka topic name for OpenLineage events")
+    public OpenLineageKafkaTransportConfig setTopicName(String topicName)
+    {
+        this.topicName = topicName;
+        return this;
+    }
+
+    public Optional<String> getClientId()
+    {
+        return clientId;
+    }
+
+    @Config("openlineage-event-listener.kafka-transport.client-id")
+    @ConfigDescription("Kafka client ID for identifying this producer")
+    public OpenLineageKafkaTransportConfig setClientId(String clientId)
+    {
+        this.clientId = Optional.ofNullable(clientId);
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getRequestTimeout()
+    {
+        return requestTimeout;
+    }
+
+    @Config("openlineage-event-listener.kafka-transport.request-timeout")
+    @ConfigDescription("Kafka request timeout")
+    public OpenLineageKafkaTransportConfig setRequestTimeout(Duration requestTimeout)
+    {
+        this.requestTimeout = requestTimeout;
+        return this;
+    }
+
+    @NotNull
+    public List<@FileExists File> getResourceConfigFiles()
+    {
+        return resourceConfigFiles;
+    }
+
+    @Config("openlineage-event-listener.kafka-transport.config.resources")
+    @ConfigDescription("Optional config files")
+    public OpenLineageKafkaTransportConfig setResourceConfigFiles(List<String> files)
+    {
+        this.resourceConfigFiles = files.stream()
+                .map(File::new)
+                .collect(toImmutableList());
+        return this;
+    }
+
+    public Optional<String> getMessageKey()
+    {
+        return messageKey;
+    }
+
+    @Config("openlineage-event-listener.kafka-transport.message-key")
+    @ConfigDescription("Optional key for all Kafka messages produced by transport. If not specified, OpenLineage will use default value based on event type")
+    public OpenLineageKafkaTransportConfig setMessageKey(String messageKey)
+    {
+        this.messageKey = Optional.ofNullable(messageKey);
+        return this;
+    }
+}

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageEventListenerKafkaIntegration.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageEventListenerKafkaIntegration.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.openlineage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.kafka.TestingKafka;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+final class TestOpenLineageEventListenerKafkaIntegration
+        extends AbstractTestQueryFramework
+{
+    private static final Logger logger = Logger.get(TestOpenLineageEventListenerKafkaIntegration.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static TestingKafka testingKafka;
+    private static final String TOPIC_NAME = "openlineage-events";
+    private static final String TRINO_URI = "http://trino-integration-test:1337";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingKafka = closeAfterClass(TestingKafka.create());
+        testingKafka.start();
+        testingKafka.createTopic(TOPIC_NAME);
+
+        return OpenLineageListenerQueryRunner.builder()
+                .addListenerProperty("openlineage-event-listener.transport.type", "KAFKA")
+                .addListenerProperty("openlineage-event-listener.kafka-transport.broker-endpoints", testingKafka.getConnectString())
+                .addListenerProperty("openlineage-event-listener.kafka-transport.topic-name", TOPIC_NAME)
+                .addListenerProperty("openlineage-event-listener.trino.uri", TRINO_URI)
+                .build();
+    }
+
+    @Test
+    void testCreateTableAsSelectFromTable()
+    {
+        String outputTable = "test_create_table_as_select_from_table";
+
+        @Language("SQL") String createTableQuery = format(
+                "CREATE TABLE %s AS SELECT * FROM tpch.tiny.nation",
+                outputTable);
+
+        String queryId = this.getQueryRunner()
+                .executeWithPlan(this.getSession(), createTableQuery)
+                .queryId()
+                .toString();
+
+        assertEventually(Duration.valueOf("10s"), () -> {
+            List<JsonNode> events = consumeOpenLineageEvents();
+            verifyOpenLineageEvent(events, queryId);
+        });
+    }
+
+    @Test
+    void testCreateTableAsSelectFromView()
+    {
+        String viewName = "test_view";
+        String outputTable = "test_create_table_as_select_from_view";
+
+        @Language("SQL") String createViewQuery = format(
+                "CREATE VIEW %s AS SELECT * FROM tpch.tiny.nation",
+                viewName);
+
+        assertQuerySucceeds(createViewQuery);
+
+        @Language("SQL") String createTableQuery = format(
+                "CREATE TABLE %s AS SELECT * FROM %s",
+                outputTable, viewName);
+
+        String queryId = this.getQueryRunner()
+                .executeWithPlan(this.getSession(), createTableQuery)
+                .queryId()
+                .toString();
+
+        assertEventually(Duration.valueOf("10s"), () -> {
+            List<JsonNode> events = consumeOpenLineageEvents();
+            verifyOpenLineageEvent(events, queryId);
+        });
+    }
+
+    private List<JsonNode> consumeOpenLineageEvents()
+    {
+        List<JsonNode> events = new ArrayList<>();
+        try (KafkaConsumer<String, String> consumer = createConsumer()) {
+            consumer.subscribe(List.of(TOPIC_NAME));
+            ConsumerRecords<String, String> records = consumer.poll(java.time.Duration.of(5, ChronoUnit.SECONDS));
+
+            for (ConsumerRecord<String, String> record : records) {
+                logger.info("Consumed OpenLineage event from Kafka: %s", record.value());
+                JsonNode event = MAPPER.readTree(record.value());
+                events.add(event);
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to consume OpenLineage events from Kafka", e);
+        }
+        return events;
+    }
+
+    private KafkaConsumer<String, String> createConsumer()
+    {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, testingKafka.getConnectString());
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "openlineage-test-consumer");
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return new KafkaConsumer<>(properties);
+    }
+
+    private void verifyOpenLineageEvent(List<JsonNode> events, String expectedQueryId)
+    {
+        assertThat(events).isNotEmpty();
+        logger.info("Verifying %d OpenLineage events for query %s", events.size(), expectedQueryId);
+
+        boolean foundExpectedEvent = false;
+        for (JsonNode event : events) {
+            for (String field : List.of("eventType", "eventTime", "job", "run")) {
+                assertThat(event.has(field)).isTrue().as("Missing field: field=%s", field);
+            }
+
+            JsonNode job = event.get("job");
+            assertThat(job.has("namespace")).isTrue();
+            assertThat(job.has("name")).isTrue();
+            String jobName = job.get("name").asText();
+            foundExpectedEvent = jobName.contains(expectedQueryId);
+
+            JsonNode run = event.get("run");
+            assertThat(run.has("runId")).isTrue();
+
+            String eventType = event.get("eventType").asText();
+            logger.info("Event type: %s, Job name: %s", eventType, jobName);
+        }
+        assertThat(foundExpectedEvent).isTrue();
+    }
+}

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/kafka/TestOpenLineageKafkaTransportConfig.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/kafka/TestOpenLineageKafkaTransportConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.openlineage.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.plugin.openlineage.transport.kafka.OpenLineageKafkaTransportConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestOpenLineageKafkaTransportConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(OpenLineageKafkaTransportConfig.class)
+                .setBrokerEndpoints(null)
+                .setTopicName(null)
+                .setClientId(null)
+                .setRequestTimeout(Duration.valueOf("10s"))
+                .setResourceConfigFiles(List.of())
+                .setMessageKey(null));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Path resource1 = Files.createTempFile(null, null);
+        Path resource2 = Files.createTempFile(null, null);
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("openlineage-event-listener.kafka-transport.broker-endpoints", "kafka1:9092,kafka2:9092")
+                .put("openlineage-event-listener.kafka-transport.topic-name", "openlineage-events")
+                .put("openlineage-event-listener.kafka-transport.client-id", "trino-test")
+                .put("openlineage-event-listener.kafka-transport.request-timeout", "30s")
+                .put("openlineage-event-listener.kafka-transport.config.resources", resource1.toString() + "," + resource2.toString())
+                .put("openlineage-event-listener.kafka-transport.message-key", "custom-key")
+                .buildOrThrow();
+
+        OpenLineageKafkaTransportConfig expected = new OpenLineageKafkaTransportConfig()
+                .setBrokerEndpoints("kafka1:9092,kafka2:9092")
+                .setTopicName("openlineage-events")
+                .setClientId("trino-test")
+                .setRequestTimeout(Duration.valueOf("30s"))
+                .setResourceConfigFiles(ImmutableList.of(resource1.toString(), resource2.toString()))
+                .setMessageKey("custom-key");
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR adds Kafka as a transport option for `trino-openlineage` event listener plugin. Currently, only console and HTTP transport are supported. 

It reuses the SSL configuration options from the `trino-kafka` module (`kafka.ssl.keystore.location, etc.`) similar to Kafka event listener plugin (#22888)

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/21599

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for Kafka transport in Trino OpenLineage Plugin (https://github.com/trinodb/trino/issues/21599)
```
