### PR TITLE
Resource groups: add per-query limits, driver-level admission control, and planning concurrency limit

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -20,7 +20,9 @@ import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.stats.CounterStat;
 import io.trino.execution.ManagedQueryExecution;
+import io.trino.execution.QueryState;
 import io.trino.execution.resourcegroups.WeightedFairQueue.Usage;
+import io.trino.server.BasicQueryStats;
 import io.trino.server.QueryStateInfo;
 import io.trino.server.ResourceGroupInfo;
 import io.trino.spi.TrinoException;
@@ -55,6 +57,9 @@ import static io.airlift.units.Duration.succinctDuration;
 import static io.trino.SystemSessionProperties.getQueryPriority;
 import static io.trino.execution.resourcegroups.ResourceUsage.ZERO;
 import static io.trino.server.QueryStateInfo.createQueryStateInfo;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_CPU_LIMIT;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_SCAN_LIMIT;
 import static io.trino.spi.StandardErrorCode.INVALID_RESOURCE_GROUP;
 import static io.trino.spi.resourcegroups.ResourceGroupState.CAN_QUEUE;
 import static io.trino.spi.resourcegroups.ResourceGroupState.CAN_RUN;
@@ -115,6 +120,13 @@ public class InternalResourceGroup
     @GuardedBy("root")
     private boolean jmxExport;
     private volatile boolean disabled;
+    private volatile long perQueryMemoryLimitBytes = Long.MAX_VALUE;
+    private volatile long perQueryCpuLimitMillis = Long.MAX_VALUE;
+    private volatile long perQueryScanLimitBytes = Long.MAX_VALUE;
+    @GuardedBy("root")
+    private int hardTotalDriverLimit = Integer.MAX_VALUE;
+    @GuardedBy("root")
+    private int hardPlanningConcurrencyLimit = Integer.MAX_VALUE;
 
     // Live data structures
     // ====================
@@ -136,6 +148,13 @@ public class InternalResourceGroup
     // CPU, memory and physical data input usage is cached because it changes very rapidly while queries are running, and would be expensive to track continuously
     @GuardedBy("root")
     private ResourceUsage cachedResourceUsage = ZERO;
+    // Active driver and planning query counts are staged without lock and promoted with lock, similar to ResourceUsage
+    private volatile int stagedActiveDrivers;
+    private volatile int stagedPlanningQueries;
+    @GuardedBy("root")
+    private int cachedActiveDrivers;
+    @GuardedBy("root")
+    private int cachedPlanningQueries;
     @GuardedBy("root")
     private long lastStartNanos;
     private final CounterStat timeBetweenStartsSec = new CounterStat();
@@ -183,6 +202,13 @@ public class InternalResourceGroup
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
+                    succinctBytes(perQueryMemoryLimitBytes),
+                    succinctDuration(perQueryCpuLimitMillis, MILLISECONDS),
+                    succinctBytes(perQueryScanLimitBytes),
+                    hardTotalDriverLimit,
+                    hardPlanningConcurrencyLimit,
+                    cachedActiveDrivers,
+                    cachedPlanningQueries,
                     Optional.of(subGroups.values().stream()
                             .filter(group -> group.getRunningQueries() + group.getQueuedQueries() > 0)
                             .map(InternalResourceGroup::getSummaryInfo)
@@ -210,6 +236,13 @@ public class InternalResourceGroup
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
+                    succinctBytes(perQueryMemoryLimitBytes),
+                    succinctDuration(perQueryCpuLimitMillis, MILLISECONDS),
+                    succinctBytes(perQueryScanLimitBytes),
+                    hardTotalDriverLimit,
+                    hardPlanningConcurrencyLimit,
+                    cachedActiveDrivers,
+                    cachedPlanningQueries,
                     Optional.empty(),
                     Optional.empty());
         }
@@ -652,6 +685,108 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
+    @Override
+    public long getPerQueryMemoryLimitBytes()
+    {
+        return perQueryMemoryLimitBytes;
+    }
+
+    @Override
+    public void setPerQueryMemoryLimitBytes(long limit)
+    {
+        checkArgument(limit > 0, "perQueryMemoryLimitBytes must be positive");
+        this.perQueryMemoryLimitBytes = limit;
+    }
+
+    @Managed
+    @Override
+    public long getPerQueryCpuLimitMillis()
+    {
+        return perQueryCpuLimitMillis;
+    }
+
+    @Override
+    public void setPerQueryCpuLimitMillis(long limit)
+    {
+        checkArgument(limit > 0, "perQueryCpuLimitMillis must be positive");
+        this.perQueryCpuLimitMillis = limit;
+    }
+
+    @Managed
+    @Override
+    public long getPerQueryScanLimitBytes()
+    {
+        return perQueryScanLimitBytes;
+    }
+
+    @Override
+    public void setPerQueryScanLimitBytes(long limit)
+    {
+        checkArgument(limit > 0, "perQueryScanLimitBytes must be positive");
+        this.perQueryScanLimitBytes = limit;
+    }
+
+    @Managed
+    @Override
+    public int getHardTotalDriverLimit()
+    {
+        synchronized (root) {
+            return hardTotalDriverLimit;
+        }
+    }
+
+    @Override
+    public void setHardTotalDriverLimit(int limit)
+    {
+        checkArgument(limit > 0, "hardTotalDriverLimit must be positive");
+        synchronized (root) {
+            boolean oldCanRun = canRunMore();
+            this.hardTotalDriverLimit = limit;
+            if (canRunMore() != oldCanRun) {
+                updateEligibility();
+            }
+        }
+    }
+
+    @Managed
+    @Override
+    public int getHardPlanningConcurrencyLimit()
+    {
+        synchronized (root) {
+            return hardPlanningConcurrencyLimit;
+        }
+    }
+
+    @Override
+    public void setHardPlanningConcurrencyLimit(int limit)
+    {
+        checkArgument(limit > 0, "hardPlanningConcurrencyLimit must be positive");
+        synchronized (root) {
+            boolean oldCanRun = canRunMore();
+            this.hardPlanningConcurrencyLimit = limit;
+            if (canRunMore() != oldCanRun) {
+                updateEligibility();
+            }
+        }
+    }
+
+    @Managed
+    public int getActiveDrivers()
+    {
+        synchronized (root) {
+            return cachedActiveDrivers;
+        }
+    }
+
+    @Managed
+    public int getPlanningQueries()
+    {
+        synchronized (root) {
+            return cachedPlanningQueries;
+        }
+    }
+
     public InternalResourceGroup getOrCreateSubGroup(String name)
     {
         requireNonNull(name, "name is null");
@@ -793,23 +928,67 @@ public class InternalResourceGroup
 
     private void stageResourceUsage()
     {
+        long perQueryMemoryLimit = perQueryMemoryLimitBytes;
+        long perQueryCpuLimit = perQueryCpuLimitMillis;
+        long perQueryScanLimit = perQueryScanLimitBytes;
+        int activeDrivers = 0;
+        int planningQueries = 0;
+
         for (Entry<ManagedQueryExecution, StagedResourceUsage> entry : runningQueries.entrySet()) {
             ManagedQueryExecution query = entry.getKey();
             StagedResourceUsage resourceUsage = entry.getValue();
 
-            ResourceUsage newResourceUsage = new ResourceUsage(
-                    query.getTotalCpuTime().toMillis(),
-                    query.getTotalMemoryReservation().toBytes(),
-                    query.getBasicQueryInfo().getQueryStats().getPhysicalInputDataSize().toBytes());
+            BasicQueryStats queryStats = query.getBasicQueryInfo().getQueryStats();
+            long cpuMillis = query.getTotalCpuTime().toMillis();
+            long memoryBytes = query.getTotalMemoryReservation().toBytes();
+            long scanBytes = queryStats.getPhysicalInputDataSize().toBytes();
+
+            ResourceUsage newResourceUsage = new ResourceUsage(cpuMillis, memoryBytes, scanBytes);
             // Update resource usage only if the query is still running.
             // We cannot use entry.setValue(...) because we don’t want to restore the query
             // in case it was removed on completion.
             StagedResourceUsage staged = resourceUsage.stage(newResourceUsage);
             runningQueries.computeIfPresent(query, (_, _) -> staged);
+
+            enforcePerQueryLimits(query, memoryBytes, cpuMillis, scanBytes, perQueryMemoryLimit, perQueryCpuLimit, perQueryScanLimit);
+
+            if (!query.isDone()) {
+                activeDrivers += queryStats.getRunningDrivers() + queryStats.getQueuedDrivers() + queryStats.getBlockedDrivers();
+                QueryState state = query.getState();
+                if (state == QueryState.PLANNING || state == QueryState.STARTING) {
+                    planningQueries++;
+                }
+            }
         }
+
+        this.stagedActiveDrivers = activeDrivers;
+        this.stagedPlanningQueries = planningQueries;
 
         for (InternalResourceGroup subGroup : dirtySubGroups) {
             subGroup.stageResourceUsage();
+        }
+    }
+
+    private void enforcePerQueryLimits(
+            ManagedQueryExecution query,
+            long memoryBytes,
+            long cpuMillis,
+            long scanBytes,
+            long memoryLimit,
+            long cpuLimit,
+            long scanLimit)
+    {
+        if (memoryLimit < Long.MAX_VALUE && memoryBytes > memoryLimit) {
+            query.fail(new TrinoException(EXCEEDED_LOCAL_MEMORY_LIMIT,
+                    format("Query exceeded resource group per-query memory limit of %s in '%s'", succinctBytes(memoryLimit), id)));
+        }
+        else if (cpuLimit < Long.MAX_VALUE && cpuMillis > cpuLimit) {
+            query.fail(new TrinoException(EXCEEDED_CPU_LIMIT,
+                    format("Query exceeded resource group per-query CPU limit of %s in '%s'", succinctDuration(cpuLimit, MILLISECONDS), id)));
+        }
+        else if (scanLimit < Long.MAX_VALUE && scanBytes > scanLimit) {
+            query.fail(new TrinoException(EXCEEDED_SCAN_LIMIT,
+                    format("Query exceeded resource group per-query scan limit of %s in '%s'", succinctBytes(scanLimit), id)));
         }
     }
 
@@ -903,6 +1082,8 @@ public class InternalResourceGroup
         checkState(Thread.holdsLock(root), "Must hold lock to refresh stats");
         synchronized (root) {
             ResourceUsage groupUsageDelta = ZERO;
+            int activeDrivers = stagedActiveDrivers;
+            int planningQueriesCount = stagedPlanningQueries;
 
             for (Entry<ManagedQueryExecution, StagedResourceUsage> entry : runningQueries.entrySet()) {
                 StagedResourceUsage resourceUsage = entry.getValue();
@@ -921,11 +1102,16 @@ public class InternalResourceGroup
                 ResourceUsage subGroupUsageDelta = subGroup.updateResourceUsageAndGetDelta();
                 groupUsageDelta = groupUsageDelta.add(subGroupUsageDelta);
                 cachedResourceUsage = cachedResourceUsage.add(subGroupUsageDelta);
+                activeDrivers += subGroup.cachedActiveDrivers;
+                planningQueriesCount += subGroup.cachedPlanningQueries;
 
                 if (!subGroupUsageDelta.equals(ZERO)) {
                     subGroup.updateEligibility();
                 }
             }
+
+            cachedActiveDrivers = activeDrivers;
+            cachedPlanningQueries = planningQueriesCount;
 
             return groupUsageDelta;
         }
@@ -1092,7 +1278,16 @@ public class InternalResourceGroup
                 // Always allow at least one running query
                 hardConcurrencyLimit = Math.max(1, hardConcurrencyLimit);
             }
-            return runningQueries.size() + descendantRunningQueries < hardConcurrencyLimit;
+            if (runningQueries.size() + descendantRunningQueries >= hardConcurrencyLimit) {
+                return false;
+            }
+            if (cachedActiveDrivers >= hardTotalDriverLimit) {
+                return false;
+            }
+            if (cachedPlanningQueries >= hardPlanningConcurrencyLimit) {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -20,7 +20,9 @@ import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.stats.CounterStat;
 import io.trino.execution.ManagedQueryExecution;
+import io.trino.execution.QueryState;
 import io.trino.execution.resourcegroups.WeightedFairQueue.Usage;
+import io.trino.server.BasicQueryStats;
 import io.trino.server.QueryStateInfo;
 import io.trino.server.ResourceGroupInfo;
 import io.trino.spi.TrinoException;
@@ -55,6 +57,9 @@ import static io.airlift.units.Duration.succinctDuration;
 import static io.trino.SystemSessionProperties.getQueryPriority;
 import static io.trino.execution.resourcegroups.ResourceUsage.ZERO;
 import static io.trino.server.QueryStateInfo.createQueryStateInfo;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_CPU_LIMIT;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_SCAN_LIMIT;
 import static io.trino.spi.StandardErrorCode.INVALID_RESOURCE_GROUP;
 import static io.trino.spi.resourcegroups.ResourceGroupState.CAN_QUEUE;
 import static io.trino.spi.resourcegroups.ResourceGroupState.CAN_RUN;
@@ -115,6 +120,13 @@ public class InternalResourceGroup
     @GuardedBy("root")
     private boolean jmxExport;
     private volatile boolean disabled;
+    private volatile long perQueryMemoryLimitBytes = Long.MAX_VALUE;
+    private volatile long perQueryCpuLimitMillis = Long.MAX_VALUE;
+    private volatile long perQueryScanLimitBytes = Long.MAX_VALUE;
+    @GuardedBy("root")
+    private int hardTotalDriverLimit = Integer.MAX_VALUE;
+    @GuardedBy("root")
+    private int hardPlanningConcurrencyLimit = Integer.MAX_VALUE;
 
     // Live data structures
     // ====================
@@ -136,6 +148,13 @@ public class InternalResourceGroup
     // CPU, memory and physical data input usage is cached because it changes very rapidly while queries are running, and would be expensive to track continuously
     @GuardedBy("root")
     private ResourceUsage cachedResourceUsage = ZERO;
+    // Active driver and planning query counts are staged without lock and promoted with lock, similar to ResourceUsage
+    private volatile int stagedActiveDrivers;
+    private volatile int stagedPlanningQueries;
+    @GuardedBy("root")
+    private int cachedActiveDrivers;
+    @GuardedBy("root")
+    private int cachedPlanningQueries;
     @GuardedBy("root")
     private long lastStartNanos;
     private final CounterStat timeBetweenStartsSec = new CounterStat();
@@ -183,6 +202,13 @@ public class InternalResourceGroup
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
+                    succinctBytes(perQueryMemoryLimitBytes),
+                    succinctDuration(perQueryCpuLimitMillis, MILLISECONDS),
+                    succinctBytes(perQueryScanLimitBytes),
+                    hardTotalDriverLimit,
+                    hardPlanningConcurrencyLimit,
+                    cachedActiveDrivers,
+                    cachedPlanningQueries,
                     Optional.of(subGroups.values().stream()
                             .filter(group -> group.getRunningQueries() + group.getQueuedQueries() > 0)
                             .map(InternalResourceGroup::getSummaryInfo)
@@ -210,6 +236,13 @@ public class InternalResourceGroup
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
+                    succinctBytes(perQueryMemoryLimitBytes),
+                    succinctDuration(perQueryCpuLimitMillis, MILLISECONDS),
+                    succinctBytes(perQueryScanLimitBytes),
+                    hardTotalDriverLimit,
+                    hardPlanningConcurrencyLimit,
+                    cachedActiveDrivers,
+                    cachedPlanningQueries,
                     Optional.empty(),
                     Optional.empty());
         }
@@ -651,6 +684,108 @@ public class InternalResourceGroup
         }
     }
 
+    @Managed
+    @Override
+    public long getPerQueryMemoryLimitBytes()
+    {
+        return perQueryMemoryLimitBytes;
+    }
+
+    @Override
+    public void setPerQueryMemoryLimitBytes(long limit)
+    {
+        checkArgument(limit > 0, "perQueryMemoryLimitBytes must be positive");
+        this.perQueryMemoryLimitBytes = limit;
+    }
+
+    @Managed
+    @Override
+    public long getPerQueryCpuLimitMillis()
+    {
+        return perQueryCpuLimitMillis;
+    }
+
+    @Override
+    public void setPerQueryCpuLimitMillis(long limit)
+    {
+        checkArgument(limit > 0, "perQueryCpuLimitMillis must be positive");
+        this.perQueryCpuLimitMillis = limit;
+    }
+
+    @Managed
+    @Override
+    public long getPerQueryScanLimitBytes()
+    {
+        return perQueryScanLimitBytes;
+    }
+
+    @Override
+    public void setPerQueryScanLimitBytes(long limit)
+    {
+        checkArgument(limit > 0, "perQueryScanLimitBytes must be positive");
+        this.perQueryScanLimitBytes = limit;
+    }
+
+    @Managed
+    @Override
+    public int getHardTotalDriverLimit()
+    {
+        synchronized (root) {
+            return hardTotalDriverLimit;
+        }
+    }
+
+    @Override
+    public void setHardTotalDriverLimit(int limit)
+    {
+        checkArgument(limit > 0, "hardTotalDriverLimit must be positive");
+        synchronized (root) {
+            boolean oldCanRun = canRunMore();
+            this.hardTotalDriverLimit = limit;
+            if (canRunMore() != oldCanRun) {
+                updateEligibility();
+            }
+        }
+    }
+
+    @Managed
+    @Override
+    public int getHardPlanningConcurrencyLimit()
+    {
+        synchronized (root) {
+            return hardPlanningConcurrencyLimit;
+        }
+    }
+
+    @Override
+    public void setHardPlanningConcurrencyLimit(int limit)
+    {
+        checkArgument(limit > 0, "hardPlanningConcurrencyLimit must be positive");
+        synchronized (root) {
+            boolean oldCanRun = canRunMore();
+            this.hardPlanningConcurrencyLimit = limit;
+            if (canRunMore() != oldCanRun) {
+                updateEligibility();
+            }
+        }
+    }
+
+    @Managed
+    public int getActiveDrivers()
+    {
+        synchronized (root) {
+            return cachedActiveDrivers;
+        }
+    }
+
+    @Managed
+    public int getPlanningQueries()
+    {
+        synchronized (root) {
+            return cachedPlanningQueries;
+        }
+    }
+
     public InternalResourceGroup getOrCreateSubGroup(String name)
     {
         requireNonNull(name, "name is null");
@@ -792,23 +927,70 @@ public class InternalResourceGroup
 
     private void stageResourceUsage()
     {
+        long perQueryMemoryLimit = perQueryMemoryLimitBytes;
+        long perQueryCpuLimit = perQueryCpuLimitMillis;
+        long perQueryScanLimit = perQueryScanLimitBytes;
+        int activeDrivers = 0;
+        int planningQueries = 0;
+
         for (Entry<ManagedQueryExecution, StagedResourceUsage> entry : runningQueries.entrySet()) {
             ManagedQueryExecution query = entry.getKey();
             StagedResourceUsage resourceUsage = entry.getValue();
 
-            ResourceUsage newResourceUsage = new ResourceUsage(
-                    query.getTotalCpuTime().toMillis(),
-                    query.getTotalMemoryReservation().toBytes(),
-                    query.getBasicQueryInfo().getQueryStats().getPhysicalInputDataSize().toBytes());
+            BasicQueryStats queryStats = query.getBasicQueryInfo().getQueryStats();
+            long cpuMillis = query.getTotalCpuTime().toMillis();
+            long memoryBytes = query.getTotalMemoryReservation().toBytes();
+            long scanBytes = queryStats.getPhysicalInputDataSize().toBytes();
+
+            ResourceUsage newResourceUsage = new ResourceUsage(cpuMillis, memoryBytes, scanBytes);
             // Update resource usage only if the query is still running.
             // We cannot use entry.setValue(...) because we don’t want to restore the query
             // in case it was removed on completion.
             StagedResourceUsage staged = resourceUsage.stage(newResourceUsage);
             runningQueries.computeIfPresent(query, (_, _) -> staged);
+
+            enforcePerQueryLimits(query, memoryBytes, cpuMillis, scanBytes, perQueryMemoryLimit, perQueryCpuLimit, perQueryScanLimit);
+
+            if (!query.isDone()) {
+                activeDrivers += queryStats.getRunningDrivers() + queryStats.getQueuedDrivers() + queryStats.getBlockedDrivers();
+                QueryState state = query.getState();
+                if (state == QueryState.PLANNING || state == QueryState.STARTING) {
+                    planningQueries++;
+                }
+            }
         }
+
+        this.stagedActiveDrivers = activeDrivers;
+        this.stagedPlanningQueries = planningQueries;
 
         for (InternalResourceGroup subGroup : dirtySubGroups) {
             subGroup.stageResourceUsage();
+        }
+    }
+
+    private void enforcePerQueryLimits(
+            ManagedQueryExecution query,
+            long memoryBytes,
+            long cpuMillis,
+            long scanBytes,
+            long memoryLimit,
+            long cpuLimit,
+            long scanLimit)
+    {
+        if (memoryLimit < Long.MAX_VALUE && memoryBytes > memoryLimit) {
+            query.fail(new TrinoException(
+                    EXCEEDED_LOCAL_MEMORY_LIMIT,
+                    format("Query exceeded resource group per-query memory limit of %s in '%s'", succinctBytes(memoryLimit), id)));
+        }
+        else if (cpuLimit < Long.MAX_VALUE && cpuMillis > cpuLimit) {
+            query.fail(new TrinoException(
+                    EXCEEDED_CPU_LIMIT,
+                    format("Query exceeded resource group per-query CPU limit of %s in '%s'", succinctDuration(cpuLimit, MILLISECONDS), id)));
+        }
+        else if (scanLimit < Long.MAX_VALUE && scanBytes > scanLimit) {
+            query.fail(new TrinoException(
+                    EXCEEDED_SCAN_LIMIT,
+                    format("Query exceeded resource group per-query scan limit of %s in '%s'", succinctBytes(scanLimit), id)));
         }
     }
 
@@ -902,6 +1084,8 @@ public class InternalResourceGroup
         checkState(Thread.holdsLock(root), "Must hold lock to refresh stats");
         synchronized (root) {
             ResourceUsage groupUsageDelta = ZERO;
+            int activeDrivers = stagedActiveDrivers;
+            int planningQueriesCount = stagedPlanningQueries;
 
             for (Entry<ManagedQueryExecution, StagedResourceUsage> entry : runningQueries.entrySet()) {
                 StagedResourceUsage resourceUsage = entry.getValue();
@@ -920,11 +1104,16 @@ public class InternalResourceGroup
                 ResourceUsage subGroupUsageDelta = subGroup.updateResourceUsageAndGetDelta();
                 groupUsageDelta = groupUsageDelta.add(subGroupUsageDelta);
                 cachedResourceUsage = cachedResourceUsage.add(subGroupUsageDelta);
+                activeDrivers += subGroup.cachedActiveDrivers;
+                planningQueriesCount += subGroup.cachedPlanningQueries;
 
                 if (!subGroupUsageDelta.equals(ZERO)) {
                     subGroup.updateEligibility();
                 }
             }
+
+            cachedActiveDrivers = activeDrivers;
+            cachedPlanningQueries = planningQueriesCount;
 
             return groupUsageDelta;
         }
@@ -1091,7 +1280,16 @@ public class InternalResourceGroup
                 // Always allow at least one running query
                 hardConcurrencyLimit = Math.max(1, hardConcurrencyLimit);
             }
-            return runningQueries.size() + descendantRunningQueries < hardConcurrencyLimit;
+            if (runningQueries.size() + descendantRunningQueries >= hardConcurrencyLimit) {
+                return false;
+            }
+            if (cachedActiveDrivers >= hardTotalDriverLimit) {
+                return false;
+            }
+            if (cachedPlanningQueries >= hardPlanningConcurrencyLimit) {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/ResourceGroupInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ResourceGroupInfo.java
@@ -45,6 +45,13 @@ public record ResourceGroupInfo(
         int numQueuedQueries,
         int numRunningQueries,
         int numEligibleSubGroups,
+        DataSize perQueryMemoryLimit,
+        Duration perQueryCpuLimit,
+        DataSize perQueryScanLimit,
+        int hardTotalDriverLimit,
+        int hardPlanningConcurrencyLimit,
+        int activeDrivers,
+        int planningQueries,
         Optional<List<ResourceGroupInfo>> subGroups,
         Optional<List<QueryStateInfo>> runningQueries)
 {
@@ -58,6 +65,9 @@ public record ResourceGroupInfo(
         requireNonNull(cpuUsage, "cpuUsage is null");
         requireNonNull(hardPhysicalDataScanLimit, "hardPhysicalDataScanLimit is null");
         requireNonNull(physicalInputDataUsage, "physicalInputDataUsage is null");
+        requireNonNull(perQueryMemoryLimit, "perQueryMemoryLimit is null");
+        requireNonNull(perQueryCpuLimit, "perQueryCpuLimit is null");
+        requireNonNull(perQueryScanLimit, "perQueryScanLimit is null");
         subGroups = subGroups.map(ImmutableList::copyOf);
         runningQueries = runningQueries.map(ImmutableList::copyOf);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockManagedQueryExecution.java
@@ -55,10 +55,13 @@ public class MockManagedQueryExecution
     private DataSize memoryUsage;
     private Duration cpuUsage;
     private DataSize physicalInputDataUsage;
+    private int runningDrivers;
+    private int queuedDrivers;
+    private int blockedDrivers;
     private QueryState state = QUEUED;
     private Throwable failureCause;
 
-    private MockManagedQueryExecution(String queryId, int priority, DataSize memoryUsage, Duration cpuUsage, DataSize physicalInputDataUsage)
+    private MockManagedQueryExecution(String queryId, int priority, DataSize memoryUsage, Duration cpuUsage, DataSize physicalInputDataUsage, int runningDrivers, int queuedDrivers, int blockedDrivers)
     {
         requireNonNull(queryId, "queryId is null");
         this.session = testSessionBuilder()
@@ -69,6 +72,9 @@ public class MockManagedQueryExecution
         this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
         this.cpuUsage = requireNonNull(cpuUsage, "cpuUsage is null");
         this.physicalInputDataUsage = requireNonNull(physicalInputDataUsage, "physicalInputDataUsage is null");
+        this.runningDrivers = runningDrivers;
+        this.queuedDrivers = queuedDrivers;
+        this.blockedDrivers = blockedDrivers;
     }
 
     public void consumeCpuTimeMillis(long cpuTimeDeltaMillis)
@@ -89,6 +95,12 @@ public class MockManagedQueryExecution
         checkState(state == RUNNING, "cannot set physical input data usage in a non-running state");
         long newDataScan = physicalInputDataUsage.toBytes() + physicalInputDataBytes;
         this.physicalInputDataUsage = DataSize.ofBytes(newDataScan);
+    }
+
+    public void setState(QueryState state)
+    {
+        this.state = state;
+        fireStateChange();
     }
 
     public void complete()
@@ -136,11 +148,11 @@ public class MockManagedQueryExecution
                         new Duration(5, NANOSECONDS),
                         new Duration(6, NANOSECONDS),
                         99,
-                        6,
-                        7,
-                        8,
+                        runningDrivers + queuedDrivers + blockedDrivers + 9,
+                        queuedDrivers,
+                        runningDrivers,
                         9,
-                        5,
+                        blockedDrivers,
                         15,
                         DataSize.ofBytes(13),
                         physicalInputDataUsage,
@@ -368,6 +380,9 @@ public class MockManagedQueryExecution
         private DataSize physicalInputDataUsage = DataSize.ofBytes(0);
         private int priority = 1;
         private String queryId = "query_id";
+        private int runningDrivers;
+        private int queuedDrivers;
+        private int blockedDrivers;
 
         public MockManagedQueryExecutionBuilder() {}
 
@@ -401,9 +416,27 @@ public class MockManagedQueryExecution
             return this;
         }
 
+        public MockManagedQueryExecutionBuilder withRunningDrivers(int runningDrivers)
+        {
+            this.runningDrivers = runningDrivers;
+            return this;
+        }
+
+        public MockManagedQueryExecutionBuilder withQueuedDrivers(int queuedDrivers)
+        {
+            this.queuedDrivers = queuedDrivers;
+            return this;
+        }
+
+        public MockManagedQueryExecutionBuilder withBlockedDrivers(int blockedDrivers)
+        {
+            this.blockedDrivers = blockedDrivers;
+            return this;
+        }
+
         public MockManagedQueryExecution build()
         {
-            return new MockManagedQueryExecution(queryId, priority, memoryUsage, cpuUsage, physicalInputDataUsage);
+            return new MockManagedQueryExecution(queryId, priority, memoryUsage, cpuUsage, physicalInputDataUsage, runningDrivers, queuedDrivers, blockedDrivers);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.trino.execution.MockManagedQueryExecution;
 import io.trino.execution.MockManagedQueryExecution.MockManagedQueryExecutionBuilder;
+import io.trino.execution.QueryState;
 import io.trino.server.QueryStateInfo;
 import io.trino.server.ResourceGroupInfo;
 import org.apache.commons.math3.distribution.BinomialDistribution;
@@ -50,6 +51,7 @@ import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED_FAIR;
 import static java.util.Collections.reverse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestResourceGroups
 {
@@ -1914,7 +1916,14 @@ public class TestResourceGroups
                 Objects.equals(actual.memoryUsage(), expected.memoryUsage()) &&
                 Objects.equals(actual.cpuUsage(), expected.cpuUsage()) &&
                 Objects.equals(actual.hardPhysicalDataScanLimit(), expected.hardPhysicalDataScanLimit()) &&
-                Objects.equals(actual.physicalInputDataUsage(), expected.physicalInputDataUsage())).isTrue();
+                Objects.equals(actual.physicalInputDataUsage(), expected.physicalInputDataUsage()) &&
+                Objects.equals(actual.perQueryMemoryLimit(), expected.perQueryMemoryLimit()) &&
+                Objects.equals(actual.perQueryCpuLimit(), expected.perQueryCpuLimit()) &&
+                Objects.equals(actual.perQueryScanLimit(), expected.perQueryScanLimit()) &&
+                actual.hardTotalDriverLimit() == expected.hardTotalDriverLimit() &&
+                actual.hardPlanningConcurrencyLimit() == expected.hardPlanningConcurrencyLimit() &&
+                actual.activeDrivers() == expected.activeDrivers() &&
+                actual.planningQueries() == expected.planningQueries()).isTrue();
     }
 
     private static void assertExceedsCpuLimit(InternalResourceGroup group, long expectedMillis)
@@ -1963,5 +1972,363 @@ public class TestResourceGroups
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isLessThanOrEqualTo(group.getHardPhysicalDataScanLimitBytes());
         assertThat(group.getPhysicalInputDataUsageBytes()).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryMemoryLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(5, MEGABYTE))
+                .build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.setMemoryUsage(DataSize.of(15, MEGABYTE));
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query1.getThrowable().getMessage()).contains("per-query memory limit");
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryCpuLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryCpuLimitMillis(1000);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumeCpuTimeMillis(500);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumeCpuTimeMillis(600);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query1.getThrowable().getMessage()).contains("per-query CPU limit");
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryScanLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryScanLimitBytes(100);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumePhysicalInputDataBytes(50);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumePhysicalInputDataBytes(60);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query1.getThrowable().getMessage()).contains("per-query scan limit");
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryLimitsDoNotAffectOtherQueries()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(15, MEGABYTE))
+                .build();
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(5, MEGABYTE))
+                .build();
+        root.run(query1);
+        root.run(query2);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardTotalDriverLimit(20);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(10)
+                .withBlockedDrivers(5)
+                .build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(3)
+                .withBlockedDrivers(2)
+                .build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query3);
+        assertThat(query3.getState()).isEqualTo(QUEUED);
+
+        query1.complete();
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query3.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimitWithSubGroups()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(10);
+        root.setHardConcurrencyLimit(10);
+        root.setHardTotalDriverLimit(15);
+
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+        child.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        child.setMaxQueuedQueries(10);
+        child.setHardConcurrencyLimit(10);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(10)
+                .withBlockedDrivers(5)
+                .build();
+        child.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+
+        query1.complete();
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardPlanningConcurrencyLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardPlanningConcurrencyLimit(1);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.setState(QueryState.PLANNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+
+        query1.setState(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryMemoryLimitAtBoundary()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(10, MEGABYTE))
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimitAtBoundary()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardTotalDriverLimit(10);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(10)
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimitIncludesQueuedDrivers()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardTotalDriverLimit(20);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(5)
+                .withQueuedDrivers(10)
+                .withBlockedDrivers(5)
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testKilledQueryDriversNotCounted()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+        root.setHardTotalDriverLimit(15);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(15, MEGABYTE))
+                .withRunningDrivers(10)
+                .build();
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(3)
+                .build();
+        root.run(query1);
+        root.run(query2);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+        assertThat(root.getActiveDrivers()).isEqualTo(3);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testActiveDriversAndPlanningQueriesObservability()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(5)
+                .withBlockedDrivers(3)
+                .build();
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(2)
+                .withQueuedDrivers(1)
+                .build();
+        root.run(query1);
+        root.run(query2);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        assertThat(root.getActiveDrivers()).isEqualTo(11);
+        assertThat(root.getPlanningQueries()).isEqualTo(0);
+
+        query1.setState(QueryState.PLANNING);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(root.getPlanningQueries()).isEqualTo(1);
+
+        query1.setState(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(root.getPlanningQueries()).isEqualTo(0);
+    }
+
+    @Test
+    public void testNewLimitSetterValidation()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+
+        assertThatThrownBy(() -> root.setPerQueryMemoryLimitBytes(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setPerQueryMemoryLimitBytes(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setPerQueryCpuLimitMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setPerQueryScanLimitBytes(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setHardTotalDriverLimit(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setHardTotalDriverLimit(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setHardPlanningConcurrencyLimit(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testDefaultLimitsDoNotEnforce()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(500, MEGABYTE))
+                .withRunningDrivers(1000)
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumeCpuTimeMillis(100_000);
+        query1.consumePhysicalInputDataBytes(10_000_000_000L);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.trino.execution.MockManagedQueryExecution;
 import io.trino.execution.MockManagedQueryExecution.MockManagedQueryExecutionBuilder;
+import io.trino.execution.QueryState;
 import io.trino.server.QueryStateInfo;
 import io.trino.server.ResourceGroupInfo;
 import org.apache.commons.math3.distribution.BinomialDistribution;
@@ -50,6 +51,7 @@ import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED_FAIR;
 import static java.util.Collections.reverse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestResourceGroups
 {
@@ -1914,7 +1916,14 @@ public class TestResourceGroups
                 Objects.equals(actual.memoryUsage(), expected.memoryUsage()) &&
                 Objects.equals(actual.cpuUsage(), expected.cpuUsage()) &&
                 Objects.equals(actual.hardPhysicalDataScanLimit(), expected.hardPhysicalDataScanLimit()) &&
-                Objects.equals(actual.physicalInputDataUsage(), expected.physicalInputDataUsage())).isTrue();
+                Objects.equals(actual.physicalInputDataUsage(), expected.physicalInputDataUsage()) &&
+                Objects.equals(actual.perQueryMemoryLimit(), expected.perQueryMemoryLimit()) &&
+                Objects.equals(actual.perQueryCpuLimit(), expected.perQueryCpuLimit()) &&
+                Objects.equals(actual.perQueryScanLimit(), expected.perQueryScanLimit()) &&
+                actual.hardTotalDriverLimit() == expected.hardTotalDriverLimit() &&
+                actual.hardPlanningConcurrencyLimit() == expected.hardPlanningConcurrencyLimit() &&
+                actual.activeDrivers() == expected.activeDrivers() &&
+                actual.planningQueries() == expected.planningQueries()).isTrue();
     }
 
     private static void assertExceedsCpuLimit(InternalResourceGroup group, long expectedMillis)
@@ -1963,5 +1972,363 @@ public class TestResourceGroups
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isLessThanOrEqualTo(group.getHardPhysicalDataScanLimitBytes());
         assertThat(group.getPhysicalInputDataUsageBytes()).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryMemoryLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(5, MEGABYTE))
+                .build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.setMemoryUsage(DataSize.of(15, MEGABYTE));
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query1.getThrowable().getMessage()).contains("per-query memory limit");
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryCpuLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryCpuLimitMillis(1000);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumeCpuTimeMillis(500);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumeCpuTimeMillis(600);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query1.getThrowable().getMessage()).contains("per-query CPU limit");
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryScanLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryScanLimitBytes(100);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumePhysicalInputDataBytes(50);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumePhysicalInputDataBytes(60);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query1.getThrowable().getMessage()).contains("per-query scan limit");
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryLimitsDoNotAffectOtherQueries()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(15, MEGABYTE))
+                .build();
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(5, MEGABYTE))
+                .build();
+        root.run(query1);
+        root.run(query2);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardTotalDriverLimit(20);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(10)
+                .withBlockedDrivers(5)
+                .build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(3)
+                .withBlockedDrivers(2)
+                .build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query3 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query3);
+        assertThat(query3.getState()).isEqualTo(QUEUED);
+
+        query1.complete();
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query3.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimitWithSubGroups()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(10);
+        root.setHardConcurrencyLimit(10);
+        root.setHardTotalDriverLimit(15);
+
+        InternalResourceGroup child = root.getOrCreateSubGroup("child");
+        child.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        child.setMaxQueuedQueries(10);
+        child.setHardConcurrencyLimit(10);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(10)
+                .withBlockedDrivers(5)
+                .build();
+        child.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        child.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+
+        query1.complete();
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardPlanningConcurrencyLimit()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardPlanningConcurrencyLimit(1);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query1);
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.setState(QueryState.PLANNING);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+
+        query1.setState(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testPerQueryMemoryLimitAtBoundary()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(10, MEGABYTE))
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimitAtBoundary()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardTotalDriverLimit(10);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(10)
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testHardTotalDriverLimitIncludesQueuedDrivers()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setHardTotalDriverLimit(20);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(5)
+                .withQueuedDrivers(10)
+                .withBlockedDrivers(5)
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder().build();
+        root.run(query2);
+        assertThat(query2.getState()).isEqualTo(QUEUED);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testKilledQueryDriversNotCounted()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+        root.setPerQueryMemoryLimitBytes(DataSize.of(10, MEGABYTE).toBytes());
+        root.setHardTotalDriverLimit(15);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(15, MEGABYTE))
+                .withRunningDrivers(10)
+                .build();
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(3)
+                .build();
+        root.run(query1);
+        root.run(query2);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        assertThat(query1.getState()).isEqualTo(FAILED);
+        assertThat(query2.getState()).isEqualTo(RUNNING);
+        assertThat(root.getActiveDrivers()).isEqualTo(3);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testActiveDriversAndPlanningQueriesObservability()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(5)
+                .withBlockedDrivers(3)
+                .build();
+        MockManagedQueryExecution query2 = new MockManagedQueryExecutionBuilder()
+                .withRunningDrivers(2)
+                .withQueuedDrivers(1)
+                .build();
+        root.run(query1);
+        root.run(query2);
+        root.updateGroupsAndProcessQueuedQueries();
+
+        assertThat(root.getActiveDrivers()).isEqualTo(11);
+        assertThat(root.getPlanningQueries()).isEqualTo(0);
+
+        query1.setState(QueryState.PLANNING);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(root.getPlanningQueries()).isEqualTo(1);
+
+        query1.setState(RUNNING);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(root.getPlanningQueries()).isEqualTo(0);
+    }
+
+    @Test
+    public void testNewLimitSetterValidation()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+
+        assertThatThrownBy(() -> root.setPerQueryMemoryLimitBytes(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setPerQueryMemoryLimitBytes(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setPerQueryCpuLimitMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setPerQueryScanLimitBytes(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setHardTotalDriverLimit(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setHardTotalDriverLimit(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> root.setHardPlanningConcurrencyLimit(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @Timeout(10)
+    public void testDefaultLimitsDoNotEnforce()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSoftMemoryLimitBytes(DataSize.of(1, GIGABYTE).toBytes());
+        root.setMaxQueuedQueries(4);
+        root.setHardConcurrencyLimit(4);
+
+        MockManagedQueryExecution query1 = new MockManagedQueryExecutionBuilder()
+                .withInitialMemoryUsage(DataSize.of(500, MEGABYTE))
+                .withRunningDrivers(1000)
+                .build();
+        root.run(query1);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
+
+        query1.consumeCpuTimeMillis(100_000);
+        query1.consumePhysicalInputDataBytes(10_000_000_000L);
+        root.updateGroupsAndProcessQueuedQueries();
+        assertThat(query1.getState()).isEqualTo(RUNNING);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
@@ -121,4 +121,59 @@ public interface ResourceGroup
      * unless it has other active subgroups.
      */
     void setDisabled(boolean disabled);
+
+    default long getPerQueryMemoryLimitBytes()
+    {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * Maximum memory a single query in this group can use. Queries exceeding
+     * this limit are killed.
+     */
+    default void setPerQueryMemoryLimitBytes(long limit) {}
+
+    default long getPerQueryCpuLimitMillis()
+    {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * Maximum CPU time a single query in this group can use. Queries exceeding
+     * this limit are killed.
+     */
+    default void setPerQueryCpuLimitMillis(long limit) {}
+
+    default long getPerQueryScanLimitBytes()
+    {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * Maximum physical data scan a single query in this group can use. Queries
+     * exceeding this limit are killed.
+     */
+    default void setPerQueryScanLimitBytes(long limit) {}
+
+    default int getHardTotalDriverLimit()
+    {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Maximum total active drivers (running + queued + blocked) across all queries
+     * in this group. When exceeded, new queries queue instead of starting.
+     */
+    default void setHardTotalDriverLimit(int limit) {}
+
+    default int getHardPlanningConcurrencyLimit()
+    {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Maximum number of queries in PLANNING or STARTING state concurrently
+     * in this group. When exceeded, new queries queue instead of starting.
+     */
+    default void setHardPlanningConcurrencyLimit(int limit) {}
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -243,5 +243,10 @@ public abstract class AbstractResourceConfigurationManager
             rate = Math.max(1, rate);
             group.setPhysicalDataScanQuotaGenerationBytesPerSecond(rate);
         }
+        match.getPerQueryMemoryLimit().map(DataSize::toBytes).ifPresent(group::setPerQueryMemoryLimitBytes);
+        match.getPerQueryCpuLimit().map(Duration::toMillis).ifPresent(group::setPerQueryCpuLimitMillis);
+        match.getPerQueryScanLimit().map(DataSize::toBytes).ifPresent(group::setPerQueryScanLimitBytes);
+        match.getHardTotalDriverLimit().ifPresent(group::setHardTotalDriverLimit);
+        match.getHardPlanningConcurrencyLimit().ifPresent(group::setHardPlanningConcurrencyLimit);
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -242,5 +242,10 @@ public abstract class AbstractResourceConfigurationManager
             rate = Math.max(1, rate);
             group.setPhysicalDataScanQuotaGenerationBytesPerSecond(rate);
         }
+        match.getPerQueryMemoryLimit().map(DataSize::toBytes).ifPresent(group::setPerQueryMemoryLimitBytes);
+        match.getPerQueryCpuLimit().map(Duration::toMillis).ifPresent(group::setPerQueryCpuLimitMillis);
+        match.getPerQueryScanLimit().map(DataSize::toBytes).ifPresent(group::setPerQueryScanLimitBytes);
+        match.getHardTotalDriverLimit().ifPresent(group::setHardTotalDriverLimit);
+        match.getHardPlanningConcurrencyLimit().ifPresent(group::setHardPlanningConcurrencyLimit);
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
@@ -51,6 +51,11 @@ public class ResourceGroupSpec
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
     private final Optional<DataSize> hardPhysicalDataScanLimit;
+    private final Optional<DataSize> perQueryMemoryLimit;
+    private final Optional<Duration> perQueryCpuLimit;
+    private final Optional<DataSize> perQueryScanLimit;
+    private final Optional<Integer> hardTotalDriverLimit;
+    private final Optional<Integer> hardPlanningConcurrencyLimit;
 
     @JsonCreator
     public ResourceGroupSpec(
@@ -66,7 +71,12 @@ public class ResourceGroupSpec
             @JsonProperty("jmxExport") Optional<Boolean> jmxExport,
             @JsonProperty("softCpuLimit") Optional<Duration> softCpuLimit,
             @JsonProperty("hardCpuLimit") Optional<Duration> hardCpuLimit,
-            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit)
+            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit,
+            @JsonProperty("perQueryMemoryLimit") Optional<DataSize> perQueryMemoryLimit,
+            @JsonProperty("perQueryCpuLimit") Optional<Duration> perQueryCpuLimit,
+            @JsonProperty("perQueryScanLimit") Optional<DataSize> perQueryScanLimit,
+            @JsonProperty("hardTotalDriverLimit") Optional<Integer> hardTotalDriverLimit,
+            @JsonProperty("hardPlanningConcurrencyLimit") Optional<Integer> hardPlanningConcurrencyLimit)
     {
         this.softCpuLimit = requireNonNull(softCpuLimit, "softCpuLimit is null");
         this.hardCpuLimit = requireNonNull(hardCpuLimit, "hardCpuLimit is null");
@@ -76,6 +86,13 @@ public class ResourceGroupSpec
         this.maxQueued = maxQueued;
         this.softConcurrencyLimit = softConcurrencyLimit;
         this.hardPhysicalDataScanLimit = requireNonNull(hardPhysicalDataScanLimit, "hardPhysicalDataScanLimit is null");
+        this.perQueryMemoryLimit = requireNonNull(perQueryMemoryLimit, "perQueryMemoryLimit is null");
+        this.perQueryCpuLimit = requireNonNull(perQueryCpuLimit, "perQueryCpuLimit is null");
+        this.perQueryScanLimit = requireNonNull(perQueryScanLimit, "perQueryScanLimit is null");
+        this.hardTotalDriverLimit = requireNonNull(hardTotalDriverLimit, "hardTotalDriverLimit is null");
+        this.hardPlanningConcurrencyLimit = requireNonNull(hardPlanningConcurrencyLimit, "hardPlanningConcurrencyLimit is null");
+        hardTotalDriverLimit.ifPresent(limit -> checkArgument(limit > 0, "hardTotalDriverLimit must be positive"));
+        hardPlanningConcurrencyLimit.ifPresent(limit -> checkArgument(limit > 0, "hardPlanningConcurrencyLimit must be positive"));
 
         checkArgument(hardConcurrencyLimit.isPresent() || maxRunning.isPresent(), "Missing required property: hardConcurrencyLimit");
         this.hardConcurrencyLimit = hardConcurrencyLimit.orElseGet(maxRunning::get);
@@ -176,6 +193,31 @@ public class ResourceGroupSpec
         return hardPhysicalDataScanLimit;
     }
 
+    public Optional<DataSize> getPerQueryMemoryLimit()
+    {
+        return perQueryMemoryLimit;
+    }
+
+    public Optional<Duration> getPerQueryCpuLimit()
+    {
+        return perQueryCpuLimit;
+    }
+
+    public Optional<DataSize> getPerQueryScanLimit()
+    {
+        return perQueryScanLimit;
+    }
+
+    public Optional<Integer> getHardTotalDriverLimit()
+    {
+        return hardTotalDriverLimit;
+    }
+
+    public Optional<Integer> getHardPlanningConcurrencyLimit()
+    {
+        return hardPlanningConcurrencyLimit;
+    }
+
     @Override
     public boolean equals(Object other)
     {
@@ -197,7 +239,12 @@ public class ResourceGroupSpec
                 jmxExport.equals(that.jmxExport) &&
                 softCpuLimit.equals(that.softCpuLimit) &&
                 hardCpuLimit.equals(that.hardCpuLimit) &&
-                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit));
+                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit) &&
+                perQueryMemoryLimit.equals(that.perQueryMemoryLimit) &&
+                perQueryCpuLimit.equals(that.perQueryCpuLimit) &&
+                perQueryScanLimit.equals(that.perQueryScanLimit) &&
+                hardTotalDriverLimit.equals(that.hardTotalDriverLimit) &&
+                hardPlanningConcurrencyLimit.equals(that.hardPlanningConcurrencyLimit));
     }
 
     // Subgroups not included, used to determine whether a group needs to be reconfigured
@@ -216,7 +263,12 @@ public class ResourceGroupSpec
                 jmxExport.equals(other.jmxExport) &&
                 softCpuLimit.equals(other.softCpuLimit) &&
                 hardCpuLimit.equals(other.hardCpuLimit) &&
-                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit));
+                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit) &&
+                perQueryMemoryLimit.equals(other.perQueryMemoryLimit) &&
+                perQueryCpuLimit.equals(other.perQueryCpuLimit) &&
+                perQueryScanLimit.equals(other.perQueryScanLimit) &&
+                hardTotalDriverLimit.equals(other.hardTotalDriverLimit) &&
+                hardPlanningConcurrencyLimit.equals(other.hardPlanningConcurrencyLimit));
     }
 
     @Override
@@ -234,7 +286,12 @@ public class ResourceGroupSpec
                 jmxExport,
                 softCpuLimit,
                 hardCpuLimit,
-                hardPhysicalDataScanLimit);
+                hardPhysicalDataScanLimit,
+                perQueryMemoryLimit,
+                perQueryCpuLimit,
+                perQueryScanLimit,
+                hardTotalDriverLimit,
+                hardPlanningConcurrencyLimit);
     }
 
     @Override
@@ -252,6 +309,11 @@ public class ResourceGroupSpec
                 .add("softCpuLimit", softCpuLimit)
                 .add("hardCpuLimit", hardCpuLimit)
                 .add("hardPhysicalDataScanLimit", hardPhysicalDataScanLimit)
+                .add("perQueryMemoryLimit", perQueryMemoryLimit)
+                .add("perQueryCpuLimit", perQueryCpuLimit)
+                .add("perQueryScanLimit", perQueryScanLimit)
+                .add("hardTotalDriverLimit", hardTotalDriverLimit)
+                .add("hardPlanningConcurrencyLimit", hardPlanningConcurrencyLimit)
                 .toString();
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
@@ -50,6 +50,11 @@ public class ResourceGroupSpec
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
     private final Optional<DataSize> hardPhysicalDataScanLimit;
+    private final Optional<DataSize> perQueryMemoryLimit;
+    private final Optional<Duration> perQueryCpuLimit;
+    private final Optional<DataSize> perQueryScanLimit;
+    private final Optional<Integer> hardTotalDriverLimit;
+    private final Optional<Integer> hardPlanningConcurrencyLimit;
 
     @JsonCreator
     public ResourceGroupSpec(
@@ -65,7 +70,12 @@ public class ResourceGroupSpec
             @JsonProperty("jmxExport") Optional<Boolean> jmxExport,
             @JsonProperty("softCpuLimit") Optional<Duration> softCpuLimit,
             @JsonProperty("hardCpuLimit") Optional<Duration> hardCpuLimit,
-            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit)
+            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit,
+            @JsonProperty("perQueryMemoryLimit") Optional<DataSize> perQueryMemoryLimit,
+            @JsonProperty("perQueryCpuLimit") Optional<Duration> perQueryCpuLimit,
+            @JsonProperty("perQueryScanLimit") Optional<DataSize> perQueryScanLimit,
+            @JsonProperty("hardTotalDriverLimit") Optional<Integer> hardTotalDriverLimit,
+            @JsonProperty("hardPlanningConcurrencyLimit") Optional<Integer> hardPlanningConcurrencyLimit)
     {
         this.softCpuLimit = requireNonNull(softCpuLimit, "softCpuLimit is null");
         this.hardCpuLimit = requireNonNull(hardCpuLimit, "hardCpuLimit is null");
@@ -75,6 +85,13 @@ public class ResourceGroupSpec
         this.maxQueued = maxQueued;
         this.softConcurrencyLimit = softConcurrencyLimit;
         this.hardPhysicalDataScanLimit = requireNonNull(hardPhysicalDataScanLimit, "hardPhysicalDataScanLimit is null");
+        this.perQueryMemoryLimit = requireNonNull(perQueryMemoryLimit, "perQueryMemoryLimit is null");
+        this.perQueryCpuLimit = requireNonNull(perQueryCpuLimit, "perQueryCpuLimit is null");
+        this.perQueryScanLimit = requireNonNull(perQueryScanLimit, "perQueryScanLimit is null");
+        this.hardTotalDriverLimit = requireNonNull(hardTotalDriverLimit, "hardTotalDriverLimit is null");
+        this.hardPlanningConcurrencyLimit = requireNonNull(hardPlanningConcurrencyLimit, "hardPlanningConcurrencyLimit is null");
+        hardTotalDriverLimit.ifPresent(limit -> checkArgument(limit > 0, "hardTotalDriverLimit must be positive"));
+        hardPlanningConcurrencyLimit.ifPresent(limit -> checkArgument(limit > 0, "hardPlanningConcurrencyLimit must be positive"));
 
         checkArgument(hardConcurrencyLimit.isPresent() || maxRunning.isPresent(), "Missing required property: hardConcurrencyLimit");
         this.hardConcurrencyLimit = hardConcurrencyLimit.orElseGet(maxRunning::get);
@@ -175,6 +192,31 @@ public class ResourceGroupSpec
         return hardPhysicalDataScanLimit;
     }
 
+    public Optional<DataSize> getPerQueryMemoryLimit()
+    {
+        return perQueryMemoryLimit;
+    }
+
+    public Optional<Duration> getPerQueryCpuLimit()
+    {
+        return perQueryCpuLimit;
+    }
+
+    public Optional<DataSize> getPerQueryScanLimit()
+    {
+        return perQueryScanLimit;
+    }
+
+    public Optional<Integer> getHardTotalDriverLimit()
+    {
+        return hardTotalDriverLimit;
+    }
+
+    public Optional<Integer> getHardPlanningConcurrencyLimit()
+    {
+        return hardPlanningConcurrencyLimit;
+    }
+
     @Override
     public boolean equals(Object other)
     {
@@ -196,7 +238,12 @@ public class ResourceGroupSpec
                 jmxExport.equals(that.jmxExport) &&
                 softCpuLimit.equals(that.softCpuLimit) &&
                 hardCpuLimit.equals(that.hardCpuLimit) &&
-                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit));
+                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit) &&
+                perQueryMemoryLimit.equals(that.perQueryMemoryLimit) &&
+                perQueryCpuLimit.equals(that.perQueryCpuLimit) &&
+                perQueryScanLimit.equals(that.perQueryScanLimit) &&
+                hardTotalDriverLimit.equals(that.hardTotalDriverLimit) &&
+                hardPlanningConcurrencyLimit.equals(that.hardPlanningConcurrencyLimit));
     }
 
     // Subgroups not included, used to determine whether a group needs to be reconfigured
@@ -215,7 +262,12 @@ public class ResourceGroupSpec
                 jmxExport.equals(other.jmxExport) &&
                 softCpuLimit.equals(other.softCpuLimit) &&
                 hardCpuLimit.equals(other.hardCpuLimit) &&
-                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit));
+                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit) &&
+                perQueryMemoryLimit.equals(other.perQueryMemoryLimit) &&
+                perQueryCpuLimit.equals(other.perQueryCpuLimit) &&
+                perQueryScanLimit.equals(other.perQueryScanLimit) &&
+                hardTotalDriverLimit.equals(other.hardTotalDriverLimit) &&
+                hardPlanningConcurrencyLimit.equals(other.hardPlanningConcurrencyLimit));
     }
 
     @Override
@@ -233,7 +285,12 @@ public class ResourceGroupSpec
                 jmxExport,
                 softCpuLimit,
                 hardCpuLimit,
-                hardPhysicalDataScanLimit);
+                hardPhysicalDataScanLimit,
+                perQueryMemoryLimit,
+                perQueryCpuLimit,
+                perQueryScanLimit,
+                hardTotalDriverLimit,
+                hardPlanningConcurrencyLimit);
     }
 
     @Override
@@ -251,6 +308,11 @@ public class ResourceGroupSpec
                 .add("softCpuLimit", softCpuLimit)
                 .add("hardCpuLimit", hardCpuLimit)
                 .add("hardPhysicalDataScanLimit", hardPhysicalDataScanLimit)
+                .add("perQueryMemoryLimit", perQueryMemoryLimit)
+                .add("perQueryCpuLimit", perQueryCpuLimit)
+                .add("perQueryScanLimit", perQueryScanLimit)
+                .add("hardTotalDriverLimit", hardTotalDriverLimit)
+                .add("hardPlanningConcurrencyLimit", hardPlanningConcurrencyLimit)
                 .toString();
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
@@ -119,7 +119,12 @@ public class ResourceGroupSpecBuilder
                 jmxExport,
                 softCpuLimit,
                 hardCpuLimit,
-                hardPhysicalDataScanLimit);
+                hardPhysicalDataScanLimit,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
     }
 
     public static class Mapper

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
@@ -62,6 +62,11 @@ final class TestingResourceGroups
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description


**Motivation**: In shared multi-tenant Trino clusters, resource groups today can limit query
count, memory, and CPU at the group level — but can't control driver-level resource consumption
or enforce per-query limits without a separate session property manager plugin. This forces
admins to maintain duplicated configuration across resource groups and session property managers
for workload isolation.


This PR Adds three categories of new controls to resource groups:

1. **Per-query resource limits** (`perQueryMemoryLimit`, `perQueryCpuLimit`, `perQueryScanLimit`) —
   Queries exceeding these limits within a resource group are killed. Enforced during
   **stageResourceUsage()** on the same periodic cadence as existing group-level resource tracking.
   Complements existing session-level properties (`query.max-memory`, `query.max-cpu-time`,
   `query.max-scan-physical-bytes`) by allowing workload-level policy directly in the resource
   group config without needing a separate session property manager.

2. **Hard total driver limit** (`hardTotalDriverLimit`) —
   Caps total active drivers (running + queued + blocked) across all queries in a group. New
   queries queue when the limit is reached. Driver counts aggregate hierarchically from subgroups.
   Addresses a real gap: a group with 5 concurrent queries can saturate cluster-wide task slots
   if each query has hundreds of drivers, starving other groups.

3. **Hard planning concurrency limit** (`hardPlanningConcurrencyLimit`) —
   Limits queries in PLANNING/STARTING state concurrently within a group. Acts as a smoothing
   mechanism for planning bursts on the coordinator.

All new limits default to MAX_VALUE (effectively disabled).



More Details in here : https://github.com/trinodb/trino/issues/28373

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({[issue](https://github.com/trinodb/trino/issues/28373)}`28373`)
```
