### PR TITLE
Fix incorrect branch properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogServiceProviderModule.java
@@ -161,7 +161,7 @@ public class CatalogServiceProviderModule
     @Singleton
     public static BranchPropertyManager createBranchPropertyManager(ConnectorServicesProvider connectorServicesProvider)
     {
-        return new BranchPropertyManager(new ConnectorCatalogServiceProvider<>("branch properties", connectorServicesProvider, ConnectorServices::getAnalyzeProperties));
+        return new BranchPropertyManager(new ConnectorCatalogServiceProvider<>("branch properties", connectorServicesProvider, ConnectorServices::getBranchProperties));
     }
 
     @Provides

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
@@ -87,6 +87,7 @@ public class ConnectorServices
     private final Map<String, PropertyMetadata<?>> schemaProperties;
     private final Map<String, PropertyMetadata<?>> columnProperties;
     private final Map<String, PropertyMetadata<?>> analyzeProperties;
+    private final Map<String, PropertyMetadata<?>> branchProperties;
     private final Set<ConnectorCapabilities> capabilities;
 
     private final AtomicBoolean shutdown = new AtomicBoolean();
@@ -208,6 +209,10 @@ public class ConnectorServices
         requireNonNull(analyzeProperties, format("Connector '%s' returned a null analyze properties set", catalogHandle));
         this.analyzeProperties = Maps.uniqueIndex(analyzeProperties, PropertyMetadata::getName);
 
+        List<PropertyMetadata<?>> branchProperties = connector.getBranchProperties();
+        requireNonNull(branchProperties, format("Connector '%s' returned a null branch properties set", catalogHandle));
+        this.branchProperties = Maps.uniqueIndex(branchProperties, PropertyMetadata::getName);
+
         Set<ConnectorCapabilities> capabilities = connector.getCapabilities();
         requireNonNull(capabilities, format("Connector '%s' returned a null capabilities set", catalogHandle));
         this.capabilities = capabilities;
@@ -322,6 +327,11 @@ public class ConnectorServices
     public Map<String, PropertyMetadata<?>> getAnalyzeProperties()
     {
         return analyzeProperties;
+    }
+
+    public Map<String, PropertyMetadata<?>> getBranchProperties()
+    {
+        return branchProperties;
     }
 
     public Set<ConnectorCapabilities> getCapabilities()

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -177,6 +177,14 @@ public interface Connector
     }
 
     /**
+     * @return the branch properties for this connector
+     */
+    default List<PropertyMetadata<?>> getBranchProperties()
+    {
+        return emptyList();
+    }
+
+    /**
      * @return the table properties for this connector
      */
     default List<PropertyMetadata<?>> getTableProperties()


### PR DESCRIPTION
## Description

`CatalogServiceProviderModule.createBranchPropertyManager` shouldn't call `getAnalyzeProperties` method.

This PR adds a new `getBranchProperties` method to SPI and use it from engine. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
