### PR TITLE
Fix Iceberg vended credentials not working with REST catalogs that return credentials via `storage-credentials` instead of `config`.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/StorageCredentialsMergingRestClient.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/StorageCredentialsMergingRestClient.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTRequest;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link RESTClient} wrapper that intercepts {@link LoadTableResponse} results and merges
+ * storage-credentials into the response's config map. This allows Trino's ioBuilder to receive
+ * vended credentials through the normal config property flow, rather than requiring the
+ * {@code SupportsStorageCredentials} interface that is bypassed when a custom ioBuilder is set.
+ */
+class StorageCredentialsMergingRestClient
+        implements RESTClient
+{
+    private final RESTClient delegate;
+
+    StorageCredentialsMergingRestClient(RESTClient delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler)
+    {
+        delegate.head(path, headers, errorHandler);
+    }
+
+    @Override
+    public <T extends RESTResponse> T delete(
+            String path,
+            Class<T> responseType,
+            Map<String, String> headers,
+            Consumer<ErrorResponse> errorHandler)
+    {
+        return delegate.delete(path, responseType, headers, errorHandler);
+    }
+
+    @Override
+    public <T extends RESTResponse> T delete(
+            String path,
+            Map<String, String> queryParams,
+            Class<T> responseType,
+            Map<String, String> headers,
+            Consumer<ErrorResponse> errorHandler)
+    {
+        return delegate.delete(path, queryParams, responseType, headers, errorHandler);
+    }
+
+    @Override
+    public <T extends RESTResponse> T get(
+            String path,
+            Map<String, String> queryParams,
+            Class<T> responseType,
+            Map<String, String> headers,
+            Consumer<ErrorResponse> errorHandler)
+    {
+        T response = delegate.get(path, queryParams, responseType, headers, errorHandler);
+        return mergeStorageCredentials(response, responseType);
+    }
+
+    @Override
+    public <T extends RESTResponse> T post(
+            String path,
+            RESTRequest body,
+            Class<T> responseType,
+            Map<String, String> headers,
+            Consumer<ErrorResponse> errorHandler)
+    {
+        T response = delegate.post(path, body, responseType, headers, errorHandler);
+        return mergeStorageCredentials(response, responseType);
+    }
+
+    @Override
+    public <T extends RESTResponse> T postForm(
+            String path,
+            Map<String, String> formData,
+            Class<T> responseType,
+            Map<String, String> headers,
+            Consumer<ErrorResponse> errorHandler)
+    {
+        return delegate.postForm(path, formData, responseType, headers, errorHandler);
+    }
+
+    @Override
+    public RESTClient withAuthSession(AuthSession session)
+    {
+        return new StorageCredentialsMergingRestClient(delegate.withAuthSession(session));
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends RESTResponse> T mergeStorageCredentials(T response, Class<T> responseType)
+    {
+        if (responseType != LoadTableResponse.class) {
+            return response;
+        }
+
+        LoadTableResponse tableResponse = (LoadTableResponse) response;
+        List<Credential> credentials = tableResponse.credentials();
+        if (credentials.isEmpty()) {
+            return response;
+        }
+
+        String tableLocation = tableResponse.tableMetadata().location();
+        Credential bestMatch = findBestMatchingCredential(credentials, tableLocation);
+        if (bestMatch == null) {
+            return response;
+        }
+
+        Map<String, String> mergedConfig = new HashMap<>(tableResponse.config());
+        mergedConfig.putAll(bestMatch.config());
+
+        return (T) LoadTableResponse.builder()
+                .withTableMetadata(tableResponse.tableMetadata())
+                .addAllConfig(mergedConfig)
+                .addAllCredentials(credentials)
+                .build();
+    }
+
+    /**
+     * Finds the credential with the longest matching prefix for the given table location.
+     * This matches the algorithm used by Iceberg's S3FileIO and GCSFileIO for selecting
+     * per-prefix storage clients.
+     */
+    private static Credential findBestMatchingCredential(List<Credential> credentials, String tableLocation)
+    {
+        Credential best = null;
+        int bestLength = -1;
+        for (Credential credential : credentials) {
+            String prefix = credential.prefix();
+            if (tableLocation.startsWith(prefix) && prefix.length() > bestLength) {
+                best = credential;
+                bestLength = prefix.length();
+            }
+        }
+        return best;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.RESTUtil;
 
@@ -135,10 +136,13 @@ public class TrinoIcebergRestCatalogFactory
             }
 
             RESTSessionCatalog icebergCatalogInstance = new RESTSessionCatalog(
-                    config -> HTTPClient.builder(config)
-                            .uri(config.get(CatalogProperties.URI))
-                            .withHeaders(RESTUtil.configHeaders(config))
-                            .build(),
+                    config -> {
+                        RESTClient client = HTTPClient.builder(config)
+                                .uri(config.get(CatalogProperties.URI))
+                                .withHeaders(RESTUtil.configHeaders(config))
+                                .build();
+                        return vendedCredentialsEnabled ? new StorageCredentialsMergingRestClient(client) : client;
+                    },
                     (context, config) -> {
                         ConnectorIdentity currentIdentity = (context.wrappedIdentity() != null)
                                 ? ((ConnectorIdentity) context.wrappedIdentity())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestStorageCredentialsMergingRestClient.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestStorageCredentialsMergingRestClient.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTRequest;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.apache.iceberg.PartitionSpec.unpartitioned;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StorageCredentialsMergingRestClient}, which merges the {@code storage-credentials}
+ * field (Iceberg REST spec >= 1.7.0) into the config map so Trino's ioBuilder can access vended credentials.
+ */
+class TestStorageCredentialsMergingRestClient
+{
+    private static final Schema TEST_SCHEMA = new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+    private static Stream<Arguments> credentialMergingScenarios()
+    {
+        return Stream.of(
+                // Storage credentials only: credentials are merged into config
+                Arguments.of(
+                        "storageCredentialsOnly",
+                        LoadTableResponse.builder()
+                                .withTableMetadata(tableMetadata("s3://bucket/warehouse/table1"))
+                                .addCredential(ImmutableCredential.builder()
+                                        .prefix("s3://bucket/warehouse/")
+                                        .config(ImmutableMap.of("s3.access-key-id", "credential-key"))
+                                        .build())
+                                .build(),
+                        ImmutableMap.of("s3.access-key-id", "credential-key")),
+                // Config only: config is unchanged
+                Arguments.of(
+                        "configOnly",
+                        LoadTableResponse.builder()
+                                .withTableMetadata(tableMetadata("s3://bucket/warehouse/table1"))
+                                .addAllConfig(ImmutableMap.of("existing-key", "existing-value"))
+                                .build(),
+                        ImmutableMap.of("existing-key", "existing-value")),
+                // Both: storage credentials override config
+                Arguments.of(
+                        "storageCredentialsOverrideConfig",
+                        LoadTableResponse.builder()
+                                .withTableMetadata(tableMetadata("s3://bucket/warehouse/table1"))
+                                .addAllConfig(ImmutableMap.of("s3.access-key-id", "config-key"))
+                                .addCredential(ImmutableCredential.builder()
+                                        .prefix("s3://bucket/")
+                                        .config(ImmutableMap.of("s3.access-key-id", "storage-credential-key"))
+                                        .build())
+                                .build(),
+                        ImmutableMap.of("s3.access-key-id", "storage-credential-key")),
+                // Neither: config is empty
+                Arguments.of(
+                        "noCredentialsNoConfig",
+                        LoadTableResponse.builder()
+                                .withTableMetadata(tableMetadata("s3://bucket/warehouse/table1"))
+                                .build(),
+                        ImmutableMap.of()));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("credentialMergingScenarios")
+    void testCredentialMerging(String scenario, LoadTableResponse response, Map<String, String> expectedConfig)
+    {
+        StorageCredentialsMergingRestClient client = new StorageCredentialsMergingRestClient(
+                new FakeRestClient(response));
+
+        LoadTableResponse result = client.get(
+                "v1/namespaces/ns/tables/table1",
+                ImmutableMap.of(),
+                LoadTableResponse.class,
+                ImmutableMap.of(),
+                error -> {});
+
+        assertThat(result.config())
+                .containsExactlyInAnyOrderEntriesOf(expectedConfig);
+    }
+
+    @Test
+    void testLongestPrefixMatchWins()
+    {
+        LoadTableResponse response = LoadTableResponse.builder()
+                .withTableMetadata(tableMetadata("s3://bucket/warehouse/db/table1"))
+                .addCredential(ImmutableCredential.builder()
+                        .prefix("s3://bucket/")
+                        .config(ImmutableMap.of("s3.access-key-id", "short-prefix-key"))
+                        .build())
+                .addCredential(ImmutableCredential.builder()
+                        .prefix("s3://bucket/warehouse/db/")
+                        .config(ImmutableMap.of("s3.access-key-id", "long-prefix-key"))
+                        .build())
+                .build();
+
+        StorageCredentialsMergingRestClient client = new StorageCredentialsMergingRestClient(
+                new FakeRestClient(response));
+
+        LoadTableResponse result = client.get(
+                "v1/namespaces/ns/tables/table1",
+                ImmutableMap.of(),
+                LoadTableResponse.class,
+                ImmutableMap.of(),
+                error -> {});
+
+        assertThat(result.config())
+                .containsEntry("s3.access-key-id", "long-prefix-key");
+    }
+
+    @Test
+    void testNoMatchingPrefixLeavesConfigUnchanged()
+    {
+        LoadTableResponse response = LoadTableResponse.builder()
+                .withTableMetadata(tableMetadata("s3://bucket/warehouse/table1"))
+                .addAllConfig(ImmutableMap.of("existing-key", "existing-value"))
+                .addCredential(ImmutableCredential.builder()
+                        .prefix("s3://other-bucket/")
+                        .config(ImmutableMap.of("s3.access-key-id", "wrong-key"))
+                        .build())
+                .build();
+
+        StorageCredentialsMergingRestClient client = new StorageCredentialsMergingRestClient(
+                new FakeRestClient(response));
+
+        LoadTableResponse result = client.get(
+                "v1/namespaces/ns/tables/table1",
+                ImmutableMap.of(),
+                LoadTableResponse.class,
+                ImmutableMap.of(),
+                error -> {});
+
+        assertThat(result.config())
+                .containsExactlyEntriesOf(ImmutableMap.of("existing-key", "existing-value"));
+    }
+
+    private static TableMetadata tableMetadata(String location)
+    {
+        return TableMetadata.newTableMetadata(TEST_SCHEMA, unpartitioned(), location, ImmutableMap.of());
+    }
+
+    private static class FakeRestClient
+            implements RESTClient
+    {
+        private final RESTResponse response;
+
+        FakeRestClient(RESTResponse response)
+        {
+            this.response = response;
+        }
+
+        @Override
+        public void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T extends RESTResponse> T delete(String path, Class<T> responseType, Map<String, String> headers, Consumer<ErrorResponse> errorHandler)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends RESTResponse> T get(String path, Map<String, String> queryParams, Class<T> responseType, Map<String, String> headers, Consumer<ErrorResponse> errorHandler)
+        {
+            return (T) response;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType, Map<String, String> headers, Consumer<ErrorResponse> errorHandler)
+        {
+            return (T) response;
+        }
+
+        @Override
+        public <T extends RESTResponse> T postForm(String path, Map<String, String> formData, Class<T> responseType, Map<String, String> headers, Consumer<ErrorResponse> errorHandler)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Iceberg Credential Vending doesn't work with REST catalogs following latests specs, specifically catalogs that don't provide the `config` fallback. Per [latest spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L3485):

> Clients must first check whether the respective credentials exist in the storage-credentials field before checking the config for credentials.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The Iceberg REST spec defines two mechanisms for credential vending:
- **`config` map** (older): credentials are returned as key-value pairs in the `config` field of `LoadTableResponse`. Trino already supports this.
- **`storage-credentials` array** (newer, preferred): credentials are returned as typed `Credential` objects with a `prefix` and `config`. Trino did not support this.

When Trino provides a custom `ioBuilder` to `RESTSessionCatalog` (which it always does), `storage-credentials` are dropped in [`RESTSessionCatalog.newFileIO()`](https://github.com/apache/iceberg/blob/apache-iceberg-1.10.1/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L981-L982) — only the `config` map is passed through. Without a custom `ioBuilder`, Iceberg handles this via the `SupportsStorageCredentials` interface, but that path is never taken in Trino.



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x ) Release notes are required, with the following suggested text:

## Iceberg connector
* Fix vended credentials not working with REST catalogs that return credentials via `storage-credentials` instead of `config`.

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
