### PR TITLE
Add per-node spill tracking

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
@@ -302,6 +302,7 @@ public class FailedDispatchQuery
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
                 DataSize.ofBytes(0),
+                ImmutableMap.of(),
                 false,
                 OptionalDouble.empty(),
                 OptionalDouble.empty(),

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
@@ -16,6 +16,7 @@ package io.trino.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -84,6 +85,12 @@ public class QueryStats
     private final DataSize peakTaskTotalMemory;
 
     private final DataSize spilledDataSize;
+    /**
+     * Spilled data size grouped by worker node ID.
+     * The map key is the node identifier (UUID string).
+     * Empty when no spilling occurred.
+     */
+    private final Map<String, DataSize> spilledDataSizeByNode;
 
     private final boolean scheduled;
     private final OptionalDouble progressPercentage;
@@ -178,6 +185,7 @@ public class QueryStats
             @JsonProperty("peakTaskTotalMemory") DataSize peakTaskTotalMemory,
 
             @JsonProperty("spilledDataSize") DataSize spilledDataSize,
+            @JsonProperty("spilledDataSizeByNode") Map<String, DataSize> spilledDataSizeByNode,
 
             @JsonProperty("scheduled") boolean scheduled,
             @JsonProperty("progressPercentage") OptionalDouble progressPercentage,
@@ -277,6 +285,7 @@ public class QueryStats
         this.peakTaskRevocableMemory = requireNonNull(peakTaskRevocableMemory, "peakTaskRevocableMemory is null");
         this.peakTaskTotalMemory = requireNonNull(peakTaskTotalMemory, "peakTaskTotalMemory is null");
         this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
+        this.spilledDataSizeByNode = ImmutableMap.copyOf(requireNonNull(spilledDataSizeByNode, "spilledDataSizeByNode is null"));
         this.scheduled = scheduled;
         this.progressPercentage = requireNonNull(progressPercentage, "progressPercentage is null");
         this.runningPercentage = requireNonNull(runningPercentage, "runningPercentage is null");
@@ -804,5 +813,11 @@ public class QueryStats
     public DataSize getSpilledDataSize()
     {
         return spilledDataSize;
+    }
+
+    @JsonProperty
+    public Map<String, DataSize> getSpilledDataSizeByNode()
+    {
+        return spilledDataSizeByNode;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -71,6 +71,12 @@ public class StageStats
     private final DataSize peakRevocableMemoryReservation;
 
     private final DataSize spilledDataSize;
+    /**
+     * Spilled data size grouped by worker node ID.
+     * The map key is the node identifier (UUID string).
+     * Empty when no spilling occurred.
+     */
+    private final Map<String, DataSize> spilledDataSizeByNode;
 
     private final Duration totalScheduledTime;
     private final Duration failedScheduledTime;
@@ -145,6 +151,7 @@ public class StageStats
             @JsonProperty("peakRevocableMemoryReservation") DataSize peakRevocableMemoryReservation,
 
             @JsonProperty("spilledDataSize") DataSize spilledDataSize,
+            @JsonProperty("spilledDataSizeByNode") Map<String, DataSize> spilledDataSizeByNode,
 
             @JsonProperty("totalScheduledTime") Duration totalScheduledTime,
             @JsonProperty("failedScheduledTime") Duration failedScheduledTime,
@@ -224,6 +231,7 @@ public class StageStats
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
         this.peakRevocableMemoryReservation = requireNonNull(peakRevocableMemoryReservation, "peakRevocableMemoryReservation is null");
         this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
+        this.spilledDataSizeByNode = ImmutableMap.copyOf(requireNonNull(spilledDataSizeByNode, "spilledDataSizeByNode is null"));
 
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.failedScheduledTime = requireNonNull(failedScheduledTime, "failedScheduledTime is null");
@@ -397,6 +405,12 @@ public class StageStats
     public DataSize getSpilledDataSize()
     {
         return spilledDataSize;
+    }
+
+    @JsonProperty
+    public Map<String, DataSize> getSpilledDataSizeByNode()
+    {
+        return spilledDataSizeByNode;
     }
 
     @JsonProperty
@@ -683,6 +697,7 @@ public class StageStats
                 zeroBytes,
                 zeroBytes,
                 zeroBytes,
+                ImmutableMap.of(),
                 zeroSeconds,
                 zeroSeconds,
                 zeroSeconds,

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -222,6 +222,7 @@ public class MockManagedQueryExecution
                         DataSize.ofBytes(26),
 
                         DataSize.ofBytes(27),
+                        ImmutableMap.of(),
 
                         !state.isDone(),
                         state.isDone() ? OptionalDouble.empty() : OptionalDouble.of(8.88),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
@@ -294,6 +294,7 @@ public class TestQueryInfo
                 succinctBytes(value),
                 succinctBytes(value),
                 succinctBytes(value),
+                ImmutableMap.of("node" + value, succinctBytes(value)),
                 Duration.succinctDuration(value, SECONDS),
                 Duration.succinctDuration(value, SECONDS),
                 Duration.succinctDuration(value, SECONDS),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
@@ -218,6 +218,7 @@ public class TestQueryStats
             DataSize.ofBytes(26),
             DataSize.ofBytes(27),
             DataSize.ofBytes(28),
+            ImmutableMap.of("node1", DataSize.ofBytes(15), "node2", DataSize.ofBytes(13)),
 
             true,
             OptionalDouble.of(8.88),

--- a/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestStageStats.java
@@ -62,6 +62,7 @@ public class TestStageStats
             DataSize.ofBytes(17),
             DataSize.ofBytes(18),
             DataSize.ofBytes(19),
+            ImmutableMap.of("node1", DataSize.ofBytes(10), "node2", DataSize.ofBytes(9)),
 
             new Duration(19, NANOSECONDS),
             new Duration(20, NANOSECONDS),

--- a/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestBasicQueryInfo.java
@@ -91,6 +91,7 @@ public class TestBasicQueryInfo
                                 DataSize.valueOf("30GB"),
                                 DataSize.valueOf("31GB"),
                                 DataSize.valueOf("32GB"),
+                                ImmutableMap.of(),
                                 true,
                                 OptionalDouble.of(100),
                                 OptionalDouble.of(0),

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfo.java
@@ -143,6 +143,7 @@ public class TestQueryStateInfo
                         DataSize.valueOf("28GB"),
                         DataSize.valueOf("29GB"),
                         DataSize.valueOf("30GB"),
+                        ImmutableMap.of(),
                         true,
                         OptionalDouble.of(8.88),
                         OptionalDouble.of(0),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Track spilled data size per worker node in addition to total spill. This enables operators to:
- Identify which nodes are spilling the most
- Detect imbalanced spill distribution across workers
- Diagnose node-specific issues

Implementation:
- Added spilledDataSizeByNode Map<String, DataSize> to StageStats
- Added spilledDataSizeByNode Map<String, DataSize> to QueryStats
- StageStateMachine aggregates spill by nodeId from TaskInfo
- QueryStateMachine aggregates per-node spill from all stages


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This change aggregates existing task-level spill data by node ID with no new metrics collection overhead. The 
data is exposed via REST API through existing @JsonProperty serialization.

I tested this feature with a 4-worker local cluster running a spill-inducing query:
```sql
SET SESSION spill_enabled = true;
SET SESSION query_max_memory_per_node = '100MB;
SELECT * FROM tpch.sf1.lineitem ORDER BY orderkey, partkey, suppkey;
```

Then, I verified per-node spill tracking via REST API:
```bash
curl -s -H "X-Trino-User: test" "http://localhost:8080/v1/query/20260209_215137_00002_xxv7n" | \
  jq '{spilledDataSize: .queryStats.spilledDataSize, spilledDataSizeByNode: .queryStats.spilledDataSizeByNode}'
```
For the spill-inducing query, this gives the following result: 
```json
{
  "spilledDataSize": "295446562B",                                        
  "spilledDataSizeByNode": {                                              
    "7ba7fb19-89eb-4ab0-9d97-a489fae4172d": "103862339B",                 
    "188560d1-7f95-4ccf-9335-7a8aac6cbee6": "14087954B",                  
    "c0e737c3-925b-4515-a41e-397db6ff79b3": "122595227B",                 
    "50eaec01-f95a-4998-9bbd-e7c89442629b": "54901042B"                   
  }                                                                       
}
```

I hope to integrate this tracking into the Trino UI in a follow-up PR. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(X) Release notes are required, with the following suggested text:

```markdown
## General
* Add per-node spill tracking to query and stage statistics, enabling operators to identify which nodes are spilling the most data. 
```