### PR TITLE
Fix dependabot config schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,11 @@ updates:
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "all"
+    ignore:
+      # Ignore major updates for all dependencies; allow only minor/patch updates.
+      - dependency-name: "*"
         update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
+          - "version-update:semver-major"
     cooldown:
       # Apply 7 day cooldown to avoid updating dependencies right away. This reduces the opportunity window
       # when supply chain is compromised.


### PR DESCRIPTION
## Description

Fixes the Dependabot configuration schema to resolve CI failures.
This addresses the issue reported in https://github.com/trinodb/trino/issues/28163

## Additional context and related issues

https://github.com/trinodb/trino/pull/28161 introduced an invalid Dependabot configuration, which caused CI to start failing. This change corrects the schema so CI runs successfully again.


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

