### PR TITLE
Support Iceberg table properties for write configuration

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -336,8 +336,10 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.MAX_PREVIOUS_VERSIO
 import static io.trino.plugin.iceberg.IcebergTableProperties.OBJECT_STORE_LAYOUT_ENABLED_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_COLUMNS_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.PARQUET_WRITER_BLOCK_SIZE;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.TARGET_MAX_FILE_SIZE;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getFormatVersion;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
@@ -453,8 +455,10 @@ import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_ENABLED;
 import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableUtil.formatVersion;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.types.TypeUtil.indexParents;
@@ -2748,6 +2752,18 @@ public class IcebergMetadata
                 throw new TrinoException(INVALID_TABLE_PROPERTY, "Data location can only be set when object store layout is enabled");
             }
             updateProperties.set(WRITE_DATA_LOCATION, dataLocation);
+        }
+
+        if (properties.containsKey(TARGET_MAX_FILE_SIZE)) {
+            DataSize targetMaxFileSize = (DataSize) properties.get(TARGET_MAX_FILE_SIZE)
+                    .orElseThrow(() -> new IllegalArgumentException("The target_max_file_size property cannot be empty"));
+            updateProperties.set(WRITE_TARGET_FILE_SIZE_BYTES, Long.toString(targetMaxFileSize.toBytes()));
+        }
+
+        if (properties.containsKey(PARQUET_WRITER_BLOCK_SIZE)) {
+            DataSize parquetWriterBlockSize = (DataSize) properties.get(PARQUET_WRITER_BLOCK_SIZE)
+                    .orElseThrow(() -> new IllegalArgumentException("The parquet_writer_block_size property cannot be empty"));
+            updateProperties.set(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(parquetWriterBlockSize.toBytes()));
         }
 
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -56,6 +56,7 @@ public class IcebergPageSinkProvider
     private final DataSize sortingFileWriterBufferSize;
     private final int sortingFileWriterMaxOpenFiles;
     private final Optional<String> sortingFileWriterLocalStagingPath;
+    private final long defaultTargetMaxFileSize;
     private final TypeManager typeManager;
     private final PageSorter pageSorter;
 
@@ -77,6 +78,7 @@ public class IcebergPageSinkProvider
         this.sortingFileWriterBufferSize = sortingFileWriterConfig.getWriterSortBufferSize();
         this.sortingFileWriterMaxOpenFiles = sortingFileWriterConfig.getMaxOpenSortFiles();
         this.sortingFileWriterLocalStagingPath = icebergConfig.getSortedWritingLocalStagingPath();
+        this.defaultTargetMaxFileSize = icebergConfig.getTargetMaxFileSize().toBytes();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
     }
@@ -114,6 +116,7 @@ public class IcebergPageSinkProvider
                 maxPartitionsPerWriter(session),
                 tableHandle.sortFields(),
                 tableHandle.sortOrderId(),
+                defaultTargetMaxFileSize,
                 sortingFileWriterBufferSize,
                 sortingFileWriterMaxOpenFiles,
                 sortingFileWriterLocalStagingPath,
@@ -147,6 +150,7 @@ public class IcebergPageSinkProvider
                         maxPartitionsPerWriter(session),
                         optimizeHandle.sortFields(),
                         optimizeHandle.sortOrderId(),
+                        defaultTargetMaxFileSize,
                         sortingFileWriterBufferSize,
                         sortingFileWriterMaxOpenFiles,
                         sortingFileWriterLocalStagingPath,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -42,7 +42,6 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
-import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
@@ -86,14 +85,12 @@ public final class IcebergSessionProperties
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
-    private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
     public static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String STATISTICS_ENABLED = "statistics_enabled";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
-    private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String IDLE_WRITER_MIN_FILE_SIZE = "idle_writer_min_file_size";
     public static final String COLLECT_EXTENDED_STATISTICS_ON_WRITE = "collect_extended_statistics_on_write";
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
@@ -260,12 +257,6 @@ public final class IcebergSessionProperties
                         parquetReaderConfig.isVectorizedDecodingEnabled(),
                         false))
                 .add(dataSizeProperty(
-                        PARQUET_WRITER_BLOCK_SIZE,
-                        "Parquet: Writer block size",
-                        parquetWriterConfig.getBlockSize(),
-                        value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
-                        false))
-                .add(dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
                         parquetWriterConfig.getPageSize(),
@@ -305,11 +296,6 @@ public final class IcebergSessionProperties
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a row type",
                         icebergConfig.isProjectionPushdownEnabled(),
-                        false))
-                .add(dataSizeProperty(
-                        TARGET_MAX_FILE_SIZE,
-                        "Target maximum size of written files; the actual size may be larger",
-                        icebergConfig.getTargetMaxFileSize(),
                         false))
                 .add(dataSizeProperty(
                         IDLE_WRITER_MIN_FILE_SIZE,
@@ -543,11 +529,6 @@ public final class IcebergSessionProperties
         return session.getProperty(PARQUET_WRITER_PAGE_VALUE_COUNT, Integer.class);
     }
 
-    public static DataSize getParquetWriterBlockSize(ConnectorSession session)
-    {
-        return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
-    }
-
     public static int getParquetWriterBatchSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
@@ -576,11 +557,6 @@ public final class IcebergSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
-    }
-
-    public static long getTargetMaxFileSize(ConnectorSession session)
-    {
-        return session.getProperty(TARGET_MAX_FILE_SIZE, DataSize.class).toBytes();
     }
 
     public static long getIdleWriterMinFileSize(ConnectorSession session)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -146,8 +146,10 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.PROTECTED_ICEBERG_N
 import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SUPPORTED_PROPERTIES;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getMaxPreviousVersions;
+import static io.trino.plugin.iceberg.IcebergTableProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getSortOrder;
+import static io.trino.plugin.iceberg.IcebergTableProperties.getTargetMaxFileSize;
 import static io.trino.plugin.iceberg.IcebergTableProperties.isDeleteAfterCommitEnabled;
 import static io.trino.plugin.iceberg.IcebergTableProperties.validateCompression;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
@@ -203,8 +205,10 @@ import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_FPP;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableUtil.formatVersion;
 import static org.apache.iceberg.expressions.Expressions.lit;
 import static org.apache.iceberg.types.Type.TypeID.BINARY;
@@ -983,6 +987,11 @@ public final class IcebergUtil
                 propertiesBuilder.put(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true");
             }
         }
+
+        getParquetWriterBlockSize(tableMetadata.getProperties())
+                .ifPresent(value -> propertiesBuilder.put(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(value.toBytes())));
+        getTargetMaxFileSize(tableMetadata.getProperties())
+                .ifPresent(value -> propertiesBuilder.put(WRITE_TARGET_FILE_SIZE_BYTES, Long.toString(value.toBytes())));
 
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -559,12 +559,11 @@ public abstract class BaseIcebergConnectorSmokeTest
         // Using a larger table forces buffered data to be written to disk
         Session withSmallRowGroups = Session.builder(getSession())
                 .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "200")
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "20kB")
                 .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "200")
                 .build();
         try (TestTable table = newTrinoTable(
                 "test_sorted_lineitem_table",
-                "WITH (sorted_by = ARRAY['comment'], format = '" + format.name() + "') AS TABLE tpch.tiny.lineitem WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['comment'], format = '" + format.name() + "'" + ", parquet_writer_block_size = '20kB'" + ") AS TABLE tpch.tiny.lineitem WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups,
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.lineitem",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1603,7 +1603,7 @@ public abstract class BaseIcebergConnectorTest
                 .build();
         try (TestTable table = newTrinoTable(
                 "test_sorting_disabled",
-                "WITH (sorted_by = ARRAY['comment']) AS SELECT * FROM nation WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['comment'], parquet_writer_block_size = '1kB') AS SELECT * FROM nation WITH NO DATA")) {
             assertUpdate(withSortingDisabled, "INSERT INTO " + table.getName() + " SELECT * FROM nation", 25);
             for (MaterializedRow row : computeActual("SELECT file_path, sort_order_id from \"" + table.getName() + "$files\"").getMaterializedRows()) {
                 assertThat(isFileSorted((String) row.getField(0), "comment")).isFalse();
@@ -1618,7 +1618,7 @@ public abstract class BaseIcebergConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_optimize_with_sort_order",
-                "WITH (sorted_by = ARRAY['comment']) AS SELECT * FROM nation WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['comment'], parquet_writer_block_size = '1kB') AS SELECT * FROM nation WITH NO DATA")) {
             assertUpdate("INSERT INTO " + table.getName() + " SELECT * FROM nation WHERE nationkey < 10", 10);
             assertUpdate("INSERT INTO " + table.getName() + " SELECT * FROM nation WHERE nationkey >= 10 AND nationkey < 20", 10);
             assertUpdate("INSERT INTO " + table.getName() + " SELECT * FROM nation WHERE nationkey >= 20", 5);
@@ -1639,7 +1639,7 @@ public abstract class BaseIcebergConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_sorted_update",
-                "WITH (sorted_by = ARRAY['comment']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['comment'], parquet_writer_block_size = '1kB') AS TABLE tpch.tiny.customer WITH NO DATA")) {
             assertUpdate(
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
                     "VALUES 1500");
@@ -5177,7 +5177,7 @@ public abstract class BaseIcebergConnectorTest
             try (TestTable table = newTrinoTable(
                     "test_split_pruning_data_file_statistics",
                     // Random double is needed to make sure rows are different. Otherwise compression may deduplicate rows, resulting in only one row group
-                    "(col " + testSetup.getTrinoTypeName() + ", r double)")) {
+                    "(col " + testSetup.getTrinoTypeName() + ", r double) WITH (parquet_writer_block_size = '1kB')")) {
                 String tableName = table.getName();
                 String values =
                         Stream.concat(
@@ -5847,9 +5847,8 @@ public abstract class BaseIcebergConnectorTest
                 .setSystemProperty("task_min_writer_count", "1")
                 // task scale writers should be disabled since we want to write with a single task writer
                 .setSystemProperty("task_scale_writers_enabled", "false")
-                .setCatalogSessionProperty("iceberg", "target_max_file_size", maxSize.toString())
                 .build();
-
+        createTableSql = format("CREATE TABLE %s WITH (target_max_file_size = '%s') AS SELECT * FROM tpch.sf1.lineitem LIMIT 200000", tableName, maxSize.toString());
         assertUpdate(session, createTableSql, 200000);
         assertThat(query(format("SELECT count(*) FROM %s", tableName))).matches("VALUES BIGINT '200000'");
         List<String> updatedFiles = getActiveFiles(tableName);
@@ -5883,9 +5882,8 @@ public abstract class BaseIcebergConnectorTest
                 .setSystemProperty("task_min_writer_count", "1")
                 // task scale writers should be disabled since we want to write with a single task writer
                 .setSystemProperty("task_scale_writers_enabled", "false")
-                .setCatalogSessionProperty("iceberg", "target_max_file_size", maxSize.toString())
                 .build();
-
+        createTableSql = format("CREATE TABLE %s WITH (sorted_by = ARRAY['shipdate'], target_max_file_size = '%s') AS SELECT * FROM tpch.sf1.lineitem LIMIT 200000", tableName, maxSize.toString());
         assertUpdate(session, createTableSql, 200000);
         assertThat(query(format("SELECT count(*) FROM %s", tableName))).matches("VALUES BIGINT '200000'");
         List<String> updatedFiles = getActiveFiles(tableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -106,7 +106,6 @@ public final class IcebergTestUtils
     {
         return Session.builder(session)
                 .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "20")
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "1kB")
                 .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "20")
                 .build();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -383,12 +383,11 @@ public class TestIcebergFileOperations
         String catalog = getSession().getCatalog().orElseThrow();
 
         assertUpdate("DROP TABLE IF EXISTS test_read_whole_splittable_file");
-        assertUpdate("CREATE TABLE test_read_whole_splittable_file(key varchar, data varchar) WITH (partitioning=ARRAY['key'])");
+        assertUpdate("CREATE TABLE test_read_whole_splittable_file(key varchar, data varchar) WITH (partitioning=ARRAY['key'], parquet_writer_block_size='1kB')");
 
         assertUpdate(
                 Session.builder(getSession())
                         .setSystemProperty(SystemSessionProperties.WRITER_SCALING_MIN_DATA_PROCESSED, "1PB")
-                        .setCatalogSessionProperty(catalog, "parquet_writer_block_size", "1kB")
                         .setCatalogSessionProperty(catalog, "orc_writer_max_stripe_size", "1kB")
                         .setCatalogSessionProperty(catalog, "orc_writer_max_stripe_rows", "1000")
                         .build(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
@@ -426,12 +426,10 @@ final class TestIcebergLocalConcurrentWrites
         ExecutorService executor = newFixedThreadPool(threads);
         String tableName = "test_concurrent_non_overlapping_updates_table_" + randomNameSuffix();
         // Force creating more parquet files
-        Session session = Session.builder(getSession())
-                .setCatalogSessionProperty("iceberg", "target_max_file_size", "1kB")
-                .build();
+        Session session = Session.builder(getSession()).build();
 
-        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT, part BIGINT) WITH (partitioning = ARRAY['part'])");
-        assertUpdate(session, " INSERT INTO " + tableName + " SELECT * FROM " +
+        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT, part BIGINT) WITH (partitioning = ARRAY['part'], target_max_file_size = '1kB')");
+        assertUpdate(" INSERT INTO " + tableName + " SELECT * FROM " +
                 "(select * from UNNEST(SEQUENCE(1, 10000)) AS t(a)) CROSS JOIN (select * from UNNEST(SEQUENCE(1, 3)) AS t(part))", 30000);
 
         // UPDATE will increase every value by 1

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
@@ -47,7 +47,7 @@ public class TestIcebergParquetComplexTypesPredicatePushDown
     public void testIcebergParquetRowTypeRowGroupPruning()
     {
         String tableName = "test_nested_column_pruning_" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " (col1Row ROW(a BIGINT, b BIGINT), col2 BIGINT) WITH (sorted_by=ARRAY['col2'])");
+        assertUpdate("CREATE TABLE " + tableName + " (col1Row ROW(a BIGINT, b BIGINT), col2 BIGINT) WITH (sorted_by=ARRAY['col2'], parquet_writer_block_size='1kB')");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM unnest(transform(SEQUENCE(1, 10000), x -> ROW(ROW(x*2, 100), x)))", 10000);
 
         // col1Row.a only contains even numbers, in the range of [2, 20000].

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
@@ -68,7 +68,7 @@ public class TestIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_row_group_reset_dictionary",
-                "(plain_col varchar, dict_col int)")) {
+                "WITH (parquet_writer_block_size = '1kB') AS SELECT CAST(NULL AS varchar) plain_col, CAST(NULL AS int) dict_col LIMIT 0")) {
             String tableName = table.getName();
             String values = IntStream.range(0, 100)
                     .mapToObj(i -> "('ABCDEFGHIJ" + i + "' , " + (i < 20 ? "1" : "null") + ")")
@@ -108,7 +108,7 @@ public class TestIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_ignore_parquet_statistics",
-                "WITH (sorted_by = ARRAY['custkey']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['custkey'], parquet_writer_block_size = '1kB') AS TABLE tpch.tiny.customer WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups(getSession()),
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
@@ -140,7 +140,7 @@ public class TestIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_pushdown_predicate_statistics",
-                "WITH (sorted_by = ARRAY['custkey']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['custkey'], parquet_writer_block_size = '1kB') AS TABLE tpch.tiny.customer WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups(getSession()),
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
@@ -170,7 +170,7 @@ public class TestIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_table_changes_function_multi_row_groups_",
-                "AS SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem WITH NO DATA")) {
+                "WITH (parquet_writer_block_size = '1kB') AS SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem WITH NO DATA")) {
             long initialSnapshot = getMostRecentSnapshotId(table.getName());
             assertUpdate(
                     withSmallRowGroups(getSession()),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSortedWriting.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSortedWriting.java
@@ -69,13 +69,12 @@ public class TestIcebergSortedWriting
         // Using a larger table forces buffered data to be written to disk
         Session withSmallRowGroups = Session.builder(getSession())
                 .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "200")
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "20kB")
                 .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "200")
                 .build();
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_sorted_lineitem_table",
-                "WITH (sorted_by = ARRAY['comment'], format = '" + format.name() + "') AS TABLE tpch.tiny.lineitem WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['comment'], format = '" + format.name() + "'" + ", parquet_writer_block_size = '20kB'" + ") AS TABLE tpch.tiny.lineitem WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups,
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.lineitem",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTablePropertyConfiguration.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTablePropertyConfiguration.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.plugin.iceberg.IcebergFileWriterFactory.getParquetWriterBlockSize;
+import static io.trino.plugin.iceberg.IcebergPageSink.getTargetMaxFileSize;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergTablePropertyConfiguration
+{
+    @Test
+    public void testTablePropertiesUsedWhenSet()
+    {
+        // Both table properties set: 20MB target file size, 5MB parquet row group size
+        Map<String, String> storageProperties = ImmutableMap.of(
+                WRITE_TARGET_FILE_SIZE_BYTES, "20971520",
+                PARQUET_ROW_GROUP_SIZE_BYTES, "5242880");
+
+        long defaultTargetFileSize = DataSize.of(1, GIGABYTE).toBytes();
+        DataSize defaultParquetBlockSize = DataSize.of(128, MEGABYTE);
+        long targetFileSize = getTargetMaxFileSize(storageProperties, defaultTargetFileSize);
+        DataSize parquetBlockSize = getParquetWriterBlockSize(storageProperties, defaultParquetBlockSize);
+
+        assertThat(targetFileSize).isEqualTo(20971520L);
+        assertThat(parquetBlockSize).isEqualTo(DataSize.of(5, MEGABYTE));
+    }
+
+    @Test
+    public void testFallsBackToDefaultsWhenTablePropertiesNotSet()
+    {
+        // Storage properties WITHOUT the table properties
+        Map<String, String> storageProperties = ImmutableMap.of();
+        long defaultTargetFileSize = DataSize.of(1, GIGABYTE).toBytes();
+        DataSize defaultParquetBlockSize = DataSize.of(128, MEGABYTE);
+
+        long targetFileSize = getTargetMaxFileSize(storageProperties, defaultTargetFileSize);
+        DataSize parquetBlockSize = getParquetWriterBlockSize(storageProperties, defaultParquetBlockSize);
+
+        // Defaults: 1GB for target file size (from connector config), 128MB for parquet block size (from connector config)
+        assertThat(targetFileSize).isEqualTo(DataSize.of(1, GIGABYTE).toBytes());
+        assertThat(parquetBlockSize).isEqualTo(DataSize.of(128, MEGABYTE));
+    }
+
+    @Test
+    public void testInvalidTablePropertiesFallBackToDefaults()
+    {
+        // Invalid table property values
+        Map<String, String> storageProperties = ImmutableMap.of(
+                WRITE_TARGET_FILE_SIZE_BYTES, "not-a-number",
+                PARQUET_ROW_GROUP_SIZE_BYTES, "invalid-value");
+        long defaultTargetFileSize = DataSize.of(1, GIGABYTE).toBytes();
+        DataSize defaultParquetBlockSize = DataSize.of(128, MEGABYTE);
+
+        long targetFileSize = getTargetMaxFileSize(storageProperties, defaultTargetFileSize);
+        DataSize parquetBlockSize = getParquetWriterBlockSize(storageProperties, defaultParquetBlockSize);
+
+        // Defaults: 1GB for target file size (from connector config), 128MB for parquet block size (from connector config)
+        assertThat(targetFileSize).isEqualTo(DataSize.of(1, GIGABYTE).toBytes());
+        assertThat(parquetBlockSize).isEqualTo(DataSize.of(128, MEGABYTE));
+    }
+}

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -70,7 +70,7 @@ public class TestLakehouseIcebergConnectorSmokeTest
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$files\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$all_entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
-        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(6 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(8 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$refs\"")).matches("VALUES (CAST(1 AS BIGINT))");
 
         // This test should get updated if a new system table is added

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergAlluxioCaching.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergAlluxioCaching.java
@@ -91,8 +91,7 @@ public class TestIcebergAlluxioCaching
     {
         onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
         onTrino().executeQuery("DROP SCHEMA IF EXISTS iceberg.test_caching");
-        onTrino().executeQuery("SET SESSION iceberg.target_max_file_size = '2MB'");
         onTrino().executeQuery("CREATE SCHEMA iceberg.test_caching with (location = 's3://" + bucketName + "/test_iceberg_caching')");
-        onTrino().executeQuery("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.customer");
+        onTrino().executeQuery("CREATE TABLE " + tableName + " WITH (target_max_file_size = '2MB') AS SELECT * FROM tpch.sf1.customer");
     }
 }


### PR DESCRIPTION
## Description

This PR converts two Iceberg write configuration settings from session properties to table properties, allowing per-table configuration that persists in the Iceberg table metadata.

### Converted Properties

1. **`target_max_file_size`** → `write.target-file-size-bytes` (Iceberg table property)
   - Controls the target maximum size of data files written by Trino
   - Default: 1GB

2. **`parquet_writer_block_size`** → `write.parquet.row-group-size-bytes` (Iceberg table property)
   - Controls the Parquet row group size
   - Default: 128MB

## Changes Made

1. **Removed session properties**: Deleted `target_max_file_size` and `parquet_writer_block_size` from IcebergSessionProperties

2. **Added table properties**: Added both properties to IcebergTableProperties with appropriate defaults

3. **Updated read logic**:
   - `IcebergPageSink.getTargetMaxFileSize()` - Reads from table's `write.target-file-size-bytes` property with 1GB default
   - `IcebergFileWriterFactory.getParquetWriterBlockSize()` - Reads from table's `write.parquet.row-group-size-bytes` property with 128MB default

4. **Added persistence**: Updated IcebergMetadata to persist these properties to Iceberg table metadata during table creation/alteration

5. **Added tests**: Comprehensive test coverage in TestIcebergTablePropertyConfiguration

## Benefits

- **Per-table control**: Different tables can have different file sizing strategies based on their specific workloads
- **Persistence**: Settings are stored in Iceberg table metadata rather than requiring session configuration
- **Iceberg native**: Uses Iceberg's standard table properties for better interoperability with other engines

Fixes #28250

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Convert `target_max_file_size` and `parquet_writer_block_size` from session properties to table properties for per-table write configuration.
```