### PR TITLE
Fix artifact-checks by running tar in native image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -14,7 +14,8 @@
 #
 FROM ghcr.io/airlift/jvmkill:latest AS jvmkill
 
-FROM redhat/ubi10-minimal:latest AS jdk-download
+# Download and extract JDK using a build platform to avoid tar extract issue while running in qemu
+FROM --platform=$BUILDPLATFORM redhat/ubi10-minimal:latest AS jdk-download
 ARG JDK_DOWNLOAD_LINK
 ARG JDK_VERSION
 ENV JAVA_HOME="/usr/lib/jvm/${JDK_VERSION}"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Apparently new `tar` no longer works under QEMU emulation used
when image arch differs from host arch. Extract JDK within container
with arch matching the host.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
