### PR TITLE
Make BaseElasticsearchConnectorTest extensible with regards to jmxBaseName

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -57,7 +57,7 @@ public abstract class BaseElasticsearchConnectorTest
 {
     private ElasticsearchServer server;
     private RestHighLevelClient client;
-    private final String jmxBaseName = randomNameSuffix();
+    protected final String jmxBaseName = randomNameSuffix();
 
     BaseElasticsearchConnectorTest(ElasticsearchServer server)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Initializing a private field in `createQueryRunner` is fraught with peril in case someone ever needs to override it. An overridden method would be called, field initialization will be skipped and tests will fail because the field is null. Initializing it in the constructor avoids that, but we also need to make this field `protected` so that the override can use it to properly initialize the coordinator properties.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- none

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
