### PR TITLE
Add content column to iceberg manifests and all_manifests

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1310,9 +1310,9 @@ SELECT * FROM "test_table$manifests";
 ```
 
 ```text
- path                                                                                                           | length          | partition_spec_id    | added_snapshot_id     | added_data_files_count  | added_rows_count | existing_data_files_count   | existing_rows_count | deleted_data_files_count    | deleted_rows_count | partition_summaries
-----------------------------------------------------------------------------------------------------------------+-----------------+----------------------+-----------------------+-------------------------+------------------+-----------------------------+---------------------+-----------------------------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- hdfs://hadoop-master:9000/user/hive/warehouse/test_table/metadata/faa19903-1455-4bb8-855a-61a1bbafbaa7-m0.avro |  6277           |   0                  | 7860805980949777961   | 1                       | 100              | 0                           | 0                   | 0                           | 0                  | {{contains_null=false, contains_nan= false, lower_bound=1, upper_bound=1},{contains_null=false, contains_nan= false, lower_bound=2021-01-12, upper_bound=2021-01-12}}
+ content | path                                                                                                           | length          | partition_spec_id    | added_snapshot_id     | added_data_files_count  | added_rows_count | existing_data_files_count   | existing_rows_count | deleted_data_files_count    | deleted_rows_count | partition_summaries
+---------+----------------------------------------------------------------------------------------------------------------+-----------------+----------------------+-----------------------+-------------------------+------------------+-----------------------------+---------------------+-----------------------------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 0       | hdfs://hadoop-master:9000/user/hive/warehouse/test_table/metadata/faa19903-1455-4bb8-855a-61a1bbafbaa7-m0.avro |  6277           |   0                  | 7860805980949777961   | 1                       | 100              | 0                           | 0                   | 0                           | 0                  | {{contains_null=false, contains_nan= false, lower_bound=1, upper_bound=1},{contains_null=false, contains_nan= false, lower_bound=2021-01-12, upper_bound=2021-01-12}}
 ```
 
 The output of the query has the following columns:
@@ -1324,6 +1324,13 @@ The output of the query has the following columns:
 * - Name
   - Type
   - Description
+* - `content`
+  - `INTEGER`
+  - Type of content stored in the manifest. The supported content types in
+    Iceberg are:
+
+    * `DATA(0)` - manifests that track data files.
+    * `DELETES(1)` - manifests that track delete files.
 * - `path`
   - `VARCHAR`
   - The manifest file location.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/AllManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/AllManifestsTable.java
@@ -43,6 +43,7 @@ public class AllManifestsTable
     {
         super(requireNonNull(icebergTable, "icebergTable is null"),
                 new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"), ImmutableList.<ColumnMetadata>builder()
+                        .add(new ColumnMetadata("content", INTEGER))
                         .add(new ColumnMetadata("path", VARCHAR))
                         .add(new ColumnMetadata("length", BIGINT))
                         .add(new ColumnMetadata("partition_spec_id", INTEGER))
@@ -68,6 +69,7 @@ public class AllManifestsTable
     protected void addRow(PageListBuilder pagesBuilder, Row row, TimeZoneKey timeZoneKey)
     {
         pagesBuilder.beginRow();
+        pagesBuilder.appendInteger(row.get("content", Integer.class));
         pagesBuilder.appendVarchar(row.get("path", String.class));
         pagesBuilder.appendBigint(row.get("length", Long.class));
         pagesBuilder.appendInteger(row.get("partition_spec_id", Integer.class));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/ManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/ManifestsTable.java
@@ -65,6 +65,7 @@ public class ManifestsTable
         tableMetadata = new ConnectorTableMetadata(
                 tableName,
                 ImmutableList.<ColumnMetadata>builder()
+                        .add(new ColumnMetadata("content", INTEGER))
                         .add(new ColumnMetadata("path", VARCHAR))
                         .add(new ColumnMetadata("length", BIGINT))
                         .add(new ColumnMetadata("partition_spec_id", INTEGER))
@@ -118,6 +119,7 @@ public class ManifestsTable
 
         snapshot.allManifests(icebergTable.io()).forEach(file -> {
             pagesBuilder.beginRow();
+            pagesBuilder.appendInteger(file.content().id());
             pagesBuilder.appendVarchar(file.path());
             pagesBuilder.appendBigint(file.length());
             pagesBuilder.appendInteger(file.partitionSpecId());


### PR DESCRIPTION
## Description
Matches https://iceberg.apache.org/docs/latest/spark-queries/#manifests


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add `content` column to `$manifests` and `$all_manifests` metadata tables. ({issue}`27975`)
```
