### PR TITLE
Unbind `S3Presigner` from `S3FileSystemLoader`

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
@@ -24,6 +24,8 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.util.concurrent.Executor;
 
+import static io.trino.filesystem.s3.S3FileSystemUtils.createS3PreSigner;
+
 public final class S3FileSystemFactory
         implements TrinoFileSystemFactory
 {
@@ -38,7 +40,7 @@ public final class S3FileSystemFactory
     {
         this.loader = new S3FileSystemLoader(openTelemetry, config, stats);
         this.client = loader.createClient();
-        this.preSigner = loader.createPreSigner();
+        this.preSigner = createS3PreSigner(config, client);
         this.context = loader.context();
         this.uploadExecutor = loader.uploadExecutor();
     }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+import java.net.URI;
+import java.util.Optional;
+
+final class S3FileSystemUtils
+{
+    private S3FileSystemUtils() {}
+
+    public static S3Presigner createS3PreSigner(S3FileSystemConfig config, S3Client s3Client)
+    {
+        Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(config);
+        Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
+        Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
+        boolean pathStyleAccess = config.isPathStyleAccess();
+        boolean useWebIdentityTokenCredentialsProvider = config.isUseWebIdentityTokenCredentialsProvider();
+        Optional<String> staticIamRole = Optional.ofNullable(config.getIamRole());
+        String staticRoleSessionName = config.getRoleSessionName();
+        String externalId = config.getExternalId();
+
+        S3Presigner.Builder s3 = S3Presigner.builder();
+        s3.s3Client(s3Client);
+
+        staticRegion.map(Region::of).ifPresent(s3::region);
+        staticEndpoint.map(URI::create).ifPresent(s3::endpointOverride);
+        s3.serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(pathStyleAccess)
+                .build());
+
+        if (useWebIdentityTokenCredentialsProvider) {
+            s3.credentialsProvider(WebIdentityTokenFileCredentialsProvider.builder()
+                    .asyncCredentialUpdateEnabled(true)
+                    .build());
+        }
+        else if (staticIamRole.isPresent()) {
+            s3.credentialsProvider(StsAssumeRoleCredentialsProvider.builder()
+                    .refreshRequest(request -> request
+                            .roleArn(staticIamRole.get())
+                            .roleSessionName(staticRoleSessionName)
+                            .externalId(externalId))
+                    .stsClient(createStsClient(config, staticCredentialsProvider))
+                    .asyncCredentialUpdateEnabled(true)
+                    .build());
+        }
+        else {
+            staticCredentialsProvider.ifPresent(s3::credentialsProvider);
+        }
+
+        return s3.build();
+    }
+
+    static StsClient createStsClient(S3FileSystemConfig config, Optional<AwsCredentialsProvider> credentialsProvider)
+    {
+        StsClientBuilder sts = StsClient.builder();
+        Optional.ofNullable(config.getStsEndpoint()).map(URI::create).ifPresent(sts::endpointOverride);
+        Optional.ofNullable(config.getStsRegion())
+                .or(() -> Optional.ofNullable(config.getRegion()))
+                .map(Region::of).ifPresent(sts::region);
+        credentialsProvider.ifPresent(sts::credentialsProvider);
+        return sts.build();
+    }
+
+    static Optional<AwsCredentialsProvider> createStaticCredentialsProvider(S3FileSystemConfig config)
+    {
+        if ((config.getAwsAccessKey() != null) || (config.getAwsSecretKey() != null)) {
+            return Optional.of(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(config.getAwsAccessKey(), config.getAwsSecretKey())));
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`S3Presigner` instance does not need to be created
at the creation time of the `S3FileSystemLoader`.

In the context of dealing with S3 security mappings, the signer, needs to be corresponding to the `S3Client` instance which corresponds to the security mapping.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://trino.io/docs/current/object-storage/file-system-s3.html#security-mapping

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
