### PR TITLE
Get connectorName without iterating over registered catalogs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TableInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TableInfo.java
@@ -62,11 +62,9 @@ public record TableInfo(
     {
         CatalogSchemaTableName tableName = metadata.getTableName(session, node.getTable());
         TableProperties tableProperties = metadata.getTableProperties(session, node.getTable());
-        Optional<String> connectorName = metadata.listCatalogs(session).stream()
-                .filter(catalogInfo -> catalogInfo.catalogName().equals(tableName.getCatalogName()))
+        Optional<String> connectorName = metadata.getCatalogInfo(session, tableName.getCatalogName())
                 .map(CatalogInfo::connectorName)
-                .map(ConnectorName::toString)
-                .findFirst();
+                .map(ConnectorName::toString);
         QualifiedObjectName objectName = new QualifiedObjectName(tableName.getCatalogName(), tableName.getSchemaTableName().getSchemaName(), tableName.getSchemaTableName().getTableName());
         return new TableInfo(connectorName, objectName, tableProperties.getPredicate());
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
@@ -98,6 +98,11 @@ public class Catalog
         return catalogStatus;
     }
 
+    public CatalogInfo toInfo()
+    {
+        return new CatalogInfo(catalogName.toString(), catalogHandle, connectorName, catalogStatus);
+    }
+
     public boolean isFailed()
     {
         return catalogConnector == null;

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -495,6 +495,11 @@ public interface Metadata
     Optional<CatalogHandle> getCatalogHandle(Session session, String catalogName);
 
     /**
+     * Returns a catalog info for the specified catalog name.
+     */
+    Optional<CatalogInfo> getCatalogInfo(Session session, String catalogName);
+
+    /**
      * Gets all the catalogs
      */
     List<CatalogInfo> listCatalogs(Session session);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1410,6 +1410,12 @@ public final class MetadataManager
     }
 
     @Override
+    public Optional<CatalogInfo> getCatalogInfo(Session session, String catalogName)
+    {
+        return transactionManager.getOptionalCatalogInfo(session.getRequiredTransactionId(), catalogName);
+    }
+
+    @Override
     public List<CatalogInfo> listCatalogs(Session session)
     {
         return transactionManager.getCatalogs(session.getRequiredTransactionId());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/InputExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/InputExtractor.java
@@ -69,11 +69,9 @@ public class InputExtractor
         CatalogSchemaTableName tableName = metadata.getTableName(session, table);
         SchemaTableName schemaTable = tableName.getSchemaTableName();
         Optional<Object> inputMetadata = metadata.getInfo(session, table);
-        Optional<String> connectorName = metadata.listCatalogs(session).stream()
-                .filter(catalogInfo -> catalogInfo.catalogName().equals(tableName.getCatalogName()))
+        Optional<String> connectorName = metadata.getCatalogInfo(session, tableName.getCatalogName())
                 .map(CatalogInfo::connectorName)
-                .map(ConnectorName::toString)
-                .findFirst();
+                .map(ConnectorName::toString);
         return new Input(
                 connectorName,
                 tableName.getCatalogName(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TableInfoSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TableInfoSupplier.java
@@ -45,11 +45,9 @@ public class TableInfoSupplier
     {
         CatalogSchemaTableName tableName = metadata.getTableName(session, node.getTable());
         TableProperties tableProperties = metadata.getTableProperties(session, node.getTable());
-        Optional<String> connectorName = metadata.listCatalogs(session).stream()
-                .filter(catalogInfo -> catalogInfo.catalogName().equals(tableName.getCatalogName()))
+        Optional<String> connectorName = metadata.getCatalogInfo(session, tableName.getCatalogName())
                 .map(CatalogInfo::connectorName)
-                .map(ConnectorName::toString)
-                .findFirst();
+                .map(ConnectorName::toString);
         QualifiedObjectName objectName = new QualifiedObjectName(tableName.getCatalogName(), tableName.getSchemaTableName().getSchemaName(), tableName.getSchemaTableName().getTableName());
         return new TableInfo(connectorName, objectName, tableProperties.getPredicate());
     }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -887,6 +887,15 @@ public class TracingMetadata
     }
 
     @Override
+    public Optional<CatalogInfo> getCatalogInfo(Session session, String catalogName)
+    {
+        Span span = startSpan("getCatalogInfo", catalogName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getCatalogInfo(session, catalogName);
+        }
+    }
+
+    @Override
     public List<CatalogInfo> listCatalogs(Session session)
     {
         Span span = startSpan("listCatalogs");

--- a/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
@@ -90,6 +90,12 @@ public class NoOpTransactionManager
     }
 
     @Override
+    public Optional<CatalogInfo> getOptionalCatalogInfo(TransactionId requiredTransactionId, String catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public CatalogMetadata getCatalogMetadata(TransactionId transactionId, CatalogHandle catalogHandle)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
@@ -57,6 +57,8 @@ public interface TransactionManager
 
     Optional<CatalogMetadata> getOptionalCatalogMetadata(TransactionId transactionId, String catalogName);
 
+    Optional<CatalogInfo> getOptionalCatalogInfo(TransactionId requiredTransactionId, String catalogName);
+
     CatalogMetadata getCatalogMetadata(TransactionId transactionId, CatalogHandle catalogHandle);
 
     CatalogMetadata getCatalogMetadataForWrite(TransactionId transactionId, CatalogHandle catalogHandle);

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -594,6 +594,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<CatalogInfo> getCatalogInfo(Session session, String catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<CatalogInfo> listCatalogs(Session session)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
+++ b/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
@@ -118,6 +118,12 @@ public class TestingTransactionManager
     }
 
     @Override
+    public Optional<CatalogInfo> getOptionalCatalogInfo(TransactionId requiredTransactionId, String catalogName)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public CatalogMetadata getCatalogMetadata(TransactionId transactionId, CatalogHandle catalogHandle)
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Avoids iterating over all active catalogs to get a connector name

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
