### PR TITLE
Enable ClassInitializationDeadlock error-prone check

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
@@ -60,7 +60,7 @@ final class LongTimestampType
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
     private final Range range;
 
-    public LongTimestampType(int precision)
+    LongTimestampType(int precision)
     {
         super(precision, LongTimestamp.class, Fixed12Block.class);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -63,7 +63,7 @@ final class LongTimestampWithTimeZoneType
     private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
-    public LongTimestampWithTimeZoneType(int precision)
+    LongTimestampWithTimeZoneType(int precision)
     {
         super(precision, LongTimestampWithTimeZone.class, Fixed12Block.class);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -58,7 +58,7 @@ final class ShortTimestampType
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
     private final Range range;
 
-    public ShortTimestampType(int precision)
+    ShortTimestampType(int precision)
     {
         super(precision, long.class, LongArrayBlock.class);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -56,7 +56,7 @@ final class ShortTimestampWithTimeZoneType
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimestampWithTimeZoneType.class, lookup(), long.class);
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
-    public ShortTimestampWithTimeZoneType(int precision)
+    ShortTimestampWithTimeZoneType(int precision)
     {
         super(precision, long.class, LongArrayBlock.class);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
@@ -19,6 +19,7 @@ import io.trino.spi.block.ValueBlock;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static java.lang.String.format;
 
+@SuppressWarnings("ClassInitializationDeadlock") // ShortTimeWithTimeZoneType and LongTimeWithTimeZoneType classes only ever access from TimeWithTimeZoneType class
 public abstract sealed class TimeWithTimeZoneType
         extends AbstractType
         implements FixedWidthType
@@ -34,7 +35,9 @@ public abstract sealed class TimeWithTimeZoneType
 
     static {
         for (int precision = 0; precision <= MAX_PRECISION; precision++) {
-            TYPES[precision] = (precision <= MAX_SHORT_PRECISION) ? new ShortTimeWithTimeZoneType(precision) : new LongTimeWithTimeZoneType(precision);
+            @SuppressWarnings("StaticInitializerReferencesSubClass")
+            TimeWithTimeZoneType type = (precision <= MAX_SHORT_PRECISION) ? new ShortTimeWithTimeZoneType(precision) : new LongTimeWithTimeZoneType(precision);
+            TYPES[precision] = type;
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimestampType.java
@@ -25,6 +25,7 @@ import static java.lang.String.format;
  * @see ShortTimestampType
  * @see LongTimestampType
  */
+@SuppressWarnings("ClassInitializationDeadlock") // ShortTimestampType and LongTimestampType classes only ever access from TimestampType class
 public abstract sealed class TimestampType
         extends AbstractType
         implements FixedWidthType
@@ -40,7 +41,9 @@ public abstract sealed class TimestampType
 
     static {
         for (int precision = 0; precision <= MAX_PRECISION; precision++) {
-            TYPES[precision] = (precision <= MAX_SHORT_PRECISION) ? new ShortTimestampType(precision) : new LongTimestampType(precision);
+            @SuppressWarnings("StaticInitializerReferencesSubClass")
+            TimestampType type = (precision <= MAX_SHORT_PRECISION) ? new ShortTimestampType(precision) : new LongTimestampType(precision);
+            TYPES[precision] = type;
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimestampWithTimeZoneType.java
@@ -23,6 +23,7 @@ import static java.lang.String.format;
  * @see ShortTimestampWithTimeZoneType
  * @see LongTimestampWithTimeZoneType
  */
+@SuppressWarnings("ClassInitializationDeadlock") // ShortTimestampWithTimeZoneType and LongTimestampWithTimeZoneType classes only ever access from TimestampWithTimeZoneType class
 public abstract sealed class TimestampWithTimeZoneType
         extends AbstractType
         implements FixedWidthType
@@ -38,7 +39,9 @@ public abstract sealed class TimestampWithTimeZoneType
 
     static {
         for (int precision = 0; precision <= MAX_PRECISION; precision++) {
-            TYPES[precision] = (precision <= MAX_SHORT_PRECISION) ? new ShortTimestampWithTimeZoneType(precision) : new LongTimestampWithTimeZoneType(precision);
+            @SuppressWarnings("StaticInitializerReferencesSubClass")
+            TimestampWithTimeZoneType type = (precision <= MAX_SHORT_PRECISION) ? new ShortTimestampWithTimeZoneType(precision) : new LongTimestampWithTimeZoneType(precision);
+            TYPES[precision] = type;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2902,6 +2902,7 @@
                                     -Xep:CatchAndPrintStackTrace:ERROR \
                                     -Xep:CatchFail:ERROR \
                                     -Xep:ClassCanBeStatic:ERROR \
+                                    -Xep:ClassInitializationDeadlock:ERROR \
                                     -Xep:ClassName:ERROR \
                                     -Xep:ClassNewInstance:ERROR \
                                     -Xep:CollectionUndefinedEquality:ERROR \


### PR DESCRIPTION
Enable ClassInitializationDeadlock error-prone check.
The problems flagged by it are real problems. Solving them in SPI would, however, require a breaking SPI change.
