### PR TITLE
Define zstd-jni in trino-hive-formats pom.xml

### DIFF
--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -137,6 +137,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
+            <version>1.5.7-7</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -438,12 +438,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.github.luben</groupId>
-                <artifactId>zstd-jni</artifactId>
-                <version>1.5.7-7</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.github.oshi</groupId>
                 <artifactId>oshi-core</artifactId>
                 <version>6.9.3</version>


### PR DESCRIPTION
## Description

The main purpose is to avoid full CI when we update the dependency. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
