### PR TITLE
Add support to cast VARBINARY to JSON using base64

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -19,6 +19,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Murmur3Hash128;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.airlift.slice.SpookyHashV2;
 import io.airlift.slice.XxHash64;
@@ -26,6 +27,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
@@ -35,7 +37,11 @@ import java.util.zip.CRC32;
 
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.operator.scalar.HmacFunctions.computeHash;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.StandardTypes.VARBINARY;
 import static io.trino.util.Failures.checkCondition;
 
 public final class VarbinaryFunctions
@@ -500,5 +506,28 @@ public final class VarbinaryFunctions
             reverse.setByte(i, inputSlice.getByte((length - 1) - i));
         }
         return reverse;
+    }
+
+    @SqlType(JSON)
+    @ScalarOperator(CAST)
+    public static Slice castToJson(@SqlType(VARBINARY) Slice binary)
+    {
+        Slice encodedBinary = toBase64(binary);
+        Slice slice = Slices.allocate(2 + encodedBinary.length());
+        SliceOutput output = slice.getOutput();
+        output.writeByte('"');
+        output.writeBytes(encodedBinary);
+        output.writeByte('"');
+        return slice;
+    }
+
+    @SqlType(VARBINARY)
+    @ScalarOperator(CAST)
+    public static Slice castFromJson(@SqlType(JSON) Slice json)
+    {
+        if (json.length() < 2 || json.getByte(0) != '"' || json.getByte(json.length() - 1) != '"') {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Expected quoted base64-encoded JSON string");
+        }
+        return fromBase64Varbinary(json.slice(1, json.length() - 2));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -51,6 +51,7 @@ import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import io.trino.type.BigintOperators;
 import io.trino.type.BooleanOperators;
@@ -81,6 +82,7 @@ import static com.fasterxml.jackson.core.JsonToken.FIELD_NAME;
 import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
 import static com.google.common.base.Verify.verify;
+import static io.trino.operator.scalar.VarbinaryFunctions.fromBase64Varchar;
 import static io.trino.plugin.base.util.JsonUtils.jsonFactoryBuilder;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -92,6 +94,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.type.DateTimes.formatTimestamp;
 import static io.trino.type.JsonType.JSON;
@@ -181,6 +184,7 @@ public final class JsonUtil
                 type instanceof DoubleType ||
                 type instanceof DecimalType ||
                 type instanceof VarcharType ||
+                type instanceof VarbinaryType ||
                 type instanceof JsonType ||
                 type instanceof TimestampType ||
                 type instanceof DateType) {
@@ -211,6 +215,7 @@ public final class JsonUtil
                 type instanceof DoubleType ||
                 type instanceof DecimalType ||
                 type instanceof VarcharType ||
+                type instanceof VarbinaryType ||
                 type instanceof JsonType) {
             return true;
         }
@@ -318,6 +323,9 @@ public final class JsonUtil
             }
             if (type instanceof VarcharType) {
                 return new VarcharJsonGeneratorWriter(type);
+            }
+            if (type instanceof VarbinaryType) {
+                return new VarbinaryJsonGeneratorWriter();
             }
             if (type instanceof JsonType) {
                 return new JsonJsonGeneratorWriter();
@@ -508,6 +516,23 @@ public final class JsonUtil
             else {
                 Slice value = type.getSlice(block, position);
                 jsonGenerator.writeString(value.toStringUtf8());
+            }
+        }
+    }
+
+    private static class VarbinaryJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                Slice value = VARBINARY.getSlice(block, position);
+                jsonGenerator.writeBinary(value.byteArray(), value.byteArrayOffset(), value.length());
             }
         }
     }
@@ -904,6 +929,9 @@ public final class JsonUtil
             if (type instanceof VarcharType) {
                 return new VarcharBlockBuilderAppender(type);
             }
+            if (type instanceof VarbinaryType) {
+                return new VarbinaryBlockBuilderAppender();
+            }
             if (type instanceof JsonType) {
                 return (parser, blockBuilder) -> {
                     String json = JSON_MAPPED_UNORDERED.writeValueAsString(parser.readValueAsTree());
@@ -1121,6 +1149,25 @@ public final class JsonUtil
             else {
                 type.writeSlice(blockBuilder, result);
             }
+        }
+    }
+
+    private static class VarbinaryBlockBuilderAppender
+            implements BlockBuilderAppender
+    {
+        @Override
+        public void append(JsonParser parser, BlockBuilder blockBuilder)
+                throws IOException
+        {
+            if (parser.getCurrentToken() == JsonToken.VALUE_NULL) {
+                blockBuilder.appendNull();
+                return;
+            }
+            if (parser.getCurrentToken() != JsonToken.VALUE_STRING) {
+                throw new JsonCastException(format("Expected a json string, but got %s", parser.getText()));
+            }
+            Slice varchar = currentTokenAsVarchar(parser);
+            VARBINARY.writeSlice(blockBuilder, fromBase64Varchar(varchar));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
@@ -13,8 +13,12 @@
  */
 package io.trino.operator.scalar;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.SqlVarbinary;
 import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.QueryFailedException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,13 +33,18 @@ import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.SqlVarbinaryTestingUtil.sqlVarbinary;
 import static io.trino.testing.SqlVarbinaryTestingUtil.sqlVarbinaryFromHex;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static io.trino.type.JsonType.JSON;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -988,6 +997,58 @@ public class TestVarbinaryFunctions
 
         assertThat(assertions.function("reverse", "CAST('racecar' AS VARBINARY)"))
                 .isEqualTo(sqlVarbinary("racecar"));
+    }
+
+    @Test
+    public void testVarbinaryToJson()
+    {
+        assertThat(assertions.expression("CAST(binary as JSON)")
+                .binding("binary", "from_base64('" + encodeBase64("hello") + "')"))
+                .hasType(JSON)
+                .isEqualTo(format("\"%s\"", encodeBase64("hello")));
+
+        assertThat(assertions.expression("CAST(CAST(row(binary) AS row(data varbinary)) as JSON)")
+                .binding("binary", "from_base64('" + encodeBase64("hello") + "')"))
+                .hasType(JSON)
+                .isEqualTo("{\"data\":\"aGVsbG8=\"}");
+
+        assertThat(assertions.expression("CAST(ARRAY[binary] as JSON)")
+                .binding("binary", "from_base64('" + encodeBase64("hello") + "')"))
+                .hasType(JSON)
+                .isEqualTo("[\"aGVsbG8=\"]");
+    }
+
+    @Test
+    public void testJsonToVarbinary()
+    {
+        SqlVarbinary helloVarbinary = new SqlVarbinary("hello".getBytes(UTF_8));
+
+        assertThat(assertions.expression("CAST(json as VARBINARY)")
+                .binding("json", "JSON '\"" + encodeBase64("hello") + "\"'"))
+                .hasType(VARBINARY)
+                .isEqualTo(helloVarbinary);
+
+        assertThat(assertions.expression("CAST(json AS row(data VARBINARY))")
+                .binding("json", "JSON '{\"data\":\"aGVsbG8=\"}'"))
+                .hasType(rowType(field("data", VARBINARY)))
+                .isEqualTo(ImmutableList.of(helloVarbinary));
+
+        assertThat(assertions.expression("CAST(json AS array(VARBINARY))")
+                .binding("json", "JSON '[\"aGVsbG8=\"]'"))
+                .hasType(new ArrayType(VARBINARY))
+                .isEqualTo(ImmutableList.of(helloVarbinary));
+
+        assertThatThrownBy(() -> assertions.expression("CAST(json AS VARBINARY)")
+                .binding("json", "JSON '123'")
+                .evaluate())
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessageContaining("Expected quoted base64-encoded JSON string");
+
+        assertThatThrownBy(() -> assertions.expression("CAST(json AS VARBINARY)")
+                .binding("json", "JSON '\"This is not base64\"'")
+                .evaluate())
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessageContaining("Illegal base64 character 20");
     }
 
     private static String encodeBase64(byte[] value)


### PR DESCRIPTION
## Description
Casting of `row(greeting varchar, varbinary planet)` to json was not possible.

This PR adds support by converting the varbinary to base64 string:
`{"greeting": "hello", "planet": "d29ybGQ="}`

Fixes https://github.com/trinodb/trino/issues/10814

## Release notes

```markdown
## General
* Add support for casting `varbinary` to `json` with base64. ({issue}`28234`)
```
