### PR TITLE
Override TASK retry policy to NONE in DirectTrinoClient

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/SessionContext.java
+++ b/core/trino-main/src/main/java/io/trino/server/SessionContext.java
@@ -23,6 +23,7 @@ import io.trino.spi.security.SelectedRole;
 import io.trino.spi.session.ResourceEstimates;
 import io.trino.transaction.TransactionId;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -236,6 +237,37 @@ public class SessionContext
     public Optional<String> getQueryDataEncoding()
     {
         return queryDataEncoding;
+    }
+
+    public SessionContext withSystemProperty(String key, String value)
+    {
+        Map<String, String> modified = new HashMap<>(systemProperties);
+        modified.put(key, value);
+        return new SessionContext(
+                protocolHeaders,
+                catalog,
+                schema,
+                path,
+                authenticatedIdentity,
+                identity,
+                originalIdentity,
+                selectedRole,
+                source,
+                traceToken,
+                userAgent,
+                remoteUserAddress,
+                timeZoneId,
+                language,
+                clientTags,
+                clientCapabilities,
+                resourceEstimates,
+                ImmutableMap.copyOf(modified),
+                catalogSessionProperties,
+                preparedStatements,
+                transactionId,
+                clientTransactionSupport,
+                clientInfo,
+                queryDataEncoding);
     }
 
     @VisibleForTesting

--- a/testing/trino-tests/src/test/java/io/trino/client/direct/TestDirectTrinoClient.java
+++ b/testing/trino-tests/src/test/java/io/trino/client/direct/TestDirectTrinoClient.java
@@ -14,9 +14,15 @@
 package io.trino.client.direct;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
 import io.trino.plugin.blackhole.BlackHolePlugin;
+import io.trino.plugin.memory.MemoryPlugin;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryFailedException;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -26,6 +32,12 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.util.concurrent.TimeUnit;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
+import static io.trino.operator.RetryPolicy.QUERY;
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -34,10 +46,10 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 public class TestDirectTrinoClient
 {
     private QueryRunner queryRunner;
+    private QueryRunner queryRunnerWithTaskRetry;
 
     @BeforeAll
     public void setup()
-            throws Exception
     {
         queryRunner = new StandaloneQueryRunner(
                 TEST_SESSION,
@@ -53,6 +65,27 @@ public class TestDirectTrinoClient
                 "   rows_per_page = 1, " +
                 "   page_processing_delay = '3s'" +
                 ")");
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", "1"));
+        queryRunner.installPlugin(new MemoryPlugin());
+        queryRunner.createCatalog("memory", "memory");
+
+        queryRunnerWithTaskRetry = new StandaloneQueryRunner(
+                TEST_SESSION,
+                builder -> builder.overrideProperties(ImmutableMap.of(
+                        "query.client.timeout", "1s",
+                        "retry-policy", "TASK")));
+        queryRunnerWithTaskRetry.installPlugin(new TpchPlugin());
+        queryRunnerWithTaskRetry.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", "1"));
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        if (queryRunnerWithTaskRetry != null) {
+            queryRunnerWithTaskRetry.close();
+            queryRunnerWithTaskRetry = null;
+        }
     }
 
     @Test
@@ -60,5 +93,102 @@ public class TestDirectTrinoClient
     public void testDirectTrinoClientLongQuery()
     {
         queryRunner.execute(TEST_SESSION, "SELECT * FROM blackhole.test_schema.slow_test_table");
+    }
+
+    @Test
+    public void testBasicQuery()
+    {
+        MaterializedResult result = queryRunner.execute(TEST_SESSION, "SELECT 1 AS col");
+
+        assertThat(result.getRowCount()).isEqualTo(1);
+        assertThat(result.getMaterializedRows().get(0).getField(0)).isEqualTo(1);
+        assertThat(result.getColumnNames()).containsExactly("col");
+    }
+
+    @Test
+    public void testEmptyResult()
+    {
+        MaterializedResult result = queryRunner.execute(TEST_SESSION, "SELECT * FROM (SELECT 'hello' AS col) WHERE 1 = 0");
+
+        assertThat(result.getRowCount()).isEqualTo(0);
+        assertThat(result.getColumnNames()).containsExactly("col");
+    }
+
+    @Test
+    public void testDdlStatement()
+    {
+        Session session = Session.builder(TEST_SESSION)
+                .setCatalog("memory")
+                .setSchema("default")
+                .build();
+
+        String tableName = "test_table_" + randomNameSuffix();
+        queryRunner.execute(session, "CREATE TABLE %s (id BIGINT)".formatted(tableName));
+        assertThat(queryRunner.tableExists(session, tableName)).isTrue();
+
+        queryRunner.execute(session, "DROP TABLE %s".formatted(tableName));
+        assertThat(queryRunner.tableExists(session, tableName)).isFalse();
+    }
+
+    @Test
+    public void testQueryFailure()
+    {
+        assertThatThrownBy(() -> queryRunner.execute(TEST_SESSION, "SELECT * FROM non_existent_table"))
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessageContaining("non_existent_table");
+    }
+
+    @Test
+    public void testUpdateStatement()
+    {
+        Session session = Session.builder(TEST_SESSION)
+                .setCatalog("memory")
+                .setSchema("default")
+                .build();
+
+        String tableName = "test_table_" + randomNameSuffix();
+        queryRunner.execute(session, "CREATE TABLE %s (id BIGINT)".formatted(tableName));
+        try {
+            MaterializedResult result = queryRunner.execute(session, "INSERT INTO %s (id) VALUES (1), (2), (3)".formatted(tableName));
+            assertThat(result.getUpdateCount()).hasValue(3L);
+        }
+        finally {
+            queryRunner.execute(session, "DROP TABLE IF EXISTS %s".formatted(tableName));
+        }
+    }
+
+    @Test
+    public void testQueryWithTaskRetryPolicyInSession()
+    {
+        Session session = Session.builder(TEST_SESSION)
+                .setSystemProperty(RETRY_POLICY, TASK.name())
+                .build();
+
+        MaterializedResult result = queryRunner.execute(session, "SELECT 1 AS col");
+
+        assertThat(result.getRowCount()).isEqualTo(1);
+        assertThat(result.getMaterializedRows().get(0).getField(0)).isEqualTo(1);
+    }
+
+    @Test
+    public void testQueryWithTaskRetryPolicyInConfig()
+    {
+        MaterializedResult result = queryRunnerWithTaskRetry.execute(TEST_SESSION, "SELECT 1 AS col");
+
+        assertThat(result.getRowCount()).isEqualTo(1);
+        assertThat(result.getMaterializedRows().get(0).getField(0)).isEqualTo(1);
+    }
+
+    @Test
+    public void testQueryWithQueryRetryPolicy()
+    {
+        Session session = Session.builder(TEST_SESSION)
+                .setSystemProperty(RETRY_POLICY, QUERY.name())
+                .build();
+
+        MaterializedResult result = queryRunner.execute(session, "SELECT 1 AS col");
+
+        assertThat(result.getRowCount()).isEqualTo(1);
+        assertThat(result.getMaterializedRows().get(0).getField(0)).isEqualTo(1);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

DirectExchangeClient does not support TASK retry policy. When it is set either in the server config or as a session property, override it to NONE before dispatching the query.

Added tests for basic query execution, DDL, updates, error handling, and retry policy override behavior.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
