### PR TITLE
Remove location from SHOW CREATE TABLE for translated table

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -368,6 +368,7 @@ public class HiveMetadata
     private static final String BUCKETING_VERSION = "bucketing_version";
     public static final String STORAGE_TABLE = "storage_table";
     public static final String TRANSACTIONAL = "transactional";
+    public static final String TRANSLATED_TO_EXTERNAL = "TRANSLATED_TO_EXTERNAL";
     public static final String PRESTO_VIEW_EXPANDED_TEXT_MARKER = "/* Presto View */";
 
     public static final String ORC_BLOOM_FILTER_COLUMNS_KEY = "orc.bloom.filter.columns";
@@ -697,7 +698,11 @@ public class HiveMetadata
         // External location property
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
         if (table.getTableType().equals(EXTERNAL_TABLE.name())) {
-            properties.put(EXTERNAL_LOCATION_PROPERTY, table.getStorage().getLocation());
+            boolean isHive3ConvertedManagedTable = "true".equalsIgnoreCase(
+                    table.getParameters().get(TRANSLATED_TO_EXTERNAL));
+            if (!isHive3ConvertedManagedTable) {
+                properties.put(EXTERNAL_LOCATION_PROPERTY, table.getStorage().getLocation());
+            }
         }
 
         // Storage format property

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -698,9 +698,8 @@ public class HiveMetadata
         // External location property
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
         if (table.getTableType().equals(EXTERNAL_TABLE.name())) {
-            boolean isHive3ConvertedManagedTable = "true".equalsIgnoreCase(
-                    table.getParameters().get(TRANSLATED_TO_EXTERNAL));
-            if (!isHive3ConvertedManagedTable) {
+            boolean isHiveConvertedManagedTable = "true".equalsIgnoreCase(table.getParameters().get(TRANSLATED_TO_EXTERNAL));
+            if (!isHiveConvertedManagedTable) {
                 properties.put(EXTERNAL_LOCATION_PROPERTY, table.getStorage().getLocation());
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -2622,4 +2622,43 @@ abstract class BaseTestHiveOnDataLake
                 testTable,
                 "Overwriting existing partition in transactional tables doesn't support DIRECT_TO_TARGET_EXISTING_DIRECTORY write mode");
     }
+
+    @Test
+    public void testShowCreateTableForManagedTable()
+    {
+        String tableName = "test_hive_managed_" + randomNameSuffix();
+        String qualifiedTableName = getFullyQualifiedTestTableName(tableName);
+
+        assertUpdate(format("CREATE TABLE %s (id bigint, name varchar)", qualifiedTableName));
+        try {
+            assertThat((String) computeScalar(format("SHOW CREATE TABLE %s", qualifiedTableName)))
+                    .doesNotContain("external_location")
+                    .doesNotContain("location")
+                    .contains("format = 'ORC'");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE %s", qualifiedTableName));
+        }
+    }
+
+    @Test
+    public void testShowCreateTableForExternalTable()
+    {
+        String tableName = "test_explicit_external_" + randomNameSuffix();
+        String qualifiedTableName = getFullyQualifiedTestTableName(tableName);
+        String tableLocation = format("s3a://%s/%s/%s", bucketName, HIVE_TEST_SCHEMA, tableName);
+
+        assertUpdate(format(
+                "CREATE TABLE %s (id bigint, name varchar) WITH (external_location = '%s')",
+                qualifiedTableName,
+                tableLocation));
+        try {
+            assertThat((String) computeScalar(format("SHOW CREATE TABLE %s", qualifiedTableName)))
+                    .contains("external_location = '" + tableLocation + "'")
+                    .contains("format = 'ORC'");
+        }
+        finally {
+            assertUpdate(format("DROP TABLE %s", qualifiedTableName));
+        }
+    }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -2629,15 +2629,14 @@ abstract class BaseTestHiveOnDataLake
         String tableName = "test_hive_managed_" + randomNameSuffix();
         String qualifiedTableName = getFullyQualifiedTestTableName(tableName);
 
-        assertUpdate(format("CREATE TABLE %s (id bigint, name varchar)", qualifiedTableName));
+        assertUpdate("CREATE TABLE " + qualifiedTableName + " (id bigint, name varchar)");
         try {
-            assertThat((String) computeScalar(format("SHOW CREATE TABLE %s", qualifiedTableName)))
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + qualifiedTableName))
                     .doesNotContain("external_location")
-                    .doesNotContain("location")
                     .contains("format = 'ORC'");
         }
         finally {
-            assertUpdate(format("DROP TABLE %s", qualifiedTableName));
+            assertUpdate("DROP TABLE " + qualifiedTableName);
         }
     }
 
@@ -2648,17 +2647,49 @@ abstract class BaseTestHiveOnDataLake
         String qualifiedTableName = getFullyQualifiedTestTableName(tableName);
         String tableLocation = format("s3a://%s/%s/%s", bucketName, HIVE_TEST_SCHEMA, tableName);
 
-        assertUpdate(format(
-                "CREATE TABLE %s (id bigint, name varchar) WITH (external_location = '%s')",
-                qualifiedTableName,
-                tableLocation));
+        assertUpdate("CREATE TABLE " + qualifiedTableName + " (id bigint, name varchar) WITH (external_location = '" + tableLocation + "')");
         try {
-            assertThat((String) computeScalar(format("SHOW CREATE TABLE %s", qualifiedTableName)))
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + qualifiedTableName))
                     .contains("external_location = '" + tableLocation + "'")
                     .contains("format = 'ORC'");
         }
         finally {
-            assertUpdate(format("DROP TABLE %s", qualifiedTableName));
+            assertUpdate("DROP TABLE " + qualifiedTableName);
+        }
+    }
+
+    @Test
+    public void testShowCreateTableForManagedTableViaHiveClient()
+    {
+        String tableName = "test_hive_translated_managed_" + randomNameSuffix();
+        String qualifiedTrino = getFullyQualifiedTestTableName(tableName);
+        String qualifiedHive = getHiveTestTableName(tableName);
+
+        try {
+            hiveMinioDataLake.runOnHive("CREATE TABLE " + qualifiedHive + " (id int, name string) STORED AS ORC");
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + qualifiedTrino))
+                    .doesNotContain("external_location");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + qualifiedTrino);
+        }
+    }
+
+    @Test
+    public void testShowCreateTableForExternalTableViaHiveClient()
+    {
+        String tableName = "test_hive_external_show_create_" + randomNameSuffix();
+        String qualifiedTrino = getFullyQualifiedTestTableName(tableName);
+        String qualifiedHive = getHiveTestTableName(tableName);
+        String location = format("s3a://%s/%s/%s/", bucketName, HIVE_TEST_SCHEMA, tableName);
+        try {
+            hiveMinioDataLake.runOnHive("CREATE EXTERNAL TABLE " + qualifiedHive + " (id int, name string) STORED AS ORC LOCATION '" + location + "'");
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + qualifiedTrino))
+                    .contains("external_location");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + qualifiedTrino);
         }
     }
 }


### PR DESCRIPTION
Fixes #28483

Currently, the SHOW CREATE TABLE command for the Hive connector returns the managed table's path as external_location. This causes confusion as to whether the table is actually managed or external, violating the Principle of Least Surprise.

This change restricts the external_location property from being printed for managed tables that were silently translated to external tables by Hive.

Additional context and related issues
Previously, the if condition only checked if the table type was EXTERNAL_TABLE before appending the external_location property to the DDL.

However, in Hive 3.x+, Hive intercepts non-transactional managed table creations and silently converts them to external tables to bypass ACID requirements. When doing so, Hive marks the table parameter "TRANSLATED_TO_EXTERNAL" as "true".

To fix this, we now explicitly check this parameter. If the table is external but was translated by Hive, we treat it as a managed table for the purpose of SHOW CREATE TABLE and omit the external_location property.

Release notes
( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

## Hive Connector
* Fix ``SHOW CREATE TABLE`` exposing ``external_location`` for managed tables. ({issue}`28483`)