### PR TITLE
Unmark updateCount as nullable in QueryResults

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/QueryResults.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryResults.java
@@ -157,7 +157,6 @@ public class QueryResults
         return updateType;
     }
 
-    @Nullable
     @JsonProperty
     @Override
     public OptionalLong getUpdateCount()


### PR DESCRIPTION
Since it was refactored to be an OptionalInt, it's required in the constructor to be non-null so it never actually is and annotation is no longer correct.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
