### PR TITLE
Remove redundant OpenLineage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,6 @@ jobs:
             - { modules: plugin/trino-mariadb }
             - { modules: plugin/trino-mongodb }
             - { modules: plugin/trino-mysql }
-            - { modules: plugin/trino-openlineage }
             - { modules: plugin/trino-opensearch }
             - { modules: plugin/trino-oracle }
             - { modules: plugin/trino-pinot }


### PR DESCRIPTION
## Description

There is another job: 
https://github.com/trinodb/trino/blob/efa2ce63cb50dd379f94104aa50bd76df7b18a11/.github/workflows/ci.yml#L460

The `test (plugin/trino-base-jdbc,plugin/trino-faker,plugin/trino-geospatial,plugin/trino-memory,plugin/trino-openlineage,plugin/trino-thrift)` takes 13m on master. 

The `test (plugin/trino-openlineage)` takes 6m on master. 

This PR removes the second job to avoid redundant Maven Install overhead. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
