### PR TITLE
Update ClickHouse JDBC dependency version to 0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
             <dependency>
                 <groupId>com.clickhouse</groupId>
                 <artifactId>clickhouse-jdbc</artifactId>
-                <version>0.7.1-patch1</version>
+                <version>0.9.5</version>
                 <classifier>all</classifier>
             </dependency>
 


### PR DESCRIPTION
## Description
 Fix https://github.com/trinodb/trino/issues/27646

## Additional context and related issues
Clickhouse version > 25.10 breaks changes. Need to update clickhouse-jdbc > 0.9.5 to fix it.