### PR TITLE
Switch to streaming JSON/page decoding

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
@@ -43,8 +43,10 @@ import io.trino.spi.TrinoTransportException;
 import jakarta.annotation.Nullable;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.time.Instant;
@@ -714,7 +716,15 @@ public final class HttpPageBufferClient
                 boolean complete = getComplete(response, uri);
                 boolean remoteTaskFailed = getTaskFailed(response, uri);
 
-                try (LittleEndianDataInputStream input = new LittleEndianDataInputStream(response.getInputStream())) {
+                InputStream inputStream = switch (response.getContent()) {
+                    case Response.InputStreamContent inputStreamContent -> inputStreamContent.inputStream();
+                    case Response.BytesContent bytesContent -> {
+                        log.warn("Expected unbuffered input stream");
+                        yield new ByteArrayInputStream(bytesContent.bytes());
+                    }
+                };
+
+                try (LittleEndianDataInputStream input = new LittleEndianDataInputStream(inputStream)) {
                     int magic = input.readInt();
                     if (magic != SERIALIZED_PAGES_MAGIC) {
                         throw new IllegalStateException(format("Invalid stream header, expected 0x%08x, but was 0x%08x", SERIALIZED_PAGES_MAGIC, magic));

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -17,8 +17,8 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.concurrent.SetThreadName;
-import io.airlift.http.client.FullJsonResponseHandler;
 import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.JsonResponse;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -38,9 +38,9 @@ import java.util.function.Supplier;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StreamingJsonResponseHandler.streamingJsonResponseHandler;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.server.InternalHeaders.TRINO_CURRENT_VERSION;
 import static io.trino.server.InternalHeaders.TRINO_MAX_WAIT;
@@ -70,7 +70,7 @@ class ContinuousTaskStatusFetcher
     private boolean running;
 
     @GuardedBy("this")
-    private ListenableFuture<FullJsonResponseHandler.JsonResponse<TaskStatus>> future;
+    private ListenableFuture<JsonResponse<TaskStatus>> future;
 
     public ContinuousTaskStatusFetcher(
             Consumer<Throwable> onFail,
@@ -153,7 +153,7 @@ class ContinuousTaskStatusFetcher
                 .build();
 
         errorTracker.startRequest();
-        future = httpClient.executeAsync(request, createFullJsonResponseHandler(taskStatusCodec));
+        future = httpClient.executeAsync(request, streamingJsonResponseHandler(taskStatusCodec));
         Futures.addCallback(future, new SimpleHttpResponseHandler<>(new TaskStatusResponseCallback(), request.getUri(), stats), executor);
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
@@ -17,8 +17,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.concurrent.SetThreadName;
-import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
 import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.JsonResponse;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
@@ -37,9 +37,9 @@ import java.util.function.Supplier;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.google.common.util.concurrent.Futures.addCallback;
-import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StreamingJsonResponseHandler.streamingJsonResponseHandler;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.execution.DynamicFiltersCollector.INITIAL_DYNAMIC_FILTERS_VERSION;
 import static io.trino.server.InternalHeaders.TRINO_CURRENT_VERSION;
@@ -165,7 +165,7 @@ class DynamicFiltersFetcher
                 .build();
 
         errorTracker.startRequest();
-        future = httpClient.executeAsync(request, createFullJsonResponseHandler(dynamicFilterDomainsCodec));
+        future = httpClient.executeAsync(request, streamingJsonResponseHandler(dynamicFilterDomainsCodec));
         addCallback(future, new SimpleHttpResponseHandler<>(new DynamicFiltersResponseCallback(dynamicFiltersVersion), request.getUri(), stats), executor);
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -26,9 +26,9 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.concurrent.SetThreadName;
-import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpUriBuilder;
+import io.airlift.http.client.JsonResponse;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -103,12 +103,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
-import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpStatus.OK;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.http.client.StreamingJsonResponseHandler.streamingJsonResponseHandler;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.SystemSessionProperties.getMaxRemoteTaskRequestSize;
 import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
@@ -797,7 +797,7 @@ public final class HttpRemoteTask
 
         updateErrorTracker.startRequest();
 
-        ListenableFuture<JsonResponse<TaskInfo>> future = httpClient.executeAsync(request, createFullJsonResponseHandler(taskInfoCodec));
+        ListenableFuture<JsonResponse<TaskInfo>> future = httpClient.executeAsync(request, streamingJsonResponseHandler(taskInfoCodec));
         checkState(currentRequest.getAndSet(future) == null, "There should be no previous request running");
 
         Futures.addCallback(
@@ -972,38 +972,44 @@ public final class HttpRemoteTask
 
     private void doScheduleAsyncCleanupRequest(Backoff cleanupBackoff, Request request, String action)
     {
-        Futures.addCallback(httpClient.executeAsync(request, createFullJsonResponseHandler(taskInfoCodec)), new FutureCallback<>()
+        Futures.addCallback(httpClient.executeAsync(request, streamingJsonResponseHandler(taskInfoCodec)), new FutureCallback<>()
         {
             @Override
             public void onSuccess(JsonResponse<TaskInfo> result)
             {
-                if (result.getStatusCode() != OK.code()) {
-                    onFailure(exceptionForErrorCode(result));
-                    return;
-                }
-
-                try {
-                    checkArgument(result.hasValue(), "TaskInfo result did not contain JSON payload; payload=%s", result.getResponseBody());
-                    updateTaskInfo(result.getValue());
-                }
-                catch (Throwable e) {
-                    log.error(e, "Error in async cleanup on %s for %s", action, request.getUri());
-                    throw e;
-                }
-                finally {
-                    // if cleanup operation has not at least started task termination, mark the task failed
-                    TaskState taskState = getTaskInfo().taskStatus().state();
-                    if (!taskState.isTerminatingOrDone()) {
-                        fatalAsyncCleanupFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), format("Unable to %s task at %s, last known state was: %s", action, request.getUri(), taskState)));
+                switch (result) {
+                    case JsonResponse.JsonValue<TaskInfo> jsonValue -> {
+                        if (jsonValue.statusCode() != OK.code()) {
+                            onFailure(new RuntimeException("Expected error code"));
+                            return;
+                        }
+                        try {
+                            updateTaskInfo(jsonValue.jsonValue());
+                        }
+                        catch (Throwable e) {
+                            log.error(e, "Error in async cleanup on %s for %s", action, request.getUri());
+                            throw e;
+                        }
+                        finally {
+                            // if cleanup operation has not at least started task termination, mark the task failed
+                            TaskState taskState = getTaskInfo().taskStatus().state();
+                            if (!taskState.isTerminatingOrDone()) {
+                                fatalAsyncCleanupFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), format("Unable to %s task at %s, last known state was: %s", action, request.getUri(), taskState)));
+                            }
+                        }
                     }
+                    case JsonResponse.Exception<TaskInfo> exception ->
+                            onFailure(exceptionForErrorCode(exception));
+                    case JsonResponse.NonJsonBytes<TaskInfo> bytes ->
+                            onFailure(new RuntimeException(bytes.stringValue()));
                 }
             }
 
-            private static RuntimeException exceptionForErrorCode(JsonResponse<TaskInfo> result)
+            private static RuntimeException exceptionForErrorCode(JsonResponse.Exception<TaskInfo> result)
             {
-                return switch (result.getStatusCode()) {
+                return switch (result.statusCode()) {
                     case HTTP_UNAVAILABLE -> new ServiceUnavailableException("Service Unavailable");
-                    default -> new RuntimeException("Unexpected http status code " + result.getStatusCode());
+                    default -> new RuntimeException("Could not execute request", result.throwable());
                 };
             }
 

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/SimpleHttpResponseHandler.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/SimpleHttpResponseHandler.java
@@ -14,18 +14,19 @@
 package io.trino.server.remotetask;
 
 import com.google.common.util.concurrent.FutureCallback;
-import io.airlift.http.client.FullJsonResponseHandler;
 import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.JsonResponse;
 import io.trino.spi.TrinoException;
 
 import java.net.URI;
+import java.util.concurrent.RejectedExecutionException;
 
 import static io.trino.spi.StandardErrorCode.REMOTE_TASK_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class SimpleHttpResponseHandler<T>
-        implements FutureCallback<FullJsonResponseHandler.JsonResponse<T>>
+        implements FutureCallback<JsonResponse<T>>
 {
     private final SimpleHttpResponseCallback<T> callback;
 
@@ -40,41 +41,59 @@ public class SimpleHttpResponseHandler<T>
     }
 
     @Override
-    public void onSuccess(FullJsonResponseHandler.JsonResponse<T> response)
+    public void onSuccess(JsonResponse<T> response)
     {
-        stats.updateSuccess();
-        stats.responseSize(response.getResponseSize());
-        try {
-            if (response.getStatusCode() == HttpStatus.OK.code() && response.hasValue()) {
-                callback.success(response.getValue());
+        if (response.statusCode() == HttpStatus.SERVICE_UNAVAILABLE.code()) {
+            onFailure(new ServiceUnavailableException(uri));
+            return;
+        }
+
+        if (response.exception().isPresent() && response.exception().stream().anyMatch(RejectedExecutionException.class::isInstance)) {
+            callback.fatal(new TrinoException(REMOTE_TASK_ERROR, format("Unexpected response from %s", uri), response.exception().orElseThrow()));
+            return;
+        }
+
+        switch (response) {
+            case JsonResponse.JsonValue<T> jsonResponse -> {
+                try {
+                    if (jsonResponse.statusCode() == HttpStatus.OK.code()) {
+                        stats.updateSuccess();
+                        stats.responseSize(jsonResponse.bytesRead());
+                        callback.success(response.jsonValue());
+                    }
+                    else {
+                        callback.fatal(new TrinoException(REMOTE_TASK_ERROR, format("Unexpected response from %s", uri)));
+                    }
+                }
+                catch (Throwable t) {
+                    // this should never happen
+                    callback.fatal(t);
+                }
             }
-            else if (response.getStatusCode() == HttpStatus.SERVICE_UNAVAILABLE.code()) {
-                callback.failed(new ServiceUnavailableException(uri));
-            }
-            else {
+            case JsonResponse.Exception<T> exceptionResponse -> {
                 // Something is broken in the server or the client, so fail the task immediately (includes 500 errors)
-                Exception cause = response.getException();
+                Throwable cause = exceptionResponse.throwable();
                 if (cause == null) {
-                    if (response.getStatusCode() == HttpStatus.OK.code()) {
+                    if (exceptionResponse.statusCode() == HttpStatus.OK.code()) {
                         cause = new TrinoException(REMOTE_TASK_ERROR, format("Expected response from %s is empty", uri));
                     }
                     else {
-                        cause = new TrinoException(REMOTE_TASK_ERROR, format("Expected response code from %s to be %s, but was %s%n%s",
+                        cause = new TrinoException(REMOTE_TASK_ERROR, format("Expected response code from %s to be %s, but was %s%n",
                                 uri,
                                 HttpStatus.OK.code(),
-                                response.getStatusCode(),
-                                response.getResponseBody()));
+                                exceptionResponse.statusCode()));
                     }
                 }
                 else {
                     cause = new TrinoException(REMOTE_TASK_ERROR, format("Unexpected response from %s", uri), cause);
                 }
-                callback.fatal(cause);
+                callback.failed(cause);
             }
-        }
-        catch (Throwable t) {
-            // this should never happen
-            callback.fatal(t);
+            case JsonResponse.NonJsonBytes<T> nonJsonResponse -> callback.fatal(new TrinoException(REMOTE_TASK_ERROR, format("Expected response code from %s to be %s, but was %s%n%s",
+                    uri,
+                    HttpStatus.OK.code(),
+                    nonJsonResponse.statusCode(),
+                    nonJsonResponse.stringValue())));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -17,9 +17,9 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.concurrent.SetThreadName;
-import io.airlift.http.client.FullJsonResponseHandler;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpUriBuilder;
+import io.airlift.http.client.JsonResponse;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -50,9 +50,9 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StreamingJsonResponseHandler.streamingJsonResponseHandler;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.operator.RetryPolicy.TASK;
 import static java.util.Objects.requireNonNull;
@@ -95,7 +95,7 @@ public class TaskInfoFetcher
     private ScheduledFuture<?> scheduledFuture;
 
     @GuardedBy("this")
-    private ListenableFuture<FullJsonResponseHandler.JsonResponse<TaskInfo>> future;
+    private ListenableFuture<JsonResponse<TaskInfo>> future;
 
     public TaskInfoFetcher(
             Consumer<Throwable> onFail,
@@ -250,7 +250,7 @@ public class TaskInfoFetcher
                 .build();
 
         errorTracker.startRequest();
-        future = httpClient.executeAsync(request, createFullJsonResponseHandler(taskInfoCodec));
+        future = httpClient.executeAsync(request, streamingJsonResponseHandler(taskInfoCodec));
         Futures.addCallback(future, new SimpleHttpResponseHandler<>(new TaskInfoResponseCallback(), request.getUri(), stats), executor);
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/MockExchangeRequestProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/MockExchangeRequestProcessor.java
@@ -31,6 +31,7 @@ import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.server.InternalHeaders;
 import io.trino.spi.Page;
 
+import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -137,7 +138,7 @@ public class MockExchangeRequestProcessor
                         .put(TRINO_BUFFER_COMPLETE, String.valueOf(result.bufferComplete()))
                         .put(TRINO_TASK_FAILED, "false")
                         .build(),
-                bytes);
+                new ByteArrayInputStream(bytes));
     }
 
     private static class RequestLocation

--- a/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
+import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -893,11 +894,11 @@ public class TestDirectExchangeClient
                             .collect(toImmutableListMultimap(entry -> entry.getKey().toString(), Map.Entry::getValue));
                     byte[] bytes = response.getInputStream().readAllBytes();
                     checkState(bytes.length > 42, "too short");
-                    savedResponse = new TestingResponse(HttpStatus.OK, headers, bytes.clone());
+                    savedResponse = new TestingResponse(HttpStatus.OK, headers, new ByteArrayInputStream(bytes.clone()));
                     // corrupt
                     bytes[42]++;
                     completedRequests++;
-                    return new TestingResponse(HttpStatus.OK, headers, bytes);
+                    return new TestingResponse(HttpStatus.OK, headers, new ByteArrayInputStream(bytes));
                 }
 
                 if (completedRequests == 1) {


### PR DESCRIPTION
Switches some of the `ResponseHandler`-s to a streaming implementation that avoids materializing response to a single `byte[]` array. This avoid unnecessary data copying and possibly humongous allocation as well, when response is large.

## Description

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
