### PR TITLE
Update RoaringBitmap to 1.6.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2292,7 +2292,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>1.3.0</version>
+                <version>1.6.10</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.