### PR TITLE
Add support for path prefix in Elasticsearch connector

### DIFF
--- a/docs/src/main/sphinx/connector/elasticsearch.md
+++ b/docs/src/main/sphinx/connector/elasticsearch.md
@@ -43,6 +43,10 @@ The following table details all general configuration properties:
 * - `elasticsearch.port`
   - Port to use to connect to Elasticsearch.
   - `9200`
+* - `elasticsearch.path-prefix`
+  - The path prefix to use when connecting to Elasticsearch. This is typically used
+    when Elasticsearch is behind a reverse proxy.
+  -
 * - `elasticsearch.default-schema-name`
   - The schema that contains all tables defined without a qualifying schema
     name.

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConfig.java
@@ -56,6 +56,7 @@ public class ElasticsearchConfig
 
     private List<String> hosts;
     private int port = 9200;
+    private String pathPrefix;
     private String defaultSchema = "default";
     private int scrollSize = 1_000;
     private Duration scrollTimeout = new Duration(1, MINUTES);
@@ -100,6 +101,19 @@ public class ElasticsearchConfig
     public ElasticsearchConfig setPort(int port)
     {
         this.port = port;
+        return this;
+    }
+
+    public Optional<String> getPathPrefix()
+    {
+        return Optional.ofNullable(pathPrefix);
+    }
+
+    @Config("elasticsearch.path-prefix")
+    @ConfigDescription("Path prefix for REST client")
+    public ElasticsearchConfig setPathPrefix(String pathPrefix)
+    {
+        this.pathPrefix = pathPrefix;
         return this;
     }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -206,6 +206,8 @@ public class ElasticsearchClient
                         .map(httpHost -> new HttpHost(httpHost, config.getPort(), config.isTlsEnabled() ? "https" : "http"))
                         .toArray(HttpHost[]::new));
 
+        config.getPathPrefix().ifPresent(builder::setPathPrefix);
+
         builder.setHttpClientConfigCallback(_ -> {
             RequestConfig requestConfig = RequestConfig.custom()
                     .setConnectTimeout(toIntExact(config.getConnectTimeout().toMillis()))
@@ -341,6 +343,11 @@ public class ElasticsearchClient
                 chosen = shardGroup.stream()
                         .min(this::shardPreference)
                         .get();
+
+                if (nodes.isEmpty()) {
+                    shards.add(new Shard(chosen.getIndex(), chosen.getShard(), Optional.empty()));
+                    continue;
+                }
                 node = nodes.get(chosen.getShard() % nodes.size());
             }
             else {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -140,6 +140,23 @@ public abstract class BaseElasticsearchConnectorTest
     }
 
     @Test
+    public void testPathPrefix()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.of("elasticsearch.path-prefix", "/test-prefix");
+
+        try (QueryRunner queryRunner = ElasticsearchQueryRunner.builder(server)
+                .addConnectorProperties(properties)
+                .build()) {
+            assertThatThrownBy(() -> queryRunner.execute("SELECT * FROM orders"))
+                    .hasMessageContaining("URI [/test-prefix/orders/_mappings], status line [HTTP/1.1 405 Method Not Allowed]");
+        }
+
+        // Verify that the original query runner is not affected
+        assertQuerySucceeds("SELECT * FROM orders");
+    }
+
+    @Test
     @Override
     public void testSelectAll()
     {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchConfig.java
@@ -57,6 +57,7 @@ public class TestElasticsearchConfig
                 .setTruststorePassword(null)
                 .setVerifyHostnames(true)
                 .setIgnorePublishAddress(false)
+                .setPathPrefix(null)
                 .setSecurity(null));
     }
 
@@ -88,6 +89,7 @@ public class TestElasticsearchConfig
                 .put("elasticsearch.tls.truststore-password", "truststore-password")
                 .put("elasticsearch.tls.verify-hostnames", "false")
                 .put("elasticsearch.ignore-publish-address", "true")
+                .put("elasticsearch.path-prefix", "/elasticsearch")
                 .put("elasticsearch.security", "AWS")
                 .buildOrThrow();
 
@@ -112,6 +114,7 @@ public class TestElasticsearchConfig
                 .setTruststorePassword("truststore-password")
                 .setVerifyHostnames(false)
                 .setIgnorePublishAddress(true)
+                .setPathPrefix("/elasticsearch")
                 .setSecurity(AWS);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION

## Description
This commit introduces support for configuring a path prefix when connecting to an Elasticsearch
instance. This feature is particularly useful when Elasticsearch is deployed behind a reverse proxy
that exposes it under a specific path, e.g. `http://example.com:80/elasticsearch`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
#26930 


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Elasticsearch Connector
* Add 'elasticsearch.path-prefix' configuration property to allow connecting to Elasticsearch instances through a reverse proxy.
```
