### PR TITLE
Send NUMBER as varchar to old clients 

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
@@ -29,6 +29,11 @@ public enum ClientCapabilities
     PARAMETRIC_DATETIME,
 
     /**
+     * Whether client supports the `NUMBER` type. When this capability is not set, the server returns `varchar` for `NUMBER` columns.
+     */
+    NUMBER,
+
+    /**
      * Whether clients support the session authorization set/reset feature
      */
     SESSION_AUTHORIZATION;

--- a/client/trino-client/src/main/java/io/trino/client/JsonDecodingUtils.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonDecodingUtils.java
@@ -66,7 +66,6 @@ import static io.trino.client.ClientStandardTypes.UUID;
 import static io.trino.client.ClientStandardTypes.VARBINARY;
 import static io.trino.client.ClientStandardTypes.VARCHAR;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
@@ -273,10 +272,7 @@ public final class JsonDecodingUtils
         public Object decode(JsonParser parser)
                 throws IOException
         {
-            // TODO maybe we could send numbers without base64. This probably requires client capabilities.
-            // Old clients apply base64 decoding to any type they don't recognize.
-            // TODO If Base64 stays, `parser.getBinaryValue(Base64Variants.MIME)` might be a better way to parse it.
-            return new BigDecimal(new String(Base64.getDecoder().decode(parser.getValueAsString()), UTF_8));
+            return new BigDecimal(parser.getValueAsString());
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
@@ -49,7 +49,6 @@ import io.trino.type.SqlIntervalYearMonth;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Base64;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -65,7 +64,6 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public final class JsonEncodingUtils
@@ -439,9 +437,9 @@ public final class JsonEncodingUtils
                 case BigDecimal bigDecimalValue -> generator.writeNumber(bigDecimalValue);
                 case SqlDate dateValue -> generator.writeString(dateValue.toString());
                 case SqlDecimal decimalValue -> generator.writeString(decimalValue.toString());
-                // Trino client protocol backward compatibility requires that any new types are base64-encoded strings.
-                // JsonDecodingUtils uses "base64 decoder" for any type it doesn't recognize.
-                case SqlNumber number -> generator.writeString(Base64.getEncoder().encodeToString(number.toString().getBytes(UTF_8)));
+                // When client does not have NUMBER capability, NUMBER values are sent as varchar (strings).
+                // When it has the capability, they are also sent as strings.
+                case SqlNumber number -> generator.writeString(number.toString());
                 case SqlIntervalDayTime intervalValue -> generator.writeString(intervalValue.toString());
                 case SqlIntervalYearMonth intervalValue -> generator.writeString(intervalValue.toString());
                 case SqlTime timeValue -> generator.writeString(timeValue.toString());

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -130,6 +130,7 @@ class Query
     @GuardedBy("this")
     private PageDeserializer deserializer;
     private final boolean supportsParametricDateTime;
+    private final boolean supportsNumberType;
 
     @GuardedBy("this")
     private OptionalLong nextToken = OptionalLong.of(0);
@@ -257,6 +258,7 @@ class Query
         this.resultsProcessorExecutor = resultsProcessorExecutor;
         this.timeoutExecutor = timeoutExecutor;
         this.supportsParametricDateTime = session.getClientCapabilities().contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
+        this.supportsNumberType = session.getClientCapabilities().contains(ClientCapabilities.NUMBER.toString());
         deserializer = createExchangePagesSerdeFactory(blockEncodingSerde, session)
                 .createDeserializer(session.getExchangeEncryptionKey().map(Ciphers::deserializeAesEncryptionKey));
     }
@@ -689,7 +691,7 @@ class Query
 
             ImmutableList.Builder<Column> list = ImmutableList.builder();
             for (int i = 0; i < columnNames.size(); i++) {
-                list.add(createColumn(columnNames.get(i), columnTypes.get(i), supportsParametricDateTime));
+                list.add(createColumn(columnNames.get(i), columnTypes.get(i), supportsParametricDateTime, supportsNumberType));
             }
             columns = list.build();
             types = outputInfo.getColumnTypes();

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
@@ -572,7 +572,7 @@ public class TestJsonEncodingUtils
     {
         ImmutableList.Builder<Column> columns = ImmutableList.builderWithExpectedSize(types.size());
         for (TypedColumn typedColumn : types) {
-            columns.add(createColumn(typedColumn.name(), typedColumn.type(), true));
+            columns.add(createColumn(typedColumn.name(), typedColumn.type(), true, true));
         }
         return createDecoder(columns.build());
     }


### PR DESCRIPTION
Trino protocol client implementation requires that any new type is send
back as a string with base64-encoded bytes. The client then decodes that
to bytes (`byte[]`), and CLI shows these in hex.

For the new high precision decimal type NUMBER, this behavior is not very
useful. Old CLI implementations show some hex digits of a string
representation. New CLI implementations unnecessarily process data with
base64.

Introduce a client capability to support `NUMBER` representation:

- old clients will get back data as `varchar`, with human-readable
  representation of the value.
- new clients will get back data as `number`, with string-based
  human-readable representation on the wire.
  - We cannot use JSON number for transmitting the data on the wire.
    This wouldn't work for Infinity and NaN values.
    Even before Infinity and NaN are present in the new type, using
    string-based representation is consistent with decimal on the wire
    representation.

--

- based on https://github.com/trinodb/trino/pull/28120
- relates to https://github.com/trinodb/trino/pull/28219

## Release notes

not for release notes yet