### PR TITLE
Create airlift group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    groups:
+      airlift:
+        patterns:
+          - "io.airlift:airbase"
+          - "io.airlift:bom"
     cooldown:
       # Apply 7 day cooldown to avoid updating dependencies right away. This reduces the opportunity window
       # when supply chain is compromised. This doesn't apply to the dependencies that we own and release.
@@ -20,9 +25,6 @@ updates:
       exclude:
         - io.airlift:*
         - io.trino:*
-    ignore:
-      # Airbase and Airlift are best updated together. Update Airbase only when updating Airlift.
-      - dependency-name: "io.airlift:airbase"
   - package-ecosystem: "npm"
     directory: "/core/trino-web-ui/src/main/resources/webapp-preview"
     schedule:


### PR DESCRIPTION
## Description

This means:
- When io.airlift:airbase has an update → Dependabot checks if io.airlift:bom also has an update
- If both have updates → Creates one PR updating both
- If only one has an update → Creates a PR for just that one

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
