### PR TITLE
KRB5CCNAME env variable should not force Kerberos auth in the CLI

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -400,8 +400,8 @@ public class ClientOptions
         if (krb5RemoteServiceName.isPresent()) {
             krb5ConfigPath.ifPresent(builder::setKerberosConfigPath);
             krb5KeytabPath.ifPresent(builder::setKerberosKeytabPath);
+            krb5CredentialCachePath.ifPresent(builder::setKerberosCredentialCachePath);
         }
-        krb5CredentialCachePath.ifPresent(builder::setKerberosCredentialCachePath);
         krb5Principal.ifPresent(builder::setKerberosPrincipal);
         if (krb5DisableRemoteServiceHostnameCanonicalization) {
             builder.setKerberosUseCanonicalHostname(false);


### PR DESCRIPTION
## Description
The trino-cli contains the following [ClientOptions.java](https://github.com/trinodb/trino/blob/master/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java#L129):

```java
    @PropertyMapping(KERBEROS_CREDENTIAL_CACHE_PATH)
    @Option(names = "--krb5-credential-cache-path", paramLabel = "<path>", description = "Kerberos credential cache path")
    public Optional<String> krb5CredentialCachePath = defaultCredentialCachePath();
```

This invokes the following code in [KerberosUtil](https://github.com/trinodb/trino/blob/master/client/trino-client/src/main/java/io/trino/client/KerberosUtil.java):
```java
public static Optional<String> defaultCredentialCachePath()
    {
        String value = nullToEmpty(System.getenv("KRB5CCNAME"));
        if (value.startsWith(FILE_PREFIX)) {
            value = value.substring(FILE_PREFIX.length());
        }
        return Optional.ofNullable(emptyToNull(value));
    }
```

Later on, the cache is set if present in [ClientOptions.java](https://github.com/trinodb/trino/blob/master/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java#L404)
```java
krb5CredentialCachePath.ifPresent(builder::setKerberosCredentialCachePath);
```

But as the default path is set when the environment variable KRB5CCNAME is set, the cache is set and enforces the following later on in [ConnectionProperties](https://github.com/trinodb/trino/blob/master/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java#L615):

```java
private static class KerberosCredentialCachePath
            extends AbstractConnectionProperty<String, File>
    {
        public KerberosCredentialCachePath()
        {
            super(PropertyName.KERBEROS_CREDENTIAL_CACHE_PATH, NOT_REQUIRED, validateKerberosWithoutDelegation(PropertyName.KERBEROS_CREDENTIAL_CACHE_PATH), FILE_CONVERTER);
        }
    }
    
    ...
    
    private static Validator<Properties> validateKerberosWithoutDelegation(PropertyName propertyName)
    {
        return validator(ConnectionProperties::isKerberosEnabled, format("Connection property %s requires %s to be set", propertyName, PropertyName.KERBEROS_REMOTE_SERVICE_NAME))
                .and(validator(
                        properties -> !KERBEROS_DELEGATION.getValueOrDefault(properties, false),
                        format("Connection property %s cannot be set if %s is enabled", propertyName, PropertyName.KERBEROS_DELEGATION)));
    }
```

```java
ConnectionProperties::isKerberosEnabled
```
Returns false as the `KERBEROS_REMOTE_SERVICE_NAME` is not set, resulting in the following error:
(path to reproduce)
```bash
export KRB5CCNAME=/tmp; java -jar trino-cli-480-SNAPSHOT-executable.jar --server http://localhost/

Connection property KerberosCredentialCachePath requires KerberosRemoteServiceName to be set
```

The fix is to only configure the cache when the `krb5RemoteServiceName` is set.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## Client
* Fix trino-cli: existence of environment variable KRB5CCNAME no longer enforces Kerberos authentication
```
