### PR TITLE
Document running tests from IntelliJ after vector API became required

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ here is `--add-modules jdk.incubator.vector` but various `*QueryRunner` classes
 might require additional options (if necessary, check the `air.test.jvm.additional-arguments` 
 property in the `pom.xml` file of the module from which the runner comes).
 
+### Running tests from the IDE
+
+When running individual test classes directly from IntelliJ, you need to
+configure the JUnit run configuration template. Go to Run/Debug Configurations >
+Edit Configuration Templates > JUnit > VM options and set the value to
+`-ea --add-modules=jdk.incubator.vector`.
+
 ### Running the full server
 
 Trino comes with sample configuration that should work out-of-the-box for


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Since trinodb/trino@bc028fde4424d33d1e99dd7d9d39af0f9962e8fc the vector API usage is no longer
optional. Maven handles the required JVM flags via surefire args but IntelliJ
does not consume these automatically.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
