### PR TITLE
Produce pages incrementally for iceberg system tables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/AllManifestsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/AllManifestsTable.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.iceberg.system;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.connector.ColumnMetadata;
@@ -66,24 +65,22 @@ public class AllManifestsTable
     }
 
     @Override
-    protected void addRow(PageListBuilder pagesBuilder, Row row, TimeZoneKey timeZoneKey)
+    protected void addRow(IcebergSystemTablePageSource pageSource, Row row, TimeZoneKey timeZoneKey)
     {
-        pagesBuilder.beginRow();
-        pagesBuilder.appendInteger(row.get("content", Integer.class));
-        pagesBuilder.appendVarchar(row.get("path", String.class));
-        pagesBuilder.appendBigint(row.get("length", Long.class));
-        pagesBuilder.appendInteger(row.get("partition_spec_id", Integer.class));
-        pagesBuilder.appendBigint(row.get("added_snapshot_id", Long.class));
-        pagesBuilder.appendInteger(row.get("added_data_files_count", Integer.class));
-        pagesBuilder.appendInteger(row.get("existing_data_files_count", Integer.class));
-        pagesBuilder.appendInteger(row.get("deleted_data_files_count", Integer.class));
-        pagesBuilder.appendInteger(row.get("added_delete_files_count", Integer.class));
-        pagesBuilder.appendInteger(row.get("existing_delete_files_count", Integer.class));
-        pagesBuilder.appendInteger(row.get("deleted_delete_files_count", Integer.class));
+        pageSource.appendInteger(row.get("content", Integer.class));
+        pageSource.appendVarchar(row.get("path", String.class));
+        pageSource.appendBigint(row.get("length", Long.class));
+        pageSource.appendInteger(row.get("partition_spec_id", Integer.class));
+        pageSource.appendBigint(row.get("added_snapshot_id", Long.class));
+        pageSource.appendInteger(row.get("added_data_files_count", Integer.class));
+        pageSource.appendInteger(row.get("existing_data_files_count", Integer.class));
+        pageSource.appendInteger(row.get("deleted_data_files_count", Integer.class));
+        pageSource.appendInteger(row.get("added_delete_files_count", Integer.class));
+        pageSource.appendInteger(row.get("existing_delete_files_count", Integer.class));
+        pageSource.appendInteger(row.get("deleted_delete_files_count", Integer.class));
         //noinspection unchecked
-        appendPartitionSummaries((ArrayBlockBuilder) pagesBuilder.nextColumn(), row.get("partition_summaries", List.class));
-        pagesBuilder.appendBigint(row.get("reference_snapshot_id", Long.class));
-        pagesBuilder.endRow();
+        appendPartitionSummaries((ArrayBlockBuilder) pageSource.nextColumn(), row.get("partition_summaries", List.class));
+        pageSource.appendBigint(row.get("reference_snapshot_id", Long.class));
     }
 
     private static void appendPartitionSummaries(ArrayBlockBuilder arrayBuilder, List<StructLike> partitionSummaries)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/EntriesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/EntriesTable.java
@@ -15,7 +15,6 @@ package io.trino.plugin.iceberg.system;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.IcebergUtil;
-import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.block.RowBlockBuilder;
@@ -137,19 +136,17 @@ public class EntriesTable
     }
 
     @Override
-    protected void addRow(PageListBuilder pagesBuilder, Row row, TimeZoneKey timeZoneKey)
+    protected void addRow(IcebergSystemTablePageSource pageSource, Row row, TimeZoneKey timeZoneKey)
     {
-        pagesBuilder.beginRow();
-        pagesBuilder.appendInteger(row.get("status", Integer.class));
-        pagesBuilder.appendBigint(row.get("snapshot_id", Long.class));
-        pagesBuilder.appendBigint(row.get("sequence_number", Long.class));
-        pagesBuilder.appendBigint(row.get("file_sequence_number", Long.class));
+        pageSource.appendInteger(row.get("status", Integer.class));
+        pageSource.appendBigint(row.get("snapshot_id", Long.class));
+        pageSource.appendBigint(row.get("sequence_number", Long.class));
+        pageSource.appendBigint(row.get("file_sequence_number", Long.class));
         StructProjection dataFile = row.get("data_file", StructProjection.class);
-        appendDataFile((RowBlockBuilder) pagesBuilder.nextColumn(), dataFile);
+        appendDataFile((RowBlockBuilder) pageSource.nextColumn(), dataFile);
         ReadableMetricsStruct readableMetrics = row.get("readable_metrics", ReadableMetricsStruct.class);
         String readableMetricsJson = readableMetricsToJson(readableMetrics, primitiveFields);
-        pagesBuilder.appendVarchar(readableMetricsJson);
-        pagesBuilder.endRow();
+        pageSource.appendVarchar(readableMetricsJson);
     }
 
     private void appendDataFile(RowBlockBuilder blockBuilder, StructProjection dataFile)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/IcebergSystemTablePageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/IcebergSystemTablePageSource.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system;
+
+import com.google.common.io.Closer;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Type;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public final class IcebergSystemTablePageSource
+        implements ConnectorPageSource
+{
+    private final List<Type> types;
+    private final TimeZoneKey timeZoneKey;
+    private final RowWriter rowWriter;
+    private final Map<String, Integer> columnNameToPosition;
+    private final PageBuilder pageBuilder;
+    private final Closer closer = Closer.create();
+    private final Iterator<FileScanTask> fileScanTasksIterator;
+
+    private boolean closed;
+    private boolean finished;
+    private int currentChannel;
+
+    public IcebergSystemTablePageSource(
+            List<Type> types,
+            TimeZoneKey timeZoneKey,
+            RowWriter rowWriter,
+            Map<String, Integer> columnNameToPosition,
+            TableScan tableScan)
+    {
+        this.types = requireNonNull(types, "types is null");
+        this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
+        this.rowWriter = requireNonNull(rowWriter, "rowWriter is null");
+        this.columnNameToPosition = requireNonNull(columnNameToPosition, "columnNameToPosition is null");
+        this.pageBuilder = new PageBuilder(types);
+        CloseableIterable<FileScanTask> fileScanTasks = closer.register(tableScan.planFiles());
+        this.fileScanTasksIterator = closer.register(fileScanTasks.iterator());
+        this.currentChannel = -1;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        verify(pageBuilder.isEmpty(), "Expected pageBuilder to be empty");
+        if (finished) {
+            return null;
+        }
+
+        checkState(!closed, "page source is closed");
+        while (!pageBuilder.isFull() && fileScanTasksIterator.hasNext()) {
+            try (CloseableIterable<StructLike> dataRows = fileScanTasksIterator.next().asDataTask().rows()) {
+                dataRows.forEach(row -> {
+                    BaseSystemTable.Row rowWrapper = new BaseSystemTable.Row(row, columnNameToPosition);
+                    writeRow(rowWrapper);
+                });
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        if (!fileScanTasksIterator.hasNext()) {
+            finished = true;
+        }
+
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return SourcePage.create(page);
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void appendInteger(Integer value)
+    {
+        if (checkNonNull(value)) {
+            INTEGER.writeLong(nextColumn(), value);
+        }
+    }
+
+    public void appendBigint(Long value)
+    {
+        if (checkNonNull(value)) {
+            BIGINT.writeLong(nextColumn(), value);
+        }
+    }
+
+    public void appendTimestampTzMillis(long millisUtc, TimeZoneKey timeZoneKey)
+    {
+        TIMESTAMP_TZ_MILLIS.writeLong(nextColumn(), packDateTimeWithZone(millisUtc, timeZoneKey));
+    }
+
+    public void appendVarchar(String value)
+    {
+        VARCHAR.writeString(nextColumn(), value);
+    }
+
+    public void appendVarcharVarcharMap(Map<String, String> values)
+    {
+        MapBlockBuilder column = (MapBlockBuilder) nextColumn();
+        column.buildEntry((keyBuilder, valueBuilder) -> values.forEach((key, value) -> {
+            VARCHAR.writeString(keyBuilder, key);
+            VARCHAR.writeString(valueBuilder, value);
+        }));
+    }
+
+    public BlockBuilder nextColumn()
+    {
+        int currentChannelValue = currentChannel;
+        currentChannel++;
+        return pageBuilder.getBlockBuilder(currentChannelValue);
+    }
+
+    @FunctionalInterface
+    public interface RowWriter
+    {
+        void writeRow(IcebergSystemTablePageSource pageSource, BaseSystemTable.Row row, TimeZoneKey timeZoneKey);
+    }
+
+    private boolean checkNonNull(Object object)
+    {
+        if (object == null) {
+            nextColumn().appendNull();
+            return false;
+        }
+        return true;
+    }
+
+    private void writeRow(BaseSystemTable.Row row)
+    {
+        beginRow();
+        rowWriter.writeRow(this, row, timeZoneKey);
+        endRow();
+    }
+
+    private void beginRow()
+    {
+        checkArgument(currentChannel == -1, "already in row");
+        pageBuilder.declarePosition();
+        currentChannel = 0;
+    }
+
+    private void endRow()
+    {
+        checkArgument(currentChannel == types.size(), "not at end of row");
+        currentChannel = -1;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/MetadataLogEntriesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/MetadataLogEntriesTable.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.iceberg.system;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
@@ -63,14 +62,12 @@ public class MetadataLogEntriesTable
     }
 
     @Override
-    protected void addRow(PageListBuilder pagesBuilder, Row row, TimeZoneKey timeZoneKey)
+    protected void addRow(IcebergSystemTablePageSource pageSource, Row row, TimeZoneKey timeZoneKey)
     {
-        pagesBuilder.beginRow();
-        pagesBuilder.appendTimestampTzMillis(row.get(TIMESTAMP_COLUMN_NAME, Long.class) / MICROSECONDS_PER_MILLISECOND, timeZoneKey);
-        pagesBuilder.appendVarchar(row.get(FILE_COLUMN_NAME, String.class));
-        pagesBuilder.appendBigint(row.get(LATEST_SNAPSHOT_ID_COLUMN_NAME, Long.class));
-        pagesBuilder.appendInteger(row.get(LATEST_SCHEMA_ID_COLUMN_NAME, Integer.class));
-        pagesBuilder.appendBigint(row.get(LATEST_SEQUENCE_NUMBER_COLUMN_NAME, Long.class));
-        pagesBuilder.endRow();
+        pageSource.appendTimestampTzMillis(row.get(TIMESTAMP_COLUMN_NAME, Long.class) / MICROSECONDS_PER_MILLISECOND, timeZoneKey);
+        pageSource.appendVarchar(row.get(FILE_COLUMN_NAME, String.class));
+        pageSource.appendBigint(row.get(LATEST_SNAPSHOT_ID_COLUMN_NAME, Long.class));
+        pageSource.appendInteger(row.get(LATEST_SCHEMA_ID_COLUMN_NAME, Integer.class));
+        pageSource.appendBigint(row.get(LATEST_SEQUENCE_NUMBER_COLUMN_NAME, Long.class));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/RefsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/RefsTable.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.iceberg.system;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
@@ -52,15 +51,13 @@ public class RefsTable
     }
 
     @Override
-    protected void addRow(PageListBuilder pagesBuilder, Row row, TimeZoneKey timeZoneKey)
+    protected void addRow(IcebergSystemTablePageSource pageSource, Row row, TimeZoneKey timeZoneKey)
     {
-        pagesBuilder.beginRow();
-        pagesBuilder.appendVarchar(row.get("name", String.class));
-        pagesBuilder.appendVarchar(row.get("type", String.class));
-        pagesBuilder.appendBigint(row.get("snapshot_id", Long.class));
-        pagesBuilder.appendBigint(row.get("max_reference_age_in_ms", Long.class));
-        pagesBuilder.appendInteger(row.get("min_snapshots_to_keep", Integer.class));
-        pagesBuilder.appendBigint(row.get("max_snapshot_age_in_ms", Long.class));
-        pagesBuilder.endRow();
+        pageSource.appendVarchar(row.get("name", String.class));
+        pageSource.appendVarchar(row.get("type", String.class));
+        pageSource.appendBigint(row.get("snapshot_id", Long.class));
+        pageSource.appendBigint(row.get("max_reference_age_in_ms", Long.class));
+        pageSource.appendInteger(row.get("min_snapshots_to_keep", Integer.class));
+        pageSource.appendBigint(row.get("max_snapshot_age_in_ms", Long.class));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/SnapshotsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/SnapshotsTable.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.iceberg.system;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.util.PageListBuilder;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
@@ -69,16 +68,14 @@ public class SnapshotsTable
     }
 
     @Override
-    protected void addRow(PageListBuilder pagesBuilder, Row row, TimeZoneKey timeZoneKey)
+    protected void addRow(IcebergSystemTablePageSource pageSource, Row row, TimeZoneKey timeZoneKey)
     {
-        pagesBuilder.beginRow();
-        pagesBuilder.appendTimestampTzMillis(row.get(COMMITTED_AT_COLUMN_NAME, Long.class) / MICROSECONDS_PER_MILLISECOND, timeZoneKey);
-        pagesBuilder.appendBigint(row.get(SNAPSHOT_ID_COLUMN_NAME, Long.class));
-        pagesBuilder.appendBigint(row.get(PARENT_ID_COLUMN_NAME, Long.class));
-        pagesBuilder.appendVarchar(row.get(OPERATION_COLUMN_NAME, String.class));
-        pagesBuilder.appendVarchar(row.get(MANIFEST_LIST_COLUMN_NAME, String.class));
+        pageSource.appendTimestampTzMillis(row.get(COMMITTED_AT_COLUMN_NAME, Long.class) / MICROSECONDS_PER_MILLISECOND, timeZoneKey);
+        pageSource.appendBigint(row.get(SNAPSHOT_ID_COLUMN_NAME, Long.class));
+        pageSource.appendBigint(row.get(PARENT_ID_COLUMN_NAME, Long.class));
+        pageSource.appendVarchar(row.get(OPERATION_COLUMN_NAME, String.class));
+        pageSource.appendVarchar(row.get(MANIFEST_LIST_COLUMN_NAME, String.class));
         //noinspection unchecked
-        pagesBuilder.appendVarcharVarcharMap(row.get(SUMMARY_COLUMN_NAME, Map.class));
-        pagesBuilder.endRow();
+        pageSource.appendVarcharVarcharMap(row.get(SUMMARY_COLUMN_NAME, Map.class));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/PageListBuilder.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/PageListBuilder.java
@@ -17,21 +17,16 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.Type;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public final class PageListBuilder
@@ -112,23 +107,9 @@ public final class PageListBuilder
         }
     }
 
-    public void appendTimestampTzMillis(long millisUtc, TimeZoneKey timeZoneKey)
-    {
-        TIMESTAMP_TZ_MILLIS.writeLong(nextColumn(), packDateTimeWithZone(millisUtc, timeZoneKey));
-    }
-
     public void appendVarchar(String value)
     {
         VARCHAR.writeString(nextColumn(), value);
-    }
-
-    public void appendVarcharVarcharMap(Map<String, String> values)
-    {
-        MapBlockBuilder column = (MapBlockBuilder) nextColumn();
-        column.buildEntry((keyBuilder, valueBuilder) -> values.forEach((key, value) -> {
-            VARCHAR.writeString(keyBuilder, key);
-            VARCHAR.writeString(valueBuilder, value);
-        }));
     }
 
     public BlockBuilder nextColumn()


### PR DESCRIPTION
## Description
Avoid using FixedPageSource and return a Page after each FileScanTask
instead of building a list of Pages and returning them in one go.
This allows incremental processing of metadata tables
and reduces peak memory usage on coordinator.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
