### PR TITLE
Rename ScalarFunction field and use enum values

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayAllMatchFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayAllMatchFunction.java
@@ -28,10 +28,11 @@ import java.lang.invoke.MethodHandle;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.lang.Boolean.FALSE;
 
 @Description("Returns true if all elements of the array match the given predicate")
-@ScalarFunction(value = "all_match", neverFails = true)
+@ScalarFunction(value = "all_match", mayFail = NEVER)
 public final class ArrayAllMatchFunction
 {
     private ArrayAllMatchFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayAnyMatchFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayAnyMatchFunction.java
@@ -28,10 +28,11 @@ import java.lang.invoke.MethodHandle;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.lang.Boolean.TRUE;
 
 @Description("Returns true if the array contains one or more elements that match the given predicate")
-@ScalarFunction(value = "any_match", neverFails = true)
+@ScalarFunction(value = "any_match", mayFail = NEVER)
 public final class ArrayAnyMatchFunction
 {
     private ArrayAnyMatchFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCardinalityFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayCardinalityFunction.java
@@ -20,8 +20,10 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.StandardTypes;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
 @Description("Returns the cardinality (length) of the array")
-@ScalarFunction(value = "cardinality", neverFails = true)
+@ScalarFunction(value = "cardinality", mayFail = NEVER)
 public final class ArrayCardinalityFunction
 {
     private ArrayCardinalityFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayDistinctFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayDistinctFunction.java
@@ -33,9 +33,10 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@ScalarFunction(value = "array_distinct", neverFails = true)
+@ScalarFunction(value = "array_distinct", mayFail = NEVER)
 @Description("Remove duplicate values from the given array")
 public final class ArrayDistinctFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayExceptFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayExceptFunction.java
@@ -29,9 +29,10 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.lang.Math.min;
 
-@ScalarFunction(value = "array_except", neverFails = true)
+@ScalarFunction(value = "array_except", mayFail = NEVER)
 @Description("Returns an array of elements that are in the first array but not the second, without duplicates.")
 public final class ArrayExceptFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFilterFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFilterFunction.java
@@ -21,10 +21,11 @@ import io.trino.spi.function.TypeParameter;
 import io.trino.spi.function.TypeParameterSpecialization;
 import io.trino.spi.type.Type;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.lang.Boolean.TRUE;
 
 @Description("Return array containing elements that match the given predicate")
-@ScalarFunction(value = "filter", neverFails = true)
+@ScalarFunction(value = "filter", mayFail = NEVER)
 public final class ArrayFilterFunction
 {
     private ArrayFilterFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayHistogramFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayHistogramFunction.java
@@ -36,9 +36,10 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.BLOCK_BUILDER;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FLAT_RETURN;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
 @Description("Return a map containing the counts of the elements in the array")
-@ScalarFunction(value = "array_histogram", neverFails = true)
+@ScalarFunction(value = "array_histogram", mayFail = NEVER)
 public final class ArrayHistogramFunction
 {
     private ArrayHistogramFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayIntersectFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayIntersectFunction.java
@@ -31,8 +31,9 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
-@ScalarFunction(value = "array_intersect", neverFails = true)
+@ScalarFunction(value = "array_intersect", mayFail = NEVER)
 @Description("Intersects elements of the two given arrays")
 public final class ArrayIntersectFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayReverseFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayReverseFunction.java
@@ -19,7 +19,9 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 
-@ScalarFunction(value = "reverse", neverFails = true)
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
+@ScalarFunction(value = "reverse", mayFail = NEVER)
 @Description("Returns an array which has the reversed order of the given array.")
 public final class ArrayReverseFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayShuffleFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayShuffleFunction.java
@@ -21,7 +21,9 @@ import io.trino.spi.function.TypeParameter;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-@ScalarFunction(value = "shuffle", deterministic = false, neverFails = true)
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
+@ScalarFunction(value = "shuffle", deterministic = false, mayFail = NEVER)
 @Description("Generates a random permutation of the given array.")
 public final class ArrayShuffleFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortFunction.java
@@ -26,8 +26,9 @@ import it.unimi.dsi.fastutil.ints.IntArrays;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
-@ScalarFunction(value = "array_sort", neverFails = true)
+@ScalarFunction(value = "array_sort", mayFail = NEVER)
 @Description("Sorts the given array in ascending order according to the natural ordering of its elements.")
 public final class ArraySortFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayUnionFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayUnionFunction.java
@@ -34,9 +34,10 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@ScalarFunction(value = "array_union", neverFails = true)
+@ScalarFunction(value = "array_union", mayFail = NEVER)
 @Description("Union elements of the two given arrays")
 public final class ArrayUnionFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraysOverlapFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraysOverlapFunction.java
@@ -28,8 +28,9 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
-@ScalarFunction(value = "arrays_overlap", neverFails = true)
+@ScalarFunction(value = "arrays_overlap", mayFail = NEVER)
 @Description("Returns true if arrays have common elements")
 public final class ArraysOverlapFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/BitwiseFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/BitwiseFunctions.java
@@ -20,6 +20,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
 public final class BitwiseFunctions
 {
@@ -52,7 +53,7 @@ public final class BitwiseFunctions
     }
 
     @Description("Bitwise NOT in 2's complement arithmetic")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseNot(@SqlType(StandardTypes.BIGINT) long num)
     {
@@ -60,7 +61,7 @@ public final class BitwiseFunctions
     }
 
     @Description("Bitwise AND in 2's complement arithmetic")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseAnd(@SqlType(StandardTypes.BIGINT) long left, @SqlType(StandardTypes.BIGINT) long right)
     {
@@ -68,7 +69,7 @@ public final class BitwiseFunctions
     }
 
     @Description("Bitwise OR in 2's complement arithmetic")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseOr(@SqlType(StandardTypes.BIGINT) long left, @SqlType(StandardTypes.BIGINT) long right)
     {
@@ -76,7 +77,7 @@ public final class BitwiseFunctions
     }
 
     @Description("Bitwise XOR in 2's complement arithmetic")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseXor(@SqlType(StandardTypes.BIGINT) long left, @SqlType(StandardTypes.BIGINT) long right)
     {
@@ -84,7 +85,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise left shift")
-    @ScalarFunction(value = "bitwise_left_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_left_shift", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long bitwiseLeftShiftTinyint(@SqlType(StandardTypes.TINYINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -96,7 +97,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise left shift")
-    @ScalarFunction(value = "bitwise_left_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_left_shift", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long bitwiseLeftShiftSmallint(@SqlType(StandardTypes.SMALLINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -108,7 +109,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise left shift")
-    @ScalarFunction(value = "bitwise_left_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_left_shift", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long bitwiseLeftShiftInteger(@SqlType(StandardTypes.INTEGER) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -120,7 +121,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise left shift")
-    @ScalarFunction(value = "bitwise_left_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_left_shift", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseLeftShiftBigint(@SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -141,7 +142,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise logical right shift")
-    @ScalarFunction(value = "bitwise_right_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long bitwiseRightShiftTinyint(@SqlType(StandardTypes.TINYINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -155,7 +156,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise logical right shift")
-    @ScalarFunction(value = "bitwise_right_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long bitwiseRightShiftSmallint(@SqlType(StandardTypes.SMALLINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -169,7 +170,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise logical right shift")
-    @ScalarFunction(value = "bitwise_right_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long bitwiseRightShiftInteger(@SqlType(StandardTypes.INTEGER) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -183,7 +184,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise logical right shift")
-    @ScalarFunction(value = "bitwise_right_shift", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseRightShiftBigint(@SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -194,7 +195,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise arithmetic right shift")
-    @ScalarFunction(value = "bitwise_right_shift_arithmetic", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift_arithmetic", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long bitwiseRightShiftArithmeticTinyint(@SqlType(StandardTypes.TINYINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -208,7 +209,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise arithmetic right shift")
-    @ScalarFunction(value = "bitwise_right_shift_arithmetic", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift_arithmetic", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long bitwiseRightShiftArithmeticSmallint(@SqlType(StandardTypes.SMALLINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -222,7 +223,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise arithmetic right shift")
-    @ScalarFunction(value = "bitwise_right_shift_arithmetic", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift_arithmetic", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long bitwiseRightShiftArithmeticInteger(@SqlType(StandardTypes.INTEGER) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {
@@ -236,7 +237,7 @@ public final class BitwiseFunctions
     }
 
     @Description("bitwise arithmetic right shift")
-    @ScalarFunction(value = "bitwise_right_shift_arithmetic", neverFails = true)
+    @ScalarFunction(value = "bitwise_right_shift_arithmetic", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long bitwiseRightShiftArithmeticBigint(@SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.INTEGER) long shift)
     {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CombineHashFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CombineHashFunction.java
@@ -18,13 +18,14 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.util.Objects.checkFromToIndex;
 
 public final class CombineHashFunction
 {
     private CombineHashFunction() {}
 
-    @ScalarFunction(value = "combine_hash", hidden = true, neverFails = true)
+    @ScalarFunction(value = "combine_hash", hidden = true, mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long getHash(@SqlType(StandardTypes.BIGINT) long previousHashValue, @SqlType(StandardTypes.BIGINT) long value)
     {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -52,6 +52,7 @@ import java.util.function.Function;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.operator.scalar.QuarterOfYearDateTimeField.QUARTER_OF_YEAR;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.Int128Math.rescale;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
@@ -110,7 +111,7 @@ public final class DateTimeFunctions
 
     private DateTimeFunctions() {}
 
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @Description("Current timestamp with time zone")
     @SqlType("timestamp(3) with time zone")
     public static long now(ConnectorSession session)
@@ -119,7 +120,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Current date")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DATE)
     public static long currentDate(ConnectorSession session)
     {
@@ -132,7 +133,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Current time zone")
-    @ScalarFunction(value = "current_timezone", neverFails = true)
+    @ScalarFunction(value = "current_timezone", mayFail = NEVER)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice currentTimeZone(ConnectorSession session)
     {
@@ -449,7 +450,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Millisecond of the second of the given interval")
-    @ScalarFunction(value = "millisecond", neverFails = true)
+    @ScalarFunction(value = "millisecond", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long millisecondFromInterval(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long milliseconds)
     {
@@ -457,7 +458,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Second of the minute of the given interval")
-    @ScalarFunction(value = "second", neverFails = true)
+    @ScalarFunction(value = "second", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long secondFromInterval(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long milliseconds)
     {
@@ -465,7 +466,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Minute of the hour of the given interval")
-    @ScalarFunction(value = "minute", neverFails = true)
+    @ScalarFunction(value = "minute", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long minuteFromInterval(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long milliseconds)
     {
@@ -473,7 +474,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Hour of the day of the given interval")
-    @ScalarFunction(value = "hour", neverFails = true)
+    @ScalarFunction(value = "hour", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long hourFromInterval(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long milliseconds)
     {
@@ -481,7 +482,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Day of the week of the given date")
-    @ScalarFunction(value = "day_of_week", alias = "dow", neverFails = true)
+    @ScalarFunction(value = "day_of_week", alias = "dow", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long dayOfWeekFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -489,7 +490,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Day of the month of the given date")
-    @ScalarFunction(value = "day", alias = "day_of_month", neverFails = true)
+    @ScalarFunction(value = "day", alias = "day_of_month", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long dayFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -497,7 +498,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Day of the month of the given interval")
-    @ScalarFunction(value = "day", alias = "day_of_month", neverFails = true)
+    @ScalarFunction(value = "day", alias = "day_of_month", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long dayFromInterval(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long milliseconds)
     {
@@ -514,7 +515,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Day of the year of the given date")
-    @ScalarFunction(value = "day_of_year", alias = "doy", neverFails = true)
+    @ScalarFunction(value = "day_of_year", alias = "doy", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long dayOfYearFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -522,7 +523,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Week of the year of the given date")
-    @ScalarFunction(value = "week", alias = "week_of_year", neverFails = true)
+    @ScalarFunction(value = "week", alias = "week_of_year", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long weekFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -538,7 +539,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Month of the year of the given date")
-    @ScalarFunction(value = "month", neverFails = true)
+    @ScalarFunction(value = "month", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long monthFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -546,7 +547,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Month of the year of the given interval")
-    @ScalarFunction(value = "month", neverFails = true)
+    @ScalarFunction(value = "month", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long monthFromInterval(@SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long months)
     {
@@ -554,7 +555,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Quarter of the year of the given date")
-    @ScalarFunction(value = "quarter", neverFails = true)
+    @ScalarFunction(value = "quarter", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long quarterFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -562,7 +563,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Year of the given date")
-    @ScalarFunction(value = "year", neverFails = true)
+    @ScalarFunction(value = "year", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long yearFromDate(@SqlType(StandardTypes.DATE) long date)
     {
@@ -570,7 +571,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Year of the given interval")
-    @ScalarFunction(value = "year", neverFails = true)
+    @ScalarFunction(value = "year", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long yearFromInterval(@SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long months)
     {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/EmptyMapConstructor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/EmptyMapConstructor.java
@@ -22,9 +22,10 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
 
 import static io.trino.spi.block.MapValueBuilder.buildMapValue;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
 @Description("Creates an empty map")
-@ScalarFunction(value = "map", neverFails = true)
+@ScalarFunction(value = "map", mayFail = NEVER)
 public final class EmptyMapConstructor
 {
     private final SqlMap emptyMap;

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatNumberFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatNumberFunction.java
@@ -23,6 +23,7 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
 public final class FormatNumberFunction
 {
@@ -40,7 +41,7 @@ public final class FormatNumberFunction
         format1Number.setRoundingMode(RoundingMode.HALF_UP);
     }
 
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @Description("Formats large number using a unit symbol")
     @SqlType(StandardTypes.VARCHAR)
     public Slice formatNumber(@SqlType(StandardTypes.BIGINT) long value)
@@ -48,7 +49,7 @@ public final class FormatNumberFunction
         return utf8Slice(format(value));
     }
 
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @Description("Formats large number using a unit symbol")
     @SqlType(StandardTypes.VARCHAR)
     public Slice formatNumber(@SqlType(StandardTypes.DOUBLE) double value)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapCardinalityFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapCardinalityFunction.java
@@ -20,7 +20,9 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.StandardTypes;
 
-@ScalarFunction(value = "cardinality", neverFails = true)
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
+@ScalarFunction(value = "cardinality", mayFail = NEVER)
 @Description("Returns the cardinality (the number of key-value pairs) of the map")
 public final class MapCardinalityFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapEntriesFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapEntriesFunction.java
@@ -27,8 +27,9 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 
 import static com.google.common.base.Verify.verify;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
-@ScalarFunction(value = "map_entries", neverFails = true)
+@ScalarFunction(value = "map_entries", mayFail = NEVER)
 @Description("Construct an array of entries from a given map")
 public class MapEntriesFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapKeys.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapKeys.java
@@ -21,7 +21,9 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.Type;
 
-@ScalarFunction(value = "map_keys", neverFails = true)
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
+@ScalarFunction(value = "map_keys", mayFail = NEVER)
 @Description("Returns the keys of the given map(K,V) as an array")
 public final class MapKeys
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapValues.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapValues.java
@@ -21,7 +21,9 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.Type;
 
-@ScalarFunction(value = "map_values", neverFails = true)
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
+@ScalarFunction(value = "map_values", mayFail = NEVER)
 @Description("Returns the values of the given map(K,V) as an array")
 public final class MapValues
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -53,6 +53,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.Decimals.longTenToNth;
 import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -134,14 +135,14 @@ public final class MathFunctions
     }
 
     @Description("Absolute value")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double abs(@SqlType(StandardTypes.DOUBLE) double num)
     {
         return Math.abs(num);
     }
 
-    @ScalarFunction(value = "abs", neverFails = true)
+    @ScalarFunction(value = "abs", mayFail = NEVER)
     @Description("Absolute value")
     public static final class Abs
     {
@@ -166,7 +167,7 @@ public final class MathFunctions
     }
 
     @Description("Absolute value")
-    @ScalarFunction(value = "abs", neverFails = true)
+    @ScalarFunction(value = "abs", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long absFloat(@SqlType(StandardTypes.REAL) long num)
     {
@@ -174,7 +175,7 @@ public final class MathFunctions
     }
 
     @Description("Arc cosine")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double acos(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -182,7 +183,7 @@ public final class MathFunctions
     }
 
     @Description("Arc sine")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double asin(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -190,7 +191,7 @@ public final class MathFunctions
     }
 
     @Description("Arc tangent")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double atan(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -198,7 +199,7 @@ public final class MathFunctions
     }
 
     @Description("Arc tangent of given fraction")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double atan2(@SqlType(StandardTypes.DOUBLE) double num1, @SqlType(StandardTypes.DOUBLE) double num2)
     {
@@ -206,7 +207,7 @@ public final class MathFunctions
     }
 
     @Description("Cube root")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double cbrt(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -214,7 +215,7 @@ public final class MathFunctions
     }
 
     @Description("Round up to nearest integer")
-    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @ScalarFunction(value = "ceiling", alias = "ceil", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long ceilingTinyint(@SqlType(StandardTypes.TINYINT) long num)
     {
@@ -222,7 +223,7 @@ public final class MathFunctions
     }
 
     @Description("Round up to nearest integer")
-    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @ScalarFunction(value = "ceiling", alias = "ceil", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long ceilingSmallint(@SqlType(StandardTypes.SMALLINT) long num)
     {
@@ -230,7 +231,7 @@ public final class MathFunctions
     }
 
     @Description("Round up to nearest integer")
-    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @ScalarFunction(value = "ceiling", alias = "ceil", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long ceilingInteger(@SqlType(StandardTypes.INTEGER) long num)
     {
@@ -238,7 +239,7 @@ public final class MathFunctions
     }
 
     @Description("Round up to nearest integer")
-    @ScalarFunction(alias = "ceil", neverFails = true)
+    @ScalarFunction(alias = "ceil", mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long ceiling(@SqlType(StandardTypes.BIGINT) long num)
     {
@@ -246,7 +247,7 @@ public final class MathFunctions
     }
 
     @Description("Round up to nearest integer")
-    @ScalarFunction(alias = "ceil", neverFails = true)
+    @ScalarFunction(alias = "ceil", mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double ceiling(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -254,14 +255,14 @@ public final class MathFunctions
     }
 
     @Description("Round up to nearest integer")
-    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @ScalarFunction(value = "ceiling", alias = "ceil", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long ceilingFloat(@SqlType(StandardTypes.REAL) long num)
     {
         return floatToRawIntBits((float) ceiling(intBitsToFloat((int) num)));
     }
 
-    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @ScalarFunction(value = "ceiling", alias = "ceil", mayFail = NEVER)
     @Description("Round up to nearest integer")
     public static final class Ceiling
     {
@@ -310,7 +311,7 @@ public final class MathFunctions
     }
 
     @Description("Round to integer by dropping digits after decimal point")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double truncate(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -318,7 +319,7 @@ public final class MathFunctions
     }
 
     @Description("Round to integer by dropping digits after decimal point")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long truncate(@SqlType(StandardTypes.REAL) long num)
     {
@@ -327,7 +328,7 @@ public final class MathFunctions
     }
 
     @Description("Cosine")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double cos(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -335,7 +336,7 @@ public final class MathFunctions
     }
 
     @Description("Hyperbolic cosine")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double cosh(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -343,7 +344,7 @@ public final class MathFunctions
     }
 
     @Description("Converts an angle in radians to degrees")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double degrees(@SqlType(StandardTypes.DOUBLE) double radians)
     {
@@ -351,7 +352,7 @@ public final class MathFunctions
     }
 
     @Description("Euler's number")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double e()
     {
@@ -359,7 +360,7 @@ public final class MathFunctions
     }
 
     @Description("Euler's number raised to the given power")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double exp(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -367,7 +368,7 @@ public final class MathFunctions
     }
 
     @Description("Round down to nearest integer")
-    @ScalarFunction(value = "floor", neverFails = true)
+    @ScalarFunction(value = "floor", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long floorTinyint(@SqlType(StandardTypes.TINYINT) long num)
     {
@@ -375,7 +376,7 @@ public final class MathFunctions
     }
 
     @Description("Round down to nearest integer")
-    @ScalarFunction(value = "floor", neverFails = true)
+    @ScalarFunction(value = "floor", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long floorSmallint(@SqlType(StandardTypes.SMALLINT) long num)
     {
@@ -383,7 +384,7 @@ public final class MathFunctions
     }
 
     @Description("Round down to nearest integer")
-    @ScalarFunction(value = "floor", neverFails = true)
+    @ScalarFunction(value = "floor", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long floorInteger(@SqlType(StandardTypes.INTEGER) long num)
     {
@@ -391,7 +392,7 @@ public final class MathFunctions
     }
 
     @Description("Round down to nearest integer")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long floor(@SqlType(StandardTypes.BIGINT) long num)
     {
@@ -399,14 +400,14 @@ public final class MathFunctions
     }
 
     @Description("Round down to nearest integer")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double floor(@SqlType(StandardTypes.DOUBLE) double num)
     {
         return Math.floor(num);
     }
 
-    @ScalarFunction(value = "floor", neverFails = true)
+    @ScalarFunction(value = "floor", mayFail = NEVER)
     @Description("Round down to nearest integer")
     public static final class Floor
     {
@@ -455,7 +456,7 @@ public final class MathFunctions
     }
 
     @Description("Round down to nearest integer")
-    @ScalarFunction(value = "floor", neverFails = true)
+    @ScalarFunction(value = "floor", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long floorFloat(@SqlType(StandardTypes.REAL) long num)
     {
@@ -463,7 +464,7 @@ public final class MathFunctions
     }
 
     @Description("Natural logarithm")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double ln(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -471,7 +472,7 @@ public final class MathFunctions
     }
 
     @Description("Logarithm to given base")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double log(@SqlType(StandardTypes.DOUBLE) double base, @SqlType(StandardTypes.DOUBLE) double number)
     {
@@ -479,7 +480,7 @@ public final class MathFunctions
     }
 
     @Description("Logarithm to base 2")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double log2(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -487,7 +488,7 @@ public final class MathFunctions
     }
 
     @Description("Logarithm to base 10")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double log10(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -495,7 +496,7 @@ public final class MathFunctions
     }
 
     @Description("Remainder of given quotient")
-    @ScalarFunction(value = "mod", neverFails = true)
+    @ScalarFunction(value = "mod", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long modTinyint(@SqlType(StandardTypes.TINYINT) long num1, @SqlType(StandardTypes.TINYINT) long num2)
     {
@@ -503,7 +504,7 @@ public final class MathFunctions
     }
 
     @Description("Remainder of given quotient")
-    @ScalarFunction(value = "mod", neverFails = true)
+    @ScalarFunction(value = "mod", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long modSmallint(@SqlType(StandardTypes.SMALLINT) long num1, @SqlType(StandardTypes.SMALLINT) long num2)
     {
@@ -511,7 +512,7 @@ public final class MathFunctions
     }
 
     @Description("Remainder of given quotient")
-    @ScalarFunction(value = "mod", neverFails = true)
+    @ScalarFunction(value = "mod", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long modInteger(@SqlType(StandardTypes.INTEGER) long num1, @SqlType(StandardTypes.INTEGER) long num2)
     {
@@ -519,7 +520,7 @@ public final class MathFunctions
     }
 
     @Description("Remainder of given quotient")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long mod(@SqlType(StandardTypes.BIGINT) long num1, @SqlType(StandardTypes.BIGINT) long num2)
     {
@@ -527,7 +528,7 @@ public final class MathFunctions
     }
 
     @Description("Remainder of given quotient")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double mod(@SqlType(StandardTypes.DOUBLE) double num1, @SqlType(StandardTypes.DOUBLE) double num2)
     {
@@ -540,7 +541,7 @@ public final class MathFunctions
     }
 
     @Description("Remainder of given quotient")
-    @ScalarFunction(value = "mod", neverFails = true)
+    @ScalarFunction(value = "mod", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long modFloat(@SqlType(StandardTypes.REAL) long num1, @SqlType(StandardTypes.REAL) long num2)
     {
@@ -548,7 +549,7 @@ public final class MathFunctions
     }
 
     @Description("The constant Pi")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double pi()
     {
@@ -556,7 +557,7 @@ public final class MathFunctions
     }
 
     @Description("Value raised to the power of exponent")
-    @ScalarFunction(alias = "pow", neverFails = true)
+    @ScalarFunction(alias = "pow", mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double power(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.DOUBLE) double exponent)
     {
@@ -564,7 +565,7 @@ public final class MathFunctions
     }
 
     @Description("Converts an angle in degrees to radians")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double radians(@SqlType(StandardTypes.DOUBLE) double degrees)
     {
@@ -572,7 +573,7 @@ public final class MathFunctions
     }
 
     @Description("A pseudo-random value")
-    @ScalarFunction(alias = "rand", deterministic = false, neverFails = true)
+    @ScalarFunction(alias = "rand", deterministic = false, mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double random()
     {
@@ -729,7 +730,7 @@ public final class MathFunctions
     }
 
     @Description("Round to nearest integer")
-    @ScalarFunction(value = "round", neverFails = true)
+    @ScalarFunction(value = "round", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long roundTinyint(@SqlType(StandardTypes.TINYINT) long num)
     {
@@ -737,7 +738,7 @@ public final class MathFunctions
     }
 
     @Description("Round to nearest integer")
-    @ScalarFunction(value = "round", neverFails = true)
+    @ScalarFunction(value = "round", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long roundSmallint(@SqlType(StandardTypes.SMALLINT) long num)
     {
@@ -745,7 +746,7 @@ public final class MathFunctions
     }
 
     @Description("Round to nearest integer")
-    @ScalarFunction(value = "round", neverFails = true)
+    @ScalarFunction(value = "round", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long roundInteger(@SqlType(StandardTypes.INTEGER) long num)
     {
@@ -753,7 +754,7 @@ public final class MathFunctions
     }
 
     @Description("Round to nearest integer")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long round(@SqlType(StandardTypes.BIGINT) long num)
     {
@@ -826,7 +827,7 @@ public final class MathFunctions
     }
 
     @Description("Round to nearest integer")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -834,7 +835,7 @@ public final class MathFunctions
     }
 
     @Description("Round to given number of decimal places")
-    @ScalarFunction(value = "round", neverFails = true)
+    @ScalarFunction(value = "round", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long roundReal(@SqlType(StandardTypes.REAL) long num)
     {
@@ -842,7 +843,7 @@ public final class MathFunctions
     }
 
     @Description("Round to given number of decimal places")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.INTEGER) long decimals)
     {
@@ -868,7 +869,7 @@ public final class MathFunctions
     }
 
     @Description("Round to given number of decimal places")
-    @ScalarFunction(value = "round", neverFails = true)
+    @ScalarFunction(value = "round", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long roundReal(@SqlType(StandardTypes.REAL) long num, @SqlType(StandardTypes.INTEGER) long decimals)
     {
@@ -898,7 +899,7 @@ public final class MathFunctions
         return floatToRawIntBits(resultAsFloat);
     }
 
-    @ScalarFunction(value = "round", neverFails = true)
+    @ScalarFunction(value = "round", mayFail = NEVER)
     @Description("Round to nearest integer")
     public static final class Round
     {
@@ -1021,7 +1022,7 @@ public final class MathFunctions
         }
     }
 
-    @ScalarFunction(value = "truncate", neverFails = true)
+    @ScalarFunction(value = "truncate", mayFail = NEVER)
     @Description("Round to integer by dropping digits after decimal point")
     public static final class Truncate
     {
@@ -1064,7 +1065,7 @@ public final class MathFunctions
         }
     }
 
-    @ScalarFunction(value = "truncate", neverFails = true)
+    @ScalarFunction(value = "truncate", mayFail = NEVER)
     @Description("Round to integer by dropping given number of digits after decimal point")
     public static final class TruncateN
     {
@@ -1110,7 +1111,7 @@ public final class MathFunctions
     }
 
     @Description("Signum")
-    @ScalarFunction(value = "sign", neverFails = true)
+    @ScalarFunction(value = "sign", mayFail = NEVER)
     public static final class Sign
     {
         private Sign() {}
@@ -1136,7 +1137,7 @@ public final class MathFunctions
         }
     }
 
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long sign(@SqlType(StandardTypes.BIGINT) long num)
     {
@@ -1144,7 +1145,7 @@ public final class MathFunctions
     }
 
     @Description("Signum")
-    @ScalarFunction(value = "sign", neverFails = true)
+    @ScalarFunction(value = "sign", mayFail = NEVER)
     @SqlType(StandardTypes.INTEGER)
     public static long signInteger(@SqlType(StandardTypes.INTEGER) long num)
     {
@@ -1152,7 +1153,7 @@ public final class MathFunctions
     }
 
     @Description("Signum")
-    @ScalarFunction(value = "sign", neverFails = true)
+    @ScalarFunction(value = "sign", mayFail = NEVER)
     @SqlType(StandardTypes.SMALLINT)
     public static long signSmallint(@SqlType(StandardTypes.SMALLINT) long num)
     {
@@ -1160,7 +1161,7 @@ public final class MathFunctions
     }
 
     @Description("Signum")
-    @ScalarFunction(value = "sign", neverFails = true)
+    @ScalarFunction(value = "sign", mayFail = NEVER)
     @SqlType(StandardTypes.TINYINT)
     public static long signTinyint(@SqlType(StandardTypes.TINYINT) long num)
     {
@@ -1168,7 +1169,7 @@ public final class MathFunctions
     }
 
     @Description("Signum")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double sign(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1176,7 +1177,7 @@ public final class MathFunctions
     }
 
     @Description("Signum")
-    @ScalarFunction(value = "sign", neverFails = true)
+    @ScalarFunction(value = "sign", mayFail = NEVER)
     @SqlType(StandardTypes.REAL)
     public static long signFloat(@SqlType(StandardTypes.REAL) long num)
     {
@@ -1184,7 +1185,7 @@ public final class MathFunctions
     }
 
     @Description("Sine")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double sin(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1192,7 +1193,7 @@ public final class MathFunctions
     }
 
     @Description("Hyperbolic sine")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double sinh(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1200,7 +1201,7 @@ public final class MathFunctions
     }
 
     @Description("Square root")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double sqrt(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1208,7 +1209,7 @@ public final class MathFunctions
     }
 
     @Description("Tangent")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double tan(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1216,7 +1217,7 @@ public final class MathFunctions
     }
 
     @Description("Hyperbolic tangent")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double tanh(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1224,7 +1225,7 @@ public final class MathFunctions
     }
 
     @Description("Test if value is not-a-number")
-    @ScalarFunction(value = "is_nan", neverFails = true)
+    @ScalarFunction(value = "is_nan", mayFail = NEVER)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean isNaN(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1232,7 +1233,7 @@ public final class MathFunctions
     }
 
     @Description("Test if value is not-a-number")
-    @ScalarFunction(value = "is_nan", neverFails = true)
+    @ScalarFunction(value = "is_nan", mayFail = NEVER)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean isNaNReal(@SqlType(StandardTypes.REAL) long value)
     {
@@ -1241,7 +1242,7 @@ public final class MathFunctions
     }
 
     @Description("Test if value is finite")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean isFinite(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1249,7 +1250,7 @@ public final class MathFunctions
     }
 
     @Description("Test if value is infinite")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean isInfinite(@SqlType(StandardTypes.DOUBLE) double num)
     {
@@ -1257,7 +1258,7 @@ public final class MathFunctions
     }
 
     @Description("Constant representing not-a-number")
-    @ScalarFunction(value = "nan", neverFails = true)
+    @ScalarFunction(value = "nan", mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double nan()
     {
@@ -1265,7 +1266,7 @@ public final class MathFunctions
     }
 
     @Description("Infinity")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.DOUBLE)
     public static double infinity()
     {
@@ -1380,7 +1381,7 @@ public final class MathFunctions
     }
 
     @Description("Cosine similarity between the given sparse vectors")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlNullable
     @SqlType(StandardTypes.DOUBLE)
     public static Double cosineSimilarity(
@@ -1408,7 +1409,7 @@ public final class MathFunctions
     }
 
     @Description("Calculates the cosine distance between the give sparse vectors")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlNullable
     @SqlType(StandardTypes.DOUBLE)
     public static Double cosineDistance(

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
@@ -30,6 +30,7 @@ import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
 import static io.trino.operator.annotations.FunctionsParserHelper.parseDescription;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.util.Objects.requireNonNull;
 
 public class ScalarHeader
@@ -76,7 +77,7 @@ public class ScalarHeader
 
         if (scalarFunction != null) {
             String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
-            builder.add(new ScalarHeader(baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic(), scalarFunction.neverFails()));
+            builder.add(new ScalarHeader(baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic(), scalarFunction.mayFail() == NEVER));
         }
 
         if (scalarOperator != null) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/SessionFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/SessionFunctions.java
@@ -27,13 +27,14 @@ import io.trino.spi.type.StandardTypes;
 import java.util.Set;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public final class SessionFunctions
 {
     private SessionFunctions() {}
 
-    @ScalarFunction(value = "$current_user", hidden = true, neverFails = true)
+    @ScalarFunction(value = "$current_user", hidden = true, mayFail = NEVER)
     @Description("Current user")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice currentUser(ConnectorSession session)
@@ -41,7 +42,7 @@ public final class SessionFunctions
         return utf8Slice(session.getUser());
     }
 
-    @ScalarFunction(value = "$current_path", hidden = true, neverFails = true)
+    @ScalarFunction(value = "$current_path", hidden = true, mayFail = NEVER)
     @Description("Retrieve current path")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice currentPath(ConnectorSession session)
@@ -50,7 +51,7 @@ public final class SessionFunctions
         return utf8Slice(((FullConnectorSession) session).getSession().getPath().toString());
     }
 
-    @ScalarFunction(value = "$current_catalog", hidden = true, neverFails = true)
+    @ScalarFunction(value = "$current_catalog", hidden = true, mayFail = NEVER)
     @Description("Current catalog")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice currentCatalog(ConnectorSession session)
@@ -60,7 +61,7 @@ public final class SessionFunctions
                 .orElse(null);
     }
 
-    @ScalarFunction(value = "$current_schema", hidden = true, neverFails = true)
+    @ScalarFunction(value = "$current_schema", hidden = true, mayFail = NEVER)
     @Description("Current schema")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice currentSchema(ConnectorSession session)
@@ -70,7 +71,7 @@ public final class SessionFunctions
                 .orElse(null);
     }
 
-    @ScalarFunction(value = "current_groups", neverFails = true)
+    @ScalarFunction(value = "current_groups", mayFail = NEVER)
     @Description("Current groups of current user")
     @SqlType("array(varchar)")
     public static Block currentGroups(ConnectorSession session)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -51,6 +51,7 @@ import static io.airlift.slice.SliceUtf8.toUpperCase;
 import static io.airlift.slice.SliceUtf8.tryGetCodePointAt;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.Chars.byteCountWithoutTrailingSpace;
 import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.Chars.trimTrailingSpaces;
@@ -93,7 +94,7 @@ public final class StringFunctions
     }
 
     @Description("Count of code points of the given string")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BIGINT)
     public static long length(@SqlType("varchar(x)") Slice slice)
@@ -102,7 +103,7 @@ public final class StringFunctions
     }
 
     @Description("Count of code points of the given string")
-    @ScalarFunction(value = "length", neverFails = true)
+    @ScalarFunction(value = "length", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BIGINT)
     public static long charLength(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
@@ -111,7 +112,7 @@ public final class StringFunctions
     }
 
     @Description("Returns length of a character string without trailing spaces")
-    @ScalarFunction(value = "$space_trimmed_length", hidden = true, neverFails = true)
+    @ScalarFunction(value = "$space_trimmed_length", hidden = true, mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long spaceTrimmedLength(@SqlType("varchar") Slice slice)
     {
@@ -119,7 +120,7 @@ public final class StringFunctions
     }
 
     @Description("Greedily removes occurrences of a pattern in a string")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters({"x", "y"})
     @SqlType("varchar(x)")
     public static Slice replace(@SqlType("varchar(x)") Slice str, @SqlType("varchar(y)") Slice search)
@@ -128,7 +129,7 @@ public final class StringFunctions
     }
 
     @Description("Greedily replaces occurrences of a pattern with a string")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters({"x", "y", "z", "u"})
     @Constraint(variable = "u", expression = "min(2147483647, x + z * (x + 1))")
     @SqlType("varchar(u)")
@@ -195,7 +196,7 @@ public final class StringFunctions
     }
 
     @Description("Reverse all code points in a given string")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice reverse(@SqlType("varchar(x)") Slice slice)
@@ -204,7 +205,7 @@ public final class StringFunctions
     }
 
     @Description("Reverse all code points in a given string")
-    @ScalarFunction(value = "reverse", neverFails = true)
+    @ScalarFunction(value = "reverse", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("char(x)")
     public static Slice charReverse(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
@@ -282,7 +283,7 @@ public final class StringFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction(alias = "substr", neverFails = true)
+    @ScalarFunction(alias = "substr", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
@@ -320,7 +321,7 @@ public final class StringFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction(value = "substring", alias = "substr", neverFails = true)
+    @ScalarFunction(value = "substring", alias = "substr", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charSubstring(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
@@ -329,7 +330,7 @@ public final class StringFunctions
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction(alias = "substr", neverFails = true)
+    @ScalarFunction(alias = "substr", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
@@ -378,7 +379,7 @@ public final class StringFunctions
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction(value = "substring", alias = "substr", neverFails = true)
+    @ScalarFunction(value = "substring", alias = "substr", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charSubstr(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
@@ -482,7 +483,7 @@ public final class StringFunctions
     }
 
     @Description("Removes whitespace from the beginning of a string")
-    @ScalarFunction(value = "ltrim", neverFails = true)
+    @ScalarFunction(value = "ltrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice leftTrim(@SqlType("varchar(x)") Slice slice)
@@ -491,7 +492,7 @@ public final class StringFunctions
     }
 
     @Description("Removes whitespace from the beginning of a string")
-    @ScalarFunction(value = "ltrim", neverFails = true)
+    @ScalarFunction(value = "ltrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charLeftTrim(@SqlType("char(x)") Slice slice)
@@ -500,7 +501,7 @@ public final class StringFunctions
     }
 
     @Description("Removes whitespace from the end of a string")
-    @ScalarFunction(value = "rtrim", neverFails = true)
+    @ScalarFunction(value = "rtrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice rightTrim(@SqlType("varchar(x)") Slice slice)
@@ -509,7 +510,7 @@ public final class StringFunctions
     }
 
     @Description("Removes whitespace from the end of a string")
-    @ScalarFunction(value = "rtrim", neverFails = true)
+    @ScalarFunction(value = "rtrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charRightTrim(@SqlType("char(x)") Slice slice)
@@ -518,7 +519,7 @@ public final class StringFunctions
     }
 
     @Description("Removes whitespace from the beginning and end of a string")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice trim(@SqlType("varchar(x)") Slice slice)
@@ -527,7 +528,7 @@ public final class StringFunctions
     }
 
     @Description("Removes whitespace from the beginning and end of a string")
-    @ScalarFunction(value = "trim", neverFails = true)
+    @ScalarFunction(value = "trim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charTrim(@SqlType("char(x)") Slice slice)
@@ -536,7 +537,7 @@ public final class StringFunctions
     }
 
     @Description("Remove the longest string containing only given characters from the beginning of a string")
-    @ScalarFunction(value = "ltrim", neverFails = true)
+    @ScalarFunction(value = "ltrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice leftTrim(@SqlType("varchar(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
@@ -545,7 +546,7 @@ public final class StringFunctions
     }
 
     @Description("Remove the longest string containing only given characters from the beginning of a string")
-    @ScalarFunction(value = "ltrim", neverFails = true)
+    @ScalarFunction(value = "ltrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charLeftTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
@@ -554,7 +555,7 @@ public final class StringFunctions
     }
 
     @Description("Remove the longest string containing only given characters from the end of a string")
-    @ScalarFunction(value = "rtrim", neverFails = true)
+    @ScalarFunction(value = "rtrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice rightTrim(@SqlType("varchar(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
@@ -563,7 +564,7 @@ public final class StringFunctions
     }
 
     @Description("Remove the longest string containing only given characters from the end of a string")
-    @ScalarFunction(value = "rtrim", neverFails = true)
+    @ScalarFunction(value = "rtrim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charRightTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
@@ -572,7 +573,7 @@ public final class StringFunctions
     }
 
     @Description("Remove the longest string containing only given characters from the beginning and end of a string")
-    @ScalarFunction(value = "trim", neverFails = true)
+    @ScalarFunction(value = "trim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice trim(@SqlType("varchar(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
@@ -581,7 +582,7 @@ public final class StringFunctions
     }
 
     @Description("Remove the longest string containing only given characters from the beginning and end of a string")
-    @ScalarFunction(value = "trim", neverFails = true)
+    @ScalarFunction(value = "trim", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice charTrim(@SqlType("char(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
@@ -631,7 +632,7 @@ public final class StringFunctions
     }
 
     @Description("Converts the string to lower case")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice lower(@SqlType("varchar(x)") Slice slice)
@@ -640,7 +641,7 @@ public final class StringFunctions
     }
 
     @Description("Converts the string to lower case")
-    @ScalarFunction(value = "lower", neverFails = true)
+    @ScalarFunction(value = "lower", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("char(x)")
     public static Slice charLower(@SqlType("char(x)") Slice slice)
@@ -649,7 +650,7 @@ public final class StringFunctions
     }
 
     @Description("Converts the string to upper case")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice upper(@SqlType("varchar(x)") Slice slice)
@@ -658,7 +659,7 @@ public final class StringFunctions
     }
 
     @Description("Converts the string to upper case")
-    @ScalarFunction(value = "upper", neverFails = true)
+    @ScalarFunction(value = "upper", mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("char(x)")
     public static Slice charUpper(@SqlType("char(x)") Slice slice)
@@ -892,7 +893,7 @@ public final class StringFunctions
     }
 
     @Description("Encodes the string to UTF-8")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toUtf8(@SqlType("varchar(x)") Slice slice)
@@ -901,7 +902,7 @@ public final class StringFunctions
     }
 
     @Description("Encodes the string to UTF-8")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toUtf8(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TypeOfFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TypeOfFunction.java
@@ -23,9 +23,10 @@ import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 
 @Description("Textual representation of expression type")
-@ScalarFunction(value = "typeof", neverFails = true)
+@ScalarFunction(value = "typeof", mayFail = NEVER)
 public final class TypeOfFunction
 {
     private TypeOfFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/UrlFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/UrlFunctions.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class UrlFunctions
@@ -47,7 +48,7 @@ public final class UrlFunctions
 
     @SqlNullable
     @Description("Extract protocol from url")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice urlExtractProtocol(@SqlType("varchar(x)") Slice url)
@@ -58,7 +59,7 @@ public final class UrlFunctions
 
     @SqlNullable
     @Description("Extract host from url")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice urlExtractHost(@SqlType("varchar(x)") Slice url)
@@ -69,7 +70,7 @@ public final class UrlFunctions
 
     @SqlNullable
     @Description("Extract port from url")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BIGINT)
     public static Long urlExtractPort(@SqlType("varchar(x)") Slice url)
@@ -83,7 +84,7 @@ public final class UrlFunctions
 
     @SqlNullable
     @Description("Extract part from url")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice urlExtractPath(@SqlType("varchar(x)") Slice url)
@@ -94,7 +95,7 @@ public final class UrlFunctions
 
     @SqlNullable
     @Description("Extract query from url")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice urlExtractQuery(@SqlType("varchar(x)") Slice url)
@@ -105,7 +106,7 @@ public final class UrlFunctions
 
     @SqlNullable
     @Description("Extract fragment from url")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
     public static Slice urlExtractFragment(@SqlType("varchar(x)") Slice url)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -36,6 +36,7 @@ import java.util.zip.CRC32;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.operator.scalar.HmacFunctions.computeHash;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.util.Failures.checkCondition;
 
 public final class VarbinaryFunctions
@@ -48,7 +49,7 @@ public final class VarbinaryFunctions
     private VarbinaryFunctions() {}
 
     @Description("Length of the given binary")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long length(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -56,7 +57,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode binary data as base64")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toBase64(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -91,7 +92,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode binary data as base64 using the URL safe alphabet")
-    @ScalarFunction(value = "to_base64url", neverFails = true)
+    @ScalarFunction(value = "to_base64url", mayFail = NEVER)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toBase64Url(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -126,7 +127,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode binary data as base32")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toBase32(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -167,7 +168,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode binary data as hex")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toHex(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -208,7 +209,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode value as a 64-bit 2's complement big endian varbinary")
-    @ScalarFunction(value = "to_big_endian_64", neverFails = true)
+    @ScalarFunction(value = "to_big_endian_64", mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toBigEndian64(@SqlType(StandardTypes.BIGINT) long value)
     {
@@ -229,7 +230,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode value as a 32-bit 2's complement big endian varbinary")
-    @ScalarFunction(value = "to_big_endian_32", neverFails = true)
+    @ScalarFunction(value = "to_big_endian_32", mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toBigEndian32(@SqlType(StandardTypes.INTEGER) long value)
     {
@@ -250,7 +251,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode value as a big endian varbinary according to IEEE 754 single-precision floating-point format")
-    @ScalarFunction(value = "to_ieee754_32", neverFails = true)
+    @ScalarFunction(value = "to_ieee754_32", mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toIEEE754Binary32(@SqlType(StandardTypes.REAL) long value)
     {
@@ -269,7 +270,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Encode value as a big endian varbinary according to IEEE 754 double-precision floating-point format")
-    @ScalarFunction(value = "to_ieee754_64", neverFails = true)
+    @ScalarFunction(value = "to_ieee754_64", mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toIEEE754Binary64(@SqlType(StandardTypes.DOUBLE) double value)
     {
@@ -288,7 +289,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute md5 hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice md5(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -298,7 +299,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute sha1 hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha1(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -308,7 +309,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute sha256 hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha256(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -316,7 +317,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute sha512 hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha512(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -324,7 +325,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute murmur3 hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice murmur3(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -332,7 +333,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute xxhash64 hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice xxhash64(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -342,7 +343,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute SpookyHashV2 32-bit hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice spookyHashV2_32(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -352,7 +353,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute SpookyHashV2 64-bit hash")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice spookyHashV2_64(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -370,7 +371,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Compute CRC-32")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.BIGINT)
     public static long crc32(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
@@ -380,7 +381,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Suffix starting at given index")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice substr(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.BIGINT) long start)
     {
@@ -388,7 +389,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Substring of given length starting at an index")
-    @ScalarFunction(neverFails = true)
+    @ScalarFunction(mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice substr(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
     {
@@ -487,7 +488,7 @@ public final class VarbinaryFunctions
     }
 
     @Description("Reverse a given varbinary")
-    @ScalarFunction(value = "reverse", neverFails = true)
+    @ScalarFunction(value = "reverse", mayFail = NEVER)
     @SqlType(StandardTypes.VARBINARY)
     public static Slice reverse(@SqlType("varbinary") Slice inputSlice)
     {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/time/LocalTimeFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/time/LocalTimeFunction.java
@@ -22,12 +22,13 @@ import io.trino.spi.function.SqlType;
 
 import java.time.LocalDateTime;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.TimeType.MAX_PRECISION;
 import static io.trino.type.DateTimes.PICOSECONDS_PER_DAY;
 import static io.trino.type.DateTimes.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.type.DateTimes.round;
 
-@ScalarFunction(value = "$localtime", hidden = true, neverFails = true)
+@ScalarFunction(value = "$localtime", hidden = true, mayFail = NEVER)
 public final class LocalTimeFunction
 {
     private LocalTimeFunction() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeFunctions.java
@@ -23,6 +23,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.TimeType.MAX_PRECISION;
 import static io.trino.type.DateTimes.HOURS_PER_DAY;
 import static io.trino.type.DateTimes.MILLISECONDS_PER_DAY;
@@ -44,7 +45,7 @@ public final class TimeFunctions
     private TimeFunctions() {}
 
     @Description("Millisecond of the second of the given time")
-    @ScalarFunction(value = "millisecond", neverFails = true)
+    @ScalarFunction(value = "millisecond", mayFail = NEVER)
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long millisecond(@SqlType("time(p)") long time)
@@ -53,7 +54,7 @@ public final class TimeFunctions
     }
 
     @Description("Second of the minute of the given time")
-    @ScalarFunction(value = "second", neverFails = true)
+    @ScalarFunction(value = "second", mayFail = NEVER)
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long second(@SqlType("time(p)") long time)
@@ -62,7 +63,7 @@ public final class TimeFunctions
     }
 
     @Description("Minute of the hour of the given time")
-    @ScalarFunction(value = "minute", neverFails = true)
+    @ScalarFunction(value = "minute", mayFail = NEVER)
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long minute(@SqlType("time(p)") long time)
@@ -71,7 +72,7 @@ public final class TimeFunctions
     }
 
     @Description("Hour of the day of the given time")
-    @ScalarFunction(value = "hour", neverFails = true)
+    @ScalarFunction(value = "hour", mayFail = NEVER)
     @LiteralParameters("p")
     @SqlType(StandardTypes.BIGINT)
     public static long hour(@SqlType("time(p)") long time)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractDay.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractDay.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Day of the month of the given timestamp")
-@ScalarFunction(value = "day", alias = "day_of_month", neverFails = true)
+@ScalarFunction(value = "day", alias = "day_of_month", mayFail = NEVER)
 public final class ExtractDay
 {
     private ExtractDay() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractDayOfWeek.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractDayOfWeek.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Day of the week of the given timestamp")
-@ScalarFunction(value = "day_of_week", alias = "dow", neverFails = true)
+@ScalarFunction(value = "day_of_week", alias = "dow", mayFail = NEVER)
 public final class ExtractDayOfWeek
 {
     private ExtractDayOfWeek() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractDayOfYear.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractDayOfYear.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Day of the year of the given timestamp")
-@ScalarFunction(value = "day_of_year", alias = "doy", neverFails = true)
+@ScalarFunction(value = "day_of_year", alias = "doy", mayFail = NEVER)
 public final class ExtractDayOfYear
 {
     private ExtractDayOfYear() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractHour.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractHour.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Hour of the day of the given timestamp")
-@ScalarFunction(value = "hour", neverFails = true)
+@ScalarFunction(value = "hour", mayFail = NEVER)
 public final class ExtractHour
 {
     private ExtractHour() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractMillisecond.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractMillisecond.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Millisecond of the second of the given timestamp")
-@ScalarFunction(value = "millisecond", neverFails = true)
+@ScalarFunction(value = "millisecond", mayFail = NEVER)
 public final class ExtractMillisecond
 {
     private ExtractMillisecond() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractMinute.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractMinute.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Minute of the hour of the given timestamp")
-@ScalarFunction(value = "minute", neverFails = true)
+@ScalarFunction(value = "minute", mayFail = NEVER)
 public final class ExtractMinute
 {
     private ExtractMinute() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractMonth.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractMonth.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Month of the year of the given timestamp")
-@ScalarFunction(value = "month", neverFails = true)
+@ScalarFunction(value = "month", mayFail = NEVER)
 public final class ExtractMonth
 {
     private ExtractMonth() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractQuarter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractQuarter.java
@@ -22,10 +22,11 @@ import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
 import static io.trino.operator.scalar.QuarterOfYearDateTimeField.QUARTER_OF_YEAR;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Quarter of the year of the given timestamp")
-@ScalarFunction(value = "quarter", neverFails = true)
+@ScalarFunction(value = "quarter", mayFail = NEVER)
 public final class ExtractQuarter
 {
     private ExtractQuarter() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractSecond.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractSecond.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Second of the minute of the given timestamp")
-@ScalarFunction(value = "second", neverFails = true)
+@ScalarFunction(value = "second", mayFail = NEVER)
 public final class ExtractSecond
 {
     private ExtractSecond() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractWeekOfYear.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractWeekOfYear.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Week of the year of the given timestamp")
-@ScalarFunction(value = "week", alias = "week_of_year", neverFails = true)
+@ScalarFunction(value = "week", alias = "week_of_year", mayFail = NEVER)
 public final class ExtractWeekOfYear
 {
     private ExtractWeekOfYear() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractYear.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractYear.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Year of the given timestamp")
-@ScalarFunction(value = "year", neverFails = true)
+@ScalarFunction(value = "year", mayFail = NEVER)
 public final class ExtractYear
 {
     private ExtractYear() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractYearOfWeek.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/ExtractYearOfWeek.java
@@ -21,10 +21,11 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Year of the ISO week of the given timestamp")
-@ScalarFunction(value = "year_of_week", alias = "yow", neverFails = true)
+@ScalarFunction(value = "year_of_week", alias = "yow", mayFail = NEVER)
 public final class ExtractYearOfWeek
 {
     private ExtractYearOfWeek() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/LastDayOfMonth.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/LastDayOfMonth.java
@@ -21,11 +21,12 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Description("Last day of the month of the given timestamp")
-@ScalarFunction(value = "last_day_of_month", neverFails = true)
+@ScalarFunction(value = "last_day_of_month", mayFail = NEVER)
 public final class LastDayOfMonth
 {
     private static final int MILLISECONDS_IN_DAY = 24 * 3600 * 1000;

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/LocalTimestamp.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/LocalTimestamp.java
@@ -25,7 +25,9 @@ import io.trino.type.DateTimes;
 
 import java.time.LocalDateTime;
 
-@ScalarFunction(value = "$localtimestamp", hidden = true, neverFails = true)
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
+
+@ScalarFunction(value = "$localtimestamp", hidden = true, mayFail = NEVER)
 public final class LocalTimestamp
 {
     private LocalTimestamp() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampToDateCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampToDateCast.java
@@ -21,11 +21,12 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.type.DateTimes.MICROSECONDS_PER_DAY;
 import static java.lang.Math.floorDiv;
 
 @ScalarOperator(CAST)
-@ScalarFunction(value = "date", neverFails = true)
+@ScalarFunction(value = "date", mayFail = NEVER)
 public final class TimestampToDateCast
 {
     private TimestampToDateCast() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/CurrentTimestamp.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/CurrentTimestamp.java
@@ -24,13 +24,14 @@ import io.trino.type.DateTimes;
 
 import java.time.Instant;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimestampWithTimeZoneType.MAX_SHORT_PRECISION;
 import static io.trino.type.DateTimes.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.type.DateTimes.round;
 import static io.trino.type.DateTimes.roundToNearest;
 
-@ScalarFunction(value = "$current_timestamp", hidden = true, neverFails = true)
+@ScalarFunction(value = "$current_timestamp", hidden = true, mayFail = NEVER)
 public final class CurrentTimestamp
 {
     private CurrentTimestamp() {}

--- a/core/trino-main/src/main/java/io/trino/type/BooleanOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BooleanOperators.java
@@ -25,6 +25,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -92,7 +93,7 @@ public final class BooleanOperators
     }
 
     @SqlType(StandardTypes.BOOLEAN)
-    @ScalarFunction(value = "$not", hidden = true, neverFails = true) // TODO: this should not be callable from SQL
+    @ScalarFunction(value = "$not", hidden = true, mayFail = NEVER) // TODO: this should not be callable from SQL
     public static boolean not(@SqlType(StandardTypes.BOOLEAN) boolean value)
     {
         return !value;

--- a/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import static io.airlift.slice.SliceUtf8.getCodePointAt;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.util.Failures.checkCondition;
 
@@ -37,7 +38,7 @@ public final class LikeFunctions
 
     private LikeFunctions() {}
 
-    @ScalarFunction(value = LIKE_FUNCTION_NAME, hidden = true, neverFails = true)
+    @ScalarFunction(value = LIKE_FUNCTION_NAME, hidden = true, mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean likeChar(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice value, @SqlType(LikePatternType.NAME) LikePattern pattern)
@@ -46,7 +47,7 @@ public final class LikeFunctions
     }
 
     // TODO: this should not be callable from SQL
-    @ScalarFunction(value = LIKE_FUNCTION_NAME, hidden = true, neverFails = true)
+    @ScalarFunction(value = LIKE_FUNCTION_NAME, hidden = true, mayFail = NEVER)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean likeVarchar(@SqlType("varchar(x)") Slice value, @SqlType(LikePatternType.NAME) LikePattern pattern)

--- a/core/trino-main/src/main/java/io/trino/type/UuidOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/UuidOperators.java
@@ -27,6 +27,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.function.ScalarFunction.MayFail.NEVER;
 import static io.trino.spi.type.UuidType.javaUuidToTrinoUuid;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static java.lang.String.format;
@@ -37,7 +38,7 @@ public final class UuidOperators
     private UuidOperators() {}
 
     @Description("Generates a random UUID")
-    @ScalarFunction(deterministic = false, neverFails = true)
+    @ScalarFunction(deterministic = false, mayFail = NEVER)
     @SqlType(StandardTypes.UUID)
     public static Slice uuid()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunction.java
@@ -18,6 +18,7 @@ import com.google.errorprone.annotations.Keep;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static io.trino.spi.function.ScalarFunction.MayFail.UNDEFINED;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -39,5 +40,12 @@ public @interface ScalarFunction
      * Describes whether function never throws any exception
      * for any possible combination of input arguments.
      */
-    boolean neverFails() default false;
+    MayFail mayFail() default UNDEFINED;
+
+    enum MayFail
+    {
+        NEVER,
+        POSSIBLY,
+        UNDEFINED;
+    }
 }


### PR DESCRIPTION
This will allow to gradually mark all functions as either safe (never fails) or unsafe (possibly fails) while keeping a default being "undefined" which means that we can capture functions that are not yet described.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
