### PR TITLE
fix: skip cloud tests for dependabot when secrets unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
   CI_SKIP_SECRETS_PRESENCE_CHECKS: ${{ secrets.CI_SKIP_SECRETS_PRESENCE_CHECKS }}
   SECRETS_PRESENT: ${{ secrets.SECRETS_PRESENT }}
-  DEPENDABOT_PR: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.client_payload.pull_request.user.login == 'dependabot[bot]' }}
+  DEPENDABOT_PR: ${{ github.repository == 'trinodb/trino' && github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' }}
   PTL_TMP_DOWNLOAD_PATH: /tmp/pt_java_downloads
 
 # Cancel previous PR builds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
   CI_SKIP_SECRETS_PRESENCE_CHECKS: ${{ secrets.CI_SKIP_SECRETS_PRESENCE_CHECKS }}
   SECRETS_PRESENT: ${{ secrets.SECRETS_PRESENT }}
+  DEPENDABOT_PR: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.client_payload.pull_request.user.login == 'dependabot[bot]' }}
   PTL_TMP_DOWNLOAD_PATH: /tmp/pt_java_downloads
 
 # Cancel previous PR builds.
@@ -578,7 +579,7 @@ jobs:
           AWS_REGION: ${{ vars.TRINO_AWS_REGION }}
         if: >-
           contains(matrix.modules, 'trino-filesystem-s3') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || (env.AWS_ACCESS_KEY_ID != '' && github.actor != 'dependabot[bot]') || env.AWS_SECRET_ACCESS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || (env.AWS_ACCESS_KEY_ID != '' && env.DEPENDABOT_PR != 'true') || env.AWS_SECRET_ACCESS_KEY != '')
         run: |
           # Create an empty S3 bucket for S3 filesystem cloud tests and add the bucket name to GitHub environment variables
           .github/bin/s3/setup-empty-s3-bucket.sh
@@ -634,7 +635,7 @@ jobs:
         # Run tests if any of the secrets is present. Do not skip tests when one secret renamed, or secret name has a typo.
         if: >-
           contains(matrix.modules, 'trino-delta-lake') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.ABFS_ACCOUNT != '' || env.ABFS_CONTAINER != '') && github.actor != 'dependabot[bot]') || env.ABFS_ACCESSKEY != '' || (env.AWS_ACCESS_KEY_ID != '' && github.actor != 'dependabot[bot]') || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.ABFS_ACCOUNT != '' || env.ABFS_CONTAINER != '') && env.DEPENDABOT_PR != 'true') || env.ABFS_ACCESSKEY != '' || (env.AWS_ACCESS_KEY_ID != '' && env.DEPENDABOT_PR != 'true') || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} ${{ format('-P {0}', matrix.profile) }} -pl :trino-delta-lake \
             -Dtesting.azure-abfs-container="${ABFS_CONTAINER}" \
@@ -715,7 +716,7 @@ jobs:
           SNOWFLAKE_CATALOG_S3_REGION: ${{ vars.SNOWFLAKE_CATALOG_S3_REGION }}
         if: >-
           contains(matrix.modules, 'trino-iceberg') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || (env.AWS_ACCESS_KEY_ID != '' && github.actor != 'dependabot[bot]') || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || (env.AWS_ACCESS_KEY_ID != '' && env.DEPENDABOT_PR != 'true') || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-iceberg ${{ format('-P {0}', matrix.profile) }} \
             -Dtesting.gcp-storage-bucket="${GCP_STORAGE_BUCKET}" \
@@ -748,7 +749,7 @@ jobs:
         if: >-
           contains(matrix.modules, 'trino-redshift') &&
           (contains(matrix.profile, 'cloud-tests') || contains(matrix.profile, 'fte-tests')) &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.AWS_ACCESS_KEY_ID != '' || env.REDSHIFT_SUBNET_GROUP_NAME != '') && github.actor != 'dependabot[bot]'))
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.AWS_ACCESS_KEY_ID != '' || env.REDSHIFT_SUBNET_GROUP_NAME != '') && env.DEPENDABOT_PR != 'true'))
         run: |
           source .github/bin/redshift/setup-aws-redshift.sh
 
@@ -916,8 +917,8 @@ jobs:
             - suite: suite-azure
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' ||
-                    (vars.AZURE_ABFS_HIERARCHICAL_CONTAINER != '' && github.actor != 'dependabot[bot]') ||
-                    (vars.AZURE_ABFS_HIERARCHICAL_ACCOUNT != '' && github.actor != 'dependabot[bot]') ||
+                    (vars.AZURE_ABFS_HIERARCHICAL_CONTAINER != '' && env.DEPENDABOT_PR != 'true') ||
+                    (vars.AZURE_ABFS_HIERARCHICAL_ACCOUNT != '' && env.DEPENDABOT_PR != 'true') ||
                     secrets.AZURE_ABFS_HIERARCHICAL_ACCESS_KEY != '' }}
 
             - suite: suite-gcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,7 +578,7 @@ jobs:
           AWS_REGION: ${{ vars.TRINO_AWS_REGION }}
         if: >-
           contains(matrix.modules, 'trino-filesystem-s3') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.AWS_ACCESS_KEY_ID != '' || env.AWS_SECRET_ACCESS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || (env.AWS_ACCESS_KEY_ID != '' && github.actor != 'dependabot[bot]') || env.AWS_SECRET_ACCESS_KEY != '')
         run: |
           # Create an empty S3 bucket for S3 filesystem cloud tests and add the bucket name to GitHub environment variables
           .github/bin/s3/setup-empty-s3-bucket.sh
@@ -634,7 +634,7 @@ jobs:
         # Run tests if any of the secrets is present. Do not skip tests when one secret renamed, or secret name has a typo.
         if: >-
           contains(matrix.modules, 'trino-delta-lake') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_ACCOUNT != '' || env.ABFS_CONTAINER != '' || env.ABFS_ACCESSKEY != '' || env.AWS_ACCESS_KEY_ID != '' || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.ABFS_ACCOUNT != '' || env.ABFS_CONTAINER != '') && github.actor != 'dependabot[bot]') || env.ABFS_ACCESSKEY != '' || (env.AWS_ACCESS_KEY_ID != '' && github.actor != 'dependabot[bot]') || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} ${{ format('-P {0}', matrix.profile) }} -pl :trino-delta-lake \
             -Dtesting.azure-abfs-container="${ABFS_CONTAINER}" \
@@ -715,7 +715,7 @@ jobs:
           SNOWFLAKE_CATALOG_S3_REGION: ${{ vars.SNOWFLAKE_CATALOG_S3_REGION }}
         if: >-
           contains(matrix.modules, 'trino-iceberg') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.AWS_ACCESS_KEY_ID != '' || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || (env.AWS_ACCESS_KEY_ID != '' && github.actor != 'dependabot[bot]') || env.AWS_SECRET_ACCESS_KEY != '' || env.GCP_CREDENTIALS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-iceberg ${{ format('-P {0}', matrix.profile) }} \
             -Dtesting.gcp-storage-bucket="${GCP_STORAGE_BUCKET}" \
@@ -748,7 +748,7 @@ jobs:
         if: >-
           contains(matrix.modules, 'trino-redshift') &&
           (contains(matrix.profile, 'cloud-tests') || contains(matrix.profile, 'fte-tests')) &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.AWS_ACCESS_KEY_ID != '' || env.REDSHIFT_SUBNET_GROUP_NAME != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.AWS_ACCESS_KEY_ID != '' || env.REDSHIFT_SUBNET_GROUP_NAME != '') && github.actor != 'dependabot[bot]'))
         run: |
           source .github/bin/redshift/setup-aws-redshift.sh
 
@@ -916,8 +916,8 @@ jobs:
             - suite: suite-azure
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' ||
-                    vars.AZURE_ABFS_HIERARCHICAL_CONTAINER != '' ||
-                    vars.AZURE_ABFS_HIERARCHICAL_ACCOUNT != '' ||
+                    (vars.AZURE_ABFS_HIERARCHICAL_CONTAINER != '' && github.actor != 'dependabot[bot]') ||
+                    (vars.AZURE_ABFS_HIERARCHICAL_ACCOUNT != '' && github.actor != 'dependabot[bot]') ||
                     secrets.AZURE_ABFS_HIERARCHICAL_ACCESS_KEY != '' }}
 
             - suite: suite-gcs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,7 +749,7 @@ jobs:
         if: >-
           contains(matrix.modules, 'trino-redshift') &&
           (contains(matrix.profile, 'cloud-tests') || contains(matrix.profile, 'fte-tests')) &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.AWS_ACCESS_KEY_ID != '' || env.REDSHIFT_SUBNET_GROUP_NAME != '') && env.DEPENDABOT_PR != 'true'))
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || ((env.AWS_ACCESS_KEY_ID != '' || env.REDSHIFT_SUBNET_GROUP_NAME != '') && env.DEPENDABOT_PR != 'true') || env.AWS_SECRET_ACCESS_KEY != '')
         run: |
           source .github/bin/redshift/setup-aws-redshift.sh
 


### PR DESCRIPTION
## Description
Fixes dependabot-originated builds that fail when cloud tests attempt to run without required secrets.

Dependabot can see repository variables but not secrets (unless specifically configured as dependabot secrets). This causes cloud integration tests to execute when `vars.AWS_ACCESS_KEY_ID` is present, but then fail when `secrets.AWS_SECRET_ACCESS_KEY` is missing, resulting in "Unable to load AWS credentials from environment variables" errors.

Fixes #28176

The issue was identified through failed dependabot PR builds where the AWS credentials check passed (because dependabot could see the variable), but the actual test execution failed when attempting to load credentials (because the secret was unavailable).

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
