### PR TITLE
Reduce lock contention on TaskInfoFetcher

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
@@ -102,8 +102,11 @@ public record TaskInfo(
         return new TaskInfo(newTaskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, estimatedMemory, needsPlan);
     }
 
-    public TaskInfo withEstimatedMemory(DataSize estimatedMemory)
+    public TaskInfo withEstimatedMemory(Optional<DataSize> estimatedMemory)
     {
-        return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, Optional.of(estimatedMemory), needsPlan);
+        if (estimatedMemory.isPresent()) {
+            return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, estimatedMemory, needsPlan);
+        }
+        return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -632,10 +632,8 @@ public final class HttpRemoteTask
         }
     }
 
-    private synchronized void processTaskUpdate(TaskInfo newValue, List<SplitAssignment> splitAssignments)
+    private synchronized void processTaskUpdate(List<SplitAssignment> splitAssignments)
     {
-        updateTaskInfo(newValue);
-
         // remove acknowledged splits, which frees memory
         for (SplitAssignment assignment : splitAssignments) {
             PlanNodeId planNodeId = assignment.getPlanNodeId();
@@ -669,10 +667,15 @@ public final class HttpRemoteTask
         updateSplitQueueSpace();
     }
 
+    // In case of failure, only update status without a TaskInfo from the worker
+    private void updateTaskInfoOnFailure(TaskStatus taskStatus)
+    {
+        taskInfoFetcher.updateTaskInfo(Optional.empty(), taskStatus);
+    }
+
     private void updateTaskInfo(TaskInfo taskInfo)
     {
-        taskStatusFetcher.updateTaskStatus(taskInfo.taskStatus());
-        taskInfoFetcher.updateTaskInfo(taskInfo);
+        taskInfoFetcher.updateTaskInfo(Optional.of(taskInfo), taskInfo.taskStatus());
     }
 
     private void scheduleUpdate()
@@ -1065,7 +1068,7 @@ public final class HttpRemoteTask
                                     .build();
                             taskStatus = failWith(taskStatus, FAILED, failures);
                         }
-                        updateTaskInfo(getTaskInfo().withTaskStatus(taskStatus));
+                        updateTaskInfoOnFailure(taskStatus);
                     }
                     catch (Throwable t) {
                         log.error(t, "Error marking task %s as failed due to %s", taskId, cause);
@@ -1102,7 +1105,7 @@ public final class HttpRemoteTask
                     // Since this TaskInfo is updated in the client without having received them from the
                     // worker, the stats may not reflect the actual final stats had we been able to reach the worker
                     // to get them.
-                    updateTaskInfo(getTaskInfo().withTaskStatus(taskStatus));
+                    updateTaskInfoOnFailure(taskStatus);
                 }
                 else {
                     // Let the status callbacks trigger the cleanup command remotely after switching states
@@ -1115,7 +1118,7 @@ public final class HttpRemoteTask
                 // down, but taskInfoFetcher still holds old state.
                 // Update taskInfo so task is not stuck in FTE execution mode which depends on final task info
                 // being delivered.
-                updateTaskInfo(getTaskInfo().withTaskStatus(taskStatus));
+                updateTaskInfoOnFailure(taskStatus);
             }
         }
     }
@@ -1216,7 +1219,8 @@ public final class HttpRemoteTask
                 currentRequest.set(null);
                 updateStats();
                 updateErrorTracker.requestSucceeded();
-                processTaskUpdate(value, splitAssignments);
+                updateTaskInfo(value);
+                processTaskUpdate(splitAssignments);
                 if (pendingRequestsCounter.addAndGet(-currentPendingRequestsCounter) > 0) {
                     // schedule an update because triggerUpdate was called in the meantime
                     scheduleUpdate();

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -140,7 +140,12 @@ public class TaskInfoFetcher
 
     public TaskInfo getTaskInfo()
     {
-        return taskInfo.get();
+        TaskInfo info = taskInfo.get();
+        TaskStatus localStatus = taskStatusFetcher.getTaskStatus();
+        if (localStatus.version() > info.taskStatus().version()) {
+            return info.withTaskStatus(localStatus);
+        }
+        return info;
     }
 
     public synchronized void start()
@@ -162,6 +167,7 @@ public class TaskInfoFetcher
         }
         if (scheduledFuture != null) {
             scheduledFuture.cancel(true);
+            scheduledFuture = null;
         }
     }
 
@@ -217,14 +223,13 @@ public class TaskInfoFetcher
 
     private synchronized void sendNextRequest()
     {
-        TaskStatus taskStatus = getTaskInfo().taskStatus();
-
         if (!running) {
             return;
         }
 
         // we already have the final task info
-        if (isDone(getTaskInfo())) {
+        TaskStatus taskStatus = getTaskInfo().taskStatus();
+        if (isDone(taskStatus)) {
             stop();
             return;
         }
@@ -254,59 +259,74 @@ public class TaskInfoFetcher
         Futures.addCallback(future, new SimpleHttpResponseHandler<>(new TaskInfoResponseCallback(), request.getUri(), stats), executor);
     }
 
-    synchronized void updateTaskInfo(TaskInfo newTaskInfo)
+    void updateTaskInfo(Optional<TaskInfo> newTaskInfo, TaskStatus newRemoteTaskStatus)
     {
         TaskStatus localTaskStatus = taskStatusFetcher.getTaskStatus();
-        TaskStatus newRemoteTaskStatus = newTaskInfo.taskStatus();
+        TaskStatus newTaskStatus = newRemoteTaskStatus;
 
-        if (!newRemoteTaskStatus.taskId().equals(taskId)) {
-            log.debug("Task ID mismatch on remote task status. Member task ID is %s, but remote task ID is %s. This will confuse finalTaskInfo listeners.", taskId, newRemoteTaskStatus.taskId());
+        if (!newTaskStatus.taskId().equals(taskId)) {
+            log.debug("Task ID mismatch on remote task status. Member task ID is %s, but remote task ID is %s. This will confuse finalTaskInfo listeners.", taskId, newTaskStatus.taskId());
         }
 
-        if (localTaskStatus.state().isDone() && newRemoteTaskStatus.state().isDone() && localTaskStatus.state() != newRemoteTaskStatus.state()) {
+        if (localTaskStatus.state().isDone() && newTaskStatus.state().isDone() && localTaskStatus.state() != newTaskStatus.state()) {
             // prefer local
-            newTaskInfo = newTaskInfo.withTaskStatus(localTaskStatus);
+            newTaskStatus = localTaskStatus;
             if (!localTaskStatus.taskId().equals(taskId)) {
-                log.debug("Task ID mismatch on local task status. Member task ID is %s, but status-fetcher ID is %s. This will confuse finalTaskInfo listeners.", taskId, newRemoteTaskStatus.taskId());
+                log.debug("Task ID mismatch on local task status. Member task ID is %s, but status-fetcher ID is %s. This will confuse finalTaskInfo listeners.", taskId, newTaskStatus.taskId());
             }
-        }
-
-        if (estimatedMemory.isPresent()) {
-            newTaskInfo = newTaskInfo.withEstimatedMemory(estimatedMemory.get());
         }
 
         boolean missingSpoolingOutputStats = false;
-        if (newTaskInfo.taskStatus().state().isDone()) {
-            boolean wasSet = spoolingOutputStats.compareAndSet(null, newTaskInfo.outputBuffers().spoolingOutputStats().orElse(null));
-            if (newTaskInfo.taskStatus().state() == TaskState.FINISHED && retryPolicy == TASK && wasSet && spoolingOutputStats.get() == null) {
+        if (newTaskStatus.state().isDone() && newTaskInfo.isPresent()) {
+            boolean wasSet = spoolingOutputStats.compareAndSet(null, newTaskInfo.get().outputBuffers().spoolingOutputStats().orElse(null));
+            if (newTaskStatus.state() == TaskState.FINISHED && retryPolicy == TASK && wasSet && spoolingOutputStats.get() == null) {
                 missingSpoolingOutputStats = true;
                 if (log.isDebugEnabled()) {
-                    log.debug("Task %s was updated to null spoolingOutputStats. Future calls to retrieveAndDropSpoolingOutputStats will fail; taskInfo=%s", taskId, taskInfoCodec.toJson(newTaskInfo));
+                    log.debug("Task %s was updated to null spoolingOutputStats. Future calls to retrieveAndDropSpoolingOutputStats will fail; taskInfo=%s",
+                            taskId, taskInfoCodec.toJson(newTaskInfo.get()));
                 }
             }
-            newTaskInfo = newTaskInfo.pruneSpoolingOutputStats();
+            newTaskInfo = newTaskInfo.map(TaskInfo::pruneSpoolingOutputStats);
         }
 
-        TaskInfo newValue = newTaskInfo;
+        TaskStatus previous = taskInfo.get().taskStatus();
+        // precheck status without lock
+        if (!previous.state().isDone() && newTaskStatus.version() >= previous.version()) {
+            TaskInfo newValue = newTaskInfo.orElseGet(this::getTaskInfo)
+                    .withEstimatedMemory(estimatedMemory)
+                    .withTaskStatus(newTaskStatus);
+
+            boolean updated = setTaskInfo(newValue);
+            if (updated && newValue.taskStatus().state().isDone()) {
+                boolean finalTaskInfoUpdated = finalTaskInfo.compareAndSet(Optional.empty(), Optional.of(newValue));
+                if (missingSpoolingOutputStats && finalTaskInfoUpdated) {
+                    log.debug("Updated finalTaskInfo for task %s to one with missing spoolingOutputStats", taskId);
+                }
+            }
+        }
+        // Update statusFetcher last so that any state-change listeners it fires will already observe
+        // the finalTaskInfo as set. Updating statusFetcher before finalTaskInfo.compareAndSet would
+        // create a race where a listener sees a terminal status but finalTaskInfo is still empty.
+        taskStatusFetcher.updateTaskStatus(newTaskStatus);
+    }
+
+    private synchronized boolean setTaskInfo(TaskInfo newValue)
+    {
         boolean updated = taskInfo.setIf(newValue, oldValue -> {
             TaskStatus oldTaskStatus = oldValue.taskStatus();
-            TaskStatus newTaskStatus = newValue.taskStatus();
             if (oldTaskStatus.state().isDone()) {
                 // never update if the task has reached a terminal state
                 return false;
             }
             // don't update to an older version (same version is ok)
-            return newTaskStatus.version() >= oldTaskStatus.version();
+            return newValue.taskStatus().version() >= oldTaskStatus.version();
         });
 
         if (updated && newValue.taskStatus().state().isDone()) {
-            taskStatusFetcher.updateTaskStatus(newTaskInfo.taskStatus());
-            boolean finalTaskInfoUpdated = finalTaskInfo.compareAndSet(Optional.empty(), Optional.of(newValue));
-            if (missingSpoolingOutputStats && finalTaskInfoUpdated) {
-                log.debug("Updated finalTaskInfo for task %s to one with missing spoolingOutputStats", taskId);
-            }
             stop();
         }
+
+        return updated;
     }
 
     private class TaskInfoResponseCallback
@@ -322,7 +342,7 @@ public class TaskInfoFetcher
 
                 updateStats(requestStartNanos);
                 errorTracker.requestSucceeded();
-                updateTaskInfo(newValue);
+                updateTaskInfo(Optional.of(newValue), newValue.taskStatus());
             }
             finally {
                 cleanupRequest();
@@ -336,7 +356,7 @@ public class TaskInfoFetcher
                 lastUpdateNanos.set(System.nanoTime());
 
                 // if task not already done, record error
-                if (!isDone(getTaskInfo())) {
+                if (!isDone(getTaskInfo().taskStatus())) {
                     errorTracker.requestFailed(cause);
                 }
             }
@@ -377,8 +397,8 @@ public class TaskInfoFetcher
         stats.infoRoundTripMillis(nanosSince(currentRequestStartNanos).toMillis());
     }
 
-    private static boolean isDone(TaskInfo taskInfo)
+    private static boolean isDone(TaskStatus taskStatus)
     {
-        return taskInfo.taskStatus().state().isDone();
+        return taskStatus.state().isDone();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
- Make updateTaskInfo unsynchronized; extract synchronized setTaskInfo helper
- Move updateTaskInfo out of synchronized processTaskUpdate in HttpRemoteTask
- Move taskStatusFetcher.updateTaskStatus to end of updateTaskInfo to fix race where listeners could observe terminal status before finalTaskInfo was set


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
