### PR TITLE
Convert long to floating point explicitly

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -1119,7 +1119,7 @@ public final class MathFunctions
         @SqlType("decimal(1,0)")
         public static long signDecimalShort(@SqlType("decimal(p, s)") long num)
         {
-            return (long) Math.signum(num);
+            return Long.signum(num);
         }
 
         @LiteralParameters({"p", "s"})
@@ -1140,7 +1140,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long sign(@SqlType(StandardTypes.BIGINT) long num)
     {
-        return (long) Math.signum(num);
+        return Long.signum(num);
     }
 
     @Description("Signum")
@@ -1148,7 +1148,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.INTEGER)
     public static long signInteger(@SqlType(StandardTypes.INTEGER) long num)
     {
-        return (long) Math.signum(num);
+        return Long.signum(num);
     }
 
     @Description("Signum")
@@ -1156,7 +1156,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.SMALLINT)
     public static long signSmallint(@SqlType(StandardTypes.SMALLINT) long num)
     {
-        return (long) Math.signum(num);
+        return Long.signum(num);
     }
 
     @Description("Signum")
@@ -1164,7 +1164,7 @@ public final class MathFunctions
     @SqlType(StandardTypes.TINYINT)
     public static long signTinyint(@SqlType(StandardTypes.TINYINT) long num)
     {
-        return (long) Math.signum(num);
+        return Long.signum(num);
     }
 
     @Description("Signum")

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -645,8 +645,8 @@ public class TestSimplifyExpressions
                 not(new Comparison(GREATER_THAN, new Constant(DOUBLE, 1.0), new Reference(DOUBLE, "D2"))),
                 not(new Comparison(GREATER_THAN, new Constant(DOUBLE, 1.0), new Reference(DOUBLE, "D2"))));
         assertSimplifiesNumericTypes(
-                not(new Comparison(GREATER_THAN, new Reference(REAL, "R1"), new Constant(REAL, Reals.toReal(1L)))),
-                not(new Comparison(GREATER_THAN, new Reference(REAL, "R1"), new Constant(REAL, Reals.toReal(1L)))));
+                not(new Comparison(GREATER_THAN, new Reference(REAL, "R1"), new Constant(REAL, Reals.toReal(1.f)))),
+                not(new Comparison(GREATER_THAN, new Reference(REAL, "R1"), new Constant(REAL, Reals.toReal(1.f)))));
         assertSimplifiesNumericTypes(
                 not(new Comparison(GREATER_THAN, new Constant(REAL, Reals.toReal(1)), new Reference(REAL, "R2"))),
                 not(new Comparison(GREATER_THAN, new Constant(REAL, Reals.toReal(1)), new Reference(REAL, "R2"))));

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestLongDecimalType.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestLongDecimalType.java
@@ -25,7 +25,6 @@ import java.math.BigDecimal;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
-import static java.lang.Math.signum;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestLongDecimalType
@@ -60,9 +59,9 @@ final class TestLongDecimalType
     {
         try {
             long actual = (long) TYPE_COMPARISON.invokeExact(decimalAsBlock(decimalA), 0, decimalAsBlock(decimalB), 0);
-            assertThat((int) signum(actual))
+            assertThat(Long.signum(actual))
                     .describedAs("bad comparison result for " + decimalA + ", " + decimalB)
-                    .isEqualTo((int) signum(expected));
+                    .isEqualTo(Long.signum(expected));
         }
         catch (Throwable throwable) {
             Throwables.throwIfUnchecked(throwable);

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftTableStatisticsReader.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftTableStatisticsReader.java
@@ -88,7 +88,7 @@ public class RedshiftTableStatisticsReader
                                     // For example, -1 indicates a unique column in which the number of distinct values is the same as the number of rows."
                                     // https://www.postgresql.org/docs/9.3/view-pg-stats.html
                                     if (distinctValuesIndicator < 0.0) {
-                                        return Math.min(-distinctValuesIndicator * rowCount, rowCount);
+                                        return Math.min(-distinctValuesIndicator * rowCount, (float) rowCount);
                                     }
                                     return distinctValuesIndicator;
                                 })

--- a/pom.xml
+++ b/pom.xml
@@ -2942,6 +2942,7 @@
                                     -Xep:InconsistentHashCode:ERROR \
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR \
                                     -Xep:InvalidInlineTag:ERROR \
+                                    -Xep:LongFloatConversion:ERROR \
                                     -Xep:MissingCasesInEnumSwitch:ERROR \
                                     -Xep:MissingOverride:ERROR \
                                     <!-- Sometimes our javadoc contains just a @see directive -->


### PR DESCRIPTION
Enable `LongFloatConversion`. This also improves Trino `signum` function implementation.
