### PR TITLE
Increase default exchange HTTP max content length to 64MB

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -328,7 +328,9 @@ public class ServerMainModule
                 .withConfigDefaults(config -> {
                     config.setIdleTimeout(new Duration(30, SECONDS));
                     config.setRequestTimeout(new Duration(10, SECONDS));
-                    config.setMaxContentLength(DataSize.of(32, MEGABYTE));
+                    // Bumping the default limit to allow large rows to be transferred between nodes
+                    // 64MB is chosen based on real world experience of using this value in production clusters
+                    config.setMaxContentLength(DataSize.of(64, MEGABYTE));
                     config.setMaxRequestsQueuedPerDestination(65536);
                     if (internalCommunicationConfig.isHttp2Enabled()) {
                         config.setMaxConnectionsPerServer(64);


### PR DESCRIPTION
## Description
Avoids "Remote page is too large" exceptions when dealing with large rows

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
