### PR TITLE
Brainfart: switch(get_value(), v -> if(v = 1, 'First'), v -> if(v = 2, 'Second', 'Default'))

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -169,6 +169,7 @@ import io.trino.operator.scalar.SessionFunctions;
 import io.trino.operator.scalar.SplitToMapFunction;
 import io.trino.operator.scalar.SplitToMultimapFunction;
 import io.trino.operator.scalar.StringFunctions;
+import io.trino.operator.scalar.SwitchFunction;
 import io.trino.operator.scalar.TDigestFunctions;
 import io.trino.operator.scalar.TryFunction;
 import io.trino.operator.scalar.TypeOfFunction;
@@ -725,6 +726,8 @@ public final class SystemFunctionBundle
                 .scalar(io.trino.operator.scalar.timetz.AtTimeZone.class)
                 .scalar(io.trino.operator.scalar.timetz.AtTimeZoneWithOffset.class)
                 .scalar(CurrentTime.class);
+
+        builder.function(SwitchFunction.SWITCH_FUNCTION);
 
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/SwitchFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/SwitchFunction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.spi.StandardErrorCode;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.Signature;
+import io.trino.spi.type.TypeSignature;
+import io.trino.sql.gen.lambda.UnaryFunctionInterface;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.util.Reflection.methodHandle;
+
+public class SwitchFunction
+        extends SqlScalarFunction
+{
+    public static final SwitchFunction SWITCH_FUNCTION = new SwitchFunction();
+    private static final MethodHandle SWITCH_METHOD_HANDLE = methodHandle(SwitchFunction.class, "switchCase", Object.class, UnaryFunctionInterface[].class);
+
+    private SwitchFunction()
+    {
+        super(FunctionMetadata.scalarBuilder("switch")
+                .description("Switch function using lambdas, for example switch(getValue(), v -> if(v = 'value1', 'return value 1'), v -> if(v = 'value2', 'return value 2', 'default value'))")
+                .signature(Signature.builder()
+                        .typeVariable("V")
+                        .typeVariable("R")
+                        .returnType(new TypeSignature("R"))
+                        .argumentType(new TypeSignature("V"))
+                        .argumentType(functionType(new TypeSignature("V"), new TypeSignature("R")))
+                        .variableArity()
+                        .build())
+                .build());
+    }
+
+    @Override
+    public SpecializedSqlScalarFunction specialize(BoundSignature boundSignature)
+    {
+        int switchCases = boundSignature.getArity() - 1;
+        if (switchCases < 1) {
+            throw new TrinoException(StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "There must be at least one switch case, usually v -> if(v = ... , 'return value')");
+        }
+
+        List<InvocationConvention.InvocationArgumentConvention> argumentConventions = new ArrayList<>();
+        argumentConventions.add(BOXED_NULLABLE);
+        List<Class<?>> interfaces = new ArrayList<>();
+        for (int i = 0; i < switchCases; i++) {
+            argumentConventions.add(FUNCTION);
+            interfaces.add(UnaryFunctionInterface.class);
+        }
+
+        Class<?> valueType = boundSignature.getArgumentType(0).getJavaType();
+        Class<?> returnType = boundSignature.getReturnType().getJavaType();
+
+        MethodHandle methodHandle = SWITCH_METHOD_HANDLE.asCollector(UnaryFunctionInterface[].class, switchCases);
+        return new ChoicesSpecializedSqlScalarFunction(
+                boundSignature,
+                FAIL_ON_NULL,
+                ImmutableList.copyOf(argumentConventions),
+                ImmutableList.copyOf(interfaces),
+                methodHandle.asType(
+                        methodHandle.type()
+                                .changeParameterType(0, Primitives.wrap(valueType))
+                                .changeReturnType(Primitives.unwrap(returnType))),
+                Optional.empty());
+    }
+
+    public static Object switchCase(Object value, UnaryFunctionInterface[] cases)
+    {
+        for (UnaryFunctionInterface function : cases) {
+            Object ret = function.apply(value);
+            if (ret != null) {
+                return ret;
+            }
+        }
+        return null;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestSwitchFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestSwitchFunction.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestSwitchFunction
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder().build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        if (assertions != null) {
+            assertions.close();
+        }
+        assertions = null;
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        assertThat(assertions.expression("switch('test1', v -> if(v = 'test1', 'foo'), v -> if(v = 'test2', 'bar', 'def'))"))
+                .isEqualTo("foo");
+
+        assertThat(assertions.expression("switch('test2', v -> if(v = 'test1', 'foo'), v -> if(v = 'test2', 'bar', 'def'))"))
+                .isEqualTo("bar");
+
+        assertThat(assertions.expression("switch('test3', v -> if(v = 'test1', 'foo'), v -> if(v = 'test2', 'bar', 'def'))"))
+                .isEqualTo("def");
+    }
+
+    @Test
+    public void testInteger()
+    {
+        assertThat(assertions.expression("switch('test1', v -> if(v = 'test1', 1), v -> if(v = 'test2', 2, -1))"))
+                .isEqualTo(1);
+
+        assertThat(assertions.expression("switch('test2', v -> if(v = 'test1', 1), v -> if(v = 'test2', 2, -1))"))
+                .isEqualTo(2);
+
+        assertThat(assertions.expression("switch('test3', v -> if(v = 'test1', 1), v -> if(v = 'test2', 2, -1))"))
+                .isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
## Description
Switch cases in a single expression are usually written like this:
`CASE get_value() WHEN v = 1 THEN 'First' WHEN v = 2 THEN 'Second' ELSE 'Default' END`

With the function of this PR, the expression can be written like this:
`switch(get_value(), v -> if(v = 1, 'First'), v -> if(v = 2, 'Second', 'Default'))`

It is shorter, but also allows more complex implementations like:
`v -> if(is_valid_value(v), 'First')`
or
`v -> if(v = 2 OR v = 3, 'Second')`: 

`switch(get_value(), v -> if(is_valid_value(v), 'First'), v -> if(v = 2 OR v = 3, 'Second', 'Default'))`

I wonder if anyone sees any potential in this function. It was fun to implement it. When a case returns `NULL`, the next case is tested.

## Release notes
I'll add this later when the PR is approved
