### PR TITLE
Return after aborting query if server is still initialising

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/InternalAuthenticationManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalAuthenticationManager.java
@@ -127,6 +127,7 @@ public class InternalAuthenticationManager
                     .type(TEXT_PLAIN_TYPE.toString())
                     .entity("Trino server is still initializing")
                     .build());
+            return;
         }
 
         Identity identity = Identity.forUser("<internal>")


### PR DESCRIPTION
## Description

Add `return;` to exit when the server isn't started.

## Additional context and related issues

We've been running into odd issues where we're seeing error messages containing:
```
{
    "type": "com.fasterxml.jackson.core.JsonParseException",
    "message": "Unrecognized token 'io': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 4]",
}
```

After looking into it, this happens when a worker restarts. We're expecting the query to break in this case, but this error message is very misleading.

From a cursory glance at other places in the code where we call `abortWith`, we then `return;`, so I'm adding this here to follow the same pattern.

This should allow the correct error message to bubble up when a worker is restarted mid-execution.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: