### PR TITLE
Add random name suffix to SQL Server test tables

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -178,6 +178,7 @@ public class TestSqlServerConnectorTest
     public void testCreateAndDropTableWithSpecialCharacterName()
     {
         for (String tableName : testTableNameTestData()) {
+            tableName = addRandomNameSuffix(tableName);
             String tableNameInSql = "\"" + tableName.replace("\"", "\"\"") + "\"";
             // Until https://github.com/trinodb/trino/issues/17 the table name is effectively lowercase
             tableName = tableName.toLowerCase(ENGLISH);
@@ -215,6 +216,7 @@ public class TestSqlServerConnectorTest
     public void testRenameFromToTableWithSpecialCharacterName()
     {
         for (String tableName : testTableNameTestData()) {
+            tableName = addRandomNameSuffix(tableName);
             String tableNameInSql = "\"" + tableName.replace("\"", "\"\"") + "\"";
             String sourceTableName = "test_rename_source_" + randomNameSuffix();
             assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
@@ -275,5 +277,17 @@ public class TestSqlServerConnectorTest
                 .add("open[bracket")
                 .add("close]bracket")
                 .build();
+    }
+
+    /**
+     * Returns a new name with a random suffix which maintains the shape of the name.
+     *
+     * <p>In particular, the suffix is added before any trailing spaces.
+     */
+    private static String addRandomNameSuffix(String name)
+    {
+        String trimmed = name.stripTrailing();
+        String trailingWhitespace = name.substring(trimmed.length());
+        return format("%s%s%s", trimmed, randomNameSuffix(), trailingWhitespace);
     }
 }


### PR DESCRIPTION
## Description

Multiple test functions create tables with names from testTableNameTestData, which can cause flaky failures when running them concurrently. Adding these random suffixes should make sure the table names never collide.

Example stack trace:

```
io.trino.testing.QueryFailedException: line 1:1: Table 'sqlserver.dbo.lowercase' already exists
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:631)
	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:613)
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:112)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:66)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:60)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:419)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:414)
	at io.trino.plugin.sqlserver.TestSqlServerConnectorTest.testCreateAndDropTableWithSpecialCharacterName(TestSqlServerConnectorTest.java:184)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
