### PR TITLE
Support NUMBER type in JDBC

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ColumnInfo.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ColumnInfo.java
@@ -236,6 +236,9 @@ class ColumnInfo
 
             case ClientStandardTypes.DECIMAL:
                 return new TypeInfo(Types.DECIMAL, java.math.BigDecimal.class);
+            case ClientStandardTypes.NUMBER:
+                // NUMERIC/DECIMAL type could suggest clients to use ResultSet.getBigDecimal, but this will fail for some values. OTHER feel safer.
+                return new TypeInfo(Types.OTHER, java.lang.Number.class);
 
             case ClientStandardTypes.VARCHAR:
                 return new TypeInfo(Types.VARCHAR, String.class);

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
@@ -238,6 +238,133 @@ public abstract class BaseTestJdbcResultSet
     }
 
     @Test
+    public void testNumber()
+            throws Exception
+    {
+        try (ConnectedStatement connectedStatement = newStatement()) {
+            checkRepresentation(connectedStatement.getStatement(), "CAST(NULL AS number)", Types.OTHER, (rs, column) -> {
+                assertThat(rs.getObject(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getByte(column)).isEqualTo((byte) 0);
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getShort(column)).isEqualTo((short) 0);
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getInt(column)).isEqualTo(0);
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getLong(column)).isEqualTo(0);
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getBigDecimal(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getFloat(column)).isEqualTo(0);
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getDouble(column)).isEqualTo(0);
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getString(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getBytes(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '0.1'", Types.OTHER, new BigDecimal("0.1"));
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '0.100'", Types.OTHER, new BigDecimal("0.1"));
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '100'", Types.OTHER, new BigDecimal("1e2"));
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '20050910133100123'", Types.OTHER, new BigDecimal("20050910133100123"));
+
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '1'", Types.OTHER, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(new BigDecimal("1"));
+                assertThat(rs.getByte(column)).isEqualTo((byte) 1);
+                assertThat(rs.getShort(column)).isEqualTo((short) 1);
+                assertThat(rs.getInt(column)).isEqualTo(1);
+                assertThat(rs.getLong(column)).isEqualTo(1);
+                assertThat(rs.getBigDecimal(column)).isEqualTo(new BigDecimal("1"));
+                assertThat(rs.getFloat(column)).isEqualTo(1f);
+                assertThat(rs.getDouble(column)).isEqualTo(1.0);
+                assertThat(rs.getString(column)).isEqualTo("1");
+                assertThatThrownBy(() -> rs.getBytes(column)).hasMessage("Value is not a byte array: 1");
+
+                ResultSetMetaData metaData = rs.getMetaData();
+                assertThat(metaData.getColumnTypeName(column)).isEqualTo("number");
+                assertThat(metaData.getColumnDisplaySize(column)).isEqualTo(0);
+                assertThat(metaData.getColumnClassName(column)).isEqualTo("java.lang.Number");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '0.12'", Types.OTHER, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(new BigDecimal("0.12"));
+                assertThat(rs.getByte(column)).isEqualTo((byte) 0);
+                assertThat(rs.getShort(column)).isEqualTo((short) 0);
+                assertThat(rs.getInt(column)).isEqualTo(0);
+                assertThat(rs.getLong(column)).isEqualTo(0);
+                assertThat(rs.getBigDecimal(column)).isEqualTo(new BigDecimal("0.12"));
+                assertThat(rs.getFloat(column)).isEqualTo(0.12f);
+                assertThat(rs.getDouble(column)).isEqualTo(0.12);
+                assertThat(rs.getString(column)).isEqualTo("0.12");
+                assertThatThrownBy(() -> rs.getBytes(column)).hasMessage("Value is not a byte array: 0.12");
+
+                ResultSetMetaData metaData = rs.getMetaData();
+                assertThat(metaData.getColumnTypeName(column)).isEqualTo("number");
+                assertThat(metaData.getColumnDisplaySize(column)).isEqualTo(0);
+                assertThat(metaData.getColumnClassName(column)).isEqualTo("java.lang.Number");
+            });
+
+            long outsideOfDoubleExactRange = 9223372036854775774L;
+            //noinspection ConstantConditions
+            verify((long) (double) outsideOfDoubleExactRange - outsideOfDoubleExactRange != 0, "outsideOfDoubleExactRange should not be exact-representable as a double");
+            checkRepresentation(connectedStatement.getStatement(), format("NUMBER '%s'", outsideOfDoubleExactRange), Types.OTHER, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(new BigDecimal("9223372036854775774"));
+                // TODO (https://github.com/trinodb/trino/issues/28146) silent numeric truncation
+                assertThat(rs.getByte(column)).isEqualTo((byte) -34);
+                assertThat(rs.getShort(column)).isEqualTo((short) -34);
+                assertThat(rs.getInt(column)).isEqualTo(-34);
+                assertThat(rs.getLong(column)).isEqualTo(9223372036854775774L);
+                assertThat(rs.getBigDecimal(column)).isEqualTo(new BigDecimal("9223372036854775774"));
+                assertThat(rs.getFloat(column)).isEqualTo(9.223372E18f);
+                assertThat(rs.getDouble(column)).isEqualTo(9.223372036854776E18);
+                assertThat(rs.getString(column)).isEqualTo("9223372036854775774");
+                assertThatThrownBy(() -> rs.getBytes(column)).hasMessage("Value is not a byte array: 9223372036854775774");
+
+                ResultSetMetaData metaData = rs.getMetaData();
+                assertThat(metaData.getColumnTypeName(column)).isEqualTo("number");
+                assertThat(metaData.getColumnDisplaySize(column)).isEqualTo(0);
+                assertThat(metaData.getColumnClassName(column)).isEqualTo("java.lang.Number");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "NUMBER '3.141592653589793238462643383279502884197169399375105820974944592307'", Types.OTHER, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(new BigDecimal("3.141592653589793238462643383279502884197169399375105820974944592307"));
+                assertThat(rs.getByte(column)).isEqualTo((byte) 3);
+                assertThat(rs.getShort(column)).isEqualTo((short) 3);
+                assertThat(rs.getInt(column)).isEqualTo(3);
+                assertThat(rs.getLong(column)).isEqualTo(3);
+                assertThat(rs.getBigDecimal(column)).isEqualTo(new BigDecimal("3.141592653589793238462643383279502884197169399375105820974944592307"));
+                assertThat(rs.getFloat(column)).isEqualTo(3.1415927f);
+                assertThat(rs.getDouble(column)).isEqualTo(3.141592653589793);
+                assertThat(rs.getString(column)).isEqualTo("3.141592653589793238462643383279502884197169399375105820974944592307");
+                assertThatThrownBy(() -> rs.getBytes(column)).hasMessage("Value is not a byte array: 3.141592653589793238462643383279502884197169399375105820974944592307");
+
+                ResultSetMetaData metaData = rs.getMetaData();
+                assertThat(metaData.getColumnTypeName(column)).isEqualTo("number");
+                assertThat(metaData.getColumnDisplaySize(column)).isEqualTo(0);
+                assertThat(metaData.getColumnClassName(column)).isEqualTo("java.lang.Number");
+            });
+
+            // TODO support NaN and Infinity
+            assertThatThrownBy(() -> checkRepresentation(connectedStatement.getStatement(), "NUMBER 'NaN'", Types.OTHER, (rs, column) -> {
+                // TODO fill this when no longer fails
+            }))
+                    .hasMessageEndingWith("'NaN' is not a valid NUMBER literal");
+
+            assertThatThrownBy(() -> checkRepresentation(connectedStatement.getStatement(), "NUMBER '+Infinity'", Types.OTHER, (rs, column) -> {
+                // TODO fill this when no longer fails
+            }))
+                    .hasMessageEndingWith("'+Infinity' is not a valid NUMBER literal");
+
+            assertThatThrownBy(() -> checkRepresentation(connectedStatement.getStatement(), "NUMBER '-Infinity'", Types.OTHER, (rs, column) -> {
+                // TODO fill this when no longer fails
+            }))
+                    .hasMessageEndingWith("'-Infinity' is not a valid NUMBER literal");
+        }
+    }
+
+    @Test
     public void testVarbinary()
             throws Exception
     {

--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
@@ -41,6 +41,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Test(singleThreaded = true)
 public class TestJdbcResultSetCompatibilityOldServer
@@ -130,6 +131,20 @@ public class TestJdbcResultSetCompatibilityOldServer
 
             removeDockerImage(imageName);
         }
+    }
+
+    @Override
+    public void testNumber()
+            throws Exception
+    {
+        if (parseInt(getTestedTrinoVersion()) < 480) {
+            try (ConnectedStatement statementWrapper = newStatement()) {
+                assertThatThrownBy(() -> statementWrapper.getStatement().executeUpdate("SELECT NUMBER '1'"))
+                        .hasMessageMatching(".*(Unknown resolvedType: NUMBER|Unknown type: number).*");
+            }
+            return;
+        }
+        super.testNumber();
     }
 
     @Override


### PR DESCRIPTION
It's mapped to `Types.OTHER` type.  Mapping to `Types.DECIMAL` and
`Types.NUMERIC` seems more appropriate for SQL `decimal` and `numeric`
types respectively (Trino doesn't have SQL standard `numeric` yet), and
may be taken as a signal that `ResultSet.getBigDecimal` is the best way
to access the data.

Its Java class, as returned from `ResultSetMetaData.getColumnClassName`,
is `java.lang.Number`, because the `ResultSet.getObject` typically
returns `java.math.BigDecimal` but sometimes also returns/will return
`java.lang.Double` for Infinity and NaN values.


- relates to https://github.com/trinodb/trino/pull/28219

.

- for https://github.com/trinodb/trino/issues/2274

## Release notes

not for release notes yet