### PR TITLE
Run CI with Java 25.0.2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: "Verify checked out commits and setup Java"
 inputs:
   java-version:
     description: "Java version to setup"
-    default: 25.0.1
+    default: 25.0.2
   cache:
     description: "Cache Maven repo (true/false/restore)"
     default: restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: 25.0.1, cache: 'true', cleanup-node: true }
+          - { java-version: 25.0.2, cache: 'true', cleanup-node: true }
           - { java-version: 26-ea, cache: 'restore', cleanup-node: true }
     timeout-minutes: 45
     steps:
@@ -208,7 +208,7 @@ jobs:
         with:
           cache: restore
           cleanup-node: true # fix "No space left on device" error
-          java-version: 25.0.1
+          java-version: 25.0.2
       - name: Maven Install
         run: |
           # build everything to make sure dependencies of impacted modules are present
@@ -548,7 +548,7 @@ jobs:
         with:
           cache: restore
           cleanup-node: ${{ format('{0}', matrix.modules == 'plugin/trino-singlestore' || matrix.modules == 'plugin/trino-exasol' || matrix.modules == 'plugin/trino-oracle' || matrix.modules == 'plugin/trino-iceberg') }}
-          java-version: ${{ matrix.jdk != '' && matrix.jdk || '25.0.1' }}
+          java-version: ${{ matrix.jdk != '' && matrix.jdk || '25.0.2' }}
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"


### PR DESCRIPTION
Update JDK used for CI from 25.0.1 to 25.0.2.

We already use 25.0.2 in the release docker images, since commit bc85193a5df4ea6f0a46c85d7f52644e4514f70e (https://github.com/trinodb/trino/pull/28000)

`air.java.version` is kept at 25.0.1 for now. 
