### PR TITLE
Bump OpenSearch to 2.19.4

### DIFF
--- a/plugin/trino-opensearch/pom.xml
+++ b/plugin/trino-opensearch/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.opensearch.version>2.19.3</dep.opensearch.version>
+        <dep.opensearch.version>2.19.4</dep.opensearch.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description
Updates org.opensearch dependency from 2.19.3 to 2.19.4 

## Additional context and related issues
Addresses a DoS vulnerability in opensearch-common 
(https://github.com/advisories/GHSA-mw3v-mmfw-3x2g).

## Release notes
( x) This is not user-visible or is docs only, and no release notes are required.