### PR TITLE
Remove no longer needed `file.encoding=UTF-8`

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -12,6 +12,5 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
--Dfile.encoding=UTF-8
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -138,7 +138,6 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
--Dfile.encoding=UTF-8
 # Allow loading dynamic agent used by JOL
 -XX:+EnableDynamicAgentLoading
 ```


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Remove no longer needed `file.encoding=UTF-8`.
Since Java 18, `file.encoding=UTF-8` by default.  (https://openjdk.org/jeps/400)


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Gone with https://github.com/trinodb/trino/commit/09ef5b5aa240a3768cc1cb2576e9d06a23cbd7a1#diff-8fe479ba1d7b53bf3463552ab8e7b1c52ad54cbbf290ab512170ba5c7a2e6213
> If you are using Java 17 or 18, the JVM must be configured to use UTF-8 as the default charset by
adding `-Dfile.encoding=UTF-8` to `etc/jvm.config`. Starting with Java 19, the Java default 
charset is UTF-8, so this configuration is not needed.


Comes back with https://github.com/trinodb/trino/commit/d4bde5c3de8b6ddd3cd5805d69297703fe77d573 without explaining why is it needed on newer Java.
@hashhar @wendigo Could you explain why it's needed?


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.