### PR TITLE
Shorten bigquery.view-expire-duration in TestBigQuerySplitManager

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
@@ -59,7 +59,7 @@ public class TestBigQuerySplitManager
         BigQueryConnectorFactory connectorFactory = new BigQueryConnectorFactory();
         connector = connectorFactory.create(
                 "bigquery",
-                ImmutableMap.of("bigquery.views-enabled", "true", "bigquery.credentials-key", BIGQUERY_CREDENTIALS_KEY),
+                ImmutableMap.of("bigquery.views-enabled", "true", "bigquery.credentials-key", BIGQUERY_CREDENTIALS_KEY, "bigquery.view-expire-duration", "30m"),
                 new TestingConnectorContext());
         bigQueryExecutor = new BigQuerySqlExecutor();
     }


### PR DESCRIPTION
## Description

Otherwise, this test leaves `_pbc_` tables for 24h. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
