### PR TITLE
Revise plugin installation instructions for Trino

### DIFF
--- a/docs/src/main/sphinx/ext/download.py
+++ b/docs/src/main/sphinx/ext/download.py
@@ -85,7 +85,7 @@ def filename(artifact, version, extension):
     extension = '.' + extension if extension else ''
     return artifact + '-' + version + extension
 
-# Download from Maven Central
+# Download from Maven Central - only trino-jdbc is still hosted in Maven Central
 def download_mc_url(artifact, version, extension):
     base = 'https://repo1.maven.org/maven2/io/trino'
     file = filename(artifact, version, extension)

--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -41,7 +41,7 @@ https://github.com/trinodb/trino/releases/download/479/trino-postgresql-479.zip
 
 ### 476 or before - Maven
 Versions prior to trino 477 also publish to the [Maven Central Repository](https://central.sonatype.com/). 
-Refer to [](plugins-list) for details.  The specific location for maven pacakges 
+Refer to [](plugins-list) for details.  The specific location for maven packages 
 is derived from the Maven coordinates of each plugin as defined in the 
 `pom.xml` of the source code for the plugin.
 

--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -29,10 +29,21 @@ automatically during Trino startup.
 Typically, downloading a plugin is not necessary because Trino binaries include
 many plugins as part of the binary package.
 
-Every Trino release publishes each plugin as a ZIP archive to the [Maven Central
-Repository](https://central.sonatype.com/). Refer to [](plugins-list) for details.
-The specific location is derived from the Maven coordinates of each plugin as
-defined in the `pom.xml` of the source code for the plugin.
+### Since 477 - Github
+
+Every Trino release since release 477 publishes each plugin as a ZIP archive
+to [github](https://github.com/trinodb/trino/releases).
+
+For example, the PostgreSQL conenctor plugin can be downloaded at
+```
+https://github.com/trinodb/trino/releases/download/479/trino-postgresql-479.zip
+```
+
+### 476 or before - Maven
+Versions prior to trino 477 also publish to the [Maven Central Repository](https://central.sonatype.com/). 
+Refer to [](plugins-list) for details.  The specific location for maven pacakges 
+is derived from the Maven coordinates of each plugin as defined in the 
+`pom.xml` of the source code for the plugin.
 
 For example, the PostgreSQL connector plugin can be found in the
 `plugin/trino-postgresql` directory, and the `pom.xml` file contains the
@@ -133,8 +144,8 @@ project. Refer to the [](/develop) for further details.
 
 The following list of plugins is available from the Trino project. They are
 included in the build and release process and the resulting the binary packages.
-You can also [download](plugins-download) them from the Maven Central Repository
-with the listed coordinates.
+For versions earlier than 477, you can also [download](plugins-download) them 
+from the Maven Central Repository with the listed coordinates.
 
 :::{list-table} List of plugins 
 :widths: 25, 25, 25, 25 

--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -34,7 +34,7 @@ many plugins as part of the binary package.
 Every Trino release since release 477 publishes each plugin as a ZIP archive
 to [github](https://github.com/trinodb/trino/releases).
 
-For example, the PostgreSQL conenctor plugin can be downloaded at
+For example, the PostgreSQL connector plugin can be downloaded at
 ```
 https://github.com/trinodb/trino/releases/download/479/trino-postgresql-479.zip
 ```

--- a/docs/src/main/sphinx/installation/plugins.md
+++ b/docs/src/main/sphinx/installation/plugins.md
@@ -27,53 +27,13 @@ automatically during Trino startup.
 ## Download
 
 Typically, downloading a plugin is not necessary because Trino binaries include
-many plugins as part of the binary package.
-
-### Since 477 - Github
-
-Every Trino release since release 477 publishes each plugin as a ZIP archive
-to [github](https://github.com/trinodb/trino/releases).
+many plugins as part of the binary package.  Individual plugin bundles are
+published as a ZIP archive to [github](https://github.com/trinodb/trino/releases)
+as part of each release.
 
 For example, the PostgreSQL connector plugin can be downloaded at
 ```
 https://github.com/trinodb/trino/releases/download/479/trino-postgresql-479.zip
-```
-
-### 476 or before - Maven
-Versions prior to trino 477 also publish to the [Maven Central Repository](https://central.sonatype.com/). 
-Refer to [](plugins-list) for details.  The specific location for maven packages 
-is derived from the Maven coordinates of each plugin as defined in the 
-`pom.xml` of the source code for the plugin.
-
-For example, the PostgreSQL connector plugin can be found in the
-`plugin/trino-postgresql` directory, and the `pom.xml` file contains the
-following identifier section:
-
-```xml
-<parent>
-    <groupId>io.trino</groupId>
-    <artifactId>trino-root</artifactId>
-    <version>470</version>
-    <relativePath>../../pom.xml</relativePath>
-</parent>
-
-<artifactId>trino-postgresql</artifactId>
-<packaging>trino-plugin</packaging>
-```
-
-The Maven coordinates are therefore `io.trino:trino-postgresql:470` with version
-or `io.trino:trino-postgresql` without version. Use this term for a [search to
-locate the
-artifact](https://central.sonatype.com/search?q=io.trino%3Atrino-postgresql).
-
-After searching, click **View all** next to **Latest version**, then click
-**Browse** to find the ZIP file for the desired version.
-
-The coordinates translate into a path to the ZIP archive on the Maven Central
-Repository. Use this URL to download the plugin.
-
-```
-https://repo1.maven.org/maven2/io/trino/trino-postgresql/470/trino-postgresql-470.zip
 ```
 
 Availability of plugins from other projects and organizations varies widely, and
@@ -144,239 +104,180 @@ project. Refer to the [](/develop) for further details.
 
 The following list of plugins is available from the Trino project. They are
 included in the build and release process and the resulting the binary packages.
-For versions earlier than 477, you can also [download](plugins-download) them 
-from the Maven Central Repository with the listed coordinates.
 
 :::{list-table} List of plugins 
-:widths: 25, 25, 25, 25 
+:widths: 30, 30, 40 
 :header-rows: 1
 
 * - Plugin directory
   - Description
-  - Maven coordinates
   - Download
 * - ai-functions
   - [](/functions/ai)
-  - [io.trino:trino-ai-functions](https://central.sonatype.com/search?q=io.trino%3Atrino-ai-functions)
   - {download_gh}`ai-functions`  
 * - bigquery
   - [](/connector/bigquery)
-  - [io.trino:trino-bigquery](https://central.sonatype.com/search?q=io.trino%3Atrino-bigquery)
   - {download_gh}`bigquery`
 * - blackhole
   - [](/connector/blackhole)
-  - [io.trino:trino-blackhole](https://central.sonatype.com/search?q=io.trino%3Atrino-blackhole)
   - {download_gh}`blackhole`
 * - cassandra
   - [](/connector/cassandra)
-  - [io.trino:trino-cassandra](https://central.sonatype.com/search?q=io.trino%3Atrino-cassandra)
   - {download_gh}`cassandra`
 * - clickhouse
   - [](/connector/clickhouse)
-  - [io.trino:trino-clickhouse](https://central.sonatype.com/search?q=io.trino%3Atrino-clickhouse)
   - {download_gh}`clickhouse`
 * - delta-lake
   - [](/connector/delta-lake)
-  - [io.trino:trino-delta-lake](https://central.sonatype.com/search?q=io.trino%3Atrino-delta-lake)
   - {download_gh}`delta-lake`
 * - druid
   - [](/connector/druid)
-  - [io.trino:trino-druid](https://central.sonatype.com/search?q=io.trino%3Atrino-druid)
   - {download_gh}`druid`
 * - duckdb
   - [](/connector/duckdb)
-  - [io.trino:trino-duckdb](https://central.sonatype.com/search?q=io.trino%3Atrino-duckdb)
   - {download_gh}`duckdb`
 * - elasticsearch
   - [](/connector/elasticsearch)
-  - [io.trino:trino-elasticsearch](https://central.sonatype.com/search?q=io.trino%3Atrino-elasticsearch)
   - {download_gh}`elasticsearch`
 * - example-http
   - [](/develop/example-http)
-  - [io.trino:trino-example-http](https://central.sonatype.com/search?q=io.trino%3Atrino-example-http)
   - {download_gh}`example-http`
 * - exasol
   - [](/connector/exasol)
-  - [io.trino:trino-exasol](https://central.sonatype.com/search?q=io.trino%3Atrino-exasol)
   - {download_gh}`exasol`
 * - exchange-filesystem
   - [](/admin/fault-tolerant-execution) exchange file system
-  - [io.trino:trino-exchange-filesystem](https://central.sonatype.com/search?q=io.trino%3Atrino-exchange-filesystem)
   - {download_gh}`exchange-filesystem`
 * - exchange-hdfs
   - [](/admin/fault-tolerant-execution) exchange file system for HDFS
-  - [io.trino:trino-exchange-hdfs](https://central.sonatype.com/search?q=io.trino%3Atrino-exchange-hdfs)
   - {download_gh}`exchange-hdfs`
 * - faker
   - [](/connector/faker)
-  - [io.trino:trino-faker](https://central.sonatype.com/search?q=io.trino%3Atrino-faker)
   - {download_gh}`faker`
 * - functions-python
   - [](/udf/python)
-  - [io.trino:trino-functions-python](https://central.sonatype.com/search?q=io.trino%3Atrino-functions-python)
   - {download_gh}`functions-python`
 * - geospatial
   - [](/functions/geospatial)
-  - [io.trino:trino-geospatial](https://central.sonatype.com/search?q=io.trino%3Atrino-geospatial)
   - {download_gh}`geospatial`
 * - google-sheets
   - [](/connector/googlesheets)
-  - [io.trino:trino-google-sheets](https://central.sonatype.com/search?q=io.trino%3Atrino-google-sheets)
   - {download_gh}`google-sheets`
 * - hive
   - [](/connector/hive)
-  - [io.trino:trino-hive](https://central.sonatype.com/search?q=io.trino%3Atrino-hive)
   - {download_gh}`hive`
 * - http-event-listener
   - [](/admin/event-listeners-http)
-  - [io.trino:trino-http-event-listener](https://central.sonatype.com/search?q=io.trino%3Atrino-http-event-listener)
   - {download_gh}`http-event-listener`
 * - http-server-event-listener
   - HTTP server event listener
-  - [io.trino:trino-http-server-event-listener](https://central.sonatype.com/search?q=io.trino%3Atrino-http-server-event-listener)
   - {download_gh}`http-server-event-listener`
 * - hudi
   - [](/connector/hudi)
-  - [io.trino:trino-hudi](https://central.sonatype.com/search?q=io.trino%3Atrino-hudi)
   - {download_gh}`hudi`
 * - iceberg
   - [](/connector/iceberg)
-  - [io.trino:trino-iceberg](https://central.sonatype.com/search?q=io.trino%3Atrino-iceberg)
   - {download_gh}`iceberg`
 * - ignite
   - [](/connector/ignite)
-  - [io.trino:trino-ignite](https://central.sonatype.com/search?q=io.trino%3Atrino-ignite)
   - {download_gh}`ignite`
 * - jmx
   - [](/connector/jmx)
-  - [io.trino:trino-jmx](https://central.sonatype.com/search?q=io.trino%3Atrino-jmx)
   - {download_gh}`jmx`
 * - kafka
   - [](/connector/kafka)
-  - [io.trino:trino-kafka](https://central.sonatype.com/search?q=io.trino%3Atrino-kafka)
   - {download_gh}`kafka`
 * - kafka-event-listener
   - [](/admin/event-listeners-kafka)
-  - [io.trino:trino-kafka-event-listener](https://central.sonatype.com/search?q=io.trino%3Atrino-kafka-event-listener)
   - {download_gh}`kafka-event-listener`
 * - lakehouse
   - [](/connector/lakehouse)
-  -
   - {download_gh}`lakehouse`
 * - loki
   - [](/connector/loki)
-  - [io.trino:trino-loki](https://central.sonatype.com/search?q=io.trino%3Atrino-loki)
   - {download_gh}`loki`
 * - mariadb
   - [](/connector/mariadb)
-  - [io.trino:trino-mariadb](https://central.sonatype.com/search?q=io.trino%3Atrino-mariadb)
   - {download_gh}`mariadb`
 * - memory
   - [](/connector/memory)
-  - [io.trino:trino-memory](https://central.sonatype.com/search?q=io.trino%3Atrino-memory)
   - {download_gh}`memory`
 * - ml
   - [](/functions/ml)
-  - [io.trino:trino-ml](https://central.sonatype.com/search?q=io.trino%3Atrino-ml)
   - {download_gh}`ml`
 * - mongodb
   - [](/connector/mongodb)
-  - [io.trino:trino-mongodb](https://central.sonatype.com/search?q=io.trino%3Atrino-mongodb)
   - {download_gh}`mongodb`
 * - mysql
   - [](/connector/mysql)
-  - [io.trino:trino-mysql](https://central.sonatype.com/search?q=io.trino%3Atrino-mysql)
   - {download_gh}`mysql`
 * - mysql-event-listener
   - [](/admin/event-listeners-mysql)
-  - [io.trino:trino-mysql-event-listener](https://central.sonatype.com/search?q=io.trino%3Atrino-mysql-event-listener)
   - {download_gh}`mysql-event-listener`
 * - opa
   - [](/security/opa-access-control)
-  - [io.trino:trino-opa](https://central.sonatype.com/search?q=io.trino%3Atrino-opa)
   - {download_gh}`opa`
 * - openlineage
   - [](/admin/event-listeners-openlineage)
-  - [io.trino:trino-openlineage](https://central.sonatype.com/search?q=io.trino%3Atrino-openlineage)
   - {download_gh}`openlineage`
 * - opensearch
   - [](/connector/opensearch)
-  - [io.trino:trino-opensearch](https://central.sonatype.com/search?q=io.trino%3Atrino-opensearch)
   - {download_gh}`opensearch`
 * - oracle
   - [](/connector/oracle)
-  - [io.trino:trino-oracle](https://central.sonatype.com/search?q=io.trino%3Atrino-oracle)
   - {download_gh}`oracle`
 * - password-authenticators
   - Password authentication
-  - [io.trino:trino-password-authenticators](https://central.sonatype.com/search?q=io.trino%3Atrino-password-authenticators)
   - {download_gh}`password-authenticators`
 * - pinot
   - [](/connector/pinot)
-  - [io.trino:trino-pinot](https://central.sonatype.com/search?q=io.trino%3Atrino-pinot)
   - {download_gh}`pinot`
 * - postgresql
   - [](/connector/postgresql)
-  - [io.trino:trino-postgresql](https://central.sonatype.com/search?q=io.trino%3Atrino-postgresql)
   - {download_gh}`postgresql`
 * - prometheus
   - [](/connector/prometheus)
-  - [io.trino:trino-prometheus](https://central.sonatype.com/search?q=io.trino%3Atrino-prometheus)
   - {download_gh}`prometheus`
 * - ranger
   - [](/security/ranger-access-control)
-  - [io.trino:trino-ranger](https://central.sonatype.com/search?q=io.trino%3Atrino-ranger)
   - {download_gh}`ranger`
 * - redis
   - [](/connector/redis)
-  - [io.trino:trino-redis](https://central.sonatype.com/search?q=io.trino%3Atrino-redis)
   - {download_gh}`redis`
 * - redshift
   - [](/connector/redshift)
-  - [io.trino:trino-redshift](https://central.sonatype.com/search?q=io.trino%3Atrino-redshift)
   - {download_gh}`redshift`
 * - resource-group-managers
   - [](/admin/resource-groups)
-  - [io.trino:trino-resource-group-managers](https://central.sonatype.com/search?q=io.trino%3Atrino-resource-group-managers)
   - {download_gh}`resource-group-managers`
 * - session-property-managers
   - [](/admin/session-property-managers)
-  - [io.trino:trino-session-property-managers](https://central.sonatype.com/search?q=io.trino%3Atrino-session-property-managers)
   - {download_gh}`session-property-managers`
 * - singlestore
   - [](/connector/singlestore)
-  - [io.trino:trino-singlestore](https://central.sonatype.com/search?q=io.trino%3Atrino-singlestore)
   - {download_gh}`singlestore`
 * - snowflake
   - [](/connector/snowflake)
-  - [io.trino:trino-snowflake](https://central.sonatype.com/search?q=io.trino%3Atrino-snowflake)
   - {download_gh}`snowflake`
 * - spooling-filesystem
   - Server side support for [](protocol-spooling)
-  - [io.trino:trino-spooling-filesystem](https://central.sonatype.com/search?q=io.trino%3Atrino-spooling-filesystem)
   - {download_gh}`spooling-filesystem`
 * - sqlserver
   - [](/connector/sqlserver)
-  - [io.trino:trino-sqlserver](https://central.sonatype.com/search?q=io.trino%3Atrino-sqlserver)
   - {download_gh}`sqlserver`
 * - teradata-functions
   - [](/functions/teradata)
-  - [io.trino:trino-teradata-functions](https://central.sonatype.com/search?q=io.trino%3Atrino-teradata-functions)
   - {download_gh}`teradata-functions`
 * - thrift
   - [](/connector/thrift)
-  - [io.trino:trino-thrift](https://central.sonatype.com/search?q=io.trino%3Atrino-thrift)
   - {download_gh}`thrift`
 * - tpcds
   - [](/connector/tpcds)
-  - [io.trino:trino-tpcds](https://central.sonatype.com/search?q=io.trino%3Atrino-tpcds)
   - {download_gh}`tpcds`
 * - tpch
   - [](/connector/tpch)
-  - [io.trino:trino-tpch](https://central.sonatype.com/search?q=io.trino%3Atrino-tpch)
   - {download_gh}`tpch`
 * - vertica
   - [](/connector/vertica)
-  - [io.trino:trino-vertica](https://central.sonatype.com/search?q=io.trino%3Atrino-vertica)
   - {download_gh}`vertica`
 :::

--- a/plugin/trino-http-server-event-listener/README.md
+++ b/plugin/trino-http-server-event-listener/README.md
@@ -5,5 +5,6 @@ in the default tarball and the default Docker image.
 
 Follow the [plugin installation instructions](https://trino.io/docs/current/installation/plugins.html)
 and optionally use the [trino-packages project](https://github.com/trinodb/trino-packages)
-or manually [download the plugin archive](https://central.sonatype.com/artifact/io.trino/trino-http-server-event-listener)
+or manually [download the plugin archive](https://trino.io/docs/current/installation/plugins.html#plugins-list)
+
 for your installation and version.


### PR DESCRIPTION
## Description

Updated plugin installation instructions to reflect changes in plugin availability since Trino release 477. Added details on downloading plugins from GitHub and removed all reference to maven central.

Relates to closed issue #28350

## Additional context and related issues

The release strategy changed between 476 and 477, but the documentation on plugin availability was unclear.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
