### PR TITLE
Fix SortingFileWriter memory tracking

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -200,6 +200,7 @@ public final class OrcWriter
             }
         }
         this.columnWriters = columnWriters.build();
+        this.columnWritersRetainedBytes = this.columnWriters.stream().mapToLong(ColumnWriter::getRetainedBytes).sum();
         this.dictionaryCompressionOptimizer = new DictionaryCompressionOptimizer(
                 sliceColumnWriters.build(),
                 stripeMinBytes,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -115,7 +115,7 @@ public final class SortingFileWriter
     @Override
     public long getMemoryUsage()
     {
-        return INSTANCE_SIZE + sortBuffer.getRetainedBytes();
+        return INSTANCE_SIZE + sortBuffer.getRetainedBytes() + outputWriter.getMemoryUsage();
     }
 
     @Override


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
The `outputWriter` can use a non-negligible amount of memory even if not used yet. For example, a new `OrcWriter` can take orders of hundreds of kilobytes. This becomes a problem when there are multiple partitions, each having its own `SortingFileWriter`, each underestimating its memory usage.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix memory accounting for insert queries on a bucketed sorted Hive or Iceberg table```
