### PR TITLE
Remove request duration histograms from DirectExchangeClient

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
@@ -179,8 +179,6 @@ public class TestDirectExchangeClient
 
         // client should have sent only 3 requests: one to get all pages, one to acknowledge and one to get the done signal
         assertStatus(status.getPageBufferClientStatuses().get(0), location, "closed", 3, 3, 3, "not scheduled");
-        assertThat(status.getRequestDuration().getDigest().getCount()).isEqualTo(2.0);
-
         exchangeClient.close();
 
         assertEventually(() -> assertThat(exchangeClient.getStatus().getPageBufferClientStatuses().get(0).getHttpRequestState())


### PR DESCRIPTION
These histograms are captured globally for the exchange http client

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
