### PR TITLE
Fail analysis if window function uses partitioning on non orderable column

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1469,6 +1469,11 @@ public class ExpressionAnalyzer
                     if (!type.isComparable()) {
                         throw semanticException(TYPE_MISMATCH, expression, "%s is not comparable, and therefore cannot be used in window function PARTITION BY", type);
                     }
+                    if (!type.isOrderable()) {
+                        // TODO this is not a hard requirement, just the implication of how we do partitioning right now, using PagesIndex and iterating over ordered values
+                        // to find partition boundaries.
+                        throw semanticException(TYPE_MISMATCH, expression, "%s is not orderable, and therefore cannot be used in window function PARTITION BY", type);
+                    }
                 }
             }
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -281,6 +281,14 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testNonOrderableWindowPartition()
+    {
+        assertFails("SELECT row_number() OVER (PARTITION BY t.x) FROM (VALUES(MAP(ARRAY['key1', 'key2', 'key3' ], ARRAY[2373, 3463, 45837])) )AS t(x)")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:40: map(varchar(4), integer) is not orderable, and therefore cannot be used in window function PARTITION BY");
+    }
+
+    @Test
     public void testNonComparableWindowOrder()
     {
         assertFails("SELECT row_number() OVER (ORDER BY t.x) FROM (VALUES(color('red'))) AS t(x)")


### PR DESCRIPTION
Currently execution requires symbols used for window function partitioning to be orderable (not just comparable). We use PagesIndex and iterating over it in order to determine partition boundaries.

This commit fixes logic of determining invalid queries.

Regarding release notes: I do not think those are required - given the queries failed also previously and we just improve user experience making failure more understandable.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
