### PR TITLE
Fix ClassCastException when Delta Lake DECIMAL stats are JSON Numbers

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -132,7 +132,8 @@ public final class DeltaLakeParquetStatisticsUtils
             return (double) jsonValue;
         }
         if (type instanceof DecimalType decimalType) {
-            BigDecimal decimal = new BigDecimal((String) jsonValue);
+            // Spark may serialize DECIMAL statistics as JSON Numbers instead of Strings
+            BigDecimal decimal = new BigDecimal(jsonValue instanceof String stringValue ? stringValue : String.valueOf(jsonValue));
 
             if (decimalType.isShort()) {
                 return Decimals.encodeShortScaledValue(decimal, decimalType.getScale());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeParquetStatisticsUtils.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.transactionlog;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.IntegerType;
 import org.apache.parquet.column.statistics.Statistics;
@@ -219,6 +220,21 @@ public class TestDeltaLakeParquetStatisticsUtils
     private static int millisToJulianDay(long timestamp)
     {
         return toIntExact(MILLISECONDS.toDays(timestamp) + JULIAN_EPOCH_OFFSET_DAYS);
+    }
+
+    @Test
+    public void testDecimalJsonValueToTrinoValueFromNumericType()
+    {
+        // Spark may serialize DECIMAL statistics as JSON Numbers instead of Strings (e.g., 36.17 vs "36.17")
+        DecimalType shortDecimal = DecimalType.createDecimalType(10, 2);
+        Object fromString = jsonValueToTrinoValue(shortDecimal, "36.17");
+        Object fromDouble = jsonValueToTrinoValue(shortDecimal, 36.17);
+        assertThat(fromDouble).isEqualTo(fromString);
+
+        // Integer JSON value (e.g., 100 instead of "100.00")
+        Object fromInteger = jsonValueToTrinoValue(shortDecimal, 100);
+        Object fromIntegerString = jsonValueToTrinoValue(shortDecimal, "100");
+        assertThat(fromInteger).isEqualTo(fromIntegerString);
     }
 
     static byte[] getIntByteArray(int i)


### PR DESCRIPTION
## Summary

Fixes #28532

Spark sometimes serializes DECIMAL column statistics as JSON Numbers (e.g., `36.17`) rather than Strings (`"36.17"`) in Delta Lake transaction log files. When Trino writes a checkpoint for such tables, `jsonValueToTrinoValue` casts the value to `String`, causing a `ClassCastException`.

## Changes

- **`DeltaLakeParquetStatisticsUtils.java`**: Use pattern matching to handle both `String` and `Number` JSON values for `DecimalType` statistics, with `String.valueOf()` as fallback for non-String types.
- **`TestDeltaLakeParquetStatisticsUtils.java`**: Added test verifying that numeric JSON values (Double, Integer) produce the same result as their String equivalents.

## Root Cause

```java
// Before — fails when Spark writes 36.17 as a JSON Number
BigDecimal decimal = new BigDecimal((String) jsonValue);

// After — handles both String and Number types
BigDecimal decimal = new BigDecimal(jsonValue instanceof String stringValue ? stringValue : String.valueOf(jsonValue));
```