### PR TITLE
Create dumb terminal on non-interactive session

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/TerminalUtils.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/TerminalUtils.java
@@ -39,9 +39,21 @@ public class TerminalUtils
     private static Terminal createTerminal()
     {
         try {
-            return TerminalBuilder.builder()
-                    .name("Trino")
-                    .build();
+            try {
+                return TerminalBuilder.builder()
+                        .system(true)
+                        .dumb(false)
+                        .name("Trino")
+                        .build();
+            }
+            catch (IllegalStateException e) {
+                // Couldn't create a real terminal so we need to fallback to a dumb one
+                return TerminalBuilder.builder()
+                        .system(true)
+                        .dumb(true)
+                        .name("Trino")
+                        .build();
+            }
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/28318
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI
* Resolve warning generated when system terminal cannot be created ({issue}`issuenumber`)
```
