### PR TITLE
Restructure diagnostics logging for fte scheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1017,8 +1017,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 return;
             }
 
-            log.debug("Scheduler debug info for %s START; reason=%s", queryStateMachine.getQueryId(), reason);
-            log.debug("General state: %s", toStringHelper(this)
+            String generalStateInfo = toStringHelper(this)
                     .add("queryState", queryStateMachine.getQueryState())
                     .add("finalQueryInfo", queryStateMachine.getFinalQueryInfo())
                     .add("maxTaskExecutionAttempts", maxTaskExecutionAttempts)
@@ -1031,7 +1030,9 @@ public class EventDrivenFaultTolerantQueryScheduler
                     .add("preSchedulingTaskContexts", preSchedulingTaskContexts)
                     .add("schedulingDelayer", schedulingDelayer)
                     .add("queryOutputSet", queryOutputSet)
-                    .toString());
+                    .toString();
+
+            log.debug("Scheduler debug info for %s START; reason=%s; general state: %s", queryStateMachine.getQueryId(), reason, generalStateInfo);
 
             stageRegistry.logDebugInfo();
 


### PR DESCRIPTION
Commit slightly restructures how debug information is logged in case we detect possible deadlock/stalling in fte scheduler. Having single line with more information makes it easier for logging post processing.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
