### PR TITLE
Pass Trino version to duckdb server

### DIFF
--- a/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClientModule.java
+++ b/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClientModule.java
@@ -27,6 +27,7 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
+import io.trino.spi.NodeVersion;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import org.duckdb.DuckDBDriver;
 
@@ -34,6 +35,7 @@ import java.util.Properties;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.duckdb.DuckDBDriver.DUCKDB_USER_AGENT_PROPERTY;
 
 public final class DuckDbClientModule
         extends AbstractConfigurationAwareModule
@@ -49,9 +51,14 @@ public final class DuckDbClientModule
     @Provides
     @Singleton
     @ForBaseJdbc
-    public static ConnectionFactory connectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
+    public static ConnectionFactory connectionFactory(
+            BaseJdbcConfig config,
+            CredentialProvider credentialProvider,
+            OpenTelemetry openTelemetry,
+            NodeVersion nodeVersion)
     {
         Properties connectionProperties = new Properties();
+        connectionProperties.setProperty(DUCKDB_USER_AGENT_PROPERTY, "trino/" + nodeVersion.toString());
         return DriverConnectionFactory.builder(
                         new DuckDBDriver(),
                         config.getConnectionUrl(),

--- a/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestDuckDbConnectorTest.java
+++ b/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestDuckDbConnectorTest.java
@@ -278,6 +278,14 @@ final class TestDuckDbConnectorTest
     }
 
     @Test
+    void testCustomUserAgent()
+    {
+        assertThat(query("SELECT filter(split(user_agent, ' '), value -> value LIKE 'trino%') FROM TABLE(system.query(query => 'SELECT user_agent FROM pragma_user_agent()'))"))
+                .skippingTypesCheck()
+                .matches("VALUES (ARRAY['trino/testversion'])");
+    }
+
+    @Test
     void testTemporaryTable()
     {
         String tableName = "test_temporary_table" + randomNameSuffix();

--- a/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestingDuckDb.java
+++ b/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestingDuckDb.java
@@ -27,6 +27,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
+import static org.duckdb.DuckDBDriver.DUCKDB_USER_AGENT_PROPERTY;
+
 public class TestingDuckDb
         implements Closeable
 {
@@ -49,7 +51,9 @@ public class TestingDuckDb
 
     public void execute(@Language("SQL") String sql)
     {
-        try (Connection connection = DriverManager.getConnection(getJdbcUrl(), new Properties());
+        Properties properties = new Properties();
+        properties.put(DUCKDB_USER_AGENT_PROPERTY, "trino/testversion");
+        try (Connection connection = DriverManager.getConnection(getJdbcUrl(), properties);
                 Statement statement = connection.createStatement()) {
             statement.execute(sql);
         }


### PR DESCRIPTION
## Description
DuckDB has a user-agent property that allows integrations to identify themselves. This PR adds a "trino" user-agent.

Example result of running `PRAGMA user_agent` after this change: `duckdb/v1.3.2(linux_amd64) jdbc trino/version`.

## Additional context and related issues
n/a


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

