### PR TITLE
Fix failure when reading table with Iceberg JDBC V0 schema

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -45,6 +45,7 @@ public class TrinoJdbcCatalogFactory
     private final ForwardingFileIoFactory fileIoFactory;
     private final IcebergJdbcClient jdbcClient;
     private final String jdbcCatalogName;
+    private final IcebergJdbcCatalogConfig.SchemaVersion schemaVersion;
     private final String defaultWarehouseDir;
     private final boolean isUniqueTableLocation;
     private final Map<String, String> catalogProperties;
@@ -69,12 +70,13 @@ public class TrinoJdbcCatalogFactory
         this.isUniqueTableLocation = requireNonNull(icebergConfig, "icebergConfig is null").isUniqueTableLocation();
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.jdbcCatalogName = jdbcConfig.getCatalogName();
+        this.schemaVersion = jdbcConfig.getSchemaVersion();
         this.defaultWarehouseDir = jdbcConfig.getDefaultWarehouseDir();
 
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.put(URI, jdbcConfig.getConnectionUrl());
         properties.put(WAREHOUSE_LOCATION, defaultWarehouseDir);
-        properties.put(PROPERTY_PREFIX + "schema-version", jdbcConfig.getSchemaVersion().toString());
+        properties.put(PROPERTY_PREFIX + "schema-version", schemaVersion.toString());
         jdbcConfig.getConnectionUser().ifPresent(user -> properties.put(PROPERTY_PREFIX + "user", user));
         jdbcConfig.getConnectionPassword().ifPresent(password -> properties.put(PROPERTY_PREFIX + "password", password));
         jdbcConfig.getRetryableStatusCodes().ifPresent(codes -> properties.put("retryable_status_codes", codes));
@@ -108,6 +110,7 @@ public class TrinoJdbcCatalogFactory
                 fileSystemFactory,
                 fileIoFactory,
                 isUniqueTableLocation,
-                defaultWarehouseDir);
+                defaultWarehouseDir,
+                schemaVersion);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
@@ -46,6 +46,7 @@ import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASS
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.CATALOG_IMPL;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
@@ -58,15 +59,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
-public class TestIcebergJdbcCatalogConnectorSmokeTest
+public abstract class BaseIcebergJdbcCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
+    private final SchemaVersion schemaVersion;
+
     private JdbcCatalog jdbcCatalog;
     private File warehouseLocation;
 
-    public TestIcebergJdbcCatalogConnectorSmokeTest()
+    public BaseIcebergJdbcCatalogConnectorSmokeTest(SchemaVersion schemaVersion)
     {
         super(new IcebergConfig().getFileFormat().toIceberg());
+        this.schemaVersion = requireNonNull(schemaVersion, "schemaVersion is null");
     }
 
     @Override
@@ -106,6 +110,7 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                                 .put("iceberg.jdbc-catalog.connection-user", USER)
                                 .put("iceberg.jdbc-catalog.connection-password", PASSWORD)
                                 .put("iceberg.jdbc-catalog.catalog-name", "tpch")
+                                .put("iceberg.jdbc-catalog.schema-version", schemaVersion.toString())
                                 .put("iceberg.register-table-procedure.enabled", "true")
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
                                 .put("iceberg.jdbc-catalog.default-warehouse-dir", warehouseLocation.getAbsolutePath())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.jdbc;
+
+import io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest
+        extends BaseIcebergJdbcCatalogConnectorSmokeTest
+{
+    public TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest()
+    {
+        super(SchemaVersion.V0);
+    }
+
+    @Test
+    @Override
+    public void testView()
+    {
+        assertThatThrownBy(super::testView)
+                .hasMessageContaining("Schema version V0 does not support views");
+    }
+
+    @Test
+    @Override
+    public void testCommentView()
+    {
+        assertThatThrownBy(super::testCommentView)
+                .hasMessageContaining("Schema version V0 does not support views");
+    }
+
+    @Test
+    @Override
+    public void testCommentViewColumn()
+    {
+        assertThatThrownBy(super::testCommentViewColumn)
+                .hasMessageContaining("Schema version V0 does not support views");
+    }
+
+    @Test
+    @Override
+    void testUnsupportedViewDialect()
+    {
+        assertThatThrownBy(super::testUnsupportedViewDialect)
+                .hasMessageContaining("Error processing metadata");
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.jdbc;
+
+import io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion;
+
+final class TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest
+        extends BaseIcebergJdbcCatalogConnectorSmokeTest
+{
+    public TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest()
+    {
+        super(SchemaVersion.V1);
+    }
+}


### PR DESCRIPTION
## Description

Iceberg JDBC catalog throws the following error even when reading a table, if `iceberg.jdbc-catalog.schema-version` is v0.

```
JDBC catalog is initialized without view support. To auto-migrate the database's schema
and enable view support, set jdbc.schema-version=V1
```

## Release notes

```markdown
## Iceberg
* Fix failure when reading tables with `iceberg.jdbc-catalog.schema-version=V0`. ({issue}`issuenumber`)
```
