### PR TITLE
Add test for predicate pushdown in `BaseConnectorTest`

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -433,6 +433,43 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testSimplePredicatePushdown()
+    {
+        if (!hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN)) {
+            assertThat(query("SELECT name FROM nation WHERE regionkey = 3"))
+                    .isNotFullyPushedDown(FilterNode.class);
+            return;
+        }
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey = 3"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey <> 3"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey < 3"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey <= 3"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey > 3"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey >= 3"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name FROM nation WHERE regionkey IN (1, 2, 3)"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT * FROM nation WHERE name IS NOT NULL"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT * FROM nation WHERE name IS NULL"))
+                .isFullyPushedDown();
+    }
+
+    @Test
     public void testLimitPushdown()
     {
         if (!hasBehavior(SUPPORTS_LIMIT_PUSHDOWN)) {


### PR DESCRIPTION
Previously, the predicate pushdown behavior was not directly verified. It was
 only tested indirectly when other features like `LIMIT`, `JOIN` or others
behavior  were exercised.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
