### PR TITLE
Add nested group resolution to LDAP group provider with optional AD matching-rule support

### DIFF
--- a/docs/src/main/sphinx/security/group-mapping.md
+++ b/docs/src/main/sphinx/security/group-mapping.md
@@ -158,9 +158,9 @@ include the user DN. This requires the following properties:
 * - `ldap.group-search-member-attribute`
   - Attribute from group documents used for filtering by member. For example,
     `cn`.
-* - `ldap.group-search-enable-nested-groups`
+* - `ldap.group-search-nested-enabled`
   - Enable nested group resolution for search-based mode. Defaults to `false`.
-* - `ldap.group-search-use-matching-rule-in-chain`
+* - `ldap.group-search-nested-use-matching-rule-in-chain`
   - Use the Active Directory `LDAP_MATCHING_RULE_IN_CHAIN` matching rule
     (`1.2.840.113556.1.4.1941`) for nested group resolution. Defaults to
     `false`.
@@ -168,12 +168,12 @@ include the user DN. This requires the following properties:
 
 By default, search-based group resolution returns only direct groups.
 
-If `ldap.group-search-enable-nested-groups=true`, Trino recursively resolves
+If `ldap.group-search-nested-enabled=true`, Trino recursively resolves
 nested group memberships (for example user → group A → group B) by repeatedly
 searching groups that contain the previously resolved group DN as a member.
 
 For Active Directory deployments, you can additionally enable
-`ldap.group-search-use-matching-rule-in-chain=true` to delegate nested group
+`ldap.group-search-nested-use-matching-rule-in-chain=true` to delegate nested group
 resolution to LDAP itself (this is only relevant when nested group resolution
 is enabled).
 

--- a/docs/src/main/sphinx/security/group-mapping.md
+++ b/docs/src/main/sphinx/security/group-mapping.md
@@ -158,7 +158,24 @@ include the user DN. This requires the following properties:
 * - `ldap.group-search-member-attribute`
   - Attribute from group documents used for filtering by member. For example,
     `cn`.
+* - `ldap.group-search-enable-nested-groups`
+  - Enable nested group resolution for search-based mode. Defaults to `false`.
+* - `ldap.group-search-use-matching-rule-in-chain`
+  - Use the Active Directory `LDAP_MATCHING_RULE_IN_CHAIN` matching rule
+    (`1.2.840.113556.1.4.1941`) for nested group resolution. Defaults to
+    `false`.
 :::
+
+By default, search-based group resolution returns only direct groups.
+
+If `ldap.group-search-enable-nested-groups=true`, Trino recursively resolves
+nested group memberships (for example user → group A → group B) by repeatedly
+searching groups that contain the previously resolved group DN as a member.
+
+For Active Directory deployments, you can additionally enable
+`ldap.group-search-use-matching-rule-in-chain=true` to delegate nested group
+resolution to LDAP itself (this is only relevant when nested group resolution
+is enabled).
 
 In case of attribute-based group resolution, Trino reads the group list
 directly from a user attribute. This requires the following property:

--- a/docs/src/main/sphinx/security/group-mapping.md
+++ b/docs/src/main/sphinx/security/group-mapping.md
@@ -158,7 +158,20 @@ include the user DN. This requires the following properties:
 * - `ldap.group-search-member-attribute`
   - Attribute from group documents used for filtering by member. For example,
     `cn`.
+* - `ldap.group-search-mode`
+  - Group resolution mode. Supported values are `DIRECT`, `RECURSIVE`, and
+    `MATCHING_RULE_IN_CHAIN`. Defaults to `DIRECT`.
 :::
+
+The `DIRECT` mode returns only direct groups.
+
+The `RECURSIVE` mode recursively resolves
+nested group memberships (for example user → group A → group B) by repeatedly
+searching groups that contain the previously resolved group DN as a member.
+
+For Active Directory deployments, use `MATCHING_RULE_IN_CHAIN` to delegate
+nested group resolution to LDAP with the `LDAP_MATCHING_RULE_IN_CHAIN` matching
+rule (`1.2.840.113556.1.4.1941`).
 
 In case of attribute-based group resolution, Trino reads the group list
 directly from a user attribute. This requires the following property:
@@ -172,6 +185,11 @@ directly from a user attribute. This requires the following property:
 * - `ldap.user-member-of-attribute`
   - Group membership attribute in user documents. For example, `memberOf`.
 :::
+
+Nested group resolution is only supported with search-based group resolution.
+With attribute-based group resolution, Trino returns the groups provided by the
+configured user membership attribute and does not recursively resolve group
+membership.
 
 ### Example configurations
 

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/DirectLdapGroupResolver.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/DirectLdapGroupResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.ldapgroup;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+
+import javax.naming.NamingException;
+
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+final class DirectLdapGroupResolver
+        implements LdapGroupResolver
+{
+    private static final Logger log = Logger.get(LdapFilteringGroupProvider.class);
+
+    private final LdapGroupSearch groupSearch;
+
+    @Inject
+    public DirectLdapGroupResolver(LdapGroupSearch groupSearch)
+    {
+        this.groupSearch = requireNonNull(groupSearch, "groupSearch is null");
+    }
+
+    @Override
+    public Set<String> resolveGroups(String user, String memberDistinguishedName)
+    {
+        try {
+            return groupSearch.searchGroups(memberDistinguishedName).stream()
+                    .map(LdapGroup::name)
+                    .collect(toImmutableSet());
+        }
+        catch (NamingException e) {
+            log.error(e, "LDAP search for user [%s] groups failed", user);
+            return ImmutableSet.of();
+        }
+    }
+}

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
@@ -67,8 +67,8 @@ public class LdapFilteringGroupProvider
         this.groupsNameAttribute = config.getLdapGroupsNameAttribute();
 
         String groupsSearchMemberAttribute = filteringConfig.getLdapGroupsSearchMemberAttribute();
-        this.enableNestedGroups = filteringConfig.isLdapGroupSearchEnableNestedGroups();
-        this.useMatchingRuleInChain = filteringConfig.isLdapGroupSearchUseMatchingRuleInChain();
+        this.enableNestedGroups = filteringConfig.isLdapGroupSearchNestedEnabled();
+        this.useMatchingRuleInChain = filteringConfig.isLdapGroupSearchNestedUseMatchingRuleInChain();
         String groupSearchMemberPredicate = useMatchingRuleInChain
                 ? String.format("%s:%s:={0}", groupsSearchMemberAttribute, LDAP_MATCHING_RULE_IN_CHAIN)
                 : String.format("%s={0}", groupsSearchMemberAttribute);
@@ -217,16 +217,21 @@ public class LdapFilteringGroupProvider
             throws NamingException
     {
         ImmutableSet.Builder<LdapGroup> groups = ImmutableSet.builder();
+        boolean missingConfiguredNameAttribute = false;
         while (search.hasMore()) {
             SearchResult groupResult = search.next();
             Attribute groupName = groupResult.getAttributes().get(groupsNameAttribute);
             if (groupName == null) {
-                log.warn("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
+                missingConfiguredNameAttribute = true;
+                log.debug("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
                 groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupResult.getNameInNamespace()));
             }
             else {
                 groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupName.get().toString()));
             }
+        }
+        if (missingConfiguredNameAttribute) {
+            log.warn("Some LDAP group objects do not have configured group name attribute [%s]. Falling back on object full name.", groupsNameAttribute);
         }
         return groups.build();
     }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
@@ -20,19 +20,26 @@ import io.trino.plugin.base.ldap.LdapClient;
 import io.trino.plugin.base.ldap.LdapQuery;
 import io.trino.spi.security.GroupProvider;
 
+import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.SearchResult;
 
+import java.util.ArrayDeque;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 public class LdapFilteringGroupProvider
         implements GroupProvider
 {
     private static final Logger log = Logger.get(LdapFilteringGroupProvider.class);
+
+    private static final String LDAP_MATCHING_RULE_IN_CHAIN = "1.2.840.113556.1.4.1941";
 
     private final LdapClient ldapClient;
     private final String ldapAdminUser;
@@ -42,6 +49,8 @@ public class LdapFilteringGroupProvider
     private final String groupBaseDN;
     private final String groupsNameAttribute;
     private final String combinedGroupSearchFilter;
+    private final boolean enableNestedGroups;
+    private final boolean useMatchingRuleInChain;
 
     @Inject
     public LdapFilteringGroupProvider(
@@ -58,13 +67,19 @@ public class LdapFilteringGroupProvider
         this.groupsNameAttribute = config.getLdapGroupsNameAttribute();
 
         String groupsSearchMemberAttribute = filteringConfig.getLdapGroupsSearchMemberAttribute();
+        this.enableNestedGroups = filteringConfig.isLdapGroupSearchEnableNestedGroups();
+        this.useMatchingRuleInChain = filteringConfig.isLdapGroupSearchUseMatchingRuleInChain();
+        String groupSearchMemberPredicate = useMatchingRuleInChain
+                ? String.format("%s:%s:={0}", groupsSearchMemberAttribute, LDAP_MATCHING_RULE_IN_CHAIN)
+                : String.format("%s={0}", groupsSearchMemberAttribute);
+
         combinedGroupSearchFilter = filteringConfig.getLdapGroupsSearchFilter()
-                .map(filter -> String.format("(&(%s)(%s={0}))", filter, groupsSearchMemberAttribute))
-                .orElse(String.format("(%s={0})", groupsSearchMemberAttribute));
+                .map(filter -> String.format("(&(%s)(%s))", filter, groupSearchMemberPredicate))
+                .orElse(String.format("(%s)", groupSearchMemberPredicate));
     }
 
     /**
-     * Perform an LDAP search for groups, fetching only the names, and returning the name of each group.
+     * Resolve direct and nested LDAP groups for the provided user.
      * Filters groups by user membership AND filter expression {@link LdapFilteringGroupProviderConfig#getLdapGroupsSearchFilter()}.
      * If {@link LdapGroupProviderConfig#getLdapGroupsNameAttribute()} is missing from group document, fallback on full name.
      * Swallows LDAP exceptions.
@@ -96,38 +111,125 @@ public class LdapFilteringGroupProvider
             return ImmutableSet.of();
         }
 
-        return userDistinguishedName.map(ldapUser -> {
+        return userDistinguishedName
+                .map(ldapUser -> {
+                    if (!enableNestedGroups) {
+                        return resolveDirectGroups(ldapUser);
+                    }
+                    return useMatchingRuleInChain ? resolveGroupsInSingleQuery(ldapUser) : resolveGroupsRecursively(ldapUser);
+                })
+                .orElse(ImmutableSet.of());
+    }
+
+    private Set<String> resolveDirectGroups(String memberDistinguishedName)
+    {
+        try {
+            return ldapClient.executeLdapQuery(ldapAdminUser, ldapAdminPassword,
+                    new LdapQuery.LdapQueryBuilder()
+                            .withSearchBase(groupBaseDN)
+                            .withAttributes(groupsNameAttribute)
+                            .withSearchFilter(combinedGroupSearchFilter)
+                            .withFilterArguments(memberDistinguishedName)
+                            .build(),
+                    search -> {
+                        if (!search.hasMore()) {
+                            log.debug("No groups found using search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, memberDistinguishedName);
+                        }
+                        return extractGroups(search).stream()
+                                .map(LdapGroup::name)
+                                .collect(toImmutableSet());
+                    });
+        }
+        catch (NamingException e) {
+            log.error(e, "LDAP group search for member [%s] failed", memberDistinguishedName);
+            return ImmutableSet.of();
+        }
+    }
+
+    private Set<String> resolveGroupsRecursively(String memberDistinguishedName)
+    {
+        Queue<String> membersToResolve = new ArrayDeque<>();
+        membersToResolve.add(memberDistinguishedName);
+        Set<String> visitedMembers = new HashSet<>();
+        Set<String> groups = new HashSet<>();
+
+        while (!membersToResolve.isEmpty()) {
+            String currentMember = membersToResolve.remove();
+            if (!visitedMembers.add(currentMember)) {
+                continue;
+            }
+
             try {
-                return ldapClient.executeLdapQuery(ldapAdminUser, ldapAdminPassword,
+                Set<LdapGroup> groupsForMember = ldapClient.executeLdapQuery(ldapAdminUser, ldapAdminPassword,
                         new LdapQuery.LdapQueryBuilder()
                                 .withSearchBase(groupBaseDN)
                                 .withAttributes(groupsNameAttribute)
                                 .withSearchFilter(combinedGroupSearchFilter)
-                                .withFilterArguments(ldapUser)
+                                .withFilterArguments(currentMember)
                                 .build(),
-                        search -> {
-                            if (!search.hasMore()) {
-                                log.debug("No groups found using search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, ldapUser);
-                            }
-                            ImmutableSet.Builder<String> groupsBuilder = ImmutableSet.builder();
-                            while (search.hasMore()) {
-                                SearchResult groupResult = search.next();
-                                Attribute groupName = groupResult.getAttributes().get(groupsNameAttribute);
-                                if (groupName == null) {
-                                    log.warn("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
-                                    groupsBuilder.add(groupResult.getNameInNamespace());
-                                }
-                                else {
-                                    groupsBuilder.add(groupName.get().toString());
-                                }
-                            }
-                            return groupsBuilder.build();
-                        });
+                                search -> {
+                                    if (!search.hasMore()) {
+                                        log.debug("No groups found using search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, currentMember);
+                                    }
+                                    return extractGroups(search);
+                                });
+
+                groupsForMember.forEach(group -> {
+                    groups.add(group.name());
+                    membersToResolve.add(group.distinguishedName());
+                });
             }
             catch (NamingException e) {
-                log.error(e, "LDAP search for user [%s] groups failed", user);
-                return ImmutableSet.<String>of();
+                log.error(e, "LDAP group search for member [%s] failed", currentMember);
+                return ImmutableSet.of();
             }
-        }).orElse(ImmutableSet.of());
+        }
+
+        return ImmutableSet.copyOf(groups);
     }
+
+    private Set<String> resolveGroupsInSingleQuery(String memberDistinguishedName)
+    {
+        try {
+            return ldapClient.executeLdapQuery(ldapAdminUser, ldapAdminPassword,
+                    new LdapQuery.LdapQueryBuilder()
+                            .withSearchBase(groupBaseDN)
+                            .withAttributes(groupsNameAttribute)
+                            .withSearchFilter(combinedGroupSearchFilter)
+                            .withFilterArguments(memberDistinguishedName)
+                            .build(),
+                    search -> {
+                        if (!search.hasMore()) {
+                            log.debug("No groups found using LDAP_MATCHING_RULE_IN_CHAIN search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, memberDistinguishedName);
+                        }
+                        return extractGroups(search).stream()
+                                .map(LdapGroup::name)
+                                .collect(toImmutableSet());
+                    });
+        }
+        catch (NamingException e) {
+            log.error(e, "LDAP group search for member [%s] failed", memberDistinguishedName);
+            return ImmutableSet.of();
+        }
+    }
+
+    private Set<LdapGroup> extractGroups(NamingEnumeration<SearchResult> search)
+            throws NamingException
+    {
+        ImmutableSet.Builder<LdapGroup> groups = ImmutableSet.builder();
+        while (search.hasMore()) {
+            SearchResult groupResult = search.next();
+            Attribute groupName = groupResult.getAttributes().get(groupsNameAttribute);
+            if (groupName == null) {
+                log.warn("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
+                groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupResult.getNameInNamespace()));
+            }
+            else {
+                groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupName.get().toString()));
+            }
+        }
+        return groups.build();
+    }
+
+    private record LdapGroup(String distinguishedName, String name) {}
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
@@ -21,7 +21,6 @@ import io.trino.plugin.base.ldap.LdapQuery;
 import io.trino.spi.security.GroupProvider;
 
 import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
 import javax.naming.directory.SearchResult;
 
 import java.util.Optional;
@@ -35,32 +34,24 @@ public class LdapFilteringGroupProvider
     private static final Logger log = Logger.get(LdapFilteringGroupProvider.class);
 
     private final LdapClient ldapClient;
+    private final LdapGroupResolver ldapGroupResolver;
     private final String ldapAdminUser;
     private final String ldapAdminPassword;
     private final String userBaseDN;
     private final String userSearchFilter;
-    private final String groupBaseDN;
-    private final String groupsNameAttribute;
-    private final String combinedGroupSearchFilter;
 
     @Inject
     public LdapFilteringGroupProvider(
             LdapClient ldapClient,
-            LdapGroupProviderConfig config,
-            LdapFilteringGroupProviderConfig filteringConfig)
+            LdapGroupResolver ldapGroupResolver,
+            LdapGroupProviderConfig config)
     {
         this.ldapClient = requireNonNull(ldapClient, "ldapClient is null");
+        this.ldapGroupResolver = requireNonNull(ldapGroupResolver, "ldapGroupResolver is null");
         this.ldapAdminUser = config.getLdapAdminUser();
         this.ldapAdminPassword = config.getLdapAdminPassword();
         this.userBaseDN = config.getLdapUserBaseDN();
         this.userSearchFilter = config.getLdapUserSearchFilter();
-        this.groupBaseDN = filteringConfig.getLdapGroupBaseDN();
-        this.groupsNameAttribute = config.getLdapGroupsNameAttribute();
-
-        String groupsSearchMemberAttribute = filteringConfig.getLdapGroupsSearchMemberAttribute();
-        combinedGroupSearchFilter = filteringConfig.getLdapGroupsSearchFilter()
-                .map(filter -> String.format("(&(%s)(%s={0}))", filter, groupsSearchMemberAttribute))
-                .orElse(String.format("(%s={0})", groupsSearchMemberAttribute));
     }
 
     /**
@@ -98,40 +89,8 @@ public class LdapFilteringGroupProvider
             return ImmutableSet.of();
         }
 
-        return userDistinguishedName.map(ldapUser -> {
-            try {
-                return ldapClient.executeLdapQuery(
-                        ldapAdminUser,
-                        ldapAdminPassword,
-                        new LdapQuery.LdapQueryBuilder()
-                                .withSearchBase(groupBaseDN)
-                                .withAttributes(groupsNameAttribute)
-                                .withSearchFilter(combinedGroupSearchFilter)
-                                .withFilterArguments(ldapUser)
-                                .build(),
-                        search -> {
-                            if (!search.hasMore()) {
-                                log.debug("No groups found using search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, ldapUser);
-                            }
-                            ImmutableSet.Builder<String> groupsBuilder = ImmutableSet.builder();
-                            while (search.hasMore()) {
-                                SearchResult groupResult = search.next();
-                                Attribute groupName = groupResult.getAttributes().get(groupsNameAttribute);
-                                if (groupName == null) {
-                                    log.warn("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
-                                    groupsBuilder.add(groupResult.getNameInNamespace());
-                                }
-                                else {
-                                    groupsBuilder.add(groupName.get().toString());
-                                }
-                            }
-                            return groupsBuilder.build();
-                        });
-            }
-            catch (NamingException e) {
-                log.error(e, "LDAP search for user [%s] groups failed", user);
-                return ImmutableSet.<String>of();
-            }
-        }).orElse(ImmutableSet.of());
+        return userDistinguishedName
+                .map(memberDistinguishedName -> ldapGroupResolver.resolveGroups(user, memberDistinguishedName))
+                .orElse(ImmutableSet.of());
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
@@ -55,7 +55,7 @@ public class LdapFilteringGroupProvider
     }
 
     /**
-     * Perform an LDAP search for groups, fetching only the names, and returning the name of each group.
+     * Resolve direct and nested LDAP groups for the provided user.
      * Filters groups by user membership AND filter expression {@link LdapFilteringGroupProviderConfig#getLdapGroupsSearchFilter()}.
      * If {@link LdapGroupProviderConfig#getLdapGroupsNameAttribute()} is missing from group document, fallback on full name.
      * Swallows LDAP exceptions.
@@ -90,7 +90,7 @@ public class LdapFilteringGroupProvider
         }
 
         return userDistinguishedName
-                .map(memberDistinguishedName -> ldapGroupResolver.resolveGroups(user, memberDistinguishedName))
+                .map(ldapGroupResolver::resolveGroups)
                 .orElse(ImmutableSet.of());
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProviderConfig.java
@@ -24,8 +24,8 @@ public class LdapFilteringGroupProviderConfig
     private String ldapGroupBaseDN;
     private String ldapGroupsSearchFilter;
     private String ldapGroupsSearchMemberAttribute = "member";
-    private boolean ldapGroupSearchEnableNestedGroups;
-    private boolean ldapGroupSearchUseMatchingRuleInChain;
+    private boolean ldapGroupSearchNestedEnabled;
+    private boolean ldapGroupSearchNestedUseMatchingRuleInChain;
 
     @NotNull
     public String getLdapGroupBaseDN()
@@ -69,29 +69,29 @@ public class LdapFilteringGroupProviderConfig
         return this;
     }
 
-    public boolean isLdapGroupSearchEnableNestedGroups()
+    public boolean isLdapGroupSearchNestedEnabled()
     {
-        return ldapGroupSearchEnableNestedGroups;
+        return ldapGroupSearchNestedEnabled;
     }
 
-    @Config("ldap.group-search-enable-nested-groups")
+    @Config("ldap.group-search-nested-enabled")
     @ConfigDescription("Enable nested group resolution for search-based LDAP group provider")
-    public LdapFilteringGroupProviderConfig setLdapGroupSearchEnableNestedGroups(boolean ldapGroupSearchEnableNestedGroups)
+    public LdapFilteringGroupProviderConfig setLdapGroupSearchNestedEnabled(boolean ldapGroupSearchNestedEnabled)
     {
-        this.ldapGroupSearchEnableNestedGroups = ldapGroupSearchEnableNestedGroups;
+        this.ldapGroupSearchNestedEnabled = ldapGroupSearchNestedEnabled;
         return this;
     }
 
-    public boolean isLdapGroupSearchUseMatchingRuleInChain()
+    public boolean isLdapGroupSearchNestedUseMatchingRuleInChain()
     {
-        return ldapGroupSearchUseMatchingRuleInChain;
+        return ldapGroupSearchNestedUseMatchingRuleInChain;
     }
 
-    @Config("ldap.group-search-use-matching-rule-in-chain")
+    @Config("ldap.group-search-nested-use-matching-rule-in-chain")
     @ConfigDescription("Enable Active Directory LDAP_MATCHING_RULE_IN_CHAIN (1.2.840.113556.1.4.1941) for nested group resolution")
-    public LdapFilteringGroupProviderConfig setLdapGroupSearchUseMatchingRuleInChain(boolean ldapGroupSearchUseMatchingRuleInChain)
+    public LdapFilteringGroupProviderConfig setLdapGroupSearchNestedUseMatchingRuleInChain(boolean ldapGroupSearchNestedUseMatchingRuleInChain)
     {
-        this.ldapGroupSearchUseMatchingRuleInChain = ldapGroupSearchUseMatchingRuleInChain;
+        this.ldapGroupSearchNestedUseMatchingRuleInChain = ldapGroupSearchNestedUseMatchingRuleInChain;
         return this;
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProviderConfig.java
@@ -24,6 +24,8 @@ public class LdapFilteringGroupProviderConfig
     private String ldapGroupBaseDN;
     private String ldapGroupsSearchFilter;
     private String ldapGroupsSearchMemberAttribute = "member";
+    private boolean ldapGroupSearchEnableNestedGroups;
+    private boolean ldapGroupSearchUseMatchingRuleInChain;
 
     @NotNull
     public String getLdapGroupBaseDN()
@@ -64,6 +66,32 @@ public class LdapFilteringGroupProviderConfig
     public LdapFilteringGroupProviderConfig setLdapGroupsSearchMemberAttribute(String ldapGroupsSearchMemberAttribute)
     {
         this.ldapGroupsSearchMemberAttribute = ldapGroupsSearchMemberAttribute;
+        return this;
+    }
+
+    public boolean isLdapGroupSearchEnableNestedGroups()
+    {
+        return ldapGroupSearchEnableNestedGroups;
+    }
+
+    @Config("ldap.group-search-enable-nested-groups")
+    @ConfigDescription("Enable nested group resolution for search-based LDAP group provider")
+    public LdapFilteringGroupProviderConfig setLdapGroupSearchEnableNestedGroups(boolean ldapGroupSearchEnableNestedGroups)
+    {
+        this.ldapGroupSearchEnableNestedGroups = ldapGroupSearchEnableNestedGroups;
+        return this;
+    }
+
+    public boolean isLdapGroupSearchUseMatchingRuleInChain()
+    {
+        return ldapGroupSearchUseMatchingRuleInChain;
+    }
+
+    @Config("ldap.group-search-use-matching-rule-in-chain")
+    @ConfigDescription("Enable Active Directory LDAP_MATCHING_RULE_IN_CHAIN (1.2.840.113556.1.4.1941) for nested group resolution")
+    public LdapFilteringGroupProviderConfig setLdapGroupSearchUseMatchingRuleInChain(boolean ldapGroupSearchUseMatchingRuleInChain)
+    {
+        this.ldapGroupSearchUseMatchingRuleInChain = ldapGroupSearchUseMatchingRuleInChain;
         return this;
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProviderConfig.java
@@ -21,9 +21,17 @@ import java.util.Optional;
 
 public class LdapFilteringGroupProviderConfig
 {
+    public enum LdapGroupSearchMode
+    {
+        DIRECT,
+        RECURSIVE,
+        MATCHING_RULE_IN_CHAIN,
+    }
+
     private String ldapGroupBaseDN;
     private String ldapGroupsSearchFilter;
     private String ldapGroupsSearchMemberAttribute = "member";
+    private LdapGroupSearchMode ldapGroupSearchMode = LdapGroupSearchMode.DIRECT;
 
     @NotNull
     public String getLdapGroupBaseDN()
@@ -64,6 +72,20 @@ public class LdapFilteringGroupProviderConfig
     public LdapFilteringGroupProviderConfig setLdapGroupsSearchMemberAttribute(String ldapGroupsSearchMemberAttribute)
     {
         this.ldapGroupsSearchMemberAttribute = ldapGroupsSearchMemberAttribute;
+        return this;
+    }
+
+    @NotNull
+    public LdapGroupSearchMode getLdapGroupSearchMode()
+    {
+        return ldapGroupSearchMode;
+    }
+
+    @Config("ldap.group-search-mode")
+    @ConfigDescription("LDAP group resolution mode")
+    public LdapFilteringGroupProviderConfig setLdapGroupSearchMode(LdapGroupSearchMode ldapGroupSearchMode)
+    {
+        this.ldapGroupSearchMode = ldapGroupSearchMode;
         return this;
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroup.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroup.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.ldapgroup;
+
+import static java.util.Objects.requireNonNull;
+
+record LdapGroup(String distinguishedName, String name)
+{
+    LdapGroup
+    {
+        requireNonNull(distinguishedName, "distinguishedName is null");
+        requireNonNull(name, "name is null");
+    }
+}

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
@@ -30,6 +30,8 @@ public class LdapGroupProviderModule
 
         if (buildConfigObject(LdapGroupProviderConfig.class).getLdapUseGroupFilter()) {
             configBinder(binder).bindConfig(LdapFilteringGroupProviderConfig.class);
+            binder.bind(LdapGroupSearch.class).in(Scopes.SINGLETON);
+            binder.bind(LdapGroupResolver.class).to(DirectLdapGroupResolver.class).in(Scopes.SINGLETON);
             binder.bind(GroupProvider.class).to(LdapFilteringGroupProvider.class).in(Scopes.SINGLETON);
         }
         else {

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
@@ -30,13 +30,22 @@ public class LdapGroupProviderModule
 
         if (buildConfigObject(LdapGroupProviderConfig.class).getLdapUseGroupFilter()) {
             configBinder(binder).bindConfig(LdapFilteringGroupProviderConfig.class);
-            binder.bind(LdapGroupSearch.class).in(Scopes.SINGLETON);
-            binder.bind(LdapGroupResolver.class).to(DirectLdapGroupResolver.class).in(Scopes.SINGLETON);
+            bindLdapGroupResolver(binder, buildConfigObject(LdapFilteringGroupProviderConfig.class));
             binder.bind(GroupProvider.class).to(LdapFilteringGroupProvider.class).in(Scopes.SINGLETON);
         }
         else {
             configBinder(binder).bindConfig(LdapSingleQueryGroupProviderConfig.class);
             binder.bind(GroupProvider.class).to(LdapSingleQueryGroupProvider.class).in(Scopes.SINGLETON);
         }
+    }
+
+    private static void bindLdapGroupResolver(Binder binder, LdapFilteringGroupProviderConfig config)
+    {
+        binder.bind(LdapGroupSearch.class).in(Scopes.SINGLETON);
+        binder.bind(LdapGroupResolver.class).to(switch (config.getLdapGroupSearchMode()) {
+            case DIRECT -> DirectLdapGroupResolver.class;
+            case RECURSIVE -> RecursiveLdapGroupResolver.class;
+            case MATCHING_RULE_IN_CHAIN -> MatchingRuleInChainLdapGroupResolver.class;
+        }).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupResolver.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupResolver.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.ldapgroup;
+
+import java.util.Set;
+
+interface LdapGroupResolver
+{
+    Set<String> resolveGroups(String user, String memberDistinguishedName);
+}

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupResolver.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupResolver.java
@@ -17,5 +17,5 @@ import java.util.Set;
 
 interface LdapGroupResolver
 {
-    Set<String> resolveGroups(String user, String memberDistinguishedName);
+    Set<String> resolveGroups(String memberDistinguishedName);
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupSearch.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupSearch.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.ldapgroup;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.plugin.base.ldap.LdapClient;
+import io.trino.plugin.base.ldap.LdapQuery;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.SearchResult;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+final class LdapGroupSearch
+{
+    private static final Logger log = Logger.get(LdapFilteringGroupProvider.class);
+
+    private final LdapClient ldapClient;
+    private final String ldapAdminUser;
+    private final String ldapAdminPassword;
+    private final String groupBaseDN;
+    private final String groupsNameAttribute;
+    private final String combinedGroupSearchFilter;
+
+    @Inject
+    public LdapGroupSearch(
+            LdapClient ldapClient,
+            LdapGroupProviderConfig config,
+            LdapFilteringGroupProviderConfig filteringConfig)
+    {
+        this.ldapClient = requireNonNull(ldapClient, "ldapClient is null");
+        this.ldapAdminUser = config.getLdapAdminUser();
+        this.ldapAdminPassword = config.getLdapAdminPassword();
+        this.groupBaseDN = filteringConfig.getLdapGroupBaseDN();
+        this.groupsNameAttribute = config.getLdapGroupsNameAttribute();
+
+        String groupsSearchMemberAttribute = filteringConfig.getLdapGroupsSearchMemberAttribute();
+        this.combinedGroupSearchFilter = filteringConfig.getLdapGroupsSearchFilter()
+                .map(filter -> String.format("(&(%s)(%s={0}))", filter, groupsSearchMemberAttribute))
+                .orElse(String.format("(%s={0})", groupsSearchMemberAttribute));
+    }
+
+    public Set<LdapGroup> searchGroups(String memberDistinguishedName)
+            throws NamingException
+    {
+        return ldapClient.executeLdapQuery(
+                ldapAdminUser,
+                ldapAdminPassword,
+                new LdapQuery.LdapQueryBuilder()
+                        .withSearchBase(groupBaseDN)
+                        .withAttributes(groupsNameAttribute)
+                        .withSearchFilter(combinedGroupSearchFilter)
+                        .withFilterArguments(memberDistinguishedName)
+                        .build(),
+                search -> {
+                    if (!search.hasMore()) {
+                        log.debug("No groups found using search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, memberDistinguishedName);
+                    }
+                    return extractGroups(search);
+                });
+    }
+
+    private Set<LdapGroup> extractGroups(NamingEnumeration<SearchResult> search)
+            throws NamingException
+    {
+        ImmutableSet.Builder<LdapGroup> groups = ImmutableSet.builder();
+        while (search.hasMore()) {
+            SearchResult groupResult = search.next();
+            Attribute groupName = groupResult.getAttributes().get(groupsNameAttribute);
+            if (groupName == null) {
+                log.warn("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
+                groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupResult.getNameInNamespace()));
+            }
+            else {
+                groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupName.get().toString()));
+            }
+        }
+        return groups.build();
+    }
+}

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupSearch.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupSearch.java
@@ -30,14 +30,14 @@ import static java.util.Objects.requireNonNull;
 
 final class LdapGroupSearch
 {
-    private static final Logger log = Logger.get(LdapFilteringGroupProvider.class);
+    private static final Logger log = Logger.get(LdapGroupSearch.class);
 
     private final LdapClient ldapClient;
     private final String ldapAdminUser;
     private final String ldapAdminPassword;
     private final String groupBaseDN;
     private final String groupsNameAttribute;
-    private final String combinedGroupSearchFilter;
+    private final String groupsSearchFilter;
 
     @Inject
     public LdapGroupSearch(
@@ -50,16 +50,15 @@ final class LdapGroupSearch
         this.ldapAdminPassword = config.getLdapAdminPassword();
         this.groupBaseDN = filteringConfig.getLdapGroupBaseDN();
         this.groupsNameAttribute = config.getLdapGroupsNameAttribute();
-
-        String groupsSearchMemberAttribute = filteringConfig.getLdapGroupsSearchMemberAttribute();
-        this.combinedGroupSearchFilter = filteringConfig.getLdapGroupsSearchFilter()
-                .map(filter -> String.format("(&(%s)(%s={0}))", filter, groupsSearchMemberAttribute))
-                .orElse(String.format("(%s={0})", groupsSearchMemberAttribute));
+        this.groupsSearchFilter = filteringConfig.getLdapGroupsSearchFilter().orElse(null);
     }
 
-    public Set<LdapGroup> searchGroups(String memberDistinguishedName)
+    public Set<LdapGroup> searchGroups(String memberDistinguishedName, String groupSearchMemberPredicate, String searchDescription)
             throws NamingException
     {
+        String combinedGroupSearchFilter = groupsSearchFilter == null
+                ? String.format("(%s)", groupSearchMemberPredicate)
+                : String.format("(&(%s)(%s))", groupsSearchFilter, groupSearchMemberPredicate);
         return ldapClient.executeLdapQuery(
                 ldapAdminUser,
                 ldapAdminPassword,
@@ -71,7 +70,7 @@ final class LdapGroupSearch
                         .build(),
                 search -> {
                     if (!search.hasMore()) {
-                        log.debug("No groups found using search [pattern=%s, arguments={%s}]", combinedGroupSearchFilter, memberDistinguishedName);
+                        log.debug("No groups found using %s [pattern=%s, arguments={%s}]", searchDescription, combinedGroupSearchFilter, memberDistinguishedName);
                     }
                     return extractGroups(search);
                 });
@@ -81,16 +80,21 @@ final class LdapGroupSearch
             throws NamingException
     {
         ImmutableSet.Builder<LdapGroup> groups = ImmutableSet.builder();
+        boolean missingConfiguredNameAttribute = false;
         while (search.hasMore()) {
             SearchResult groupResult = search.next();
             Attribute groupName = groupResult.getAttributes().get(groupsNameAttribute);
             if (groupName == null) {
-                log.warn("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
+                missingConfiguredNameAttribute = true;
+                log.debug("The group object [%s] does not have group name attribute [%s]. Falling back on object full name.", groupResult, groupsNameAttribute);
                 groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupResult.getNameInNamespace()));
             }
             else {
                 groups.add(new LdapGroup(groupResult.getNameInNamespace(), groupName.get().toString()));
             }
+        }
+        if (missingConfiguredNameAttribute) {
+            log.warn("Some LDAP group objects do not have configured group name attribute [%s]. Falling back on object full name.", groupsNameAttribute);
         }
         return groups.build();
     }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/MatchingRuleInChainLdapGroupResolver.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/MatchingRuleInChainLdapGroupResolver.java
@@ -24,28 +24,29 @@ import java.util.Set;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
-final class DirectLdapGroupResolver
+final class MatchingRuleInChainLdapGroupResolver
         implements LdapGroupResolver
 {
-    private static final Logger log = Logger.get(DirectLdapGroupResolver.class);
+    private static final String LDAP_MATCHING_RULE_IN_CHAIN = "1.2.840.113556.1.4.1941";
+    private static final Logger log = Logger.get(MatchingRuleInChainLdapGroupResolver.class);
 
     private final LdapGroupSearch groupSearch;
     private final String groupSearchMemberPredicate;
 
     @Inject
-    public DirectLdapGroupResolver(
+    public MatchingRuleInChainLdapGroupResolver(
             LdapGroupSearch groupSearch,
             LdapFilteringGroupProviderConfig filteringConfig)
     {
         this.groupSearch = requireNonNull(groupSearch, "groupSearch is null");
-        this.groupSearchMemberPredicate = String.format("%s={0}", filteringConfig.getLdapGroupsSearchMemberAttribute());
+        this.groupSearchMemberPredicate = String.format("%s:%s:={0}", filteringConfig.getLdapGroupsSearchMemberAttribute(), LDAP_MATCHING_RULE_IN_CHAIN);
     }
 
     @Override
     public Set<String> resolveGroups(String memberDistinguishedName)
     {
         try {
-            return groupSearch.searchGroups(memberDistinguishedName, groupSearchMemberPredicate, "search").stream()
+            return groupSearch.searchGroups(memberDistinguishedName, groupSearchMemberPredicate, "LDAP_MATCHING_RULE_IN_CHAIN search").stream()
                     .map(LdapGroup::name)
                     .collect(toImmutableSet());
         }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/RecursiveLdapGroupResolver.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/RecursiveLdapGroupResolver.java
@@ -19,21 +19,23 @@ import io.airlift.log.Logger;
 
 import javax.naming.NamingException;
 
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Queue;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
-final class DirectLdapGroupResolver
+final class RecursiveLdapGroupResolver
         implements LdapGroupResolver
 {
-    private static final Logger log = Logger.get(DirectLdapGroupResolver.class);
+    private static final Logger log = Logger.get(RecursiveLdapGroupResolver.class);
 
     private final LdapGroupSearch groupSearch;
     private final String groupSearchMemberPredicate;
 
     @Inject
-    public DirectLdapGroupResolver(
+    public RecursiveLdapGroupResolver(
             LdapGroupSearch groupSearch,
             LdapFilteringGroupProviderConfig filteringConfig)
     {
@@ -44,14 +46,30 @@ final class DirectLdapGroupResolver
     @Override
     public Set<String> resolveGroups(String memberDistinguishedName)
     {
-        try {
-            return groupSearch.searchGroups(memberDistinguishedName, groupSearchMemberPredicate, "search").stream()
-                    .map(LdapGroup::name)
-                    .collect(toImmutableSet());
+        Queue<String> membersToResolve = new ArrayDeque<>();
+        membersToResolve.add(memberDistinguishedName);
+        Set<String> visitedMembers = new HashSet<>();
+        Set<String> groups = new HashSet<>();
+
+        while (!membersToResolve.isEmpty()) {
+            String currentMember = membersToResolve.remove();
+            if (!visitedMembers.add(currentMember)) {
+                continue;
+            }
+
+            try {
+                Set<LdapGroup> groupsForMember = groupSearch.searchGroups(currentMember, groupSearchMemberPredicate, "search");
+                groupsForMember.forEach(group -> {
+                    groups.add(group.name());
+                    membersToResolve.add(group.distinguishedName());
+                });
+            }
+            catch (NamingException e) {
+                log.error(e, "LDAP group search for member [%s] failed", currentMember);
+                return ImmutableSet.of();
+            }
         }
-        catch (NamingException e) {
-            log.error(e, "LDAP group search for member [%s] failed", memberDistinguishedName);
-            return ImmutableSet.of();
-        }
+
+        return ImmutableSet.copyOf(groups);
     }
 }

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapFilteringGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapFilteringGroupProviderConfig.java
@@ -31,8 +31,8 @@ final class TestLdapFilteringGroupProviderConfig
                 .setLdapGroupBaseDN(null)
                 .setLdapGroupsSearchFilter(null)
                 .setLdapGroupsSearchMemberAttribute("member")
-                .setLdapGroupSearchEnableNestedGroups(false)
-                .setLdapGroupSearchUseMatchingRuleInChain(false));
+                .setLdapGroupSearchNestedEnabled(false)
+                .setLdapGroupSearchNestedUseMatchingRuleInChain(false));
     }
 
     @Test
@@ -42,15 +42,15 @@ final class TestLdapFilteringGroupProviderConfig
                 "ldap.group-base-dn", "ou=group,dc=trino,dc=io",
                 "ldap.group-search-filter", "(cn=dev*)",
                 "ldap.group-search-member-attribute", "memberUser",
-                "ldap.group-search-enable-nested-groups", "true",
-                "ldap.group-search-use-matching-rule-in-chain", "true");
+                "ldap.group-search-nested-enabled", "true",
+                "ldap.group-search-nested-use-matching-rule-in-chain", "true");
 
         LdapFilteringGroupProviderConfig expected = new LdapFilteringGroupProviderConfig()
                 .setLdapGroupBaseDN("ou=group,dc=trino,dc=io")
                 .setLdapGroupsSearchFilter("(cn=dev*)")
                 .setLdapGroupsSearchMemberAttribute("memberUser")
-                .setLdapGroupSearchEnableNestedGroups(true)
-                .setLdapGroupSearchUseMatchingRuleInChain(true);
+                .setLdapGroupSearchNestedEnabled(true)
+                .setLdapGroupSearchNestedUseMatchingRuleInChain(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapFilteringGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapFilteringGroupProviderConfig.java
@@ -30,7 +30,9 @@ final class TestLdapFilteringGroupProviderConfig
         assertRecordedDefaults(recordDefaults(LdapFilteringGroupProviderConfig.class)
                 .setLdapGroupBaseDN(null)
                 .setLdapGroupsSearchFilter(null)
-                .setLdapGroupsSearchMemberAttribute("member"));
+                .setLdapGroupsSearchMemberAttribute("member")
+                .setLdapGroupSearchEnableNestedGroups(false)
+                .setLdapGroupSearchUseMatchingRuleInChain(false));
     }
 
     @Test
@@ -39,12 +41,16 @@ final class TestLdapFilteringGroupProviderConfig
         Map<String, String> properties = ImmutableMap.of(
                 "ldap.group-base-dn", "ou=group,dc=trino,dc=io",
                 "ldap.group-search-filter", "(cn=dev*)",
-                "ldap.group-search-member-attribute", "memberUser");
+                "ldap.group-search-member-attribute", "memberUser",
+                "ldap.group-search-enable-nested-groups", "true",
+                "ldap.group-search-use-matching-rule-in-chain", "true");
 
         LdapFilteringGroupProviderConfig expected = new LdapFilteringGroupProviderConfig()
                 .setLdapGroupBaseDN("ou=group,dc=trino,dc=io")
                 .setLdapGroupsSearchFilter("(cn=dev*)")
-                .setLdapGroupsSearchMemberAttribute("memberUser");
+                .setLdapGroupsSearchMemberAttribute("memberUser")
+                .setLdapGroupSearchEnableNestedGroups(true)
+                .setLdapGroupSearchUseMatchingRuleInChain(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapFilteringGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapFilteringGroupProviderConfig.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.ldapgroup.LdapFilteringGroupProviderConfig.LdapGroupSearchMode.DIRECT;
+import static io.trino.plugin.ldapgroup.LdapFilteringGroupProviderConfig.LdapGroupSearchMode.MATCHING_RULE_IN_CHAIN;
 
 final class TestLdapFilteringGroupProviderConfig
 {
@@ -30,7 +32,8 @@ final class TestLdapFilteringGroupProviderConfig
         assertRecordedDefaults(recordDefaults(LdapFilteringGroupProviderConfig.class)
                 .setLdapGroupBaseDN(null)
                 .setLdapGroupsSearchFilter(null)
-                .setLdapGroupsSearchMemberAttribute("member"));
+                .setLdapGroupsSearchMemberAttribute("member")
+                .setLdapGroupSearchMode(DIRECT));
     }
 
     @Test
@@ -39,12 +42,14 @@ final class TestLdapFilteringGroupProviderConfig
         Map<String, String> properties = ImmutableMap.of(
                 "ldap.group-base-dn", "ou=group,dc=trino,dc=io",
                 "ldap.group-search-filter", "(cn=dev*)",
-                "ldap.group-search-member-attribute", "memberUser");
+                "ldap.group-search-member-attribute", "memberUser",
+                "ldap.group-search-mode", "MATCHING_RULE_IN_CHAIN");
 
         LdapFilteringGroupProviderConfig expected = new LdapFilteringGroupProviderConfig()
                 .setLdapGroupBaseDN("ou=group,dc=trino,dc=io")
                 .setLdapGroupsSearchFilter("(cn=dev*)")
-                .setLdapGroupsSearchMemberAttribute("memberUser");
+                .setLdapGroupsSearchMemberAttribute("memberUser")
+                .setLdapGroupSearchMode(MATCHING_RULE_IN_CHAIN);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
@@ -60,7 +60,7 @@ public class TestLdapGroupProviderIntegration
     private static final ConfigBuilder WITH_GROUP_FILTER_NESTED = builder -> {
         builder.put("ldap.use-group-filter", "true");
         builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
-        builder.put("ldap.group-search-enable-nested-groups", "true");
+        builder.put("ldap.group-search-nested-enabled", "true");
         return builder;
     };
 
@@ -164,7 +164,7 @@ public class TestLdapGroupProviderIntegration
                 .put("ldap.group-search-member-attribute", "member")
                 .put("ldap.group-name-attribute", "cn")
                 .put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com")
-                .put("ldap.group-search-enable-nested-groups", "true")
+                .put("ldap.group-search-nested-enabled", "true")
                 .put("ldap.group-search-filter", groupFilter)
                 .buildOrThrow();
         GroupProvider groupsProvider = factory.create(config);
@@ -201,7 +201,7 @@ public class TestLdapGroupProviderIntegration
                 .put("ldap.group-search-member-attribute", "some-attribute-that-does-not-exist")
                 .put("ldap.group-name-attribute", "cn")
                 .put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com")
-                .put("ldap.group-search-enable-nested-groups", "true")
+                .put("ldap.group-search-nested-enabled", "true")
                 .buildOrThrow();
         GroupProvider groupsProvider = factory.create(config);
 

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
@@ -46,28 +46,32 @@ public class TestLdapGroupProviderIntegration
 {
     private final LdapGroupProviderFactory factory = new LdapGroupProviderFactory();
 
-    private static final List<ConfigBuilder> CONFIG_BUILDERS;
+    private static final ConfigBuilder WITH_MEMBER_OF = builder -> {
+        builder.put("ldap.user-member-of-attribute", "memberOf");
+        return builder;
+    };
 
-    static {
-        ConfigBuilder withMemberOf = builder -> {
-            builder.put("ldap.user-member-of-attribute", "memberOf");
-            return builder;
-        };
+    private static final ConfigBuilder WITH_GROUP_FILTER = builder -> {
+        builder.put("ldap.use-group-filter", "true");
+        builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
+        return builder;
+    };
 
-        ConfigBuilder withGroupFilter = builder -> {
-            builder.put("ldap.use-group-filter", "true");
-            builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
-            return builder;
-        };
+    private static final ConfigBuilder WITH_GROUP_FILTER_NESTED = builder -> {
+        builder.put("ldap.use-group-filter", "true");
+        builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
+        builder.put("ldap.group-search-enable-nested-groups", "true");
+        return builder;
+    };
 
-        CONFIG_BUILDERS = ImmutableList.of(withMemberOf, withGroupFilter);
-    }
+    private static final List<ConfigBuilder> CONFIG_BUILDERS = ImmutableList.of(WITH_MEMBER_OF, WITH_GROUP_FILTER, WITH_GROUP_FILTER_NESTED);
 
     private Closer closer;
     private Map<String, String> baseConfig;
     private DisposableSubContext clients;
     private DisposableSubContext developers;
     private DisposableSubContext qualityAssurance;
+    private DisposableSubContext engineering;
 
     @BeforeAll
     public void setup()
@@ -107,6 +111,9 @@ public class TestLdapGroupProviderIntegration
         qualityAssurance = openLdapServer.createGroup(groupsOU, "qualityAssurance");
         openLdapServer.addUserToGroup(alicea, qualityAssurance);
         openLdapServer.addUserToGroup(bobq, qualityAssurance);
+
+        engineering = openLdapServer.createGroup(groupsOU, "engineering");
+        openLdapServer.addUserToGroup(developers, engineering);
     }
 
     @AfterAll
@@ -119,8 +126,11 @@ public class TestLdapGroupProviderIntegration
     @Test
     public void testGetGroups()
     {
+        assertGetGroups(WITH_MEMBER_OF, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance"));
+        assertGetGroups(WITH_GROUP_FILTER, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance"));
+        assertGetGroups(WITH_GROUP_FILTER_NESTED, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance", "engineering"));
+
         for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroups(configBuilder, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance"));
             assertGetGroups(configBuilder, "johnb", ImmutableSet.of("clients"));
             assertGetGroups(configBuilder, "bobq", ImmutableSet.of("qualityAssurance"));
             assertGetGroups(configBuilder, "carlp", ImmutableSet.of());
@@ -140,10 +150,10 @@ public class TestLdapGroupProviderIntegration
     @Test
     public void testGetGroupsWithGroupsFilter()
     {
-        assertGetGroupsWithGroupsFilter("alicea", "cn=*", ImmutableSet.of("clients", "developers", "qualityAssurance"));
+        assertGetGroupsWithGroupsFilter("alicea", "cn=*", ImmutableSet.of("clients", "developers", "qualityAssurance", "engineering"));
         assertGetGroupsWithGroupsFilter("alicea", "cn=dev*", ImmutableSet.of("developers"));
         assertGetGroupsWithGroupsFilter("alicea", "(|(cn=dev*)(cn=cl*))", ImmutableSet.of("developers", "clients"));
-        assertGetGroupsWithGroupsFilter("alicea", "(&(objectclass=groupOfNames)(!(ou:dn:=external)))", ImmutableSet.of("developers", "qualityAssurance"));
+        assertGetGroupsWithGroupsFilter("alicea", "(&(objectclass=groupOfNames)(!(ou:dn:=external)))", ImmutableSet.of("developers", "qualityAssurance", "engineering"));
     }
 
     private void assertGetGroupsWithGroupsFilter(String userName, String groupFilter, Set<String> expectedGroups)
@@ -154,6 +164,7 @@ public class TestLdapGroupProviderIntegration
                 .put("ldap.group-search-member-attribute", "member")
                 .put("ldap.group-name-attribute", "cn")
                 .put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com")
+                .put("ldap.group-search-enable-nested-groups", "true")
                 .put("ldap.group-search-filter", groupFilter)
                 .buildOrThrow();
         GroupProvider groupsProvider = factory.create(config);
@@ -167,9 +178,6 @@ public class TestLdapGroupProviderIntegration
     public void testGetGroupForMissingUserReturnsEmpty()
     {
         for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroupForMissingUserReturnsEmpty(configBuilder);
-            assertGetGroupForMissingUserReturnsEmpty(configBuilder);
-            assertGetGroupForMissingUserReturnsEmpty(configBuilder);
             assertGetGroupForMissingUserReturnsEmpty(configBuilder);
         }
     }
@@ -193,6 +201,7 @@ public class TestLdapGroupProviderIntegration
                 .put("ldap.group-search-member-attribute", "some-attribute-that-does-not-exist")
                 .put("ldap.group-name-attribute", "cn")
                 .put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com")
+                .put("ldap.group-search-enable-nested-groups", "true")
                 .buildOrThrow();
         GroupProvider groupsProvider = factory.create(config);
 
@@ -204,15 +213,12 @@ public class TestLdapGroupProviderIntegration
     @Test
     public void testGetGroupsWithBadGroupNameReturnsFullName()
     {
-        for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-        }
+        assertGetGroupsWithBadGroupNameReturnsFullName(WITH_MEMBER_OF, ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName()));
+        assertGetGroupsWithBadGroupNameReturnsFullName(WITH_GROUP_FILTER, ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName()));
+        assertGetGroupsWithBadGroupNameReturnsFullName(WITH_GROUP_FILTER_NESTED, ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName(), engineering.getDistinguishedName()));
     }
 
-    private void assertGetGroupsWithBadGroupNameReturnsFullName(ConfigBuilder configBuilder)
+    private void assertGetGroupsWithBadGroupNameReturnsFullName(ConfigBuilder configBuilder, Set<String> expectedGroups)
     {
         Map<String, String> config = configBuilder.apply(new HashMap<>(baseConfig));
         config.put("ldap.group-name-attribute", "some-attribute-that-does-not-exist");
@@ -220,22 +226,19 @@ public class TestLdapGroupProviderIntegration
 
         Set<String> groups = groupsProvider.getGroups("alicea");
 
-        assertThat(groups).containsAll(ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName()));
+        assertThat(groups).containsAll(expectedGroups);
     }
 
     @Test
     public void testGetGroupsConcurrently()
             throws InterruptedException
     {
-        for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroupsConcurrently(configBuilder);
-            assertGetGroupsConcurrently(configBuilder);
-            assertGetGroupsConcurrently(configBuilder);
-            assertGetGroupsConcurrently(configBuilder);
-        }
+        assertGetGroupsConcurrently(WITH_MEMBER_OF, ImmutableSet.of("clients", "qualityAssurance", "developers"));
+        assertGetGroupsConcurrently(WITH_GROUP_FILTER, ImmutableSet.of("clients", "qualityAssurance", "developers"));
+        assertGetGroupsConcurrently(WITH_GROUP_FILTER_NESTED, ImmutableSet.of("clients", "qualityAssurance", "developers", "engineering"));
     }
 
-    private void assertGetGroupsConcurrently(ConfigBuilder configBuilder)
+    private void assertGetGroupsConcurrently(ConfigBuilder configBuilder, Set<String> expectedAliceGroups)
             throws InterruptedException
     {
         Map<String, String> config = configBuilder.apply(new HashMap<>(baseConfig));
@@ -245,7 +248,7 @@ public class TestLdapGroupProviderIntegration
         CountDownLatch latch = new CountDownLatch(4);
 
         CompletableFuture.supplyAsync(() -> groupsProvider.getGroups("alicea"), executor).whenComplete((g, t) -> {
-            assertThat(g).containsAll(ImmutableSet.of("clients", "qualityAssurance", "developers"));
+            assertThat(g).containsAll(expectedAliceGroups);
             latch.countDown();
         });
 

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
@@ -46,28 +46,32 @@ public class TestLdapGroupProviderIntegration
 {
     private final LdapGroupProviderFactory factory = new LdapGroupProviderFactory();
 
-    private static final List<ConfigBuilder> CONFIG_BUILDERS;
+    private static final ConfigBuilder WITH_MEMBER_OF = builder -> {
+        builder.put("ldap.user-member-of-attribute", "memberOf");
+        return builder;
+    };
 
-    static {
-        ConfigBuilder withMemberOf = builder -> {
-            builder.put("ldap.user-member-of-attribute", "memberOf");
-            return builder;
-        };
+    private static final ConfigBuilder WITH_GROUP_FILTER = builder -> {
+        builder.put("ldap.use-group-filter", "true");
+        builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
+        return builder;
+    };
 
-        ConfigBuilder withGroupFilter = builder -> {
-            builder.put("ldap.use-group-filter", "true");
-            builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
-            return builder;
-        };
+    private static final ConfigBuilder WITH_GROUP_FILTER_NESTED = builder -> {
+        builder.put("ldap.use-group-filter", "true");
+        builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
+        builder.put("ldap.group-search-mode", "RECURSIVE");
+        return builder;
+    };
 
-        CONFIG_BUILDERS = ImmutableList.of(withMemberOf, withGroupFilter);
-    }
+    private static final List<ConfigBuilder> CONFIG_BUILDERS = ImmutableList.of(WITH_MEMBER_OF, WITH_GROUP_FILTER, WITH_GROUP_FILTER_NESTED);
 
     private Closer closer;
     private Map<String, String> baseConfig;
     private DisposableSubContext clients;
     private DisposableSubContext developers;
     private DisposableSubContext qualityAssurance;
+    private DisposableSubContext engineering;
 
     @BeforeAll
     public void setup()
@@ -107,6 +111,10 @@ public class TestLdapGroupProviderIntegration
         qualityAssurance = openLdapServer.createGroup(groupsOU, "qualityAssurance");
         openLdapServer.addUserToGroup(alicea, qualityAssurance);
         openLdapServer.addUserToGroup(bobq, qualityAssurance);
+
+        engineering = openLdapServer.createGroup(groupsOU, "engineering");
+        openLdapServer.addUserToGroup(developers, engineering);
+        openLdapServer.addUserToGroup(engineering, developers);
     }
 
     @AfterAll
@@ -119,8 +127,11 @@ public class TestLdapGroupProviderIntegration
     @Test
     public void testGetGroups()
     {
+        assertGetGroups(WITH_MEMBER_OF, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance"));
+        assertGetGroups(WITH_GROUP_FILTER, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance"));
+        assertGetGroups(WITH_GROUP_FILTER_NESTED, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance", "engineering"));
+
         for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroups(configBuilder, "alicea", ImmutableSet.of("clients", "developers", "qualityAssurance"));
             assertGetGroups(configBuilder, "johnb", ImmutableSet.of("clients"));
             assertGetGroups(configBuilder, "bobq", ImmutableSet.of("qualityAssurance"));
             assertGetGroups(configBuilder, "carlp", ImmutableSet.of());
@@ -134,16 +145,16 @@ public class TestLdapGroupProviderIntegration
 
         Set<String> groups = groupsProvider.getGroups(userName);
 
-        assertThat(groups).containsAll(expectedGroups);
+        assertThat(groups).isEqualTo(expectedGroups);
     }
 
     @Test
     public void testGetGroupsWithGroupsFilter()
     {
-        assertGetGroupsWithGroupsFilter("alicea", "cn=*", ImmutableSet.of("clients", "developers", "qualityAssurance"));
+        assertGetGroupsWithGroupsFilter("alicea", "cn=*", ImmutableSet.of("clients", "developers", "qualityAssurance", "engineering"));
         assertGetGroupsWithGroupsFilter("alicea", "cn=dev*", ImmutableSet.of("developers"));
         assertGetGroupsWithGroupsFilter("alicea", "(|(cn=dev*)(cn=cl*))", ImmutableSet.of("developers", "clients"));
-        assertGetGroupsWithGroupsFilter("alicea", "(&(objectclass=groupOfNames)(!(ou:dn:=external)))", ImmutableSet.of("developers", "qualityAssurance"));
+        assertGetGroupsWithGroupsFilter("alicea", "(&(objectclass=groupOfNames)(!(ou:dn:=external)))", ImmutableSet.of("developers", "qualityAssurance", "engineering"));
     }
 
     private void assertGetGroupsWithGroupsFilter(String userName, String groupFilter, Set<String> expectedGroups)
@@ -154,6 +165,7 @@ public class TestLdapGroupProviderIntegration
                 .put("ldap.group-search-member-attribute", "member")
                 .put("ldap.group-name-attribute", "cn")
                 .put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com")
+                .put("ldap.group-search-mode", "RECURSIVE")
                 .put("ldap.group-search-filter", groupFilter)
                 .buildOrThrow();
         GroupProvider groupsProvider = factory.create(config);
@@ -167,9 +179,6 @@ public class TestLdapGroupProviderIntegration
     public void testGetGroupForMissingUserReturnsEmpty()
     {
         for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroupForMissingUserReturnsEmpty(configBuilder);
-            assertGetGroupForMissingUserReturnsEmpty(configBuilder);
-            assertGetGroupForMissingUserReturnsEmpty(configBuilder);
             assertGetGroupForMissingUserReturnsEmpty(configBuilder);
         }
     }
@@ -193,6 +202,7 @@ public class TestLdapGroupProviderIntegration
                 .put("ldap.group-search-member-attribute", "some-attribute-that-does-not-exist")
                 .put("ldap.group-name-attribute", "cn")
                 .put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com")
+                .put("ldap.group-search-mode", "RECURSIVE")
                 .buildOrThrow();
         GroupProvider groupsProvider = factory.create(config);
 
@@ -204,15 +214,12 @@ public class TestLdapGroupProviderIntegration
     @Test
     public void testGetGroupsWithBadGroupNameReturnsFullName()
     {
-        for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-            assertGetGroupsWithBadGroupNameReturnsFullName(configBuilder);
-        }
+        assertGetGroupsWithBadGroupNameReturnsFullName(WITH_MEMBER_OF, ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName()));
+        assertGetGroupsWithBadGroupNameReturnsFullName(WITH_GROUP_FILTER, ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName()));
+        assertGetGroupsWithBadGroupNameReturnsFullName(WITH_GROUP_FILTER_NESTED, ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName(), engineering.getDistinguishedName()));
     }
 
-    private void assertGetGroupsWithBadGroupNameReturnsFullName(ConfigBuilder configBuilder)
+    private void assertGetGroupsWithBadGroupNameReturnsFullName(ConfigBuilder configBuilder, Set<String> expectedGroups)
     {
         Map<String, String> config = configBuilder.apply(new HashMap<>(baseConfig));
         config.put("ldap.group-name-attribute", "some-attribute-that-does-not-exist");
@@ -220,22 +227,19 @@ public class TestLdapGroupProviderIntegration
 
         Set<String> groups = groupsProvider.getGroups("alicea");
 
-        assertThat(groups).containsAll(ImmutableSet.of(clients.getDistinguishedName(), developers.getDistinguishedName(), qualityAssurance.getDistinguishedName()));
+        assertThat(groups).containsAll(expectedGroups);
     }
 
     @Test
     public void testGetGroupsConcurrently()
             throws InterruptedException
     {
-        for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
-            assertGetGroupsConcurrently(configBuilder);
-            assertGetGroupsConcurrently(configBuilder);
-            assertGetGroupsConcurrently(configBuilder);
-            assertGetGroupsConcurrently(configBuilder);
-        }
+        assertGetGroupsConcurrently(WITH_MEMBER_OF, ImmutableSet.of("clients", "qualityAssurance", "developers"));
+        assertGetGroupsConcurrently(WITH_GROUP_FILTER, ImmutableSet.of("clients", "qualityAssurance", "developers"));
+        assertGetGroupsConcurrently(WITH_GROUP_FILTER_NESTED, ImmutableSet.of("clients", "qualityAssurance", "developers", "engineering"));
     }
 
-    private void assertGetGroupsConcurrently(ConfigBuilder configBuilder)
+    private void assertGetGroupsConcurrently(ConfigBuilder configBuilder, Set<String> expectedAliceGroups)
             throws InterruptedException
     {
         Map<String, String> config = configBuilder.apply(new HashMap<>(baseConfig));
@@ -245,7 +249,7 @@ public class TestLdapGroupProviderIntegration
         CountDownLatch latch = new CountDownLatch(4);
 
         CompletableFuture.supplyAsync(() -> groupsProvider.getGroups("alicea"), executor).whenComplete((g, _) -> {
-            assertThat(g).containsAll(ImmutableSet.of("clients", "qualityAssurance", "developers"));
+            assertThat(g).containsAll(expectedAliceGroups);
             latch.countDown();
         });
 


### PR DESCRIPTION
- Fixes #30285

### Motivation
- Enable resolving nested LDAP group memberships for the search-based LDAP group provider.
- Provide an option to delegate nested membership resolution to Active Directory using the `LDAP_MATCHING_RULE_IN_CHAIN` matching rule.
- Keep nested group behavior explicit and configurable without changing attribute-based (`memberOf`) group resolution.

### Description
- Added `ldap.group-search-mode` for search-based LDAP group resolution, with three supported modes:
  - `DIRECT` returns only direct group memberships and is the default.
  - `RECURSIVE` resolves nested memberships through client-side recursive LDAP searches.
  - `MATCHING_RULE_IN_CHAIN` delegates nested membership resolution to Active Directory.
- Extracted the existing direct group lookup into preparatory `LdapGroup`, `LdapGroupResolver`, and `LdapGroupSearch` components.
- Added direct, recursive, and Active Directory matching-rule resolver implementations selected at startup.
- Updated `LdapFilteringGroupProvider` to resolve the user DN and delegate group lookup to the configured resolver.
- Clarified that nested group resolution applies only to search-based group resolution. Attribute-based (`memberOf`) resolution returns the groups provided by the configured user membership attribute and does not recursively resolve parent groups.
- Updated configuration and integration tests to cover direct resolution, recursive resolution including cycles, mode mapping, and the default mode.

### Release notes
- ( ) This is not user-visible or is docs only, and no release notes are required.
- ( ) Release notes are required. Please propose a release note for me.
- (x) Release notes are required, with the following suggested text:

```markdown
# LDAP group provider
* Add support for nested group resolution in search-based LDAP group provider mode, with optional Active Directory `LDAP_MATCHING_RULE_IN_CHAIN` support.
```
