### PR TITLE
Allow a JDBC connector to define the column type

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -296,19 +296,25 @@ public abstract class BaseJdbcClient
         for (int column = 1; column <= metadata.getColumnCount(); column++) {
             // Use getColumnLabel method because query pass-through table function may contain column aliases
             String name = metadata.getColumnLabel(column);
-            JdbcTypeHandle jdbcTypeHandle = new JdbcTypeHandle(
-                    metadata.getColumnType(column),
-                    Optional.ofNullable(metadata.getColumnTypeName(column)),
-                    Optional.of(metadata.getPrecision(column)),
-                    Optional.of(metadata.getScale(column)),
-                    Optional.empty(), // TODO support arrays
-                    Optional.of(metadata.isCaseSensitive(column) ? CASE_SENSITIVE : CASE_INSENSITIVE));
+            JdbcTypeHandle jdbcTypeHandle = getColumnTypeHandle(metadata, column);
             Type type = toColumnMapping(session, connection, jdbcTypeHandle)
                     .orElseThrow(() -> new UnsupportedOperationException(format("Unsupported type: %s of column: %s", jdbcTypeHandle, name)))
                     .getType();
             columns.add(new JdbcColumnHandle(name, jdbcTypeHandle, type));
         }
         return columns.build();
+    }
+
+    protected JdbcTypeHandle getColumnTypeHandle(ResultSetMetaData metadata, int column)
+            throws SQLException
+    {
+        return new JdbcTypeHandle(
+                metadata.getColumnType(column),
+                Optional.ofNullable(metadata.getColumnTypeName(column)),
+                Optional.of(metadata.getPrecision(column)),
+                Optional.of(metadata.getScale(column)),
+                Optional.empty(), // TODO support arrays
+                Optional.of(metadata.isCaseSensitive(column) ? CASE_SENSITIVE : CASE_INSENSITIVE));
     }
 
     @Override
@@ -326,13 +332,7 @@ public abstract class BaseJdbcClient
                 }
                 allColumns++;
                 String columnName = resultSet.getString("COLUMN_NAME");
-                JdbcTypeHandle typeHandle = new JdbcTypeHandle(
-                        getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
-                        Optional.ofNullable(resultSet.getString("TYPE_NAME")),
-                        getInteger(resultSet, "COLUMN_SIZE"),
-                        getInteger(resultSet, "DECIMAL_DIGITS"),
-                        Optional.empty(),
-                        Optional.ofNullable(caseSensitivityMapping.get(columnName)));
+                JdbcTypeHandle typeHandle = getColumnTypeHandle(resultSet, Optional.ofNullable(caseSensitivityMapping.get(columnName)));
                 Optional<ColumnMapping> columnMapping = toColumnMapping(session, connection, typeHandle);
                 log.debug("Mapping data type of '%s' column '%s': %s mapped to %s", schemaTableName, columnName, typeHandle, columnMapping);
                 boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
@@ -462,15 +462,8 @@ public abstract class BaseJdbcClient
                         }
 
                         String columnName = resultSet.getString("COLUMN_NAME");
-                        JdbcTypeHandle typeHandle = new JdbcTypeHandle(
-                                getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
-                                Optional.ofNullable(resultSet.getString("TYPE_NAME")),
-                                getInteger(resultSet, "COLUMN_SIZE"),
-                                getInteger(resultSet, "DECIMAL_DIGITS"),
-                                // arrayDimensions
-                                Optional.<Integer>empty(),
-                                // This code doesn't do getCaseSensitivityForColumns. However, this does not impact the ColumnMetadata returned.
-                                Optional.<CaseSensitivity>empty());
+                        // This code doesn't do getCaseSensitivityForColumns. However, this does not impact the ColumnMetadata returned.
+                        JdbcTypeHandle typeHandle = getColumnTypeHandle(resultSet, Optional.<CaseSensitivity>empty());
                         boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
                         Optional<String> comment = Optional.ofNullable(emptyToNull(resultSet.getString("REMARKS")));
                         toColumnMapping(session, connection, typeHandle).ifPresent(columnMapping -> {
@@ -525,6 +518,19 @@ public abstract class BaseJdbcClient
             currentTableColumns = null;
             return currentTableMetadata;
         }
+    }
+
+    protected JdbcTypeHandle getColumnTypeHandle(ResultSet resultSet, Optional<CaseSensitivity> caseSensitivity)
+            throws SQLException
+    {
+        return new JdbcTypeHandle(
+                getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
+                Optional.ofNullable(resultSet.getString("TYPE_NAME")),
+                getInteger(resultSet, "COLUMN_SIZE"),
+                getInteger(resultSet, "DECIMAL_DIGITS"),
+                // arrayDimensions
+                Optional.<Integer>empty(),
+                caseSensitivity);
     }
 
     private static void cleanupSuppressing(Throwable inflight, CheckedRunnable cleanup)


### PR DESCRIPTION
## Description
 
This small change allows a connector to influence the creation of SQL types.

## Additional context and related issues

This is in response to [issue#27890](https://github.com/trinodb/trino/issues/27890). (fixes #27890)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`27890`)
```
