### PR TITLE
Update Elasticsearch in trino-ranger plugin

### DIFF
--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -19,7 +19,40 @@
         <!-- TODO: remove once Ranger upgrades to Jetty 12 -->
         <dep.jetty11.version>11.0.26</dep.jetty11.version>
         <dep.ranger.version>2.7.0</dep.ranger.version>
+        <!-- TODO: update with ranger version which fixes elasticsearch CVEs -->
+        <dep.elasticsearch.version>7.17.29</dep.elasticsearch.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Fix CVE-affected artifacts and resolve version conflicts -->
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <version>${dep.elasticsearch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch-core</artifactId>
+                <version>${dep.elasticsearch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch-secure-sm</artifactId>
+                <version>${dep.elasticsearch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch-x-content</artifactId>
+                <version>${dep.elasticsearch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${dep.elasticsearch.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
The current trino-ranger version pulls in vulnerable Elasticsearch
dependencies via transitive imports.

This change upgrades Elasticsearch from 7.10.2 to 7.17.29 and ensures
secure versions are used.

This addresses multiple CVEs, including:
- CVE-2021-22145
- CVE-2023-31418
- CVE-2024-23444
- CVE-2024-52979
- CVE-2025-37727
- CVE-2025-37731

These vulnerabilities affect memory disclosure, resource consumption,
and authentication bypass.


## Additional context and related issues
Dependency Management section added to handle affected elasticsearch artifacts


## Release notes
( x) This is not user-visible or is docs only, and no release notes are required.
