### PR TITLE
Parallelize Parquet checkpoint reads in the Delta Lake connector

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -198,9 +198,23 @@ values. Typical usage does not require you to configure them.
     is parallelized.
   - `8`
 * - `delta.checkpoint-processing.parallelism`
-  - Number of threads used for retrieving checkpoint files of each table. Currently, only 
-    retrievals of V2 Checkpoint's sidecar files are parallelized.
+  - Number of threads used for processing Parquet checkpoint files for each
+    table
   - `4`
+* - `delta.checkpoint-processing.v1-parallel-processing.enabled`
+  - Enable parallel processing for V1 checkpoints
+  - `false`
+* - `delta.checkpoint-processing.v2-parallel-processing.enabled`
+  - Enable fully parallel processing for V2 checkpoint sidecar files (by
+    default, sidecar files are opened in parallel but read serially)
+  - `false`
+* - `delta.checkpoint-processing.intra-file-parallel-processing.enabled`
+  - Enable parallel processing of individual checkpoint Parquet files by
+    subdividing into splits
+  - `false`
+* - `delta.checkpoint-processing.intra-file-parallel-processing.split-size`
+  - Goal split size for parallel processing of individual checkpoint Parquet files
+  - `128MB`
 * - `delta.load-metadata-from-checksum-file`
   - Speed up query planning by reading table metadata and protocol
     entries from the Delta version checksum file (`<version>.crc`) when

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -22,6 +22,7 @@ import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDuration;
+import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
 import io.trino.plugin.base.configuration.ThreadCountParser;
 import io.trino.plugin.hive.HiveCompressionOption;
@@ -95,6 +96,10 @@ public class DeltaLakeConfig
     private boolean deltaLogFileSystemCacheDisabled;
     private int metadataParallelism = 8;
     private int checkpointProcessingParallelism = 4;
+    private boolean checkpointV1ParallelProcessingEnabled;
+    private boolean checkpointV2ParallelProcessingEnabled;
+    private boolean checkpointIntraFileParallelProcessingEnabled;
+    private DataSize checkpointIntraFileParallelProcessingSplitSize = DataSize.of(128, MEGABYTE);
     private boolean loadMetadataFromChecksumFile = true;
 
     public Duration getMetadataCacheTtl()
@@ -581,11 +586,65 @@ public class DeltaLakeConfig
         return checkpointProcessingParallelism;
     }
 
-    @ConfigDescription("Limits per table scan checkpoint files processing parallelism")
+    @ConfigDescription("Limits per table scan checkpoint file processing parallelism for checkpoint Parquet files")
     @Config("delta.checkpoint-processing.parallelism")
     public DeltaLakeConfig setCheckpointProcessingParallelism(int checkpointProcessingParallelism)
     {
         this.checkpointProcessingParallelism = checkpointProcessingParallelism;
+        return this;
+    }
+
+    public boolean isCheckpointV1ParallelProcessingEnabled()
+    {
+        return checkpointV1ParallelProcessingEnabled;
+    }
+
+    @Config("delta.checkpoint-processing.v1-parallel-processing.enabled")
+    @ConfigDescription("Enable parallel processing for v1 checkpoints")
+    public DeltaLakeConfig setCheckpointV1ParallelProcessingEnabled(boolean checkpointV1ParallelProcessingEnabled)
+    {
+        this.checkpointV1ParallelProcessingEnabled = checkpointV1ParallelProcessingEnabled;
+        return this;
+    }
+
+    public boolean isCheckpointV2ParallelProcessingEnabled()
+    {
+        return checkpointV2ParallelProcessingEnabled;
+    }
+
+    @Config("delta.checkpoint-processing.v2-parallel-processing.enabled")
+    @ConfigDescription("Enable fully parallel processing for v2 checkpoint sidecar files")
+    public DeltaLakeConfig setCheckpointV2ParallelProcessingEnabled(boolean checkpointV2ParallelProcessingEnabled)
+    {
+        this.checkpointV2ParallelProcessingEnabled = checkpointV2ParallelProcessingEnabled;
+        return this;
+    }
+
+    public boolean isCheckpointIntraFileParallelProcessingEnabled()
+    {
+        return checkpointIntraFileParallelProcessingEnabled;
+    }
+
+    @Config("delta.checkpoint-processing.intra-file-parallel-processing.enabled")
+    @ConfigDescription("Enable parallel processing of individual checkpoint Parquet files by subdividing them into splits")
+    public DeltaLakeConfig setCheckpointIntraFileParallelProcessingEnabled(boolean checkpointIntraFileParallelProcessingEnabled)
+    {
+        this.checkpointIntraFileParallelProcessingEnabled = checkpointIntraFileParallelProcessingEnabled;
+        return this;
+    }
+
+    @NotNull
+    @MinDataSize("1B")
+    public DataSize getCheckpointIntraFileParallelProcessingSplitSize()
+    {
+        return checkpointIntraFileParallelProcessingSplitSize;
+    }
+
+    @Config("delta.checkpoint-processing.intra-file-parallel-processing.split-size")
+    @ConfigDescription("Target split size for parallel processing of individual checkpoint Parquet files")
+    public DeltaLakeConfig setCheckpointIntraFileParallelProcessingSplitSize(DataSize checkpointIntraFileParallelProcessingSplitSize)
+    {
+        this.checkpointIntraFileParallelProcessingSplitSize = checkpointIntraFileParallelProcessingSplitSize;
         return this;
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TableSnapshot.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TableSnapshot.java
@@ -26,6 +26,7 @@ import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.LastCheckpoint;
+import io.trino.plugin.deltalake.transactionlog.checkpoint.ParallelUnorderedIterator;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.TransactionLogTail;
 import io.trino.plugin.deltalake.transactionlog.reader.TransactionLogReader;
 import io.trino.spi.TrinoException;
@@ -37,13 +38,19 @@ import io.trino.spi.type.TypeManager;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -70,6 +77,7 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 public class TableSnapshot
 {
     private static final int INSTANCE_SIZE = instanceSize(TableSnapshot.class);
+    private static final int CHECKPOINT_FILE_PROCESSING_QUEUE_SIZE = 32_678;
 
     private final Optional<LastCheckpoint> lastCheckpoint;
     private final SchemaTableName table;
@@ -223,6 +231,55 @@ public class TableSnapshot
                 + sizeOf(cachedProtocol, ProtocolEntry::getRetainedSizeInBytes);
     }
 
+    private record CheckpointFileSplit(
+            TrinoInputFile checkpointFile,
+            long start,
+            long length,
+            long fileSize)
+    {
+        private CheckpointFileSplit
+        {
+            requireNonNull(checkpointFile, "checkpointFile is null");
+            checkArgument(start >= 0, "start must be non-negative");
+            checkArgument(length >= 0, "length must be non-negative");
+            checkArgument(fileSize >= 0, "fileSize must be non-negative");
+            checkArgument(start <= fileSize, "start (%s) must be less than or equal to fileSize (%s)", start, fileSize);
+            checkArgument(length <= fileSize - start, "length (%s) with start (%s) must fit within fileSize (%s)", length, start, fileSize);
+        }
+    }
+
+    private Stream<CheckpointFileSplit> computeSplits(TrinoInputFile checkpointFile, long splitSize)
+    {
+        checkArgument(splitSize > 0, "splitSize must be positive");
+        return computeSplits(checkpointFile, getCheckpointFileSize(checkpointFile), splitSize);
+    }
+
+    private Stream<CheckpointFileSplit> computeSplits(TrinoInputFile checkpointFile, long fileSize, long splitSize)
+    {
+        checkArgument(splitSize > 0, "splitSize must be positive");
+
+        long splitCount;
+        if (fileSize == 0) {
+            splitCount = 1;
+        }
+        else {
+            splitCount = (fileSize + splitSize - 1) / splitSize;
+        }
+
+        return LongStream.range(0, splitCount)
+                .mapToObj(i -> {
+                    long start = i * splitSize;
+                    long length = Math.min(splitSize, fileSize - start);
+                    return new CheckpointFileSplit(checkpointFile, start, length, fileSize);
+                });
+    }
+
+    private CheckpointFileSplit computeSingletonSplit(TrinoInputFile checkpointFile)
+    {
+        long fileSize = getCheckpointFileSize(checkpointFile);
+        return new CheckpointFileSplit(checkpointFile, 0, fileSize, fileSize);
+    }
+
     public Stream<DeltaLakeTransactionLogEntry> getCheckpointTransactionLogEntries(
             ConnectorSession session,
             Set<CheckpointEntryIterator.EntryType> entryTypes,
@@ -233,7 +290,11 @@ public class TableSnapshot
             Optional<MetadataAndProtocolEntry> metadataAndProtocol,
             TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
             Optional<Predicate<String>> addStatsMinMaxColumnFilter,
-            Executor executor)
+            Executor checkpointProcessingExecutor,
+            boolean checkpointV1ParallelProcessingEnabled,
+            boolean checkpointV2ParallelProcessingEnabled,
+            boolean checkpointIntraFileParallelProcessingEnabled,
+            long checkpointIntraFileParallelProcessingSplitSize)
             throws IOException
     {
         if (lastCheckpoint.isEmpty()) {
@@ -247,14 +308,38 @@ public class TableSnapshot
             checkState(metadataAndProtocol.isPresent(), "metadata and protocol information is needed to process the add log entries");
         }
 
-        return getCheckpointPartPaths(checkpoint).stream()
+        List<TrinoInputFile> checkpointFiles = getCheckpointPartPaths(checkpoint).stream()
                 .map(fileSystem::newInputFile)
-                .flatMap(checkpointFile -> getCheckpointTransactionLogEntries(
+                .collect(toImmutableList());
+
+        Optional<MetadataEntry> metadataEntry = metadataAndProtocol.map(MetadataAndProtocolEntry::metadataEntry);
+        Optional<ProtocolEntry> protocolEntry = metadataAndProtocol.map(MetadataAndProtocolEntry::protocolEntry);
+
+        if (checkpoint.v2Checkpoint().isEmpty()) {
+            return getV1CheckpointTransactionLogEntries(
+                    session,
+                    entryTypes,
+                    checkpointSchemaManager,
+                    typeManager,
+                    stats,
+                    metadataEntry,
+                    protocolEntry,
+                    partitionConstraint,
+                    addStatsMinMaxColumnFilter,
+                    checkpointFiles,
+                    checkpointProcessingExecutor,
+                    checkpointV1ParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingSplitSize);
+        }
+
+        return checkpointFiles
+                .stream()
+                .flatMap(checkpointFile -> getV2CheckpointTransactionLogEntriesFrom(
                         session,
-                        fileSystem,
                         entryTypes,
-                        metadataAndProtocol.map(MetadataAndProtocolEntry::metadataEntry),
-                        metadataAndProtocol.map(MetadataAndProtocolEntry::protocolEntry),
+                        metadataEntry,
+                        protocolEntry,
                         checkpointSchemaManager,
                         typeManager,
                         stats,
@@ -262,72 +347,80 @@ public class TableSnapshot
                         checkpointFile,
                         partitionConstraint,
                         addStatsMinMaxColumnFilter,
-                        executor));
+                        fileSystem,
+                        checkpointProcessingExecutor,
+                        checkpointV2ParallelProcessingEnabled,
+                        checkpointIntraFileParallelProcessingEnabled,
+                        checkpointIntraFileParallelProcessingSplitSize));
+    }
+
+    private Stream<DeltaLakeTransactionLogEntry> getV1CheckpointTransactionLogEntries(
+            ConnectorSession session,
+            Set<CheckpointEntryIterator.EntryType> entryTypes,
+            CheckpointSchemaManager checkpointSchemaManager,
+            TypeManager typeManager,
+            FileFormatDataSourceStats stats,
+            Optional<MetadataEntry> metadataEntry,
+            Optional<ProtocolEntry> protocolEntry,
+            TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
+            Optional<Predicate<String>> addStatsMinMaxColumnFilter,
+            List<TrinoInputFile> checkpointFiles,
+            Executor checkpointProcessingExecutor,
+            boolean checkpointV1ParallelProcessingEnabled,
+            boolean checkpointIntraFileParallelProcessingEnabled,
+            long checkpointIntraFileParallelProcessingSplitSize)
+    {
+        Function<CheckpointFileSplit, Supplier<Stream<DeltaLakeTransactionLogEntry>>> checkpointFileSplitStreamBuilder =
+                checkpointFileSplit -> {
+                    return () -> buildCheckpointFileSplitStream(
+                            checkpointFileSplit,
+                            session,
+                            checkpointSchemaManager,
+                            typeManager,
+                            entryTypes,
+                            metadataEntry,
+                            protocolEntry,
+                            stats,
+                            partitionConstraint,
+                            addStatsMinMaxColumnFilter);
+                };
+
+        boolean parallelizable = checkpointV1ParallelProcessingEnabled && (checkpointFiles.size() > 1 || checkpointIntraFileParallelProcessingEnabled);
+
+        if (parallelizable) {
+            Function<TrinoInputFile, Supplier<Stream<CheckpointFileSplit>>> checkpointFileSplitSupplierBuilder =
+                    checkpointIntraFileParallelProcessingEnabled
+                            ? checkpointFile -> () -> computeSplits(
+                                    checkpointFile,
+                                    checkpointIntraFileParallelProcessingSplitSize)
+                            : checkpointFile -> () -> Stream.of(computeSingletonSplit(checkpointFile));
+
+            // Note: we plan the splits first before reading from any of the files. In principle
+            // we should be able to interleave planning and reading, but this would require a
+            // more sophisticated iterator. Moreover, split planning is still much cheaper than
+            // the actual checkpoint scan and decode, so we don't lose much by doing it first
+            List<CheckpointFileSplit> checkpointFileSplits = ParallelUnorderedIterator.stream(
+                    checkpointFiles.stream().map(checkpointFileSplitSupplierBuilder).collect(toImmutableList()),
+                    checkpointProcessingExecutor).collect(toImmutableList());
+
+            checkState(!checkpointFileSplits.isEmpty(), "Checkpoint file splits unexpectedly empty");
+
+            return ParallelUnorderedIterator.stream(
+                    checkpointFileSplits.stream().map(checkpointFileSplitStreamBuilder).collect(toImmutableList()),
+                    checkpointProcessingExecutor,
+                    CHECKPOINT_FILE_PROCESSING_QUEUE_SIZE);
+        }
+
+        Stream<CheckpointFileSplit> checkpointFileSplits =
+                checkpointFiles.stream().map(this::computeSingletonSplit);
+
+        return checkpointFileSplits
+                .flatMap(checkpointFileSplit -> checkpointFileSplitStreamBuilder.apply(checkpointFileSplit).get());
     }
 
     public Optional<Long> getLastCheckpointVersion()
     {
         return lastCheckpoint.map(LastCheckpoint::version);
-    }
-
-    private Stream<DeltaLakeTransactionLogEntry> getCheckpointTransactionLogEntries(
-            ConnectorSession session,
-            TrinoFileSystem fileSystem,
-            Set<CheckpointEntryIterator.EntryType> entryTypes,
-            Optional<MetadataEntry> metadataEntry,
-            Optional<ProtocolEntry> protocolEntry,
-            CheckpointSchemaManager checkpointSchemaManager,
-            TypeManager typeManager,
-            FileFormatDataSourceStats stats,
-            LastCheckpoint checkpoint,
-            TrinoInputFile checkpointFile,
-            TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
-            Optional<Predicate<String>> addStatsMinMaxColumnFilter,
-            Executor executor)
-    {
-        long fileSize;
-        try {
-            fileSize = checkpointFile.length();
-        }
-        catch (FileNotFoundException e) {
-            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, format("%s mentions a non-existent checkpoint file for table: %s", checkpoint, table));
-        }
-        catch (IOException e) {
-            throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Unexpected IO exception occurred while retrieving the length of the file: %s for the table %s", checkpoint, table), e);
-        }
-        if (checkpoint.v2Checkpoint().isPresent()) {
-            return getV2CheckpointTransactionLogEntriesFrom(
-                    session,
-                    entryTypes,
-                    metadataEntry,
-                    protocolEntry,
-                    checkpointSchemaManager,
-                    typeManager,
-                    stats,
-                    checkpoint,
-                    checkpointFile,
-                    partitionConstraint,
-                    addStatsMinMaxColumnFilter,
-                    fileSystem,
-                    fileSize,
-                    executor);
-        }
-        CheckpointEntryIterator checkpointEntryIterator = new CheckpointEntryIterator(
-                checkpointFile,
-                session,
-                fileSize,
-                checkpointSchemaManager,
-                typeManager,
-                entryTypes,
-                metadataEntry,
-                protocolEntry,
-                stats,
-                parquetReaderOptions,
-                checkpointRowStatisticsWritingEnabled,
-                domainCompactionThreshold,
-                partitionConstraint,
-                addStatsMinMaxColumnFilter);
-        return stream(checkpointEntryIterator).onClose(checkpointEntryIterator::close);
     }
 
     private Stream<DeltaLakeTransactionLogEntry> getV2CheckpointTransactionLogEntriesFrom(
@@ -343,8 +436,10 @@ public class TableSnapshot
             TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
             Optional<Predicate<String>> addStatsMinMaxColumnFilter,
             TrinoFileSystem fileSystem,
-            long fileSize,
-            Executor executor)
+            Executor checkpointProcessingExecutor,
+            boolean checkpointV2ParallelProcessingEnabled,
+            boolean checkpointIntraFileParallelProcessingEnabled,
+            long checkpointIntraFileParallelProcessingSplitSize)
     {
         // Sidecar files contain only ADD and REMOVE entry types. https://github.com/delta-io/delta/blob/master/PROTOCOL.md#v2-spec
         Set<CheckpointEntryIterator.EntryType> dataEntryTypes = Sets.intersection(entryTypes, Set.of(ADD, REMOVE));
@@ -361,9 +456,33 @@ public class TableSnapshot
                 partitionConstraint,
                 addStatsMinMaxColumnFilter,
                 fileSystem,
-                fileSize);
+                checkpointProcessingExecutor,
+                checkpointV2ParallelProcessingEnabled,
+                checkpointIntraFileParallelProcessingEnabled,
+                checkpointIntraFileParallelProcessingSplitSize);
         if (dataEntryTypes.isEmpty()) {
             return v2CheckpointEntries;
+        }
+
+        Location sidecarDirectoryPath = checkpointFile.location().sibling("_sidecars");
+
+        if (checkpointV2ParallelProcessingEnabled) {
+            return getV2CheckpointTransactionLogEntriesFromSidecarsInParallel(
+                    v2CheckpointEntries,
+                    sidecarDirectoryPath,
+                    session,
+                    entryTypes,
+                    metadataEntry,
+                    protocolEntry,
+                    checkpointSchemaManager,
+                    typeManager,
+                    stats,
+                    partitionConstraint,
+                    addStatsMinMaxColumnFilter,
+                    fileSystem,
+                    checkpointProcessingExecutor,
+                    checkpointIntraFileParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingSplitSize);
         }
 
         List<CompletableFuture<Stream<DeltaLakeTransactionLogEntry>>> logEntryStreamFutures = v2CheckpointEntries
@@ -373,10 +492,12 @@ public class TableSnapshot
                     }
                     // Sidecar files are retrieved in parallel using a bounded executor
                     return supplyAsync(() -> {
-                        Location sidecar = checkpointFile.location().sibling("_sidecars").appendPath(v2checkpointEntry.getSidecar().path());
+                        Location sidecar = sidecarDirectoryPath.appendPath(v2checkpointEntry.getSidecar().path());
                         CheckpointEntryIterator iterator = new CheckpointEntryIterator(
                                 fileSystem.newInputFile(sidecar),
                                 session,
+                                0,
+                                v2checkpointEntry.getSidecar().sizeInBytes(),
                                 v2checkpointEntry.getSidecar().sizeInBytes(),
                                 checkpointSchemaManager,
                                 typeManager,
@@ -390,13 +511,81 @@ public class TableSnapshot
                                 partitionConstraint,
                                 addStatsMinMaxColumnFilter);
                         return stream(iterator).onClose(iterator::close);
-                    }, executor);
+                    }, checkpointProcessingExecutor);
                 })
                 .collect(toImmutableList());
         // Return the stream to retrieve the values of the futures lazily and allow streamlined split generation
         return logEntryStreamFutures.stream()
                 .mapMulti((logEntryStream, builder)
                         -> getFutureValue(logEntryStream, TrinoException.class).forEach(builder));
+    }
+
+    private Stream<DeltaLakeTransactionLogEntry> getV2CheckpointTransactionLogEntriesFromSidecarsInParallel(
+            Stream<DeltaLakeTransactionLogEntry> v2CheckpointEntries,
+            Location sidecarDirectoryPath,
+            ConnectorSession session,
+            Set<CheckpointEntryIterator.EntryType> entryTypes,
+            Optional<MetadataEntry> metadataEntry,
+            Optional<ProtocolEntry> protocolEntry,
+            CheckpointSchemaManager checkpointSchemaManager,
+            TypeManager typeManager,
+            FileFormatDataSourceStats stats,
+            TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
+            Optional<Predicate<String>> addStatsMinMaxColumnFilter,
+            TrinoFileSystem fileSystem,
+            Executor checkpointProcessingExecutor,
+            boolean checkpointIntraFileParallelProcessingEnabled,
+            long checkpointIntraFileParallelProcessingSplitSize)
+    {
+        Function<CheckpointFileSplit, Supplier<Stream<DeltaLakeTransactionLogEntry>>> sidecarFileSplitStreamBuilder =
+                checkpointFileSplit -> {
+                    return () -> buildCheckpointFileSplitStream(
+                            checkpointFileSplit,
+                            session,
+                            checkpointSchemaManager,
+                            typeManager,
+                            entryTypes,
+                            metadataEntry,
+                            protocolEntry,
+                            stats,
+                            partitionConstraint,
+                            addStatsMinMaxColumnFilter);
+                };
+
+        Map<Boolean, List<DeltaLakeTransactionLogEntry>> partitionedV2CheckpointEntries =
+                v2CheckpointEntries.collect(Collectors.partitioningBy(v2checkpointEntry -> v2checkpointEntry.getSidecar() != null));
+
+        List<DeltaLakeTransactionLogEntry> sidecarEntries = partitionedV2CheckpointEntries.get(true);
+        List<DeltaLakeTransactionLogEntry> nonSidecarEntries = partitionedV2CheckpointEntries.get(false);
+
+        List<TrinoInputFile> sidecarFiles = sidecarEntries.stream()
+                .map(entry -> {
+                    SidecarEntry sidecarEntry = entry.getSidecar();
+                    Location sidecarPath = sidecarDirectoryPath.appendPath(sidecarEntry.path());
+                    return fileSystem.newInputFile(sidecarPath);
+                })
+                .collect(toImmutableList());
+
+        // Note: we could use sidecarEntry.sizeInBytes() to determine the sidecar file length, rather than checking the
+        // length directly from the file in computeSplits. This has the advantage of eliminating the need for I/O to check
+        // the length while planning. However, at this time, Trino will always fetch the length anyway in TrinoParquetDataSource,
+        // and the length is cached once fetched -- so, using sizeInBytes wouldn't save us any calls overall. Moreover,
+        // fetching the length at planning time allows us to write more precise and deterministic file system access tests
+        Function<TrinoInputFile, Supplier<Stream<CheckpointFileSplit>>> sidecarFileSplitSupplierBuilder =
+                checkpointIntraFileParallelProcessingEnabled
+                        ? sidecarFile -> () -> computeSplits(sidecarFile, checkpointIntraFileParallelProcessingSplitSize)
+                        : sidecarFile -> () -> Stream.of(computeSingletonSplit(sidecarFile));
+
+        List<CheckpointFileSplit> sidecarFileSplits = ParallelUnorderedIterator.stream(
+                    sidecarFiles.stream().map(sidecarFileSplitSupplierBuilder).collect(toImmutableList()),
+                    checkpointProcessingExecutor).collect(toImmutableList());
+
+        Stream<DeltaLakeTransactionLogEntry> sidecarFileEntries = ParallelUnorderedIterator.stream(
+                sidecarFileSplits.stream().map(sidecarFileSplitStreamBuilder).collect(toImmutableList()),
+                checkpointProcessingExecutor,
+                CHECKPOINT_FILE_PROCESSING_QUEUE_SIZE);
+
+        return Stream.concat(nonSidecarEntries.stream(), sidecarFileEntries);
     }
 
     private Stream<DeltaLakeTransactionLogEntry> getV2CheckpointEntries(
@@ -412,7 +601,10 @@ public class TableSnapshot
             TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
             Optional<Predicate<String>> addStatsMinMaxColumnFilter,
             TrinoFileSystem fileSystem,
-            long fileSize)
+            Executor checkpointProcessingExecutor,
+            boolean checkpointV2ParallelProcessingEnabled,
+            boolean checkpointIntraFileParallelProcessingEnabled,
+            long checkpointIntraFileParallelProcessingSplitSize)
     {
         if (checkpointFile.location().fileName().endsWith(".json")) {
             try {
@@ -425,28 +617,90 @@ public class TableSnapshot
             }
         }
         if (checkpointFile.location().fileName().endsWith(".parquet")) {
-            CheckpointEntryIterator checkpointEntryIterator = new CheckpointEntryIterator(
-                    fileSystem.newInputFile(checkpointFile.location()),
-                    session,
-                    fileSize,
-                    checkpointSchemaManager,
-                    typeManager,
+            ImmutableSet<CheckpointEntryIterator.EntryType> entryTypesWithSidecar =
                     ImmutableSet.<CheckpointEntryIterator.EntryType>builder()
                             .addAll(entryTypes)
                             .add(SIDECAR)
-                            .build(),
-                    metadataEntry,
-                    protocolEntry,
-                    stats,
-                    parquetReaderOptions,
-                    checkpointRowStatisticsWritingEnabled,
-                    domainCompactionThreshold,
-                    partitionConstraint,
-                    addStatsMinMaxColumnFilter);
-            return stream(checkpointEntryIterator)
-                    .onClose(checkpointEntryIterator::close);
+                            .build();
+
+            Function<CheckpointFileSplit, Supplier<Stream<DeltaLakeTransactionLogEntry>>> checkpointFileSplitStreamBuilder =
+                    checkpointFileSplit -> {
+                        return () -> buildCheckpointFileSplitStream(
+                                checkpointFileSplit,
+                                session,
+                                checkpointSchemaManager,
+                                typeManager,
+                                entryTypesWithSidecar,
+                                metadataEntry,
+                                protocolEntry,
+                                stats,
+                                partitionConstraint,
+                                addStatsMinMaxColumnFilter);
+                    };
+
+            List<CheckpointFileSplit> checkpointFileSplits;
+            if (checkpointV2ParallelProcessingEnabled && checkpointIntraFileParallelProcessingEnabled) {
+                checkpointFileSplits = computeSplits(checkpointFile, checkpointIntraFileParallelProcessingSplitSize).collect(toImmutableList());
+            }
+            else {
+                checkpointFileSplits = ImmutableList.of(computeSingletonSplit(checkpointFile));
+            }
+
+            return ParallelUnorderedIterator.stream(
+                    checkpointFileSplits.stream().map(checkpointFileSplitStreamBuilder).collect(toImmutableList()),
+                    checkpointProcessingExecutor,
+                    CHECKPOINT_FILE_PROCESSING_QUEUE_SIZE);
         }
         throw new IllegalArgumentException("Unsupported v2 checkpoint file format: " + checkpointFile.location());
+    }
+
+    private Stream<DeltaLakeTransactionLogEntry> buildCheckpointFileSplitStream(
+            CheckpointFileSplit checkpointFileSplit,
+            ConnectorSession session,
+            CheckpointSchemaManager checkpointSchemaManager,
+            TypeManager typeManager,
+            Set<CheckpointEntryIterator.EntryType> entryTypes,
+            Optional<MetadataEntry> metadataEntry,
+            Optional<ProtocolEntry> protocolEntry,
+            FileFormatDataSourceStats stats,
+            TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
+            Optional<Predicate<String>> addStatsMinMaxColumnFilter)
+    {
+        CheckpointEntryIterator checkpointEntryIterator = new CheckpointEntryIterator(
+                checkpointFileSplit.checkpointFile(),
+                session,
+                checkpointFileSplit.start(),
+                checkpointFileSplit.length(),
+                checkpointFileSplit.fileSize(),
+                checkpointSchemaManager,
+                typeManager,
+                entryTypes,
+                metadataEntry,
+                protocolEntry,
+                stats,
+                parquetReaderOptions,
+                checkpointRowStatisticsWritingEnabled,
+                domainCompactionThreshold,
+                partitionConstraint,
+                addStatsMinMaxColumnFilter);
+
+        return stream(checkpointEntryIterator)
+                .onClose(checkpointEntryIterator::close);
+    }
+
+    private long getCheckpointFileSize(TrinoInputFile checkpointFile)
+    {
+        try {
+            return checkpointFile.length();
+        }
+        catch (FileNotFoundException e) {
+            String lastCheckpointMemo = lastCheckpoint.map(LastCheckpoint::toString).orElse("<unknown>");
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, format("%s mentions a non-existent checkpoint file for table: %s", lastCheckpointMemo, table), e);
+        }
+        catch (IOException e) {
+            String lastCheckpointMemo = lastCheckpoint.map(LastCheckpoint::toString).orElse("<unknown>");
+            throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Unexpected IO exception occurred while retrieving the length of the file: %s for the table %s", lastCheckpointMemo, table), e);
+        }
     }
 
     public record MetadataAndProtocolEntry(MetadataEntry metadataEntry, ProtocolEntry protocolEntry)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -75,6 +75,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -122,6 +123,10 @@ public class TransactionLogAccess
     private final int domainCompactionThreshold;
     private final DataSize transactionLogMaxCachedFileSize;
     private final int checkpointProcessingParallelism;
+    private final boolean checkpointV1ParallelProcessingEnabled;
+    private final boolean checkpointV2ParallelProcessingEnabled;
+    private final boolean checkpointIntraFileParallelProcessingEnabled;
+    private final long checkpointIntraFileParallelProcessingSplitSize;
     private final TransactionLogReaderFactory transactionLogReaderFactory;
 
     private final Cache<TableLocation, TableSnapshot> tableSnapshots;
@@ -148,6 +153,10 @@ public class TransactionLogAccess
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
         this.transactionLogMaxCachedFileSize = deltaLakeConfig.getTransactionLogMaxCachedFileSize();
         this.checkpointProcessingParallelism = deltaLakeConfig.getCheckpointProcessingParallelism();
+        this.checkpointV1ParallelProcessingEnabled = deltaLakeConfig.isCheckpointV1ParallelProcessingEnabled();
+        this.checkpointV2ParallelProcessingEnabled = deltaLakeConfig.isCheckpointV2ParallelProcessingEnabled();
+        this.checkpointIntraFileParallelProcessingEnabled = deltaLakeConfig.isCheckpointIntraFileParallelProcessingEnabled();
+        this.checkpointIntraFileParallelProcessingSplitSize = deltaLakeConfig.getCheckpointIntraFileParallelProcessingSplitSize().toBytes();
         this.transactionLogReaderFactory = requireNonNull(transactionLogReaderFactory, "transactionLogReaderFactory is null");
 
         tableSnapshots = EvictableCacheBuilder.newBuilder()
@@ -461,21 +470,33 @@ public class TransactionLogAccess
     {
         List<Transaction> transactions = tableSnapshot.getTransactions();
         TrinoFileSystem fileSystem = fileSystemFactory.create(session, credentialsHandle);
-        try (Stream<DeltaLakeTransactionLogEntry> checkpointEntries = tableSnapshot.getCheckpointTransactionLogEntries(
-                session,
-                ImmutableSet.of(ADD),
-                checkpointSchemaManager,
-                typeManager,
-                fileSystem,
-                fileFormatDataSourceStats,
-                Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
-                partitionConstraint,
-                Optional.of(addStatsMinMaxColumnFilter),
-                new BoundedExecutor(executorService, checkpointProcessingParallelism))) {
-            return activeAddEntries(checkpointEntries, transactions, fileSystem)
-                    .filter(partitionConstraint.isAll()
-                            ? _ -> true
-                            : addAction -> partitionMatchesPredicate(addAction.getCanonicalPartitionValues(), partitionConstraint.getDomains().orElseThrow()));
+        Executor checkpointProcessingExecutor = new BoundedExecutor(executorService, checkpointProcessingParallelism);
+        try {
+            Stream<DeltaLakeTransactionLogEntry> checkpointEntries = tableSnapshot.getCheckpointTransactionLogEntries(
+                    session,
+                    ImmutableSet.of(ADD),
+                    checkpointSchemaManager,
+                    typeManager,
+                    fileSystem,
+                    fileFormatDataSourceStats,
+                    Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
+                    partitionConstraint,
+                    Optional.of(addStatsMinMaxColumnFilter),
+                    checkpointProcessingExecutor,
+                    checkpointV1ParallelProcessingEnabled,
+                    checkpointV2ParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingSplitSize);
+            try {
+                return activeAddEntries(checkpointEntries, transactions, fileSystem)
+                        .filter(partitionConstraint.isAll()
+                                ? _ -> true
+                                : addAction -> partitionMatchesPredicate(addAction.getCanonicalPartitionValues(), partitionConstraint.getDomains().orElseThrow()));
+            }
+            catch (Throwable e) {
+                checkpointEntries.close();
+                throw e;
+            }
         }
         catch (IOException e) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error reading transaction log for " + tableSnapshot.getTable(), e);
@@ -643,8 +664,22 @@ public class TransactionLogAccess
     {
         try {
             // Passing TupleDomain.all() because this method is used for getting all entries
+            Executor checkpointProcessingExecutor = new BoundedExecutor(executorService, checkpointProcessingParallelism);
             try (Stream<DeltaLakeTransactionLogEntry> checkpointEntries = tableSnapshot.getCheckpointTransactionLogEntries(
-                    session, entryTypes, checkpointSchemaManager, typeManager, fileSystem, stats, Optional.empty(), TupleDomain.all(), Optional.of(alwaysTrue()), new BoundedExecutor(executorService, checkpointProcessingParallelism))) {
+                    session,
+                    entryTypes,
+                    checkpointSchemaManager,
+                    typeManager,
+                    fileSystem,
+                    stats,
+                    Optional.empty(),
+                    TupleDomain.all(),
+                    Optional.of(alwaysTrue()),
+                    checkpointProcessingExecutor,
+                    checkpointV1ParallelProcessingEnabled,
+                    checkpointV2ParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingSplitSize)) {
                 return checkpointMapper.apply(checkpointEntries);
             }
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -161,6 +161,8 @@ public class CheckpointEntryIterator
     public CheckpointEntryIterator(
             TrinoInputFile checkpoint,
             ConnectorSession session,
+            long start,
+            long length,
             long fileSize,
             CheckpointSchemaManager checkpointSchemaManager,
             TypeManager typeManager,
@@ -209,8 +211,8 @@ public class CheckpointEntryIterator
 
         this.pageSource = ParquetPageSourceFactory.createPageSource(
                 checkpoint,
-                0,
-                fileSize,
+                start,
+                length,
                 columns,
                 disjunctDomainsBuilder.build(), // OR-ed condition
                 true,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriterManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriterManager.java
@@ -68,6 +68,10 @@ public class CheckpointWriterManager
     private final JsonCodec<LastCheckpoint> lastCheckpointCodec;
     private final Executor executorService;
     private final int checkpointProcessingParallelism;
+    private final boolean checkpointV1ParallelProcessingEnabled;
+    private final boolean checkpointV2ParallelProcessingEnabled;
+    private final boolean checkpointIntraFileParallelProcessingEnabled;
+    private final long checkpointIntraFileParallelProcessingSplitSize;
 
     @Inject
     public CheckpointWriterManager(
@@ -90,6 +94,10 @@ public class CheckpointWriterManager
         this.lastCheckpointCodec = requireNonNull(lastCheckpointCodec, "lastCheckpointCodec is null");
         this.executorService = requireNonNull(executorService, "ExecutorService is null");
         this.checkpointProcessingParallelism = deltaLakeConfig.getCheckpointProcessingParallelism();
+        this.checkpointV1ParallelProcessingEnabled = deltaLakeConfig.isCheckpointV1ParallelProcessingEnabled();
+        this.checkpointV2ParallelProcessingEnabled = deltaLakeConfig.isCheckpointV2ParallelProcessingEnabled();
+        this.checkpointIntraFileParallelProcessingEnabled = deltaLakeConfig.isCheckpointIntraFileParallelProcessingEnabled();
+        this.checkpointIntraFileParallelProcessingSplitSize = deltaLakeConfig.getCheckpointIntraFileParallelProcessingSplitSize().toBytes();
     }
 
     public void writeCheckpoint(ConnectorSession session, TableSnapshot snapshot, VendedCredentialsHandle credentialsHandle)
@@ -109,6 +117,7 @@ public class CheckpointWriterManager
 
             TrinoFileSystem fileSystem = fileSystemFactory.create(session, credentialsHandle);
             List<DeltaLakeTransactionLogEntry> checkpointLogEntries;
+            Executor checkpointProcessingExecutor = new BoundedExecutor(executorService, checkpointProcessingParallelism);
             try (Stream<DeltaLakeTransactionLogEntry> checkpointLogEntriesStream = snapshot.getCheckpointTransactionLogEntries(
                     session,
                     ImmutableSet.of(METADATA, PROTOCOL),
@@ -119,7 +128,11 @@ public class CheckpointWriterManager
                     Optional.empty(),
                     TupleDomain.all(),
                     Optional.empty(),
-                    new BoundedExecutor(executorService, checkpointProcessingParallelism))) {
+                    checkpointProcessingExecutor,
+                    checkpointV1ParallelProcessingEnabled,
+                    checkpointV2ParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingEnabled,
+                    checkpointIntraFileParallelProcessingSplitSize)) {
                 checkpointLogEntries = checkpointLogEntriesStream.filter(entry -> entry.getMetaData() != null || entry.getProtocol() != null)
                         .collect(toImmutableList());
             }
@@ -145,6 +158,7 @@ public class CheckpointWriterManager
                 checkpointBuilder.addLogEntry(protocolLogEntry);
 
                 // read remaining entries from checkpoint register them in writer
+                checkpointProcessingExecutor = new BoundedExecutor(executorService, checkpointProcessingParallelism);
                 try (Stream<DeltaLakeTransactionLogEntry> checkpointLogEntriesStream = snapshot.getCheckpointTransactionLogEntries(
                         session,
                         ImmutableSet.of(TRANSACTION, ADD, REMOVE),
@@ -155,7 +169,11 @@ public class CheckpointWriterManager
                         Optional.of(new MetadataAndProtocolEntry(metadataLogEntry.getMetaData(), protocolLogEntry.getProtocol())),
                         TupleDomain.all(),
                         Optional.of(alwaysTrue()),
-                        new BoundedExecutor(executorService, checkpointProcessingParallelism))) {
+                        checkpointProcessingExecutor,
+                        checkpointV1ParallelProcessingEnabled,
+                        checkpointV2ParallelProcessingEnabled,
+                        checkpointIntraFileParallelProcessingEnabled,
+                        checkpointIntraFileParallelProcessingSplitSize)) {
                     checkpointLogEntriesStream.forEach(checkpointBuilder::addLogEntry);
                 }
             }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/ParallelUnorderedIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/ParallelUnorderedIterator.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog.checkpoint;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.concurrent.DynamicSizeBoundQueue;
+import io.airlift.concurrent.ExecutorServiceAdapter;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static io.airlift.concurrent.MoreFutures.allAsListWithCancellationOnFailure;
+import static io.airlift.concurrent.MoreFutures.asVoid;
+import static java.util.Objects.requireNonNull;
+
+public class ParallelUnorderedIterator<T>
+        extends AbstractIterator<T>
+        implements AutoCloseable
+{
+    private static final int DEFAULT_QUEUE_CAPACITY = 1_024;
+
+    private sealed interface QueueElement
+            permits Complete, Failure, Entry {}
+
+    private record Complete()
+            implements QueueElement {}
+
+    private record Failure(Throwable throwable)
+            implements QueueElement
+    {
+        private Failure
+        {
+            requireNonNull(throwable, "throwable is null");
+        }
+    }
+
+    private record Entry<T>(T value)
+            implements QueueElement
+    {
+        private Entry
+        {
+            requireNonNull(value, "value is null");
+        }
+    }
+
+    private static final Complete COMPLETE = new Complete();
+
+    private final SettableFuture<Void> allStreamsCompletionFuture = SettableFuture.create();
+
+    private final Executor executor;
+    private final DynamicSizeBoundQueue<QueueElement> queue;
+    private volatile boolean cancellationRequested;
+
+    public static <T> Stream<T> stream(
+            List<Supplier<Stream<T>>> streamSuppliers,
+            Executor executor)
+    {
+        return stream(streamSuppliers, executor, DEFAULT_QUEUE_CAPACITY);
+    }
+
+    public static <T> Stream<T> stream(
+            List<Supplier<Stream<T>>> streamSuppliers,
+            Executor executor,
+            int queueCapacity)
+    {
+        ParallelUnorderedIterator<T> iterator = new ParallelUnorderedIterator<>(executor, queueCapacity);
+        iterator.start(streamSuppliers);
+        return Streams.stream(iterator).onClose(iterator::close);
+    }
+
+    private ParallelUnorderedIterator(
+            Executor executor,
+            int queueCapacity)
+    {
+        this.executor = requireNonNull(executor, "executor is null");
+        queue = new DynamicSizeBoundQueue<>(queueCapacity, _ -> 1);
+    }
+
+    private void start(List<Supplier<Stream<T>>> streamSuppliers)
+    {
+        ListeningExecutorService listeningExecutorService = listeningDecorator(ExecutorServiceAdapter.from(executor));
+
+        List<ListenableFuture<Void>> streamFutures = streamSuppliers
+                .stream()
+                .map(streamSupplier -> asVoid(listeningExecutorService.submit(() -> runProducer(streamSupplier))))
+                .collect(toImmutableList());
+
+        ListenableFuture<Void> allStreamsFuture = asVoid(allAsListWithCancellationOnFailure(streamFutures));
+        allStreamsCompletionFuture.setFuture(allStreamsFuture);
+
+        Futures.addCallback(
+                allStreamsFuture,
+                new FutureCallback<>()
+                {
+                    @Override
+                    public void onSuccess(Void result)
+                    {
+                        queue.forcePut(COMPLETE);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable throwable)
+                    {
+                        queue.forcePut(new Failure(throwable));
+                    }
+                },
+                directExecutor());
+    }
+
+    @Override
+    protected T computeNext()
+    {
+        try {
+            QueueElement element = queue.take();
+
+            return switch (element) {
+                case Entry<?> entry -> {
+                    @SuppressWarnings("unchecked")
+                    T value = (T) entry.value();
+                    yield value;
+                }
+                case Failure(Throwable throwable) -> throw new RuntimeException("Error in nested iterator within ParallelUnorderedIterator", throwable);
+                case Complete _ -> endOfData();
+            };
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        cancellationRequested = true;
+        queue.forcePut(COMPLETE);
+        allStreamsCompletionFuture.cancel(true);
+    }
+
+    private void runProducer(Supplier<Stream<T>> supplier)
+    {
+        try (Stream<T> stream = requireNonNull(supplier.get(), "supplier returned null stream")) {
+            Iterator<T> iterator = stream.iterator();
+
+            while (iterator.hasNext()) {
+                queue.put(new Entry<>(requireNonNull(iterator.next(), "entry is null")));
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (cancellationRequested) {
+                return;
+            }
+            throw new RuntimeException("Interrupted while producing elements", e);
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -594,7 +594,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", 0, 19019))
                         .add(new CacheOperation("Input.readFully", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", 0, 19019))
-                        .addCopies(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet"), 2)
+                        .add(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet"))
                         .add(new CacheOperation("Alluxio.writeCache", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", 0, 19019))
                         .build());
 
@@ -603,7 +603,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                 "SELECT * FROM v2_checkpoint_parquet",
                 ImmutableMultiset.<CacheOperation>builder()
                         .addCopies(new CacheOperation("Alluxio.readCached", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", 0, 19019), 2)
-                        .addCopies(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet"), 4)
+                        .addCopies(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet"), 2)
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", 0, 9415))
                         .add(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet"))
                         .add(new CacheOperation("Input.readFully", "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", 0, 9415))
@@ -619,7 +619,7 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                 "SELECT * FROM v2_checkpoint_parquet",
                 ImmutableMultiset.<CacheOperation>builder()
                         .addCopies(new CacheOperation("Alluxio.readCached", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", 0, 19019), 2)
-                        .addCopies(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet"), 4)
+                        .addCopies(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet"), 2)
                         .add(new CacheOperation("Alluxio.readCached", "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", 0, 9415))
                         .add(new CacheOperation("InputFile.length", "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000002.json"))

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Resources;
@@ -51,6 +52,7 @@ import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingSession;
@@ -1535,6 +1537,8 @@ public class TestDeltaLakeBasic
             CheckpointEntryIterator checkpointEntryIterator = new CheckpointEntryIterator(
                     checkpoint,
                     SESSION,
+                    0,
+                    checkpoint.length(),
                     checkpoint.length(),
                     new CheckpointSchemaManager(TESTING_TYPE_MANAGER),
                     TESTING_TYPE_MANAGER,
@@ -2127,6 +2131,43 @@ public class TestDeltaLakeBasic
         assertUpdate("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')".formatted(tableName, tableLocation.toUri()));
         assertThat(query("DESCRIBE " + tableName)).result().projected("Column", "Type").skippingTypesCheck().matches("VALUES ('c', 'integer')");
         assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1, 2, 3, 4, 5, 6, 7");
+    }
+
+    /**
+     * @see databricks73.person
+     * @see deltalake.multipart_checkpoint
+     * @see deltalake.v2_checkpoint_json
+     * @see deltalake.v2_checkpoint_parquet
+     * @see deltalake.multipart_v2_checkpoint
+     */
+    @Test
+    public void testCheckpointQueriesMatchAcrossCheckpointParallelProcessingModes()
+            throws Exception
+    {
+        Session serialSession = createCheckpointParallelProcessingProcessingCatalog(false, false);
+        Session parallelSession = createCheckpointParallelProcessingProcessingCatalog(true, false);
+        Session intraFileParallelSession = createCheckpointParallelProcessingProcessingCatalog(true, true);
+
+        List<Session> sessions = ImmutableList.of(serialSession, parallelSession, intraFileParallelSession);
+        List<CheckpointSmokeTestTable> checkpointTables = ImmutableList.of(
+                new CheckpointSmokeTestTable("checkpoint_v1_single_" + randomNameSuffix(), "databricks73/person", "SELECT name, age FROM %s ORDER BY age, name"),
+                new CheckpointSmokeTestTable("checkpoint_v1_multipart_" + randomNameSuffix(), "deltalake/multipart_checkpoint", "SELECT c FROM %s ORDER BY c"),
+                new CheckpointSmokeTestTable("checkpoint_v2_json_" + randomNameSuffix(), "deltalake/v2_checkpoint_json", "SELECT a, b FROM %s ORDER BY a, b"),
+                new CheckpointSmokeTestTable("checkpoint_v2_parquet_" + randomNameSuffix(), "deltalake/v2_checkpoint_parquet", "SELECT a, b FROM %s ORDER BY a, b"),
+                new CheckpointSmokeTestTable("checkpoint_v2_multipart_" + randomNameSuffix(), "deltalake/multipart_v2_checkpoint", "SELECT a, b FROM %s ORDER BY a, b"));
+
+        for (CheckpointSmokeTestTable checkpointTable : checkpointTables) {
+            for (Session session : sessions) {
+                registerResourceTable(session, new ResourceTable(checkpointTable.tableName(), checkpointTable.resourcePath()));
+            }
+
+            MaterializedResult serialResult = computeActual(serialSession, checkpointTable.query());
+            MaterializedResult parallelResult = computeActual(parallelSession, checkpointTable.query());
+            MaterializedResult intraFileParallelResult = computeActual(intraFileParallelSession, checkpointTable.query());
+
+            assertThat(parallelResult).isEqualTo(serialResult);
+            assertThat(intraFileParallelResult).isEqualTo(serialResult);
+        }
     }
 
     /**
@@ -3056,6 +3097,47 @@ public class TestDeltaLakeBasic
         return transactionLog.getProtocol();
     }
 
+    private Session createCheckpointParallelProcessingProcessingCatalog(boolean checkpointParallelProcessingEnabled, boolean checkpointIntraFileParallelProcessingEnabled)
+            throws IOException
+    {
+        String catalogName = "delta_checkpoint_processing_" + randomNameSuffix();
+        String schemaName = getSession().getSchema().orElseThrow();
+        Path metastoreDir = Files.createDirectories(catalogDir.resolve(catalogName));
+
+        getQueryRunner().createCatalog(
+                catalogName,
+                DeltaLakeConnectorFactory.CONNECTOR_NAME,
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore", "file")
+                        .put("hive.metastore.catalog.dir", metastoreDir.toUri().toString())
+                        .put("fs.hadoop.enabled", "true")
+                        .put("delta.register-table-procedure.enabled", "true")
+                        .put("delta.enable-non-concurrent-writes", "true")
+                        .put("delta.transaction-log.max-cached-file-size", "0B")
+                        .put("delta.checkpoint-processing.parallelism", checkpointParallelProcessingEnabled ? "4" : "1")
+                        .put("delta.checkpoint-processing.v1-parallel-processing.enabled", Boolean.toString(checkpointParallelProcessingEnabled))
+                        .put("delta.checkpoint-processing.v2-parallel-processing.enabled", Boolean.toString(checkpointParallelProcessingEnabled))
+                        .put("delta.checkpoint-processing.intra-file-parallel-processing.enabled", Boolean.toString(checkpointIntraFileParallelProcessingEnabled))
+                        .put("delta.checkpoint-processing.intra-file-parallel-processing.split-size", "1kB")
+                        .buildOrThrow());
+
+        getQueryRunner().execute("CREATE SCHEMA IF NOT EXISTS " + catalogName + "." + schemaName);
+
+        return Session.builder(getSession())
+                .setCatalog(catalogName)
+                .setSchema(schemaName)
+                .build();
+    }
+
+    private void registerResourceTable(Session session, ResourceTable resourceTable)
+    {
+        assertUpdate(
+                session,
+                "CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')".formatted(
+                        resourceTable.tableName(),
+                        getResourceLocation(resourceTable.resourcePath()).toExternalForm()));
+    }
+
     private String getTableLocation(String tableName)
     {
         Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
@@ -3074,5 +3156,13 @@ public class TestDeltaLakeBasic
         return TransactionLogTail.getEntriesFromJson(entryNumber, FILE_SYSTEM.newInputFile(getTransactionLogJsonEntryPath(transactionLogDir, entryNumber)), DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE)
                 .orElseThrow()
                 .getEntriesList(FILE_SYSTEM);
+    }
+
+    private record CheckpointSmokeTestTable(String tableName, String resourcePath, String queryTemplate)
+    {
+        private String query()
+        {
+            return queryTemplate.formatted(tableName);
+        }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -76,6 +76,10 @@ public class TestDeltaLakeConfig
                 .setDeltaLogFileSystemCacheDisabled(false)
                 .setMetadataParallelism(8)
                 .setCheckpointProcessingParallelism(4)
+                .setCheckpointV1ParallelProcessingEnabled(false)
+                .setCheckpointV2ParallelProcessingEnabled(false)
+                .setCheckpointIntraFileParallelProcessingEnabled(false)
+                .setCheckpointIntraFileParallelProcessingSplitSize(DataSize.of(128, MEGABYTE))
                 .setLoadMetadataFromChecksumFile(true));
     }
 
@@ -119,6 +123,10 @@ public class TestDeltaLakeConfig
                 .put("delta.fs.cache.disable-transaction-log-caching", "true")
                 .put("delta.metadata.parallelism", "10")
                 .put("delta.checkpoint-processing.parallelism", "8")
+                .put("delta.checkpoint-processing.v1-parallel-processing.enabled", "true")
+                .put("delta.checkpoint-processing.v2-parallel-processing.enabled", "true")
+                .put("delta.checkpoint-processing.intra-file-parallel-processing.enabled", "true")
+                .put("delta.checkpoint-processing.intra-file-parallel-processing.split-size", "256MB")
                 .put("delta.load-metadata-from-checksum-file", "false")
                 .buildOrThrow();
 
@@ -159,6 +167,10 @@ public class TestDeltaLakeConfig
                 .setDeltaLogFileSystemCacheDisabled(true)
                 .setMetadataParallelism(10)
                 .setCheckpointProcessingParallelism(8)
+                .setCheckpointV1ParallelProcessingEnabled(true)
+                .setCheckpointV2ParallelProcessingEnabled(true)
+                .setCheckpointIntraFileParallelProcessingEnabled(true)
+                .setCheckpointIntraFileParallelProcessingSplitSize(DataSize.of(256, MEGABYTE))
                 .setLoadMetadataFromChecksumFile(false);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.io.Resources;
+import io.airlift.units.DataSize;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
@@ -80,6 +81,7 @@ public class TestDeltaLakeFileOperations
 {
     private static final int MAX_PREFIXES_COUNT = 10;
 
+    private Path catalogDir;
     private HiveMetastore metastore;
     // TODO: Consider waiting for scheduled task completion instead of manual triggering
     private DeltaLakeTableMetadataScheduler metadataScheduler;
@@ -88,7 +90,7 @@ public class TestDeltaLakeFileOperations
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Path catalogDir = Files.createTempDirectory("catalog-dir");
+        catalogDir = Files.createTempDirectory("catalog-dir");
         closeAfterClass(() -> deleteRecursively(catalogDir, ALLOW_INSECURE));
 
         DistributedQueryRunner queryRunner = DeltaLakeQueryRunner.builder()
@@ -1203,6 +1205,290 @@ public class TestDeltaLakeFileOperations
     }
 
     /**
+     * @see databricks73.person
+     */
+    @Test
+    public void testV1SinglePartCheckpointFileOperationsAcrossCheckpointProcessingModes()
+            throws Exception
+    {
+        ImmutableMultiset<FileOperation> serialAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000013.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000010.checkpoint.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000010.checkpoint.parquet", "InputFile.newInput"), 2)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000011.json", "InputFile.newStream"), 2)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000012.json", "InputFile.newStream"), 2)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000013.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000011.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000012.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000013.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000014.json", "InputFile.length"))
+                .addCopies(new FileOperation(DATA, "no partition", "InputFile.newInput"), 12)
+                .build();
+        ImmutableMultiset<FileOperation> parallelAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000013.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000010.checkpoint.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000010.checkpoint.parquet", "InputFile.newInput"), 44)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000011.json", "InputFile.newStream"), 2)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000012.json", "InputFile.newStream"), 2)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000013.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000011.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000012.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000013.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000014.json", "InputFile.length"))
+                .addCopies(new FileOperation(DATA, "no partition", "InputFile.newInput"), 12)
+                .build();
+
+        assertCheckpointQueryFileOperationsAcrossCheckpointProcessingModes(
+                "checkpoint_v1_single",
+                "databricks73/person",
+                "SELECT name, age FROM %s ORDER BY age, name",
+                serialAccesses,
+                serialAccesses,
+                serialAccesses,
+                parallelAccesses);
+    }
+
+    /**
+     * @see deltalake.multipart_checkpoint
+     */
+    @Test
+    public void testV1MultipartCheckpointFileOperationsAcrossCheckpointProcessingModes()
+            throws Exception
+    {
+        ImmutableMultiset<FileOperation> serialAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000007.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000001.0000000002.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000001.0000000002.parquet", "InputFile.newInput"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000002.0000000002.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000002.0000000002.parquet", "InputFile.newInput"), 2)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000007.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000007.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000008.json", "InputFile.length"))
+                .addCopies(new FileOperation(DATA, "no partition", "InputFile.newInput"), 7)
+                .build();
+        ImmutableMultiset<FileOperation> parallelAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000007.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000001.0000000002.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000001.0000000002.parquet", "InputFile.newInput"), 28)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000002.0000000002.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000006.checkpoint.0000000002.0000000002.parquet", "InputFile.newInput"), 26)
+                .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000007.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000007.json", "InputFile.length"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000008.json", "InputFile.length"))
+                .addCopies(new FileOperation(DATA, "no partition", "InputFile.newInput"), 7)
+                .build();
+
+        assertCheckpointQueryFileOperationsAcrossCheckpointProcessingModes(
+                "checkpoint_v1_multipart",
+                "deltalake/multipart_checkpoint",
+                "SELECT c FROM %s ORDER BY c",
+                serialAccesses,
+                serialAccesses,
+                serialAccesses,
+                parallelAccesses);
+    }
+
+    /**
+     * @see deltalake.v2_checkpoint_json
+     */
+    @Test
+    public void testV2CheckpointJsonFileOperationsAcrossCheckpointProcessingModes()
+            throws Exception
+    {
+        ImmutableMultiset<FileOperation> serialAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000001.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.73a4ddb8-2bfc-40d8-b09f-1b6a0abdfb04.json", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.73a4ddb8-2bfc-40d8-b09f-1b6a0abdfb04.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.90cf4e21-dbaa-41d6-8ae5-6709cfbfbfe0.parquet", "InputFile.length"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.90cf4e21-dbaa-41d6-8ae5-6709cfbfbfe0.parquet", "InputFile.newInput"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.length"))
+                .add(new FileOperation(DATA, "no partition", "InputFile.newInput"))
+                .build();
+        ImmutableMultiset<FileOperation> parallelAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000001.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.73a4ddb8-2bfc-40d8-b09f-1b6a0abdfb04.json", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.73a4ddb8-2bfc-40d8-b09f-1b6a0abdfb04.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.90cf4e21-dbaa-41d6-8ae5-6709cfbfbfe0.parquet", "InputFile.length"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.90cf4e21-dbaa-41d6-8ae5-6709cfbfbfe0.parquet", "InputFile.newInput"), 9)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.length"))
+                .add(new FileOperation(DATA, "no partition", "InputFile.newInput"))
+                .build();
+
+        assertCheckpointQueryFileOperationsAcrossCheckpointProcessingModes(
+                "checkpoint_v2_json",
+                "deltalake/v2_checkpoint_json",
+                "SELECT a, b FROM %s ORDER BY a, b",
+                serialAccesses,
+                serialAccesses,
+                serialAccesses,
+                parallelAccesses);
+    }
+
+    /**
+     * @see deltalake.v2_checkpoint_parquet
+     */
+    @Test
+    public void testV2CheckpointParquetFileOperationsAcrossCheckpointProcessingModes()
+            throws Exception
+    {
+        ImmutableMultiset<FileOperation> serialAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000001.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", "InputFile.length"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", "InputFile.newInput"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.newInput"), 2)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.length"))
+                .add(new FileOperation(DATA, "no partition", "InputFile.newInput"))
+                .build();
+        ImmutableMultiset<FileOperation> parallelAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000001.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", "InputFile.length"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", "InputFile.newInput"), 10)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.newInput"), 38)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.length"))
+                .add(new FileOperation(DATA, "no partition", "InputFile.newInput"))
+                .build();
+
+        assertCheckpointQueryFileOperationsAcrossCheckpointProcessingModes(
+                "checkpoint_v2_parquet",
+                "deltalake/v2_checkpoint_parquet",
+                "SELECT a, b FROM %s ORDER BY a, b",
+                serialAccesses,
+                serialAccesses,
+                serialAccesses,
+                parallelAccesses);
+    }
+
+    /**
+     * @see deltalake.multipart_v2_checkpoint
+     */
+    @Test
+    public void testMultipartV2CheckpointFileOperationsAcrossCheckpointProcessingModes()
+            throws Exception
+    {
+        ImmutableMultiset<FileOperation> serialAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000004.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.42f48375-5c72-4d2f-8dcc-7ce4d45e2d8c.json", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.42f48375-5c72-4d2f-8dcc-7ce4d45e2d8c.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000001.0000000004.9f573e40-495e-4fb5-9a86-638dbdf0909e.parquet", "InputFile.length"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000001.0000000004.9f573e40-495e-4fb5-9a86-638dbdf0909e.parquet", "InputFile.newInput"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000002.0000000004.72848a80-e6d1-40fd-b702-344ecbb4c2fa.parquet", "InputFile.length"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000002.0000000004.72848a80-e6d1-40fd-b702-344ecbb4c2fa.parquet", "InputFile.newInput"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000003.0000000004.93080a9b-6c0d-4a19-ac28-e3654e3096f9.parquet", "InputFile.length"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000003.0000000004.93080a9b-6c0d-4a19-ac28-e3654e3096f9.parquet", "InputFile.newInput"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000004.0000000004.994ab05a-4806-4f96-8e7b-5dcf653a8e48.parquet", "InputFile.length"))
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000004.0000000004.994ab05a-4806-4f96-8e7b-5dcf653a8e48.parquet", "InputFile.newInput"))
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.length"))
+                .addCopies(new FileOperation(DATA, "no partition", "InputFile.newInput"), 4)
+                .build();
+        ImmutableMultiset<FileOperation> parallelAccesses = ImmutableMultiset.<FileOperation>builder()
+                .add(new FileOperation(CHECKSUM, "00000000000000000004.crc", "InputFile.newStream"))
+                .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.42f48375-5c72-4d2f-8dcc-7ce4d45e2d8c.json", "InputFile.length"), 2)
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.42f48375-5c72-4d2f-8dcc-7ce4d45e2d8c.json", "InputFile.newStream"), 2)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000001.0000000004.9f573e40-495e-4fb5-9a86-638dbdf0909e.parquet", "InputFile.length"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000001.0000000004.9f573e40-495e-4fb5-9a86-638dbdf0909e.parquet", "InputFile.newInput"), 10)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000002.0000000004.72848a80-e6d1-40fd-b702-344ecbb4c2fa.parquet", "InputFile.length"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000002.0000000004.72848a80-e6d1-40fd-b702-344ecbb4c2fa.parquet", "InputFile.newInput"), 10)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000003.0000000004.93080a9b-6c0d-4a19-ac28-e3654e3096f9.parquet", "InputFile.length"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000003.0000000004.93080a9b-6c0d-4a19-ac28-e3654e3096f9.parquet", "InputFile.newInput"), 4)
+                .add(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000004.0000000004.994ab05a-4806-4f96-8e7b-5dcf653a8e48.parquet", "InputFile.length"))
+                .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.0000000004.0000000004.994ab05a-4806-4f96-8e7b-5dcf653a8e48.parquet", "InputFile.newInput"), 9)
+                .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", "InputFile.length"))
+                .addCopies(new FileOperation(DATA, "no partition", "InputFile.newInput"), 4)
+                .build();
+
+        assertCheckpointQueryFileOperationsAcrossCheckpointProcessingModes(
+                "checkpoint_v2_multipart",
+                "deltalake/multipart_v2_checkpoint",
+                "SELECT a, b FROM %s ORDER BY a, b",
+                serialAccesses,
+                serialAccesses,
+                serialAccesses,
+                parallelAccesses);
+    }
+
+    private void assertCheckpointQueryFileOperationsAcrossCheckpointProcessingModes(
+            String tableNamePrefix,
+            String resourcePath,
+            @Language("SQL") String queryTemplate,
+            Multiset<FileOperation> serialExpectedAccesses,
+            Multiset<FileOperation> intraFileOnlyExpectedAccesses,
+            Multiset<FileOperation> fileParallelExpectedAccesses,
+            Multiset<FileOperation> parallelExpectedAccesses)
+            throws Exception
+    {
+        String tableName = tableNamePrefix + "_" + randomNameSuffix();
+        String dataPath = getResourceLocation(resourcePath).toExternalForm();
+
+        Session serialSession = createCheckpointParallelProcessingSession(false, false, false);
+        Session intraFileOnlySession = createCheckpointParallelProcessingSession(false, false, true);
+        Session fileParallelSession = createCheckpointParallelProcessingSession(true, true, false);
+        Session parallelSession = createCheckpointParallelProcessingSession(true, true, true);
+
+        for (Session session : ImmutableList.of(serialSession, intraFileOnlySession, fileParallelSession, parallelSession)) {
+            assertUpdate(session, format("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')", tableName, dataPath));
+        }
+
+        String query = queryTemplate.formatted(tableName);
+
+        Multiset<FileOperation> serial = getFileSystemAccesses(serialSession, query);
+        Multiset<FileOperation> intraFileOnly = getFileSystemAccesses(intraFileOnlySession, query);
+        Multiset<FileOperation> fileParallel = getFileSystemAccesses(fileParallelSession, query);
+        Multiset<FileOperation> parallel = getFileSystemAccesses(parallelSession, query);
+
+        assertMultisetsEqual(serial, serialExpectedAccesses);
+        assertMultisetsEqual(intraFileOnly, intraFileOnlyExpectedAccesses);
+        assertMultisetsEqual(fileParallel, fileParallelExpectedAccesses);
+        assertMultisetsEqual(parallel, parallelExpectedAccesses);
+    }
+
+    private Session createCheckpointParallelProcessingSession(
+            boolean checkpointFileParallelProcessingEnabled,
+            boolean checkpointV2ParallelProcessingEnabled,
+            boolean checkpointIntraFileParallelProcessingEnabled)
+            throws Exception
+    {
+        String catalogName = "delta_checkpoint_processing_" + randomNameSuffix();
+        String schemaName = getSession().getSchema().orElseThrow();
+        Path metastoreDir = Files.createDirectories(catalogDir.resolve(catalogName));
+
+        getQueryRunner().createCatalog(
+                catalogName,
+                DeltaLakeConnectorFactory.CONNECTOR_NAME,
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore", "file")
+                        .put("hive.metastore.catalog.dir", metastoreDir.toUri().toString())
+                        .put("fs.hadoop.enabled", "true")
+                        .put("delta.register-table-procedure.enabled", "true")
+                        .put("delta.enable-non-concurrent-writes", "true")
+                        .put("delta.transaction-log.max-cached-file-size", "0B")
+                        .put("delta.checkpoint-processing.parallelism", "4")
+                        .put("delta.checkpoint-processing.v1-parallel-processing.enabled", Boolean.toString(checkpointFileParallelProcessingEnabled))
+                        .put("delta.checkpoint-processing.v2-parallel-processing.enabled", Boolean.toString(checkpointV2ParallelProcessingEnabled))
+                        .put("delta.checkpoint-processing.intra-file-parallel-processing.enabled", Boolean.toString(checkpointIntraFileParallelProcessingEnabled))
+                        .put("delta.checkpoint-processing.intra-file-parallel-processing.split-size", DataSize.ofBytes(1_024).toString())
+                        .buildOrThrow());
+
+        getQueryRunner().execute("CREATE SCHEMA IF NOT EXISTS " + catalogName + "." + schemaName);
+
+        return Session.builder(getSession())
+                .setCatalog(catalogName)
+                .setSchema(schemaName)
+                .build();
+    }
+
+    /**
      * @see deltalake.checksum
      */
     @Test
@@ -1388,7 +1674,7 @@ public class TestDeltaLakeFileOperations
         assertFileSystemAccesses("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')".formatted(tableName, tableLocation.toUri()),
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
-                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.length"), 2)
+                        .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.length"))
                         .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.newInput"))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", "InputFile.length")) // TransactionLogTail.getEntriesFromJson access non-existing file as end of tail
                         .build());
@@ -1397,7 +1683,7 @@ public class TestDeltaLakeFileOperations
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", "InputFile.newStream"))
                         .add(new FileOperation(CHECKSUM, "00000000000000000001.crc", "InputFile.newStream"))
-                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.length"), 4) // TODO (https://github.com/trinodb/trino/issues/18916) should be checked once per query
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.length"), 2) // TODO (https://github.com/trinodb/trino/issues/18916) should be checked once per query
                         .addCopies(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.156b3304-76b2-49c3-a9a1-626f07df27c9.parquet", "InputFile.newInput"), 2) // TODO (https://github.com/trinodb/trino/issues/18916) should be checked once per query
                         .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", "InputFile.length"))
                         .add(new FileOperation(CHECKPOINT, "00000000000000000001.checkpoint.0000000001.0000000001.03288d7e-af16-44ed-829c-196064a71812.parquet", "InputFile.newInput"))
@@ -1616,11 +1902,16 @@ public class TestDeltaLakeFileOperations
 
     private void assertFileSystemAccesses(Session session, @Language("SQL") String query, Multiset<FileOperation> expectedAccesses)
     {
-        assertUpdate("CALL system.flush_metadata_cache()");
+        assertMultisetsEqual(getFileSystemAccesses(session, query), expectedAccesses);
+    }
+
+    private Multiset<FileOperation> getFileSystemAccesses(Session session, @Language("SQL") String query)
+    {
+        assertUpdate(session, "CALL system.flush_metadata_cache()");
 
         getDistributedQueryRunner().executeWithPlan(session, query);
         List<SpanData> spanData = getDistributedQueryRunner().getSpans();
-        assertMultisetsEqual(getOperations(spanData), expectedAccesses);
+        return getOperations(spanData);
     }
 
     private Multiset<FileOperation> getOperations(List<SpanData> spanData)
@@ -1701,7 +1992,7 @@ public class TestDeltaLakeFileOperations
     private void registerTable(String name, String resourcePath)
     {
         String dataPath = getResourceLocation(resourcePath).toExternalForm();
-        getQueryRunner().execute(format("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')", name, dataPath));
+        assertUpdate(format("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')", name, dataPath));
     }
 
     private URL getResourceLocation(String resourcePath)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.filesystem.TrinoFileSystem;
@@ -219,6 +220,78 @@ public class TestTransactionLogAccess
         assertThat(addFileEntry.getSize()).isEqualTo(2687);
         assertThat(addFileEntry.getModificationTime()).isEqualTo(1579190188000L);
         assertThat(addFileEntry.isDataChange()).isFalse();
+    }
+
+    /**
+     * @see databricks73.person
+     * @see deltalake.multipart_checkpoint
+     * @see deltalake.v2_checkpoint_json
+     * @see deltalake.v2_checkpoint_parquet
+     * @see deltalake.multipart_v2_checkpoint
+     */
+    @Test
+    public void testGetActiveAddEntriesMatrixByCheckpointShapeAndParallelism()
+            throws Exception
+    {
+        assertActiveEntriesEquivalentAcrossCheckpointProcessingModes("person", "databricks73/person");
+        assertActiveEntriesEquivalentAcrossCheckpointProcessingModes("multipart_checkpoint", "deltalake/multipart_checkpoint");
+        assertActiveEntriesEquivalentAcrossCheckpointProcessingModes("v2_checkpoint_json", "deltalake/v2_checkpoint_json");
+        assertActiveEntriesEquivalentAcrossCheckpointProcessingModes("v2_checkpoint_parquet", "deltalake/v2_checkpoint_parquet");
+        assertActiveEntriesEquivalentAcrossCheckpointProcessingModes("multipart_v2_checkpoint", "deltalake/multipart_v2_checkpoint");
+    }
+
+    private void assertActiveEntriesEquivalentAcrossCheckpointProcessingModes(String tableName, String resourcePath)
+            throws Exception
+    {
+        List<AddFileEntry> serialEntries = getActiveAddEntries(tableName, resourcePath, new DeltaLakeConfig());
+        List<AddFileEntry> intraFileOnlyEntries = getActiveAddEntries(
+                tableName,
+                resourcePath,
+                new DeltaLakeConfig()
+                        .setCheckpointProcessingParallelism(2)
+                        .setCheckpointIntraFileParallelProcessingEnabled(true)
+                        .setCheckpointIntraFileParallelProcessingSplitSize(DataSize.ofBytes(1_024)));
+        List<AddFileEntry> fileParallelEntries = getActiveAddEntries(
+                tableName,
+                resourcePath,
+                new DeltaLakeConfig()
+                        .setCheckpointProcessingParallelism(2)
+                        .setCheckpointV1ParallelProcessingEnabled(true)
+                        .setCheckpointV2ParallelProcessingEnabled(true));
+        List<AddFileEntry> parallelEntries = getActiveAddEntries(
+                tableName,
+                resourcePath,
+                new DeltaLakeConfig()
+                        .setCheckpointProcessingParallelism(2)
+                        .setCheckpointV1ParallelProcessingEnabled(true)
+                        .setCheckpointV2ParallelProcessingEnabled(true)
+                        .setCheckpointIntraFileParallelProcessingEnabled(true)
+                        .setCheckpointIntraFileParallelProcessingSplitSize(DataSize.ofBytes(1_024)));
+
+        assertThat(intraFileOnlyEntries).containsExactlyInAnyOrderElementsOf(serialEntries);
+        assertThat(fileParallelEntries).containsExactlyInAnyOrderElementsOf(serialEntries);
+        assertThat(parallelEntries).containsExactlyInAnyOrderElementsOf(serialEntries);
+        assertThat(serialEntries).isNotEmpty();
+    }
+
+    private List<AddFileEntry> getActiveAddEntries(
+            String tableName,
+            String resourcePath,
+            DeltaLakeConfig deltaLakeConfig)
+            throws Exception
+    {
+        setupTransactionLogAccess(
+                tableName,
+                getClass().getClassLoader().getResource(resourcePath).toString(),
+                deltaLakeConfig,
+                Optional.empty());
+
+        TrinoFileSystem fileSystem = tracingFileSystemFactory.create(SESSION, tableLocation);
+        MetadataEntry metadataEntry = transactionLogAccess.getMetadataEntry(SESSION, fileSystem, tableSnapshot);
+        ProtocolEntry protocolEntry = transactionLogAccess.getProtocolEntry(SESSION, fileSystem, tableSnapshot);
+        try (Stream<AddFileEntry> addFileEntries = transactionLogAccess.getActiveFiles(SESSION, createTable(metadataEntry, protocolEntry), tableSnapshot, TupleDomain.all(), alwaysTrue())) {
+            return addFileEntries.collect(toImmutableList());
+        }
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTableSnapshot.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake.transactionlog;
 
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
@@ -44,25 +45,29 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_LOCATION;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.deltalake.DeltaLakeConfig.DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE;
+import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.deltalake.transactionlog.TableSnapshot.MetadataAndProtocolEntry;
 import static io.trino.plugin.deltalake.transactionlog.TableSnapshot.load;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.readLastCheckpoint;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.ADD;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.PROTOCOL;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
-import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -171,7 +176,11 @@ public class TestTableSnapshot
                 Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
                 TupleDomain.all(),
                 Optional.of(alwaysTrue()),
-                executorService)) {
+                executorService,
+                false,
+                false,
+                false,
+                128L * 1024 * 1024)) {
             List<DeltaLakeTransactionLogEntry> entries = stream.collect(toImmutableList());
 
             assertThat(entries).hasSize(9);
@@ -222,7 +231,11 @@ public class TestTableSnapshot
                 Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
                 TupleDomain.all(),
                 Optional.of(alwaysTrue()),
-                executorService)) {
+                executorService,
+                false,
+                false,
+                false,
+                128L * 1024 * 1024)) {
             List<DeltaLakeTransactionLogEntry> entries = stream.collect(toImmutableList());
 
             assertThat(entries).hasSize(10);
@@ -284,10 +297,232 @@ public class TestTableSnapshot
         assertThat(tableSnapshot.getVersion()).isEqualTo(13L);
     }
 
+    /**
+     * @see deltalake.multipart_checkpoint
+     */
+    @Test
+    public void testMultipartV1CheckpointParallelProcessingSubmitsTasksToExecutor()
+            throws Exception
+    {
+        String tableLocation = getClass().getClassLoader().getResource("deltalake/multipart_checkpoint").toURI().toString();
+        VendedCredentialsHandle fixtureCredentialsHandle = VendedCredentialsHandle.empty(tableLocation);
+        TrinoFileSystem fileSystem = tracingFileSystemFactory.create(SESSION, fixtureCredentialsHandle);
+        Optional<LastCheckpoint> lastCheckpoint = readLastCheckpoint(fileSystem, tableLocation);
+        TableSnapshot tableSnapshot = load(
+                SESSION,
+                new FileSystemTransactionLogReader(tableLocation, fixtureCredentialsHandle, tracingFileSystemFactory),
+                new SchemaTableName("schema", "multipart_checkpoint"),
+                lastCheckpoint,
+                tableLocation,
+                parquetReaderOptions,
+                true,
+                domainCompactionThreshold,
+                DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE,
+                Optional.empty());
+
+        try (ExecutorService metadataExecutor = newDirectExecutorService();
+                RecordingExecutor serialCheckpointExecutor = new RecordingExecutor(4, "test-checkpoint-serial-submissions-%s");
+                RecordingExecutor fileParallelCheckpointExecutor = new RecordingExecutor(4, "test-checkpoint-file-parallel-submissions-%s");
+                RecordingExecutor intraFileCheckpointExecutor = new RecordingExecutor(4, "test-checkpoint-intra-file-submissions-%s")) {
+            TestingConnectorContext context = new TestingConnectorContext();
+            TypeManager typeManager = context.getTypeManager();
+            TransactionLogAccess transactionLogAccess = new TransactionLogAccess(
+                    typeManager,
+                    new CheckpointSchemaManager(typeManager),
+                    new DeltaLakeConfig(),
+                    new FileFormatDataSourceStats(),
+                    tracingFileSystemFactory,
+                    new ParquetReaderConfig(),
+                    metadataExecutor,
+                    new FileSystemTransactionLogReaderFactory(tracingFileSystemFactory));
+
+            MetadataEntry metadataEntry = transactionLogAccess.getMetadataEntry(SESSION, fileSystem, tableSnapshot);
+            ProtocolEntry protocolEntry = transactionLogAccess.getProtocolEntry(SESSION, fileSystem, tableSnapshot);
+            tableSnapshot.setCachedMetadata(Optional.of(metadataEntry));
+            tableSnapshot.setCachedProtocol(Optional.of(protocolEntry));
+
+            List<DeltaLakeTransactionLogEntry> serialEntries = readCheckpointEntries(
+                    tableSnapshot,
+                    fileSystem,
+                    metadataEntry,
+                    protocolEntry,
+                    serialCheckpointExecutor,
+                    false,
+                    false,
+                    false,
+                    1_024);
+            List<DeltaLakeTransactionLogEntry> fileParallelEntries = readCheckpointEntries(
+                    tableSnapshot,
+                    fileSystem,
+                    metadataEntry,
+                    protocolEntry,
+                    fileParallelCheckpointExecutor,
+                    true,
+                    false,
+                    false,
+                    1_024);
+            List<DeltaLakeTransactionLogEntry> intraFileEntries = readCheckpointEntries(
+                    tableSnapshot,
+                    fileSystem,
+                    metadataEntry,
+                    protocolEntry,
+                    intraFileCheckpointExecutor,
+                    true,
+                    false,
+                    true,
+                    1_024);
+
+            assertThat(serialEntries).containsExactlyInAnyOrderElementsOf(fileParallelEntries);
+            assertThat(intraFileEntries).containsExactlyInAnyOrderElementsOf(serialEntries);
+
+            assertThat(serialCheckpointExecutor.getSubmittedTaskCount()).isZero();
+            assertThat(fileParallelCheckpointExecutor.getSubmittedTaskCount()).isGreaterThan(1);
+            assertThat(intraFileCheckpointExecutor.getSubmittedTaskCount()).isGreaterThan(fileParallelCheckpointExecutor.getSubmittedTaskCount());
+        }
+    }
+
+    /**
+     * @see databricks73.person
+     * @see deltalake.multipart_checkpoint
+     * @see deltalake.v2_checkpoint_json
+     * @see deltalake.v2_checkpoint_parquet
+     * @see deltalake.multipart_v2_checkpoint
+     */
+    @Test
+    public void readsCheckpointFilesAcrossCheckpointProcessingModes()
+            throws Exception
+    {
+        List<CheckpointFixture> fixtures = ImmutableList.of(
+                new CheckpointFixture("person", "databricks73/person"),
+                new CheckpointFixture("multipart_checkpoint", "deltalake/multipart_checkpoint"),
+                new CheckpointFixture("v2_checkpoint_json", "deltalake/v2_checkpoint_json"),
+                new CheckpointFixture("v2_checkpoint_parquet", "deltalake/v2_checkpoint_parquet"),
+                new CheckpointFixture("multipart_v2_checkpoint", "deltalake/multipart_v2_checkpoint"));
+
+        try (ExecutorService metadataExecutor = newDirectExecutorService();
+                ExecutorService serialCheckpointExecutor = newDirectExecutorService();
+                ExecutorService parallelCheckpointExecutor = newFixedThreadPool(4, daemonThreadsNamed("test-checkpoint-processing-%s"))) {
+            TestingConnectorContext context = new TestingConnectorContext();
+            TypeManager typeManager = context.getTypeManager();
+            TransactionLogAccess transactionLogAccess = new TransactionLogAccess(
+                    typeManager,
+                    new CheckpointSchemaManager(typeManager),
+                    new DeltaLakeConfig(),
+                    new FileFormatDataSourceStats(),
+                    tracingFileSystemFactory,
+                    new ParquetReaderConfig(),
+                    metadataExecutor,
+                    new FileSystemTransactionLogReaderFactory(tracingFileSystemFactory));
+
+            for (CheckpointFixture fixture : fixtures) {
+                assertCheckpointEntriesEquivalentAcrossCheckpointProcessingModes(
+                        fixture,
+                        transactionLogAccess,
+                        serialCheckpointExecutor,
+                        parallelCheckpointExecutor);
+            }
+        }
+    }
+
+    private void assertCheckpointEntriesEquivalentAcrossCheckpointProcessingModes(
+            CheckpointFixture fixture,
+            TransactionLogAccess transactionLogAccess,
+            ExecutorService serialCheckpointExecutor,
+            ExecutorService parallelCheckpointExecutor)
+            throws Exception
+    {
+        String tableLocation = getClass().getClassLoader().getResource(fixture.resourcePath()).toURI().toString();
+        VendedCredentialsHandle fixtureCredentialsHandle = VendedCredentialsHandle.empty(tableLocation);
+        TrinoFileSystem fileSystem = tracingFileSystemFactory.create(SESSION, fixtureCredentialsHandle);
+        Optional<LastCheckpoint> lastCheckpoint = readLastCheckpoint(fileSystem, tableLocation);
+        TableSnapshot tableSnapshot = load(
+                SESSION,
+                new FileSystemTransactionLogReader(tableLocation, fixtureCredentialsHandle, tracingFileSystemFactory),
+                new SchemaTableName("schema", fixture.tableName()),
+                lastCheckpoint,
+                tableLocation,
+                parquetReaderOptions,
+                true,
+                domainCompactionThreshold,
+                DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE,
+                Optional.empty());
+
+        MetadataEntry metadataEntry = transactionLogAccess.getMetadataEntry(SESSION, fileSystem, tableSnapshot);
+        ProtocolEntry protocolEntry = transactionLogAccess.getProtocolEntry(SESSION, fileSystem, tableSnapshot);
+        tableSnapshot.setCachedMetadata(Optional.of(metadataEntry));
+        tableSnapshot.setCachedProtocol(Optional.of(protocolEntry));
+
+        List<DeltaLakeTransactionLogEntry> serialEntries = readCheckpointEntries(
+                tableSnapshot,
+                fileSystem,
+                metadataEntry,
+                protocolEntry,
+                serialCheckpointExecutor,
+                false,
+                false,
+                false,
+                1_024);
+        List<DeltaLakeTransactionLogEntry> parallelEntries = readCheckpointEntries(
+                tableSnapshot,
+                fileSystem,
+                metadataEntry,
+                protocolEntry,
+                parallelCheckpointExecutor,
+                true,
+                true,
+                false,
+                1_024);
+        List<DeltaLakeTransactionLogEntry> parallelEntriesWithIntraFileProcessing = readCheckpointEntries(
+                tableSnapshot,
+                fileSystem,
+                metadataEntry,
+                protocolEntry,
+                parallelCheckpointExecutor,
+                true,
+                true,
+                true,
+                1_024);
+
+        assertThat(serialEntries).isNotEmpty();
+        assertThat(parallelEntries).containsExactlyInAnyOrderElementsOf(serialEntries);
+        assertThat(parallelEntriesWithIntraFileProcessing).containsExactlyInAnyOrderElementsOf(serialEntries);
+    }
+
     private void assertFileSystemAccesses(TestingTelemetry.CheckedRunnable<?> callback, Multiset<FileOperation> expectedAccesses)
             throws Exception
     {
         assertMultisetsEqual(getOperations(testingTelemetry.captureSpans(callback::run)), expectedAccesses);
+    }
+
+    private List<DeltaLakeTransactionLogEntry> readCheckpointEntries(
+            TableSnapshot tableSnapshot,
+            TrinoFileSystem fileSystem,
+            MetadataEntry metadataEntry,
+            ProtocolEntry protocolEntry,
+            Executor checkpointProcessingExecutor,
+            boolean checkpointV1ParallelProcessingEnabled,
+            boolean checkpointV2ParallelProcessingEnabled,
+            boolean checkpointIntraFileParallelProcessingEnabled,
+            long checkpointIntraFileParallelProcessingSplitSize)
+            throws IOException
+    {
+        try (Stream<DeltaLakeTransactionLogEntry> stream = tableSnapshot.getCheckpointTransactionLogEntries(
+                SESSION,
+                ImmutableSet.of(ADD, PROTOCOL),
+                checkpointSchemaManager,
+                TESTING_TYPE_MANAGER,
+                fileSystem,
+                new FileFormatDataSourceStats(),
+                Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
+                TupleDomain.all(),
+                Optional.of(alwaysTrue()),
+                checkpointProcessingExecutor,
+                checkpointV1ParallelProcessingEnabled,
+                checkpointV2ParallelProcessingEnabled,
+                checkpointIntraFileParallelProcessingEnabled,
+                checkpointIntraFileParallelProcessingSplitSize)) {
+            return stream.collect(toImmutableList());
+        }
     }
 
     private Multiset<FileOperation> getOperations(List<SpanData> spans)
@@ -306,4 +541,36 @@ public class TestTableSnapshot
             requireNonNull(operationType, "operationType is null");
         }
     }
+
+    private static final class RecordingExecutor
+            implements Executor, AutoCloseable
+    {
+        private final AtomicInteger submittedTaskCount = new AtomicInteger();
+        private final ExecutorService delegate;
+
+        private RecordingExecutor(int threads, String threadNameFormat)
+        {
+            delegate = newFixedThreadPool(threads, daemonThreadsNamed(threadNameFormat));
+        }
+
+        @Override
+        public void execute(Runnable command)
+        {
+            submittedTaskCount.incrementAndGet();
+            delegate.execute(command);
+        }
+
+        public int getSubmittedTaskCount()
+        {
+            return submittedTaskCount.get();
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.shutdownNow();
+        }
+    }
+
+    private record CheckpointFixture(String tableName, String resourcePath) {}
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -24,6 +24,9 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.metadata.BlockMetadata;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.reader.MetadataReader;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
@@ -34,6 +37,7 @@ import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.RemoveFileEntry;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeParquetFileStatistics;
+import io.trino.plugin.hive.parquet.TrinoParquetDataSource;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
@@ -63,6 +67,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -102,8 +107,10 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.Float.floatToIntBits;
+import static java.lang.Math.toIntExact;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -970,6 +977,152 @@ public class TestCheckpointEntryIterator
         assertThat(txnEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(0L);
     }
 
+    @Test
+    public void testReadEntriesFromCheckpointFileSplits()
+            throws IOException
+    {
+        MetadataEntry metadataEntry = new MetadataEntry(
+                "metadataId",
+                "metadataName",
+                "metadataDescription",
+                new MetadataEntry.Format(
+                        "metadataFormatProvider",
+                        ImmutableMap.of()),
+                "{\"type\":\"struct\",\"fields\":" +
+                        "[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                1000);
+        ProtocolEntry protocolEntry = new ProtocolEntry(1, 1, Optional.empty(), Optional.empty());
+
+        int numAddEntries = 1000;
+        Set<AddFileEntry> addFileEntries = IntStream.rangeClosed(1, numAddEntries)
+                .mapToObj(index -> new AddFileEntry(
+                        "part-%04d-%s.parquet".formatted(index, UUID.randomUUID().toString().repeat(32)),
+                        ImmutableMap.of(),
+                        1000 + index,
+                        10_000 + index,
+                        true,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableMap.of(),
+                        Optional.empty()))
+                .collect(toImmutableSet());
+
+        CheckpointEntries entries = new CheckpointEntries(
+                metadataEntry,
+                protocolEntry,
+                ImmutableSet.of(),
+                addFileEntries,
+                ImmutableSet.of());
+
+        CheckpointWriter writer = new CheckpointWriter(
+                TESTING_TYPE_MANAGER,
+                checkpointSchemaManager,
+                "test",
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.of(4, KILOBYTE))
+                        .setMaxPageSize(DataSize.of(1, KILOBYTE))
+                        .build());
+
+        File targetFile = File.createTempFile("testReadEntriesFromCheckpointFileSplits-", ".checkpoint.parquet");
+        targetFile.deleteOnExit();
+
+        String targetPath = "file://" + targetFile.getAbsolutePath();
+        targetFile.delete(); // file must not exist when writer is called
+        writer.write(entries, createOutputFile(targetPath));
+
+        URI checkpointUri = URI.create(targetPath);
+        TrinoInputFile checkpointFile = createInputFile(checkpointUri);
+        long fileSize = checkpointFile.length();
+        List<BlockMetadata> rowGroups = readBlocks(checkpointFile);
+        assertThat(rowGroups.size()).isBetween(16, 64);
+
+        List<DeltaLakeTransactionLogEntry> wholeFileTransactionLogEntries = ImmutableList.copyOf(createCheckpointEntryIterator(
+                        checkpointFile,
+                        0,
+                        fileSize,
+                        fileSize,
+                        ImmutableSet.of(METADATA, PROTOCOL, ADD),
+                        Optional.of(metadataEntry),
+                        Optional.of(protocolEntry),
+                        TupleDomain.all(),
+                        Optional.of(alwaysTrue())));
+
+        assertThat(wholeFileTransactionLogEntries).hasSize(numAddEntries + 2);
+
+        List<Long> splitSizes = LongStream.of(3, 11, 29)
+                .map(divisor -> Math.max(1, fileSize / divisor))
+                .distinct()
+                .boxed()
+                .toList();
+
+        for (long splitSize : splitSizes) {
+            List<CheckpointFileSplit> splits = computeSplits(fileSize, splitSize);
+            List<ImmutableList<DeltaLakeTransactionLogEntry>> entriesBySplit = splits.stream()
+                    .map(split -> ImmutableList.copyOf(createCheckpointEntryIterator(
+                            checkpointFile,
+                            split.start(),
+                            split.length(),
+                            fileSize,
+                            ImmutableSet.of(METADATA, PROTOCOL, ADD),
+                            Optional.of(metadataEntry),
+                            Optional.of(protocolEntry),
+                            TupleDomain.all(),
+                            Optional.of(alwaysTrue()))))
+                    .toList();
+
+            for (int index = 0; index < splits.size(); index++) {
+                CheckpointFileSplit split = splits.get(index);
+                long splitEnd = split.start() + split.length();
+
+                // Each split may span zero, one, or many row groups. We expect that each iterator has the same number of
+                // entries as the sum of all row groups covered by the split
+                long expectedEntryCount = rowGroups.stream()
+                        .filter(block -> split.start() <= getRowGroupStart(block) && getRowGroupStart(block) < splitEnd)
+                        .mapToLong(BlockMetadata::rowCount)
+                        .sum();
+
+                assertThat(entriesBySplit.get(index))
+                        .hasSize(toIntExact(expectedEntryCount));
+            }
+
+            List<DeltaLakeTransactionLogEntry> entriesFromSplits = entriesBySplit.stream()
+                    .flatMap(List::stream)
+                    .toList();
+
+            assertThat(entriesFromSplits).containsExactlyElementsOf(wholeFileTransactionLogEntries);
+        }
+
+        List<CheckpointFileSplit> rowGroupSplits = computeRowGroupSplits(rowGroups, fileSize);
+        List<ImmutableList<DeltaLakeTransactionLogEntry>> entriesByRowGroupSplit = rowGroupSplits.stream()
+                .map(split -> ImmutableList.copyOf(createCheckpointEntryIterator(
+                        checkpointFile,
+                        split.start(),
+                        split.length(),
+                        fileSize,
+                        ImmutableSet.of(METADATA, PROTOCOL, ADD),
+                        Optional.of(metadataEntry),
+                        Optional.of(protocolEntry),
+                        TupleDomain.all(),
+                        Optional.of(alwaysTrue()))))
+                .toList();
+
+        // When splits align precisely with row group boundaries, we expect that each iterator has
+        // precisely the same number of entries as the corresponding row group in Parquet
+        for (int index = 0; index < rowGroupSplits.size(); index++) {
+            long expectedEntryCount = rowGroups.get(index).rowCount();
+            assertThat(entriesByRowGroupSplit.get(index))
+                    .hasSize(toIntExact(expectedEntryCount));
+        }
+
+        List<DeltaLakeTransactionLogEntry> entriesFromRowGroupSplits = entriesByRowGroupSplit.stream()
+                .flatMap(List::stream)
+                .toList();
+
+        assertThat(entriesFromRowGroupSplits).containsExactlyElementsOf(wholeFileTransactionLogEntries);
+    }
+
     private MetadataEntry readMetadataEntry(URI checkpointUri)
             throws IOException
     {
@@ -1005,13 +1158,40 @@ public class TestCheckpointEntryIterator
             Optional<Predicate<String>> addStatsMinMaxColumnFilter)
             throws IOException
     {
-        TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS).create(SESSION);
-        TrinoInputFile checkpointFile = fileSystem.newInputFile(Location.of(checkpointUri.toString()));
+        TrinoInputFile checkpointFile = createInputFile(checkpointUri);
+        long fileSize = checkpointFile.length();
+
+        return createCheckpointEntryIterator(
+                checkpointFile,
+                0,
+                fileSize,
+                fileSize,
+                entryTypes,
+                metadataEntry,
+                protocolEntry,
+                partitionConstraint,
+                addStatsMinMaxColumnFilter);
+    }
+
+    private CheckpointEntryIterator createCheckpointEntryIterator(
+            TrinoInputFile checkpointFile,
+            long start,
+            long length,
+            long fileSize,
+            Set<CheckpointEntryIterator.EntryType> entryTypes,
+            Optional<MetadataEntry> metadataEntry,
+            Optional<ProtocolEntry> protocolEntry,
+            TupleDomain<DeltaLakeColumnHandle> partitionConstraint,
+            Optional<Predicate<String>> addStatsMinMaxColumnFilter)
+    {
+        requireNonNull(checkpointFile, "checkpointFile is null");
 
         return new CheckpointEntryIterator(
                 checkpointFile,
                 SESSION,
-                checkpointFile.length(),
+                start,
+                length,
+                fileSize,
                 checkpointSchemaManager,
                 TESTING_TYPE_MANAGER,
                 entryTypes,
@@ -1028,8 +1208,66 @@ public class TestCheckpointEntryIterator
                 addStatsMinMaxColumnFilter);
     }
 
+    private static TrinoInputFile createInputFile(URI checkpointUri)
+    {
+        TrinoFileSystem fileSystem = new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS).create(SESSION);
+        return fileSystem.newInputFile(Location.of(checkpointUri.toString()));
+    }
+
     private static TrinoOutputFile createOutputFile(String path)
     {
         return new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS).create(SESSION).newOutputFile(Location.of(path));
+    }
+
+    private record CheckpointFileSplit(long start, long length) {}
+
+    private static List<CheckpointFileSplit> computeSplits(long fileSize, long splitSize)
+    {
+        long splitCount;
+        if (fileSize == 0) {
+            splitCount = 1;
+        }
+        else {
+            splitCount = (fileSize + splitSize - 1) / splitSize;
+        }
+
+        return LongStream.range(0, splitCount)
+                .mapToObj(index -> {
+                    long start = index * splitSize;
+                    long length = Math.min(splitSize, fileSize - start);
+                    return new CheckpointFileSplit(start, length);
+                })
+                .toList();
+    }
+
+    private static List<CheckpointFileSplit> computeRowGroupSplits(List<BlockMetadata> rowGroups, long fileSize)
+    {
+        List<Long> rowGroupOffsets = rowGroups.stream()
+                .map(TestCheckpointEntryIterator::getRowGroupStart)
+                .distinct()
+                .sorted()
+                .toList();
+
+        return IntStream.range(0, rowGroupOffsets.size())
+                .mapToObj(index -> {
+                    long start = rowGroupOffsets.get(index);
+                    long end = (index + 1 < rowGroupOffsets.size()) ? rowGroupOffsets.get(index + 1) : fileSize;
+                    return new CheckpointFileSplit(start, end - start);
+                })
+                .toList();
+    }
+
+    private static List<BlockMetadata> readBlocks(TrinoInputFile checkpointFile)
+            throws IOException
+    {
+        try (TrinoParquetDataSource dataSource = new TrinoParquetDataSource(checkpointFile, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats())) {
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            return parquetMetadata.getBlocks();
+        }
+    }
+
+    private static long getRowGroupStart(BlockMetadata block)
+    {
+        return block.columns().getFirst().getStartingPos();
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -498,6 +498,8 @@ public class TestCheckpointWriter
         Iterator<DeltaLakeTransactionLogEntry> checkpointEntryIterator = new CheckpointEntryIterator(
                 checkpointFile,
                 SESSION,
+                0,
+                checkpointFile.length(),
                 checkpointFile.length(),
                 checkpointSchemaManager,
                 typeManager,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestParallelUnorderedIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestParallelUnorderedIterator.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog.checkpoint;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestParallelUnorderedIterator
+{
+    @Test
+    public void testAcceptsEmptyListOfStreams()
+    {
+        try (ExecutorService executor = newFixedThreadPool(1, daemonThreadsNamed("test-parallel-iterator-empty-%s"))) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(ImmutableList.of(), executor)) {
+                assertThat(merged.collect(toImmutableList())).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    public void testMergesArbitraryElementTypeFromStreams()
+    {
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(
+                () -> ImmutableList.of(1, 2, 3).stream(),
+                () -> ImmutableList.of(4, 5).stream(),
+                () -> ImmutableList.of(6).stream());
+
+        try (ExecutorService executor = newFixedThreadPool(3, daemonThreadsNamed("test-parallel-iterator-%s"))) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor)) {
+                List<Integer> values = merged.collect(toImmutableList());
+                assertThat(values).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6);
+            }
+        }
+    }
+
+    @Test
+    public void testSubmitsOneTaskPerStreamToExecutor()
+    {
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(
+                () -> ImmutableList.of(1, 2, 3).stream(),
+                () -> ImmutableList.of(4, 5).stream(),
+                () -> ImmutableList.of(6).stream());
+
+        try (RecordingExecutor executor = new RecordingExecutor(3, "test-parallel-iterator-submissions-%s")) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor)) {
+                assertThat(merged.collect(toImmutableList())).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6);
+            }
+
+            assertThat(executor.getSubmittedTaskCount()).isEqualTo(streamSuppliers.size());
+        }
+    }
+
+    @Test
+    public void testPropagatesProducerFailure()
+    {
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(
+                () -> ImmutableList.of(1, 2).stream(),
+                () -> {
+                    throw new IllegalStateException("boom");
+                });
+
+        try (ExecutorService executor = newFixedThreadPool(2, daemonThreadsNamed("test-parallel-iterator-failure-%s"))) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor)) {
+                assertThatThrownBy(() -> merged.collect(toImmutableList()))
+                        .hasCauseInstanceOf(IllegalStateException.class)
+                        .cause()
+                        .hasMessageContaining("boom");
+            }
+        }
+    }
+
+    @Test
+    public void testPropagatesProducerFailureDuringIteration()
+    {
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(() -> failingStreamAfterFirstElement());
+
+        try (ExecutorService executor = newFixedThreadPool(1, daemonThreadsNamed("test-parallel-iterator-iteration-failure-%s"))) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor)) {
+                Iterator<Integer> iterator = merged.iterator();
+
+                assertThat(iterator.hasNext()).isTrue();
+                assertThat(iterator.next()).isEqualTo(1);
+                assertThatThrownBy(iterator::hasNext)
+                        .hasCauseInstanceOf(IllegalStateException.class)
+                        .cause()
+                        .hasMessageContaining("boom during iteration");
+            }
+        }
+    }
+
+    @Test
+    public void testRejectsNullElement()
+    {
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(() -> Stream.of(1, null));
+
+        try (ExecutorService executor = newFixedThreadPool(1, daemonThreadsNamed("test-parallel-iterator-null-%s"))) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor)) {
+                assertThatThrownBy(() -> merged.collect(toImmutableList()))
+                        .hasCauseInstanceOf(NullPointerException.class)
+                        .cause()
+                        .hasMessageContaining("entry is null");
+            }
+        }
+    }
+
+    @Test
+    public void testMergesMixedEmptyAndNonEmptyStreams()
+    {
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(
+                Stream::<Integer>empty,
+                () -> ImmutableList.of(1, 2).stream(),
+                Stream::<Integer>empty,
+                () -> ImmutableList.of(3).stream());
+
+        try (ExecutorService executor = newFixedThreadPool(4, daemonThreadsNamed("test-parallel-iterator-empty-mixed-%s"))) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor)) {
+                assertThat(merged.collect(toImmutableList()))
+                        .containsExactlyInAnyOrder(1, 2, 3);
+            }
+        }
+    }
+
+    @Test
+    public void testCloseUnblocksBlockedProducer()
+            throws InterruptedException
+    {
+        CountDownLatch secondElementRead = new CountDownLatch(1);
+        CountDownLatch streamClosed = new CountDownLatch(1);
+
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(() -> interruptibleStream(secondElementRead, streamClosed));
+
+        try (ExecutorService executor = newFixedThreadPool(1, daemonThreadsNamed("test-parallel-iterator-close-%s"))) {
+            Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor, 1);
+            try {
+                assertThat(secondElementRead.await(5, SECONDS)).isTrue();
+
+                merged.close();
+
+                assertThat(streamClosed.await(5, SECONDS)).isTrue();
+            }
+            finally {
+                merged.close();
+            }
+        }
+    }
+
+    @Test
+    public void testPropagatesUnexpectedProducerInterrupt()
+            throws InterruptedException
+    {
+        CountDownLatch secondElementRead = new CountDownLatch(1);
+        AtomicReference<Thread> producerThread = new AtomicReference<>();
+        ThreadFactory delegate = daemonThreadsNamed("test-parallel-iterator-interrupt-%s");
+
+        List<Supplier<Stream<Integer>>> streamSuppliers = ImmutableList.of(() -> interruptibleStream(secondElementRead));
+
+        try (ExecutorService executor = newFixedThreadPool(1, runnable -> {
+            Thread thread = delegate.newThread(runnable);
+            producerThread.set(thread);
+            return thread;
+        })) {
+            try (Stream<Integer> merged = ParallelUnorderedIterator.stream(streamSuppliers, executor, 1)) {
+                assertThat(secondElementRead.await(5, SECONDS)).isTrue();
+                assertThat(producerThread.get()).isNotNull();
+                producerThread.get().interrupt();
+
+                assertThatThrownBy(() -> merged.collect(toImmutableList()))
+                        .hasCauseInstanceOf(RuntimeException.class)
+                        .cause()
+                        .hasMessageContaining("Interrupted while producing elements");
+            }
+        }
+    }
+
+    private static Stream<Integer> interruptibleStream(CountDownLatch secondElementRead)
+    {
+        return interruptibleStream(secondElementRead, new CountDownLatch(0));
+    }
+
+    private static Stream<Integer> interruptibleStream(CountDownLatch secondElementRead, CountDownLatch streamClosed)
+    {
+        AtomicInteger index = new AtomicInteger();
+        Iterator<Integer> iterator = new Iterator<>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return index.get() < 2;
+            }
+
+            @Override
+            public Integer next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                int value = index.incrementAndGet();
+                if (value == 2) {
+                    secondElementRead.countDown();
+                }
+                return value;
+            }
+        };
+        return stream(iterator)
+                .onClose(streamClosed::countDown);
+    }
+
+    private static Stream<Integer> failingStreamAfterFirstElement()
+    {
+        AtomicInteger index = new AtomicInteger();
+        Iterator<Integer> iterator = new Iterator<>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return index.get() < 2;
+            }
+
+            @Override
+            public Integer next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                if (index.getAndIncrement() == 0) {
+                    return 1;
+                }
+                throw new IllegalStateException("boom during iteration");
+            }
+        };
+        return stream(iterator);
+    }
+
+    private static final class RecordingExecutor
+            implements Executor, AutoCloseable
+    {
+        private final AtomicInteger submittedTaskCount = new AtomicInteger();
+        private final ExecutorService delegate;
+
+        private RecordingExecutor(int threads, String threadNameFormat)
+        {
+            delegate = newFixedThreadPool(threads, daemonThreadsNamed(threadNameFormat));
+        }
+
+        @Override
+        public void execute(Runnable command)
+        {
+            submittedTaskCount.incrementAndGet();
+            delegate.execute(command);
+        }
+
+        public int getSubmittedTaskCount()
+        {
+            return submittedTaskCount.get();
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.shutdownNow();
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -97,6 +97,8 @@ public class TestDeltaLakeFileStatistics
         CheckpointEntryIterator metadataEntryIterator = new CheckpointEntryIterator(
                 checkpointFile,
                 SESSION,
+                0,
+                checkpointFile.length(),
                 checkpointFile.length(),
                 checkpointSchemaManager,
                 typeManager,
@@ -113,6 +115,8 @@ public class TestDeltaLakeFileStatistics
         CheckpointEntryIterator protocolEntryIterator = new CheckpointEntryIterator(
                 checkpointFile,
                 SESSION,
+                0,
+                checkpointFile.length(),
                 checkpointFile.length(),
                 checkpointSchemaManager,
                 typeManager,
@@ -130,6 +134,8 @@ public class TestDeltaLakeFileStatistics
         CheckpointEntryIterator checkpointEntryIterator = new CheckpointEntryIterator(
                 checkpointFile,
                 SESSION,
+                0,
+                checkpointFile.length(),
                 checkpointFile.length(),
                 checkpointSchemaManager,
                 typeManager,


### PR DESCRIPTION
**Branched off of https://github.com/trinodb/trino/pull/28381, which I anticipate will merge soon. Please ignore the first commit at this time.**

## Description
Parallelize Parquet checkpoint reads in the Delta Lake connector

Delta uses checkpoints to represent point-in-time snapshots of the table -- notably, the full set of active files. Readers and writers of Delta tables can reason about the current state of the table by loading latest checkpoint and reading all the intervening commit

Most queries and write operations must load the checkpoint either in full or in part before proceeding. For large tables, the checkpoints can grow to be extremely large, so checkpoint loading is important for overall query performance

This PR introduces full support for parallel reads of checkpoint files in Delta tables. We introduce configuration properties, `delta.checkpoint-processing.v{1,2}-parallel-processing.enabled`, that enable parallel processing for v1 and v2 checkpoints, respectively. Additionally, we introduce `delta.checkpoint-processing.intra-file-parallel-processing.enabled`, which enables splitting and parallel processing of individual checkpoint Parquet files, and `delta.checkpoint-processing.intra-file-parallel-processing.split-size`, controlling the goal split size for intra-file parallel processing (default 128 MiB). All new boolean configurations default to off to minimize the risk of performance regression or resource exhaustion on upgrade. The existing `delta.checkpoint-processing.parallelism` configuration properties controls parallelism per table

The exact shape and degree of parallelism depends on both the configuration and the structure of the checkpoint:

Checkpoint shape | v{1,2}-parallel-processing only | + intra-file-parallel-processing
-- | -- | --
Single-part v1 checkpoint | No parallelism | Parallelized splits over checkpoint file
Multipart v1 checkpoint | Parallelized across files; each file serial | Parallelized splits over all files
Monolithic v2 checkpoint | No parallelism | Parallelized splits over main checkpoint file
v2 checkpoint with sidecars | Parallelized across sidecar files; each file serial | Parallelized splits over all files

### Implementation

* Introduce a new `ParallelUnorderedIterator` class representing a parallel stream of several serial sub-iterators
  * `ParallelUnorderedIterator` accepts a `List<Supplier<Stream<T>>>`
    * Using a list means that we know the number of underlying streams ahead of time, which simplifies the iterator implementation
    * Using a `Supplier` allows us to defer the work of initializing the stream (e.g. `CheckpointEntryIterator` fetches Parquet metadata on construction)
  * `ParallelUnorderedIterator` spins out background producer workers using the provided executor. These producers continually pull from their respective iterators and push onto a shared queue, which is pulled from in `computeNext` on the consumer thread
* Augment the existing file level `CheckpointEntryIterator` to accept an offset and a length, thereby supporting scanning a split of a checkpoint file rather than scanning the whole file in full
* Refactor `TableSnapshot#getCheckpointTransactionLogEntries` to support parallel processing
  * Rather than chaining the file-level `CheckpointEntryIterator` instances into a single serialized stream, pass them into a `ParallelUnorderedIterator`
  * Introduce a lightweight planning step for intra-file parallelism (fetch file size, divide by target split size, and create a separate iterator per split); create a separate `CheckpointEntryIterator` per split
  * The public interface, `public Stream<DeltaLakeTransactionLogEntry> getCheckpointTransactionLogEntries(...)`, remains identical

## Additional context and related issues

A [previous patch](https://github.com/trinodb/trino/pull/25469) introduced a partial solution for parallelism for v2 checkpoint sidecar files. This approach was narrower in scope -- it only parallelized the initialization of the checkpoint iterators, not the actual loading of the checkpoint data. However, we do build on work from that patch, reusing the same executor and the `delta.checkpoint-processing.parallelism` configuration property

The Delta spec does not require any particular ordering of entries within a checkpoint, nor does it mandate that the files constituting a checkpoint be processed in any particular order -- so, the decision to use an unordered iterator should be safe

This PR introduces a tremendous amount of new tests based on existing features, mostly asserting that the parallel and serial code paths produce equivalent results on the same underlying tables. I erred on the side of caution by writing tests that are as exhaustive as possible, even at the cost of redundancy; if we so chose, I'm happy to remove some of these from the PR

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
Support parallel processing of Delta Lake checkpoint files
```