### PR TITLE
Propagate access control exception

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestRetryDriver.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestRetryDriver.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import io.airlift.units.Duration;
+import io.trino.hive.thrift.metastore.MetaException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestRetryDriver
+{
+    @Test
+    void testSuccessfulCall()
+            throws Exception
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+        String result = RetryDriver.retry().maxAttempts(3).run("test", () -> {
+            attempts.incrementAndGet();
+            return "success";
+        });
+
+        assertThat(result).isEqualTo("success");
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testRetryOnFailure()
+            throws Exception
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+        String result = RetryDriver.retry()
+                .maxAttempts(3)
+                .exponentialBackoff(new Duration(1, MILLISECONDS), new Duration(10, MILLISECONDS),
+                        new Duration(1, SECONDS), 2.0)
+                .run("test", () -> {
+                    if (attempts.incrementAndGet() < 3) {
+                        throw new RuntimeException("Temporary failure");
+                    }
+                    return "success";
+                });
+
+        assertThat(result).isEqualTo("success");
+        assertThat(attempts.get()).isEqualTo(3);
+    }
+
+    @Test
+    void testStopOnSpecificException()
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        assertThatThrownBy(
+                () -> RetryDriver.retry().maxAttempts(5).stopOn(IllegalArgumentException.class).run("test", () -> {
+                    attempts.incrementAndGet();
+                    throw new IllegalArgumentException("Stop immediately");
+                })).isInstanceOf(IllegalArgumentException.class).hasMessage("Stop immediately");
+
+        // Should stop on first attempt without retrying
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testDoNotRetryOnAccessControlException()
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        // Simulate MetaException wrapping AccessControlException (as seen in HDFS
+        // permission denied errors)
+        assertThatThrownBy(() -> RetryDriver.retry()
+                .maxAttempts(5)
+                .exponentialBackoff(new Duration(1, MILLISECONDS), new Duration(10, MILLISECONDS),
+                        new Duration(1, SECONDS), 2.0)
+                .run("test", () -> {
+                    attempts.incrementAndGet();
+                    throw new MetaException(
+                            "org.apache.hadoop.security.AccessControlException: Permission denied: user=testuser, access=EXECUTE, inode=\"/user/hive\"");
+                })).isInstanceOf(MetaException.class).hasMessageContaining("AccessControlException");
+
+        // Should stop on first attempt without retrying
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testDoNotRetryOnNestedAccessControlException()
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        // Simulate exception with AccessControlException in the cause chain
+        Exception accessControlCause = new RuntimeException(
+                "org.apache.hadoop.security.AccessControlException: Permission denied");
+        Exception wrappedException = new RuntimeException("Wrapper exception", accessControlCause);
+
+        assertThatThrownBy(() -> RetryDriver.retry()
+                .maxAttempts(5)
+                .exponentialBackoff(new Duration(1, MILLISECONDS), new Duration(10, MILLISECONDS),
+                        new Duration(1, SECONDS), 2.0)
+                .run("test", () -> {
+                    attempts.incrementAndGet();
+                    throw wrappedException;
+                })).isInstanceOf(RuntimeException.class).hasMessageContaining("Wrapper exception");
+
+        // Should stop on first attempt without retrying
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testRetryOnOtherMetaException()
+            throws Exception
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        // MetaException without AccessControlException should be retried
+        String result = RetryDriver.retry()
+                .maxAttempts(3)
+                .exponentialBackoff(new Duration(1, MILLISECONDS), new Duration(10, MILLISECONDS),
+                        new Duration(1, SECONDS), 2.0)
+                .run("test", () -> {
+                    if (attempts.incrementAndGet() < 3) {
+                        throw new MetaException("Temporary metastore error");
+                    }
+                    return "success";
+                });
+
+        assertThat(result).isEqualTo("success");
+        assertThat(attempts.get()).isEqualTo(3);
+    }
+
+    @Test
+    void testMaxAttemptsExceeded()
+    {
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        assertThatThrownBy(() -> RetryDriver.retry()
+                .maxAttempts(3)
+                .exponentialBackoff(new Duration(1, MILLISECONDS), new Duration(10, MILLISECONDS),
+                        new Duration(1, SECONDS), 2.0)
+                .run("test", () -> {
+                    attempts.incrementAndGet();
+                    throw new RuntimeException("Always fails");
+                })).isInstanceOf(RuntimeException.class).hasMessage("Always fails");
+
+        assertThat(attempts.get()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

**Background**

This issue occurs when using StorageBasedAuthorizationProvider in Hive Metastore.
In this case, an AccessControlException can be thrown during authorization checks, but the error is not propagated to the client immediately, causing the client to wait until the metastore Thrift timeout expires (default: 10s).

Relevant code:
- https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java#L429-L451

**Fix**
This change propagates AccessControlExceptions to the client immediately, avoiding unnecessary waits for the Thrift timeout.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Here is the exception message sent from metastore.
```
MetaException(message:java.security.AccessControlException: Permission denied: user=..., access=EXECUTE, inode="/user/...":...:services:drwx------
	at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.check(FSPermissionChecker.java:399)
	at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.checkTraverse(FSPermissionChecker.java:315)
	at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.checkPermission(FSPermissionChecker.java:242)
	at org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer$RangerAccessControlEnforcer.checkDefaultEnforcer(RangerHdfsAuthorizer.java:589)
	at org.apache.ranger.authorization.hadoop.RangerHdfsAuthorizer$RangerAccessControlEnforcer.checkPermission(RangerHdfsAuthorizer.java:377)
	at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.checkPermission(FSPermissionChecker.java:193)
	at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPermission(FSDirectory.java:1877)
	at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPermission(FSDirectory.java:1861)
	at org.apache.hadoop.hdfs.server.namenode.FSDirectory.checkPathAccess(FSDirectory.java:1811)
	at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.checkAccess(FSNamesystem.java:8048)
	at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.checkAccess(NameNodeRpcServer.java:2234)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.checkAccess(ClientNamenodeProtocolServerSideTranslatorPB.java:1659)
	at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:523)
	at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:991)
	at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:872)
	at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:818)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1729)
	at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2678)
)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
