### PR TITLE
Fix `TestIcebergBigLakeMetastoreConnectorSmokeTest#testCreateTableWithTrailingSpaceInLocation` failure

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -255,7 +255,7 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
 
         assertThat(query(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS a, 'INDIA' AS b, true AS c", tableName, tableLocationWithTrailingSpace))).failure()
                 .hasMessage("Failed to create transaction")
-                .hasStackTraceContaining("Malformed request: The table `location` property can only point to the default location");
+                .hasStackTraceContaining("Malformed request: The table `location` property must point to a location in the catalog.");
     }
 
     @Test


### PR DESCRIPTION
## Description

The example failure: https://github.com/trinodb/trino/actions/runs/21127616534/job/60752195949?pr=27949

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.