### PR TITLE
Clean up BigQuery datasets regardless of labels

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.plugin.bigquery;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
-import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
@@ -47,13 +46,11 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents;
-import static com.google.cloud.bigquery.BigQuery.DatasetListOption.labelFilter;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class BigQueryQueryRunner
@@ -176,18 +173,6 @@ public final class BigQueryQueryRunner
         public void dropDatasetIfExists(String dataset)
         {
             bigQuery.delete(dataset, deleteContents());
-        }
-
-        public List<String> getSelfCreatedDatasets()
-        {
-            ImmutableList.Builder<String> datasetNames = ImmutableList.builder();
-            for (Dataset dataset : bigQuery.listDatasets(
-                    labelFilter(format("labels.%s:%s",
-                            BIG_QUERY_SQL_EXECUTOR_LABEL.getKey(),
-                            BIG_QUERY_SQL_EXECUTOR_LABEL.getValue()))).iterateAll()) {
-                datasetNames.add(dataset.getDatasetId().getDataset());
-            }
-            return datasetNames.build();
         }
 
         public List<String> getTableNames(String dataset)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryInstanceCleaner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryInstanceCleaner.java
@@ -69,14 +69,12 @@ public class TestBigQueryInstanceCleaner
     public void cleanUpDatasets()
     {
         LOG.info("Identifying datasets to drop...");
-        // Drop all datasets with our label created more than 24 hours ago
-        List<String> selfCreatedDatasets = bigQuerySqlExecutor.getSelfCreatedDatasets();
-        TableResult result = bigQuerySqlExecutor.executeQuery(format("" +
+        // Drop all datasets except 'tpch' and 'test' schemas
+        TableResult result = bigQuerySqlExecutor.executeQuery(
                         "SELECT schema_name " +
                         "FROM INFORMATION_SCHEMA.SCHEMATA " +
                         "WHERE datetime_diff(current_datetime(), datetime(creation_time), HOUR) > 24 " +
-                        "AND schema_name IN (%s)",
-                selfCreatedDatasets.stream().collect(joining("','", "'", "'"))));
+                        "AND schema_name NOT IN ('tpch', 'test')");
         List<String> datasetsToDrop = Streams.stream(result.getValues())
                 .map(fieldValues -> fieldValues.get("schema_name").getStringValue())
                 .collect(toImmutableList());


### PR DESCRIPTION
## Description

There are numerous leftover datasets in BigQuery caused by missing labels.
I propose updating TestBigQueryInstanceCleaner to drop tables regardless of their labels.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
