### PR TITLE
Map google.protobuf.Struct to JSON in decoder

### DIFF
--- a/lib/trino-record-decoder/src/test/resources/decoder/protobuf/test_struct.proto
+++ b/lib/trino-record-decoder/src/test/resources/decoder/protobuf/test_struct.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+message schema {
+    int32 id = 1;
+    google.protobuf.Struct metadata = 2;
+    google.protobuf.Value any_value = 3;
+    google.protobuf.ListValue tags = 4;
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.kafka.encoder.protobuf;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.inject.Inject;
 import com.google.protobuf.Descriptors;
@@ -60,6 +61,10 @@ public class ProtobufSchemaParser
 {
     private static final String ANY_TYPE_NAME = "google.protobuf.Any";
     private static final String TIMESTAMP_TYPE_NAME = "google.protobuf.Timestamp";
+    private static final Set<String> STRUCT_TYPES = ImmutableSet.of(
+            "google.protobuf.Struct",
+            "google.protobuf.Value",
+            "google.protobuf.ListValue");
     private final TypeManager typeManager;
     private final boolean isProtobufAnySupportEnabled;
 
@@ -148,6 +153,9 @@ public class ProtobufSchemaParser
             return createTimestampType(6);
         }
         else if (isProtobufAnySupportEnabled && descriptor.getFullName().equals(ANY_TYPE_NAME)) {
+            return typeManager.getType(new TypeSignature(JSON));
+        }
+        else if (STRUCT_TYPES.contains(descriptor.getFullName())) {
             return typeManager.getType(new TypeSignature(JSON));
         }
 

--- a/plugin/trino-kafka/src/test/resources/protobuf/test_struct.proto
+++ b/plugin/trino-kafka/src/test/resources/protobuf/test_struct.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+message schema {
+    int32 id = 1;
+    google.protobuf.Struct metadata = 2;
+    google.protobuf.Value any_value = 3;
+    google.protobuf.ListValue tags = 4;
+}


### PR DESCRIPTION
## Description

Map `google.protobuf.Struct`, `google.protobuf.Value`, and `google.protobuf.ListValue` well-known types to Trino's `JSON` type in the Kafka protobuf schema parser and decoder. This follows the same pattern used for `google.protobuf.Any` (which is already mapped to JSON, per https://github.com/trinodb/trino/commit/5ebbd2e46ec318a4e35725f0cc5fe27d5c70ae00).

I don't believe any configuration flag is needed like the one used for `google.protobuf.Any`. Unlike `Any` (which
requires a `DescriptorProvider` to resolve the `type_url` field), `Struct` is entirely self-describing and always safe to decode as JSON.

See the description in https://github.com/trinodb/trino/issues/28294 for why this approach is appropriate.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The changes span two modules:

- Schema parsing in `ProtobufSchemaParser`: Intercepts `Struct`/`Value`/`ListValue` types *before* the recursive type detection and maps them to JSON.

- Runtime decoding in `ProtobufColumnDecoder` and `ProtobufValueProvider`: Converts `Struct` `DynamicMessage` instances to sorted JSON strings using `JsonFormat.printer()`. Handles `Struct` both as top-level fields and when nested inside arrays, maps, or row types.

The `sorted()` helper in `ProtobufColumnDecoder` was also generalized to handle non-object JSON values (e.g., `"foo"` from a `Value` field or `["foo","bar"]` from a `ListValue` field) by using `Object.class` instead of `Map.class` in the Jackson mapper. This is backward-compatible since existing callers (`Any`, `Oneof`) always produce JSON objects.

Closes https://github.com/trinodb/trino/issues/28294

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
* Add support for `google.protobuf.Struct`, `Value`, and `ListValue` types in the Kafka protobuf decoder, mapping them to Trino's `JSON` type.
```