### PR TITLE
Add npm dependabot for webapp-preview

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,17 @@ updates:
     ignore:
       # Airbase and Airlift are best updated together. Update Airbase only when updating Airlift.
       - dependency-name: "io.airlift:airbase"
+  - package-ecosystem: "npm"
+    directory: "/core/trino-web-ui/src/main/resources/webapp-preview"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "all"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    cooldown:
+      # Apply 7 day cooldown to avoid updating dependencies right away. This reduces the opportunity window
+      # when supply chain is compromised.
+      default-days: 7


### PR DESCRIPTION
## Description

Add npm dependabot for webapp-preview to keep frontend dependencies current.

## Additional context and related issues

Node dependencies change quickly. Recent `npm audit` and `npm outdated` show multiple vulnerabilities and outdated packages:

webapp-preview:
```
9 vulnerabilities (2 moderate, 1 high, 6 critical)
```

webapp:
```
14 vulnerabilities (3 moderate, 11 high)
```

Policy:

* Allow only minor and patch updates to avoid breaking changes
* Do not add Dependabot for classic UI because it has very old dependencies with multiple breaking changes

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
