### PR TITLE
Improve doc on Apache Ranger required policies

### DIFF
--- a/docs/src/main/sphinx/security/ranger-access-control.md
+++ b/docs/src/main/sphinx/security/ranger-access-control.md
@@ -183,17 +183,44 @@ The following table lists the configuration properties for the Ranger access con
 
 ## Required policies
 
-* Users must have permission to execute queries in Trino. Without a policy in
-  Apache Ranger to grant this permission, users are not able to execute any
-  query.
-  * To allow this, create a policy in Apache Ranger for a `queryId` resource
-    with a value `*` and with the `execute` permission for the user `{USER}`.
-* Users must have permission to impersonate themselves in Trino. Without a
-  policy in Apache Ranger to grant this permission, users are not able to
-  execute any query.
-  * To allow this, create a policy in Apache Ranger for a `trinouser` resource
-    with value `{USER}` and with the `impersonate` permission for user `{USER}`.
-* External clients can use the `system.runtime.kill_query()` procedure to 
-  kill running queries. Add a policy with Schema `system`, Database
-  `runtime` and Procedure `kill_query` with `execute` permission for user
-  `{USER}`.
+:::{list-table}
+:widths: 52, 22, 10, 16
+:header-rows: 1
+
+* - Description
+  - Resource
+  - User
+  - Permission(s)
+* - Users must have permission to execute queries in Trino. Without a policy in
+    Apache Ranger to grant this permission, users are not able to execute any
+    query.
+  - Query ID `*`
+  - `{USER}`
+  - `execute`
+* - Users must have permission to impersonate themselves in Trino. Without a
+    policy in Apache Ranger to grant this permission, users are not able to
+    execute any query.
+  - Trino User `{USER}`
+  - `{USER}`
+  - `impersonate`
+* - External clients can use the `system.runtime.kill_query()` procedure to
+    kill running queries.
+  - Schema `system`
+    Database `runtime`
+    Procedure `kill_query`
+  - `{USER}`
+  - `execute`
+* - (Optional) In order to perform a graceful shutdown of a worker, a separate 
+    user can be created. Note that it is possible to set up an
+    additional {doc}`password file <password-file>` authentication for this.
+  - System Information
+  - Any
+  - `write_sysinfo`
+* - (Optional) In order to retrieve metrics from the `/metrics` endpoint, a 
+    special user can be created. Note that it is possible to set up an 
+    additional {doc}`password file <password-file>` authentication for this.
+  - System Information
+  - Any
+  - `read_sysinfo`
+
+:::


### PR DESCRIPTION
## Description
The required policies are hard to guess, I've created a table with their description.
<img width="1179" height="739" alt="Screenshot 2026-01-23 at 23-24-54 Ranger access control — Trino 480-SNAPSHOT Documentation" src="https://github.com/user-attachments/assets/4f8ff45c-c81f-4534-9764-3f3b6373f0e1" />


## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: