### PR TITLE
Add and use linked byte buffers for S3OutputStream

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputFile.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputFile.java
@@ -19,6 +19,7 @@ import io.trino.filesystem.encryption.EncryptionKey;
 import io.trino.memory.context.AggregatedMemoryContext;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Optional;
@@ -56,8 +57,7 @@ final class S3OutputFile
                 location,
                 key,
                 false,
-                data,
-                0,
+                new ByteArrayInputStream(data),
                 data.length);
     }
 
@@ -71,8 +71,7 @@ final class S3OutputFile
                 location,
                 key,
                 true,
-                data,
-                0,
+                new ByteArrayInputStream(data),
                 data.length);
     }
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
@@ -14,6 +14,8 @@
 package io.trino.filesystem.s3;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import io.trino.filesystem.FileMayHaveAlreadyExistedException;
 import io.trino.filesystem.encryption.EncryptionKey;
 import io.trino.memory.context.AggregatedMemoryContext;
@@ -33,10 +35,13 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
+import java.io.SequenceInputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,19 +51,20 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.filesystem.s3.S3FileSystemConfig.ObjectCannedAcl.getCannedAcl;
 import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.NONE;
 import static io.trino.filesystem.s3.S3FileSystemConfig.StorageClassType.toStorageClass;
 import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
 import static io.trino.filesystem.s3.S3SseRequestConfigurator.setEncryptionSettings;
-import static java.lang.Math.clamp;
-import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static java.lang.System.arraycopy;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
-import static java.util.Objects.checkFromIndexSize;
+import static java.util.Collections.enumeration;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
@@ -66,6 +72,8 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 final class S3OutputStream
         extends OutputStream
 {
+    private static final int BUFFER_SIZE = toIntExact(DataSize.of(128, KILOBYTE).toBytes());
+
     private final List<CompletedPart> parts = new ArrayList<>();
     private final LocalMemoryContext memoryContext;
     private final Executor uploadExecutor;
@@ -77,11 +85,9 @@ final class S3OutputStream
     private final StorageClass storageClass;
     private final ObjectCannedACL cannedAcl;
     private final Optional<EncryptionKey> key;
+    private final LinkedBuffer buffer;
 
     private int currentPartNumber;
-    private byte[] buffer = new byte[0];
-    private int bufferSize;
-    private int initialBufferSize = 64;
 
     private boolean closed;
     private boolean failed;
@@ -105,7 +111,7 @@ final class S3OutputStream
         this.storageClass = toStorageClass(context.storageClass());
         this.cannedAcl = getCannedAcl(context.cannedAcl());
         this.key = requireNonNull(key, "key is null");
-
+        this.buffer = new LinkedBuffer(BUFFER_SIZE);
         verify(key.isEmpty() || context.s3SseContext().sseType() == NONE, "Encryption key cannot be used with SSE configuration");
     }
 
@@ -115,9 +121,8 @@ final class S3OutputStream
             throws IOException
     {
         ensureOpen();
-        ensureCapacity(1);
-        buffer[bufferSize] = (byte) b;
-        bufferSize++;
+        buffer.write(b);
+        memoryContext.setBytes(buffer.size());
         flushBuffer(false);
     }
 
@@ -126,18 +131,19 @@ final class S3OutputStream
             throws IOException
     {
         ensureOpen();
-
+        // make sure we don't exceed the part size
         while (length > 0) {
-            ensureCapacity(length);
-
-            int copied = min(buffer.length - bufferSize, length);
-            arraycopy(bytes, offset, buffer, bufferSize, copied);
-            bufferSize += copied;
-
+            int capacity = partSize - buffer.size();
+            if (capacity >= length) {
+                buffer.write(bytes, offset, length);
+                memoryContext.setBytes(buffer.size());
+                break;
+            }
+            buffer.write(bytes, offset, capacity);
+            memoryContext.setBytes(buffer.size());
             flushBuffer(false);
-
-            offset += copied;
-            length -= copied;
+            offset += capacity;
+            length -= capacity;
         }
     }
 
@@ -199,20 +205,6 @@ final class S3OutputStream
         }
     }
 
-    private void ensureCapacity(int extra)
-    {
-        int capacity = min(partSize, bufferSize + extra);
-        if (buffer.length < capacity) {
-            int target = max(buffer.length, initialBufferSize);
-            if (target < capacity) {
-                target += target / 2; // increase 50%
-                target = clamp(target, capacity, partSize);
-            }
-            buffer = Arrays.copyOf(buffer, target);
-            memoryContext.setBytes(buffer.length);
-        }
-    }
-
     private void flushBuffer(boolean finished)
             throws IOException
     {
@@ -225,9 +217,9 @@ final class S3OutputStream
                         location,
                         key,
                         false,
-                        buffer,
-                        0,
-                        bufferSize);
+                        buffer.takeInputStream(),
+                        buffer.size());
+                buffer.reset();
                 return;
             }
             catch (Throwable e) {
@@ -237,17 +229,15 @@ final class S3OutputStream
         }
 
         // the multipart upload API only allows the last part to be smaller than 5MB
-        if ((bufferSize == partSize) || (finished && (bufferSize > 0))) {
-            byte[] data = buffer;
-            int length = bufferSize;
-
+        if ((buffer.size() >= partSize) || (finished && (buffer.size() > 0))) {
+            int dataLength = buffer.size();
+            @SuppressWarnings("resource")
+            InputStream dataInputStream = buffer.takeInputStream();
             if (finished) {
-                this.buffer = null;
+                buffer.close();
             }
             else {
-                this.buffer = new byte[0];
-                this.initialBufferSize = partSize;
-                bufferSize = 0;
+                buffer.reset();
             }
             memoryContext.setBytes(0);
 
@@ -260,7 +250,7 @@ final class S3OutputStream
                 throw e;
             }
             multipartUploadStarted = true;
-            inProgressUploadFuture = supplyAsync(() -> uploadPage(data, length), uploadExecutor);
+            inProgressUploadFuture = supplyAsync(() -> uploadPage(dataInputStream, dataLength), uploadExecutor);
         }
     }
 
@@ -284,7 +274,7 @@ final class S3OutputStream
         }
     }
 
-    private CompletedPart uploadPage(byte[] data, int length)
+    private CompletedPart uploadPage(InputStream inputStream, int length)
     {
         if (uploadId.isEmpty()) {
             CreateMultipartUploadRequest request = CreateMultipartUploadRequest.builder()
@@ -324,9 +314,7 @@ final class S3OutputStream
                                 () -> setEncryptionSettings(builder, context.s3SseContext())))
                 .build();
 
-        ByteBuffer bytes = ByteBuffer.wrap(data, 0, length);
-
-        UploadPartResponse response = client.uploadPart(request, RequestBody.fromByteBuffer(bytes));
+        UploadPartResponse response = client.uploadPart(request, RequestBody.fromInputStream(inputStream, length));
 
         CompletedPart part = CompletedPart.builder()
                 .partNumber(currentPartNumber)
@@ -388,13 +376,10 @@ final class S3OutputStream
             S3Location location,
             Optional<EncryptionKey> key,
             boolean exclusiveCreate,
-            byte[] data,
-            int dataOffset,
+            InputStream inputStream,
             int dataLength)
             throws IOException
     {
-        checkFromIndexSize(dataOffset, dataLength, data.length);
-
         PutObjectRequest request = PutObjectRequest.builder()
                 .overrideConfiguration(context::applyCredentialProviderOverride)
                 .acl(getCannedAcl(context.cannedAcl()))
@@ -416,10 +401,8 @@ final class S3OutputStream
                 })
                 .build();
 
-        ByteBuffer bytes = ByteBuffer.wrap(data, dataOffset, dataLength);
-
         try {
-            client.putObject(request, RequestBody.fromByteBuffer(bytes));
+            client.putObject(request, RequestBody.fromInputStream(inputStream, dataLength));
         }
         catch (SdkException putObjectException) {
             // When `location` already exists, the operation will fail with `412 Precondition Failed`
@@ -437,6 +420,100 @@ final class S3OutputStream
                 throw new FileAlreadyExistsException(location.toString());
             }
             throw new IOException("Put failed for bucket [%s] key [%s]: %s".formatted(location.bucket(), location.key(), putObjectException), putObjectException);
+        }
+    }
+
+    @VisibleForTesting
+    static class LinkedBuffer
+            implements Closeable
+    {
+        private final int bufferSize;
+        private final List<InputStream> parts;
+        private byte[] currentBuffer;
+        private int currentOffset;
+
+        public LinkedBuffer(int bufferSize)
+        {
+            this.bufferSize = bufferSize;
+            this.parts = new ArrayList<>();
+            this.currentBuffer = new byte[bufferSize];
+            this.currentOffset = 0;
+        }
+
+        public void write(int b)
+        {
+            checkState(currentBuffer != null, "LinkedBuffer is closed");
+            if (remainingCapacity() == 0) {
+                parts.add(new ByteArrayInputStream(currentBuffer));
+                resetBuffer();
+            }
+            currentBuffer[currentOffset++] = (byte) b;
+        }
+
+        public void write(byte[] bytes, int offset, int length)
+        {
+            checkState(currentBuffer != null, "LinkedBuffer is closed");
+            while (length > 0) {
+                int bytesToWrite = min(length, remainingCapacity());
+
+                arraycopy(bytes, offset, currentBuffer, currentOffset, bytesToWrite);
+
+                currentOffset += bytesToWrite;
+                offset += bytesToWrite;
+                length -= bytesToWrite;
+
+                if (remainingCapacity() == 0) {
+                    parts.add(new ByteArrayInputStream(currentBuffer));
+                    resetBuffer();
+                }
+            }
+        }
+
+        public int size()
+        {
+            return parts.size() * bufferSize + currentOffset;
+        }
+
+        public int chunks()
+        {
+            return parts.size();
+        }
+
+        public InputStream takeInputStream()
+        {
+            if (currentOffset == 0) {
+                return new SequenceInputStream(enumeration(ImmutableList.copyOf(parts)));
+            }
+            return new SequenceInputStream(enumeration(ImmutableList.<InputStream>builder()
+                    .addAll(ImmutableList.copyOf(parts))
+                    .add(new ByteArrayInputStream(Arrays.copyOf(currentBuffer, currentOffset)))
+                    .build()));
+        }
+
+        public void reset()
+        {
+            currentBuffer = new byte[bufferSize];
+            currentOffset = 0;
+            parts.clear();
+        }
+
+        private int remainingCapacity()
+        {
+            return bufferSize - currentOffset;
+        }
+
+        private void resetBuffer()
+        {
+            currentBuffer = new byte[bufferSize];
+            currentOffset = 0;
+        }
+
+        @Override
+        public void close()
+        {
+            currentBuffer = null;
+            currentOffset = 0;
+            parts.clear();
         }
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestLinkedBuffer.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestLinkedBuffer.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.trino.filesystem.s3.S3OutputStream.LinkedBuffer;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("resource")
+public class TestLinkedBuffer
+{
+    @Test
+    void testEmptyBuffer()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+
+        assertThat(buffer.size()).isZero();
+        assertThat(buffer.takeInputStream().readAllBytes()).isEmpty();
+    }
+
+    @Test
+    void testSingleWrite()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+
+        buffer.write(42);
+
+        assertThat(buffer.size()).isEqualTo(1);
+        assertThat(buffer.takeInputStream().readAllBytes()).containsExactly(42);
+    }
+
+    @Test
+    void testMultipleWrite()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+        byte[] chunk1 = {1, 2, 3};
+        byte[] chunk2 = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
+
+        buffer.write(chunk1, 0, chunk1.length);
+        buffer.write(chunk2, 0, chunk2.length);
+
+        assertThat(buffer.size()).isEqualTo(14);
+
+        byte[] expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
+        assertThat(buffer.takeInputStream().readAllBytes()).isEqualTo(expected);
+    }
+
+    @Test
+    void testSmallWriteWithOffsetAndLength()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+        byte[] source = {0, 0, 1, 2, 3, 0, 0};
+
+        buffer.write(source, 2, 3);
+
+        assertThat(buffer.size()).isEqualTo(3);
+        assertThat(buffer.takeInputStream().readAllBytes()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void testLargeWriteWithOffsetAndLength()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+        byte[] source = testBytes(1000);
+
+        buffer.write(source, 300, 700);
+
+        assertThat(buffer.size()).isEqualTo(700);
+        assertThat(buffer.takeInputStream().readAllBytes()).isEqualTo(Arrays.copyOfRange(source, 300, 1000));
+    }
+
+    @Test
+    void testBufferExpansion()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(20);
+        byte[] data = testBytes(25);
+
+        buffer.write(data, 0, data.length);
+
+        // writing 25 bytes should trigger expansion
+        assertThat(buffer.chunks()).isEqualTo(1);
+        assertThat(buffer.size()).isEqualTo(25);
+        assertThat(buffer.takeInputStream().readAllBytes()).isEqualTo(data);
+    }
+
+    @Test
+    void testMaxBufferSizeCeiling()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+        byte[] data = testBytes(100);
+
+        buffer.write(data, 0, data.length);
+
+        // writing 100 should hit max buffer size
+        assertThat(buffer.size()).isEqualTo(100);
+        assertThat(buffer.takeInputStream().readAllBytes()).isEqualTo(data);
+    }
+
+    @Test
+    void testReset()
+            throws IOException
+    {
+        LinkedBuffer buffer = new LinkedBuffer(10);
+        byte[] data = {1, 2, 3, 4, 5};
+
+        buffer.write(data, 0, data.length);
+        assertThat(buffer.size()).isEqualTo(5);
+
+        buffer.reset();
+
+        assertThat(buffer.size()).isZero();
+        assertThat(buffer.takeInputStream().readAllBytes()).isEmpty();
+
+        buffer.write(data, 0, data.length);
+        assertThat(buffer.size()).isEqualTo(5);
+        assertThat(buffer.takeInputStream().readAllBytes()).isEqualTo(data);
+    }
+
+    private static byte[] testBytes(int length)
+    {
+        byte[] result = new byte[length];
+        for (int i = 0; i < length; i++) {
+            result[i] = (byte) (i % 256);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This avoid both data copying when buffer grows and single humongous allocations while uploading data to s3.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Fixes https://github.com/trinodb/trino/issues/27553



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
