### PR TITLE
Disable `TestDeltaLakeLocalConcurrentWritesTest.testConcurrentInsertsSelectingFromTheSameTemporalVersionedTable`

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
@@ -263,6 +263,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
     }
 
     @Test
+    @Disabled // TODO https://github.com/trinodb/trino/issues/21725 Fix flaky test
     void testConcurrentInsertsSelectingFromTheSameTemporalVersionedTable()
             throws Exception
     {


### PR DESCRIPTION
## Description

* Relates to #21725

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
