### PR TITLE
Pass the additional module to HiveConnectorFactory as a Supplier

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
@@ -53,6 +53,7 @@ import org.weakref.jmx.guice.MBeanModule;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
@@ -71,14 +72,14 @@ public class HiveConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         checkStrictSpiVersionMatch(context, this);
-        return createConnector(catalogName, config, context, EMPTY_MODULE, Optional.empty(), false, Optional.empty());
+        return createConnector(catalogName, config, context, () -> EMPTY_MODULE, Optional.empty(), false, Optional.empty());
     }
 
     public static Connector createConnector(
             String catalogName,
             Map<String, String> config,
             ConnectorContext context,
-            Module module,
+            Supplier<Module> module,
             Optional<HiveMetastore> metastore,
             boolean metastoreImpersonationEnabled,
             Optional<TrinoFileSystemFactory> fileSystemFactory)
@@ -101,7 +102,7 @@ public class HiveConnectorFactory
                     new MBeanServerModule(),
                     new ConnectorContextModule(catalogName, context),
                     binder -> newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(HiveSessionProperties.class).in(Scopes.SINGLETON),
-                    module);
+                    module.get());
 
             Injector injector = app
                     .doNotInitializeLogging()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHiveConnectorFactory.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -76,7 +77,7 @@ public class TestingHiveConnectorFactory
         if (metastore.isEmpty() && !config.containsKey("hive.metastore")) {
             configBuilder.put("hive.metastore", "file");
         }
-        Module module = binder -> {
+        Supplier<Module> module = () -> binder -> {
             newMapBinder(binder, String.class, TrinoFileSystemFactory.class)
                     .addBinding("local").toInstance(new LocalFileSystemFactory(localFileSystemRootPath));
             configBinder(binder).bindConfigDefaults(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Sometimes this module may end up being installed multiple times, and this is a problem for two reasons:

1. Some Guice bindinds cannot be made twice, though usually Guice won't complain
2. If this is an instance of an `AbstractConfigurationAwareModule`, and the module is installed twice *in two different contexts*, then we'll try to set a configuration factory twice on it, which is a herd error.

In fact, this is now explicitly prohibited in Airlift 387: see trinodb/trino@3843c695a2b0ea517f107f68625b10b6f0da1c1c.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

It's not causing issues right now, but it may in the future.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
