### PR TITLE
Cleanup ScalarStatsCalculator row size estimates

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -19,6 +19,7 @@ import io.trino.Session;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.FixedWidthType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TinyintType;
@@ -109,6 +110,11 @@ public class ScalarStatsCalculator
                 estimate.setLowValue(doubleValue.getAsDouble());
                 estimate.setHighValue(doubleValue.getAsDouble());
             }
+
+            if (type instanceof FixedWidthType fixedWidthType) {
+                estimate.setAverageRowSize(fixedWidthTypeSizeEstimate(fixedWidthType));
+            }
+
             return estimate.build();
         }
 
@@ -136,11 +142,16 @@ public class ScalarStatsCalculator
                 return nullStatsEstimate();
             }
 
-            if (value instanceof Constant) {
-                return SymbolStatsEstimate.builder()
+            if (value instanceof Constant constant) {
+                SymbolStatsEstimate.Builder estimate = SymbolStatsEstimate.builder()
                         .setNullsFraction(0)
-                        .setDistinctValuesCount(1)
-                        .build();
+                        .setDistinctValuesCount(1);
+
+                if (constant.type() instanceof FixedWidthType fixedWidthType) {
+                    estimate.setAverageRowSize(fixedWidthTypeSizeEstimate(fixedWidthType));
+                }
+
+                return estimate.build();
             }
 
             return SymbolStatsEstimate.unknown();
@@ -172,13 +183,21 @@ public class ScalarStatsCalculator
                 }
             }
 
+            double averageRowSize;
+            if (node.type() instanceof FixedWidthType fixedWidthType) {
+                averageRowSize = fixedWidthTypeSizeEstimate(fixedWidthType);
+            }
+            else {
+                // Source average row size is a reasonable approximation for CAST result
+                averageRowSize = sourceStats.getAverageRowSize();
+            }
+
             return SymbolStatsEstimate.builder()
                     .setNullsFraction(sourceStats.getNullsFraction())
                     .setLowValue(lowValue)
                     .setHighValue(highValue)
                     .setDistinctValuesCount(distinctValuesCount)
-                    // Source average row size is a reasonable approximation for CAST result
-                    .setAverageRowSize(sourceStats.getAverageRowSize())
+                    .setAverageRowSize(averageRowSize)
                     .build();
         }
 
@@ -299,6 +318,12 @@ public class ScalarStatsCalculator
                     .setAverageRowSize(max(left.getAverageRowSize(), right.getAverageRowSize()))
                     .build();
         }
+    }
+
+    private static double fixedWidthTypeSizeEstimate(FixedWidthType fixedWidthType)
+    {
+        // Additional byte for "is null"
+        return fixedWidthType.getFixedSize() + 1;
     }
 
     private static SymbolStatsEstimate nullStatsEstimate()

--- a/core/trino-main/src/test/java/io/trino/cost/TestScalarStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestScalarStatsCalculator.java
@@ -72,49 +72,57 @@ public class TestScalarStatsCalculator
                 .distinctValuesCount(1.0)
                 .lowValue(7)
                 .highValue(7)
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .averageRowSize(TINYINT.getFixedSize() + 1);
 
         assertCalculate(new Constant(SMALLINT, 8L))
                 .distinctValuesCount(1.0)
                 .lowValue(8)
                 .highValue(8)
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .averageRowSize(SMALLINT.getFixedSize() + 1);
 
         assertCalculate(new Constant(INTEGER, 9L))
                 .distinctValuesCount(1.0)
                 .lowValue(9)
                 .highValue(9)
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .averageRowSize(INTEGER.getFixedSize() + 1);
 
         assertCalculate(new Constant(BIGINT, MAX_VALUE))
                 .distinctValuesCount(1.0)
                 .lowValue(Long.MAX_VALUE)
                 .highValue(Long.MAX_VALUE)
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .averageRowSize(BIGINT.getFixedSize() + 1);
 
         assertCalculate(new Constant(DOUBLE, 7.5))
                 .distinctValuesCount(1.0)
                 .lowValue(7.5)
                 .highValue(7.5)
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .averageRowSize(DOUBLE.getFixedSize() + 1);
 
         assertCalculate(new Constant(createDecimalType(3, 1), Decimals.valueOfShort(new BigDecimal("75.5"))))
                 .distinctValuesCount(1.0)
                 .lowValue(75.5)
                 .highValue(75.5)
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .averageRowSize(createDecimalType(3, 1).getFixedSize() + 1);
 
         assertCalculate(new Constant(VarcharType.VARCHAR, Slices.utf8Slice("blah")))
                 .distinctValuesCount(1.0)
                 .lowValueUnknown()
                 .highValueUnknown()
-                .nullsFraction(0.0);
+                .nullsFraction(0.0)
+                .dataSizeUnknown();
 
         assertCalculate(new Constant(UnknownType.UNKNOWN, null))
                 .distinctValuesCount(0.0)
                 .lowValueUnknown()
                 .highValueUnknown()
-                .nullsFraction(1.0);
+                .nullsFraction(1.0)
+                .dataSizeUnknown();
     }
 
     @Test
@@ -192,7 +200,7 @@ public class TestScalarStatsCalculator
                 .highValue(17.0)
                 .distinctValuesCount(10)
                 .nullsFraction(0.3)
-                .averageRowSize(2.0);
+                .averageRowSize(BIGINT.getFixedSize() + 1);
     }
 
     @Test
@@ -215,7 +223,7 @@ public class TestScalarStatsCalculator
                 .highValue(3.0)
                 .distinctValuesCount(2)
                 .nullsFraction(0.3)
-                .averageRowSize(2.0);
+                .averageRowSize(BIGINT.getFixedSize() + 1);
     }
 
     @Test
@@ -237,7 +245,7 @@ public class TestScalarStatsCalculator
                 .highValue(3.0)
                 .distinctValuesCountUnknown()
                 .nullsFraction(0.3)
-                .averageRowSize(2.0);
+                .averageRowSize(BIGINT.getFixedSize() + 1);
     }
 
     @Test
@@ -260,7 +268,7 @@ public class TestScalarStatsCalculator
                 .highValue(10.0)
                 .distinctValuesCount(4)
                 .nullsFraction(0.3)
-                .averageRowSize(2.0);
+                .averageRowSize(DOUBLE.getFixedSize() + 1);
     }
 
     @Test
@@ -273,7 +281,7 @@ public class TestScalarStatsCalculator
                 .highValueUnknown()
                 .distinctValuesCountUnknown()
                 .nullsFractionUnknown()
-                .dataSizeUnknown();
+                .averageRowSize(BIGINT.getFixedSize() + 1);
     }
 
     private SymbolStatsAssertion assertCalculate(Expression scalarExpression)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -783,7 +783,7 @@ public class TestColumnMask
                 .containsAll(
                         """
                         VALUES
-                         (VARCHAR 'orderkey', CAST(NULL AS double), 1e0, 0e1, NULL, '7', '7'),
+                         (VARCHAR 'orderkey', 135e3, 1e0, 0e1, NULL, '7', '7'),
                          (VARCHAR 'clerk', 15e3, 1e3, 0e1, NULL, CAST(NULL AS varchar), CAST(NULL AS varchar)),
                          (NULL, NULL, NULL, NULL, 15e3, NULL, NULL)
                         """);
@@ -791,7 +791,7 @@ public class TestColumnMask
                 .matches(
                         """
                         VALUES
-                         (VARCHAR 'orderkey', CAST(NULL AS double), 1e0, 0e1, NULL, VARCHAR '7', VARCHAR '7'),
+                         (VARCHAR 'orderkey', 135e3, 1e0, 0e1, NULL, VARCHAR '7', VARCHAR '7'),
                          (NULL, NULL, NULL, NULL, 15e3, NULL, NULL)
                         """);
         assertThat(assertions.query("SHOW STATS FOR (SELECT clerk FROM orders)"))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
@@ -409,7 +409,7 @@ public class TestShowStats
         assertQuery(
                 "SHOW STATS FOR (SELECT 1 AS x FROM nation_partitioned)",
                 "VALUES " +
-                        "   ('x', null, 1, 0, null, 1, 1), " +
+                        "   ('x', 125.0, 1, 0, null, 1, 1), " +
                         "   (null, null, null, null, 25, null, null)");
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Uses the fixed size for casts and constants of fixed-width types to estimate the size per position.

## Additional context and related issues

Follows up from https://github.com/trinodb/trino/pull/27871


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

