### PR TITLE
Fix MinIO deprecated environment variables

### DIFF
--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMinIo.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMinIo.java
@@ -71,7 +71,7 @@ public class TestS3FileSystemMinIo
                 .region(Region.of(Minio.MINIO_REGION))
                 .forcePathStyle(true)
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(Minio.MINIO_ACCESS_KEY, Minio.MINIO_SECRET_KEY)))
+                        AwsBasicCredentials.create(Minio.MINIO_ROOT_USER, Minio.MINIO_ROOT_PASSWORD)))
                 .build();
     }
 
@@ -87,8 +87,8 @@ public class TestS3FileSystemMinIo
                         .setEndpoint(minio.getMinioAddress())
                         .setRegion(Minio.MINIO_REGION)
                         .setPathStyleAccess(true)
-                        .setAwsAccessKey(Minio.MINIO_ACCESS_KEY)
-                        .setAwsSecretKey(Minio.MINIO_SECRET_KEY)
+                        .setAwsAccessKey(Minio.MINIO_ROOT_USER)
+                        .setAwsSecretKey(Minio.MINIO_ROOT_PASSWORD)
                         .setStreamingPartSize(streamingPartSize),
                 new S3FileSystemStats());
     }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3Retries.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3Retries.java
@@ -100,7 +100,7 @@ public class TestS3Retries
                 .region(Region.of(Minio.MINIO_REGION))
                 .forcePathStyle(true)
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(Minio.MINIO_ACCESS_KEY, Minio.MINIO_SECRET_KEY)))
+                        AwsBasicCredentials.create(Minio.MINIO_ROOT_USER, Minio.MINIO_ROOT_PASSWORD)))
                 .httpClient(ApacheHttpClient.builder()
                         // react to timeouts faster so that the test completes faster
                         .socketTimeout(Duration.ofSeconds(1))

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestTrinoS3FileSystemMinio.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestTrinoS3FileSystemMinio.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.TestInstance;
 import java.net.URI;
 
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -72,8 +72,8 @@ public class TestTrinoS3FileSystemMinio
     {
         Configuration config = new Configuration(false);
         config.set("trino.s3.endpoint", minio.getMinioAddress());
-        config.set("trino.s3.access-key", MINIO_ACCESS_KEY);
-        config.set("trino.s3.secret-key", MINIO_SECRET_KEY);
+        config.set("trino.s3.access-key", MINIO_ROOT_USER);
+        config.set("trino.s3.secret-key", MINIO_ROOT_PASSWORD);
         config.set("trino.s3.path-style-access", "true");
 
         return config;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -38,9 +38,9 @@ import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.nio.file.Files.createTempDirectory;
 import static java.util.Objects.requireNonNull;
 
@@ -120,8 +120,8 @@ public final class DeltaLakeQueryRunner
         {
             addDeltaProperties(ImmutableMap.<String, String>builder()
                     .put("fs.native-s3.enabled", "true")
-                    .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                    .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                    .put("s3.aws-access-key", MINIO_ROOT_USER)
+                    .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                     .put("s3.region", MINIO_REGION)
                     .put("s3.endpoint", minio.getMinioAddress())
                     .put("s3.path-style-access", "true")

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -93,9 +93,9 @@ import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_SCHEMA;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -142,8 +142,8 @@ public class TestDeltaLakeConnectorTest
                     // required by the file metastore
                     .put("fs.hadoop.enabled", "true")
                     .put("fs.native-s3.enabled", "true")
-                    .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                    .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                    .put("s3.aws-access-key", MINIO_ROOT_USER)
+                    .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                     .put("s3.region", MINIO_REGION)
                     .put("s3.endpoint", minio.getMinioAddress())
                     .put("s3.path-style-access", "true")

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,8 +36,8 @@ public class TestDeltaLakeMinioAndHmsConnectorSmokeTest
     {
         return ImmutableMap.<String, String>builder()
                 .put("fs.native-s3.enabled", "true")
-                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .put("s3.region", MINIO_REGION)
                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                 .put("s3.path-style-access", "true")
@@ -50,8 +50,8 @@ public class TestDeltaLakeMinioAndHmsConnectorSmokeTest
     {
         return ImmutableMap.<String, String>builder()
                 .put("fs.native-s3.enabled", "true")
-                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .put("s3.region", MINIO_REGION)
                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                 .put("s3.path-style-access", "true")

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndLockBasedSynchronizerSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndLockBasedSynchronizerSmokeTest.java
@@ -41,9 +41,9 @@ import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEventually;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,8 +90,8 @@ public class TestDeltaLakeMinioAndLockBasedSynchronizerSmokeTest
                     // required by the file metastore
                     .put("fs.hadoop.enabled", "true")
                     .put("fs.native-s3.enabled", "true")
-                    .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                    .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                    .put("s3.aws-access-key", MINIO_ROOT_USER)
+                    .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                     .put("s3.region", MINIO_REGION)
                     .put("s3.endpoint", minio.getMinioAddress())
                     .put("s3.path-style-access", "true")

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePreferredPartitioning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePreferredPartitioning.java
@@ -28,9 +28,9 @@ import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 
@@ -67,8 +67,8 @@ public class TestDeltaLakePreferredPartitioning
                     // required by the file metastore
                     .put("fs.hadoop.enabled", "true")
                     .put("fs.native-s3.enabled", "true")
-                    .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                    .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                    .put("s3.aws-access-key", MINIO_ROOT_USER)
+                    .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                     .put("s3.region", MINIO_REGION)
                     .put("s3.endpoint", minio.getMinioAddress())
                     .put("s3.path-style-access", "true")

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.TestInstance;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -56,8 +56,8 @@ public class TestDeltaLakeSharedHiveMetastoreWithViews
                     .put("hive.metastore", "thrift")
                     .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
                     .put("fs.native-s3.enabled", "true")
-                    .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                    .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                    .put("s3.aws-access-key", MINIO_ROOT_USER)
+                    .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                     .put("s3.region", MINIO_REGION)
                     .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                     .put("s3.path-style-access", "true")

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/containers/MinioStorage.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/containers/MinioStorage.java
@@ -61,14 +61,14 @@ public class MinioStorage
         Minio.Builder minioBuilder = Minio.builder()
                 .withNetwork(network)
                 .withEnvVars(ImmutableMap.<String, String>builder()
-                        .put("MINIO_ACCESS_KEY", ACCESS_KEY)
-                        .put("MINIO_SECRET_KEY", SECRET_KEY)
+                        .put("MINIO_ROOT_USER", ACCESS_KEY)
+                        .put("MINIO_ROOT_PASSWORD", SECRET_KEY)
                         .buildOrThrow());
 
         kms.ifPresent(aKms -> minioBuilder
                 .withEnvVars(ImmutableMap.<String, String>builder()
-                        .put("MINIO_ACCESS_KEY", ACCESS_KEY)
-                        .put("MINIO_SECRET_KEY", SECRET_KEY)
+                        .put("MINIO_ROOT_USER", ACCESS_KEY)
+                        .put("MINIO_ROOT_PASSWORD", SECRET_KEY)
                         .put("MINIO_KMS_KES_ENDPOINT", aKms.getMinioKesEndpointURL())
                         .put("MINIO_KMS_KES_CERT_FILE", "/kms_client.crt")
                         .put("MINIO_KMS_KES_KEY_FILE", "/kms_client.key")

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCustomCatalogConnectorSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCustomCatalogConnectorSmokeTest.java
@@ -32,9 +32,9 @@ import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,8 +63,8 @@ public class TestHiveCustomCatalogConnectorSmokeTest
                 .addHiveProperty("s3.path-style-access", "true")
                 .addHiveProperty("s3.region", MINIO_REGION)
                 .addHiveProperty("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
-                .addHiveProperty("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .addHiveProperty("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .addHiveProperty("s3.aws-access-key", MINIO_ROOT_USER)
+                .addHiveProperty("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .setCreateTpchSchemas(false) // Create the required tpch tables after the initialisation of the query runner
                 .build();
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/Hive4MinioDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/Hive4MinioDataLake.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import static io.trino.plugin.hive.containers.Hive4HiveServer.HIVE_SERVER_PORT;
 import static io.trino.plugin.hive.containers.Hive4Metastore.HIVE4_IMAGE;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.State.STARTED;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static io.trino.testing.containers.TestContainers.getPathFromClassPathResource;
 
 public class Hive4MinioDataLake
@@ -55,8 +55,8 @@ public class Hive4MinioDataLake
                         "HIVE_SERVER2_THRIFT_PORT", String.valueOf(HIVE_SERVER_PORT),
                         "SERVICE_OPTS", "-Xmx1G -Dhive.metastore.uris=%s".formatted(hiveMetastore.getInternalHiveMetastoreEndpoint()),
                         "IS_RESUME", "true",
-                        "AWS_ACCESS_KEY_ID", MINIO_ACCESS_KEY,
-                        "AWS_SECRET_KEY", MINIO_SECRET_KEY))
+                        "AWS_ACCESS_KEY_ID", MINIO_ROOT_USER,
+                        "AWS_SECRET_KEY", MINIO_ROOT_PASSWORD))
                 .withNetwork(network)
                 .withExposePorts(Set.of(HIVE_SERVER_PORT))
                 .withFilesToMount(hiveFilesToMount);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
@@ -27,8 +27,8 @@ import static io.trino.plugin.hive.containers.HiveMinioDataLake.State.INITIAL;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.State.STARTED;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.State.STARTING;
 import static io.trino.plugin.hive.containers.HiveMinioDataLake.State.STOPPED;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.Network.newNetwork;
 
@@ -53,8 +53,8 @@ public abstract class HiveMinioDataLake
                 Minio.builder()
                         .withNetwork(network)
                         .withEnvVars(ImmutableMap.<String, String>builder()
-                                .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
-                                .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)
+                                .put("MINIO_ROOT_USER", MINIO_ROOT_USER)
+                                .put("MINIO_ROOT_PASSWORD", MINIO_ROOT_PASSWORD)
                                 .put("MINIO_REGION", MINIO_DEFAULT_REGION)
                                 .buildOrThrow())
                         .build());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreCatalogs.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreCatalogs.java
@@ -32,9 +32,9 @@ import java.util.Optional;
 import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,8 +84,8 @@ public class TestHiveMetastoreCatalogs
                 .put("s3.path-style-access", "true")
                 .put("s3.region", MINIO_REGION)
                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
-                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .buildOrThrow();
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -35,9 +35,9 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.util.Objects.requireNonNull;
 
 public final class S3HiveQueryRunner
@@ -64,8 +64,8 @@ public final class S3HiveQueryRunner
                 .setHiveMetastoreEndpoint(hiveMinioDataLake.getHiveMetastoreEndpoint())
                 .setS3Endpoint("http://" + hiveMinioDataLake.getMinio().getMinioApiEndpoint())
                 .setS3Region(MINIO_REGION)
-                .setS3AccessKey(MINIO_ACCESS_KEY)
-                .setS3SecretKey(MINIO_SECRET_KEY)
+                .setS3AccessKey(MINIO_ROOT_USER)
+                .setS3SecretKey(MINIO_ROOT_PASSWORD)
                 .setBucketName(hiveMinioDataLake.getBucketName());
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3FileSystemAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestS3FileSystemAccessOperations.java
@@ -40,9 +40,9 @@ import static com.google.common.collect.Maps.uniqueIndex;
 import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.util.stream.Collectors.toCollection;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -67,8 +67,8 @@ public class TestS3FileSystemAccessOperations
                 .setHiveProperties(ImmutableMap.<String, String>builder()
                         .put("hive.metastore.disable-location-checks", "true")
                         .put("fs.native-s3.enabled", "true")
-                        .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                        .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                        .put("s3.aws-access-key", MINIO_ROOT_USER)
+                        .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                         .put("s3.region", MINIO_REGION)
                         .put("s3.endpoint", minio.getMinioAddress())
                         .put("s3.path-style-access", "true")

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/HudiQueryRunner.java
@@ -35,9 +35,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.util.Objects.requireNonNull;
 
 public final class HudiQueryRunner
@@ -60,8 +60,8 @@ public final class HudiQueryRunner
     {
         return new Builder("s3://" + hiveMinioDataLake.getBucketName() + "/")
                 .addConnectorProperty("fs.native-s3.enabled", "true")
-                .addConnectorProperty("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .addConnectorProperty("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .addConnectorProperty("s3.aws-access-key", MINIO_ROOT_USER)
+                .addConnectorProperty("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .addConnectorProperty("s3.region", MINIO_REGION)
                 .addConnectorProperty("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                 .addConnectorProperty("s3.path-style-access", "true");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -45,9 +45,9 @@ import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThri
 import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
 import static io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.ICEBERG_METASTORE_STORAGE_FORMAT;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
@@ -86,8 +86,8 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                                 .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("fs.native-s3.enabled", "true")
-                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -55,9 +55,9 @@ import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendC
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
 import static java.util.Objects.requireNonNull;
@@ -361,8 +361,8 @@ public final class IcebergQueryRunner
                             "iceberg.catalog.type", "HIVE_METASTORE",
                             "hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString(),
                             "fs.native-s3.enabled", "true",
-                            "s3.aws-access-key", MINIO_ACCESS_KEY,
-                            "s3.aws-secret-key", MINIO_SECRET_KEY,
+                            "s3.aws-access-key", MINIO_ROOT_USER,
+                            "s3.aws-secret-key", MINIO_ROOT_PASSWORD,
                             "s3.region", MINIO_REGION,
                             "s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress(),
                             "s3.path-style-access", "true",
@@ -402,8 +402,8 @@ public final class IcebergQueryRunner
                             "iceberg.catalog.type", "TESTING_FILE_METASTORE",
                             "hive.metastore.catalog.dir", "s3://%s/".formatted(bucketName),
                             "fs.native-s3.enabled", "true",
-                            "s3.aws-access-key", MINIO_ACCESS_KEY,
-                            "s3.aws-secret-key", MINIO_SECRET_KEY,
+                            "s3.aws-access-key", MINIO_ROOT_USER,
+                            "s3.aws-secret-key", MINIO_ROOT_PASSWORD,
                             "s3.region", MINIO_REGION,
                             "s3.endpoint", "http://" + minio.getMinioApiEndpoint(),
                             "s3.path-style-access", "true",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViewExpiredSnapshotCleanup.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViewExpiredSnapshotCleanup.java
@@ -57,9 +57,9 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getTrinoCatalog;
 import static io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog.TRINO_CREATED_BY_VALUE;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,8 +88,8 @@ public class TestIcebergMaterializedViewExpiredSnapshotCleanup
                 .setIcebergProperties(ImmutableMap.of(
                         "iceberg.materialized-views.refresh-max-snapshots-to-expire", "5",
                         "fs.native-s3.enabled", "true",
-                        "s3.aws-access-key", MINIO_ACCESS_KEY,
-                        "s3.aws-secret-key", MINIO_SECRET_KEY,
+                        "s3.aws-access-key", MINIO_ROOT_USER,
+                        "s3.aws-secret-key", MINIO_ROOT_PASSWORD,
                         "s3.region", MINIO_REGION,
                         "s3.endpoint", minio.getMinioAddress(),
                         "iceberg.register-table-procedure.enabled", "true",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -32,9 +32,9 @@ import static com.google.common.io.Resources.getResource;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
@@ -67,8 +67,8 @@ public class TestIcebergMinioOrcConnectorTest
                                 .put("iceberg.file-format", format.name())
                                 .put("fs.hadoop.enabled", "true")
                                 .put("fs.native-s3.enabled", "true")
-                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", minio.getMinioAddress())
                                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFiltersMixedCase.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFiltersMixedCase.java
@@ -30,9 +30,9 @@ import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertContains;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -57,8 +57,8 @@ public class TestIcebergParquetWithBloomFiltersMixedCase
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("fs.native-s3.enabled", "true")
-                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", minio.getMinioAddress())
                                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPartitionEvolutionOnSameColumn.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPartitionEvolutionOnSameColumn.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,8 +49,8 @@ public class TestIcebergPartitionEvolutionOnSameColumn
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("fs.native-s3.enabled", "true")
-                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", minio.getMinioAddress())
                                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTableByTemporal.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergReadVersionedTableByTemporal.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.api.TestInstance;
 
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -52,8 +52,8 @@ public class TestIcebergReadVersionedTableByTemporal
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("fs.native-s3.enabled", "true")
-                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", minio.getMinioAddress())
                                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveThriftMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestSharedHiveThriftMetastore.java
@@ -35,9 +35,9 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -84,8 +84,8 @@ public class TestSharedHiveThriftMetastore
                         .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                         .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                         .put("fs.native-s3.enabled", "true")
-                        .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                        .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                        .put("s3.aws-access-key", MINIO_ROOT_USER)
+                        .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                         .put("s3.region", MINIO_REGION)
                         .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                         .put("s3.path-style-access", "true")
@@ -102,8 +102,8 @@ public class TestSharedHiveThriftMetastore
                         .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                         .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                         .put("fs.native-s3.enabled", "true")
-                        .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                        .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                        .put("s3.aws-access-key", MINIO_ROOT_USER)
+                        .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                         .put("s3.region", MINIO_REGION)
                         .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                         .put("s3.path-style-access", "true")
@@ -119,8 +119,8 @@ public class TestSharedHiveThriftMetastore
                 .put("hive.metastore", "thrift")
                 .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                 .put("fs.native-s3.enabled", "true")
-                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .put("s3.region", MINIO_REGION)
                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveCatalogWithoutLock.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveCatalogWithoutLock.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Map;
 
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -52,8 +52,8 @@ final class TestIcebergHiveCatalogWithoutLock
                                 .put("hive.metastore.uri", hiveMinioDataLake.getHiveMetastoreEndpoint().toString())
                                 .put("iceberg.hive-catalog.locking-enabled", "false")
                                 .put("fs.native-s3.enabled", "true")
-                                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                                 .put("s3.region", MINIO_REGION)
                                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                                 .put("s3.path-style-access", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -74,9 +74,9 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.FORMAT_VERSION_PROP
 import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -142,8 +142,8 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                 OpenTelemetry.noop(),
                 new S3FileSystemConfig()
                         .setEndpoint(dataLake.getMinio().getMinioAddress())
-                        .setAwsAccessKey(MINIO_ACCESS_KEY)
-                        .setAwsSecretKey(MINIO_SECRET_KEY)
+                        .setAwsAccessKey(MINIO_ROOT_USER)
+                        .setAwsSecretKey(MINIO_ROOT_PASSWORD)
                         .setRegion(MINIO_REGION)
                         .setPathStyleAccess(true),
                 new S3FileSystemStats());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergVendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergVendingRestCatalogConnectorSmokeTest.java
@@ -53,9 +53,9 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,7 +97,7 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
 
         this.warehouseLocation = "s3://%s/default/".formatted(bucketName);
 
-        AwsCredentials credentials = AwsBasicCredentials.create(MINIO_ACCESS_KEY, MINIO_SECRET_KEY);
+        AwsCredentials credentials = AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
         StsClient stsClient = StsClient.builder()
                 .endpointOverride(URI.create(minio.getMinioAddress()))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
@@ -138,8 +138,8 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
                 .setRegion(MINIO_REGION)
                 .setEndpoint(minio.getMinioAddress())
                 .setPathStyleAccess(true)
-                .setAwsAccessKey(MINIO_ACCESS_KEY)
-                .setAwsSecretKey(MINIO_SECRET_KEY), new S3FileSystemStats()
+                .setAwsAccessKey(MINIO_ROOT_USER)
+                .setAwsSecretKey(MINIO_ROOT_PASSWORD), new S3FileSystemStats()
         ).create(SESSION);
     }
 

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.TestInstance;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -56,8 +56,8 @@ public abstract class BaseLakehouseConnectorSmokeTest
                 .addLakehouseProperty("hive.metastore.uri", hiveMinio.getHiveMetastoreEndpoint().toString())
                 .addLakehouseProperty("fs.hadoop.enabled", "true")
                 .addLakehouseProperty("fs.native-s3.enabled", "true")
-                .addLakehouseProperty("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .addLakehouseProperty("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .addLakehouseProperty("s3.aws-access-key", MINIO_ROOT_USER)
+                .addLakehouseProperty("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .addLakehouseProperty("s3.region", MINIO_REGION)
                 .addLakehouseProperty("s3.endpoint", hiveMinio.getMinio().getMinioAddress())
                 .addLakehouseProperty("s3.path-style-access", "true")

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
@@ -42,9 +42,9 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -72,8 +72,8 @@ public class TestLakehouseConnectorTest
                 .addLakehouseProperty("hive.metastore.uri", hiveMinio.getHiveMetastoreEndpoint().toString())
                 .addLakehouseProperty("fs.hadoop.enabled", "true")
                 .addLakehouseProperty("fs.native-s3.enabled", "true")
-                .addLakehouseProperty("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .addLakehouseProperty("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .addLakehouseProperty("s3.aws-access-key", MINIO_ROOT_USER)
+                .addLakehouseProperty("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .addLakehouseProperty("s3.region", MINIO_REGION)
                 .addLakehouseProperty("s3.endpoint", hiveMinio.getMinio().getMinioAddress())
                 .addLakehouseProperty("s3.path-style-access", "true")

--- a/plugin/trino-spooling-filesystem/src/test/java/io/trino/spooling/filesystem/TestFileSystemSpoolingManagerMinio.java
+++ b/plugin/trino-spooling-filesystem/src/test/java/io/trino/spooling/filesystem/TestFileSystemSpoolingManagerMinio.java
@@ -60,8 +60,8 @@ public class TestFileSystemSpoolingManagerMinio
                 .setEndpoint(minio.getMinioAddress())
                 .setRegion(MINIO_REGION)
                 .setPathStyleAccess(true)
-                .setAwsAccessKey(Minio.MINIO_ACCESS_KEY)
-                .setAwsSecretKey(Minio.MINIO_SECRET_KEY)
+                .setAwsAccessKey(Minio.MINIO_ROOT_USER)
+                .setAwsSecretKey(Minio.MINIO_ROOT_PASSWORD)
                 .setStreamingPartSize(DataSize.valueOf("5.5MB"));
         return new FileSystemSpoolingManager(spoolingConfig, new S3FileSystemFactory(noop(), filesystemConfig, new S3FileSystemStats()), new SimpleFileSystemLayout(), new TestingNode("nodeId"));
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
@@ -38,8 +38,8 @@ public class Minio
 
     public static final String MINIO_CONTAINER_NAME = "minio";
 
-    private static final String MINIO_ACCESS_KEY = "minio-access-key";
-    private static final String MINIO_SECRET_KEY = "minio-secret-key";
+    private static final String MINIO_ROOT_USER = "minio-access-key";
+    private static final String MINIO_ROOT_PASSWORD = "minio-secret-key";
     private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
             .asCanonicalNameString();
 
@@ -73,8 +73,8 @@ public class Minio
     {
         DockerContainer container = new DockerContainer(MINIO_RELEASE, MINIO_CONTAINER_NAME)
                 .withEnv(ImmutableMap.<String, String>builder()
-                        .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
-                        .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)
+                        .put("MINIO_ROOT_USER", MINIO_ROOT_USER)
+                        .put("MINIO_ROOT_PASSWORD", MINIO_ROOT_PASSWORD)
                         .buildOrThrow())
                 .withCommand("server", "--address", format("0.0.0.0:%d", MINIO_PORT), "--console-address", format("0.0.0.0:%d", MINIO_CONSOLE_PORT), "/data")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
@@ -46,8 +46,8 @@ public class SpoolingMinio
 {
     private static final String MINIO_SPOOLING_BUCKET = "spooling";
     private static final String MINIO_SPOOLING_CONTAINER_NAME = "spooling-minio";
-    private static final String MINIO_ACCESS_KEY = "minio-access-key";
-    private static final String MINIO_SECRET_KEY = "minio-secret-key";
+    private static final String MINIO_ROOT_USER = "minio-access-key";
+    private static final String MINIO_ROOT_PASSWORD = "minio-secret-key";
     private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
             .asCanonicalNameString();
 
@@ -99,8 +99,8 @@ public class SpoolingMinio
 
         DockerContainer container = new DockerContainer(MINIO_RELEASE, MINIO_SPOOLING_CONTAINER_NAME)
                 .withEnv(ImmutableMap.<String, String>builder()
-                        .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
-                        .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)
+                        .put("MINIO_ROOT_USER", MINIO_ROOT_USER)
+                        .put("MINIO_ROOT_PASSWORD", MINIO_ROOT_PASSWORD)
                         .buildOrThrow())
                 .withCopyFileToContainer(forHostPath(minioBucketDirectory), "/data/" + MINIO_SPOOLING_BUCKET)
                 .withCommand("server", "--address", format("0.0.0.0:%d", MINIO_PORT), "--console-address", format("0.0.0.0:%d", MINIO_CONSOLE_PORT), "/data")

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/S3ClientFactory.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/S3ClientFactory.java
@@ -24,8 +24,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 import java.net.URI;
 
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
-import static io.trino.testing.minio.MinioClient.DEFAULT_MINIO_ACCESS_KEY;
-import static io.trino.testing.minio.MinioClient.DEFAULT_MINIO_SECRET_KEY;
+import static io.trino.testing.minio.MinioClient.DEFAULT_MINIO_ROOT_PASSWORD;
+import static io.trino.testing.minio.MinioClient.DEFAULT_MINIO_ROOT_USER;
 
 final class S3ClientFactory
 {
@@ -51,7 +51,7 @@ final class S3ClientFactory
 
     private static S3Client createMinioS3Client()
     {
-        AwsCredentials credentials = AwsBasicCredentials.create(DEFAULT_MINIO_ACCESS_KEY, DEFAULT_MINIO_SECRET_KEY);
+        AwsCredentials credentials = AwsBasicCredentials.create(DEFAULT_MINIO_ROOT_USER, DEFAULT_MINIO_ROOT_PASSWORD);
         AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(credentials);
 
         return S3Client.builder()

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -50,8 +50,8 @@ public class Minio
     public static final int MINIO_CONSOLE_PORT = 4567;
 
     // defaults
-    public static final String MINIO_ACCESS_KEY = "accesskey";
-    public static final String MINIO_SECRET_KEY = "secretkey";
+    public static final String MINIO_ROOT_USER = "accesskey";
+    public static final String MINIO_ROOT_PASSWORD = "secretkey";
     public static final String MINIO_REGION = "us-east-1";
 
     public static Builder builder()
@@ -157,7 +157,7 @@ public class Minio
 
     public MinioClient createMinioClient()
     {
-        return new MinioClient(getMinioAddress(), MINIO_ACCESS_KEY, MINIO_SECRET_KEY);
+        return new MinioClient(getMinioAddress(), MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
     }
 
     public static class Builder
@@ -172,8 +172,8 @@ public class Minio
                             MINIO_API_PORT,
                             MINIO_CONSOLE_PORT);
             this.envVars = ImmutableMap.<String, String>builder()
-                    .put("MINIO_ACCESS_KEY", MINIO_ACCESS_KEY)
-                    .put("MINIO_SECRET_KEY", MINIO_SECRET_KEY)
+                    .put("MINIO_ROOT_USER", MINIO_ROOT_USER)
+                    .put("MINIO_ROOT_PASSWORD", MINIO_ROOT_PASSWORD)
                     .buildOrThrow();
         }
 

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/minio/MinioClient.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/minio/MinioClient.java
@@ -65,8 +65,8 @@ public class MinioClient
     private final Logger logger = Logger.get(MinioClient.class);
 
     public static final String DEFAULT_MINIO_ENDPOINT = "http://minio:9080";
-    public static final String DEFAULT_MINIO_ACCESS_KEY = "minio-access-key";
-    public static final String DEFAULT_MINIO_SECRET_KEY = "minio-secret-key";
+    public static final String DEFAULT_MINIO_ROOT_USER = "minio-access-key";
+    public static final String DEFAULT_MINIO_ROOT_PASSWORD = "minio-secret-key";
 
     private static final Set<String> createdBuckets = Sets.newConcurrentHashSet();
 
@@ -82,7 +82,7 @@ public class MinioClient
 
     public MinioClient()
     {
-        this(DEFAULT_MINIO_ENDPOINT, DEFAULT_MINIO_ACCESS_KEY, DEFAULT_MINIO_SECRET_KEY);
+        this(DEFAULT_MINIO_ENDPOINT, DEFAULT_MINIO_ROOT_USER, DEFAULT_MINIO_ROOT_PASSWORD);
     }
 
     public MinioClient(String endpoint, String accessKey, String secretKey)

--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/IcebergCostBasedPlanTestSetup.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/IcebergCostBasedPlanTestSetup.java
@@ -48,9 +48,9 @@ import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.iceberg.CatalogType.TESTING_FILE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FILE_EXTENSION;
 import static io.trino.plugin.iceberg.catalog.AbstractIcebergTableOperations.ICEBERG_METASTORE_STORAGE_FORMAT;
-import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.nio.file.Files.createTempDirectory;
 import static java.util.Locale.ENGLISH;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
@@ -106,8 +106,8 @@ public class IcebergCostBasedPlanTestSetup
                 .put("hive.metastore.catalog.dir", temporaryMetastoreDirectory.toString())
                 .put("fs.native-s3.enabled", "true")
                 .put("fs.hadoop.enabled", "true")
-                .put("s3.aws-access-key", MINIO_ACCESS_KEY)
-                .put("s3.aws-secret-key", MINIO_SECRET_KEY)
+                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
                 .put("s3.region", MINIO_REGION)
                 .put("s3.endpoint", minio.getMinioAddress())
                 .put("s3.path-style-access", "true")


### PR DESCRIPTION
## Description

Replace deprecated MinIO environment variables `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` with `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` to eliminate deprecation warnings in test logs.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #28024

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
