### PR TITLE
Allow a JDBC Connector to define its default schema

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -1882,7 +1882,7 @@ public abstract class BaseJdbcClient
         return name;
     }
 
-    private static RemoteTableName getRemoteTable(ResultSet resultSet)
+    protected RemoteTableName getRemoteTable(ResultSet resultSet)
             throws SQLException
     {
         return new RemoteTableName(


### PR DESCRIPTION
## Description

SQLite is unique in that it does not support schemas but manages two dummy schemas in its SQL and DDL commands:
- main
- temp

This minor modification enables support for connectors like this.

## Additional context and related issues

This is in response to [issue#27891](https://github.com/trinodb/trino/issues/27891)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`27891`)
```
