### PR TITLE
Add return after abort when server is still initializing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/InternalAuthenticationManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalAuthenticationManager.java
@@ -127,6 +127,7 @@ public class InternalAuthenticationManager
                     .type(TEXT_PLAIN_TYPE.toString())
                     .entity("Trino server is still initializing")
                     .build());
+            return;
         }
 
         Identity identity = Identity.forUser("<internal>")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

From what I can tell, this method should not continue execution after calling `abortWith`, as all other places return after it.
Queries will still fail in this case, but the error that's reported in these cases was very misleading, since the response that's sent from here was not valid json:

```json
{
    "type": "com.fasterxml.jackson.core.JsonParseException",
    "message": "Unrecognized token 'io': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 4]",
}
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
