### PR TITLE
Surface JSON serialization errors in server log

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/EofExceptionSuppressingWriterInterceptor.java
+++ b/core/trino-main/src/main/java/io/trino/server/EofExceptionSuppressingWriterInterceptor.java
@@ -13,7 +13,6 @@
  */
 package io.trino.server;
 
-import io.airlift.log.Logger;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.ext.Provider;
@@ -24,11 +23,9 @@ import java.io.IOException;
 
 @Provider
 @Priority(11)
-public class IoExceptionSuppressingWriterInterceptor
+public class EofExceptionSuppressingWriterInterceptor
         implements WriterInterceptor
 {
-    private static final Logger log = Logger.get(IoExceptionSuppressingWriterInterceptor.class);
-
     @Override
     public void aroundWriteTo(WriterInterceptorContext context)
             throws WebApplicationException
@@ -42,7 +39,7 @@ public class IoExceptionSuppressingWriterInterceptor
                 // This is not an error, so we suppress it.
                 return;
             }
-            log.warn("Could not write to output: %s(%s)", e.getClass().getSimpleName(), e.getMessage());
+            throw new WebApplicationException(e);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -317,7 +317,7 @@ public class ServerMainModule
         binder.bind(NullSafeHashCompiler.class).in(Scopes.SINGLETON);
         binder.bind(PagesIndex.Factory.class).to(PagesIndex.DefaultFactory.class);
         binder.bind(PagesInputStreamFactory.class);
-        jaxrsBinder(binder).bind(IoExceptionSuppressingWriterInterceptor.class);
+        jaxrsBinder(binder).bind(EofExceptionSuppressingWriterInterceptor.class);
 
         // exchange client
         binder.bind(DirectExchangeClientSupplier.class).to(DirectExchangeClientFactory.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Consider endpoint which returns an entity (object) to be serialized for form a JSON response. When serialization fails in the middle, the failure should be surfaced in the server log as an error (at ERROR level). Before the change it was reported at WARN level only and without full stacktrace.

Given that this commit slightly changes the behavior of `IoExceptionSuppressingWriterInterceptor`, the class is renamed accordingly.

- fixes part of https://github.com/trinodb/trino/issues/27993
