### PR TITLE
Install udev in the docker image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -44,7 +44,8 @@ RUN \
       curl-minimal grep `# required by health-check` \
       zlib `#required by java` \
       shadow-utils `# required by useradd` \
-      tar `# required to support kubectl cp` && \
+      tar `# required to support kubectl cp` \
+      udev `# required by oshi` && \
       rm -rf /tmp/overlay/var/cache/*
 
 # Use ubi10 micro as it's more secure


### PR DESCRIPTION
Oshi complains about it:

> WARN    main    oshi.software.os.linux.LinuxOperatingSystem     Did not find udev library in operating system. Some features may not work.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
