### PR TITLE
Drop catalog even if we are not able to get catalog metadata

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
@@ -25,9 +25,12 @@ import io.trino.spi.transaction.IsolationLevel;
 import io.trino.transaction.InternalConnector;
 import io.trino.transaction.TransactionId;
 
+import java.util.Optional;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.connector.CatalogHandle.createRootCatalogHandle;
+import static io.trino.metadata.CatalogMetadata.SecurityManagement;
 import static io.trino.metadata.CatalogStatus.FAILING;
 import static io.trino.spi.StandardErrorCode.CATALOG_UNAVAILABLE;
 import static java.lang.String.format;
@@ -96,6 +99,12 @@ public class Catalog
     public CatalogStatus getCatalogStatus()
     {
         return catalogStatus;
+    }
+
+    public Optional<SecurityManagement> getSecurityManagement()
+    {
+        return Optional.ofNullable(catalogConnector)
+                .map(ConnectorServices::getSecurityManagement);
     }
 
     public CatalogInfo toInfo()

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -848,14 +848,13 @@ public final class MetadataManager
     @Override
     public void dropCatalog(Session session, CatalogName catalog, boolean cascade)
     {
-        Optional<CatalogMetadata> catalogMetadata = Optional.empty();
         // there is a potential race condition here, TODO: https://github.com/trinodb/trino/issues/26927
-        Optional<Catalog> optionalCatalog = catalogManager.getCatalog(catalog);
-        if (optionalCatalog.isPresent() && optionalCatalog.get().getCatalogStatus() == OPERATIONAL) {
-            catalogMetadata = Optional.of(getCatalogMetadataForWrite(session, catalog.toString()));
-        }
+        boolean systemSecurityManagement = catalogManager.getCatalog(catalog)
+                .filter(foundCatalog -> foundCatalog.getCatalogStatus() == OPERATIONAL)
+                .flatMap(Catalog::getSecurityManagement)
+                .orElse(CONNECTOR) == SYSTEM;
         catalogManager.dropCatalog(catalog, cascade);
-        if (catalogMetadata.isPresent() && catalogMetadata.get().getSecurityManagement() == SYSTEM) {
+        if (systemSecurityManagement) {
             systemSecurityMetadata.catalogDropped(session, catalog);
         }
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -26,6 +26,7 @@ import io.trino.server.SessionContext;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.Plugin;
 import io.trino.spi.QueryId;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
@@ -55,6 +56,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.QueryState.FAILED;
 import static io.trino.execution.QueryState.RUNNING;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -73,6 +75,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 @Execution(SAME_THREAD) // metadataManager.getActiveQueryIds() is shared mutable state that affects the test outcome
 public class TestMetadataManager
 {
+    private final AtomicBoolean failMetadataCall = new AtomicBoolean();
     private QueryRunner queryRunner;
     private MetadataManager metadataManager;
 
@@ -89,6 +92,12 @@ public class TestMetadataManager
                 SchemaTableName viewTableName = new SchemaTableName("UPPER_CASE_SCHEMA", "test_view");
 
                 MockConnectorFactory connectorFactory = MockConnectorFactory.builder()
+                        .withMetadataWrapper(connectorMetadata -> {
+                            if (failMetadataCall.get()) {
+                                throw new TrinoException(GENERIC_INTERNAL_ERROR, new IllegalStateException("Failed to get connector metadata"));
+                            }
+                            return connectorMetadata;
+                        })
                         .withListSchemaNames(session -> ImmutableList.of("UPPER_CASE_SCHEMA"))
                         .withGetTableHandle((session, schemaTableName) -> {
                             if (schemaTableName.equals(viewTableName)) {
@@ -221,6 +230,21 @@ public class TestMetadataManager
         // TODO (https://github.com/trinodb/trino/issues/17) this should return 100 rows
         assertThat(queryRunner.execute("SELECT * FROM system.jdbc.columns WHERE table_schem = 'UPPER_CASE_TABLE' AND table_name = 'UPPER_CASE_TABLE'"))
                 .isEmpty();
+    }
+
+    @Test
+    public void testDropCatalogFailure()
+    {
+        try {
+            queryRunner.execute("CREATE CATALOG drop_mock_catalog USING mock");
+            assertThat(queryRunner.execute("SHOW CATALOGS").getOnlyColumnAsSet()).contains("drop_mock_catalog");
+            failMetadataCall.set(true);
+            queryRunner.execute("DROP CATALOG drop_mock_catalog");
+            assertThat(queryRunner.execute("SHOW CATALOGS").getOnlyColumnAsSet()).doesNotContain("drop_mock_catalog");
+        }
+        finally {
+            failMetadataCall.set(false);
+        }
     }
 
     // Probabilistic partial regression test for https://github.com/trinodb/trino/issues/28017


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

During getCatalogMetadataForWrite - we could actually load metadata from the connector (and interact with datasource), and this operation could fail, but we still want to drop the catalog, because catalogMetadata needed only for post-drop action - looks like this is just some hook, so we don't want to fail main operation. 

In the same way as Create Catalog works:

```
    @Override
    public void createCatalog(Session session, CatalogName catalog, ConnectorName connectorName, Map<String, String> properties, boolean notExists)
    {
        catalogManager.createCatalog(catalog, connectorName, properties, notExists);
        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalog.toString());
        if (catalogMetadata.getSecurityManagement() == SYSTEM) {
            systemSecurityMetadata.catalogCreated(session, catalog);
        }
    }
```

We kind of create catalog in anyway, even if post create action will fail.
So I think the same approach should be applied for Drop catalog to be aligned with Create catalog flow.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Prevent `DROP CATALOG` failure when catalog is not functioning properly.
```
