### PR TITLE
Cleanup obsolete JVM configuration

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -12,5 +12,3 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-all/jvm.config
@@ -13,6 +13,4 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading
 -XX:+ExitOnOutOfMemoryError

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-ignite/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-ignite/jvm.config
@@ -13,5 +13,3 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-kafka-sasl-plaintext/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-kafka-sasl-plaintext/jvm.config
@@ -12,6 +12,3 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading
--XX:+UnlockDiagnosticVMOptions

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-snowflake/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-snowflake/jvm.config
@@ -14,5 +14,3 @@
 -Djdk.nio.maxCachedBufferSize=0
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -11,5 +11,3 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -10,5 +10,3 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/trino/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/trino/etc/jvm.config
@@ -12,5 +12,3 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

After recent changes (Slice and JDK update) some of the JVM flags we set in the product tests are no longer needed

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
