### PR TITLE
Upgrade Confluent Kafka version

### DIFF
--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.wire.version>5.2.1</dep.wire.version>
+        <dep.wire.version>5.5.0</dep.wire.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -176,6 +176,12 @@
             <groupId>com.google.api.grpc</groupId>
             <artifactId>proto-google-common-protos</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ClassLoaderSafeSchemaRegistryClient.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ClassLoaderSafeSchemaRegistryClient.java
@@ -17,11 +17,16 @@ import com.google.common.base.Ticker;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Association;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryDeployment;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOrUpdateRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.trino.spi.classloader.ThreadContextClassLoader;
@@ -52,6 +57,15 @@ public class ClassLoaderSafeSchemaRegistryClient
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.parseSchema(schemaType, schemaString, references);
+        }
+    }
+
+    @Override
+    public ParsedSchema parseSchemaOrElseThrow(io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema)
+            throws IOException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.parseSchemaOrElseThrow(schema);
         }
     }
 
@@ -121,6 +135,24 @@ public class ClassLoaderSafeSchemaRegistryClient
     }
 
     @Override
+    public SchemaRegistryDeployment getSchemaRegistryDeployment()
+            throws RestClientException, IOException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSchemaRegistryDeployment();
+        }
+    }
+
+    @Override
+    public SchemaRegistryServerVersion getSchemaRegistryServerVersion()
+            throws RestClientException, IOException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSchemaRegistryServerVersion();
+        }
+    }
+
+    @Override
     @SuppressWarnings("deprecation")
     public Schema getByID(int id)
             throws IOException, RestClientException
@@ -146,6 +178,33 @@ public class ClassLoaderSafeSchemaRegistryClient
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.getId(subject, schema, normalize);
+        }
+    }
+
+    @Override
+    public String getGuid(String subject, ParsedSchema schema)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getGuid(subject, schema, false);
+        }
+    }
+
+    @Override
+    public String getGuid(String subject, ParsedSchema schema, boolean normalize)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getGuid(subject, schema, normalize);
+        }
+    }
+
+    @Override
+    public RegisterSchemaResponse getIdWithResponse(String subject, ParsedSchema schema, boolean normalize)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getIdWithResponse(subject, schema, normalize);
         }
     }
 
@@ -309,6 +368,15 @@ public class ClassLoaderSafeSchemaRegistryClient
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.getSchemaBySubjectAndId(subject, id);
+        }
+    }
+
+    @Override
+    public ParsedSchema getSchemaByGuid(String guid, String format)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSchemaByGuid(guid, format);
         }
     }
 
@@ -613,6 +681,51 @@ public class ClassLoaderSafeSchemaRegistryClient
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.setMode(mode, subject, force);
+        }
+    }
+
+    @Override
+    public AssociationResponse createAssociation(AssociationCreateOrUpdateRequest request)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.createAssociation(request);
+        }
+    }
+
+    @Override
+    public AssociationResponse createOrUpdateAssociation(AssociationCreateOrUpdateRequest request)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.createOrUpdateAssociation(request);
+        }
+    }
+
+    @Override
+    public List<Association> getAssociationsBySubject(String subject, String resourceType, List<String> associationTypes, String lifecycle, int offset, int limit)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getAssociationsBySubject(subject, resourceType, associationTypes, lifecycle, offset, limit);
+        }
+    }
+
+    @Override
+    public List<Association> getAssociationsByResourceId(String resourceId, String resourceType, List<String> associationTypes, String lifecycle, int offset, int limit)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getAssociationsByResourceId(resourceId, resourceType, associationTypes, lifecycle, offset, limit);
+        }
+    }
+
+    @Override
+    public void deleteAssociations(String resourceId, String resourceType, List<String> associationTypes, boolean cascadeLifecycle)
+            throws IOException, RestClientException
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            delegate.deleteAssociations(resourceId, resourceType, associationTypes, cascadeLifecycle);
         }
     }
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaLatestConnectorSmokeTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaLatestConnectorSmokeTest.java
@@ -29,7 +29,7 @@ public class TestKafkaLatestConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        TestingKafka testingKafka = closeAfterClass(TestingKafka.create("7.1.1"));
+        TestingKafka testingKafka = closeAfterClass(TestingKafka.create("8.1.1"));
         testingKafka.start();
         return KafkaQueryRunner.builder(testingKafka)
                 .setTables(REQUIRED_TPCH_TABLES)

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/protobuf/TestKafkaProtobufWithSchemaRegistryMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/protobuf/TestKafkaProtobufWithSchemaRegistryMinimalFunctionality.java
@@ -385,7 +385,10 @@ public class TestKafkaProtobufWithSchemaRegistryMinimalFunctionality
                 .addAll(newMessages)
                 .build();
         assertCount(topicName, allMessages.size());
-        assertQuery(evolvedQuery, getExpectedValues(allMessages, getEvolvedSchema(), isKeyIncluded));
+        String expectedValues = getExpectedValues(allMessages, getEvolvedSchema(), isKeyIncluded);
+        // TODO this is taking more than 1 minute to have the latest schema and assert the evolved query results,
+        //  investigate and optimize if possible (https://github.com/trinodb/trino/issues/28438)
+        assertQueryEventually(getSession(), evolvedQuery, expectedValues, io.airlift.units.Duration.valueOf("2m"));
     }
 
     private static String getExpectedValues(List<ProducerRecord<DynamicMessage, DynamicMessage>> messages, Descriptor descriptor, boolean isKeyIncluded)

--- a/plugin/trino-pinot/src/test/resources/alltypes_nullable_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/alltypes_nullable_realtimeSpec.json
@@ -59,7 +59,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/alltypes_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/alltypes_realtimeSpec.json
@@ -59,7 +59,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/customer_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/customer_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/date_time_fields_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/date_time_fields_realtimeSpec.json
@@ -30,7 +30,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/dup_table_lower_case_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/dup_table_lower_case_realtimeSpec.json
@@ -28,7 +28,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/dup_table_mixed_case_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/dup_table_mixed_case_realtimeSpec.json
@@ -28,7 +28,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/duplicate_values_in_columns_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/duplicate_values_in_columns_realtimeSpec.json
@@ -30,7 +30,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/hybrid_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/hybrid_realtimeSpec.json
@@ -40,7 +40,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/json_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/json_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/mixed_case_distinct_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/mixed_case_distinct_realtimeSpec.json
@@ -31,7 +31,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/mixed_case_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/mixed_case_realtimeSpec.json
@@ -43,7 +43,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/mixed_case_table_name_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/mixed_case_table_name_realtimeSpec.json
@@ -43,7 +43,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/nation_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/nation_realtimeSpec.json
@@ -31,7 +31,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/orders_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/orders_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/quotes_in_column_name_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/quotes_in_column_name_realtimeSpec.json
@@ -28,7 +28,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/realtimeSpec.json
@@ -27,7 +27,7 @@
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
       "stream.kafka.zk.broker.url": "zookeeper:2181/",
-      "stream.kafka.broker.list": "kafka:9092",
+      "stream.kafka.broker.list": "kafka:9093",
       "realtime.segment.flush.threshold.time": "24h",
       "realtime.segment.flush.threshold.size": "0",
       "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/region_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/region_realtimeSpec.json
@@ -31,7 +31,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/reserved_keyword_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/reserved_keyword_realtimeSpec.json
@@ -28,7 +28,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/string_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/string_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/too_many_broker_rows_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/too_many_broker_rows_realtimeSpec.json
@@ -28,7 +28,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/plugin/trino-pinot/src/test/resources/too_many_rows_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/too_many_rows_realtimeSpec.json
@@ -28,7 +28,7 @@
             "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
-            "stream.kafka.broker.list": "kafka:9092",
+            "stream.kafka.broker.list": "kafka:9093",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <dep.avro.version>1.12.1</dep.avro.version>
         <dep.aws-sdk.version>1.12.797</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
-        <dep.confluent.version>7.8.0</dep.confluent.version>
+        <dep.confluent.version>8.1.1</dep.confluent.version>
         <dep.docker.images.version>123</dep.docker.images.version>
         <dep.drift.version>1.24</dep.drift.version>
         <!-- TODO: remove once updated to airbase 250 -->
@@ -208,7 +208,7 @@
         <dep.okio.version>3.16.4</dep.okio.version>
         <dep.netty.version>4.2.10.Final</dep.netty.version>
         <dep.parquet.version>1.17.0</dep.parquet.version>
-        <dep.protobuf.version>3.25.8</dep.protobuf.version>
+        <dep.protobuf.version>4.33.2</dep.protobuf.version>
         <dep.slice.version>2.5</dep.slice.version>
         <dep.swagger.version>2.2.42</dep.swagger.version>
         <dep.takari.version>2.3.2</dep.takari.version>

--- a/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
+++ b/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
@@ -25,8 +25,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
@@ -50,7 +51,6 @@ import java.util.stream.Stream;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MILLIS;
-import static org.testcontainers.containers.KafkaContainer.KAFKA_PORT;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public final class TestingKafka
@@ -58,14 +58,15 @@ public final class TestingKafka
 {
     private static final Logger log = Logger.get(TestingKafka.class);
 
-    private static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.9.0";
+    private static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "8.1.1";
     private static final int SCHEMA_REGISTRY_PORT = 8081;
+    private static final int KAFKA_PORT = 9092;
 
     private static final DockerImageName KAFKA_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
     private static final DockerImageName SCHEMA_REGISTRY_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-schema-registry");
 
     private final Network network;
-    private final KafkaContainer kafka;
+    private final ConfluentKafkaContainer kafka;
     private final GenericContainer<?> schemaRegistry;
     private final boolean withSchemaRegistry;
     private final Closer closer = Closer.create();
@@ -96,10 +97,11 @@ public final class TestingKafka
         // Modify the template directly instead.
         MountableFile kafkaLogTemplate = forClasspathResource("log4j-kafka.properties.template");
         MountableFile schemaRegistryLogTemplate = forClasspathResource("log4j-schema-registry.properties.template");
-        kafka = new KafkaContainer(KAFKA_IMAGE_NAME.withTag(confluentPlatformVersion))
+        kafka = new ConfluentKafkaContainer(KAFKA_IMAGE_NAME.withTag(confluentPlatformVersion))
                 .withStartupAttempts(3)
                 .withNetwork(network)
                 .withNetworkAliases("kafka")
+                .withEnv("CLUSTER_ID", "test-cluster-" + UUID.randomUUID().toString().replaceAll("-", ""))
                 .withCopyFileToContainer(
                         kafkaLogTemplate,
                         "/etc/confluent/docker/log4j.properties.template");
@@ -107,7 +109,7 @@ public final class TestingKafka
                 .withStartupAttempts(3)
                 .withNetwork(network)
                 .withNetworkAliases("schema-registry")
-                .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
+                .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9093")
                 .withEnv("SCHEMA_REGISTRY_HOST_NAME", "0.0.0.0")
                 .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + SCHEMA_REGISTRY_PORT)
                 .withEnv("SCHEMA_REGISTRY_HEAP_OPTS", "-Xmx1G")
@@ -185,7 +187,7 @@ public final class TestingKafka
             command.add("--replication-factor");
             command.add(Integer.toString(replication));
             command.add("--bootstrap-server");
-            command.add("localhost:9092");
+            command.add("localhost:9093");
             if (enableLogAppendTime) {
                 command.add("--config");
                 command.add("message.timestamp.type=LogAppendTime");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR upgrades Confluent Kafka to 8.1.1 for testing.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Removed the use of deprecated org.testcontainers.containers.KafkaContainer,
instead using org.testcontainers.kafka.ConfluentKafkaContainer. In ConfluentKafkaContainer,
PLAINTEXT and BROKER ports are swapped. So, we need to change the broker port from 9092 to 9093.

Old KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9093,BROKER://0.0.0.0:9092
New KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,BROKER://0.0.0.0:9093,CONTROLLER://0.0.0.0:9094

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
