### PR TITLE
Add a new query runner main with spark4-iceberg in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/SparkIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/SparkIceberg.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.testing.containers.BaseTestContainer;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.testing.TestingProperties.getDockerImagesVersion;
+
+public class SparkIceberg
+        extends BaseTestContainer
+{
+    public static final String SPARK4_ICEBERG_IMAGE = "ghcr.io/trinodb/testing/spark4-iceberg:" + getDockerImagesVersion();
+
+    public static final String HOST_NAME = "spark";
+
+    private static final int SPARK_THRIFT_PORT = 10213;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private SparkIceberg(
+            String image,
+            String hostName,
+            Set<Integer> ports,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int startupRetryLimit)
+    {
+        super(
+                image,
+                hostName,
+                ports,
+                filesToMount,
+                envVars,
+                network,
+                startupRetryLimit);
+    }
+
+    @Override
+    protected void setupContainer()
+    {
+        super.setupContainer();
+        withRunCommand(
+                ImmutableList.of(
+                        "spark-submit",
+                        "--master", "local[*]",
+                        "--class", "org.apache.spark.sql.hive.thriftserver.HiveThriftServer2",
+                        "--name", "Thrift JDBC/ODBC Server",
+                        "--packages", "org.apache.spark:spark-avro_2.12:3.2.1",
+                        "--conf", "spark.hive.server2.thrift.port=" + SPARK_THRIFT_PORT,
+                        "spark-internal"));
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<Builder, SparkIceberg>
+    {
+        private Builder()
+        {
+            this.image = SPARK4_ICEBERG_IMAGE;
+            this.hostName = HOST_NAME;
+            this.exposePorts = ImmutableSet.of(SPARK_THRIFT_PORT);
+        }
+
+        @Override
+        public SparkIceberg build()
+        {
+            return new SparkIceberg(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/SparkIcebergHive3MinioDataLake.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/SparkIcebergHive3MinioDataLake.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.base.util.AutoCloseableCloser;
+import io.trino.plugin.hive.containers.Hive3MinioDataLake;
+import io.trino.plugin.hive.containers.HiveHadoop;
+import io.trino.testing.containers.Minio;
+
+import static io.trino.testing.containers.TestContainers.getPathFromClassPathResource;
+
+public final class SparkIcebergHive3MinioDataLake
+        implements AutoCloseable
+{
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+    private final Hive3MinioDataLake hiveMinio;
+    private final SparkIceberg spark;
+
+    public SparkIcebergHive3MinioDataLake(String bucketName)
+    {
+        hiveMinio = closer.register(new Hive3MinioDataLake(bucketName));
+        hiveMinio.start();
+
+        SparkIceberg.Builder sparkIcebergBuilder = SparkIceberg.builder()
+                .withNetwork(hiveMinio.getNetwork())
+                .withFilesToMount(ImmutableMap.of(
+                        "/spark/conf/spark-defaults.conf", getPathFromClassPathResource("spark/spark-defaults.conf"),
+                        "/spark/conf/log4j2.properties", getPathFromClassPathResource("spark/log4j2.properties")));
+        spark = closer.register(sparkIcebergBuilder.build());
+        spark.start();
+    }
+
+    public HiveHadoop hiveHadoop()
+    {
+        return hiveMinio.getHiveHadoop();
+    }
+
+    public Minio minio()
+    {
+        return hiveMinio.getMinio();
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        closer.close();
+    }
+}

--- a/plugin/trino-iceberg/src/test/resources/spark/log4j2.properties
+++ b/plugin/trino-iceberg/src/test/resources/spark/log4j2.properties
@@ -1,0 +1,15 @@
+rootLogger.level = error
+rootLogger.appenderRef.stdout.ref = console
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+
+logger.repl.name = org.apache.spark.repl.Main
+logger.repl.level = error
+
+# SPARK-34128: Suppress undesirable TTransportException warnings involved in THRIFT-4805
+appender.console.filter.1.type = RegexFilter
+appender.console.filter.1.regex = .*Thrift error occurred during processing of message.*
+appender.console.filter.1.onMatch = deny
+appender.console.filter.1.onMismatch = neutral

--- a/plugin/trino-iceberg/src/test/resources/spark/spark-defaults.conf
+++ b/plugin/trino-iceberg/src/test/resources/spark/spark-defaults.conf
@@ -1,0 +1,26 @@
+spark.sql.catalogImplementation=hive
+spark.sql.warehouse.dir=hdfs://hadoop-master:9000/user/hive/warehouse
+spark.sql.hive.thriftServer.singleSession=false
+
+spark.sql.catalog.spark_catalog = org.apache.iceberg.spark.SparkSessionCatalog
+spark.sql.catalog.spark_catalog.type = hive
+
+spark.hadoop.fs.defaultFS=hdfs://hadoop-master:9000
+spark.hive.metastore.uris=thrift://hadoop-master:9083
+spark.hive.metastore.warehouse.dir=hdfs://hadoop-master:9000/user/hive/warehouse
+spark.hive.metastore.schema.verification=false
+; disabling caching allows us to run spark queries interchangeably with trino's
+spark.sql.catalog.iceberg_test.cache-enabled=false
+spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+
+spark.hadoop.fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
+spark.hadoop.fs.s3n.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
+spark.hadoop.fs.s3a.endpoint=http://minio:4566
+spark.hadoop.fs.s3a.path.style.access=true
+spark.hadoop.fs.s3a.access.key=accesskey
+spark.hadoop.fs.s3a.secret.key=secretkey
+spark.hadoop.fs.s3a.threads.keepalivetime=6000
+spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+spark.hadoop.fs.s3a.connection.establish.timeout=3000
+spark.hadoop.fs.s3a.connection.timeout=200000
+spark.hadoop.fs.s3a.multipart.purge.age=86400


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This contribution adds scaffolding which can be used to test compatibility scenarios between Spark and Trino on an Iceberg Data Lake running on HMS and MinIO object store.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

While the contribution as it is can be used for interactive purposes only, with the help of an SQL executor it could be employed in testing automatically compatibility scenarios between Spark and Iceberg.

```
public final class SparkSqlExecutor
        implements SqlExecutor
    private final String url;

    public SparkSqlExecutor(String url)
    {
        this.url = requireNonNull(url, "url is null");
    }

    @Override
    public void execute(String sql)
    {
        try (Connection connection = DriverManager.getConnection(url);
                Statement statement = connection.createStatement()) {
            statement.execute(sql);
        }
        catch (SQLException e) {
            throw new RuntimeException(e);
        }
    }
}
```

Such a scaffolding could potentially perform scenarios which currently require a product test environment (e.g. `EnvSinglenodeSparkIceberg`).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
