### PR TITLE
Use ExactConversionsSupport for narrowing checks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -16,8 +16,6 @@ package io.trino.operator.scalar;
 import com.google.common.math.DoubleMath;
 import com.google.common.math.LongMath;
 import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Shorts;
-import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.TrinoException;
@@ -69,6 +67,9 @@ import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
+import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToShortExact;
 
 public final class MathFunctions
 {
@@ -766,12 +767,10 @@ public final class MathFunctions
     public static long roundTinyint(@SqlType(StandardTypes.TINYINT) long num, @SqlType(StandardTypes.INTEGER) long decimals)
     {
         long rounded = roundLong(num, decimals);
-        try {
-            return SignedBytes.checkedCast(rounded);
+        if (!isLongToByteExact(rounded)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + rounded);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + rounded, e);
-        }
+        return (byte) rounded;
     }
 
     @Description("Round to nearest integer")
@@ -780,12 +779,10 @@ public final class MathFunctions
     public static long roundSmallint(@SqlType(StandardTypes.SMALLINT) long num, @SqlType(StandardTypes.INTEGER) long decimals)
     {
         long rounded = roundLong(num, decimals);
-        try {
-            return Shorts.checkedCast(rounded);
+        if (!isLongToShortExact(rounded)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + rounded);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + rounded, e);
-        }
+        return (short) rounded;
     }
 
     @Description("Round to nearest integer")
@@ -794,12 +791,10 @@ public final class MathFunctions
     public static long roundInteger(@SqlType(StandardTypes.INTEGER) long num, @SqlType(StandardTypes.INTEGER) long decimals)
     {
         long rounded = roundLong(num, decimals);
-        try {
-            return toIntExact(rounded);
+        if (!isLongToIntExact(rounded)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for integer: " + rounded);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for integer: " + rounded, e);
-        }
+        return (int) rounded;
     }
 
     @Description("Round to nearest integer")

--- a/core/trino-main/src/main/java/io/trino/type/BigintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BigintOperators.java
@@ -40,8 +40,10 @@ import static io.trino.spi.function.OperatorType.NEGATION;
 import static io.trino.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
+import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToShortExact;
 
 public final class BigintOperators
 {
@@ -133,12 +135,10 @@ public final class BigintOperators
     @SqlType(StandardTypes.INTEGER)
     public static long castToInteger(@SqlType(StandardTypes.BIGINT) long value)
     {
-        try {
-            return toIntExact(value);
+        if (!isLongToIntExact(value)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for integer: " + value);
         }
-        catch (ArithmeticException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for integer: " + value, e);
-        }
+        return (int) value;
     }
 
     @ScalarOperator(SATURATED_FLOOR_CAST)
@@ -166,24 +166,20 @@ public final class BigintOperators
     @SqlType(StandardTypes.SMALLINT)
     public static long castToSmallint(@SqlType(StandardTypes.BIGINT) long value)
     {
-        try {
-            return Shorts.checkedCast(value);
+        if (!isLongToShortExact(value)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + value);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + value, e);
-        }
+        return (short) value;
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.TINYINT)
     public static long castToTinyint(@SqlType(StandardTypes.BIGINT) long value)
     {
-        try {
-            return SignedBytes.checkedCast(value);
+        if (!isLongToByteExact(value)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + value);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + value, e);
-        }
+        return (byte) value;
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -73,6 +73,9 @@ import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.multiplyExact;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
+import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToShortExact;
 import static java.math.RoundingMode.HALF_UP;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -272,12 +275,10 @@ public final class DecimalCasts
             longResult = -((-decimal + tenToScale / 2) / tenToScale);
         }
 
-        try {
-            return toIntExact(longResult);
-        }
-        catch (ArithmeticException e) {
+        if (!isLongToIntExact(longResult)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INTEGER", longResult));
         }
+        return (int) longResult;
     }
 
     @UsedByGeneratedCode
@@ -330,12 +331,10 @@ public final class DecimalCasts
             longResult = -((-decimal + tenToScale / 2) / tenToScale);
         }
 
-        try {
-            return Shorts.checkedCast(longResult);
-        }
-        catch (IllegalArgumentException e) {
+        if (!isLongToShortExact(longResult)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", longResult));
         }
+        return (short) longResult;
     }
 
     @UsedByGeneratedCode
@@ -389,12 +388,10 @@ public final class DecimalCasts
             longResult = -((-decimal + tenToScale / 2) / tenToScale);
         }
 
-        try {
-            return SignedBytes.checkedCast(longResult);
-        }
-        catch (IllegalArgumentException e) {
+        if (!isLongToByteExact(longResult)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", longResult));
         }
+        return (byte) longResult;
     }
 
     @UsedByGeneratedCode

--- a/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
@@ -40,6 +40,8 @@ import static io.trino.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
+import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToShortExact;
 
 public final class IntegerOperators
 {
@@ -128,24 +130,20 @@ public final class IntegerOperators
     @SqlType(StandardTypes.SMALLINT)
     public static long castToSmallint(@SqlType(StandardTypes.INTEGER) long value)
     {
-        try {
-            return Shorts.checkedCast(value);
+        if (!isLongToShortExact(value)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + value);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + value, e);
-        }
+        return (short) value;
     }
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.TINYINT)
     public static long castToTinyint(@SqlType(StandardTypes.INTEGER) long value)
     {
-        try {
-            return SignedBytes.checkedCast(value);
+        if (!isLongToByteExact(value)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + value);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + value, e);
-        }
+        return (byte) value;
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
@@ -13,7 +13,6 @@
  */
 package io.trino.type;
 
-import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.LiteralParameter;
@@ -38,6 +37,7 @@ import static io.trino.spi.function.OperatorType.NEGATION;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
+import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
 
 public final class TinyintOperators
 {
@@ -47,36 +47,33 @@ public final class TinyintOperators
     @SqlType(StandardTypes.TINYINT)
     public static long add(@SqlType(StandardTypes.TINYINT) long left, @SqlType(StandardTypes.TINYINT) long right)
     {
-        try {
-            return SignedBytes.checkedCast(left + right);
+        long result = left + right;
+        if (!isLongToByteExact(result)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint addition overflow: %s + %s", left, right));
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint addition overflow: %s + %s", left, right), e);
-        }
+        return (byte) result;
     }
 
     @ScalarOperator(SUBTRACT)
     @SqlType(StandardTypes.TINYINT)
     public static long subtract(@SqlType(StandardTypes.TINYINT) long left, @SqlType(StandardTypes.TINYINT) long right)
     {
-        try {
-            return SignedBytes.checkedCast(left - right);
+        long result = left - right;
+        if (!isLongToByteExact(result)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint subtraction overflow: %s - %s", left, right));
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint subtraction overflow: %s - %s", left, right), e);
-        }
+        return (byte) result;
     }
 
     @ScalarOperator(MULTIPLY)
     @SqlType(StandardTypes.TINYINT)
     public static long multiply(@SqlType(StandardTypes.TINYINT) long left, @SqlType(StandardTypes.TINYINT) long right)
     {
-        try {
-            return SignedBytes.checkedCast(left * right);
+        long result = left * right;
+        if (!isLongToByteExact(result)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint multiplication overflow: %s * %s", left, right));
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint multiplication overflow: %s * %s", left, right), e);
-        }
+        return (byte) result;
     }
 
     @ScalarOperator(DIVIDE)
@@ -107,12 +104,11 @@ public final class TinyintOperators
     @SqlType(StandardTypes.TINYINT)
     public static long negate(@SqlType(StandardTypes.TINYINT) long value)
     {
-        try {
-            return SignedBytes.checkedCast(-value);
+        long result = -value;
+        if (!isLongToByteExact(result)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "tinyint negation overflow: " + value);
         }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "tinyint negation overflow: " + value, e);
-        }
+        return (byte) result;
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -42,9 +42,9 @@ import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
 
 public final class RealType
         extends AbstractIntType
@@ -89,14 +89,10 @@ public final class RealType
     @Override
     public void writeLong(BlockBuilder blockBuilder, long value)
     {
-        int floatValue;
-        try {
-            floatValue = toIntExact(value);
-        }
-        catch (ArithmeticException e) {
+        if (!isLongToIntExact(value)) {
             throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Value (%sb) is not a valid single-precision float", Long.toBinaryString(value)));
         }
-        writeInt(blockBuilder, floatValue);
+        writeInt(blockBuilder, (int) value);
     }
 
     public void writeFloat(BlockBuilder blockBuilder, float value)


### PR DESCRIPTION
## Description
In Java 23, ExactConversionsSupport was added and this allows checking if a cast is exact without a catch/rethrow structure. This simplifies a bunch of numeric conversion logic.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
