### PR TITLE
Allow dual licensed UI dependency

### DIFF
--- a/core/trino-web-ui/src/main/resources/allowed-licenses.txt
+++ b/core/trino-web-ui/src/main/resources/allowed-licenses.txt
@@ -1,3 +1,4 @@
+"(MPL-2.0 OR Apache-2.0)"
 "0BSD"
 "Apache-2.0"
 "BSD-2-Clause"


### PR DESCRIPTION
Fixes logical merge conflict between

- https://github.com/trinodb/trino/pull/27832
- and some other PR adding a new dependency with a new version string

The logical merge conflict causes all CI builds to fail.
