### PR TITLE
Skip verify method in BigQuery smoke test

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -841,7 +841,7 @@ public class BigQueryMetadata
             boolean replace,
             boolean ignoreExisting)
     {
-        // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
+        // TODO Fix BaseBigQueryFailureRecoveryTest and TestBigQueryWithDifferentProjectIdConnectorSmokeTest when implementing this method
         ConnectorMetadata.super.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
@@ -24,6 +24,7 @@ import static io.trino.plugin.bigquery.BigQueryQueryRunner.BIGQUERY_CREDENTIALS_
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
         extends BaseConnectorSmokeTest
@@ -60,6 +61,30 @@ public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
                  SUPPORTS_UPDATE -> false;
             default -> super.hasBehavior(connectorBehavior);
         };
+    }
+
+    @Test
+    @Override
+    public void verifySupportsRowLevelDeleteDeclaration()
+    {
+        // This connector does not support modifying table rows
+        abort("skipped");
+    }
+
+    @Test
+    @Override
+    public void verifySupportsUpdateDeclaration()
+    {
+        // This connector does not support modifying table rows
+        abort("skipped");
+    }
+
+    @Test
+    @Override
+    public void verifySupportsRowLevelUpdateDeclaration()
+    {
+        // This connector does not support modifying table rows
+        abort("skipped");
     }
 
     @Test


### PR DESCRIPTION
## Description

The purpose is to avoid creating redundant tables on BigQuery.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.