### PR TITLE
Make nullable ColumnMetadata fields Optional

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -256,9 +256,9 @@ public class InformationSchemaPageSource
                         column.getDefaultValue().orElse(null),
                         column.isNullable() ? "YES" : "NO",
                         column.getType().getDisplayName(),
-                        column.getComment(),
-                        column.getExtraInfo(),
-                        column.getComment());
+                        column.getComment().orElse(null),
+                        column.getExtraInfo().orElse(null),
+                        column.getComment().orElse(null));
                 ordinalPosition++;
                 if (isLimitExhausted()) {
                     return;

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -329,7 +329,7 @@ public class ColumnJdbcTable
                     // nullable
                     column.isNullable() ? DatabaseMetaData.columnNullable : DatabaseMetaData.columnNoNulls,
                     // remarks
-                    column.getComment(),
+                    column.getComment().orElse(null),
                     // column_def
                     null,
                     // sql_data_type

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -658,7 +658,7 @@ public final class ShowQueriesRewrite
                                 column.getDefaultValue().map(value -> parseDefaultColumnValueExpression(value, objectName, node)),
                                 column.isNullable(),
                                 propertyNodes,
-                                Optional.ofNullable(column.getComment()));
+                                column.getComment());
                     })
                     .collect(toImmutableList());
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
@@ -123,7 +123,7 @@ public class TestCommentTask
         getFutureValue(setComment(COLUMN, columnName, Optional.of("new test column comment")));
         TableHandle tableHandle = metadata.getTableHandle(testSession, tableName).get();
         ConnectorTableMetadata connectorTableMetadata = metadata.getTableMetadata(testSession, tableHandle).metadata();
-        assertThat(Optional.ofNullable(connectorTableMetadata.getColumns().stream().filter(column -> "test".equals(column.getName())).collect(onlyElement()).getComment()))
+        assertThat(connectorTableMetadata.getColumns().stream().filter(column -> "test".equals(column.getName())).collect(onlyElement()).getComment())
                 .isEqualTo(Optional.of("new test column comment"));
     }
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -778,6 +778,36 @@
                                     <new>method void io.trino.spi.eventlistener.QueryStatistics::&lt;init&gt;(java.time.Duration, java.time.Duration, java.time.Duration, java.time.Duration, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.time.Duration&gt;, long, long, long, long, long, long, long, long, long, long, long, long, long, long, double, double, java.util.List&lt;io.trino.spi.eventlistener.StageGcStatistics&gt;, int, boolean, java.util.List&lt;io.trino.spi.eventlistener.StageCpuDistribution&gt;, java.util.List&lt;io.trino.spi.eventlistener.StageOutputBufferUtilization&gt;, java.util.List&lt;io.trino.spi.eventlistener.StageOutputBufferMetrics&gt;, java.util.List&lt;io.trino.spi.eventlistener.StageTaskStatistics&gt;, java.util.List&lt;io.trino.spi.eventlistener.DynamicFilterDomainStatistics&gt;, java.util.function.Supplier&lt;java.util.List&lt;java.lang.String&gt;&gt;, java.util.List&lt;io.trino.spi.eventlistener.QueryPlanOptimizerStatistics&gt;, java.util.Map&lt;java.lang.String, io.trino.spi.metrics.Metrics&gt;, java.util.Map&lt;java.lang.String, io.trino.spi.metrics.Metrics&gt;, java.util.Optional&lt;java.lang.String&gt;)</new>
                                     <justification>Expose exchange performance metrics via event listener SPI</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method java.lang.String io.trino.spi.connector.ColumnMetadata::getComment()</old>
+                                    <new>method java.util.Optional&lt;java.lang.String&gt; io.trino.spi.connector.ColumnMetadata::getComment()</new>
+                                    <justification>Make field optional</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method java.lang.String io.trino.spi.connector.ColumnMetadata::getComment()</old>
+                                    <new>method java.util.Optional&lt;java.lang.String&gt; io.trino.spi.connector.ColumnMetadata::getComment()</new>
+                                    <annotation>@jakarta.annotation.Nullable</annotation>
+                                    <justification>Make field optional</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method java.lang.String io.trino.spi.connector.ColumnMetadata::getExtraInfo()</old>
+                                    <new>method java.util.Optional&lt;java.lang.String&gt; io.trino.spi.connector.ColumnMetadata::getExtraInfo()</new>
+                                    <justification>Make field optional</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method java.lang.String io.trino.spi.connector.ColumnMetadata::getExtraInfo()</old>
+                                    <new>method java.util.Optional&lt;java.lang.String&gt; io.trino.spi.connector.ColumnMetadata::getExtraInfo()</new>
+                                    <annotation>@jakarta.annotation.Nullable</annotation>
+                                    <justification>Make field optional</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
@@ -14,7 +14,6 @@
 package io.trino.spi.connector;
 
 import io.trino.spi.type.Type;
-import jakarta.annotation.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -33,14 +32,14 @@ public class ColumnMetadata
     private final Type type;
     private final Optional<String> defaultValue;
     private final boolean nullable;
-    private final String comment;
-    private final String extraInfo;
+    private final Optional<String> comment;
+    private final Optional<String> extraInfo;
     private final boolean hidden;
     private final Map<String, Object> properties;
 
     public ColumnMetadata(String name, Type type)
     {
-        this(name, type, Optional.empty(), true, null, null, false, emptyMap());
+        this(name, type, Optional.empty(), true, Optional.empty(), Optional.empty(), false, emptyMap());
     }
 
     // VisibleForTesting
@@ -49,14 +48,16 @@ public class ColumnMetadata
             Type type,
             Optional<String> defaultValue,
             boolean nullable,
-            String comment,
-            String extraInfo,
+            Optional<String> comment,
+            Optional<String> extraInfo,
             boolean hidden,
             Map<String, Object> properties)
     {
         checkNotEmpty(name, "name");
         requireNonNull(type, "type is null");
         requireNonNull(defaultValue, "defaultValue is null");
+        requireNonNull(comment, "comment is null");
+        requireNonNull(extraInfo, "extraInfo is null");
         requireNonNull(properties, "properties is null");
 
         this.name = name.toLowerCase(ENGLISH);
@@ -89,14 +90,12 @@ public class ColumnMetadata
         return nullable;
     }
 
-    @Nullable // TODO make it Optional
-    public String getComment()
+    public Optional<String> getComment()
     {
         return comment;
     }
 
-    @Nullable // TODO make it Optional
-    public String getExtraInfo()
+    public Optional<String> getExtraInfo()
     {
         return extraInfo;
     }
@@ -124,12 +123,10 @@ public class ColumnMetadata
         sb.append("name='").append(name).append('\'');
         sb.append(", type=").append(type);
         sb.append(", ").append(nullable ? "nullable" : "nonnull");
-        if (comment != null) {
-            sb.append(", comment='").append(comment).append('\'');
-        }
-        if (extraInfo != null) {
-            sb.append(", extraInfo='").append(extraInfo).append('\'');
-        }
+        comment.ifPresent(text ->
+                sb.append(", comment='").append(text).append('\''));
+        extraInfo.ifPresent(text ->
+                sb.append(", extraInfo='").append(text).append('\''));
         if (hidden) {
             sb.append(", hidden");
         }
@@ -193,8 +190,8 @@ public class ColumnMetadata
             this.type = columnMetadata.getType();
             this.defaultValue = columnMetadata.getDefaultValue();
             this.nullable = columnMetadata.isNullable();
-            this.comment = Optional.ofNullable(columnMetadata.getComment());
-            this.extraInfo = Optional.ofNullable(columnMetadata.getExtraInfo());
+            this.comment = columnMetadata.getComment();
+            this.extraInfo = columnMetadata.getExtraInfo();
             this.hidden = columnMetadata.isHidden();
             this.properties = columnMetadata.getProperties();
         }
@@ -254,8 +251,8 @@ public class ColumnMetadata
                     type,
                     defaultValue,
                     nullable,
-                    comment.orElse(null),
-                    extraInfo.orElse(null),
+                    comment,
+                    extraInfo,
                     hidden,
                     properties);
         }

--- a/core/trino-spi/src/test/java/io/trino/spi/connector/TestColumnMetadata.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/connector/TestColumnMetadata.java
@@ -31,8 +31,8 @@ class TestColumnMetadata
                 INTEGER,
                 Optional.of("1"),
                 false,
-                "test_comment",
-                "test_extra_info",
+                Optional.of("test_comment"),
+                Optional.of("test_extra_info"),
                 false,
                 ImmutableMap.of("test_key", "test_value"));
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -953,7 +953,7 @@ public abstract class BaseJdbcClient
 
     protected String getColumnDefinitionSql(ConnectorSession session, ColumnMetadata column, String columnName)
     {
-        if (column.getComment() != null) {
+        if (column.getComment().isPresent()) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
         }
         StringBuilder sb = new StringBuilder()
@@ -1342,7 +1342,7 @@ public abstract class BaseJdbcClient
 
     private void addColumn(ConnectorSession session, RemoteTableName table, ColumnMetadata column)
     {
-        if (column.getComment() != null) {
+        if (column.getComment().isPresent()) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding columns with comments");
         }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -724,7 +724,7 @@ public class BigQueryMetadata
                     targetTable.projectId(),
                     targetTable.datasetName(),
                     generateTemporaryTableName(session));
-            createTable(client, pageSinkTable.projectId(), pageSinkTable.datasetName(), pageSinkTable.tableName(), ImmutableList.of(typeManager.toField(pageSinkIdColumnName, TRINO_PAGE_SINK_ID_COLUMN_TYPE, null)), Optional.empty());
+            createTable(client, pageSinkTable.projectId(), pageSinkTable.datasetName(), pageSinkTable.tableName(), ImmutableList.of(typeManager.toField(pageSinkIdColumnName, TRINO_PAGE_SINK_ID_COLUMN_TYPE, Optional.empty())), Optional.empty());
             closer.register(() -> bigQueryClientFactory.create(session).dropTable(pageSinkTable.toTableId()));
 
             insertIntoSinkTable(session, pageSinkTable, pageSinkIdColumnName, fragments);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeManager.java
@@ -43,7 +43,6 @@ import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import jakarta.annotation.Nullable;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -213,7 +212,7 @@ public final class BigQueryTypeManager
         return format("FROM_BASE64('%s')", Base64.getEncoder().encodeToString(slice.getBytes()));
     }
 
-    public Field toField(String name, Type type, @Nullable String comment)
+    public Field toField(String name, Type type, Optional<String> comment)
     {
         if (type instanceof ArrayType arrayType) {
             Type elementType = arrayType.getElementType();
@@ -222,14 +221,14 @@ public final class BigQueryTypeManager
         return toInnerField(name, type, false, comment);
     }
 
-    private Field toInnerField(String name, Type type, boolean repeated, @Nullable String comment)
+    private Field toInnerField(String name, Type type, boolean repeated, Optional<String> comment)
     {
         Field.Builder builder;
         if (type instanceof RowType rowType) {
-            builder = Field.newBuilder(name, StandardSQLTypeName.STRUCT, toFieldList(rowType)).setDescription(comment);
+            builder = Field.newBuilder(name, StandardSQLTypeName.STRUCT, toFieldList(rowType)).setDescription(comment.orElse(null));
         }
         else {
-            builder = Field.newBuilder(name, toStandardSqlTypeName(type)).setDescription(comment);
+            builder = Field.newBuilder(name, toStandardSqlTypeName(type)).setDescription(comment.orElse(null));
         }
         if (repeated) {
             builder = builder.setMode(REPEATED);
@@ -243,7 +242,7 @@ public final class BigQueryTypeManager
         for (RowType.Field field : rowType.getFields()) {
             String fieldName = field.getName()
                     .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "ROW type does not have field names declared: " + rowType));
-            fields.add(toField(fieldName, field.getType(), null));
+            fields.add(toField(fieldName, field.getType(), Optional.empty()));
         }
         return FieldList.of(fields.build());
     }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -376,7 +376,7 @@ public class CassandraMetadata
             if (column.getName().getBytes(UTF_8).length > COLUMN_NAME_BYTES_LIMIT) {
                 throw new TrinoException(NOT_SUPPORTED, "Column name is too long. The maximum supported length is %s bytes: %s".formatted(COLUMN_NAME_BYTES_LIMIT, column.getName()));
             }
-            if (column.getComment() != null) {
+            if (column.getComment().isPresent()) {
                 throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
             }
             columnNames.add(column.getName());

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -486,9 +486,7 @@ public class ClickHouseClient
             // By default, the clickhouse column is not allowed to be null
             sb.append(toWriteMapping(session, column.getType()).getDataType());
         }
-        if (column.getComment() != null) {
-            sb.append(format(" COMMENT %s", clickhouseVarcharLiteral(column.getComment())));
-        }
+        column.getComment().ifPresent(comment -> sb.append(format(" COMMENT %s", clickhouseVarcharLiteral(comment))));
         return sb.toString();
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -160,7 +160,6 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
-import jakarta.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
@@ -944,7 +943,7 @@ public class DeltaLakeMetadata
     private static ColumnMetadata getColumnMetadata(DeltaLakeTable deltaTable, DeltaLakeColumnHandle column)
     {
         if (column.projectionInfo().isPresent() || column.columnType() == SYNTHESIZED) {
-            return getColumnMetadata(column, null, true, Optional.empty());
+            return getColumnMetadata(column, Optional.empty(), true, Optional.empty());
         }
         DeltaLakeColumn deltaColumn = deltaTable.findColumn(column.baseColumnName());
         return getColumnMetadata(
@@ -4511,7 +4510,7 @@ public class DeltaLakeMetadata
         return metastore;
     }
 
-    private static ColumnMetadata getColumnMetadata(DeltaLakeColumnHandle column, @Nullable String comment, boolean nullability, Optional<String> generationExpression)
+    private static ColumnMetadata getColumnMetadata(DeltaLakeColumnHandle column, Optional<String> comment, boolean nullability, Optional<String> generationExpression)
     {
         String columnName;
         Type columnType;
@@ -4528,7 +4527,7 @@ public class DeltaLakeMetadata
                 .setName(columnName)
                 .setType(columnType)
                 .setHidden(column.columnType() == SYNTHESIZED)
-                .setComment(Optional.ofNullable(comment))
+                .setComment(comment)
                 .setNullable(nullability)
                 .setExtraInfo(generationExpression.map(expression -> "generated: " + expression))
                 .build();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTable.java
@@ -86,7 +86,7 @@ public record DeltaLakeTable(List<DeltaLakeColumn> columns, List<String> constra
                 columns.add(new DeltaLakeColumn(columnName,
                         columnTypes.get(columnName),
                         columnsNullability.getOrDefault(columnName, true),
-                        columnComments.get(columnName),
+                        Optional.ofNullable(columnComments.get(columnName)),
                         columnsMetadata.get(columnName),
                         Optional.ofNullable(columnGenerations.get(columnName))));
             }
@@ -97,7 +97,7 @@ public record DeltaLakeTable(List<DeltaLakeColumn> columns, List<String> constra
                     .build());
         }
 
-        public Builder addColumn(String name, Object type, boolean nullable, @Nullable String comment, @Nullable Map<String, Object> metadata)
+        public Builder addColumn(String name, Object type, boolean nullable, Optional<String> comment, @Nullable Map<String, Object> metadata)
         {
             columns.add(new DeltaLakeColumn(name, type, nullable, comment, metadata, Optional.empty()));
             return this;
@@ -127,7 +127,7 @@ public record DeltaLakeTable(List<DeltaLakeColumn> columns, List<String> constra
         public Builder setColumnComment(String name, @Nullable String comment)
         {
             DeltaLakeColumn oldColumn = findColumn(name);
-            DeltaLakeColumn newColumn = new DeltaLakeColumn(oldColumn.name, oldColumn.type, oldColumn.nullable, comment, oldColumn.metadata, oldColumn.generationExpression);
+            DeltaLakeColumn newColumn = new DeltaLakeColumn(oldColumn.name, oldColumn.type, oldColumn.nullable, Optional.ofNullable(comment), oldColumn.metadata, oldColumn.generationExpression);
             columns.set(columns.indexOf(oldColumn), newColumn);
             return this;
         }
@@ -153,12 +153,13 @@ public record DeltaLakeTable(List<DeltaLakeColumn> columns, List<String> constra
         }
     }
 
-    public record DeltaLakeColumn(String name, Object type, boolean nullable, @Nullable String comment, @Nullable Map<String, Object> metadata, Optional<String> generationExpression)
+    public record DeltaLakeColumn(String name, Object type, boolean nullable, Optional<String> comment, @Nullable Map<String, Object> metadata, Optional<String> generationExpression)
     {
         public DeltaLakeColumn
         {
             checkArgument(!name.isEmpty(), "name is empty");
             requireNonNull(type, "type is null");
+            requireNonNull(comment, "comment is null");
             requireNonNull(generationExpression, "generationExpression is null");
         }
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -271,7 +271,7 @@ public final class DeltaLakeSchemaSupport
         return schema.buildOrThrow();
     }
 
-    private static Map<String, Object> serializeStructField(String name, Object type, @Nullable String comment, boolean nullable, @Nullable Map<String, Object> metadata)
+    private static Map<String, Object> serializeStructField(String name, Object type, Optional<String> comment, boolean nullable, @Nullable Map<String, Object> metadata)
     {
         // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#struct-field
         ImmutableMap.Builder<String, Object> fieldContents = ImmutableMap.builder();
@@ -281,9 +281,7 @@ public final class DeltaLakeSchemaSupport
         fieldContents.put("nullable", nullable);
 
         ImmutableMap.Builder<String, Object> columnMetadata = ImmutableMap.builder();
-        if (comment != null) {
-            columnMetadata.put("comment", comment);
-        }
+        comment.ifPresent(value -> columnMetadata.put("comment", value));
         if (metadata != null) {
             metadata.entrySet().stream()
                     .filter(entry -> !entry.getKey().equals("comment"))
@@ -348,7 +346,7 @@ public final class DeltaLakeSchemaSupport
                     }
                     Object fieldType = serializeColumnType(columnMappingMode, maxColumnId, field.getType());
                     Map<String, Object> metadata = generateColumnMetadata(columnMappingMode, maxColumnId);
-                    return serializeStructField(name, fieldType, null, true, metadata);
+                    return serializeStructField(name, fieldType, Optional.empty(), true, metadata);
                 })
                 .collect(toImmutableList()));
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -164,7 +164,7 @@ public class TestDeltaLakePageSink
         DeltaLakeConfig deltaLakeConfig = new DeltaLakeConfig();
         DeltaLakeTable.Builder deltaTable = DeltaLakeTable.builder();
         for (DeltaLakeColumnHandle column : getColumnHandles()) {
-            deltaTable.addColumn(column.columnName(), serializeColumnType(NONE, new AtomicInteger(), column.type()), true, null, ImmutableMap.of());
+            deltaTable.addColumn(column.columnName(), serializeColumnType(NONE, new AtomicInteger(), column.type()), true, Optional.empty(), ImmutableMap.of());
         }
         String schemaString = serializeSchemaAsJson(deltaTable.build());
         DeltaLakeOutputTableHandle tableHandle = new DeltaLakeOutputTableHandle(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
@@ -236,7 +236,7 @@ public class TestDeltaLakeSchemaSupport
         List<DeltaLakeColumnHandle> columnHandles = ImmutableList.of(arrayColumn, structColumn, mapColumn);
         DeltaLakeTable.Builder deltaTable = DeltaLakeTable.builder();
         for (DeltaLakeColumnHandle column : columnHandles) {
-            deltaTable.addColumn(column.columnName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.baseType()), true, null, ImmutableMap.of());
+            deltaTable.addColumn(column.columnName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.baseType()), true, Optional.empty(), ImmutableMap.of());
         }
 
         String jsonEncoding = serializeSchemaAsJson(deltaTable.build());
@@ -256,7 +256,7 @@ public class TestDeltaLakeSchemaSupport
 
         DeltaLakeTable.Builder deltaTable = DeltaLakeTable.builder();
         for (ColumnMetadata column : schema) {
-            deltaTable.addColumn(column.getName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.getType()), true, null, ImmutableMap.of());
+            deltaTable.addColumn(column.getName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.getType()), true, Optional.empty(), ImmutableMap.of());
         }
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1525,7 +1525,7 @@ public class HiveMetadata
         HiveTableHandle handle = (HiveTableHandle) tableHandle;
         failIfAvroSchemaIsSet(handle);
 
-        metastore.addColumn(handle.getSchemaName(), handle.getTableName(), column.getName(), toHiveType(column.getType()), column.getComment());
+        metastore.addColumn(handle.getSchemaName(), handle.getTableName(), column.getName(), toHiveType(column.getType()), column.getComment().orElse(null));
     }
 
     @Override
@@ -3782,7 +3782,7 @@ public class HiveMetadata
         }
 
         List<Column> dataColumns = tableMetadata.getColumns().stream()
-                .map(columnMetadata -> new Column(columnMetadata.getName(), toHiveType(columnMetadata.getType()), Optional.ofNullable(columnMetadata.getComment()), ImmutableMap.of()))
+                .map(columnMetadata -> new Column(columnMetadata.getName(), toHiveType(columnMetadata.getType()), columnMetadata.getComment(), ImmutableMap.of()))
                 .collect(toImmutableList());
         if (!isSupportedBucketing(bucketInfo.get().bucketedBy(), dataColumns, tableMetadata.getTable().getTableName())) {
             throw new TrinoException(NOT_SUPPORTED, "Cannot create a table bucketed on an unsupported type");
@@ -3835,7 +3835,7 @@ public class HiveMetadata
                     toHiveType(column.getType()),
                     column.getType(),
                     columnType,
-                    Optional.ofNullable(column.getComment())));
+                    column.getComment()));
             ordinal++;
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -48,7 +48,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import jakarta.annotation.Nullable;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Days;
 import org.joda.time.LocalDateTime;
@@ -583,10 +582,9 @@ public final class HiveUtil
         }
     }
 
-    @Nullable
-    public static String columnExtraInfo(boolean partitionKey)
+    public static Optional<String> columnExtraInfo(boolean partitionKey)
     {
-        return partitionKey ? "partition key" : null;
+        return partitionKey ? Optional.of("partition key") : Optional.empty();
     }
 
     public static NullableValue getPrefilledColumnValue(
@@ -846,7 +844,7 @@ public final class HiveUtil
                 .setName(handle.getName())
                 .setType(handle.getType())
                 .setComment(handle.isHidden() ? Optional.empty() : columnComment.get(handle.getName()))
-                .setExtraInfo(Optional.ofNullable(columnExtraInfo(handle.isPartitionKey())))
+                .setExtraInfo(columnExtraInfo(handle.isPartitionKey()))
                 .setHidden(handle.isHidden())
                 .setProperties(getPartitionProjectionTrinoColumnProperties(table, handle.getName()))
                 .build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2856,7 +2856,7 @@ public class IcebergMetadata
                     })
                     .orElse(null);
 
-            updateSchema.addColumn(null, column.getName(), icebergType, column.getComment(), defaultLiteral);
+            updateSchema.addColumn(null, column.getName(), icebergType, column.getComment().orElse(null), defaultLiteral);
             switch (position) {
                 case ColumnPosition.First _ -> updateSchema.moveFirst(column.getName());
                 case ColumnPosition.After after -> updateSchema.moveAfter(column.getName(), after.columnName());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -859,7 +859,7 @@ public final class IcebergUtil
                         .isOptional(column.isNullable())
                         .withName(column.getName())
                         .ofType(type)
-                        .withDoc(column.getComment());
+                        .withDoc(column.getComment().orElse(null));
 
                 // Set initial-default and write-default if present
                 // Note: DEFAULT NULL results in icebergDefault=null, which we skip since null is already the implicit default

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -536,7 +536,7 @@ public class MariaDbClient
 
     private void addColumn(ConnectorSession session, RemoteTableName table, ColumnMetadata column, String position)
     {
-        if (column.getComment() != null) {
+        if (column.getComment().isPresent()) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding columns with comments");
         }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryMetadata.java
@@ -356,7 +356,7 @@ public class MemoryMetadata
         for (int i = 0; i < tableMetadata.getColumns().size(); i++) {
             ColumnMetadata column = tableMetadata.getColumns().get(i);
             MemoryColumnHandle handle = new MemoryColumnHandle(i, column.getName(), column.getType());
-            columns.add(new ColumnInfo(handle, column.getDefaultValue(), column.isNullable(), Optional.ofNullable(column.getComment())));
+            columns.add(new ColumnInfo(handle, column.getDefaultValue(), column.isNullable(), column.getComment()));
         }
 
         tableIds.put(tableMetadata.getTable(), tableId);
@@ -458,7 +458,7 @@ public class MemoryMetadata
 
         List<ColumnInfo> columns = ImmutableList.<ColumnInfo>builderWithExpectedSize(table.columns().size() + 1)
                 .addAll(table.columns())
-                .add(new ColumnInfo(newColumn, column.getDefaultValue(), column.isNullable(), Optional.ofNullable(column.getComment())))
+                .add(new ColumnInfo(newColumn, column.getDefaultValue(), column.isNullable(), column.getComment()))
                 .build();
 
         tables.put(tableId, new TableInfo(tableId, table.schemaName(), table.tableName(), columns, table.truncated(), table.dataFragments(), table.comment()));

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -873,7 +873,7 @@ public class MongoMetadata
     private static List<MongoColumnHandle> buildColumnHandles(ConnectorTableMetadata tableMetadata)
     {
         return tableMetadata.getColumns().stream()
-                .map(m -> new MongoColumnHandle(m.getName(), ImmutableList.of(), m.getType(), m.isHidden(), false, Optional.ofNullable(m.getComment())))
+                .map(m -> new MongoColumnHandle(m.getName(), ImmutableList.of(), m.getType(), m.isHidden(), false, m.getComment()))
                 .collect(toList());
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -363,7 +363,8 @@ public class MongoSession
         Document newColumn = new Document();
         newColumn.append(FIELDS_NAME_KEY, columnMetadata.getName());
         newColumn.append(FIELDS_TYPE_KEY, columnMetadata.getType().getDisplayName());
-        newColumn.append(COMMENT_KEY, columnMetadata.getComment());
+        columnMetadata.getComment()
+                .ifPresent(comment -> newColumn.append(COMMENT_KEY, comment));
         newColumn.append(FIELDS_HIDDEN_KEY, false);
         columns.add(newColumn);
 

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -518,7 +518,7 @@ public class MySqlClient
     @Override
     protected String getColumnDefinitionSql(ConnectorSession session, ColumnMetadata column, String columnName)
     {
-        if (column.getComment() != null) {
+        if (column.getComment().isPresent()) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
         }
 
@@ -960,7 +960,7 @@ public class MySqlClient
 
     private void addColumn(ConnectorSession session, RemoteTableName table, ColumnMetadata column, String position)
     {
-        if (column.getComment() != null) {
+        if (column.getComment().isPresent()) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding columns with comments");
         }
 

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftColumnHandle.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftColumnHandle.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record ThriftColumnHandle(String columnName, Type columnType, String comment, boolean hidden)
+public record ThriftColumnHandle(String columnName, Type columnType, Optional<String> comment, boolean hidden)
         implements ColumnHandle
 {
     public ThriftColumnHandle
@@ -35,7 +35,7 @@ public record ThriftColumnHandle(String columnName, Type columnType, String comm
         return ColumnMetadata.builder()
                 .setName(columnName)
                 .setType(columnType)
-                .setComment(Optional.ofNullable(comment))
+                .setComment(comment)
                 .setHidden(hidden)
                 .build();
     }

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/TestThriftIndexPageSource.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/TestThriftIndexPageSource.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.IntStream;
@@ -319,7 +320,7 @@ public class TestThriftIndexPageSource
 
     private static ThriftColumnHandle column(String name, Type type)
     {
-        return new ThriftColumnHandle(name, type, null, false);
+        return new ThriftColumnHandle(name, type, Optional.empty(), false);
     }
 
     private static List<List<Integer>> generateKeys(int beginInclusive, int endExclusive)

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftProjectionPushdown.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/TestThriftProjectionPushdown.java
@@ -129,7 +129,7 @@ public class TestThriftProjectionPushdown
                 new ScalarStatsCalculator(tester().getPlannerContext()));
 
         String columnName = "orderstatus";
-        ColumnHandle columnHandle = new ThriftColumnHandle(columnName, VARCHAR, "", false);
+        ColumnHandle columnHandle = new ThriftColumnHandle(columnName, VARCHAR, Optional.of(""), false);
 
         ConnectorTableHandle tableWithColumns = new ThriftTableHandle(
                 TINY_SCHEMA,
@@ -164,7 +164,7 @@ public class TestThriftProjectionPushdown
 
         String columnName = "orderstatus";
 
-        ColumnHandle columnHandle = new ThriftColumnHandle(columnName, VARCHAR, "", false);
+        ColumnHandle columnHandle = new ThriftColumnHandle(columnName, VARCHAR, Optional.of(""), false);
 
         ConnectorTableHandle projectedThriftHandle = new ThriftTableHandle(
                 TINY_SCHEMA,
@@ -198,8 +198,8 @@ public class TestThriftProjectionPushdown
     {
         PruneTableScanColumns rule = new PruneTableScanColumns(tester().getMetadata());
 
-        ThriftColumnHandle nationKeyColumn = new ThriftColumnHandle("nationKey", VARCHAR, "", false);
-        ThriftColumnHandle nameColumn = new ThriftColumnHandle("name", VARCHAR, "", false);
+        ThriftColumnHandle nationKeyColumn = new ThriftColumnHandle("nationKey", VARCHAR, Optional.of(""), false);
+        ThriftColumnHandle nameColumn = new ThriftColumnHandle("name", VARCHAR, Optional.of(""), false);
 
         tester().assertThat(rule)
                 .withSession(SESSION)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* ColumnMetadata fields `comment` and `extraInfo` are now Optional ({issue}`issuenumber`)
```
