### PR TITLE
Remove redundant version from trino-test-jdbc-compatibility-old-driver pom.xml

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.18.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
