### PR TITLE
Remove OSHI dependency

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -44,8 +44,7 @@ RUN \
       curl-minimal grep `# required by health-check` \
       zlib `#required by java` \
       shadow-utils `# required by useradd` \
-      tar `# required to support kubectl cp` \
-      udev `# required by oshi` && \
+      tar `# required to support kubectl cp` && \
       rm -rf /tmp/overlay/var/cache/*
 
 # Use ubi10 micro as it's more secure

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -46,11 +46,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.oshi</groupId>
-            <artifactId>oshi-core-java25</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>
@@ -534,12 +529,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>jna</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/core/trino-main/src/test/java/io/trino/util/TestMachineInfo.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestMachineInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestMachineInfo
+{
+    @Test
+    void testParseLinuxPhysicalProcessorCount()
+    {
+        List<String> cpuInfoLines =
+                """
+                processor : 0
+                physical id : 0
+                core id : 0
+
+                processor : 1
+                physical id : 0
+                core id : 0
+
+                processor : 2
+                physical id : 0
+                core id : 1
+
+                processor : 3
+                physical id : 0
+                core id : 1
+                """.lines().toList();
+
+        assertThat(MachineInfo.parseLinuxPhysicalProcessorCount(cpuInfoLines))
+                .isEqualTo(Optional.of(2));
+    }
+
+    @Test
+    void testParseLinuxPhysicalProcessorCountWithoutCoreIds()
+    {
+        List<String> cpuInfoLines =
+                """
+                processor : 0
+                flags : avx512f avx512_vbmi2
+
+                processor : 1
+                flags : avx512f avx512_vbmi2
+                """.lines().toList();
+
+        assertThat(MachineInfo.parseLinuxPhysicalProcessorCount(cpuInfoLines))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testParseLinuxCpuFlagsIntersection()
+    {
+        List<String> cpuInfoLines =
+                """
+                processor : 0
+                flags : avx512f avx512_vbmi2 asimd
+
+                processor : 1
+                flags : avx512f asimd
+                """.lines().toList();
+
+        assertThat(MachineInfo.parseLinuxCpuFlags(cpuInfoLines))
+                .isEqualTo(Set.of("avx512f", "neon"));
+    }
+
+    @Test
+    void testParseLinuxCpuFlagsSingleProcessor()
+    {
+        List<String> cpuInfoLines =
+                """
+                processor : 0
+                flags : avx512f asimd
+                """.lines().toList();
+
+        assertThat(MachineInfo.parseLinuxCpuFlags(cpuInfoLines))
+                .isEqualTo(Set.of("avx512f", "neon"));
+    }
+}

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -245,12 +245,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>jna</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -436,12 +436,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.github.oshi</groupId>
-                <artifactId>oshi-core-java25</artifactId>
-                <version>6.9.3</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value-annotations</artifactId>
                 <version>1.11.1</version>
@@ -1652,7 +1646,6 @@
             </dependency>
 
             <dependency>
-                <!-- org.testcontainers:testcontainer's dependencies pull two different versions of this artifact and this is to negotiate the version -->
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
                 <version>${dep.jna.version}</version>
@@ -1660,19 +1653,7 @@
 
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna-jpms</artifactId>
-                <version>${dep.jna.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
-                <version>${dep.jna.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna-platform-jpms</artifactId>
                 <version>${dep.jna.version}</version>
             </dependency>
 
@@ -2625,26 +2606,6 @@
                                 <resources>
                                     <resource>org/publicsuffix/list/effective_tld_names.dat</resource>
                                 </resources>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
-                                        <groupId>net.java.dev.jna</groupId>
-                                        <artifactId>jna</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>net.java.dev.jna</groupId>
-                                        <artifactId>jna-jpms</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>net.java.dev.jna</groupId>
-                                        <artifactId>jna-platform</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>net.java.dev.jna</groupId>
-                                        <artifactId>jna-platform-jpms</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
                             </exception>
                             <exception>
                                 <conflictingDependencies>

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -73,12 +73,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>jna</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Remove OSHI from `trino-main` and replace `MachineInfo` with direct platform reads.

- Linux physical processor count: parse `/proc/cpuinfo` (`physical id` + `core id`) and fall back to logical processor count if topology keys are unavailable.
- Linux CPU flags: parse `/proc/cpuinfo` `flags`/`Features`, normalize tokens, then keep only flags present on every CPU section.
- macOS (dev-only): on `aarch64`, assume `neon`; otherwise return no SIMD flags.

## Why this is safe

Our OSHI usage here was only:
1. physical processor count
2. CPU feature flags

For Linux feature flags, OSHI already reads `/proc/cpuinfo` (`CpuInfo.queryFeatureFlags`). Trino then applied its own normalization/intersection logic. This change keeps Trino-owned behavior but removes the extra dependency layer.

For physical processor count, we intentionally use a simpler `/proc/cpuinfo` parser. When machine topology metadata is missing, behavior remains safe by falling back to `Runtime.availableProcessors()`.

For macOS, this only affects local development. Production is Linux-only, and Apple Silicon has baseline NEON support, so using `aarch64 -> neon` is sufficient to exercise SIMD paths in dev.

## Dependency/runtime impact

- Removes direct OSHI dependency from `trino-main`.
- Removes OSHI-related `udev` requirement from the Docker image.
- Removes no-longer-needed JPMS JNA entries (`jna-jpms`, `jna-platform-jpms`) while keeping `jna`/`jna-platform` where still required in the reactor.

## Validation

- Added Linux parser-focused tests for physical core parsing.
- Added Linux CPU flag tests for cross-CPU intersection and single-CPU parsing.
- Existing fallback behavior remains: if machine metadata cannot be read, code uses safe defaults.
