### PR TITLE
Add function validation to check for missing declared lambda classes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -261,6 +261,9 @@ public class FunctionManager
                     verifyFunctionSignature(parameterType.equals(InOut.class), "Expected IN_OUT argument type to be InOut");
                     break;
                 case FUNCTION:
+                    verifyFunctionSignature(lambdaArgumentIndex < scalarFunctionImplementation.getLambdaInterfaces().size(),
+                            "Expected %d lambdaInterface(s) in ScalarFunctionImplementation but %s interfaces are declared",
+                            lambdaArgumentIndex + 1, scalarFunctionImplementation.getLambdaInterfaces().size());
                     Class<?> lambdaInterface = scalarFunctionImplementation.getLambdaInterfaces().get(lambdaArgumentIndex);
                     verifyFunctionSignature(parameterType.equals(lambdaInterface),
                             "Expected function interface to be %s, but is %s", lambdaInterface, parameterType);


### PR DESCRIPTION
## Description
ScalarFunctions with incorrect lambda class declarations throw IndexOutOfBounds:
```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/java.util.ImmutableCollections$ListN.get(ImmutableCollections.java:725)
	at io.trino.metadata.FunctionManager.verifyMethodHandleSignature(FunctionManager.java:264)
	at io.trino.metadata.FunctionManager.getScalarFunctionImplementationInternal(FunctionManager.java:116)
	at io.trino.metadata.FunctionManager.lambda$getScalarFunctionImplementation$0(FunctionManager.java:93)
``` 

This PR throws:
```
io.trino.testing.QueryFailedException: Expected 1 lambdaInterface classes in ScalarFunctionImplementation but 0 interfaces are declared

	at io.trino.testing.TestingDirectTrinoClient.toMaterializedRows(TestingDirectTrinoClient.java:79)
	at io.trino.testing.TestingDirectTrinoClient.lambda$execute$0(TestingDirectTrinoClient.java:67)
	at io.trino.testing.StandaloneQueryRunner.executeWithPlan(StandaloneQueryRunner.java:119)
```

This can be tested by:
Replace `ImmutableList.of(UnaryFunctionInterface.class),` with `ImmutableList.of(),` in [`ArrayTransformFunction`](https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTransformFunction.java#L113)

Run `TestArrayTransformFunction`


## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
