### PR TITLE
Add Debug Logs for Spilling and Unspilling Partitions in GenericPartitioningSpiller

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
@@ -375,7 +375,8 @@ public class DefaultPageJoiner
                     probeTypes,
                     partitionGenerator.get(),
                     spillContext.newLocalSpillContext(),
-                    memoryTrackingContext.newAggregateUserMemoryContext()));
+                    memoryTrackingContext.newAggregateUserMemoryContext(),
+                    "LookupJoinOperator"));
         }
 
         PartitioningSpiller.PartitioningSpillResult result = spiller.get().partitionAndSpill(page, spillInfoSnapshot.getSpillMask());

--- a/core/trino-main/src/main/java/io/trino/spiller/GenericPartitioningSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/GenericPartitioningSpiller.java
@@ -19,6 +19,7 @@ import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.ThreadSafe;
+import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.PartitionFunction;
@@ -45,18 +46,22 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.airlift.units.DataSize.succinctBytes;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public class GenericPartitioningSpiller
         implements PartitioningSpiller
 {
+    private static final Logger log = Logger.get(GenericPartitioningSpiller.class);
+
     private final List<Type> types;
     private final PartitionFunction partitionFunction;
     private final Closer closer = Closer.create();
     private final SingleStreamSpillerFactory spillerFactory;
     private final SpillContext spillContext;
     private final AggregatedMemoryContext memoryContext;
+    private final String operatorName;
 
     private final List<PageBuilder> pageBuilders;
     private final List<Optional<SingleStreamSpiller>> spillers;
@@ -69,7 +74,8 @@ public class GenericPartitioningSpiller
             PartitionFunction partitionFunction,
             SpillContext spillContext,
             AggregatedMemoryContext memoryContext,
-            SingleStreamSpillerFactory spillerFactory)
+            SingleStreamSpillerFactory spillerFactory,
+            String operatorName)
     {
         requireNonNull(spillContext, "spillContext is null");
 
@@ -81,6 +87,7 @@ public class GenericPartitioningSpiller
         requireNonNull(memoryContext, "memoryContext is null");
         closer.register(memoryContext::close);
         this.memoryContext = memoryContext;
+        this.operatorName = requireNonNull(operatorName, "operatorName is null");
         int partitionCount = partitionFunction.partitionCount();
 
         ImmutableList.Builder<PageBuilder> pageBuilders = ImmutableList.builder();
@@ -98,6 +105,12 @@ public class GenericPartitioningSpiller
         readingStarted = true;
         getFutureValue(flush(partition));
         spilledPartitions.remove(partition);
+
+        log.debug(
+                "Unspilling partition %d for operator %s",
+                partition,
+                operatorName);
+
         return getSpiller(partition).getSpilledPages();
     }
 
@@ -186,6 +199,16 @@ public class GenericPartitioningSpiller
         }
         Page page = pageBuilder.build();
         pageBuilder.reset();
+
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Spilling partition %d for operator %s, sizeInBytes %s, retainedSizeInBytes %s",
+                    partition,
+                    operatorName,
+                    succinctBytes(page.getSizeInBytes()),
+                    succinctBytes(page.getRetainedSizeInBytes()));
+        }
+
         return getSpiller(partition).spill(page);
     }
 

--- a/core/trino-main/src/main/java/io/trino/spiller/GenericPartitioningSpillerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/GenericPartitioningSpillerFactory.java
@@ -39,8 +39,9 @@ public class GenericPartitioningSpillerFactory
             List<Type> types,
             PartitionFunction partitionFunction,
             SpillContext spillContext,
-            AggregatedMemoryContext memoryContext)
+            AggregatedMemoryContext memoryContext,
+            String operatorName)
     {
-        return new GenericPartitioningSpiller(types, partitionFunction, spillContext, memoryContext, singleStreamSpillerFactory);
+        return new GenericPartitioningSpiller(types, partitionFunction, spillContext, memoryContext, singleStreamSpillerFactory, operatorName);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/spiller/PartitioningSpillerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/PartitioningSpillerFactory.java
@@ -26,11 +26,12 @@ public interface PartitioningSpillerFactory
             List<Type> types,
             PartitionFunction partitionFunction,
             SpillContext spillContext,
-            AggregatedMemoryContext memoryContext);
+            AggregatedMemoryContext memoryContext,
+            String operatorName);
 
     static PartitioningSpillerFactory unsupportedPartitioningSpillerFactory()
     {
-        return (types, partitionFunction, spillContext, memoryContext) -> {
+        return (types, partitionFunction, spillContext, memoryContext, operatorName) -> {
             throw new UnsupportedOperationException();
         };
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -172,7 +172,7 @@ public final class TaskTestUtils
                 (types, spillContext, memoryContext, parallelSpill) -> {
                     throw new UnsupportedOperationException();
                 },
-                (types, partitionFunction, spillContext, memoryContext) -> {
+                (types, partitionFunction, spillContext, memoryContext, operatorName) -> {
                     throw new UnsupportedOperationException();
                 },
                 new PagesIndex.TestingFactory(false),

--- a/core/trino-main/src/test/java/io/trino/spiller/TestGenericPartitioningSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestGenericPartitioningSpiller.java
@@ -110,7 +110,8 @@ public class TestGenericPartitioningSpiller
                 TYPES,
                 new FourFixedPartitionsPartitionFunction(0),
                 mockSpillContext(),
-                mockMemoryContext(scheduledExecutor))) {
+                mockMemoryContext(scheduledExecutor),
+                "testOperator")) {
             RowPagesBuilder builder = RowPagesBuilder.rowPagesBuilder(TYPES);
             builder.addSequencePage(10, SECOND_PARTITION_START, 5, 10, 15);
             builder.addSequencePage(10, FIRST_PARTITION_START, -5, 0, 5);
@@ -166,7 +167,8 @@ public class TestGenericPartitioningSpiller
                 TYPES,
                 new ModuloPartitionFunction(0, 4),
                 mockSpillContext(),
-                mockMemoryContext(scheduledExecutor))) {
+                mockMemoryContext(scheduledExecutor),
+                "testOperator")) {
             Page page = SequencePageBuilder.createSequencePage(TYPES, 10, FIRST_PARTITION_START, 5, 10, 15);
             PartitioningSpillResult spillResult = spiller.partitionAndSpill(page, partition -> true);
             assertThat(spillResult.getRetained().getPositionCount()).isEqualTo(0);
@@ -193,7 +195,8 @@ public class TestGenericPartitioningSpiller
                 types,
                 new ModuloPartitionFunction(0, partitionCount),
                 mockSpillContext(),
-                memoryContext)) {
+                memoryContext,
+                "testOperator")) {
             for (int i = 0; i < 50_000; i++) {
                 Page page = SequencePageBuilder.createSequencePage(types, partitionCount, 0);
                 PartitioningSpillResult spillResult = spiller.partitionAndSpill(page, partition -> true);


### PR DESCRIPTION
Changes:
- Log partition number, operator name, and data sizes during spill/unspill
- Add operatorName parameter to PartitioningSpillerFactory.create()
- Update LookupJoinOperator to pass operator name for probe side spilling

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR adds debug logging to `GenericPartitioningSpiller` to improve observability of spilling behavior, where currently no debug logs exist. This PR came out of an investigation of spilling and unspilling that occurs during the probe side of hash joins.

The new logs include operator name, partition number, and data sizes for each spill/unspill operation (using `sizeInBytes` and `retainedSizeInBytes`). See attached screenshot. 

<img width="2054" height="1034" alt="Examples of Spilling and Unspilling in GenericPartitioningSpiller" src="https://github.com/user-attachments/assets/964f48fb-69aa-4fbd-9515-83e86f602e2b" />

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is my first contribution to Trino. I am open to any notes or revisions. 

To avoid passing the entire OperatorContext, I pass only the name of the operator. 

I followed the `FormatStringShouldUsePlaceholders` rule that was enabled in [this PR](https://github.com/trinodb/trino/pull/27643). 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: