### PR TITLE
Added trino-logger-event-listener

### DIFF
--- a/plugin/trino-logger-event-listener/README.md
+++ b/plugin/trino-logger-event-listener/README.md
@@ -1,0 +1,375 @@
+# Trino Logger Event Listener
+
+This is a Trino plugin that logs query events to a file using Airlift Logger.
+
+## Configuration
+
+The Logger Event Listener can be configured through Trino properties. Add the following properties to your Trino configuration:
+
+### Basic Configuration
+
+```properties
+# Enable the query log event listener plugin
+event-listener.type=logger
+
+# Log query created events
+logger-event-listener.log-created=true
+
+# Log query completed events
+logger-event-listener.log-completed=true
+
+# Log query executed events
+logger-event-listener.log-executed=true
+
+# Path to the log file (optional, default: logger.log)
+logger-event-listener.log-file-path=/var/log/trino/logger.log
+```
+
+### Advanced Configuration: Field Control
+
+#### Exclude Sensitive Fields
+
+Exclude specific fields from being logged (their values will be replaced with null):
+
+```properties
+# Comma-separated list of fields to exclude
+# Example: payload,user,sourceCode,password
+logger-event-listener.excluded-fields=payload,user,sourceCode
+```
+
+#### Truncate Large Fields
+
+Control the maximum size of field values to prevent excessive log sizes:
+
+```properties
+# Maximum field size before truncation (default: 4KB)
+# Supported units: B, KB, MB, GB
+logger-event-listener.max-field-size=8KB
+```
+
+#### Selective Field Truncation (by Size)
+
+Truncate specific fields (like `query` and `stageInfo`) if they exceed a size limit:
+
+```properties
+# Comma-separated list of field names to truncate
+# These fields will be truncated if they exceed the truncation-size-limit
+logger-event-listener.truncated-fields=query,stageInfo,sourceCode
+
+# Maximum size for truncated fields (default: 2KB)
+# Supported units: B, KB, MB, GB
+logger-event-listener.truncation-size-limit=2KB
+```
+
+When a field exceeds the truncation size limit, it will be truncated with a `...[TRUNCATED]` suffix appended.
+
+### Event Filtering
+
+Filter out events from being logged based on specific attributes. This is useful for reducing log noise by excluding events you don't care about.
+
+#### Ignore by Query State
+
+Skip logging events for specific query states:
+
+```properties
+# Comma-separated list of query states to ignore
+# Examples: RUNNING, QUEUED, WAITING, PLANNING, FINISHING, FINISHED, FAILED, CANCELED
+logger-event-listener.ignored-query-states=RUNNING,QUEUED
+```
+
+#### Ignore by Update Type
+
+Skip logging for specific update types (INSERT, UPDATE, DELETE, etc.):
+
+```properties
+# Comma-separated list of update types to ignore
+logger-event-listener.ignored-update-types=INSERT,UPDATE,DELETE
+```
+
+#### Ignore by Query Type
+
+Skip logging for specific query types (DML, DDL, UTILITY, EXPLAIN, etc.):
+
+```properties
+# Comma-separated list of query types to ignore
+logger-event-listener.ignored-query-types=UTILITY,EXPLAIN
+```
+
+#### Ignore by Failure Type
+
+Skip logging for specific failure types (only applies to QueryCompletedEvent):
+
+```properties
+# Comma-separated list of failure types to ignore
+# Examples: USER_ERROR, INTERNAL_ERROR, EXTERNAL, INSUFFICIENT_RESOURCES
+logger-event-listener.ignored-failure-types=USER_ERROR
+```
+
+### Complete Configuration Example
+
+```properties
+# Enable events
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+logger-event-listener.log-executed=false
+
+# Log file path
+logger-event-listener.log-file-path=/var/log/trino/logger.log
+
+# Exclude sensitive information
+logger-event-listener.excluded-fields=payload,user,password,authorizationToken,sourceCode
+
+# Limit field sizes
+logger-event-listener.max-field-size=16KB
+
+# Truncate specific large fields
+logger-event-listener.truncated-fields=query,stageInfo,plan
+logger-event-listener.truncation-size-limit=2KB
+
+# Ignore certain events
+logger-event-listener.ignored-query-states=RUNNING,QUEUED
+logger-event-listener.ignored-update-types=INSERT
+logger-event-listener.ignored-query-types=UTILITY,EXPLAIN
+logger-event-listener.ignored-failure-types=USER_ERROR
+```
+
+## Logged Events
+
+The plugin logs the following event types as JSON:
+
+- **QueryCreatedEvent**: Logged when a query is created
+- **QueryCompletedEvent**: Logged when a query completes (successfully or with error)
+- **QueryExecutionEvent**: Logged for query execution events
+
+## Log Output
+
+Each event is logged as a JSON string with the prefix indicating the event type:
+- `QUERY_CREATED: {json}`
+- `QUERY_COMPLETED: {json}`
+- `QUERY_EXECUTED: {json}`
+
+## Features
+
+### Field Exclusion
+When a field is in the excluded fields list, its value will be replaced with `null` in the logged output. This is useful for:
+- Sensitive information (passwords, tokens, API keys)
+- PII (personally identifiable information)
+- Large payloads that aren't needed for logging
+
+### Field Size Limiting
+Generic limit on all field values. Fields larger than the configured `max-field-size` will be completely truncated.
+
+### Selective Field Truncation
+Selectively truncate specific fields (like `query`, `stageInfo`, or `plan`) to a configurable byte limit. This allows you to:
+- Preserve most of the field content (truncated, not excluded)
+- Keep important metadata for debugging
+- Control log size for specific verbose fields
+- Works independently from field exclusion
+
+### Event Filtering
+Filter out events from logging based on specific attributes (query state, update type, query type, failure type). This helps:
+- Reduce log noise and storage
+- Focus on specific event types
+- Skip routine operations (e.g., UTILITY queries, RUNNING state)
+- Ignore common error types
+
+## Configuration File Example
+
+Create or modify `etc/event-listener.properties`:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+logger-event-listener.log-executed=false
+logger-event-listener.log-file-path=/var/log/trino/logger.log
+logger-event-listener.excluded-fields=payload,sourceCode,password
+logger-event-listener.max-field-size=4KB
+logger-event-listener.truncated-fields=query,stageInfo
+logger-event-listener.truncation-size-limit=2KB
+logger-event-listener.ignored-query-states=RUNNING,QUEUED
+logger-event-listener.ignored-query-types=UTILITY
+```
+
+Then include this in `etc/config.properties`:
+
+```properties
+event-listener.config-file=/path/to/event-listener.properties
+```
+
+## Building
+
+Build the plugin with Maven:
+
+```bash
+mvn clean package
+```
+
+## Installation
+
+Copy the built JAR file to the Trino plugins directory:
+
+```bash
+cp target/trino-logger-event-listener-*.jar $TRINO_HOME/plugin/trino-logger-event-listener/
+```
+
+## Usage Examples
+
+### Example 1: Minimal Logging Setup
+
+Log all events with minimal configuration:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+logger-event-listener.log-executed=true
+```
+
+### Example 2: Privacy-Focused Setup
+
+Exclude sensitive information while keeping full query details:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+
+# Exclude PII and sensitive data
+logger-event-listener.excluded-fields=user,principal,password,authorizationToken,clientInfo,remoteClientAddress
+
+# Keep full content for non-sensitive fields
+logger-event-listener.max-field-size=32KB
+```
+
+### Example 3: Performance-Focused Setup
+
+Truncate large fields to reduce log size and improve performance:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+
+# Truncate verbose fields
+logger-event-listener.truncated-fields=query,plan,stageInfo,failures,warnings,operatorSummaries
+logger-event-listener.truncation-size-limit=1KB
+
+# Generic field size limit
+logger-event-listener.max-field-size=8KB
+```
+
+### Example 4: Noise Reduction Setup
+
+Filter out routine events to focus on important queries:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=false
+logger-event-listener.log-completed=true
+logger-event-listener.log-executed=false
+
+# Ignore routine query states
+logger-event-listener.ignored-query-states=RUNNING,QUEUED
+
+# Ignore maintenance/utility operations
+logger-event-listener.ignored-query-types=UTILITY
+
+# Ignore only successful completions without errors
+# (only log failed queries)
+logger-event-listener.ignored-failure-types=
+```
+
+### Example 5: Comprehensive Production Setup
+
+Balanced setup for production environments:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+logger-event-listener.log-executed=false
+
+# Log file path
+logger-event-listener.log-file-path=/var/log/trino/logger.log
+
+# Exclude sensitive data
+logger-event-listener.excluded-fields=user,principal,password,session_properties,clientInfo
+
+# Limit overall field sizes
+logger-event-listener.max-field-size=16KB
+
+# Truncate specific large fields
+logger-event-listener.truncated-fields=query,plan,stageInfo,failures,operatorSummaries
+logger-event-listener.truncation-size-limit=2KB
+
+# Filter out noise
+logger-event-listener.ignored-query-states=RUNNING
+logger-event-listener.ignored-query-types=UTILITY,EXPLAIN
+logger-event-listener.ignored-update-types=
+logger-event-listener.ignored-failure-types=USER_ERROR
+```
+
+### Example 6: Development/Debugging Setup
+
+Capture full details for debugging:
+
+```properties
+event-listener.type=logger
+logger-event-listener.log-created=true
+logger-event-listener.log-completed=true
+logger-event-listener.log-executed=true
+
+# Log file path
+logger-event-listener.log-file-path=/tmp/trino-logger.log
+
+# No field exclusions for full visibility
+logger-event-listener.excluded-fields=
+
+# Large field size limit
+logger-event-listener.max-field-size=64KB
+
+# No truncation - keep everything
+logger-event-listener.truncated-fields=
+
+# Don't filter any events
+logger-event-listener.ignored-query-states=
+logger-event-listener.ignored-query-types=
+logger-event-listener.ignored-update-types=
+logger-event-listener.ignored-failure-types=
+```
+
+## Sample Log Output
+
+### QueryCreatedEvent
+
+```
+QUERY_CREATED: {"queryId":"20260211_123456_00000_abcde","user":"analytics_user","queryState":"CREATED","query":"SELECT * FROM table1 WHERE id > 100","catalog":"hive","schema":"default","queryType":"SELECT"}
+```
+
+### QueryCompletedEvent (Successful)
+
+```
+QUERY_COMPLETED: {"queryId":"20260211_123456_00000_abcde","user":null,"queryState":"FINISHED","errorCode":null,"errorType":null,"failureType":null,"cpuTimeMillis":1250,"wallTimeMillis":2500,"peakMemoryBytes":5242880,"outputRows":15000}
+```
+
+### QueryCompletedEvent (Failed)
+
+```
+QUERY_COMPLETED: {"queryId":"20260211_123456_00000_bcdef","user":null,"queryState":"FAILED","errorCode":"OPTIMIZER","errorType":"OPTIMIZER_TIMEOUT","failureType":"SYSTEM_ERROR","failureMessage":"Query optimizer timeout exceeded","cpuTimeMillis":850,"wallTimeMillis":5000}
+```
+
+### With Truncated Fields
+
+```
+QUERY_CREATED: {"queryId":"20260211_123456_00000_cdefg","query":"SELECT col1, col2 FROM very_long_table_name WHERE condition1 = true AND condition2 = false AND...[TRUNCATED]","plan":"Fragment 0 [source: {2} -> output]\n  Output layout: [col1, col2]\n  Output partitioning: SINGLE\n  - Project[projectLocations: [Column{name...[TRUNCATED]"}
+```
+
+## Dependencies
+
+The plugin uses:
+- **Airlift**: For logging and configuration
+- **Jackson**: For JSON serialization
+- **Trino SPI**: For event listener interface
+

--- a/plugin/trino-logger-event-listener/pom.xml
+++ b/plugin/trino-logger-event-listener/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>480-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-logger-event-listener</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - Logger event listener</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>**/module-info.java</excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListener.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListener.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import com.google.inject.Inject;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Event listener that logs query events to a file using Airlift Logger.
+ * <p>
+ * The listener logs all configured event types (QUERY_CREATED, QUERY_COMPLETED)
+ * as JSON to the configured log file path.
+ * <p>
+ * Supports:
+ * - Excluding specific fields from log output
+ * - Truncating large field values to prevent excessive log sizes
+ */
+public class LoggerEventListener
+        implements EventListener
+{
+    private final Logger log = Logger.get(LoggerEventListener.class);
+
+    private final JsonCodec<QueryCompletedEvent> queryCompletedEventJsonCodec;
+    private final JsonCodec<QueryCreatedEvent> queryCreatedEventJsonCodec;
+    private final QueryEventFieldFilter fieldFilter;
+    private final QueryEventFilterPolicy filterPolicy;
+
+    private final boolean logCreated;
+    private final boolean logCompleted;
+
+    @Inject
+    public LoggerEventListener(
+            JsonCodec<QueryCompletedEvent> queryCompletedEventJsonCodec,
+            JsonCodec<QueryCreatedEvent> queryCreatedEventJsonCodec,
+            LoggerEventListenerConfig config)
+    {
+        this.queryCompletedEventJsonCodec = requireNonNull(queryCompletedEventJsonCodec, "queryCompletedEventJsonCodec is null");
+        this.queryCreatedEventJsonCodec = requireNonNull(queryCreatedEventJsonCodec, "queryCreatedEventJsonCodec is null");
+        this.fieldFilter = new QueryEventFieldFilter(
+                config.getExcludedFields(),
+                config.getMaxFieldSize(),
+                config.getTruncatedFields(),
+                config.getTruncationSizeLimit());
+        this.filterPolicy = new QueryEventFilterPolicy(
+                config.getIgnoredQueryStates(),
+                config.getIgnoredUpdateTypes(),
+                config.getIgnoredQueryTypes(),
+                config.getIgnoredFailureTypes());
+
+        this.logCreated = config.getLogCreated();
+        this.logCompleted = config.getLogCompleted();
+
+        log.info("LoggerEventListener initialized with logCreated=%s, logCompleted=%s, excludedFields=%s, maxFieldSize=%s, truncatedFields=%s, truncationSizeLimit=%s, ignoredQueryStates=%s, ignoredUpdateTypes=%s, ignoredQueryTypes=%s, ignoredFailureTypes=%s",
+                logCreated, logCompleted, config.getExcludedFields(), config.getMaxFieldSize(),
+                config.getTruncatedFields(), config.getTruncationSizeLimit(), config.getIgnoredQueryStates(),
+                config.getIgnoredUpdateTypes(), config.getIgnoredQueryTypes(), config.getIgnoredFailureTypes());
+    }
+
+    @Override
+    public void queryCreated(QueryCreatedEvent queryCreatedEvent)
+    {
+        if (logCreated && filterPolicy.shouldLogQueryCreated(queryCreatedEvent)) {
+            try {
+                String json = queryCreatedEventJsonCodec.toJson(queryCreatedEvent);
+                String filtered = fieldFilter.applyFiltering(json);
+                log.info("QUERY_CREATED: %s", filtered);
+            }
+            catch (Exception e) {
+                log.error(e, "Failed to log query created event");
+            }
+        }
+    }
+
+    @Override
+    public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
+    {
+        if (logCompleted && filterPolicy.shouldLogQueryCompleted(queryCompletedEvent)) {
+            try {
+                String json = queryCompletedEventJsonCodec.toJson(queryCompletedEvent);
+                String filtered = fieldFilter.applyFiltering(json);
+                log.info("QUERY_COMPLETED: %s", filtered);
+            }
+            catch (Exception e) {
+                log.error(e, "Failed to log query completed event");
+            }
+        }
+    }
+}

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListenerConfig.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListenerConfig.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static java.util.Objects.requireNonNull;
+
+public class LoggerEventListenerConfig
+{
+    private final EnumSet<LoggerEventType> loggedEvents = EnumSet.noneOf(LoggerEventType.class);
+    private String logFilePath = "logger.log";
+    private Set<String> excludedFields = Collections.emptySet();
+    private DataSize maxFieldSize = DataSize.of(4, KILOBYTE);
+    private Set<String> truncatedFields = Collections.emptySet();
+    private DataSize truncationSizeLimit = DataSize.of(2, KILOBYTE);
+    private Set<String> ignoredQueryStates = Collections.emptySet();
+    private Set<String> ignoredUpdateTypes = Collections.emptySet();
+    private Set<String> ignoredQueryTypes = Collections.emptySet();
+    private Set<String> ignoredFailureTypes = Collections.emptySet();
+
+    @ConfigDescription("Will log io.trino.spi.eventlistener.QueryCreatedEvent")
+    @Config("logger-event-listener.log-created")
+    public LoggerEventListenerConfig setLogCreated(boolean logCreated)
+    {
+        if (logCreated) {
+            loggedEvents.add(LoggerEventType.QUERY_CREATED);
+        }
+        return this;
+    }
+
+    public boolean getLogCreated()
+    {
+        return loggedEvents.contains(LoggerEventType.QUERY_CREATED);
+    }
+
+    @ConfigDescription("Will log io.trino.spi.eventlistener.QueryCompletedEvent")
+    @Config("logger-event-listener.log-completed")
+    public LoggerEventListenerConfig setLogCompleted(boolean logCompleted)
+    {
+        if (logCompleted) {
+            loggedEvents.add(LoggerEventType.QUERY_COMPLETED);
+        }
+        return this;
+    }
+
+    public boolean getLogCompleted()
+    {
+        return loggedEvents.contains(LoggerEventType.QUERY_COMPLETED);
+    }
+
+    @ConfigDescription("Path to the log file where query events will be written")
+    @Config("logger-event-listener.log-file-path")
+    public LoggerEventListenerConfig setLogFilePath(String logFilePath)
+    {
+        this.logFilePath = logFilePath;
+        return this;
+    }
+
+    public String getLogFilePath()
+    {
+        return logFilePath;
+    }
+
+    public EnumSet<LoggerEventType> getLoggedEvents()
+    {
+        return loggedEvents.clone();
+    }
+
+    public Set<String> getExcludedFields()
+    {
+        return this.excludedFields;
+    }
+
+    @ConfigDescription("Comma-separated list of field names to be excluded from the log event (their value will be replaced with null). E.g.: 'payload,user'")
+    @Config("logger-event-listener.excluded-fields")
+    public LoggerEventListenerConfig setExcludedFields(Set<String> excludedFields)
+    {
+        this.excludedFields = requireNonNull(excludedFields, "excludedFields is null").stream()
+                .filter(field -> !field.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    public DataSize getMaxFieldSize()
+    {
+        return maxFieldSize;
+    }
+
+    @ConfigDescription("Maximum size for any field value in the log event. Larger values will be truncated. Default: 4KB")
+    @Config("logger-event-listener.max-field-size")
+    public LoggerEventListenerConfig setMaxFieldSize(DataSize maxFieldSize)
+    {
+        this.maxFieldSize = requireNonNull(maxFieldSize, "maxFieldSize is null");
+        return this;
+    }
+
+    public Set<String> getTruncatedFields()
+    {
+        return this.truncatedFields;
+    }
+
+    @ConfigDescription("Comma-separated list of field names that should be truncated if they exceed the truncation size limit. E.g.: 'query,stageInfo,sourceCode'")
+    @Config("logger-event-listener.truncated-fields")
+    public LoggerEventListenerConfig setTruncatedFields(Set<String> truncatedFields)
+    {
+        this.truncatedFields = requireNonNull(truncatedFields, "truncatedFields is null").stream()
+                .filter(field -> !field.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    public DataSize getTruncationSizeLimit()
+    {
+        return truncationSizeLimit;
+    }
+
+    @ConfigDescription("Maximum size in bytes for fields specified in truncated-fields. Values exceeding this limit will be truncated with [TRUNCATED] suffix. Default: 2KB")
+    @Config("logger-event-listener.truncation-size-limit")
+    public LoggerEventListenerConfig setTruncationSizeLimit(DataSize truncationSizeLimit)
+    {
+        this.truncationSizeLimit = requireNonNull(truncationSizeLimit, "truncationSizeLimit is null");
+        return this;
+    }
+
+    public Set<String> getIgnoredQueryStates()
+    {
+        return this.ignoredQueryStates;
+    }
+
+    @ConfigDescription("Comma-separated list of query states to ignore when logging. E.g.: 'RUNNING,QUEUED,WAITING'")
+    @Config("logger-event-listener.ignored-query-states")
+    public LoggerEventListenerConfig setIgnoredQueryStates(Set<String> ignoredQueryStates)
+    {
+        this.ignoredQueryStates = requireNonNull(ignoredQueryStates, "ignoredQueryStates is null").stream()
+                .filter(state -> !state.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    public Set<String> getIgnoredUpdateTypes()
+    {
+        return this.ignoredUpdateTypes;
+    }
+
+    @ConfigDescription("Comma-separated list of update types to ignore when logging. E.g.: 'INSERT,UPDATE,DELETE'")
+    @Config("logger-event-listener.ignored-update-types")
+    public LoggerEventListenerConfig setIgnoredUpdateTypes(Set<String> ignoredUpdateTypes)
+    {
+        this.ignoredUpdateTypes = requireNonNull(ignoredUpdateTypes, "ignoredUpdateTypes is null").stream()
+                .filter(type -> !type.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    public Set<String> getIgnoredQueryTypes()
+    {
+        return this.ignoredQueryTypes;
+    }
+
+    @ConfigDescription("Comma-separated list of query types to ignore when logging. E.g.: 'DML,DDL,UTILITY,EXPLAIN'")
+    @Config("logger-event-listener.ignored-query-types")
+    public LoggerEventListenerConfig setIgnoredQueryTypes(Set<String> ignoredQueryTypes)
+    {
+        this.ignoredQueryTypes = requireNonNull(ignoredQueryTypes, "ignoredQueryTypes is null").stream()
+                .filter(type -> !type.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    public Set<String> getIgnoredFailureTypes()
+    {
+        return this.ignoredFailureTypes;
+    }
+
+    @ConfigDescription("Comma-separated list of failure types to ignore when logging. E.g.: 'USER_ERROR,INTERNAL_ERROR'")
+    @Config("logger-event-listener.ignored-failure-types")
+    public LoggerEventListenerConfig setIgnoredFailureTypes(Set<String> ignoredFailureTypes)
+    {
+        this.ignoredFailureTypes = requireNonNull(ignoredFailureTypes, "ignoredFailureTypes is null").stream()
+                .filter(type -> !type.isBlank())
+                .collect(toImmutableSet());
+        return this;
+    }
+}

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListenerFactory.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListenerFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.EventListenerFactory;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
+
+public class LoggerEventListenerFactory
+        implements EventListenerFactory
+{
+    @Override
+    public String getName()
+    {
+        return "logger";
+    }
+
+    @Override
+    public EventListener create(Map<String, String> config, EventListenerContext context)
+    {
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.listener." + getName(),
+                new JsonModule(),
+                binder -> {
+                    binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
+                    binder.bind(Tracer.class).toInstance(context.getTracer());
+                    jsonCodecBinder(binder).bindJsonCodec(QueryCompletedEvent.class);
+                    jsonCodecBinder(binder).bindJsonCodec(QueryCreatedEvent.class);
+                    configBinder(binder).bindConfig(LoggerEventListenerConfig.class);
+                    binder.bind(LoggerEventListener.class).in(Scopes.SINGLETON);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(LoggerEventListener.class);
+    }
+}

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListenerPlugin.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventListenerPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.trino.spi.Plugin;
+import io.trino.spi.eventlistener.EventListenerFactory;
+
+import static java.util.Collections.singletonList;
+
+public class LoggerEventListenerPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<EventListenerFactory> getEventListenerFactories()
+    {
+        return singletonList(new LoggerEventListenerFactory());
+    }
+}

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventType.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/LoggerEventType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+public enum LoggerEventType
+{
+    QUERY_CREATED,
+    QUERY_COMPLETED,
+}

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/QueryEventFieldFilter.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/QueryEventFieldFilter.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.airlift.units.DataSize;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utility class to handle JSON serialization of query events with field exclusion and truncation.
+ * <p>
+ * Features:
+ * - Exclude fields completely (replaced with null in output)
+ * - Truncate specific fields to a maximum size limit
+ */
+public class QueryEventFieldFilter
+{
+    private final Set<String> excludedFields;
+    private final Set<String> truncatedFields;
+    private final long maxFieldSizeBytes;
+    private final long truncationSizeLimitBytes;
+
+    public QueryEventFieldFilter(
+            Set<String> excludedFields,
+            DataSize maxFieldSize,
+            Set<String> truncatedFields,
+            DataSize truncationSizeLimit)
+    {
+        this.excludedFields = requireNonNull(excludedFields, "excludedFields is null");
+        this.maxFieldSizeBytes = requireNonNull(maxFieldSize, "maxFieldSize is null").toBytes();
+        this.truncatedFields = requireNonNull(truncatedFields, "truncatedFields is null");
+        this.truncationSizeLimitBytes = requireNonNull(truncationSizeLimit, "truncationSizeLimit is null").toBytes();
+    }
+
+    /**
+     * Apply field filtering (truncation and exclusion) to a JSON string.
+     * Optimized to avoid creating multiple intermediate String objects.
+     */
+    public String applyFiltering(String json)
+    {
+        json = applyFieldExclusion(json);
+        if (truncatedFields.isEmpty()) {
+            return json;
+        }
+        return applyFieldTruncation(json);
+    }
+
+    private String applyFieldExclusion(String json)
+    {
+        if (excludedFields.isEmpty() || json.isEmpty()) {
+            return json;
+        }
+        for (String field : excludedFields) {
+            json = nullOutFieldInJson(json, field);
+        }
+        return json;
+    }
+
+    /**
+     * Apply truncation to specified fields in the JSON string.
+     * Reuses the same StringBuilder to minimize allocations.
+     */
+    private String applyFieldTruncation(String json)
+    {
+        if (truncatedFields.isEmpty() || json.isEmpty()) {
+            return json;
+        }
+        for (String field : truncatedFields) {
+            json = truncateFieldInJson(json, field);
+        }
+        return json;
+    }
+
+    /**
+     * Truncate a specific field value in JSON string if it exceeds the size limit.
+     * Works with string values enclosed in quotes. Optimized to avoid substring allocations.
+     */
+    private String truncateFieldInJson(String json, String fieldName)
+    {
+        String fieldPattern = "\"" + fieldName + "\":\"";
+        int fieldIndex = json.indexOf(fieldPattern);
+
+        if (fieldIndex == -1) {
+            return json;
+        }
+
+        int valueStartIndex = fieldIndex + fieldPattern.length();
+        int valueEndIndex = json.indexOf("\"", valueStartIndex);
+
+        if (valueEndIndex == -1) {
+            return json;
+        }
+
+        String fieldValue = json.substring(valueStartIndex, valueEndIndex);
+        byte[] valueBytes = fieldValue.getBytes(StandardCharsets.UTF_8);
+
+        long effectiveLimit = Math.min(maxFieldSizeBytes, truncationSizeLimitBytes);
+        if (valueBytes.length <= effectiveLimit) {
+            return json;
+        }
+
+        // Truncate the value
+        String truncatedValue = truncateString(fieldValue, effectiveLimit);
+
+        // Escape quotes in truncated value for JSON using StringBuilder for efficiency
+        String escapedValue = escapeJsonString(truncatedValue);
+
+        // Replace the original value with truncated value
+        return json.substring(0, valueStartIndex) + escapedValue + json.substring(valueEndIndex);
+    }
+
+    private static String nullOutFieldInJson(String json, String fieldName)
+    {
+        String stringFieldPattern = "\"" + fieldName + "\":\"";
+        int fieldIndex = json.indexOf(stringFieldPattern);
+        if (fieldIndex == -1) {
+            return json;
+        }
+
+        int valueStartIndex = fieldIndex + stringFieldPattern.length();
+        int valueEndIndex = json.indexOf("\"", valueStartIndex);
+        if (valueEndIndex == -1) {
+            return json;
+        }
+
+        return json.substring(0, fieldIndex)
+                + "\"" + fieldName + "\":null"
+                + json.substring(valueEndIndex + 1);
+    }
+
+    /**
+     * Truncate a string to accommodate max bytes while handling UTF-8 properly.
+     */
+    public static String truncateString(String value, long maxBytes)
+    {
+        if (value == null || maxBytes <= 0) {
+            return value;
+        }
+
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= maxBytes) {
+            return value;
+        }
+
+        // Truncate string to fit within maxBytes
+        String truncated = new String(bytes, 0, (int) Math.min(maxBytes, bytes.length), StandardCharsets.UTF_8);
+
+        // Remove any incomplete characters at the end
+        while (truncated.getBytes(StandardCharsets.UTF_8).length > maxBytes && truncated.length() > 0) {
+            truncated = truncated.substring(0, truncated.length() - 1);
+        }
+
+        return truncated + "...[TRUNCATED]";
+    }
+
+    /**
+     * Escape special JSON characters in a string using StringBuilder to minimize allocations.
+     */
+    private static String escapeJsonString(String str)
+    {
+        StringBuilder result = new StringBuilder(str.length() + 16); // Reserve space for escapes
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            switch (c) {
+                case '\\' -> result.append("\\\\");
+                case '"' -> result.append("\\\"");
+                case '\b' -> result.append("\\b");
+                case '\f' -> result.append("\\f");
+                case '\n' -> result.append("\\n");
+                case '\r' -> result.append("\\r");
+                case '\t' -> result.append("\\t");
+                default -> result.append(c);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/QueryEventFilterPolicy.java
+++ b/plugin/trino-logger-event-listener/src/main/java/io/trino/plugin/eventlistener/logger/QueryEventFilterPolicy.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.QueryFailureInfo;
+import io.trino.spi.eventlistener.QueryMetadata;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utility class to filter query events based on configured ignore patterns.
+ * <p>
+ * Allows events to be skipped from logging based on:
+ * - Query state (RUNNING, QUEUED, FINISHED, etc.)
+ * - Update type (INSERT, UPDATE, DELETE, etc.)
+ * - Query type (DML, DDL, UTILITY, EXPLAIN, etc.)
+ * - Failure type (USER_ERROR, INTERNAL_ERROR, EXTERNAL, etc.)
+ */
+public class QueryEventFilterPolicy
+{
+    private final Set<String> ignoredQueryStates;
+    private final Set<String> ignoredUpdateTypes;
+    private final Set<String> ignoredQueryTypes;
+    private final Set<String> ignoredFailureTypes;
+
+    public QueryEventFilterPolicy(
+            Set<String> ignoredQueryStates,
+            Set<String> ignoredUpdateTypes,
+            Set<String> ignoredQueryTypes,
+            Set<String> ignoredFailureTypes)
+    {
+        this.ignoredQueryStates = requireNonNull(ignoredQueryStates, "ignoredQueryStates is null");
+        this.ignoredUpdateTypes = requireNonNull(ignoredUpdateTypes, "ignoredUpdateTypes is null");
+        this.ignoredQueryTypes = requireNonNull(ignoredQueryTypes, "ignoredQueryTypes is null");
+        this.ignoredFailureTypes = requireNonNull(ignoredFailureTypes, "ignoredFailureTypes is null");
+    }
+
+    /**
+     * Check if a QueryCreatedEvent should be logged (not ignored).
+     * Optimized: avoids isEmpty() checks and caches metadata calls.
+     */
+    public boolean shouldLogQueryCreated(QueryCreatedEvent event)
+    {
+        QueryMetadata metadata = event.getMetadata();
+
+        // Check query state - fast path since it's required
+        if (ignoredQueryStates.contains(metadata.getQueryState())) {
+            return false;
+        }
+
+        // Check update type if present
+        Optional<String> updateType = metadata.getUpdateType();
+        if (updateType.isPresent() && ignoredUpdateTypes.contains(updateType.get())) {
+            return false;
+        }
+
+        // Check query type if present
+        Optional<String> queryType = event.getContext().getQueryType()
+                .map(Enum::name);
+        if (queryType.isPresent() && ignoredQueryTypes.contains(queryType.get())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a QueryCompletedEvent should be logged (not ignored).
+     * Optimized: avoids isEmpty() checks and caches metadata calls.
+     */
+    public boolean shouldLogQueryCompleted(QueryCompletedEvent event)
+    {
+        QueryMetadata metadata = event.getMetadata();
+
+        // Check query state
+        if (ignoredQueryStates.contains(metadata.getQueryState())) {
+            return false;
+        }
+
+        // Check update type if present
+        Optional<String> updateType = metadata.getUpdateType();
+        if (updateType.isPresent() && ignoredUpdateTypes.contains(updateType.get())) {
+            return false;
+        }
+
+        // Check query type if present
+        Optional<String> queryType = event.getContext().getQueryType()
+                .map(Enum::name);
+        if (queryType.isPresent() && ignoredQueryTypes.contains(queryType.get())) {
+            return false;
+        }
+
+        // Check failure type if present
+        Optional<QueryFailureInfo> failure = event.getFailureInfo();
+        if (failure.isPresent()) {
+            Optional<String> failureType = failure.get().getFailureType();
+            if (failureType.isPresent() && ignoredFailureTypes.contains(failureType.get())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListener.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListener.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.airlift.json.JsonCodec;
+import io.trino.spi.TrinoWarning;
+import io.trino.spi.WarningCode;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryContext;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.QueryIOMetadata;
+import io.trino.spi.eventlistener.QueryMetadata;
+import io.trino.spi.eventlistener.QueryStatistics;
+import io.trino.spi.session.ResourceEstimates;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class TestLoggerEventListener
+{
+    @Test
+    public void testQueryCreatedEventLogged()
+    {
+        LoggerEventListener listener = new LoggerEventListener(
+                JsonCodec.jsonCodec(QueryCompletedEvent.class),
+                JsonCodec.jsonCodec(QueryCreatedEvent.class),
+                new LoggerEventListenerConfig().setLogCreated(true));
+        QueryCreatedEvent event = new QueryCreatedEvent(Instant.now(), createContext(), createMetadata("QUEUED"));
+        assertThatCode(() -> listener.queryCreated(event)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testQueryCompletedEventLogged()
+    {
+        LoggerEventListener listener = new LoggerEventListener(
+                JsonCodec.jsonCodec(QueryCompletedEvent.class),
+                JsonCodec.jsonCodec(QueryCreatedEvent.class),
+                new LoggerEventListenerConfig().setLogCompleted(true));
+        QueryCompletedEvent event = new QueryCompletedEvent(
+                createMetadata("FINISHED"),
+                createStatistics(),
+                createContext(),
+                new QueryIOMetadata(List.of(), Optional.empty()),
+                Optional.empty(),
+                Optional.empty(),
+                List.of(new TrinoWarning(new WarningCode(1, "WARN"), "warn")),
+                Instant.now(),
+                Instant.now(),
+                Instant.now());
+        assertThatCode(() -> listener.queryCompleted(event)).doesNotThrowAnyException();
+    }
+
+    private static QueryContext createContext()
+    {
+        return new QueryContext(
+                "user",
+                "user",
+                Set.of(),
+                Optional.empty(),
+                Set.of(),
+                Set.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Set.of(),
+                Set.of(),
+                Optional.empty(),
+                "UTC",
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Map.of(),
+                new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty()),
+                "127.0.0.1",
+                "test",
+                "test",
+                Optional.empty(),
+                "TASK");
+    }
+
+    private static QueryMetadata createMetadata(String state)
+    {
+        return new QueryMetadata(
+                "query-id",
+                Optional.empty(),
+                Optional.empty(),
+                "SELECT 1",
+                Optional.empty(),
+                Optional.empty(),
+                state,
+                List.of(),
+                List.of(),
+                URI.create("http://localhost/query-id"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static QueryStatistics createStatistics()
+    {
+        return new QueryStatistics(
+                Duration.ZERO,
+                Duration.ZERO,
+                Duration.ZERO,
+                Duration.ZERO,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                List.of(),
+                0,
+                true,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                Map.of(),
+                Map.of(),
+                Optional.empty());
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListenerConfig.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListenerConfig.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.airlift.configuration.ConfigurationFactory;
+import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLoggerEventListenerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(ConfigAssertions.recordDefaults(LoggerEventListenerConfig.class)
+                .setLogCreated(false)
+                .setLogCompleted(false)
+                .setLogFilePath("logger.log")
+                .setExcludedFields(Set.of())
+                .setMaxFieldSize(DataSize.of(4, KILOBYTE))
+                .setTruncatedFields(Set.of())
+                .setTruncationSizeLimit(DataSize.of(2, KILOBYTE))
+                .setIgnoredQueryStates(Set.of())
+                .setIgnoredUpdateTypes(Set.of())
+                .setIgnoredQueryTypes(Set.of())
+                .setIgnoredFailureTypes(Set.of()));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = Map.ofEntries(
+                Map.entry("logger-event-listener.log-created", "true"),
+                Map.entry("logger-event-listener.log-completed", "true"),
+                Map.entry("logger-event-listener.log-file-path", "/var/log/trino/logger.log"),
+                Map.entry("logger-event-listener.excluded-fields", "payload,user,sourceCode"),
+                Map.entry("logger-event-listener.max-field-size", "8kB"),
+                Map.entry("logger-event-listener.truncated-fields", "query,stageInfo"),
+                Map.entry("logger-event-listener.truncation-size-limit", "1kB"),
+                Map.entry("logger-event-listener.ignored-query-states", "RUNNING,QUEUED"),
+                Map.entry("logger-event-listener.ignored-update-types", "INSERT,UPDATE"),
+                Map.entry("logger-event-listener.ignored-query-types", "UTILITY"),
+                Map.entry("logger-event-listener.ignored-failure-types", "USER_ERROR"));
+
+        assertFullMapping(properties, new LoggerEventListenerConfig()
+                .setLogCreated(true)
+                .setLogCompleted(true)
+                .setLogFilePath("/var/log/trino/logger.log")
+                .setExcludedFields(Set.of("payload", "user", "sourceCode"))
+                .setMaxFieldSize(DataSize.of(8, KILOBYTE))
+                .setTruncatedFields(Set.of("query", "stageInfo"))
+                .setTruncationSizeLimit(DataSize.of(1, KILOBYTE))
+                .setIgnoredQueryStates(Set.of("RUNNING", "QUEUED"))
+                .setIgnoredUpdateTypes(Set.of("INSERT", "UPDATE"))
+                .setIgnoredQueryTypes(Set.of("UTILITY"))
+                .setIgnoredFailureTypes(Set.of("USER_ERROR")));
+    }
+
+    @Test
+    public void testExcludedFieldsFilteringBlankValues()
+    {
+        Map<String, String> properties = Map.of(
+                "logger-event-listener.excluded-fields", "payload, , user");
+
+        LoggerEventListenerConfig config = new ConfigurationFactory(properties)
+                .build(LoggerEventListenerConfig.class);
+
+        assertThat(config.getExcludedFields()).containsExactlyInAnyOrder("payload", "user");
+    }
+
+    @Test
+    public void testTruncatedFieldsFilteringBlankValues()
+    {
+        Map<String, String> properties = Map.of(
+                "logger-event-listener.truncated-fields", "query, , stageInfo");
+
+        LoggerEventListenerConfig config = new ConfigurationFactory(properties)
+                .build(LoggerEventListenerConfig.class);
+
+        assertThat(config.getTruncatedFields()).containsExactlyInAnyOrder("query", "stageInfo");
+    }
+
+    @Test
+    public void testIgnoredQueryStatesFilteringBlankValues()
+    {
+        Map<String, String> properties = Map.of(
+                "logger-event-listener.ignored-query-states", "RUNNING, , QUEUED");
+
+        LoggerEventListenerConfig config = new ConfigurationFactory(properties)
+                .build(LoggerEventListenerConfig.class);
+
+        assertThat(config.getIgnoredQueryStates()).containsExactlyInAnyOrder("RUNNING", "QUEUED");
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListenerFactory.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListenerFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.spi.eventlistener.EventListenerFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLoggerEventListenerFactory
+{
+    @Test
+    public void testFactoryName()
+    {
+        LoggerEventListenerFactory factory = new LoggerEventListenerFactory();
+        assertThat(factory.getName()).isEqualTo("logger");
+    }
+
+    @Test
+    public void testFactoryCreatesListener()
+    {
+        LoggerEventListenerFactory factory = new LoggerEventListenerFactory();
+        assertThat(factory.create(
+                Map.of("logger-event-listener.log-created", "true"),
+                new TestingEventListenerContext())).isNotNull();
+    }
+
+    private static class TestingEventListenerContext
+            implements EventListenerFactory.EventListenerContext
+    {
+        @Override
+        public String getVersion()
+        {
+            return "test";
+        }
+
+        @Override
+        public OpenTelemetry getOpenTelemetry()
+        {
+            return OpenTelemetry.noop();
+        }
+
+        @Override
+        public Tracer getTracer()
+        {
+            return OpenTelemetry.noop().getTracer("test");
+        }
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListenerPlugin.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventListenerPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.trino.spi.eventlistener.EventListenerFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLoggerEventListenerPlugin
+{
+    @Test
+    public void testPluginInitialization()
+    {
+        LoggerEventListenerPlugin plugin = new LoggerEventListenerPlugin();
+        assertThat(plugin).isNotNull();
+    }
+
+    @Test
+    public void testGetEventListenerFactories()
+    {
+        LoggerEventListenerPlugin plugin = new LoggerEventListenerPlugin();
+        Iterable<EventListenerFactory> factories = plugin.getEventListenerFactories();
+
+        assertThat(factories).isNotNull();
+        assertThat(factories.iterator().hasNext()).isTrue();
+
+        EventListenerFactory factory = factories.iterator().next();
+        assertThat(factory).isNotNull();
+        assertThat(factory).isInstanceOf(LoggerEventListenerFactory.class);
+    }
+
+    @Test
+    public void testGetFactoryName()
+    {
+        LoggerEventListenerPlugin plugin = new LoggerEventListenerPlugin();
+        Iterable<EventListenerFactory> factories = plugin.getEventListenerFactories();
+        EventListenerFactory factory = factories.iterator().next();
+
+        assertThat(factory.getName()).isEqualTo("logger");
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventType.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestLoggerEventType.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLoggerEventType
+{
+    @Test
+    public void testEventTypeValues()
+    {
+        assertThat(LoggerEventType.QUERY_CREATED).isNotNull();
+        assertThat(LoggerEventType.QUERY_COMPLETED).isNotNull();
+    }
+
+    @Test
+    public void testEventTypeNames()
+    {
+        assertThat(LoggerEventType.QUERY_CREATED).hasToString("QUERY_CREATED");
+        assertThat(LoggerEventType.QUERY_COMPLETED).hasToString("QUERY_COMPLETED");
+    }
+
+    @Test
+    public void testEventTypeCount()
+    {
+        LoggerEventType[] values = LoggerEventType.values();
+        assertThat(values).hasSize(2);
+    }
+
+    @Test
+    public void testEventTypeValueOf()
+    {
+        assertThat(LoggerEventType.valueOf("QUERY_CREATED")).isEqualTo(LoggerEventType.QUERY_CREATED);
+        assertThat(LoggerEventType.valueOf("QUERY_COMPLETED")).isEqualTo(LoggerEventType.QUERY_COMPLETED);
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestQueryEventFieldFilter.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestQueryEventFieldFilter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQueryEventFieldFilter
+{
+    @Test
+    public void testTruncateStringWithinLimit()
+    {
+        String value = "SELECT * FROM table";
+        String result = QueryEventFieldFilter.truncateString(value, 100);
+        assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void testTruncateStringExceedsLimit()
+    {
+        String value = "SELECT * FROM very_very_very_long_table_name";
+        String result = QueryEventFieldFilter.truncateString(value, 20);
+        assertThat(result).contains("...[TRUNCATED]");
+        assertThat(result.length()).isLessThanOrEqualTo(35); // Approximate bounds
+    }
+
+    @Test
+    public void testTruncateStringNull()
+    {
+        String result = QueryEventFieldFilter.truncateString(null, 20);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testTruncateStringZeroLimit()
+    {
+        String value = "test string";
+        String result = QueryEventFieldFilter.truncateString(value, 0);
+        assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void testTruncateStringNegativeLimit()
+    {
+        String value = "test string";
+        String result = QueryEventFieldFilter.truncateString(value, -1);
+        assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void testTruncateMultibyteCharacters()
+    {
+        String value = "SELECT * FROM table WHERE emoji = '😀😀😀😀😀'";
+        int maxBytes = 30;
+        String result = QueryEventFieldFilter.truncateString(value, maxBytes);
+        assertThat(result).contains("...[TRUNCATED]");
+        int truncationMarkerBytes = "...[TRUNCATED]".getBytes(StandardCharsets.UTF_8).length;
+        assertThat(result.getBytes(StandardCharsets.UTF_8).length).isLessThanOrEqualTo(maxBytes + truncationMarkerBytes);
+    }
+
+    @Test
+    public void testFilterInitialization()
+    {
+        QueryEventFieldFilter filter = new QueryEventFieldFilter(
+                Set.of("user", "password"),
+                DataSize.of(4, KILOBYTE),
+                Set.of("query"),
+                DataSize.of(2, KILOBYTE));
+
+        // Just verify it initializes without errors
+        assertThat(filter).isNotNull();
+    }
+
+    @Test
+    public void testFilterWithEmptyExclusions()
+    {
+        QueryEventFieldFilter filter = new QueryEventFieldFilter(
+                Set.of(),
+                DataSize.of(4, KILOBYTE),
+                Set.of(),
+                DataSize.of(2, KILOBYTE));
+
+        assertThat(filter).isNotNull();
+    }
+
+    @Test
+    public void testFilterWithLargeDataSize()
+    {
+        QueryEventFieldFilter filter = new QueryEventFieldFilter(
+                Set.of("field1"),
+                DataSize.of(100, KILOBYTE),
+                Set.of("field2"),
+                DataSize.of(50, KILOBYTE));
+
+        assertThat(filter).isNotNull();
+    }
+}

--- a/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestQueryEventFilterPolicy.java
+++ b/plugin/trino-logger-event-listener/src/test/java/io/trino/plugin/eventlistener/logger/TestQueryEventFilterPolicy.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.logger;
+
+import io.trino.spi.ErrorCode;
+import io.trino.spi.ErrorType;
+import io.trino.spi.TrinoWarning;
+import io.trino.spi.WarningCode;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryContext;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.QueryFailureInfo;
+import io.trino.spi.eventlistener.QueryIOMetadata;
+import io.trino.spi.eventlistener.QueryMetadata;
+import io.trino.spi.eventlistener.QueryStatistics;
+import io.trino.spi.session.ResourceEstimates;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQueryEventFilterPolicy
+{
+    @Test
+    public void testShouldFilterCreatedByState()
+    {
+        QueryEventFilterPolicy filter = new QueryEventFilterPolicy(Set.of("QUEUED"), Set.of(), Set.of(), Set.of());
+        assertThat(filter.shouldLogQueryCreated(new QueryCreatedEvent(
+                Instant.now(),
+                createContext(),
+                createMetadata("QUEUED", Optional.empty(), "SELECT")))).isFalse();
+    }
+
+    @Test
+    public void testShouldFilterCompletedByFailureType()
+    {
+        QueryEventFilterPolicy filter = new QueryEventFilterPolicy(Set.of(), Set.of(), Set.of(), Set.of("USER_ERROR"));
+        QueryCompletedEvent event = new QueryCompletedEvent(
+                createMetadata("FAILED", Optional.empty(), "SELECT"),
+                createStatistics(),
+                createContext(),
+                new QueryIOMetadata(List.of(), Optional.empty()),
+                Optional.empty(),
+                Optional.of(new QueryFailureInfo(
+                        new ErrorCode(1, "USER_ERROR", ErrorType.USER_ERROR),
+                        Optional.of("USER_ERROR"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        "{}")),
+                List.of(new TrinoWarning(new WarningCode(1, "WARN"), "warn")),
+                Instant.now(),
+                Instant.now(),
+                Instant.now());
+
+        assertThat(filter.shouldLogQueryCompleted(event)).isFalse();
+    }
+
+    private static QueryMetadata createMetadata(String state, Optional<String> updateType, String query)
+    {
+        return new QueryMetadata(
+                "query-id",
+                Optional.empty(),
+                Optional.empty(),
+                query,
+                updateType,
+                Optional.empty(),
+                state,
+                List.of(),
+                List.of(),
+                URI.create("http://localhost/query-id"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static QueryContext createContext()
+    {
+        return new QueryContext(
+                "user",
+                "user",
+                Set.of(),
+                Optional.empty(),
+                Set.of(),
+                Set.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Set.of(),
+                Set.of(),
+                Optional.empty(),
+                "UTC",
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Map.of(),
+                new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty()),
+                "127.0.0.1",
+                "test",
+                "test",
+                Optional.empty(),
+                "TASK");
+    }
+
+    private static QueryStatistics createStatistics()
+    {
+        return new QueryStatistics(
+                Duration.ZERO,
+                Duration.ZERO,
+                Duration.ZERO,
+                Duration.ZERO,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                List.of(),
+                0,
+                true,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                Map.of(),
+                Map.of(),
+                Optional.empty());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <module>plugin/trino-kafka-event-listener</module>
         <module>plugin/trino-lakehouse</module>
         <module>plugin/trino-ldap-group-provider</module>
+        <module>plugin/trino-logger-event-listener</module>
         <module>plugin/trino-loki</module>
         <module>plugin/trino-mariadb</module>
         <module>plugin/trino-memory</module>
@@ -1195,6 +1196,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-kafka-event-listener</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-logger-event-listener</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Description

Add a QueryLogEventListener that emits structured per-query events to configured sinks (logs/HTTP/metrics).  
The listener captures query lifecycle events (submission, planning, execution, completion/failure) and forwards a compact, stable event payload suitable for auditing, observability, and downstream analytics.

Key changes:
- trino-main: add QueryLogEventListener implementation and lifecycle hook
- trino-spi: (if applicable) add SPI interfaces/types for event payload
- config: new configuration properties to enable/configure the listener and sinks
- tests: unit + integration coverage for happy path and failure cases

## Additional context and related issues

- Background: operators and observability tooling need a lightweight, stable per-query event stream for auditing and external monitoring without depending on system tables or the UI.
- Backward compatibility: opt-in by default (no behavioral change when listener is not enabled)
- Performance: low overhead when enabled; batching and async delivery used to avoid adding latency
- Risk: low — changes are isolated to event-listener wiring and an opt-in implementation
- Testing: unit tests added (files: [paths to unit tests]); integration test added (files: [paths to integration tests])

Manual test steps:
1. Enable the listener in etc/catalog or etc/config.properties:
   - querylog.listener.enabled=true
   - querylog.listener.sink=[log|http|noop]
2. Run a representative query that previously exercised planner/executor paths.
3. Verify an event is emitted containing: queryId, user, state, durationMs, error (if any), stats.

Reviewer guidance:
- Focus on correctness of the emitted payload (fields, nullability, stable names)
- Verify performance/async delivery (no blocking on query completion)
- Check configuration surface and docs
- Suggested reviewers: @trinodb/core-dev, maintainers of observability/instrumentation

## Release notes

(x) Release notes are required. Please propose a release note for me.

Proposed release-note (short):
* Add QueryLogEventListener — optional per-query event emission for auditing and observability. (#{issuenumber})

Proposed release-note (detailed):
* Query logging — new QueryLogEventListener produces structured per-query events (submission, completion, failure) to configured sinks (log/HTTP). Opt-in via configuration; no migration required. (#{issuenumber})