### PR TITLE
Populate snapshot summary in iceberg ConnectorOutputMetadata

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergCommitMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergCommitMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+
+import java.util.Map;
+
+final class IcebergCommitMetadata
+        implements ConnectorOutputMetadata
+{
+    private final Map<String, String> commitMetrics;
+
+    @JsonCreator
+    public IcebergCommitMetadata(@JsonProperty("commitMetrics") Map<String, String> commitMetrics)
+    {
+        this.commitMetrics = ImmutableMap.copyOf(commitMetrics);
+    }
+
+    @Override
+    @JsonProperty
+    public Map<String, String> getInfo()
+    {
+        return commitMetrics;
+    }
+}


### PR DESCRIPTION
## Description
Adds useful information to TableFinish operator summary of CTAS, INSERT and REFRESH MV queries
e.g.
```
"connectorOutputMetadata" : {
  "trino_query_id" : "20260120_051928_00000_uh66u",
  "trino_user" : "raunaq.morarka",
  "added-data-files" : "5",
  "added-records" : "25",
  "added-files-size" : "5577",
  "changed-partition-count" : "5",
  "total-records" : "25",
  "total-files-size" : "5577",
  "total-data-files" : "5",
  "total-delete-files" : "0",
  "total-position-deletes" : "0",
  "total-equality-deletes" : "0",
  "engine-version" : "dev",
  "engine-name" : "trino",
  "iceberg-version" : "Apache Iceberg 1.10.1 (commit ccb8bc435062171e64bc8b7e5f56e6aed9c5b934)"
}
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
