### PR TITLE
Add `@Flaky` to TestHiveMerge

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMerge.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMerge.java
@@ -15,6 +15,7 @@ package io.trino.tests.product.hive;
 
 import io.trino.tempto.assertions.QueryAssert;
 import io.trino.tempto.query.QueryResult;
+import io.trino.testng.services.Flaky;
 import io.trino.tests.product.hive.util.TemporaryHiveTable;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -34,6 +35,8 @@ import static io.trino.tests.product.hive.BucketingType.NONE;
 import static io.trino.tests.product.hive.TestHiveTransactionalTable.TEST_TIMEOUT;
 import static io.trino.tests.product.hive.TestHiveTransactionalTable.tableName;
 import static io.trino.tests.product.hive.TestHiveTransactionalTable.verifySelectForTrinoAndHive;
+import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_ISSUES;
+import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_MATCH;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -44,6 +47,7 @@ public class TestHiveMerge
         extends HiveProductTest
 {
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeSimpleSelect()
     {
         withTemporaryTable("merge_simple_select_target", false, NONE, targetTable -> {
@@ -69,6 +73,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeSimpleSelectPartitioned()
     {
         withTemporaryTable("merge_simple_select_partitioned_target", true, NONE, targetTable -> {
@@ -94,6 +99,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT, dataProvider = "partitionedAndBucketedProvider")
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeUpdateWithVariousLayouts(boolean partitioned, String bucketing)
     {
         BucketingType bucketingType = bucketing.isEmpty() ? NONE : BUCKETED_V2;
@@ -131,6 +137,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeUnBucketedUnPartitionedFailure()
     {
         withTemporaryTable("merge_with_various_formats_failure", false, NONE, targetTable -> {
@@ -168,6 +175,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeMultipleOperationsUnbucketedUnpartitioned()
     {
         withTemporaryTable("merge_multiple", false, NONE, targetTable -> {
@@ -177,6 +185,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeMultipleOperationsUnbucketedPartitioned()
     {
         withTemporaryTable("merge_multiple", true, NONE, targetTable -> {
@@ -186,6 +195,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeMultipleOperationsBucketedUnpartitioned()
     {
         withTemporaryTable("merge_multiple", false, BUCKETED_V2, targetTable -> {
@@ -261,6 +271,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeSimpleQuery()
     {
         withTemporaryTable("merge_simple_query_target", false, NONE, targetTable -> {
@@ -281,6 +292,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeAllInserts()
     {
         withTemporaryTable("merge_all_inserts", false, NONE, targetTable -> {
@@ -299,6 +311,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeSimpleQueryPartitioned()
     {
         withTemporaryTable("merge_simple_query_partitioned_target", true, NONE, targetTable -> {
@@ -320,6 +333,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeAllColumnsUpdated()
     {
         withTemporaryTable("merge_all_columns_updated_target", false, NONE, targetTable -> {
@@ -341,6 +355,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeAllMatchesDeleted()
     {
         withTemporaryTable("merge_all_matches_deleted_target", false, NONE, targetTable -> {
@@ -362,6 +377,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000, dataProvider = "partitionedBucketedFailure")
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeMultipleRowsMatchFails(String createTableSql)
     {
         withTemporaryTable("merge_all_matches_deleted_target", true, NONE, targetTable -> {
@@ -398,6 +414,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeFailingPartitioning()
     {
         String testDescription = "failing_merge";
@@ -424,6 +441,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeFailureWithDifferentPartitioning()
     {
         testMergeWithDifferentPartitioningInternal(
@@ -433,6 +451,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000, dataProvider = "targetAndSourceWithDifferentPartitioning")
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeWithDifferentPartitioning(String testDescription, String createTargetTableSql, String createSourceTableSql)
     {
         testMergeWithDifferentPartitioningInternal(testDescription, createTargetTableSql, createSourceTableSql);
@@ -500,6 +519,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeQueryWithStrangeCapitalization()
     {
         withTemporaryTable("test_without_aliases_target", false, NONE, targetTable -> {
@@ -519,6 +539,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeWithoutTablesAliases()
     {
         withTemporaryTable("test_without_aliases_target", false, NONE, targetTable -> {
@@ -543,6 +564,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeWithUnpredictablePredicates()
     {
         withTemporaryTable("test_without_aliases_target", false, NONE, targetTable -> {
@@ -584,6 +606,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeWithSimplifiedUnpredictablePredicates()
     {
         withTemporaryTable("test_without_aliases_target", false, NONE, targetTable -> {
@@ -609,6 +632,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeCasts()
     {
         withTemporaryTable("merge_cast_target", false, NONE, targetTable -> {
@@ -631,6 +655,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeSubqueries()
     {
         withTemporaryTable("merge_nation_target", false, NONE, targetTable -> {
@@ -656,6 +681,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = 60 * 60 * 1000)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeOriginalFilesTarget()
     {
         withTemporaryTable("region", false, NONE, targetTable -> {
@@ -678,6 +704,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeOverManySplits()
     {
         withTemporaryTable("delete_select", false, NONE, targetTable -> {
@@ -696,6 +723,7 @@ public class TestHiveMerge
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testMergeFalseJoinCondition()
     {
         withTemporaryTable("join_false", false, NONE, targetTable -> {


### PR DESCRIPTION
## Description

The failed example:
```
Root cause HDFS error:
org.apache.hadoop.ipc.RemoteException: File /user/hive/warehouse/test_merge_multiple_false_bucketed_v2_qddf1rdv2x/delete_delta_0000002_0000002_0000/bucket_00000 could only be written to 0 of the 1 minReplication nodes. There are 1 datanode(s) running and no node(s) are excluded in this operation.

Query that failed on first attempt:
MERGE INTO test_merge_multiple_false_BUCKETED_V2_qddf1rdv2x t USING (SELECT * FROM (VALUES ('joe_16', 3000, 83000, 'jill_16', '16 Eop Ct'), ... )) AS s(customer, purchases, zipcode, spouse, address) ON t.customer = s.customer WHEN MATCHED THEN UPDATE SET purchases = s.purchases, zipcode = s.zipcode, spouse = s.spouse, address = s.address

Test retried but ultimately failed with:
java.lang.AssertionError: Could not find rows:
 [joe_20, 3000, 83000, jill_20, 20 Eop Ct]
[joe_21, 3000, 83000, jill_21, 21 Eop Ct]
[joe_24, 3000, 83000, jill_24, 24 Eop Ct]
[joe_28, 3000, 83000, jill_28, 28 Eop Ct]

Full stack trace:
io.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Query failed (#20260220_210539_00040_d3svt): Error committing write to Hive
  at io.trino.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:119)
  at io.trino.tempto.query.JdbcQueryExecutor.executeQuery(JdbcQueryExecutor.java:84)
  at io.trino.tests.product.hive.TestHiveMerge.testMergeMultipleOperationsInternal(TestHiveMerge.java:213)
  at io.trino.tests.product.hive.TestHiveMerge.lambda$testMergeMultipleOperationsBucketedUnpartitioned$0(TestHiveMerge.java:194)
  at io.trino.tests.product.hive.TestHiveMerge.testMergeMultipleOperationsBucketedUnpartitioned(TestHiveMerge.java:191)
Caused by: io.trino.spi.TrinoException: Error committing write to Hive
  at io.trino.plugin.hive.orc.OrcFileWriter.commit(OrcFileWriter.java:194)
  at io.trino.plugin.hive.SortingFileWriter.commit(SortingFileWriter.java:144)
  at io.trino.plugin.hive.MergeFileWriter.commit(MergeFileWriter.java:193)
  at io.trino.plugin.hive.HiveWriter.commit(HiveWriter.java:93)
  at io.trino.plugin.hive.HivePageSink.doMergeSinkFinish(HivePageSink.java:198)
Caused by: org.apache.hadoop.ipc.RemoteException: File /user/hive/warehouse/test_merge_multiple_false_bucketed_v2_qddf1rdv2x/delete_delta_0000002_0000002_0000/bucket_00000 could only be written to 0 of the 1 minReplication nodes. There are 1 datanode(s) running and no node(s) are excluded in this operation.
  at org.apache.hadoop.hdfs.server.blockmanagement.BlockManager.chooseTarget4NewBlock(BlockManager.java:2121)
  at org.apache.hadoop.hdfs.server.namenode.FSDirWriteFileOp.chooseTargetForNewBlock(FSDirWriteFileOp.java:286)
  at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getAdditionalBlock(FSNamesystem.java:2706)

Secondary error - filesystem leak after primary failure:
ERROR fs-leak-detector-0 io.trino.filesystem.tracking.TrackingState HdfsOutputStream with location 'hdfs://hadoop-master:9000/user/hive/warehouse/test_merge_multiple_false_bucketed_v2_qddf1rdv2x/delta_0000002_0000002_0000/bucket_00000' was not closed properly and leaked.
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
