### PR TITLE
Support GCS vended credentials in Iceberg REST catalog

### DIFF
--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsStorageFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsStorageFactory.java
@@ -14,6 +14,8 @@
 package io.trino.filesystem.gcs;
 
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.inject.Inject;
@@ -22,11 +24,16 @@ import io.trino.spi.security.ConnectorIdentity;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 
 import static com.google.cloud.storage.StorageRetryStrategy.getUniformStorageRetryStrategy;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
 import static java.util.Objects.requireNonNull;
 
 public class GcsStorageFactory
@@ -60,11 +67,13 @@ public class GcsStorageFactory
     {
         try {
             StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder();
-            if (projectId != null) {
-                storageOptionsBuilder.setProjectId(projectId);
-            }
 
-            gcsAuth.setAuth(storageOptionsBuilder, identity);
+            if (!setOAuthCredentials(storageOptionsBuilder, identity)) {
+                if (projectId != null) {
+                    storageOptionsBuilder.setProjectId(projectId);
+                }
+                gcsAuth.setAuth(storageOptionsBuilder, identity);
+            }
 
             endpoint.ifPresent(storageOptionsBuilder::setHost);
 
@@ -86,5 +95,24 @@ public class GcsStorageFactory
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private boolean setOAuthCredentials(StorageOptions.Builder builder, ConnectorIdentity identity)
+    {
+        if (identity.getExtraCredentials().containsKey(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY)) {
+            String accessToken = identity.getExtraCredentials().get(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY);
+            Optional<Date> expireAt = Optional.ofNullable(identity.getExtraCredentials().get(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY))
+                    .map(Long::parseLong)
+                    .map(Instant::ofEpochMilli)
+                    .map(Date::from);
+            builder.setCredentials(GoogleCredentials.create(new AccessToken(accessToken, expireAt.orElse(null))));
+
+            String effectiveProjectId = identity.getExtraCredentials().getOrDefault(EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY, projectId);
+            if (effectiveProjectId != null) {
+                builder.setProjectId(effectiveProjectId);
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsStorageFactory.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsStorageFactory.java
@@ -14,12 +14,18 @@
 package io.trino.filesystem.gcs;
 
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Storage;
+import com.google.common.collect.ImmutableMap;
 import io.trino.spi.security.ConnectorIdentity;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestGcsStorageFactory
@@ -37,5 +43,87 @@ final class TestGcsStorageFactory
         }
 
         assertThat(actualCredentials).isEqualTo(NoCredentials.getInstance());
+    }
+
+    @Test
+    void testVendedOAuthToken()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+
+        ConnectorIdentity identity = ConnectorIdentity.forUser("test")
+                .withExtraCredentials(ImmutableMap.of(
+                        EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.test-token"))
+                .build();
+
+        try (Storage storage = storageFactory.create(identity)) {
+            Credentials credentials = storage.getOptions().getCredentials();
+            assertThat(credentials).isInstanceOf(GoogleCredentials.class);
+            GoogleCredentials googleCredentials = (GoogleCredentials) credentials;
+            AccessToken accessToken = googleCredentials.getAccessToken();
+            assertThat(accessToken).isNotNull();
+            assertThat(accessToken.getTokenValue()).isEqualTo("ya29.test-token");
+        }
+    }
+
+    @Test
+    void testVendedOAuthTokenWithExpiration()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+
+        ConnectorIdentity identity = ConnectorIdentity.forUser("test")
+                .withExtraCredentials(ImmutableMap.of(
+                        EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.test-token",
+                        EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY, "1700000000000"))
+                .build();
+
+        try (Storage storage = storageFactory.create(identity)) {
+            Credentials credentials = storage.getOptions().getCredentials();
+            assertThat(credentials).isInstanceOf(GoogleCredentials.class);
+            GoogleCredentials googleCredentials = (GoogleCredentials) credentials;
+            AccessToken accessToken = googleCredentials.getAccessToken();
+            assertThat(accessToken).isNotNull();
+            assertThat(accessToken.getTokenValue()).isEqualTo("ya29.test-token");
+            assertThat(accessToken.getExpirationTime()).isNotNull();
+            assertThat(accessToken.getExpirationTime().getTime()).isEqualTo(1700000000000L);
+        }
+    }
+
+    @Test
+    void testVendedProjectId()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setAuthType(AuthType.APPLICATION_DEFAULT)
+                .setProjectId("static-project");
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+
+        ConnectorIdentity identity = ConnectorIdentity.forUser("test")
+                .withExtraCredentials(ImmutableMap.of(
+                        EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.test-token",
+                        EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY, "vended-project"))
+                .build();
+
+        try (Storage storage = storageFactory.create(identity)) {
+            assertThat(storage.getOptions().getProjectId()).isEqualTo("vended-project");
+        }
+    }
+
+    @Test
+    void testStaticConfigUsedWithoutVendedCredentials()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setAuthType(AuthType.APPLICATION_DEFAULT)
+                .setProjectId("static-project");
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+
+        try (Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"))) {
+            assertThat(storage.getOptions().getProjectId()).isEqualTo("static-project");
+            assertThat(storage.getOptions().getCredentials()).isEqualTo(NoCredentials.getInstance());
+        }
     }
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConstants.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConstants.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+public final class GcsFileSystemConstants
+{
+    public static final String EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY = "internal$gcs_oauth2_token";
+    public static final String EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY = "internal$gcs_oauth2_token_expires_at";
+    public static final String EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY = "internal$gcs_project_id";
+
+    private GcsFileSystemConstants() {}
+}

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -376,6 +376,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-client</artifactId>
             <scope>runtime</scope>
@@ -785,6 +797,7 @@
                                 <exclude>**/TestIcebergS3TablesConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
+                                <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
                                 <exclude>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</exclude>
@@ -852,6 +865,7 @@
                                 <include>**/TestIcebergS3TablesConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
+                                <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestTrinoSnowflakeCatalog.java</include>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -20,9 +20,13 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.gcp.GCPProperties;
 
 import java.util.Map;
 
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
@@ -44,25 +48,51 @@ public class IcebergRestCatalogFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
-        if (vendedCredentialsEnabled &&
-                fileIoProperties.containsKey(S3FileIOProperties.ACCESS_KEY_ID) &&
-                fileIoProperties.containsKey(S3FileIOProperties.SECRET_ACCESS_KEY) &&
-                fileIoProperties.containsKey(S3FileIOProperties.SESSION_TOKEN)) {
-            // Do not include original credentials as they should not be used in vended mode
-            ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
-                    .withGroups(identity.getGroups())
-                    .withPrincipal(identity.getPrincipal())
-                    .withEnabledSystemRoles(identity.getEnabledSystemRoles())
-                    .withConnectorRole(identity.getConnectorRole())
-                    .withExtraCredentials(ImmutableMap.<String, String>builder()
-                            .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, fileIoProperties.get(S3FileIOProperties.ACCESS_KEY_ID))
-                            .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, fileIoProperties.get(S3FileIOProperties.SECRET_ACCESS_KEY))
-                            .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, fileIoProperties.get(S3FileIOProperties.SESSION_TOKEN))
-                            .buildOrThrow())
-                    .build();
-            return fileSystemFactory.create(identityWithExtraCredentials);
+        if (vendedCredentialsEnabled) {
+            ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
+
+            // handle s3
+            if (fileIoProperties.containsKey(S3FileIOProperties.ACCESS_KEY_ID) &&
+                    fileIoProperties.containsKey(S3FileIOProperties.SECRET_ACCESS_KEY) &&
+                    fileIoProperties.containsKey(S3FileIOProperties.SESSION_TOKEN)) {
+                extraCredentialsBuilder
+                        .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, fileIoProperties.get(S3FileIOProperties.ACCESS_KEY_ID))
+                        .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, fileIoProperties.get(S3FileIOProperties.SECRET_ACCESS_KEY))
+                        .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, fileIoProperties.get(S3FileIOProperties.SESSION_TOKEN));
+            }
+
+            // handle gcs
+            if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
+                extraCredentialsBuilder.put(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, fileIoProperties.get(GCPProperties.GCS_OAUTH2_TOKEN));
+                addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY);
+                addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
+            }
+
+            Map<String, String> extraCredentials = extraCredentialsBuilder.buildOrThrow();
+            if (!extraCredentials.isEmpty()) {
+                ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
+                        .withGroups(identity.getGroups())
+                        .withPrincipal(identity.getPrincipal())
+                        .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                        .withConnectorRole(identity.getConnectorRole())
+                        .withExtraCredentials(extraCredentials)
+                        .build();
+                return fileSystemFactory.create(identityWithExtraCredentials);
+            }
         }
 
         return fileSystemFactory.create(identity);
+    }
+
+    private static void addOptionalProperty(
+            ImmutableMap.Builder<String, String> builder,
+            Map<String, String> fileIoProperties,
+            String vendedKey,
+            String extraCredentialKey)
+    {
+        String value = fileIoProperties.get(vendedKey);
+        if (value != null) {
+            builder.put(extraCredentialKey, value);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -32,7 +32,7 @@ import io.trino.plugin.tpcds.TpcdsPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.containers.IcebergRestCatalogBackendContainer;
+import io.trino.testing.containers.IcebergS3RestCatalogBackendContainer;
 import io.trino.testing.containers.Minio;
 import io.trino.tpch.TpchTable;
 import org.apache.iceberg.catalog.Catalog;
@@ -261,7 +261,7 @@ public final class IcebergQueryRunner
 
             AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(AssumeRoleRequest.builder().build());
             @SuppressWarnings("resource")
-            IcebergRestCatalogBackendContainer restCatalogBackendContainer = new IcebergRestCatalogBackendContainer(
+            IcebergS3RestCatalogBackendContainer restCatalogBackendContainer = new IcebergS3RestCatalogBackendContainer(
                     Optional.of(network),
                     warehouseLocation,
                     assumeRoleResponse.credentials().accessKeyId(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
@@ -13,67 +13,66 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
-import io.opentelemetry.api.OpenTelemetry;
+import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
-import io.trino.filesystem.s3.S3FileSystemConfig;
-import io.trino.filesystem.s3.S3FileSystemFactory;
-import io.trino.filesystem.s3.S3FileSystemStats;
+import io.trino.filesystem.gcs.GcsFileSystemConfig;
+import io.trino.filesystem.gcs.GcsFileSystemFactory;
+import io.trino.filesystem.gcs.GcsServiceAccountAuth;
+import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
+import io.trino.filesystem.gcs.GcsStorageFactory;
 import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.QueryFailedException;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
-import io.trino.testing.containers.IcebergRestCatalogBackendContainer;
-import io.trino.testing.containers.Minio;
-import io.trino.testing.minio.MinioClient;
+import io.trino.testing.containers.IcebergGcsRestCatalogBackendContainer;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.Network;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
+import java.io.UncheckedIOException;
+import java.util.Base64;
 
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.containers.Minio.MINIO_REGION;
-import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
-import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.FileFormat.PARQUET;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestIcebergVendingRestCatalogConnectorSmokeTest
+final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
-    private final String bucketName;
-    private String warehouseLocation;
-    private IcebergRestCatalogBackendContainer restCatalogBackendContainer;
-    private Minio minio;
+    private static final Logger LOG = Logger.get(TestIcebergGcsVendingRestCatalogConnectorSmokeTest.class);
 
-    public TestIcebergVendingRestCatalogConnectorSmokeTest()
+    private final String gcpCredentialKey;
+    private final String warehouseLocation;
+
+    private IcebergGcsRestCatalogBackendContainer restCatalog;
+
+    public TestIcebergGcsVendingRestCatalogConnectorSmokeTest()
     {
         super(new IcebergConfig().getFileFormat().toIceberg());
-        this.bucketName = "test-iceberg-vending-rest-connector-smoke-test-" + randomNameSuffix();
+        gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
+        String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+        warehouseLocation = "gs://%s/gcs-vending-rest-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
 
     @Override
@@ -81,8 +80,8 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
     {
         return switch (connectorBehavior) {
             case SUPPORTS_CREATE_MATERIALIZED_VIEW,
-                    SUPPORTS_RENAME_MATERIALIZED_VIEW,
-                    SUPPORTS_RENAME_SCHEMA -> false;
+                 SUPPORTS_RENAME_MATERIALIZED_VIEW,
+                 SUPPORTS_RENAME_SCHEMA -> false;
             default -> super.hasBehavior(connectorBehavior);
         };
     }
@@ -91,41 +90,34 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Network network = Network.newNetwork();
-        minio = closeAfterClass(Minio.builder().withNetwork(network).build());
-        minio.start();
-        minio.createBucket(bucketName);
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
 
-        this.warehouseLocation = "s3://%s/default/".formatted(bucketName);
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
+                .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        AccessToken accessToken = credentials.refreshAccessToken();
 
-        AwsCredentials credentials = AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
-        StsClient stsClient = StsClient.builder()
-                .endpointOverride(URI.create(minio.getMinioAddress()))
-                .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                .region(Region.of(MINIO_REGION))
-                .build();
+        JsonMapper mapper = new JsonMapper();
+        JsonNode jsonKey = mapper.readTree(gcpCredentials);
+        String gcpProjectId = jsonKey.get("project_id").asText();
 
-        AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(AssumeRoleRequest.builder().build());
-        restCatalogBackendContainer = closeAfterClass(new IcebergRestCatalogBackendContainer(
-                Optional.of(network),
+        restCatalog = closeAfterClass(new IcebergGcsRestCatalogBackendContainer(
                 warehouseLocation,
-                assumeRoleResponse.credentials().accessKeyId(),
-                assumeRoleResponse.credentials().secretAccessKey(),
-                assumeRoleResponse.credentials().sessionToken()));
-        restCatalogBackendContainer.start();
+                gcpProjectId,
+                accessToken.getTokenValue(),
+                accessToken.getExpirationTime().getTime()));
+        restCatalog.start();
 
         return IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "rest")
-                                .put("iceberg.rest-catalog.uri", "http://" + restCatalogBackendContainer.getRestCatalogEndpoint())
+                                .put("iceberg.rest-catalog.uri", restCatalog.catalogUri())
                                 .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
-                                .put("fs.native-s3.enabled", "true")
-                                .put("s3.region", MINIO_REGION)
-                                .put("s3.endpoint", minio.getMinioAddress())
-                                .put("s3.path-style-access", "true")
+                                .put("fs.native-gcs.enabled", "true")
+                                .put("gcs.auth-type", "APPLICATION_DEFAULT")
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -135,13 +127,32 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
     @BeforeAll
     public void initFileSystem()
     {
-        this.fileSystem = new S3FileSystemFactory(OpenTelemetry.noop(), new S3FileSystemConfig()
-                .setRegion(MINIO_REGION)
-                .setEndpoint(minio.getMinioAddress())
-                .setPathStyleAccess(true)
-                .setAwsAccessKey(MINIO_ROOT_USER)
-                .setAwsSecretKey(MINIO_ROOT_PASSWORD), new S3FileSystemStats()
-        ).create(SESSION);
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        GcsFileSystemConfig config = new GcsFileSystemConfig();
+        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
+        GcsStorageFactory storageFactory;
+        try {
+            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+    }
+
+    @AfterAll
+    public void removeTestData()
+    {
+        if (fileSystem == null) {
+            return;
+        }
+        try {
+            fileSystem.deleteDirectory(Location.of(warehouseLocation));
+        }
+        catch (IOException e) {
+            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
+            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+        }
     }
 
     @Test
@@ -170,14 +181,15 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
     protected String getMetadataLocation(String tableName)
     {
         try (RESTSessionCatalog catalog = new RESTSessionCatalog()) {
-            catalog.initialize("rest-catalog", ImmutableMap.of(CatalogProperties.URI, "http://" + restCatalogBackendContainer.getRestCatalogEndpoint()));
+            catalog.initialize("rest-catalog", ImmutableMap.of(CatalogProperties.URI, restCatalog.catalogUri()));
             SessionCatalog.SessionContext context = new SessionCatalog.SessionContext(
                     "user-default",
                     "user",
                     ImmutableMap.of(),
                     ImmutableMap.of(),
                     SESSION.getIdentity());
-            return ((BaseTable) catalog.loadTable(context, toIdentifier(tableName))).operations().current().metadataFileLocation();
+            TableIdentifier identifier = TableIdentifier.of(getSession().getSchema().orElseThrow(), tableName);
+            return ((BaseTable) catalog.loadTable(context, identifier)).operations().current().metadataFileLocation();
         }
         catch (IOException e) {
             throw new RuntimeException(e);
@@ -193,7 +205,12 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
     @Override
     protected boolean locationExists(String location)
     {
-        return Files.exists(Path.of(location));
+        try {
+            return fileSystem.newInputFile(Location.of(location)).exists();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Test
@@ -297,6 +314,11 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
 
     @Test
     @Override
+    @Disabled("TODO: Re-enable once https://github.com/apache/iceberg/pull/15734 is merged and bumped in Trino")
+    public void testDropTableWithMissingDataFile() {}
+
+    @Test
+    @Override
     public void testDropTableWithMissingManifestListFile()
     {
         assertThatThrownBy(super::testDropTableWithMissingManifestListFile)
@@ -323,19 +345,11 @@ public class TestIcebergVendingRestCatalogConnectorSmokeTest
     @Override
     protected void deleteDirectory(String location)
     {
-        try (MinioClient minioClient = minio.createMinioClient()) {
-            String prefix = "s3://" + bucketName + "/";
-            String key = location.substring(prefix.length());
-
-            for (String file : minioClient.listObjects(bucketName, key)) {
-                minioClient.removeObject(bucketName, file);
-            }
-            assertThat(minioClient.listObjects(bucketName, key)).isEmpty();
+        try {
+            fileSystem.deleteDirectory(Location.of(location));
         }
-    }
-
-    private TableIdentifier toIdentifier(String tableName)
-    {
-        return TableIdentifier.of(getSession().getSchema().orElseThrow(), tableName);
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestIcebergRestCatalogFileSystemFactory
+{
+    @Test
+    void testS3VendedCredentials()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return null;
+        };
+
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setBaseUri("http://localhost")
+                .setVendedCredentialsEnabled(true);
+        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "test-access-key",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "test-secret-key",
+                S3FileIOProperties.SESSION_TOKEN, "test-session-token");
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "test-access-key")
+                .containsEntry(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, "test-secret-key")
+                .containsEntry(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, "test-session-token");
+    }
+
+    @Test
+    void testGcsVendedCredentialsWithOAuthTokenOnly()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return null;
+        };
+
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setBaseUri("http://localhost")
+                .setVendedCredentialsEnabled(true);
+        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token");
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.test-token")
+                .doesNotContainKey(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY)
+                .doesNotContainKey(EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
+    }
+
+    @Test
+    void testGcsVendedCredentialsWithAllProperties()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return null;
+        };
+
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setBaseUri("http://localhost")
+                .setVendedCredentialsEnabled(true);
+        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+
+        Map<String, String> fileIoProperties = ImmutableMap.<String, String>builder()
+                .put(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token")
+                .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, "1700000000000")
+                .put(GCPProperties.GCS_PROJECT_ID, "my-gcp-project")
+                .buildOrThrow();
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.test-token")
+                .containsEntry(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY, "1700000000000")
+                .containsEntry(EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY, "my-gcp-project");
+    }
+
+    @Test
+    void testGcsVendedCredentialsDisabled()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return null;
+        };
+
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setBaseUri("http://localhost")
+                .setVendedCredentialsEnabled(false);
+        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token",
+                GCPProperties.GCS_PROJECT_ID, "my-gcp-project");
+
+        ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
+        factory.create(originalIdentity, fileIoProperties);
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials()).isEmpty();
+    }
+
+    @Test
+    void testNoVendedCredentialsInProperties()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return null;
+        };
+
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setBaseUri("http://localhost")
+                .setVendedCredentialsEnabled(true);
+        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+
+        ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
+        factory.create(originalIdentity, ImmutableMap.of());
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isSameAs(originalIdentity);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3VendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3VendingRestCatalogConnectorSmokeTest.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.s3.S3FileSystemConfig;
+import io.trino.filesystem.s3.S3FileSystemFactory;
+import io.trino.filesystem.s3.S3FileSystemStats;
+import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
+import io.trino.plugin.iceberg.IcebergConfig;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.testing.QueryFailedException;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.containers.IcebergS3RestCatalogBackendContainer;
+import io.trino.testing.containers.Minio;
+import io.trino.testing.minio.MinioClient;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static java.lang.String.format;
+import static org.apache.iceberg.FileFormat.PARQUET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestIcebergS3VendingRestCatalogConnectorSmokeTest
+        extends BaseIcebergConnectorSmokeTest
+{
+    private final String bucketName;
+    private String warehouseLocation;
+    private IcebergS3RestCatalogBackendContainer restCatalogBackendContainer;
+    private Minio minio;
+
+    public TestIcebergS3VendingRestCatalogConnectorSmokeTest()
+    {
+        super(new IcebergConfig().getFileFormat().toIceberg());
+        this.bucketName = "test-iceberg-vending-rest-connector-smoke-test-" + randomNameSuffix();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                    SUPPORTS_RENAME_MATERIALIZED_VIEW,
+                    SUPPORTS_RENAME_SCHEMA -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Network network = Network.newNetwork();
+        minio = closeAfterClass(Minio.builder().withNetwork(network).build());
+        minio.start();
+        minio.createBucket(bucketName);
+
+        this.warehouseLocation = "s3://%s/default/".formatted(bucketName);
+
+        AwsCredentials credentials = AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
+        StsClient stsClient = StsClient.builder()
+                .endpointOverride(URI.create(minio.getMinioAddress()))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.of(MINIO_REGION))
+                .build();
+
+        AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(AssumeRoleRequest.builder().build());
+        restCatalogBackendContainer = closeAfterClass(new IcebergS3RestCatalogBackendContainer(
+                Optional.of(network),
+                warehouseLocation,
+                assumeRoleResponse.credentials().accessKeyId(),
+                assumeRoleResponse.credentials().secretAccessKey(),
+                assumeRoleResponse.credentials().sessionToken()));
+        restCatalogBackendContainer.start();
+
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.file-format", format.name())
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", "http://" + restCatalogBackendContainer.getRestCatalogEndpoint())
+                                .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                                .put("iceberg.writer-sort-buffer-size", "1MB")
+                                .put("fs.native-s3.enabled", "true")
+                                .put("s3.region", MINIO_REGION)
+                                .put("s3.endpoint", minio.getMinioAddress())
+                                .put("s3.path-style-access", "true")
+                                .buildOrThrow())
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    @Override
+    @BeforeAll
+    public void initFileSystem()
+    {
+        this.fileSystem = new S3FileSystemFactory(OpenTelemetry.noop(), new S3FileSystemConfig()
+                .setRegion(MINIO_REGION)
+                .setEndpoint(minio.getMinioAddress())
+                .setPathStyleAccess(true)
+                .setAwsAccessKey(MINIO_ROOT_USER)
+                .setAwsSecretKey(MINIO_ROOT_PASSWORD), new S3FileSystemStats()
+        ).create(SESSION);
+    }
+
+    @Test
+    @Override
+    public void testMaterializedView()
+    {
+        assertThatThrownBy(super::testMaterializedView)
+                .hasMessageContaining("createMaterializedView is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRenameSchema()
+    {
+        assertThatThrownBy(super::testRenameSchema)
+                .hasMessageContaining("renameNamespace is not supported for Iceberg REST catalog");
+    }
+
+    @Override
+    protected void dropTableFromCatalog(String tableName)
+    {
+        // TODO: Get register table tests working
+    }
+
+    @Override
+    protected String getMetadataLocation(String tableName)
+    {
+        try (RESTSessionCatalog catalog = new RESTSessionCatalog()) {
+            catalog.initialize("rest-catalog", ImmutableMap.of(CatalogProperties.URI, "http://" + restCatalogBackendContainer.getRestCatalogEndpoint()));
+            SessionCatalog.SessionContext context = new SessionCatalog.SessionContext(
+                    "user-default",
+                    "user",
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    SESSION.getIdentity());
+            return ((BaseTable) catalog.loadTable(context, toIdentifier(tableName))).operations().current().metadataFileLocation();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected String schemaPath()
+    {
+        return format("%s%s", warehouseLocation, getSession().getSchema().orElseThrow());
+    }
+
+    @Override
+    protected boolean locationExists(String location)
+    {
+        return Files.exists(Path.of(location));
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithTableLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithTableLocation)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithComments()
+    {
+        assertThatThrownBy(super::testRegisterTableWithComments)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithShowCreateTable()
+    {
+        assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithReInsert()
+    {
+        assertThatThrownBy(super::testRegisterTableWithReInsert)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithDroppedTable()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDroppedTable)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithDifferentTableName()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithMetadataFile()
+    {
+        assertThatThrownBy(super::testRegisterTableWithMetadataFile)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithTrailingSpaceInLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTable()
+    {
+        assertThatThrownBy(super::testUnregisterTable)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRepeatUnregisterTable()
+    {
+        assertThatThrownBy(super::testRepeatUnregisterTable)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingMetadataFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingMetadataFile)
+                .hasMessageMatching("Failed to load table: (.*)");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingSnapshotFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingSnapshotFile)
+                .isInstanceOf(QueryFailedException.class)
+                .cause()
+                .hasMessageContaining("Failed to drop table")
+                .hasNoCause();
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithMissingManifestListFile()
+    {
+        assertThatThrownBy(super::testDropTableWithMissingManifestListFile)
+                .hasMessageContaining("Table location should not exist");
+    }
+
+    @Test
+    @Override
+    public void testDropTableWithNonExistentTableLocation()
+    {
+        assertThatThrownBy(super::testDropTableWithNonExistentTableLocation)
+                .hasMessageMatching("Failed to load table: (.*)");
+    }
+
+    @Override
+    protected boolean isFileSorted(Location path, String sortColumnName)
+    {
+        if (format == PARQUET) {
+            return checkParquetFileSorting(fileSystem.newInputFile(path), sortColumnName);
+        }
+        return checkOrcFileSorting(fileSystem, path, sortColumnName);
+    }
+
+    @Override
+    protected void deleteDirectory(String location)
+    {
+        try (MinioClient minioClient = minio.createMinioClient()) {
+            String prefix = "s3://" + bucketName + "/";
+            String key = location.substring(prefix.length());
+
+            for (String file : minioClient.listObjects(bucketName, key)) {
+                minioClient.removeObject(bucketName, file);
+            }
+            assertThat(minioClient.listObjects(bucketName, key)).isEmpty();
+        }
+    }
+
+    private TableIdentifier toIdentifier(String tableName)
+    {
+        return TableIdentifier.of(getSession().getSchema().orElseThrow(), tableName);
+    }
+}

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergGcsRestCatalogBackendContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergGcsRestCatalogBackendContainer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+
+public class IcebergGcsRestCatalogBackendContainer
+        extends BaseTestContainer
+{
+    public IcebergGcsRestCatalogBackendContainer(
+            String warehouseLocation,
+            String gcpProjectId,
+            String accessToken,
+            long accessTokenExpiresAt)
+    {
+        super(
+                "apache/iceberg-rest-fixture:1.10.1",
+                "iceberg-rest",
+                ImmutableSet.of(8181),
+                ImmutableMap.of(),
+                ImmutableMap.of(
+                        "CATALOG_INCLUDE__CREDENTIALS", "true",
+                        "CATALOG_WAREHOUSE", warehouseLocation,
+                        "CATALOG_IO__IMPL", "org.apache.iceberg.gcp.gcs.GCSFileIO",
+                        "CATALOG_GCS_PROJECT__ID", gcpProjectId,
+                        "CATALOG_GCS_OAUTH2_TOKEN", accessToken,
+                        "CATALOG_GCS_OAUTH2_TOKEN_EXPIRES_AT", Long.toString(accessTokenExpiresAt)),
+                Optional.empty(),
+                5);
+    }
+
+    public String catalogUri()
+    {
+        return "http://" + getMappedHostAndPortForExposedPort(8181).toString();
+    }
+}

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergS3RestCatalogBackendContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergS3RestCatalogBackendContainer.java
@@ -21,10 +21,10 @@ import java.util.Optional;
 
 import static io.trino.testing.containers.Minio.MINIO_REGION;
 
-public class IcebergRestCatalogBackendContainer
+public class IcebergS3RestCatalogBackendContainer
         extends BaseTestContainer
 {
-    public IcebergRestCatalogBackendContainer(
+    public IcebergS3RestCatalogBackendContainer(
             Optional<Network> network,
             String warehouseLocation,
             String minioAccessKey,


### PR DESCRIPTION
## Description

The Iceberg REST catalog spec allows the catalog server to return file IO properties in the load-table response. These can include cloud-specific credentials that override the connector's static settings on a per-table basis ("vended credentials").

Trino already supports vended S3 credentials (access key, secret key, session token), but GCS properties from the REST catalog response are currently ignored. This means users connecting to a REST catalog that vends GCS credentials (e.g., Tabular, Polaris, or custom implementations) cannot use them for GCS-backed tables.

For example, a REST catalog server managing tables across multiple GCP
projects might vend different `gcs.project-id` and `gcs.oauth2.token`
values per table. Without this change, Trino would always use the
statically configured credentials, which may not have access to all
tables.

This change adds support for the following GCS properties from vended credentials:

- `gcs.oauth2.token` / `gcs.oauth2.token-expires-at` — short-lived OAuth2 access token and its expiration
- `gcs.project-id` — GCP project ID (can differ per table if the catalog manages tables across projects)

These properties are extracted from `fileIoProperties` in `IcebergRestCatalogFileSystemFactory` and passed through `ConnectorIdentity` extra credentials to the GCS filesystem layer, where `GcsStorageFactory` creates an authenticated `Storage` client using the vended token.

These properties are extracted from `fileIoProperties` in
[IcebergRestCatalogFileSystemFactory] and passed through
`ConnectorIdentity` extra credentials to the GCS filesystem layer:


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->


Fixes https://github.com/trinodb/trino/issues/24518


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
## Iceberg
* Add support for vended credentials on GCS. ({issue}`24518 `)
```

