### PR TITLE
Fix whitespace after switch token in new test

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1820,7 +1820,7 @@ public class TestIcebergSparkCompatibility
 
     private String getIcebergCompressionCodecTableProperty(StorageFormat storageFormat)
     {
-        return switch(storageFormat) {
+        return switch (storageFormat) {
             case AVRO -> "write.avro.compression-codec";
             case PARQUET -> "write.parquet.compression-codec";
             case ORC -> "write.orc.compression-codec";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

I added this by mistake in ...
https://github.com/trinodb/trino/pull/28259

This _should_ error but I can't seem to make a reliable repro. https://checkstyle.sourceforge.io/checks/whitespace/whitespaceafter.html

https://github.com/airlift/airbase/blob/561dfde7b5c5e92fe00f6fedc69c808175c3d083/airbase-policy/src/main/resources/checkstyle/airbase-checks.xml#L152

I want to fix this now before it breaks someone's build later.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* N.A
```
