### PR TITLE
Clarify what characters are allowed when appending query metadata

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.targetJdk>11</project.build.targetJdk>
         <main-class>io.trino.cli.Trino</main-class>
-        <dep.jline.version>3.30.6</dep.jline.version>
+        <dep.jline.version>4.0.0</dep.jline.version>
     </properties>
 
     <dependencies>

--- a/docs/src/main/sphinx/connector/query-comment-format.fragment
+++ b/docs/src/main/sphinx/connector/query-comment-format.fragment
@@ -1,8 +1,9 @@
 ### Appending query metadata
 
 The optional parameter `query.comment-format` allows you to configure a SQL
-comment that is sent to the datasource with each query. The format of this
-comment can contain any characters and the following metadata:
+comment that is sent to the data source with each query. The format of this
+comment can contain letters, digits, underscores, hyphens, commas, spaces, equal
+signs, and the following metadata placeholders:
 
 - `$QUERY_ID`: The identifier of the query.
 - `$USER`: The name of the user who submits the query to Trino.
@@ -11,8 +12,8 @@ comment can contain any characters and the following metadata:
 - `$TRACE_TOKEN`: The trace token configured with the client tool.
 
 The comment can provide more context about the query. This additional
-information is available in the logs of the datasource. To include environment
-variables from the Trino cluster with the comment , use the
+information is available in the logs of the data source. To include environment
+variables from the Trino cluster with the comment, use the
 `${ENV:VARIABLE-NAME}` syntax.
 
 The following example sets a simple comment that identifies each query sent by
@@ -23,7 +24,7 @@ query.comment-format=Query sent by Trino.
 ```
 
 With this configuration, a query such as `SELECT * FROM example_table;` is
-sent to the datasource with the comment appended:
+sent to the data source with the comment appended:
 
 ```text
 SELECT * FROM example_table; /*Query sent by Trino.*/
@@ -32,12 +33,12 @@ SELECT * FROM example_table; /*Query sent by Trino.*/
 The following example improves on the preceding example by using metadata:
 
 ```text
-query.comment-format=Query $QUERY_ID sent by user $USER from Trino.
+query.comment-format=Query $QUERY_ID /*sent by user $USER from Trino.*/
 ```
 
 If `Jane` sent the query with the query identifier
 `20230622_180528_00000_bkizg`, the following comment string is sent to the
-datasource:
+data source:
 
 ```text
 SELECT * FROM example_table; /*Query 20230622_180528_00000_bkizg sent by user Jane from Trino.*/


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

* Specifies what characters are allowed when appending query metadata using `query.comment-format`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* [property](https://github.com/trinodb/trino/blob/e0809f92d81b655f36614bba40738c82197829c5/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifierConfig.java#L27)
* [property validation method](https://github.com/trinodb/trino/blob/e0809f92d81b655f36614bba40738c82197829c5/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/logging/FormatInterpolator.java#L61)

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
