### PR TITLE
 Improve error message when failed to get BigQuery destination table

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -540,7 +540,15 @@ public class BigQueryClient
             jobConfiguration = bigQuery.create(jobInfo).getConfiguration();
         }
         catch (BigQueryException e) {
-            throw new TrinoException(BIGQUERY_INVALID_STATEMENT, "Failed to get destination table for query. " + firstNonNull(e.getMessage(), e), e);
+            throw new TrinoException(
+                    BIGQUERY_INVALID_STATEMENT,
+                    "Failed to get destination table for query. code: %s, reason: %s, retryable: %s, debug: %s, message: %s".formatted(
+                            e.getCode(),
+                            e.getReason(),
+                            e.isRetryable(),
+                            e.getDebugInfo(),
+                            firstNonNull(e.getMessage(), e)),
+                    e);
         }
 
         return requireNonNull(((QueryJobConfiguration) jobConfiguration).getDestinationTable(), "Cannot determine destination table for query");


### PR DESCRIPTION
## Description

`TestBigQueryAvroConnectorTest.testLimitPushdownWithMaterializedView` is flaky https://github.com/trinodb/trino/issues/27924. 
However, the failed message doesn't contain helpful info:

https://github.com/trinodb/trino/actions/runs/21004175205/job/60382105470
```
Error:  io.trino.plugin.bigquery.TestBigQueryAvroConnectorTest.testLimitPushdownWithMaterializedView -- Time elapsed: 53.97 s <<< ERROR!
io.trino.testing.QueryFailedException: Failed to get destination table for query. java.lang.InterruptedException
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:588)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:571)
	at io.trino.sql.query.QueryAssertions$QueryAssert.hasCorrectResultsRegardlessOfPushdown(QueryAssertions.java:601)
	at io.trino.sql.query.QueryAssertions$QueryAssert.isFullyPushedDown(QueryAssertions.java:464)
	at io.trino.plugin.bigquery.BaseBigQueryConnectorTest.assertNativeQueryWithLimitPushdown(BaseBigQueryConnectorTest.java:1361)
	at io.trino.plugin.bigquery.BaseBigQueryConnectorTest.assertLimitPushdownOnRegionTable(BaseBigQueryConnectorTest.java:1346)
	at io.trino.plugin.bigquery.BaseBigQueryConnectorTest.testLimitPushdownWithMaterializedView(BaseBigQueryConnectorTest.java:1284)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT * FROM test.region_mv_klbkffsf22')) LIMIT 10
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:595)
		... 11 more
Caused by: io.trino.spi.TrinoException: Failed to get destination table for query. java.lang.InterruptedException
	at io.trino.plugin.bigquery.BigQueryClient.getDestinationTable(BigQueryClient.java:543)
	at io.trino.plugin.bigquery.ptf.Query$QueryFunction.analyze(Query.java:117)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction.analyze(ClassLoaderSafeConnectorTableFunction.java:82)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTableFunctionInvocation(StatementAnalyzer.java:1721)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTableFunctionInvocation(StatementAnalyzer.java:533)
	at io.trino.sql.tree.TableFunctionInvocation.accept(TableFunctionInvocation.java:56)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:552)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:5106)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:3179)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:533)
	at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:552)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:560)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1606)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:533)
	at io.trino.sql.tree.Query.accept(Query.java:130)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:552)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:512)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:501)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:98)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:87)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:284)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:219)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:884)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:158)
	at io.trino.$gen.Trino_testversion____20260114_175302_1.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: com.google.cloud.bigquery.BigQueryException: java.lang.InterruptedException
	at com.google.cloud.bigquery.BigQueryException.translateAndThrow(BigQueryException.java:130)
	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:501)
	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:422)
	at io.trino.plugin.bigquery.BigQueryClient.getDestinationTable(BigQueryClient.java:540)
	... 34 more
Caused by: java.lang.InterruptedException
	at com.google.common.util.concurrent.AbstractFutureState.blockingGet(AbstractFutureState.java:231)
	at com.google.common.util.concurrent.Platform.get(Platform.java:54)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:253)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:96)
	at com.google.common.util.concurrent.ForwardingFuture.get(ForwardingFuture.java:66)
	at com.google.api.gax.retrying.BasicRetryingFuture.setAttemptFuture(BasicRetryingFuture.java:98)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:106)
	at com.google.cloud.bigquery.BigQueryRetryHelper.run(BigQueryRetryHelper.java:108)
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:62)
	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:469)
	... 36 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
