### PR TITLE
Write checkpoint if needed on CREATE OR REPLACE without schema change

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1382,9 +1382,7 @@ public class DeltaLakeMetadata
                 if (replaceExistingTable) {
                     List<DeltaLakeColumnHandle> existingColumns = getColumns(tableHandle.getMetadataEntry(), tableHandle.getProtocolEntry());
                     List<DeltaLakeColumnHandle> newColumns = getColumns(metadataEntry, protocolEntry);
-                    if (isNewCheckpointFileRequired(existingColumns, newColumns)) {
-                        writeCheckpoint(session, schemaTableName, location, tableHandle.toCredentialsHandle(), commitVersion);
-                    }
+                    writeCheckpointIfNeeded(session, schemaTableName, location, tableHandle.toCredentialsHandle(), tableHandle.getReadVersion(), checkpointInterval, commitVersion, Optional.of(existingColumns), Optional.of(newColumns));
                 }
             }
         }
@@ -1542,12 +1540,12 @@ public class DeltaLakeMetadata
 
         OptionalLong readVersion = OptionalLong.empty();
         ProtocolEntry protocolEntry;
+        Optional<List<DeltaLakeColumnHandle>> existingColumns = Optional.empty();
 
-        boolean isNewCheckpointFileRequired = false;
         if (replaceExistingTable) {
             protocolEntry = protocolEntryForTable(ProtocolEntry.builder(handle.getProtocolEntry()), containsTimestampType, tableMetadata.getProperties());
             readVersion = OptionalLong.of(handle.getReadVersion());
-            isNewCheckpointFileRequired = isNewCheckpointFileRequired(getColumns(handle.getMetadataEntry(), handle.getProtocolEntry()), columnHandles.build());
+            existingColumns = Optional.of(getColumns(handle.getMetadataEntry(), handle.getProtocolEntry()));
         }
         else {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session, location);
@@ -1570,7 +1568,7 @@ public class DeltaLakeMetadata
                 columnMappingMode,
                 maxFieldId,
                 replace,
-                isNewCheckpointFileRequired,
+                existingColumns,
                 readVersion,
                 protocolEntry);
     }
@@ -1759,8 +1757,8 @@ public class DeltaLakeMetadata
             transactionLogWriter.flush();
             writeCommitted = true;
 
-            if (handle.replace() && handle.readVersion().isPresent() && handle.isSchemaChanged()) {
-                writeCheckpoint(session, schemaTableName, location, handle.toCredentialsHandle(), commitVersion);
+            if (handle.replace() && handle.readVersion().isPresent()) {
+                writeCheckpointIfNeeded(session, schemaTableName, handle.location(), handle.toCredentialsHandle(), handle.readVersion().getAsLong(), handle.checkpointInterval(), commitVersion, handle.existingColumns(), Optional.of(handle.inputColumns()));
             }
 
             if (isCollectExtendedStatisticsColumnStatisticsOnWrite(session) && !computedStatistics.isEmpty()) {
@@ -2323,7 +2321,7 @@ public class DeltaLakeMetadata
             long commitVersion = Failsafe.with(TRANSACTION_CONFLICT_RETRY_POLICY)
                     .get(context -> commitInsertOperation(session, handle, sourceTableHandles, isolationLevel, dataFileInfos, readVersion, context.getAttemptCount()));
             writeCommitted = true;
-            writeCheckpointIfNeeded(session, handle.tableName(), handle.location(), handle.credentialsHandle(), handle.readVersion(), handle.metadataEntry().getCheckpointInterval(), commitVersion);
+            writeCheckpointIfNeeded(session, handle.tableName(), handle.location(), handle.credentialsHandle(), handle.readVersion(), handle.metadataEntry().getCheckpointInterval(), commitVersion, Optional.empty(), Optional.empty());
             enqueueUpdateInfo(session, handle.tableName().getSchemaName(), handle.tableName().getTableName(), commitVersion, handle.metadataEntry().getSchemaString(), Optional.ofNullable(handle.metadataEntry().getDescription()));
 
             if (isCollectExtendedStatisticsColumnStatisticsOnWrite(session) && !computedStatistics.isEmpty() && !dataFileInfos.isEmpty()) {
@@ -2713,7 +2711,7 @@ public class DeltaLakeMetadata
                     handle.getMetadataEntry().getSchemaString(),
                     Optional.ofNullable(handle.getMetadataEntry().getDescription()));
 
-            writeCheckpointIfNeeded(session, handle.getSchemaTableName(), handle.getLocation(), handle.toCredentialsHandle(), handle.getReadVersion(), checkpointInterval, commitVersion);
+            writeCheckpointIfNeeded(session, handle.getSchemaTableName(), handle.getLocation(), handle.toCredentialsHandle(), handle.getReadVersion(), checkpointInterval, commitVersion, Optional.empty(), Optional.empty());
         }
         catch (RuntimeException e) {
             if (!writeCommitted) {
@@ -2995,7 +2993,9 @@ public class DeltaLakeMetadata
                     optimizeHandle.getCredentialsHandle(),
                     optimizeHandle.getCurrentVersion().orElseThrow(),
                     checkpointInterval,
-                    commitVersion);
+                    commitVersion,
+                    Optional.empty(),
+                    Optional.empty());
         }
         catch (Exception e) {
             if (!writeCommitted) {
@@ -3183,29 +3183,57 @@ public class DeltaLakeMetadata
             VendedCredentialsHandle credentialsHandle,
             long readVersion,
             Optional<Long> checkpointInterval,
-            long newVersion)
+            long newVersion,
+            Optional<List<DeltaLakeColumnHandle>> existingColumns,
+            Optional<List<DeltaLakeColumnHandle>> newColumns)
     {
         try {
             // We are writing checkpoint synchronously. It should not be long lasting operation for tables where transaction log is not humongous.
             // Tables with really huge transaction logs would behave poorly in read flow already.
-            long lastCheckpointVersion = getLastCheckpointVersion(session, table, tableLocation, readVersion, credentialsHandle);
-            if (newVersion - lastCheckpointVersion < checkpointInterval.orElse(defaultCheckpointInterval)) {
-                return;
+            if (isCheckpointNeeded(
+                    session,
+                    table,
+                    tableLocation,
+                    credentialsHandle,
+                    readVersion,
+                    checkpointInterval,
+                    newVersion,
+                    existingColumns,
+                    newColumns)) {
+                writeCheckpoint(session, table, tableLocation, credentialsHandle, newVersion);
             }
-
-            // TODO: There is a race possibility here(https://github.com/trinodb/trino/issues/12004),
-            // which may result in us not writing checkpoints at exactly the planned frequency.
-            // The snapshot obtained above may already be on a version higher than `newVersion` because some other transaction could have just been committed.
-            // This does not pose correctness issue but may be confusing if someone looks into transaction log.
-            // To fix that we should allow for getting snapshot for given version.
-
-            writeCheckpoint(session, table, tableLocation, credentialsHandle, newVersion);
         }
         catch (Exception e) {
             // We can't fail here as transaction was already committed, in case of INSERT this could result
             // in inserting data twice if client saw an error and decided to retry
             LOG.error(e, "Failed to write checkpoint for table %s for version %s", table, newVersion);
         }
+    }
+
+    private boolean isCheckpointNeeded(
+            ConnectorSession session,
+            SchemaTableName table,
+            String tableLocation,
+            VendedCredentialsHandle credentialsHandle,
+            long readVersion,
+            Optional<Long> checkpointInterval,
+            long newVersion,
+            Optional<List<DeltaLakeColumnHandle>> existingColumns,
+            Optional<List<DeltaLakeColumnHandle>> newColumns)
+    {
+        // If columns have changed: we need to write a new checkpoint regardless of interval
+        if (columnChangeRequiresCheckpoint(existingColumns, newColumns)) {
+            return true;
+        }
+
+        // If we've reached the checkpoint writing interval: we need to write a checkpoint
+        // TODO: There is a race possibility here(https://github.com/trinodb/trino/issues/12004),
+        // which may result in us not writing checkpoints at exactly the planned frequency.
+        // The snapshot obtained above may already be on a version higher than `newVersion` because some other transaction could have just been committed.
+        // This does not pose correctness issue but may be confusing if someone looks into transaction log.
+        // To fix that we should allow for getting snapshot for given version.
+        long lastCheckpointVersion = getLastCheckpointVersion(session, table, tableLocation, readVersion, credentialsHandle);
+        return newVersion - lastCheckpointVersion >= checkpointInterval.orElse(defaultCheckpointInterval);
     }
 
     private void writeCheckpoint(ConnectorSession session, SchemaTableName table, String tableLocation, VendedCredentialsHandle credentialsHandle, long newVersion)
@@ -3216,13 +3244,18 @@ public class DeltaLakeMetadata
         checkpointWriterManager.writeCheckpoint(session, snapshot, credentialsHandle);
     }
 
-    private static boolean isNewCheckpointFileRequired(List<DeltaLakeColumnHandle> existingColumns, List<DeltaLakeColumnHandle> newColumns)
+    private static boolean columnChangeRequiresCheckpoint(
+            Optional<List<DeltaLakeColumnHandle>> existingColumns,
+            Optional<List<DeltaLakeColumnHandle>> newColumns)
     {
-        Map<String, Type> newColumnHandles = newColumns.stream()
+        if (existingColumns.isEmpty() || newColumns.isEmpty()) {
+            return false;
+        }
+        Map<String, Type> newColumnHandles = newColumns.get().stream()
                 .filter(column -> !isMetadataColumnHandle(column))
                 .collect(toImmutableMap(DeltaLakeColumnHandle::columnName, DeltaLakeColumnHandle::type));
 
-        for (DeltaLakeColumnHandle existingColumn : existingColumns) {
+        for (DeltaLakeColumnHandle existingColumn : existingColumns.get()) {
             if (isMetadataColumnHandle(existingColumn)) {
                 continue;
             }
@@ -4329,7 +4362,9 @@ public class DeltaLakeMetadata
                     tableHandle.toCredentialsHandle(),
                     tableHandle.getReadVersion(),
                     tableHandle.getMetadataEntry().getCheckpointInterval(),
-                    commitDeleteOperationResult.commitVersion());
+                    commitDeleteOperationResult.commitVersion(),
+                    Optional.empty(),
+                    Optional.empty());
             enqueueUpdateInfo(
                     session,
                     tableHandle.getSchemaName(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -42,7 +42,7 @@ public record DeltaLakeOutputTableHandle(
         ColumnMappingMode columnMappingMode,
         OptionalInt maxColumnId,
         boolean replace,
-        boolean isSchemaChanged,
+        Optional<List<DeltaLakeColumnHandle>> existingColumns,
         OptionalLong readVersion,
         ProtocolEntry protocolEntry)
         implements ConnectorOutputTableHandle
@@ -59,6 +59,7 @@ public record DeltaLakeOutputTableHandle(
         requireNonNull(schemaString, "schemaString is null");
         requireNonNull(columnMappingMode, "columnMappingMode is null");
         requireNonNull(maxColumnId, "maxColumnId is null");
+        requireNonNull(existingColumns, "existingColumns is null");
         requireNonNull(readVersion, "readVersion is null");
         requireNonNull(protocolEntry, "protocolEntry is null");
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1446,7 +1446,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     }
 
     @Test
-    public void testCreateOrReplaceCheckpointing()
+    public void testCreateOrReplaceWithSameSchemaWritesCheckpoint()
     {
         String tableName = "test_create_or_replace_checkpointing_" + randomNameSuffix();
         assertUpdate(
@@ -1463,27 +1463,64 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         assertThat(listCheckpointFiles(transactionLogDirectory)).isEmpty();
         assertQuery("SELECT * FROM " + tableName, "VALUES (1,'ala'),  (2,'kota'), (3, 'psa')");
 
-        // replace table
+        // replace table with same schema, expect a checkpoint because the checkpoint interval threshold has been reached
         assertUpdate(
-                format("CREATE OR REPLACE TABLE %s (a_number integer) " +
+                format("CREATE OR REPLACE TABLE %s (a_number integer, a_string varchar) " +
                                 " WITH (checkpoint_interval = 2)",
                         tableName));
         assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(1);
         assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
 
-        assertUpdate(format("INSERT INTO " + tableName + " VALUES 1", tableName), 1);
+        assertUpdate(format("INSERT INTO " + tableName + " VALUES (1, 'bobra')", tableName), 1);
         assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(1);
-        assertQuery("SELECT * FROM " + tableName, "VALUES 1");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'bobra')");
 
         // replace table with selection
         assertUpdate(
-                format("CREATE OR REPLACE TABLE %s (a_string) " +
+                format("CREATE OR REPLACE TABLE %s (a_number, a_string) " +
                                 " WITH (checkpoint_interval = 2) " +
-                                " AS VALUES 'bobra', 'kreta'",
+                                " AS VALUES (1, 'bobra'), (2, 'kreta')",
                         tableName),
                 2);
         assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(2);
-        assertQuery("SELECT * FROM " + tableName, "VALUES 'bobra', 'kreta'");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'bobra'), (2, 'kreta')");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testCreateOrReplaceWithDifferentSchemaWritesCheckpoint()
+    {
+        String tableName = "test_create_or_replace_checkpointing_" + randomNameSuffix();
+        assertUpdate(
+                format("CREATE OR REPLACE TABLE %s (a_number, a_string) " +
+                                " WITH (location = '%s', " +
+                                "       partitioned_by = ARRAY['a_number']) " +
+                                " AS VALUES (1, 'ala')",
+                        tableName,
+                        getLocationForTable(bucketName, tableName)),
+                1);
+        String transactionLogDirectory = format("%s/_delta_log", tableName);
+
+        assertUpdate(format("INSERT INTO %s VALUES (2, 'kota'), (3, 'psa')", tableName), 2);
+        assertThat(listCheckpointFiles(transactionLogDirectory)).isEmpty();
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1,'ala'),  (2,'kota'), (3, 'psa')");
+
+        // replace table with same schema and a large checkpoint_interval, expect no new checkpoint
+        assertUpdate(
+                format("CREATE OR REPLACE TABLE %s (a_number integer, a_string varchar) " +
+                                " WITH (checkpoint_interval = 100)",
+                        tableName));
+        assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(0);
+        assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
+
+        // replace table with a different schema and a large checkpoint_interval, expect a new checkpoint because columns have changed
+        assertUpdate(
+                format("CREATE OR REPLACE TABLE %s (a_number integer, a_string integer) " +
+                                " WITH (checkpoint_interval = 100)",
+                        tableName));
+        assertThat(listCheckpointFiles(transactionLogDirectory)).hasSize(1);
+        assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
 
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -181,7 +181,7 @@ public class TestDeltaLakePageSink
                 NONE,
                 OptionalInt.empty(),
                 false,
-                false,
+                Optional.of(getColumnHandles()),
                 OptionalLong.empty(),
                 new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()));
 


### PR DESCRIPTION
## Description

Fixes regression in Delta Lake where we stopped writing checkpoints on CREATE OR REPLACE without a schema change. See #28310 for full explanation.

This PR has two commits:
- First commit improves the original test from #21609 to test without a schema change. These tests will fail, showing the issue written up in #28310.
- Second commit then fixes the underlying issue

I'm relying on tests included in #27886 to ensure the other use case of "Delta needs to write a checkpoint on schema change" works properly, e.g. [here](https://github.com/trinodb/trino/pull/27886/changes#diff-f8407debd31f7e168ce7c1259a228f6a5538c536d53f5e2c343df2f4e6fcf595R344).

I've taken the liberty of renaming `isNewCheckpointFileRequired` to specify exactly what it does, and including the schema-change check as part of `writeCheckpointIfNeeded`, which makes the logic easier to follow.

## Additional context and related issues

Fixes #28310

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: