### PR TITLE
Rename getAccessTokenClaims method

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/JweTokenSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/JweTokenSerializer.java
@@ -112,7 +112,7 @@ public class JweTokenSerializer
     {
         requireNonNull(tokenPair, "tokenPair is null");
 
-        Map<String, Object> claims = client.getClaims(tokenPair.accessToken()).orElseThrow(() -> new IllegalArgumentException("Claims are missing"));
+        Map<String, Object> claims = client.getAccessTokenClaims(tokenPair.accessToken()).orElseThrow(() -> new IllegalArgumentException("Access Token claims are missing"));
         if (!claims.containsKey(principalField)) {
             throw new IllegalArgumentException(format("%s field is missing", principalField));
         }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
@@ -178,7 +178,7 @@ public class NimbusOAuth2Client
     }
 
     @Override
-    public Optional<Map<String, Object>> getClaims(String accessToken)
+    public Optional<Map<String, Object>> getAccessTokenClaims(String accessToken)
     {
         checkState(loaded, "OAuth2 client not initialized");
         return getJWTClaimsSet(accessToken).map(JWTClaimsSet::getClaims);

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -74,7 +74,7 @@ public class OAuth2Authenticator
         if (tokenPair.expiration().before(Date.from(Instant.now()))) {
             return Optional.empty();
         }
-        Optional<Map<String, Object>> claims = client.getClaims(tokenPair.accessToken());
+        Optional<Map<String, Object>> claims = client.getAccessTokenClaims(tokenPair.accessToken());
         if (claims.isEmpty()) {
             return Optional.empty();
         }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
@@ -29,7 +29,7 @@ public interface OAuth2Client
     Response getOAuth2Response(String code, URI callbackUri, Optional<String> nonce)
             throws ChallengeFailedException;
 
-    Optional<Map<String, Object>> getClaims(String accessToken);
+    Optional<Map<String, Object>> getAccessTokenClaims(String accessToken);
 
     Response refreshTokens(String refreshToken)
             throws ChallengeFailedException;

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
@@ -139,7 +139,7 @@ public class OAuth2WebUiAuthenticationFilter
 
     private Optional<Map<String, Object>> getAccessTokenClaims(TokenPair tokenPair)
     {
-        return client.getClaims(tokenPair.accessToken());
+        return client.getAccessTokenClaims(tokenPair.accessToken());
     }
 
     private void needAuthentication(ContainerRequestContext request, Optional<TokenPair> tokenPair)

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -1088,7 +1088,7 @@ public class TestResourceSecurity
                 }
 
                 @Override
-                public Optional<Map<String, Object>> getClaims(String accessToken)
+                public Optional<Map<String, Object>> getAccessTokenClaims(String accessToken)
                 {
                     return Optional.of(jwtParser.parseSignedClaims(accessToken).getPayload());
                 }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
@@ -217,7 +217,7 @@ public class TestJweTokenSerializer
         }
 
         @Override
-        public Optional<Map<String, Object>> getClaims(String accessToken)
+        public Optional<Map<String, Object>> getAccessTokenClaims(String accessToken)
         {
             return Optional.of(claims);
         }

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -1325,7 +1325,7 @@ public class TestWebUi
         }
 
         @Override
-        public Optional<Map<String, Object>> getClaims(String accessToken)
+        public Optional<Map<String, Object>> getAccessTokenClaims(String accessToken)
         {
             return Optional.of(claims);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Be more specific from what token this method can get claims.
Implementation-wise, NimbusOAuth2Client, for example, utilises JWTProcessor configured specifically for accessTokenProcessor, which cannot be reused for other tokens.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.