### PR TITLE
Cleanup node for Lakehouse connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,7 @@ jobs:
         timeout-minutes: 15
         with:
           cache: restore
-          cleanup-node: ${{ format('{0}', matrix.modules == 'plugin/trino-singlestore' || matrix.modules == 'plugin/trino-exasol' || matrix.modules == 'plugin/trino-oracle' || matrix.modules == 'plugin/trino-iceberg') }}
+          cleanup-node: ${{ format('{0}', matrix.modules == 'plugin/trino-singlestore' || matrix.modules == 'plugin/trino-exasol' || matrix.modules == 'plugin/trino-oracle' || matrix.modules == 'plugin/trino-iceberg' || matrix.modules == 'plugin/trino-lakehouse') }}
           java-version: ${{ matrix.jdk != '' && matrix.jdk || '25.0.2' }}
       - name: Maven Install
         run: |


### PR DESCRIPTION
## Description

Relates to https://github.com/trinodb/trino/actions/runs/21976392001/job/63489349585?pr=28283
```
...
2026-02-13T00:08:21.405-0600	ERROR	ForkJoinPool-1-worker-4	tc.ghcr.io/trinodb/testing/hdp3.1-hive:123	Could not start container
com.github.dockerjava.api.exception.InternalServerErrorException: Status 500: {"message":"failed to create prepare snapshot dir: failed to create temp dir: mkdir /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/new-344706935: no space left on device"}
...
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.