### PR TITLE
Fix failure when executing `date_add` function with larger value

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
@@ -30,7 +30,6 @@ import static io.trino.type.DateTimes.getMicrosOfMilli;
 import static io.trino.type.DateTimes.round;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
-import static java.lang.Math.toIntExact;
 
 @Description("Add the specified amount of time to the given timestamp")
 @ScalarFunction("date_add")
@@ -50,7 +49,7 @@ public final class DateAdd
             long epochMillis = scaleEpochMicrosToMillis(timestamp);
             int microsOfMilli = getMicrosOfMilli(timestamp);
 
-            epochMillis = DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit).add(epochMillis, toIntExact(value));
+            epochMillis = DateTimeFunctions.getTimestampField(ISOChronology.getInstanceUTC(), unit).add(epochMillis, value);
 
             if (precision <= 3) {
                 epochMillis = round(epochMillis, (int) (3 - precision));

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateAdd.java
@@ -29,7 +29,6 @@ import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateTimeEncoding.updateMillisUtc;
 import static io.trino.type.DateTimes.round;
 import static io.trino.util.DateTimeZoneIndex.unpackChronology;
-import static java.lang.Math.toIntExact;
 
 @Description("Add the specified amount of time to the given timestamp")
 @ScalarFunction("date_add")
@@ -48,7 +47,7 @@ public final class DateAdd
         try {
             long epochMillis = unpackMillisUtc(packedEpochMillis);
 
-            epochMillis = getTimestampField(unpackChronology(packedEpochMillis), unit).add(epochMillis, toIntExact(value));
+            epochMillis = getTimestampField(unpackChronology(packedEpochMillis), unit).add(epochMillis, value);
             epochMillis = round(epochMillis, (int) (3 - precision));
 
             return updateMillisUtc(epochMillis, packedEpochMillis);
@@ -66,7 +65,7 @@ public final class DateAdd
             @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone timestamp)
     {
         try {
-            long epochMillis = getTimestampField(unpackChronology(timestamp.getTimeZoneKey()), unit).add(timestamp.getEpochMillis(), toIntExact(value));
+            long epochMillis = getTimestampField(unpackChronology(timestamp.getTimeZoneKey()), unit).add(timestamp.getEpochMillis(), value);
 
             return LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMillis, timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
         }


### PR DESCRIPTION
## Description

Fixes #27899

## Release notes

```markdown
## General
* Fix failure when executing `date_add` function with larger value. ({issue}`27899`)
```
