### PR TITLE
Add default compression codec for parquet in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -410,6 +410,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testShowCreateTable()
     {
+        String compressionCodec = format == PARQUET ? "   compression_codec = 'ZSTD',\n" : "";
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
                 .matches("\\QCREATE TABLE iceberg.tpch.orders (\n" +
                         "   orderkey bigint,\n" +
@@ -423,6 +424,7 @@ public abstract class BaseIcebergConnectorTest
                         "   comment varchar\n" +
                         ")\n" +
                         "WITH (\n" +
+                        compressionCodec +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
                         "   location = '\\E.*/tpch/orders-.*\\Q'\n" +
@@ -1318,6 +1320,7 @@ public abstract class BaseIcebergConnectorTest
                         "FROM tpch.tiny.orders",
                 "SELECT count(*) from orders");
 
+        String compressionCodec = format == PARQUET ? "   compression_codec = 'ZSTD',\n" : "";
         assertThat(computeScalar("SHOW CREATE TABLE test_create_partitioned_table_as")).isEqualTo(format(
                 "CREATE TABLE %s.%s.%s (\n" +
                         "   \"order key\" bigint,\n" +
@@ -1325,6 +1328,7 @@ public abstract class BaseIcebergConnectorTest
                         "   order_status varchar\n" +
                         ")\n" +
                         "WITH (\n" +
+                        compressionCodec +
                         "   format = '%s',\n" +
                         "   format_version = 2,\n" +
                         "   location = '%s',\n" +
@@ -1688,6 +1692,7 @@ public abstract class BaseIcebergConnectorTest
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
+                "   compression_codec = 'ZSTD',\n" +
                 format("   format = '%s',\n", format) +
                 "   format_version = 2,\n" +
                 format("   location = '%s'\n", tempDirPath) +
@@ -1697,6 +1702,7 @@ public abstract class BaseIcebergConnectorTest
                 "   _x bigint\n" +
                 ")\n" +
                 "WITH (\n" +
+                "   compression_codec = 'ZSTD',\n" +
                 "   format = '" + format + "',\n" +
                 "   format_version = 2,\n" +
                 "   location = '" + tempDirPath + "'\n" +
@@ -1995,6 +2001,7 @@ public abstract class BaseIcebergConnectorTest
     {
         File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
         String tempDirPath = tempDir.toURI().toASCIIString() + randomNameSuffix();
+        String compressionCodec = format == PARQUET ? "compression_codec = 'ZSTD',\n   " : "";
 
         // LIKE source INCLUDING PROPERTIES copies all the properties of the source table, including the `location`.
         // For this reason the source and the copied table will share the same directory.
@@ -2003,11 +2010,12 @@ public abstract class BaseIcebergConnectorTest
         assertThat(getTablePropertiesString("test_create_table_like_original")).isEqualTo(format(
                 """
                         WITH (
-                           format = '%s',
+                           %sformat = '%s',
                            format_version = 2,
                            location = '%s',
                            partitioning = ARRAY['adate']
                         )""",
+                compressionCodec,
                 format,
                 tempDirPath));
 
@@ -2019,10 +2027,11 @@ public abstract class BaseIcebergConnectorTest
         assertThat(getTablePropertiesString("test_create_table_like_copy1")).isEqualTo(format(
                 """
                         WITH (
-                           format = '%s',
+                           %sformat = '%s',
                            format_version = 2,
                            location = '%s'
                         )""",
+                compressionCodec,
                 format,
                 getTableLocation("test_create_table_like_copy1")));
 
@@ -2030,10 +2039,11 @@ public abstract class BaseIcebergConnectorTest
         assertThat(getTablePropertiesString("test_create_table_like_copy2")).isEqualTo(format(
                 """
                         WITH (
-                           format = '%s',
+                           %sformat = '%s',
                            format_version = 2,
                            location = '%s'
                         )""",
+                compressionCodec,
                 format,
                 getTableLocation("test_create_table_like_copy2")));
         assertUpdate("DROP TABLE test_create_table_like_copy2");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -849,6 +849,12 @@ public abstract class BaseIcebergSystemTables
         try (TestTable table = newTrinoTable("test_properties", "(x BIGINT,y DOUBLE) WITH (sorted_by = ARRAY['y'])")) {
             Table icebergTable = loadTable(table.getName());
             Map<String, String> actualProperties = getTableProperties(table.getName());
+            if (format == PARQUET) {
+                assertThat(actualProperties).hasSize(8);
+                assertThat(actualProperties).contains(entry("write.parquet.compression-codec", "zstd"));
+            } else {
+                assertThat(actualProperties).hasSize(7);
+            }
             assertThat(actualProperties).contains(
                     entry("format", "iceberg/" + format.name()),
                     entry("provider", "iceberg"),


### PR DESCRIPTION
## Description
Following PR #25755, if a user doesn't explicitly set the `compression-codec`  for Parquet, the `write.parquet.compression-codec` property is removed. Consequently, Trino falls back to the global `iceberg.compression-codec` configuration (defaulting to `ZSTD`) to write data files.

However, if Spark is used to rewrite these data files, it defaults to `GZIP` compression. To avoid this inconsistency, could we modify the logic to only remove the `write.parquet.compression-codec` property if the file format is not `Parquet`?

Or maybe we should configure a default compression codec for each file format?

## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Add default compression codec `ZSTD` for parquet in Iceberg
```
