### PR TITLE
Add `number`, high precision decimal type

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientStandardTypes.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientStandardTypes.java
@@ -25,6 +25,7 @@ public final class ClientStandardTypes
     public static final String DECIMAL = "decimal";
     public static final String REAL = "real";
     public static final String DOUBLE = "double";
+    public static final String NUMBER = "number";
     public static final String HYPER_LOG_LOG = "HyperLogLog";
     public static final String QDIGEST = "qdigest";
     public static final String TDIGEST = "tdigest";

--- a/client/trino-client/src/main/java/io/trino/client/JsonDecodingUtils.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonDecodingUtils.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -48,6 +49,7 @@ import static io.trino.client.ClientStandardTypes.IPADDRESS;
 import static io.trino.client.ClientStandardTypes.JSON;
 import static io.trino.client.ClientStandardTypes.KDB_TREE;
 import static io.trino.client.ClientStandardTypes.MAP;
+import static io.trino.client.ClientStandardTypes.NUMBER;
 import static io.trino.client.ClientStandardTypes.P4_HYPER_LOG_LOG;
 import static io.trino.client.ClientStandardTypes.QDIGEST;
 import static io.trino.client.ClientStandardTypes.REAL;
@@ -64,6 +66,7 @@ import static io.trino.client.ClientStandardTypes.UUID;
 import static io.trino.client.ClientStandardTypes.VARBINARY;
 import static io.trino.client.ClientStandardTypes.VARCHAR;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
@@ -78,6 +81,7 @@ public final class JsonDecodingUtils
     private static final TinyintDecoder TINYINT_DECODER = new TinyintDecoder();
     private static final DoubleDecoder DOUBLE_DECODER = new DoubleDecoder();
     private static final RealDecoder REAL_DECODER = new RealDecoder();
+    private static final NumberDecoder NUMBER_DECODER = new NumberDecoder();
     private static final BooleanDecoder BOOLEAN_DECODER = new BooleanDecoder();
     private static final StringDecoder STRING_DECODER = new StringDecoder();
     private static final Base64Decoder BASE_64_DECODER = new Base64Decoder();
@@ -114,6 +118,8 @@ public final class JsonDecodingUtils
                 return DOUBLE_DECODER;
             case REAL:
                 return REAL_DECODER;
+            case NUMBER:
+                return NUMBER_DECODER;
             case BOOLEAN:
                 return BOOLEAN_DECODER;
             case ARRAY:
@@ -257,6 +263,20 @@ public final class JsonDecodingUtils
                 default:
                     throw illegalToken(parser);
             }
+        }
+    }
+
+    private static class NumberDecoder
+            implements TypeDecoder
+    {
+        @Override
+        public Object decode(JsonParser parser)
+                throws IOException
+        {
+            // TODO maybe we could send numbers without base64. This probably requires client capabilities.
+            // Old clients apply base64 decoding to any type they don't recognize.
+            // TODO If Base64 stays, `parser.getBinaryValue(Base64Variants.MIME)` might be a better way to parse it.
+            return new BigDecimal(new String(Base64.getDecoder().decode(parser.getValueAsString()), UTF_8));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -266,6 +266,7 @@ import io.trino.type.IntervalDayTimeOperators;
 import io.trino.type.IntervalYearMonthOperators;
 import io.trino.type.IpAddressOperators;
 import io.trino.type.LikeFunctions;
+import io.trino.type.NumberOperators;
 import io.trino.type.QuantileDigestOperators;
 import io.trino.type.RealOperators;
 import io.trino.type.SmallintOperators;
@@ -325,6 +326,7 @@ import static io.trino.type.DecimalCasts.DECIMAL_TO_BOOLEAN_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_DOUBLE_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_INTEGER_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_JSON_CAST;
+import static io.trino.type.DecimalCasts.DECIMAL_TO_NUMBER_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_REAL_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_SMALLINT_CAST;
 import static io.trino.type.DecimalCasts.DECIMAL_TO_TINYINT_CAST;
@@ -332,6 +334,7 @@ import static io.trino.type.DecimalCasts.DECIMAL_TO_VARCHAR_CAST;
 import static io.trino.type.DecimalCasts.DOUBLE_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.INTEGER_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.JSON_TO_DECIMAL_CAST;
+import static io.trino.type.DecimalCasts.NUMBER_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.REAL_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.SMALLINT_TO_DECIMAL_CAST;
 import static io.trino.type.DecimalCasts.TINYINT_TO_DECIMAL_CAST;
@@ -463,6 +466,7 @@ public final class SystemFunctionBundle
                 .scalars(TinyintOperators.class)
                 .scalars(DoubleOperators.class)
                 .scalars(RealOperators.class)
+                .scalars(NumberOperators.class)
                 .scalars(VarcharOperators.class)
                 .scalars(DateOperators.class)
                 .scalars(IntervalDayTimeOperators.class)
@@ -547,6 +551,7 @@ public final class SystemFunctionBundle
                 .aggregates(MultimapAggregationFunction.class)
                 .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_REAL_CAST, DECIMAL_TO_BOOLEAN_CAST, DECIMAL_TO_TINYINT_CAST, DECIMAL_TO_SMALLINT_CAST)
                 .functions(VARCHAR_TO_DECIMAL_CAST, INTEGER_TO_DECIMAL_CAST, BIGINT_TO_DECIMAL_CAST, DOUBLE_TO_DECIMAL_CAST, REAL_TO_DECIMAL_CAST, BOOLEAN_TO_DECIMAL_CAST, TINYINT_TO_DECIMAL_CAST, SMALLINT_TO_DECIMAL_CAST)
+                .functions(NUMBER_TO_DECIMAL_CAST, DECIMAL_TO_NUMBER_CAST)
                 .functions(JSON_TO_DECIMAL_CAST, DECIMAL_TO_JSON_CAST)
                 .functions(featuresConfig.isLegacyArithmeticDecimalOperators() ? LEGACY_DECIMAL_ADD_OPERATOR : DECIMAL_ADD_OPERATOR)
                 .functions(featuresConfig.isLegacyArithmeticDecimalOperators() ? LEGACY_DECIMAL_SUBTRACT_OPERATOR : DECIMAL_SUBTRACT_OPERATOR)

--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -73,6 +73,7 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
 import static io.trino.spi.type.QuantileDigestParametricType.QDIGEST;
 import static io.trino.spi.type.RealType.REAL;
@@ -136,6 +137,7 @@ public final class TypeRegistry
         addType(TINYINT);
         addType(DOUBLE);
         addType(REAL);
+        addType(NUMBER);
         addType(VARBINARY);
         addType(DATE);
         addType(INTERVAL_YEAR_MONTH);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
@@ -34,6 +34,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.SqlNumber;
 import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
@@ -436,6 +437,9 @@ public final class JsonEncodingUtils
                 case BigDecimal bigDecimalValue -> generator.writeNumber(bigDecimalValue);
                 case SqlDate dateValue -> generator.writeString(dateValue.toString());
                 case SqlDecimal decimalValue -> generator.writeString(decimalValue.toString());
+                // Trino client protocol backward compatibility requires that any new types are base64-encoded strings.
+                // JsonDecodingUtils uses "base64 decoder" for any type it doesn't recognize.
+                case SqlNumber number -> generator.writeString(number.base64Encoded());
                 case SqlIntervalDayTime intervalValue -> generator.writeString(intervalValue.toString());
                 case SqlIntervalYearMonth intervalValue -> generator.writeString(intervalValue.toString());
                 case SqlTime timeValue -> generator.writeString(timeValue.toString());

--- a/core/trino-main/src/main/java/io/trino/testing/MaterializedResult.java
+++ b/core/trino-main/src/main/java/io/trino/testing/MaterializedResult.java
@@ -27,12 +27,14 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.SqlNumber;
 import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.Type;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetTime;
@@ -322,6 +324,7 @@ public class MaterializedResult
                 case SqlTimestamp sqlTimestamp -> sqlTimestamp.toLocalDateTime();
                 case SqlTimestampWithTimeZone sqlTimestampWithTimeZone -> sqlTimestampWithTimeZone.toZonedDateTime();
                 case SqlDecimal sqlDecimal -> sqlDecimal.toBigDecimal();
+                case SqlNumber sqlNumber -> new BigDecimal(sqlNumber.stringified());
                 default -> trinoValue;
             };
             convertedValues.add(convertedValue);

--- a/core/trino-main/src/main/java/io/trino/type/BigintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BigintOperators.java
@@ -23,6 +23,9 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
@@ -195,6 +198,13 @@ public final class BigintOperators
     public static long castToReal(@SqlType(StandardTypes.BIGINT) long value)
     {
         return floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return TrinoNumber.from(new BigDecimal(value));
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
@@ -22,6 +22,9 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
@@ -164,6 +167,13 @@ public final class IntegerOperators
     public static long castToReal(@SqlType(StandardTypes.INTEGER) long value)
     {
         return floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType(StandardTypes.INTEGER) long value)
+    {
+        return TrinoNumber.from(new BigDecimal(value));
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/type/NumberOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/NumberOperators.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.function.OperatorType.ADD;
+import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.function.OperatorType.MODULUS;
+import static io.trino.spi.function.OperatorType.MULTIPLY;
+import static io.trino.spi.function.OperatorType.NEGATION;
+import static io.trino.spi.function.OperatorType.SUBTRACT;
+import static java.lang.String.format;
+
+public final class NumberOperators
+{
+    private NumberOperators() {}
+
+    @ScalarOperator(ADD)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber add(@SqlType(StandardTypes.NUMBER) TrinoNumber left, @SqlType(StandardTypes.NUMBER) TrinoNumber right)
+    {
+        return TrinoNumber.from(left.toBigDecimal().add(right.toBigDecimal()));
+    }
+
+    @ScalarOperator(SUBTRACT)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber subtract(@SqlType(StandardTypes.NUMBER) TrinoNumber left, @SqlType(StandardTypes.NUMBER) TrinoNumber right)
+    {
+        return TrinoNumber.from(left.toBigDecimal().subtract(right.toBigDecimal()));
+    }
+
+    @ScalarOperator(MULTIPLY)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber multiply(@SqlType(StandardTypes.NUMBER) TrinoNumber left, @SqlType(StandardTypes.NUMBER) TrinoNumber right)
+    {
+        return TrinoNumber.from(left.toBigDecimal().multiply(right.toBigDecimal()));
+    }
+
+    @ScalarOperator(DIVIDE)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber divide(@SqlType(StandardTypes.NUMBER) TrinoNumber dividend, @SqlType(StandardTypes.NUMBER) TrinoNumber divisor)
+    {
+        BigDecimal dividendBigDecimal = dividend.toBigDecimal();
+        BigDecimal divisorBigDecimal = divisor.toBigDecimal();
+        // Modeled after decimal division, see DecimalOperators.decimalDivideOperator
+        int resultScale = Math.max(dividendBigDecimal.scale() + divisorBigDecimal.precision() + 1, 6);
+        try {
+            return TrinoNumber.from(dividendBigDecimal.divide(divisorBigDecimal, resultScale, RoundingMode.HALF_UP));
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(DIVISION_BY_ZERO, "Division by zero", e);
+        }
+    }
+
+    @ScalarOperator(MODULUS)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber modulus(@SqlType(StandardTypes.NUMBER) TrinoNumber dividend, @SqlType(StandardTypes.NUMBER) TrinoNumber divisor)
+    {
+        try {
+            return TrinoNumber.from(dividend.toBigDecimal().remainder(divisor.toBigDecimal()));
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(DIVISION_BY_ZERO, "Division by zero", e);
+        }
+    }
+
+    @ScalarOperator(NEGATION)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber negate(@SqlType(StandardTypes.NUMBER) TrinoNumber value)
+    {
+        return TrinoNumber.from(value.toBigDecimal().negate());
+    }
+
+    @ScalarOperator(CAST)
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.NUMBER) TrinoNumber value)
+    {
+        String stringValue = value.toBigDecimal().toString();
+        // String is all-ASCII, so String.length() here returns actual code points count
+        if (stringValue.length() <= x) {
+            return utf8Slice(stringValue);
+        }
+        throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", stringValue, x));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
@@ -22,6 +22,9 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
@@ -159,6 +162,13 @@ public final class SmallintOperators
     public static long castToReal(@SqlType(StandardTypes.SMALLINT) long value)
     {
         return floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType(StandardTypes.SMALLINT) long value)
+    {
+        return TrinoNumber.from(new BigDecimal(value));
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
@@ -21,6 +21,9 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
@@ -152,6 +155,13 @@ public final class TinyintOperators
     public static long castToReal(@SqlType(StandardTypes.TINYINT) long value)
     {
         return floatToRawIntBits((float) value);
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType(StandardTypes.TINYINT) long value)
+    {
+        return TrinoNumber.from(new BigDecimal(value));
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
@@ -18,6 +18,7 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.MapType;
+import io.trino.spi.type.NumberType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimeType;
@@ -362,6 +363,7 @@ public final class TypeCoercion
                 case StandardTypes.REAL -> Optional.of(REAL);
                 case StandardTypes.DOUBLE -> Optional.of(DOUBLE);
                 case StandardTypes.DECIMAL -> Optional.of(createDecimalType(3, 0));
+                case StandardTypes.NUMBER -> Optional.of(NumberType.NUMBER);
                 default -> Optional.empty();
             };
             case StandardTypes.SMALLINT -> switch (resultTypeBase) {
@@ -370,6 +372,7 @@ public final class TypeCoercion
                 case StandardTypes.REAL -> Optional.of(REAL);
                 case StandardTypes.DOUBLE -> Optional.of(DOUBLE);
                 case StandardTypes.DECIMAL -> Optional.of(createDecimalType(5, 0));
+                case StandardTypes.NUMBER -> Optional.of(NumberType.NUMBER);
                 default -> Optional.empty();
             };
             case StandardTypes.INTEGER -> switch (resultTypeBase) {
@@ -377,17 +380,21 @@ public final class TypeCoercion
                 case StandardTypes.REAL -> Optional.of(REAL);
                 case StandardTypes.DOUBLE -> Optional.of(DOUBLE);
                 case StandardTypes.DECIMAL -> Optional.of(createDecimalType(10, 0));
+                case StandardTypes.NUMBER -> Optional.of(NumberType.NUMBER);
                 default -> Optional.empty();
             };
             case StandardTypes.BIGINT -> switch (resultTypeBase) {
                 case StandardTypes.REAL -> Optional.of(REAL);
                 case StandardTypes.DOUBLE -> Optional.of(DOUBLE);
                 case StandardTypes.DECIMAL -> Optional.of(createDecimalType(19, 0));
+                case StandardTypes.NUMBER -> Optional.of(NumberType.NUMBER);
                 default -> Optional.empty();
             };
             case StandardTypes.DECIMAL -> switch (resultTypeBase) {
                 case StandardTypes.REAL -> Optional.of(REAL);
                 case StandardTypes.DOUBLE -> Optional.of(DOUBLE);
+                // TODO there should be coercion from DECIMAL to NUMBER, however this currently breaks arithmetics between integer types and decimals
+                //case StandardTypes.NUMBER -> Optional.of(NumberType.NUMBER);
                 default -> Optional.empty();
             };
             case StandardTypes.REAL -> switch (resultTypeBase) {

--- a/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
@@ -19,6 +19,9 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
@@ -146,6 +149,19 @@ public final class VarcharOperators
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType("varchar(x)") Slice slice)
+    {
+        try {
+            return TrinoNumber.from(new BigDecimal(slice.toStringUtf8().trim()));
+        }
+        catch (NumberFormatException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to NUMBER", slice.toStringUtf8()), e);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
@@ -14,6 +14,7 @@
 package io.trino.type;
 
 import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.SqlNumber;
 import io.trino.sql.query.QueryAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -433,6 +434,22 @@ public class TestBigintOperators
         assertThat(assertions.expression("cast(a as real)")
                 .binding("a", "BIGINT '0'"))
                 .isEqualTo(0.0f);
+    }
+
+    @Test
+    public void testCastToNumber()
+    {
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "BIGINT '37'"))
+                .isEqualTo(new SqlNumber("37"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "-100000000017"))
+                .isEqualTo(new SqlNumber("-100000000017"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "BIGINT '0'"))
+                .isEqualTo(new SqlNumber("0"));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.trino.spi.type.SqlNumber;
 import io.trino.sql.query.QueryAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -419,6 +420,22 @@ public class TestIntegerOperators
         assertThat(assertions.expression("cast(a as tinyint)")
                 .binding("a", "INTEGER '17'"))
                 .isEqualTo((byte) 17);
+    }
+
+    @Test
+    public void testCastToNumber()
+    {
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "INTEGER '37'"))
+                .isEqualTo(new SqlNumber("37"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "INTEGER '-1000017'"))
+                .isEqualTo(new SqlNumber("-1000017"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "INTEGER '0'"))
+                .isEqualTo(new SqlNumber("0"));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
@@ -1,0 +1,2766 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.SqlNumber;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.sql.query.QueryAssertions.ExpressionAssertProvider;
+import io.trino.testing.QueryFailedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.math.BigDecimal;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static io.trino.spi.function.OperatorType.ADD;
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.OperatorType.INDETERMINATE;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.function.OperatorType.MODULUS;
+import static io.trino.spi.function.OperatorType.MULTIPLY;
+import static io.trino.spi.function.OperatorType.NEGATION;
+import static io.trino.spi.function.OperatorType.SUBTRACT;
+import static io.trino.spi.type.NumberType.NUMBER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static java.lang.Math.max;
+import static java.math.RoundingMode.HALF_UP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestNumberOperators
+{
+    private final String[] bigDecimals = new String[] {
+            "0",
+            "-0",
+            "0e3",
+            "000.000",
+            "000.000e3",
+            "1",
+            "-1",
+            "1e3",
+            "100.000",
+            "100.000e3",
+            "100.001",
+            "100.001e3",
+            "127",
+            "128",
+            "255",
+            "256",
+            "1234567890123456",
+            "-1234567890123456",
+            "12345678901234567890123456789012345678",
+            "-12345678901234567890123456789012345678",
+            ".1234567890123456",
+            "-.1234567890123456",
+            ".12345678901234567890123456789012345678",
+            "-.12345678901234567890123456789012345678",
+            "20050910133100123",
+            "20050910.133100123",
+            "100000000000000000000000000000000000000",
+            "31439044302034031134344223124861871213334921133581369",
+            "3.141592653589793238462643383279502884197169399375105820974944592307",
+    };
+
+    private final String[] decimals = new String[] {
+            "0",
+            "3",
+            "1234",
+            "1001",
+            "3.14159",
+            "0.1003",
+            "1.1003",
+            "10007",
+            "127",
+            "128",
+            "255",
+            "256",
+    };
+
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    void testParse()
+    {
+        for (String number : bigDecimals) {
+            String expression = "NUMBER '%s'".formatted(number);
+            assertThat(assertions.expression(expression)).describedAs(expression)
+                    .isEqualTo(number(new BigDecimal(number).stripTrailingZeros().toString()));
+        }
+    }
+
+    /**
+     * Compare arithmetic results between Trino NUMBER and {@link BigDecimal}.
+     */
+    @Test
+    void testVerifyArithmeticWithBigDecimal()
+    {
+        for (String left : bigDecimals) {
+            BigDecimal leftBigDecimal = new BigDecimal(left);
+            String leftExpression = "NUMBER '%s'".formatted(left);
+            for (String right : bigDecimals) {
+                BigDecimal rightBigDecimal = new BigDecimal(right);
+                String rightExpression = "NUMBER '%s'".formatted(right);
+                for (var testedOperator : TestedArithmeticOperator.values()) {
+                    ExpressionAssertProvider operatorCall = assertions.expression("l %s r".formatted(testedOperator.operator))
+                            .binding("l", leftExpression)
+                            .binding("r", rightExpression);
+                    BigDecimal expected;
+                    try {
+                        expected = testedOperator.bigDecimalReferenceImplementation.apply(leftBigDecimal, rightBigDecimal);
+                    }
+                    catch (ArithmeticException e) {
+                        if (nullToEmpty(e.getMessage()).matches("/ by zero|Division by zero|Division undefined|BigInteger divide by zero")) {
+                            assertTrinoExceptionThrownBy(operatorCall::evaluate)
+                                    .hasErrorCode(DIVISION_BY_ZERO);
+                            continue;
+                        }
+                        throw new RuntimeException("Failed to calculate expected value for %s(%s, %s)".formatted(testedOperator.name(), left, right), e);
+                    }
+                    assertThat(operatorCall).as("%s(%s, %s)".formatted(testedOperator.operator, leftExpression, rightExpression))
+                            .isEqualTo(number(expected.stripTrailingZeros().toString()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Compare comparison results between Trino NUMBER and {@link BigDecimal}.
+     */
+    @Test
+    void testVerifyComparisonWithBigDecimal()
+    {
+        for (String left : bigDecimals) {
+            BigDecimal leftBigDecimal = new BigDecimal(left);
+            String leftExpression = "NUMBER '%s'".formatted(left);
+            for (String right : bigDecimals) {
+                BigDecimal rightBigDecimal = new BigDecimal(right);
+                String rightExpression = "NUMBER '%s'".formatted(right);
+                for (var testedOperator : TestedComparisonOperator.values()) {
+                    boolean expected = testedOperator.bigDecimalReferenceImplementation.test(leftBigDecimal, rightBigDecimal);
+                    assertThat(assertions.expression("l %s r".formatted(testedOperator.operator))
+                            .binding("l", leftExpression)
+                            .binding("r", rightExpression))
+                            .as("%s(%s, %s)".formatted(testedOperator.operator, leftExpression, rightExpression))
+                            .isEqualTo(expected);
+                }
+            }
+        }
+    }
+
+    /**
+     * Compare arithmetic results between Trino NUMBER and DECIMAL.
+     */
+    @Test
+    void testVerifyArithmeticWithTrinoDecimal()
+    {
+        for (String left : decimals) {
+            String leftExpression = "NUMBER '%s'".formatted(left);
+            for (String right : decimals) {
+                String rightExpression = "NUMBER '%s'".formatted(right);
+                for (var testedOperator : TestedArithmeticOperator.values()) {
+                    ExpressionAssertProvider operatorCall = assertions.expression("l %s r".formatted(testedOperator.operator))
+                            .binding("l", leftExpression)
+                            .binding("r", rightExpression);
+                    SqlDecimal expected;
+                    try {
+                        expected = (SqlDecimal) assertions.expression("l %s r".formatted(testedOperator.operator))
+                                .binding("l", "DECIMAL '%s'".formatted(left))
+                                .binding("r", "DECIMAL '%s'".formatted(right))
+                                .evaluate().value();
+                    }
+                    catch (QueryFailedException e) {
+                        if (nullToEmpty(e.getMessage()).matches("Division by zero")) {
+                            assertTrinoExceptionThrownBy(operatorCall::evaluate)
+                                    .hasErrorCode(DIVISION_BY_ZERO);
+                            continue;
+                        }
+                        throw new RuntimeException("Failed to calculate expected value for %s(%s, %s)".formatted(testedOperator.name(), left, right), e);
+                    }
+                    assertThat(operatorCall).as("%s(%s, %s)".formatted(testedOperator.operator, leftExpression, rightExpression))
+                            .isEqualTo(number(expected.toBigDecimal().stripTrailingZeros().toString()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Compare comparison results between Trino NUMBER and DECIMAL.
+     */
+    @Test
+    void testVerifyComparisonWithTrinoDecimal()
+    {
+        for (String left : decimals) {
+            String leftExpression = "NUMBER '%s'".formatted(left);
+            for (String right : decimals) {
+                String rightExpression = "NUMBER '%s'".formatted(right);
+                for (var testedOperator : TestedComparisonOperator.values()) {
+                    boolean expected = (boolean) assertions.expression("l %s r".formatted(testedOperator.operator))
+                            .binding("l", "DECIMAL '%s'".formatted(left))
+                            .binding("r", "DECIMAL '%s'".formatted(right))
+                            .evaluate().value();
+                    assertThat(assertions.expression("l %s r".formatted(testedOperator.operator))
+                            .binding("l", leftExpression)
+                            .binding("r", rightExpression))
+                            .as("%s(%s, %s)".formatted(testedOperator.operator, leftExpression, rightExpression))
+                            .isEqualTo(expected);
+                }
+            }
+        }
+    }
+
+    @Test
+    void testAdd()
+    {
+        assertThat(assertions.operator(ADD, "NUMBER '137.7'", "NUMBER '17.1'"))
+                .isEqualTo(number("154.8"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-1'", "NUMBER '-2'"))
+                .isEqualTo(number("-3"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '1'", "NUMBER '2'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '.1234567890123456'", "NUMBER '.1234567890123456'"))
+                .isEqualTo(number("0.2469135780246912"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-.1234567890123456'", "NUMBER '-.1234567890123456'"))
+                .isEqualTo(number("-0.2469135780246912"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '1234567890123456'", "NUMBER '1234567890123456'"))
+                .isEqualTo(number("2469135780246912"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '123456789012345678'", "NUMBER '123456789012345678'"))
+                .isEqualTo(number("246913578024691356"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '.123456789012345678'", "NUMBER '.123456789012345678'"))
+                .isEqualTo(number("0.246913578024691356"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '1234567890123456789'", "NUMBER '1234567890123456789'"))
+                .isEqualTo(number("2469135780246913578"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '12345678901234567890123456789012345678'"))
+                .isEqualTo(number("24691357802469135780246913578024691356"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("0"));
+
+        // negative numbers
+        assertThat(assertions.operator(ADD, "NUMBER '12345678901234567890'", "NUMBER '-12345678901234567890'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-12345678901234567890'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-12345678901234567890'", "NUMBER '-12345678901234567890'"))
+                .isEqualTo(number("-2.469135780246913578E+19"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '12345678901234567890'", "NUMBER '-12345678901234567891'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-12345678901234567891'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-12345678901234567890'", "NUMBER '12345678901234567891'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '12345678901234567891'", "NUMBER '-12345678901234567890'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '999999999999999999'", "NUMBER '999999999999999999'"))
+                .isEqualTo(number("1999999999999999998"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '999999999999999999'", "NUMBER '.999999999999999999'"))
+                .isEqualTo(number("999999999999999999.999999999999999999"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '123456789012345678901234567890'", "NUMBER '.12345678'"))
+                .isEqualTo(number("123456789012345678901234567890.12345678"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '.123456789012345678901234567890'", "NUMBER '12345678'"))
+                .isEqualTo(number("12345678.12345678901234567890123456789"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '.12345678'", "NUMBER '123456789012345678901234567890'"))
+                .isEqualTo(number("123456789012345678901234567890.12345678"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '12345678'", "NUMBER '.123456789012345678901234567890'"))
+                .isEqualTo(number("12345678.12345678901234567890123456789"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '1'"))
+                .isEqualTo(number("1E+38"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '.1'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("99999999999999999999999999999999999999.1"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '1'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("1E+38"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '.1'"))
+                .isEqualTo(number("99999999999999999999999999999999999999.1"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("199999999999999999999999999999999999998"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '-99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-199999999999999999999999999999999999998"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '17014000000000000000000000000000000000'", "NUMBER '-7014000000000000000000000000000000000.1'"))
+                .isEqualTo(number("9999999999999999999999999999999999999.9"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '17015000000000000000000000000000000000'", "NUMBER '-7015000000000000000000000000000000000.1'"))
+                .isEqualTo(number("9999999999999999999999999999999999999.9"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '10'", "NUMBER '0.0000000000000000000000000000000000001'"))
+                .isEqualTo(number("10.0000000000000000000000000000000000001"));
+    }
+
+    @Test
+    void testSubtract()
+    {
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '107.7'", "NUMBER '17.1'"))
+                .isEqualTo(number("90.6"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-1'", "NUMBER '-2'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '1'", "NUMBER '2'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '.1234567890123456'", "NUMBER '.1234567890123456'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-.1234567890123456'", "NUMBER '-.1234567890123456'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '1234567890123456'", "NUMBER '1234567890123456'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '1234567890123456789'", "NUMBER '1234567890123456789'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '.1234567890123456789'", "NUMBER '.1234567890123456789'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '12345678901234567890'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '12345678901234567890123456789012345678'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-12345678901234567890'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("-2.469135780246913578E+19"));
+
+        // negative numbers
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '12345678901234567890'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-12345678901234567890'", "NUMBER '-12345678901234567890'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-12345678901234567890'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("-2.469135780246913578E+19"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '12345678901234567890'", "NUMBER '12345678901234567891'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-12345678901234567891'", "NUMBER '-12345678901234567890'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-12345678901234567890'", "NUMBER '-12345678901234567891'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '12345678901234567891'", "NUMBER '12345678901234567890'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '999999999999999999'", "NUMBER '999999999999999999'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '999999999999999999'", "NUMBER '.999999999999999999'"))
+                .isEqualTo(number("999999999999999998.000000000000000001"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '123456789012345678901234567890'", "NUMBER '.00000001'"))
+                .isEqualTo(number("123456789012345678901234567889.99999999"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '.000000000000000000000000000001'", "NUMBER '87654321'"))
+                .isEqualTo(number("-87654320.999999999999999999999999999999"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '.00000001'", "NUMBER '123456789012345678901234567890'"))
+                .isEqualTo(number("-123456789012345678901234567889.99999999"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '12345678'", "NUMBER '.000000000000000000000000000001'"))
+                .isEqualTo(number("12345677.999999999999999999999999999999"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '1'"))
+                .isEqualTo(number("-1E+38"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '.1'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-99999999999999999999999999999999999998.9"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-1'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-1E+38"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '.1'"))
+                .isEqualTo(number("99999999999999999999999999999999999998.9"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-199999999999999999999999999999999999998"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '17014000000000000000000000000000000000'", "NUMBER '7014000000000000000000000000000000000.1'"))
+                .isEqualTo(number("9999999999999999999999999999999999999.9"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '17015000000000000000000000000000000000'", "NUMBER '7015000000000000000000000000000000000.1'"))
+                .isEqualTo(number("9999999999999999999999999999999999999.9"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '10'", "NUMBER '0.0000000000000000000000000000000000001'"))
+                .isEqualTo(number("9.9999999999999999999999999999999999999"));
+    }
+
+    @Test
+    void testMultiply()
+    {
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "NUMBER '1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "NUMBER '-1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '1'", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-1'", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12'", "NUMBER '3'"))
+                .isEqualTo(number("36"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12'", "NUMBER '-3'"))
+                .isEqualTo(number("-36"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-12'", "NUMBER '3'"))
+                .isEqualTo(number("-36"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '1234567890123456'", "NUMBER '3'"))
+                .isEqualTo(number("3703703670370368"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1234567890123456'", "NUMBER '3'"))
+                .isEqualTo(number("0.3703703670370368"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1234567890123456'", "NUMBER '.3'"))
+                .isEqualTo(number("0.03703703670370368"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "NUMBER '1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "NUMBER '-1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '1'", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-1'", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12345678901234567'", "NUMBER '123456789012345670'"))
+                .isEqualTo(number("1.52415787532388345526596755677489E+33"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-12345678901234567'", "NUMBER '123456789012345670'"))
+                .isEqualTo(number("-1.52415787532388345526596755677489E+33"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-12345678901234567'", "NUMBER '-123456789012345670'"))
+                .isEqualTo(number("1.52415787532388345526596755677489E+33"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.12345678901234567'", "NUMBER '.123456789012345670'"))
+                .isEqualTo(number("0.0152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "1"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "-1"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '1'", "0"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-1'", "0"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '3'"))
+                .isEqualTo(number("37037036703703703670370370367037037034"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '1234567890123456789.0123456789012345678'", "NUMBER '3'"))
+                .isEqualTo(number("3703703670370370367.0370370367037037034"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.12345678901234567890123456789012345678'", "NUMBER '3'"))
+                .isEqualTo(number("0.37037036703703703670370370367037037034"));
+
+        assertThat(assertions.operator(MULTIPLY, "0", "NUMBER '1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "0", "NUMBER '-1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "1", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "-1", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '3'", "NUMBER '12345678901234567890123456789012345678'"))
+                .isEqualTo(number("37037036703703703670370370367037037034"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '3'", "NUMBER '1234567890123456789.0123456789012345678'"))
+                .isEqualTo(number("3703703670370370367.0370370367037037034"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '3'", "NUMBER '.12345678901234567890123456789012345678'"))
+                .isEqualTo(number("0.37037036703703703670370370367037037034"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "NUMBER '1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '0'", "NUMBER '-1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '1'", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-1'", "NUMBER '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '3'", "NUMBER '2'"))
+                .isEqualTo(number("6"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '3'", "NUMBER '0.2'"))
+                .isEqualTo(number("0.6"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1234567890123456789'", "NUMBER '.1234567890123456789'"))
+                .isEqualTo(number("0.01524157875323883675019051998750190521"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1234567890123456789'", "NUMBER '.12345678901234567890'"))
+                .isEqualTo(number("0.01524157875323883675019051998750190521"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1'", "NUMBER '.12345678901234567890123456789012345678'"))
+                .isEqualTo(number("0.012345678901234567890123456789012345678"));
+
+        // large multiplications
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '9'"))
+                .isEqualTo(number("111111110111111111011111111101111111102"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.12345678901234567890123456789012345678'", "NUMBER '9'"))
+                .isEqualTo(number("1.11111110111111111011111111101111111102"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '-9'"))
+                .isEqualTo(number("-111111110111111111011111111101111111102"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.12345678901234567890123456789012345678'", "NUMBER '-9'"))
+                .isEqualTo(number("-1.11111110111111111011111111101111111102"));
+
+        // exceeding max precision
+        assertThat(assertions.operator(
+                MULTIPLY,
+                "NUMBER '66253166201757048147019387751429455554737010320073440042660951972479154873726992102003231643719422615777393043'",
+                "NUMBER '18262774589350675530582336394934775228395046345354563393581350068572539440130541361187755243849469688290680443'"))
+                .isEqualTo(number("1.2099666401734756302615960804662809455013260652052016476208956457442034413389008286145859185565320271851315022978671553334828770682233313021073582891886195122714730571619107009764269825599972382875203E+219"));
+    }
+
+    @Test
+    void testDivide()
+    {
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '3'"))
+                .isEqualTo(number("0.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1.0'", "NUMBER '3'"))
+                .isEqualTo(number("0.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1.0'", "NUMBER '0.1'"))
+                .isEqualTo(number("1E+1"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1.0'", "NUMBER '9.0'"))
+                .isEqualTo(number("0.111111"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '500.00'", "NUMBER '0.1'"))
+                .isEqualTo(number("5E+3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '100.00'", "NUMBER '0.3'"))
+                .isEqualTo(number("333.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '100.00'", "NUMBER '0.30'"))
+                .isEqualTo(number("333.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '100.00'", "NUMBER '-0.30'"))
+                .isEqualTo(number("-333.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-100.00'", "NUMBER '0.30'"))
+                .isEqualTo(number("-333.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '200.00'", "NUMBER '0.3'"))
+                .isEqualTo(number("666.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '200.00000'", "NUMBER '0.3'"))
+                .isEqualTo(number("666.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '200.00000'", "NUMBER '-0.3'"))
+                .isEqualTo(number("-666.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-200.00000'", "NUMBER '0.3'"))
+                .isEqualTo(number("-666.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '999999999999999999'", "NUMBER '1'"))
+                .isEqualTo(number("999999999999999999"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9'", "NUMBER '000000000000000003'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9.0'", "NUMBER '3.0'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '999999999999999999'", "NUMBER '500000000000000000'"))
+                .isEqualTo(number("2"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '999999999999999999'"))
+                .isEqualTo(number("1E-18"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '999999999999999999'"))
+                .isEqualTo(number("-1E-18"));
+
+        // round
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9'", "NUMBER '5'"))
+                .isEqualTo(number("1.8"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '7'", "NUMBER '5'"))
+                .isEqualTo(number("1.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-9'", "NUMBER '5'"))
+                .isEqualTo(number("-1.8"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-7'", "NUMBER '5'"))
+                .isEqualTo(number("-1.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-9'", "NUMBER '-5'"))
+                .isEqualTo(number("1.8"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-7'", "NUMBER '-5'"))
+                .isEqualTo(number("1.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9'", "NUMBER '-5'"))
+                .isEqualTo(number("-1.8"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '7'", "NUMBER '-5'"))
+                .isEqualTo(number("-1.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '2'"))
+                .isEqualTo(number("-0.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '-2'"))
+                .isEqualTo(number("-0.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '3'"))
+                .isEqualTo(number("-0.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '10'", "NUMBER '.000000001'"))
+                .isEqualTo(number("1E+10"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-10'", "NUMBER '.000000001'"))
+                .isEqualTo(number("-1E+10"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '10'", "NUMBER '-.000000001'"))
+                .isEqualTo(number("-1E+10"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-10'", "NUMBER '-.000000001'"))
+                .isEqualTo(number("1E+10"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '200000000000000000000000000000000000'", "NUMBER '0.30'"))
+                .isEqualTo(number("666666666666666666666666666666666666.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '200000000000000000000000000000000000'", "NUMBER '-0.30'"))
+                .isEqualTo(number("-666666666666666666666666666666666666.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-.20000000000000000000000000000000000000'", "NUMBER '0.30'"))
+                .isEqualTo(number("-0.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-.20000000000000000000000000000000000000'", "NUMBER '-0.30'"))
+                .isEqualTo(number("0.666667"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '.20000000000000000000000000000000000000'", "NUMBER '0.30'"))
+                .isEqualTo(number("0.666667"));
+
+        // round
+        assertThat(assertions.operator(DIVIDE, "NUMBER '500000000000000000000000000000075'", "NUMBER '50'"))
+                .isEqualTo(number("10000000000000000000000000000001.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '500000000000000000000000000000070'", "NUMBER '50'"))
+                .isEqualTo(number("10000000000000000000000000000001.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-500000000000000000000000000000075'", "NUMBER '50'"))
+                .isEqualTo(number("-10000000000000000000000000000001.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-500000000000000000000000000000070'", "NUMBER '50'"))
+                .isEqualTo(number("-10000000000000000000000000000001.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '500000000000000000000000000000075'", "NUMBER '-50'"))
+                .isEqualTo(number("-10000000000000000000000000000001.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '500000000000000000000000000000070'", "NUMBER '-50'"))
+                .isEqualTo(number("-10000000000000000000000000000001.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-500000000000000000000000000000075'", "NUMBER '-50'"))
+                .isEqualTo(number("10000000000000000000000000000001.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-500000000000000000000000000000070'", "NUMBER '-50'"))
+                .isEqualTo(number("10000000000000000000000000000001.4"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '2'"))
+                .isEqualTo(number("-0.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '-2'"))
+                .isEqualTo(number("-0.5"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '3'"))
+                .isEqualTo(number("-0.333333"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '0.1'", "NUMBER '.0000000000000000001'"))
+                .isEqualTo(number("1E+18"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-0.1'", "NUMBER '.0000000000000000001'"))
+                .isEqualTo(number("-1E+18"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '0.1'", "NUMBER '-.0000000000000000001'"))
+                .isEqualTo(number("-1E+18"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-0.1'", "NUMBER '-.0000000000000000001'"))
+                .isEqualTo(number("1E+18"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9'", "NUMBER '000000000000000003.0'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("1E-38"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-1E-38"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '-99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-1E-38"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-1'", "NUMBER '-99999999999999999999999999999999999999'"))
+                .isEqualTo(number("1E-38"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '11111111111111111111111111111111111111'"))
+                .isEqualTo(number("9"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '11111111111111111111111111111111111111'"))
+                .isEqualTo(number("-9"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '-11111111111111111111111111111111111111'"))
+                .isEqualTo(number("-9"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '-11111111111111111111111111111111111111'"))
+                .isEqualTo(number("9"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '11111111111111111111111111111111111111'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("0.111111111111111111111111111111111111111"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-11111111111111111111111111111111111111'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-0.111111111111111111111111111111111111111"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '11111111111111111111111111111111111111'", "NUMBER '-99999999999999999999999999999999999999'"))
+                .isEqualTo(number("-0.111111111111111111111111111111111111111"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-11111111111111111111111111111111111111'", "NUMBER '-99999999999999999999999999999999999999'"))
+                .isEqualTo(number("0.111111111111111111111111111111111111111"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '99999999999999999999999999999999999998'", "NUMBER '99999999999999999999999999999999999999'"))
+                .isEqualTo(number("0.99999999999999999999999999999999999999"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9999999999999999999999999999999999999.8'", "NUMBER '9999999999999999999999999999999999999.9'"))
+                .isEqualTo(number("0.99999999999999999999999999999999999999"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9999999999999999999999.9'", "NUMBER '1111111111111111111111.100'"))
+                .isEqualTo(number("9"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1635619.3155'", "NUMBER '47497517.7405'"))
+                .isEqualTo(number("0.0344358904066548"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '.1'"))
+                .isEqualTo(number("1.2345678901234567890123456789012345678E+38"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '12345678901234567890123456789012345678'", "NUMBER '.12345678901234567890123456789012345678'"))
+                .isEqualTo(number("1E+38"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '.12345678901234567890123456789012345678'"))
+                .isEqualTo(number("8.100000072900000663390006036849054935918"));
+
+        // division by zero tests
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '0'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "NUMBER '1.000000000000000000000000000000000000'", "NUMBER '0'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "NUMBER '1.000000000000000000000000000000000000'", "NUMBER '0.0000000000000000000000000000000000000'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "NUMBER '1'", "NUMBER '0.0000000000000000000000000000000000000'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '1000'", "NUMBER '25'"))
+                .isEqualTo(number("4E+1"));
+    }
+
+    @Test
+    void testModulus()
+    {
+        assertThat(assertions.operator(MODULUS, "NUMBER '1'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '10'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '10.0'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '10.0'", "NUMBER '3.000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3.0000000000000000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.00000000000000000'", "NUMBER '3.00000000000000000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.00000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '.1'", "NUMBER '.03'"))
+                .isEqualTo(number("0.01"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '.0001'", "NUMBER '.03'"))
+                .isEqualTo(number("0.0001"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-10'", "NUMBER '3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '10'", "NUMBER '-3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-10'", "NUMBER '-3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.00000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7.00000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.0000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7.0000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9.00000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9.00000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9.0000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9.0000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '-3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.00000000000000000'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '.01'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0.01"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '-3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7'", "NUMBER '-3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9'", "NUMBER '3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9'", "NUMBER '-3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9'", "NUMBER '-3.0000000000000000000000000000000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '99999999999999999999999999999999999997'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '99999999999999999999999999999999999997'", "NUMBER '3.0000000000000000'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-99999999999999999999999999999999999997'", "NUMBER '3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '99999999999999999999999999999999999997'", "NUMBER '-3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-99999999999999999999999999999999999997'", "NUMBER '-3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '99999999999999999999999999999999999999'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-99999999999999999999999999999999999999'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0.000000000000000000000000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0.000000000000000000000000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.000000000000000000000000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7.000000000000000000000000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7.000000000000000000000000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7.000000000000000000000000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9.000000000000000000000000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9.000000000000000000000000000000000000'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9.000000000000000000000000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9.000000000000000000000000000000000000'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '0'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7'", "NUMBER '3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '7'", "NUMBER '-3'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-7'", "NUMBER '-3'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9'", "NUMBER '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9'", "NUMBER '-3'"))
+                .isEqualTo(number("0"));
+
+        // division by zero tests
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "NUMBER '1'", "NUMBER '0'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "NUMBER '1.000000000000000000000000000000000000'", "NUMBER '0'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "NUMBER '1.000000000000000000000000000000000000'", "NUMBER '0.0000000000000000000000000000000000000'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "NUMBER '1'", "NUMBER '0.0000000000000000000000000000000000000'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "NUMBER '1'", "NUMBER '0'")::evaluate)
+                .hasErrorCode(DIVISION_BY_ZERO);
+    }
+
+    @Test
+    void testNegation()
+    {
+        assertThat(assertions.operator(NEGATION, "NUMBER '1'"))
+                .isEqualTo(number("-1"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '-1'"))
+                .isEqualTo(number("1"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '123456.00000010' "))
+                .isEqualTo(number("-123456.0000001"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '1234567.00500010734' "))
+                .isEqualTo(number("-1234567.00500010734"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '-1234567.00500010734' "))
+                .isEqualTo(number("1234567.00500010734"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '0' "))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '0.00000000000000000000' "))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '12345678901234567890123456789012345678'"))
+                .isEqualTo(number("-12345678901234567890123456789012345678"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '-12345678901234567890123456789012345678'"))
+                .isEqualTo(number("12345678901234567890123456789012345678"));
+
+        assertThat(assertions.operator(NEGATION, "NUMBER '123456789012345678.90123456789012345678'"))
+                .isEqualTo(number("-123456789012345678.90123456789012345678"));
+    }
+
+    @Test
+    void testEqual()
+    {
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '0037'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '37.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37.0'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-0.000'", "NUMBER '0.00000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '38'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '38.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37.0'", "NUMBER '38'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-37.000'", "NUMBER '37.000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-123456789123456789'", "NUMBER '-123456789123456789'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-123456789123456789'", "NUMBER '123456789123456789'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '037.0'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-0.000'", "NUMBER '0.000000000000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37'", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-37'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37.0000000000000000'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37.0000000000000000'", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '037.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-0.000000000000000000000000000000000'", "NUMBER '0.000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000038.0000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-00000000037.0000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '37.0000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000036.0000000000000000000000'", "NUMBER '37.0000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '0037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '0.0000000000000000000000000000000'", "NUMBER '-0.000000000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '00000000038.0000000000000000000000'", "NUMBER '000000000037.00000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(EQUAL, "NUMBER '-00000000038.0000000000000000000000'", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    void testNotEqual()
+    {
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '0037'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37.0'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '0'")
+                .binding("b", "NUMBER '-0.00'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '-37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '38.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37.0'")
+                .binding("b", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '-37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '-999999999999999999'")
+                .binding("b", "NUMBER '-999999999999999999'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '-999999999999999999'")
+                .binding("b", "NUMBER '999999999999999998'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '0'")
+                .binding("b", "NUMBER '-0.0000000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '-000000000037.00000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '38.0000000000000000'")
+                .binding("b", "NUMBER '00000000038.0000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '-987654321987654321'")
+                .binding("b", "NUMBER '-987654321987654321.00000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '037.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '0.0000000000000000000000000000'")
+                .binding("b", "NUMBER '-0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000038.0000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000000037.00000000000000000000'")
+                .binding("b", "NUMBER '-37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '37.0000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '-00000000000037.00000000000000000000'")
+                .binding("b", "NUMBER '-37.0000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '0037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '0.00000000000000000000000000000000000'")
+                .binding("b", "NUMBER '-0.000000000000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000038.0000000000000000000000'")
+                .binding("b", "NUMBER '000000000037.00000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a != b")
+                .binding("a", "NUMBER '00000000000037.00000000000000000000'")
+                .binding("b", "NUMBER '-00000000000037.00000000000000000000'"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    void testLessThan()
+    {
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '0037'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '37.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37.0'", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '0037.0'", "NUMBER '00036.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '0038.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '0037.0'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-100'", "NUMBER '20'"))
+                .isEqualTo(true);
+
+        // test possible overflow on rescale
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '1'", "NUMBER '10000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '1.0000000000000000'", "NUMBER '10000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-123456789123456789'", "NUMBER '-123456789123456789'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-123456789123456789'", "NUMBER '123456789123456789'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '037.0'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '037.0'", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '37.00000000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '037.0'", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-100'", "NUMBER '20.00000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '38.0000000000000000'", "NUMBER '00000000038.0000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-987654321987654321'", "NUMBER '-987654321987654321.00000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37.0000000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '037.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '036.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37.0000000000000000000000000'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000001'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '038.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-00000000000100.000000000000'", "NUMBER '20'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '37.0000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-00000000000037.00000000000000000000'", "NUMBER '-37.0000000000000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37.0000000000000000000000000'", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37.0000000000000000000000000'", "NUMBER '00000037.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '37.0000000000000000000000000'", "NUMBER '00000036.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '38.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '000000000037.00000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN, "NUMBER '-00000000000100.000000000000'", "NUMBER '0000000020.0000000000000'"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    void testGreaterThan()
+    {
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '0037'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37.0'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '0037.0'")
+                .binding("b", "NUMBER '00038.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '0036.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '0037.0'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '100'")
+                .binding("b", "NUMBER '-20'"))
+                .isEqualTo(true);
+
+        // test possible overflow on rescale
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '10000000000000000'")
+                .binding("b", "NUMBER '1'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '10000000000000000'")
+                .binding("b", "NUMBER '1.0000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '-123456789123456788'")
+                .binding("b", "NUMBER '-123456789123456789'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '-123456789123456789'")
+                .binding("b", "NUMBER '123456789123456789'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '36.00000000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '100'")
+                .binding("b", "NUMBER '-0000000020.00000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '38.0000000000000000'")
+                .binding("b", "NUMBER '00000000038.0000000000000000000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '-987654321987654320'")
+                .binding("b", "NUMBER '-987654321987654321.00000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '037.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '038.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000001'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '036.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '0000000000100.000000000000'")
+                .binding("b", "NUMBER '20'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000002'")
+                .binding("b", "NUMBER '37.0000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '-00000000000037.00000000000000000000'")
+                .binding("b", "NUMBER '-37.0000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '00000037.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '00000038.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '36.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '000000000036.9999999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a > b")
+                .binding("a", "NUMBER '000000000000100.0000000000000000000000'")
+                .binding("b", "NUMBER '-0000000020.00000000000000000000000'"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    void testLessThanOrEqual()
+    {
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '36'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '000036.99999'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '0037'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '37.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37.0'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '0038.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '0037.0'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-100'", "NUMBER '20'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-123456789123456789'", "NUMBER '-123456789123456789'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-123456789123456789'", "NUMBER '123456789123456789'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '037.0'", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '037.0'", "NUMBER '00000000036.9999999999999999999'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '037.0'", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '37.00000000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '037.0'", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-100'", "NUMBER '20.00000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '38.0000000000000000'", "NUMBER '00000000038.0000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-987654321987654321'", "NUMBER '-987654321987654321.00000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '036.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '000036.99999999'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '037.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000001'", "NUMBER '38'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '038.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-00000000000100.000000000000'", "NUMBER '20'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '37.0000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-00000000000037.00000000000000000000'", "NUMBER '-37.0000000000000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '00000036.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37.0000000000000000000000000'", "NUMBER '00000037.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '38.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '00000000037.0000000000000000000000'", "NUMBER '000000000037.00000000000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '-00000000000100.000000000000'", "NUMBER '0000000020.0000000000000'"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    void testGreaterThanOrEqual()
+    {
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '38'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '000038.00001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '0037'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37.0'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '0036.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '0037.0'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '100'")
+                .binding("b", "NUMBER '-20'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '-123456789123456789'")
+                .binding("b", "NUMBER '-123456789123456789'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '-123456789123456789'")
+                .binding("b", "NUMBER '123456789123456789'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000038.0000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000037.0000000000000000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000037.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '36.9999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37'")
+                .binding("b", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '037.0'")
+                .binding("b", "NUMBER '00000000036.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '100'")
+                .binding("b", "NUMBER '-0000000020.00000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '38.0000000000000000'")
+                .binding("b", "NUMBER '00000000038.0000000000000000000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '-987654321987654321'")
+                .binding("b", "NUMBER '-987654321987654321.00000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '038.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '000037.00000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '037.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000001'")
+                .binding("b", "NUMBER '36'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '036.0'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '0000000000100.000000000000'")
+                .binding("b", "NUMBER '20'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '37.0000000000000001'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '-00000000000037.00000000000000000000'")
+                .binding("b", "NUMBER '-37.0000000000000001'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '00000038.0000000000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '37.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '37.0000000000000000000000000'")
+                .binding("b", "NUMBER '00000037.0000000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '36.0000000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '00000000037.0000000000000000000000'")
+                .binding("b", "NUMBER '000000000036.9999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a >= b")
+                .binding("a", "NUMBER '000000000000100.0000000000000000000000'")
+                .binding("b", "NUMBER '-0000000020.00000000000000000000000'"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    void testBetween()
+    {
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '333333333333333333'")
+                .binding("low", "NUMBER '-111111111111111111'")
+                .binding("high", "NUMBER '999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '333333333333333333'")
+                .binding("low", "NUMBER '-111111111111111111'")
+                .binding("high", "NUMBER '9999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1'")
+                .binding("low", "NUMBER '-5.00000000000000000000'")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6'")
+                .binding("low", "NUMBER '-5.00000000000000000000'")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6'")
+                .binding("low", "NUMBER '-5.00000000000000000000'")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '333333333333333333'")
+                .binding("low", "NUMBER '-1111111111111111111'")
+                .binding("high", "NUMBER '9999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1.00000000000000000000'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6.00000000000000000000'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6.00000000000000000000'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '333333333333333333.3'")
+                .binding("low", "NUMBER '-111111111111111111'")
+                .binding("high", "NUMBER '999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1.00000000000000000000'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5.00000000000000000000' "))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6.00000000000000000000'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5.00000000000000000000' "))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6.00000000000000000000'")
+                .binding("low", "NUMBER '-5'")
+                .binding("high", "NUMBER '5.00000000000000000000' "))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '333333333333333333.3'")
+                .binding("low", "NUMBER '-111111111111111111'")
+                .binding("high", "NUMBER '9999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1.00000000000000000000'")
+                .binding("low", "NUMBER '-5.00000000000000000000' ")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6.00000000000000000000'")
+                .binding("low", "NUMBER '-5.00000000000000000000' ")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6.00000000000000000000'")
+                .binding("low", "NUMBER '-5.00000000000000000000' ")
+                .binding("high", "NUMBER '5'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '333333333333333333.3'")
+                .binding("low", "NUMBER '-111111111111111111.1'")
+                .binding("high", "NUMBER '999999999999999999'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '1.00000000000000000000'")
+                .binding("low", "NUMBER '-5.00000000000000000000' ")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '-6.00000000000000000000'")
+                .binding("low", "NUMBER '-5.00000000000000000000' ")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("value BETWEEN low AND high")
+                .binding("value", "NUMBER '6.00000000000000000000'")
+                .binding("low", "NUMBER '-5.00000000000000000000' ")
+                .binding("high", "NUMBER '5.00000000000000000000'"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    void testAddNumberBigint()
+    {
+        // number + bigint
+        assertThat(assertions.operator(ADD, "NUMBER '123456789012345678'", "123456789012345678"))
+                .isEqualTo(number("246913578024691356"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '.123456789012345678'", "123456789012345678"))
+                .isEqualTo(number("123456789012345678.123456789012345678"));
+
+        assertThat(assertions.operator(ADD, "NUMBER '-1234567890123456789'", "1234567890123456789"))
+                .isEqualTo(number("0"));
+
+        // bigint + number
+        assertThat(assertions.operator(ADD, "123456789012345678", "NUMBER '123456789012345678'"))
+                .isEqualTo(number("246913578024691356"));
+
+        assertThat(assertions.operator(ADD, "123456789012345678", "NUMBER '.123456789012345678'"))
+                .isEqualTo(number("123456789012345678.123456789012345678"));
+
+        assertThat(assertions.operator(ADD, "1234567890123456789", "NUMBER '-1234567890123456789'"))
+                .isEqualTo(number("0"));
+    }
+
+    @Test
+    void testSubtractNumberBigint()
+    {
+        // number - bigint
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '1234567890123456789'", "1234567890123456789"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '.1234567890123456789'", "1234567890123456789"))
+                .isEqualTo(number("-1234567890123456788.8765432109876543211"));
+
+        assertThat(assertions.operator(SUBTRACT, "NUMBER '-1234567890123456789'", "1234567890123456789"))
+                .isEqualTo(number("-2469135780246913578"));
+
+        // bigint - number
+        assertThat(assertions.operator(SUBTRACT, "1234567890123456789", "NUMBER '1234567890123456789'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(SUBTRACT, "1234567890123456789", "NUMBER '.1234567890123456789'"))
+                .isEqualTo(number("1234567890123456788.8765432109876543211"));
+
+        assertThat(assertions.operator(SUBTRACT, "-1234567890123456789", "NUMBER '1234567890123456789'"))
+                .isEqualTo(number("-2469135780246913578"));
+    }
+
+    @Test
+    void testMultiplyNumberBigint()
+    {
+        // number bigint
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '12345678901234567'", "12345678901234567"))
+                .isEqualTo(number("152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-12345678901234567'", "12345678901234567"))
+                .isEqualTo(number("-152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-12345678901234567'", "-12345678901234567"))
+                .isEqualTo(number("152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1234567890'", "BIGINT '3'"))
+                .isEqualTo(number("0.370370367"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '.1234567890'", "BIGINT '0'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "NUMBER '-.1234567890'", "BIGINT '0'"))
+                .isEqualTo(number("0"));
+
+        // bigint number
+        assertThat(assertions.operator(MULTIPLY, "12345678901234567", "NUMBER '12345678901234567'"))
+                .isEqualTo(number("152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "12345678901234567", "NUMBER '-12345678901234567'"))
+                .isEqualTo(number("-152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "-12345678901234567", "NUMBER '-12345678901234567'"))
+                .isEqualTo(number("152415787532388345526596755677489"));
+
+        assertThat(assertions.operator(MULTIPLY, "BIGINT '3'", "NUMBER '.1234567890'"))
+                .isEqualTo(number("0.370370367"));
+
+        assertThat(assertions.operator(MULTIPLY, "BIGINT '3'", "NUMBER '.0000000000'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MULTIPLY, "BIGINT '-3'", "NUMBER '.0000000000'"))
+                .isEqualTo(number("0"));
+    }
+
+    @Test
+    void testDivideNumberBigint()
+    {
+        // bigint / number
+        assertThat(assertions.operator(DIVIDE, "BIGINT '9'", "NUMBER '3.0'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '-9'", "NUMBER '3.0'"))
+                .isEqualTo(number("-3"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '9'", "NUMBER '-3.0'"))
+                .isEqualTo(number("-3"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '-9'", "NUMBER '-3.0'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '9'", "NUMBER '000000000000000003.0'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '18'", "NUMBER '0.01'"))
+                .isEqualTo(number("1.8E+3"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '9'", "NUMBER '00000000000000000.1'"))
+                .isEqualTo(number("9E+1"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '9'", "NUMBER '300.0'"))
+                .isEqualTo(number("0.03"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '-9'", "NUMBER '300.0'"))
+                .isEqualTo(number("-0.03"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '9'", "NUMBER '-300.0'"))
+                .isEqualTo(number("-0.03"));
+
+        assertThat(assertions.operator(DIVIDE, "BIGINT '-9'", "NUMBER '-300.0'"))
+                .isEqualTo(number("0.03"));
+
+        // number / bigint
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9.0'", "BIGINT '3'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-9.0'", "BIGINT '3'"))
+                .isEqualTo(number("-3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9.0'", "BIGINT '-3'"))
+                .isEqualTo(number("-3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-9.0'", "BIGINT '-3'"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '0.018'", "BIGINT '9'"))
+                .isEqualTo(number("0.002"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-0.018'", "BIGINT '9'"))
+                .isEqualTo(number("-0.002"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '0.018'", "BIGINT '-9'"))
+                .isEqualTo(number("-0.002"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-0.018'", "BIGINT '-9'"))
+                .isEqualTo(number("0.002"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '.999'", "BIGINT '9'"))
+                .isEqualTo(number("0.111"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9.0'", "BIGINT '300'"))
+                .isEqualTo(number("0.03"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-9.0'", "BIGINT '300'"))
+                .isEqualTo(number("-0.03"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '9.0'", "BIGINT '-300'"))
+                .isEqualTo(number("-0.03"));
+
+        assertThat(assertions.operator(DIVIDE, "NUMBER '-9.0'", "BIGINT '-300'"))
+                .isEqualTo(number("0.03"));
+    }
+
+    @Test
+    void testModulusNumberBigint()
+    {
+        // bigint % number
+        assertThat(assertions.operator(MODULUS, "BIGINT '13'", "NUMBER '9.0'"))
+                .isEqualTo(number("4"));
+
+        assertThat(assertions.operator(MODULUS, "BIGINT '18'", "NUMBER '0.01'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "BIGINT '9'", "NUMBER '.1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "BIGINT '-9'", "NUMBER '.1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "BIGINT '9'", "NUMBER '-.1'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "BIGINT '-9'", "NUMBER '-.1'"))
+                .isEqualTo(number("0"));
+
+        // number % bigint
+        assertThat(assertions.operator(MODULUS, "NUMBER '13.0'", "BIGINT '9'"))
+                .isEqualTo(number("4"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-13.0'", "BIGINT '9'"))
+                .isEqualTo(number("-4"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '13.0'", "BIGINT '-9'"))
+                .isEqualTo(number("4"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-13.0'", "BIGINT '-9'"))
+                .isEqualTo(number("-4"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '18.00'", "BIGINT '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9.0'", "BIGINT '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9.0'", "BIGINT '3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '9.0'", "BIGINT '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '-9.0'", "BIGINT '-3'"))
+                .isEqualTo(number("0"));
+
+        assertThat(assertions.operator(MODULUS, "NUMBER '5.128'", "BIGINT '2'"))
+                .isEqualTo(number("1.128"));
+    }
+
+    @Test
+    void testMultiplyNumberDecimal()
+    {
+        // TODO All These fail because currently there is no coercion between DECIMAL and NUMBER
+
+        // number decimal
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "NUMBER '12345678901234567'", "DECIMAL '12345678901234567'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (number, decimal(17,0)) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "NUMBER '-12345678901234567'", "DECIMAL '12345678901234567'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (number, decimal(17,0)) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "NUMBER '-12345678901234567'", "DECIMAL '-12345678901234567'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (number, decimal(17,0)) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "NUMBER '.1234567890'", "DECIMAL '3'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (number, decimal(1,0)) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "NUMBER '.1234567890'", "DECIMAL '0'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (number, decimal(1,0)) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "NUMBER '-.1234567890'", "DECIMAL '0'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (number, decimal(1,0)) for function $operator$multiply");
+
+        // decimal number
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567'", "NUMBER '12345678901234567'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (decimal(17,0), number) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567'", "NUMBER '-12345678901234567'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (decimal(17,0), number) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '-12345678901234567'", "NUMBER '-12345678901234567'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (decimal(17,0), number) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '3'", "NUMBER '.1234567890'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (decimal(1,0), number) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '3'", "NUMBER '.0000000000'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (decimal(1,0), number) for function $operator$multiply");
+
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '-3'", "NUMBER '.0000000000'")::evaluate)
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessageContaining("Unexpected parameters (decimal(1,0), number) for function $operator$multiply");
+    }
+
+    @Test
+    void testIdentical()
+    {
+        assertThat(assertions.operator(IDENTICAL, "CAST(NULL AS number)", "CAST(NULL AS number)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '37'", "NUMBER '37'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "37", "38"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NULL", "37"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "37", "NULL"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '-2'", "NUMBER '-3'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '-2'", "CAST(NULL AS number)"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '-2'", "NUMBER '-2'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "CAST(NULL AS number)", "NUMBER '-2'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '12345678901234567.89012345678901234567'", "NUMBER '12345678901234567.8902345678901234567'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '12345678901234567.89012345678901234567'", "CAST(NULL AS number)"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "CAST(NULL AS number)", "CAST(NULL AS number)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '-12345678901234567.89012345678901234567'", "NUMBER '-12345678901234567.89012345678901234567'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "CAST(NULL AS number)", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '12345678901234567.89012345678901234567'", "NUMBER '-3'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '12345678901234567.89012345678901234567'", "CAST(NULL AS number)"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "CAST(NULL AS number)", "CAST(NULL AS number)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '00000000000000007.80000000000000000000'", "NUMBER '7.8'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "CAST(NULL AS number)", "NUMBER '7.8'"))
+                .isEqualTo(false);
+
+        // with unknown
+        assertThat(assertions.operator(IDENTICAL, "NULL", "NUMBER '-2'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '-2'", "NULL"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NULL", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER '12345678901234567.89012345678901234567'", "NULL"))
+                .isEqualTo(false);
+
+        // delegation from other operator (exercises block-position convention implementation)
+        assertThat(assertions.operator(IDENTICAL, "ARRAY [1.23, 4.56]", "ARRAY [1.23, 4.56]"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "ARRAY [1.23, NULL]", "ARRAY [1.23, 4.56]"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "ARRAY [1.23, NULL]", "ARRAY [NULL, 4.56]"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "ARRAY [1234567890.123456789, 9876543210.987654321]", "ARRAY [1234567890.123456789, 9876543210.987654321]"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "ARRAY [1234567890.123456789, NULL]", "ARRAY [1234567890.123456789, 9876543210.987654321]"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "ARRAY [1234567890.123456789, NULL]", "ARRAY [NULL, 9876543210.987654321]"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    void testNullIf()
+    {
+        assertThat(assertions.function("nullif", "NUMBER '-2'", "NUMBER '-3'"))
+                .isEqualTo(number("-2"));
+
+        assertThat(assertions.function("nullif", "NUMBER '-2'", "CAST(NULL AS number)"))
+                .isEqualTo(number("-2"));
+
+        assertThat(assertions.function("nullif", "NUMBER '-2'", "NUMBER '-2'"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "CAST(NULL AS number)", "NUMBER '-2'"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "CAST(NULL AS number)", "CAST(NULL AS number)"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "NUMBER '12345678901234567.8902345678901234567'"))
+                .isEqualTo(number("12345678901234567.89012345678901234567"));
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "CAST(NULL AS number)"))
+                .isEqualTo(number("12345678901234567.89012345678901234567"));
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "CAST(NULL AS number)", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "CAST(NULL AS number)", "CAST(NULL AS number)"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "NUMBER '-3'"))
+                .isEqualTo(number("12345678901234567.89012345678901234567"));
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "CAST(NULL AS number)"))
+                .isEqualTo(number("12345678901234567.89012345678901234567"));
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("nullif", "CAST(NULL AS number)", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isNull(NUMBER);
+
+        // with unknown
+        assertThat(assertions.function("nullif", "NULL", "NULL"))
+                .isNull(UnknownType.UNKNOWN);
+
+        assertThat(assertions.function("nullif", "NULL", "NUMBER '-2'"))
+                .isNull(UnknownType.UNKNOWN);
+
+        assertThat(assertions.function("nullif", "NUMBER '-2'", "NULL"))
+                .isEqualTo(number("-2"));
+
+        assertThat(assertions.function("nullif", "NULL", "NUMBER '12345678901234567.89012345678901234567'"))
+                .isNull(UnknownType.UNKNOWN);
+
+        assertThat(assertions.function("nullif", "NUMBER '12345678901234567.89012345678901234567'", "NULL"))
+                .isEqualTo(number("12345678901234567.89012345678901234567"));
+    }
+
+    @Test
+    void testCoalesce()
+    {
+        assertThat(assertions.function("coalesce", "NUMBER '2.1'", "null", "CAST(NULL AS number)"))
+                .isEqualTo(number("2.1"));
+
+        assertThat(assertions.function("coalesce", "CAST(NULL AS number)", "null", "CAST(NULL AS number)"))
+                .isNull(NUMBER);
+
+        assertThat(assertions.function("coalesce", "NUMBER '3'", "NUMBER '2.1'", "null", "CAST(NULL AS number)"))
+                .isEqualTo(number("3"));
+
+        assertThat(assertions.function("coalesce", "CAST(NULL AS number)", "null", "CAST(NULL AS number)"))
+                .isNull(NUMBER);
+    }
+
+    @Test
+    void testIndeterminate()
+    {
+        assertThat(assertions.operator(INDETERMINATE, "CAST(NULL AS number)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(INDETERMINATE, "NUMBER '.999'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(INDETERMINATE, "NUMBER '18'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(INDETERMINATE, "NUMBER '9.0'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.operator(INDETERMINATE, "NUMBER '12345678901234567.89012345678901234567'"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    void testCastToVarchar()
+    {
+        assertThat(assertions.expression("cast(a as varchar)")
+                .binding("a", "NUMBER '0'"))
+                .hasType(VARCHAR)
+                .isEqualTo("0");
+
+        assertThat(assertions.expression("cast(a as varchar)")
+                .binding("a", "NUMBER '12345.6789'"))
+                .hasType(VARCHAR)
+                .isEqualTo("12345.6789");
+
+        assertThat(assertions.expression("cast(a as varchar)")
+                .binding("a", "NUMBER '-12345.6789'"))
+                .hasType(VARCHAR)
+                .isEqualTo("-12345.6789");
+
+        assertThat(assertions.expression("cast(a as varchar)")
+                .binding("a", "NUMBER '3.141592653589793238462643383279502884197169399375105820974944592307'"))
+                .hasType(VARCHAR)
+                .isEqualTo("3.141592653589793238462643383279502884197169399375105820974944592307");
+
+        assertThat(assertions.expression("cast(a as varchar)")
+                .binding("a", "NUMBER '123456789e-4'"))
+                .hasType(VARCHAR)
+                .isEqualTo("12345.6789");
+
+        assertThat(assertions.expression("cast(a as varchar)")
+                .binding("a", "NUMBER '123456789e+4'"))
+                .hasType(VARCHAR)
+                .isEqualTo("1.23456789E+12");
+
+        assertThat(assertions.expression("cast(a as varchar(4))")
+                .binding("a", "NUMBER '1234'"))
+                .hasType(createVarcharType(4))
+                .isEqualTo("1234");
+
+        assertTrinoExceptionThrownBy(assertions.expression("cast(a as varchar(3))")
+                .binding("a", "NUMBER '1234'")::evaluate)
+                .hasMessage("Value 1234 cannot be represented as varchar(3)");
+
+        assertTrinoExceptionThrownBy(assertions.expression("cast(a as varchar(3))")
+                .binding("a", "NUMBER '1e9'")::evaluate)
+                .hasMessage("Value 1E+9 cannot be represented as varchar(3)");
+    }
+
+    private enum TestedArithmeticOperator
+    {
+        ADD("+", BigDecimal::add),
+        SUBTRACT("-", BigDecimal::subtract),
+        MULTIPLY("*", BigDecimal::multiply),
+        DIVIDE("/", (a, b) -> a.divide(b, max(6, a.stripTrailingZeros().scale() + b.stripTrailingZeros().precision() + 1), HALF_UP)),
+        MODULUS("%", BigDecimal::remainder),
+        /**/;
+
+        private final String operator;
+        private final BiFunction<BigDecimal, BigDecimal, BigDecimal> bigDecimalReferenceImplementation;
+
+        TestedArithmeticOperator(String operator, BiFunction<BigDecimal, BigDecimal, BigDecimal> bigDecimalReferenceImplementation)
+        {
+            this.operator = operator;
+            this.bigDecimalReferenceImplementation = bigDecimalReferenceImplementation;
+        }
+    }
+
+    private enum TestedComparisonOperator
+    {
+        EQUAL("=", (a, b) -> a.compareTo(b) == 0),
+        NOT_EQUAL("!=", (a, b) -> a.compareTo(b) != 0),
+        LESS_THAN("<", (a, b) -> a.compareTo(b) < 0),
+        LESS_THAN_OR_EQUAL("<=", (a, b) -> a.compareTo(b) <= 0),
+        GREATER_THAN(">", (a, b) -> a.compareTo(b) > 0),
+        GREATER_THAN_OR_EQUAL(">=", (a, b) -> a.compareTo(b) >= 0),
+        /**/;
+
+        private final String operator;
+        private final BiPredicate<BigDecimal, BigDecimal> bigDecimalReferenceImplementation;
+
+        TestedComparisonOperator(String operator, BiPredicate<BigDecimal, BigDecimal> bigDecimalReferenceImplementation)
+        {
+            this.operator = operator;
+            this.bigDecimalReferenceImplementation = bigDecimalReferenceImplementation;
+        }
+    }
+
+    private static SqlNumber number(String value)
+    {
+        return new SqlNumber(value);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.trino.spi.type.SqlNumber;
 import io.trino.spi.type.Type;
 import io.trino.sql.query.QueryAssertions;
 import org.junit.jupiter.api.AfterAll;
@@ -479,6 +480,22 @@ public class TestSmallintOperators
         assertThat(assertions.expression("cast(a as real)")
                 .binding("a", "SMALLINT '0'"))
                 .isEqualTo(0.0f);
+    }
+
+    @Test
+    public void testCastToNumber()
+    {
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "SMALLINT '37'"))
+                .isEqualTo(new SqlNumber("37"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "SMALLINT '-10017'"))
+                .isEqualTo(new SqlNumber("-10017"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "SMALLINT '0'"))
+                .isEqualTo(new SqlNumber("0"));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.trino.spi.type.SqlNumber;
 import io.trino.sql.query.QueryAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -476,6 +477,22 @@ public class TestTinyintOperators
         assertThat(assertions.expression("cast(a as real)")
                 .binding("a", "TINYINT '0'"))
                 .isEqualTo(0.0f);
+    }
+
+    @Test
+    public void testCastToNumber()
+    {
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "TINYINT '37'"))
+                .isEqualTo(new SqlNumber("37"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "TINYINT '-117'"))
+                .isEqualTo(new SqlNumber("-117"));
+
+        assertThat(assertions.expression("CAST(a AS number)")
+                .binding("a", "TINYINT '0'"))
+                .isEqualTo(new SqlNumber("0"));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestVarcharOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestVarcharOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.trino.spi.type.SqlNumber;
 import io.trino.sql.query.QueryAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,6 +29,7 @@ import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -138,6 +140,14 @@ public class TestVarcharOperators
         assertThat(assertions.expression("CAST(VARCHAR ' 21 ' AS TINYINT)"))
                 .hasType(TINYINT)
                 .isEqualTo((byte) 21);
+
+        assertThat(assertions.expression("CAST(VARCHAR '13.37' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber("13.37"));
+
+        assertThat(assertions.expression("CAST(VARCHAR ' 13.37 ' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber("13.37"));
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.VariableWidthBlock;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import io.trino.spi.function.ScalarOperator;
+
+import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.XX_HASH_64;
+import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
+import static java.lang.invoke.MethodHandles.lookup;
+
+/**
+ * A high precision decimal type. The precise limits and rounding behavior are considered an
+ * implementation detail and may evolve over time together with the unstable binary format.
+ * <p>
+ * Stack representation of this type is {@link TrinoNumber} which wraps a slice with the format documented below.
+ * <b>Note:</b> the binary format is not stable and may change between releases. Only the Java API is considered stable.
+ * <p>
+ * <h2>Current unstable binary format</h2>
+ * <pre>
+ *    ┌───────────────────────┬─────────────────────────┐
+ *    │  header (16-bit, LE)  │ unsigned magnitude (BE) │
+ *    └───────────────────────┴─────────────────────────┘
+ *     └─────────────────────┘
+ *             2 bytes                0+ bytes
+ * </pre>
+ * <dl>
+ *     <dt>header</dt>
+ *     <dd>A 16 bit number stored in little-endian byte order.
+ *         The most significant bit indicates whether the number is negative (1) or non-negative (0).
+ *         The remaining 15 bits store the scale + {@value TrinoNumber#SCALE_BASE} as an unsigned integer.
+ *      </dd>
+ *     <dt>unsigned magnitude</dt>
+ *     <dd>A big-endian minimal representation of the absolute value of the unscaled integer containing digits of the value.
+ *         The representation is minimal, i.e. it does not have leading zero bytes.
+ *         This guarantees that two numerically equal values have the same binary representation.
+ *     </dd>
+ * </dl>
+ * <p>
+ * A value stored like this represents the following number:
+ * <pre>
+ *     (-1)^sign * magnitude * 10^(-scale)
+ * </pre>
+ */
+public class NumberType
+        extends AbstractVariableWidthType
+{
+    public static final String NAME = "number";
+    public static final NumberType NUMBER = new NumberType();
+
+    // Precision loss prevents creation of values that would occupy very large amount of memory.
+    // Max precision is implementation detail and subject to change.
+    static final int MAX_DECIMAL_PRECISION = 200;
+
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(NumberType.class, lookup(), TrinoNumber.class);
+
+    private NumberType()
+    {
+        super(new TypeSignature(NAME), TrinoNumber.class);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return true;
+    }
+
+    @Override
+    public TypeOperatorDeclaration getTypeOperatorDeclaration(TypeOperators typeOperators)
+    {
+        return TYPE_OPERATOR_DECLARATION;
+    }
+
+    @Override
+    public Object getObjectValue(Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        return new SqlNumber(((TrinoNumber) getObject(block, position)).toBigDecimal());
+    }
+
+    @Override
+    public Object getObject(Block block, int position)
+    {
+        VariableWidthBlock valueBlock = (VariableWidthBlock) block.getUnderlyingValueBlock();
+        int valuePosition = block.getUnderlyingValuePosition(position);
+        Slice slice = valueBlock.getSlice(valuePosition);
+        return new TrinoNumber(slice);
+    }
+
+    @Override
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        TrinoNumber decimal = (TrinoNumber) value;
+        ((VariableWidthBlockBuilder) blockBuilder).writeEntry(decimal.bytes());
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return other == NUMBER;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().hashCode();
+    }
+
+    @ScalarOperator(EQUAL)
+    private static boolean equalOperator(TrinoNumber left, TrinoNumber right)
+    {
+        return left.bytes().equals(right.bytes());
+    }
+
+    // TODO EQUAL with block, position, block, position
+    // TODO EQUAL with flat slice, block position
+
+    @ScalarOperator(XX_HASH_64)
+    private static long xxHash64Operator(TrinoNumber value)
+    {
+        Slice slice = value.bytes();
+        return XxHash64.hash(slice);
+    }
+
+    // TODO XX_HASH_64 with block, position
+    // TODO XX_HASH_64 with flat slice
+
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
+    private static long comparisonOperator(TrinoNumber left, TrinoNumber right)
+    {
+        // TODO NaN
+        return left.toBigDecimal().compareTo(right.toBigDecimal());
+    }
+
+    // TODO COMPARISON_UNORDERED_LAST with block, position, block, position
+
+    @ScalarOperator(LESS_THAN)
+    private static boolean lessThanOperator(TrinoNumber left, TrinoNumber right)
+    {
+        return left.toBigDecimal().compareTo(right.toBigDecimal()) < 0;
+    }
+
+    // TODO LESS_THAN_OR_EQUAL with object, object ?
+    // TODO LESS_THAN_OR_EQUAL with block, position, block, position ?
+
+    // TODO LESS_THAN with block, position, block, position
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlNumber.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlNumber.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import java.math.BigDecimal;
+import java.util.Base64;
+import java.util.Objects;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public final class SqlNumber
+{
+    private final String stringified;
+    private final String base64Encoded;
+
+    public SqlNumber(BigDecimal value)
+    {
+        this(value.toString());
+    }
+
+    public SqlNumber(String value)
+    {
+        stringified = value;
+        base64Encoded = Base64.getEncoder().encodeToString(stringified.getBytes(UTF_8));
+    }
+
+    public String stringified()
+    {
+        return stringified;
+    }
+
+    public String base64Encoded()
+    {
+        return base64Encoded;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof SqlNumber that)) {
+            return false;
+        }
+        return Objects.equals(stringified, that.stringified);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(stringified);
+    }
+
+    @Override
+    public String toString()
+    {
+        return stringified;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/type/StandardTypes.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/StandardTypes.java
@@ -23,6 +23,7 @@ public final class StandardTypes
     public static final String BOOLEAN = BooleanType.NAME;
     public static final String DATE = DateType.NAME;
     public static final String DECIMAL = DecimalType.NAME;
+    public static final String NUMBER = NumberType.NAME;
     public static final String REAL = RealType.NAME;
     public static final String DOUBLE = DoubleType.NAME;
     public static final String HYPER_LOG_LOG = HyperLogLogType.NAME;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TrinoNumber.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TrinoNumber.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HexFormat;
+
+import static io.trino.spi.type.DecimalType.checkArgument;
+import static java.math.RoundingMode.HALF_UP;
+
+/**
+ * Stack representation for {@link NumberType}. See there for binary format specification.
+ */
+public class TrinoNumber
+{
+    static final int SCALE_BASE = 1 << 14;
+    private static final int MIN_SCALE = -SCALE_BASE;
+    private static final int MAX_SCALE = (SCALE_BASE - 1);
+
+    private static short header(boolean negated, int scale)
+    {
+        checkArgument(MIN_SCALE <= scale && scale <= MAX_SCALE, "Scale out of range: %s", scale);
+        short header = (short) ((scale + SCALE_BASE) & 0x7fff);
+        if (negated) {
+            header = (short) (header | 0x8000);
+        }
+        return header;
+    }
+
+    private static short scaleFromHeader(short header)
+    {
+        return (short) ((header & 0x7fff) - SCALE_BASE);
+    }
+
+    private static boolean negatedFromHeader(short header)
+    {
+        return (header & 0x8000) != 0;
+    }
+
+    private final Slice bytes;
+
+    public TrinoNumber(Slice bytes)
+    {
+        switch (bytes.length()) {
+            case 0, 1 -> throw new IllegalArgumentException("Invalid bytes length for TrinoNumber: " + bytes.length());
+            case 2 -> {
+                // zero
+                // TODO support ±infinity and NaN
+                short header = bytes.getShort(0);
+                checkArgument(!negatedFromHeader(header) && scaleFromHeader(header) == 0, "Invalid header for TrinoNumber with unscaled zero value: %s", header);
+            }
+            default -> {
+                if (bytes.getByte(2) == 0) {
+                    throw new IllegalArgumentException("TrinoNumber has leading zero byte in unscaled value: " +
+                            HexFormat.of().withDelimiter(" ").formatHex(bytes.byteArray(), bytes.byteArrayOffset(), bytes.length()));
+                }
+            }
+        }
+        this.bytes = bytes;
+    }
+
+    public BigDecimal toBigDecimal()
+    {
+        // little-endian
+        short header = bytes.getShort(0);
+        int unscaledBytesLength = bytes.length() - 2;
+
+        boolean negated = negatedFromHeader(header);
+        int scale = scaleFromHeader(header);
+        int signum = unscaledBytesLength == 0 ? 0 : (negated ? -1 : 1);
+        // big-endian
+        BigInteger unscaled = new BigInteger(signum, bytes.byteArray(), bytes.byteArrayOffset() + 2, unscaledBytesLength);
+        return new BigDecimal(unscaled, scale);
+    }
+
+    public static TrinoNumber from(BigDecimal bigDecimal)
+    {
+        return from(bigDecimal, NumberType.MAX_DECIMAL_PRECISION);
+    }
+
+    // visible for testing
+    static TrinoNumber from(BigDecimal bigDecimal, int maxDecimalPrecision)
+    {
+        BigDecimal normalized = bigDecimal.stripTrailingZeros();
+        if (normalized.precision() > maxDecimalPrecision) {
+            normalized = normalized.setScale(
+                    normalized.scale() - (normalized.precision() - maxDecimalPrecision),
+                    HALF_UP);
+        }
+        BigInteger unscaledValue = normalized.unscaledValue();
+        Slice slice;
+        boolean negated = unscaledValue.signum() < 0;
+        if (negated) {
+            unscaledValue = unscaledValue.negate();
+        }
+        byte[] unscaledBytes = unscaledValue.toByteArray();
+        int unscaledBytesOffset = 0;
+        int unscaledBytesLength = unscaledBytes.length;
+        if (unscaledBytes[0] == 0) {
+            // BigInteger.toByteArray outputs 2-complement big-endian bytes, so even though the value is known to be positive,
+            // there still needs to be one bit reserved for the sign, which sometimes results in a leading zero byte.
+            unscaledBytesOffset++;
+            unscaledBytesLength--;
+        }
+        slice = Slices.allocate(2 + unscaledBytesLength);
+        slice.setShort(0, header(negated, normalized.scale()));
+        slice.setBytes(2, unscaledBytes, unscaledBytesOffset, unscaledBytesLength);
+        return new TrinoNumber(slice);
+    }
+
+    Slice bytes()
+    {
+        return bytes;
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTrinoNumber.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTrinoNumber.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static java.math.RoundingMode.UNNECESSARY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+class TestTrinoNumber
+{
+    private static final int TEST_MAX_DECIMAL_PRECISION = 30;
+
+    @Test
+    void testBigDecimalRoundTrip()
+    {
+        assertRoundTrip(BigDecimal.ZERO);
+        assertRoundTrip(BigDecimal.ONE);
+        assertRoundTrip(BigDecimal.TWO);
+        assertRoundTrip(BigDecimal.TEN, new BigDecimal("1e1"));
+
+        assertRoundTrip(new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("0.000"), new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("0").setScale(3, UNNECESSARY), new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("0").setScale(-3, UNNECESSARY), new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("0.00001"));
+        assertRoundTrip(new BigDecimal("1"));
+        assertRoundTrip(new BigDecimal("10"), new BigDecimal("1e1"));
+        assertRoundTrip(new BigDecimal("127"));
+        assertRoundTrip(new BigDecimal("128"));
+        assertRoundTrip(new BigDecimal("255"));
+        assertRoundTrip(new BigDecimal("256"));
+        assertRoundTrip(new BigDecimal("1000"), new BigDecimal("1e3"));
+        assertRoundTrip(new BigDecimal("1000.000"), new BigDecimal("1e3"));
+        assertRoundTrip(new BigDecimal("1000.0001"));
+
+        assertRoundTrip(new BigDecimal("-0"));
+        assertRoundTrip(new BigDecimal("-0.000"), new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("0").setScale(3, UNNECESSARY).negate(), new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("0").setScale(-3, UNNECESSARY).negate(), new BigDecimal("0"));
+        assertRoundTrip(new BigDecimal("-0.00001"));
+        assertRoundTrip(new BigDecimal("-1"));
+        assertRoundTrip(new BigDecimal("-10"), new BigDecimal("-1e1"));
+        assertRoundTrip(new BigDecimal("-127"));
+        assertRoundTrip(new BigDecimal("-128"));
+        assertRoundTrip(new BigDecimal("-255"));
+        assertRoundTrip(new BigDecimal("-256"));
+        assertRoundTrip(new BigDecimal("-1000"), new BigDecimal("-1e3"));
+        assertRoundTrip(new BigDecimal("-1000.000"), new BigDecimal("-1e3"));
+        assertRoundTrip(new BigDecimal("-1000.0001"));
+
+        assertRoundTrip(new BigDecimal("20050910133100123"));
+        assertRoundTrip(new BigDecimal("20050910133100123.000000"), new BigDecimal("20050910133100123"));
+        assertRoundTrip(new BigDecimal("20050910.133100123"));
+        assertRoundTrip(new BigDecimal("20050910.133100123000000"), new BigDecimal("20050910.133100123"));
+
+        assertRoundTrip(new BigDecimal("3.1415926535897932384626433832"));
+        assertRoundTrip(new BigDecimal("0.0000000000000000000000000000000000000000000314159265358979323846264338328"));
+
+        // exceeding [test] max precision
+        assertRoundTrip(
+                new BigDecimal("3.141592653589793238462643383279502884197169399375105820974944592307"),
+                new BigDecimal("3.14159265358979323846264338328"));
+        assertRoundTrip(
+                new BigDecimal("0.00000000000000000000000000000000000000000003141592653589793238462643383279502884197169399375105820974944592307"),
+                new BigDecimal("0.0000000000000000000000000000000000000000000314159265358979323846264338328"));
+        assertRoundTrip(
+                new BigDecimal("444555666777888999555666777888999555666777888999555666777888999"),
+                new BigDecimal("444555666777888999555666777889000000000000000000000000000000000").stripTrailingZeros());
+        assertRoundTrip(
+                new BigDecimal("444555666777888999555666.777888999555666777888999555666777888999"),
+                new BigDecimal("444555666777888999555666.777889000000000000000000000000000000000").stripTrailingZeros());
+        assertRoundTrip(
+                new BigDecimal("444555666777888999555666777888.999555666777888999555666777888999"),
+                new BigDecimal("444555666777888999555666777889"));
+        assertRoundTrip(
+                new BigDecimal("4445556667778889995556667778889995556667.77888999555666777888999"),
+                new BigDecimal("4445556667778889995556667778890000000000").stripTrailingZeros());
+    }
+
+    private void assertRoundTrip(BigDecimal jdkBigDecimal)
+    {
+        assertRoundTrip(jdkBigDecimal, jdkBigDecimal);
+    }
+
+    private void assertRoundTrip(BigDecimal inputJdkBigDecimal, BigDecimal resultingJdkBigDecimal)
+    {
+        if (inputJdkBigDecimal.stripTrailingZeros().precision() <= TEST_MAX_DECIMAL_PRECISION) {
+            assertThat(resultingJdkBigDecimal)
+                    .isEqualByComparingTo(inputJdkBigDecimal);
+        }
+        else {
+            assertThat(resultingJdkBigDecimal)
+                    .isCloseTo(inputJdkBigDecimal, withPercentage(0.000000000000000000000000001));
+        }
+        TrinoNumber converted = TrinoNumber.from(inputJdkBigDecimal, TEST_MAX_DECIMAL_PRECISION);
+        assertThat(converted.toBigDecimal()).isEqualTo(resultingJdkBigDecimal);
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/H2QueryRunner.java
@@ -70,6 +70,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -283,6 +284,15 @@ public class H2QueryRunner
                         row.add(decimalValue
                                 .setScale(decimalType.getScale(), HALF_UP)
                                 .round(new MathContext(decimalType.getPrecision())));
+                    }
+                }
+                else if (NUMBER == type) {
+                    BigDecimal value = resultSet.getBigDecimal(i);
+                    if (resultSet.wasNull()) {
+                        row.add(null);
+                    }
+                    else {
+                        row.add(value.stripTrailingZeros());
                     }
                 }
                 else if (JSON.equals(type)) {

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
@@ -64,6 +64,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -256,6 +257,10 @@ public class TestingTrinoClient
         }
         if (type instanceof DecimalType) {
             return new BigDecimal((String) value);
+        }
+        if (type == NUMBER) {
+            //noinspection RedundantCast
+            return (BigDecimal) value;
         }
         if (type == UUID) {
             return java.util.UUID.fromString((String) value);


### PR DESCRIPTION
This adds a new Trino called `number`. It's non-parametric type
similar to `decimal`, but supporting much higher precision and dynamic
scales.

Stack representation is variable-width and Slice-based, with content
structure  documented (see `NumberType` class doc). The exact
representation is not part of SPI. SPI implementers are required to use
Java APIs to read and write values of the new type. The current
implementation and format is likely not the most optimal one and may
change in the future.

Operations on the new type are currently implemented by delegating to
JDK's `BigDecimal`. This simplifies implementation so that we can
initially focus on the semantics. The operators will later be
reimplemented to reduce allocations.

- for https://github.com/trinodb/trino/issues/2274 

## Release notes

not for release notes yet