### PR TITLE
Report deletion vector count in IcebergSplitSource.getMetrics

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -529,7 +529,8 @@ public class IcebergSplitSource
                 "dataManifests", new LongCount(scanMetrics.scannedDataManifests().value()),
                 "deleteManifests", new LongCount(scanMetrics.scannedDeleteManifests().value()),
                 "equalityDeleteFiles", new LongCount(scanMetrics.equalityDeleteFiles().value()),
-                "positionalDeleteFiles", new LongCount(scanMetrics.positionalDeleteFiles().value())));
+                "positionalDeleteFiles", new LongCount(scanMetrics.positionalDeleteFiles().value()),
+                "deletionVectorFiles", new LongCount(scanMetrics.dvs().value())));
     }
 
     @Override


### PR DESCRIPTION
## Description

```
trino:tpch> EXPLAIN ANALYZE VERBOSE SELECT * FROM region;
                                                                                         Query Plan
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Trino version: testversion
 Queued: 2.45ms, Analysis: 5.62ms, Planning: 36.45ms, Execution: 167.54ms, Finishing: 0.00ns
...
     TableScan[table = iceberg:tpch.region$data@3632375038726047818]
         Layout: [regionkey:bigint, name:varchar, comment:varchar]
         Estimates: {rows: 5 (945B), cpu: 945, memory: 0B, network: 0B}
         CPU: 8.00ms (100.00%), Scheduled: 10.00ms (100.00%), Blocked: 0.00ns (?%), Output: 4 rows (319B)
         connector metrics:
           'ParquetReaderCompressionFormat_ZSTD' = LongCount{total=372}
         splits generation metrics:
           'dataFileSizeBytes' = LongCount{total=874}
           'dataFiles' = LongCount{total=1}
           'dataManifests' = LongCount{total=1}
           'deleteFileSizeBytes' = LongCount{total=42}
           'deleteManifests' = LongCount{total=1}
           'deletionVectorFiles' = LongCount{total=1}
...
```

* Follow-up of https://github.com/trinodb/trino/pull/27788

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
