### PR TITLE
Support listFilesStartingFrom in TrinoFileSystem

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.filesystem.EmulatedListFilesStartingFromIterator;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
@@ -66,6 +67,7 @@ import java.util.concurrent.ExecutorService;
 import static com.azure.storage.common.implementation.Constants.HeaderConstants.ETAG_WILDCARD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.filesystem.TrinoFileSystem.checkStartingFrom;
 import static io.trino.filesystem.azure.AzureUtils.blobCustomerProvidedKey;
 import static io.trino.filesystem.azure.AzureUtils.encodedKey;
 import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
@@ -307,21 +309,61 @@ public class AzureFileSystem
         try {
             // blob API returns directories as blobs, so it cannot be used when Gen2 is enabled
             return isHierarchicalNamespaceEnabled(azureLocation)
-                    ? listGen2Files(azureLocation)
-                    : listBlobFiles(azureLocation);
+                    ? listGen2Files(azureLocation, Optional.empty())
+                    : listBlobFiles(azureLocation, Optional.empty());
         }
         catch (RuntimeException e) {
             throw handleAzureException(e, "listing files", azureLocation);
         }
     }
 
-    private FileIterator listGen2Files(AzureLocation location)
+    /**
+     * {@inheritDoc}
+     *
+     * <p>On ADLS Gen2 (hierarchical namespace) the native recursive listing returns results in a
+     * depth-first order that does not match the lexicographic ordering required by this API, so
+     * the server-side {@code startFrom} cursor cannot be used directly. This implementation
+     * instead sends a conservative lower bound (truncating {@code startingFrom} at the first
+     * character {@code <= '/'}) and applies a client-side filter over the results. This preserves
+     * correctness while typically still allowing the server to skip a large portion of the
+     * directory. On flat-namespace (blob) storage the native cursor is used directly.
+     */
+    @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        checkStartingFrom(startingFrom);
+        if (startingFrom.isEmpty()) {
+            return listFiles(location);
+        }
+
+        AzureLocation azureLocation = new AzureLocation(location);
+
+        try {
+            return isHierarchicalNamespaceEnabled(azureLocation)
+                    ? listGen2Files(azureLocation, Optional.of(startingFrom))
+                    : listBlobFiles(azureLocation, Optional.of(startingFrom));
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "listing files", azureLocation);
+        }
+    }
+
+    private FileIterator listGen2Files(AzureLocation location, Optional<String> startingFrom)
             throws IOException
     {
         DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location, Optional.empty());
+        ListPathsOptions options = new ListPathsOptions().setRecursive(true);
+
+        // In ADLS Gen2 recursive listing, startFrom does not implement the same lexicographic ordering as required by
+        // listFilesStartingFrom. Use a conservative server-side lower bound (truncating startingFrom), then filter client-side
+        startingFrom.map(AzureFileSystem::startingFromLowerBound)
+                .filter(not(String::isEmpty))
+                .ifPresent(options::setStartFrom);
+
         PagedIterable<PathItem> pathItems;
         if (location.path().isEmpty()) {
-            pathItems = fileSystemClient.listPaths(new ListPathsOptions().setRecursive(true), null);
+            pathItems = fileSystemClient.listPaths(options, null);
         }
         else {
             DataLakeDirectoryClient directoryClient = createDirectoryClient(fileSystemClient, location.path());
@@ -331,18 +373,27 @@ public class AzureFileSystem
             if (!directoryClient.getProperties().isDirectory()) {
                 throw new TrinoFileSystemException("Location is not a directory: " + location);
             }
-            pathItems = directoryClient.listPaths(true, false, null, null);
+
+            pathItems = directoryClient.listPaths(options, null, null);
         }
-        return new AzureDataLakeFileIterator(
+        FileIterator iterator = new AzureDataLakeFileIterator(
                 location,
                 pathItems.stream()
                         .filter(not(PathItem::isDirectory))
                         .iterator());
+        if (startingFrom.isPresent()) {
+            return new EmulatedListFilesStartingFromIterator(iterator, location.location(), startingFrom.orElseThrow());
+        }
+        return iterator;
     }
 
-    private FileIterator listBlobFiles(AzureLocation location)
+    private FileIterator listBlobFiles(AzureLocation location, Optional<String> startingFrom)
     {
-        PagedIterable<BlobItem> blobItems = createBlobContainerClient(location, Optional.empty()).listBlobs(new ListBlobsOptions().setPrefix(location.directoryPath()), null);
+        String directoryPath = location.directoryPath();
+        ListBlobsOptions options = new ListBlobsOptions().setPrefix(directoryPath);
+        startingFrom.ifPresent(startFrom -> options.setStartFrom(directoryPath.concat(startFrom)));
+
+        PagedIterable<BlobItem> blobItems = createBlobContainerClient(location, Optional.empty()).listBlobs(options, null);
         return new AzureBlobFileIterator(location, blobItems.iterator());
     }
 
@@ -660,6 +711,19 @@ public class AzureFileSystem
             throw new IllegalArgumentException();
         }
         return fileSystemClient;
+    }
+
+    private static String startingFromLowerBound(String startingFrom)
+    {
+        // Truncate startingFrom to immediately before the first character that is either equal to or lexicographically
+        // smaller than '/'. This is a workaround to disambiguate the startFrom cursor given that Azure Data Lake Storage
+        // Gen2 orders directories before files in listing results
+        for (int index = 0; index < startingFrom.length(); index++) {
+            if (startingFrom.charAt(index) <= '/') {
+                return startingFrom.substring(0, index);
+            }
+        }
+        return startingFrom;
     }
 
     private static DataLakeDirectoryClient createDirectoryClient(DataLakeFileSystemClient fileSystemClient, String directoryName)

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -54,12 +54,14 @@ import java.util.Set;
 import static com.google.cloud.storage.Storage.BlobListOption.currentDirectory;
 import static com.google.cloud.storage.Storage.BlobListOption.matchGlob;
 import static com.google.cloud.storage.Storage.BlobListOption.pageSize;
+import static com.google.cloud.storage.Storage.BlobListOption.startOffset;
 import static com.google.cloud.storage.Storage.SignUrlOption.withExtHeaders;
 import static com.google.cloud.storage.Storage.SignUrlOption.withV4Signature;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.partition;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.filesystem.TrinoFileSystem.checkStartingFrom;
 import static io.trino.filesystem.gcs.GcsUtils.encodedKey;
 import static io.trino.filesystem.gcs.GcsUtils.getBlob;
 import static io.trino.filesystem.gcs.GcsUtils.handleGcsException;
@@ -217,6 +219,24 @@ public class GcsFileSystem
         GcsLocation gcsLocation = new GcsLocation(normalizeToDirectory(location));
         try {
             return new GcsFileIterator(gcsLocation, getPage(gcsLocation));
+        }
+        catch (RuntimeException e) {
+            throw handleGcsException(e, "listing files", gcsLocation);
+        }
+    }
+
+    @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        checkStartingFrom(startingFrom);
+        if (startingFrom.isEmpty()) {
+            return listFiles(location);
+        }
+
+        GcsLocation gcsLocation = new GcsLocation(normalizeToDirectory(location));
+        try {
+            return new GcsFileIterator(gcsLocation, getPage(gcsLocation, startOffset(gcsLocation.path() + startingFrom)));
         }
         catch (RuntimeException e) {
             throw handleGcsException(e, "listing files", gcsLocation);

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.s3;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import io.airlift.units.Duration;
+import io.trino.filesystem.EmulatedListFilesStartingFromIterator;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
@@ -59,6 +60,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.partition;
 import static com.google.common.collect.Multimaps.toMultimap;
+import static io.trino.filesystem.TrinoFileSystem.checkStartingFrom;
 import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.NONE;
 import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
@@ -159,7 +161,7 @@ final class S3FileSystem
     public void deleteDirectory(Location location)
             throws IOException
     {
-        FileIterator iterator = listObjects(location, true);
+        FileIterator iterator = listObjects(location, true, "");
         while (iterator.hasNext()) {
             List<Location> files = new ArrayList<>();
             while ((files.size() < 1000) && iterator.hasNext()) {
@@ -237,38 +239,15 @@ final class S3FileSystem
     public FileIterator listFiles(Location location)
             throws IOException
     {
-        return listObjects(location, false);
+        return listObjects(location, false, "");
     }
 
-    private FileIterator listObjects(Location location, boolean includeDirectoryObjects)
+    @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {
-        S3Location s3Location = new S3Location(location);
-
-        String key = s3Location.key();
-        if (!key.isEmpty() && !key.endsWith("/")) {
-            key += "/";
-        }
-
-        ListObjectsV2Request request = ListObjectsV2Request.builder()
-                .overrideConfiguration(context::applyCredentialProviderOverride)
-                // Restore status will not be added to the response without requested
-                .optionalObjectAttributes(OptionalObjectAttributes.RESTORE_STATUS)
-                .requestPayer(requestPayer)
-                .bucket(s3Location.bucket())
-                .prefix(key)
-                .build();
-
-        try {
-            Stream<S3Object> s3ObjectStream = client.listObjectsV2Paginator(request).contents().stream();
-            if (!includeDirectoryObjects) {
-                s3ObjectStream = s3ObjectStream.filter(object -> !object.key().endsWith("/"));
-            }
-            return new S3FileIterator(s3Location, s3ObjectStream.iterator());
-        }
-        catch (SdkException e) {
-            throw new TrinoFileSystemException("Failed to list location: " + location, e);
-        }
+        checkStartingFrom(startingFrom);
+        return listObjects(location, false, startingFrom);
     }
 
     @Override
@@ -303,16 +282,7 @@ final class S3FileSystem
         S3Location s3Location = new S3Location(location);
         Location baseLocation = s3Location.baseLocation();
 
-        String key = s3Location.key();
-        if (!key.isEmpty() && !key.endsWith("/")) {
-            key += "/";
-        }
-
-        ListObjectsV2Request request = ListObjectsV2Request.builder()
-                .overrideConfiguration(context::applyCredentialProviderOverride)
-                .requestPayer(requestPayer)
-                .bucket(s3Location.bucket())
-                .prefix(key)
+        ListObjectsV2Request request = listObjectsRequest(s3Location, directoryKey(s3Location.key()))
                 .delimiter("/")
                 .build();
 
@@ -386,6 +356,64 @@ final class S3FileSystem
         catch (URISyntaxException e) {
             throw new TrinoFileSystemException("Failed to convert pre-signed URI to URI", e);
         }
+    }
+
+    private FileIterator listObjects(Location location, boolean includeDirectoryObjects, String startingFrom)
+            throws IOException
+    {
+        S3Location s3Location = new S3Location(location);
+        String keyPrefix = directoryKey(s3Location.key());
+        ListObjectsV2Request.Builder request = listObjectsRequest(s3Location, keyPrefix);
+
+        try {
+            if (!startingFrom.isEmpty()) {
+                // S3 startAfter is exclusive. Start slightly earlier and filter client-side to
+                // preserve the inclusive listFilesStartingFrom semantics.
+                String startingAfter = keyPrefix + truncateLastCodePoint(startingFrom);
+                if (!startingAfter.isEmpty()) {
+                    request.startAfter(startingAfter);
+                }
+            }
+
+            Stream<S3Object> s3ObjectStream = client.listObjectsV2Paginator(request.build()).contents().stream();
+            if (!includeDirectoryObjects) {
+                s3ObjectStream = s3ObjectStream.filter(object -> !object.key().endsWith("/"));
+            }
+
+            S3FileIterator iterator = new S3FileIterator(s3Location, s3ObjectStream.iterator());
+            if (!startingFrom.isEmpty()) {
+                return new EmulatedListFilesStartingFromIterator(iterator, s3Location.location(), startingFrom);
+            }
+            return iterator;
+        }
+        catch (SdkException e) {
+            throw new TrinoFileSystemException("Failed to list location: " + location, e);
+        }
+    }
+
+    private ListObjectsV2Request.Builder listObjectsRequest(S3Location location, String keyPrefix)
+    {
+        return ListObjectsV2Request.builder()
+                .overrideConfiguration(context::applyCredentialProviderOverride)
+                // Restore status will only be added to the response if requested
+                .optionalObjectAttributes(OptionalObjectAttributes.RESTORE_STATUS)
+                .requestPayer(requestPayer)
+                .bucket(location.bucket())
+                .prefix(keyPrefix);
+    }
+
+    private static String directoryKey(String key)
+    {
+        if (!key.isEmpty() && !key.endsWith("/")) {
+            return key + "/";
+        }
+        return key;
+    }
+
+    private static String truncateLastCodePoint(String value)
+    {
+        verify(!value.isEmpty(), "value is empty");
+        return value.substring(0, value.offsetByCodePoints(value.length(), -1));
     }
 
     private static Map<String, List<String>> filterHeaders(Map<String, List<String>> headers)

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMinIo.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemMinIo.java
@@ -114,6 +114,15 @@ public class TestS3FileSystemMinIo
 
     @Test
     @Override
+    public void testListFilesStartingFrom()
+            throws IOException
+    {
+        // MinIO is not hierarchical but has hierarchical naming constraints. For example it's not possible to have two blobs "level0" and "level0/level1".
+        testListFilesStartingFrom(true);
+    }
+
+    @Test
+    @Override
     public void testDeleteDirectory()
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/EmulatedListFilesStartingFromIterator.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/EmulatedListFilesStartingFromIterator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public final class EmulatedListFilesStartingFromIterator
+        implements FileIterator
+{
+    private final FileIterator delegate;
+    private final String locationPath;
+    private final String startingFrom;
+    private FileEntry nextEntry;
+
+    public EmulatedListFilesStartingFromIterator(FileIterator delegate, Location location, String startingFrom)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+
+        String locationPath = location.path();
+        this.locationPath = (locationPath.isEmpty() || locationPath.endsWith("/")) ? locationPath : locationPath + "/";
+
+        this.startingFrom = requireNonNull(startingFrom, "startingFrom is null");
+    }
+
+    @Override
+    public boolean hasNext()
+            throws IOException
+    {
+        loadNextEntry();
+        return nextEntry != null;
+    }
+
+    @Override
+    public FileEntry next()
+            throws IOException
+    {
+        loadNextEntry();
+        if (nextEntry == null) {
+            throw new NoSuchElementException();
+        }
+
+        FileEntry result = nextEntry;
+        nextEntry = null;
+        return result;
+    }
+
+    private void loadNextEntry()
+            throws IOException
+    {
+        if (nextEntry != null) {
+            return;
+        }
+
+        while (delegate.hasNext()) {
+            FileEntry entry = delegate.next();
+            String entryPath = entry.location().path();
+            checkState(entryPath.startsWith(locationPath), "Expected listed file to start with directory path '%s': %s", locationPath, entry.location());
+
+            String entryTail = entryPath.substring(locationPath.length());
+            if (entryTail.compareTo(startingFrom) >= 0) {
+                nextEntry = entry;
+                return;
+            }
+        }
+
+        nextEntry = null;
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
@@ -24,6 +24,9 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 /**
  * TrinoFileSystem is the main abstraction for Trino to interact with data in cloud-like storage
  * systems. This replaces uses HDFS APIs in Trino.  This is not a full replacement of the HDFS, and
@@ -218,7 +221,7 @@ public interface TrinoFileSystem
      * exact name of the prefix, it is not included in the results.
      * <p>
      * The returned FileEntry locations will start with the specified location exactly
-     * and are lexicographically sorted (except for local HDFS which has the system-dependant
+     * and are lexicographically sorted (except for local HDFS which has the system-dependent
      * ordering).
      *
      * @param location the directory to list
@@ -226,6 +229,56 @@ public interface TrinoFileSystem
      */
     FileIterator listFiles(Location location)
             throws IOException;
+
+    /**
+     * Lists files within the specified directory recursively, including only files where the
+     * remainder of the path after the location is lexicographically greater than or equal to
+     * {@code startingFrom}. The location can be empty, listing all files in the file system where
+     * the path is greater than or equal to {@code startingFrom}. The location is always interpreted
+     * as a directory, whether or not it ends with a slash; {@code startingFrom} is compared against
+     * the portion of the path that follows the directory's (implicit or explicit) trailing slash.
+     * If the location does not exist, an empty iterator is returned. {@code startingFrom} must
+     * contain only ASCII characters (code points 0-127) and may be empty, in which case the
+     * behavior is identical to {@link #listFiles(Location)}.
+     * <p>
+     * For hierarchical file systems, if the path is not a directory, an exception is
+     * raised. For blob file systems, all blobs that start with the location are listed, subject
+     * to the {@code startingFrom} constraint.
+     * <p>
+     * The returned FileEntry locations start with the specified location exactly and are
+     * lexicographically sorted (except for local HDFS which has the system-dependent ordering).
+     * When non-ASCII filenames are present, the exact sort order may differ between
+     * implementations: object stores commonly sort by UTF-8 byte order, while in-memory and
+     * local implementations sort by Java {@link String#compareTo char-by-char order}. Because
+     * every non-ASCII code point is strictly greater than every ASCII character under all of
+     * these orderings, an ASCII {@code startingFrom} never excludes a non-ASCII filename.
+     * Callers that rely on a specific sort order should restrict usage to directories whose
+     * filenames are entirely ASCII.
+     *
+     * @param location the directory to list
+     * @param startingFrom the inclusive lower bound for the path remainder after {@code location};
+     *         must contain only ASCII characters
+     * @throws IllegalArgumentException if location is not valid for this file system, or if
+     *         {@code startingFrom} contains non-ASCII characters
+     */
+    default FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        checkStartingFrom(startingFrom);
+        if (startingFrom.isEmpty()) {
+            return listFiles(location);
+        }
+
+        return new EmulatedListFilesStartingFromIterator(listFiles(location), location, startingFrom);
+    }
+
+    static void checkStartingFrom(String startingFrom)
+    {
+        requireNonNull(startingFrom, "startingFrom is null");
+        for (int i = 0; i < startingFrom.length(); i++) {
+            checkArgument(startingFrom.charAt(i) <= 0x7F, "startingFrom must contain only ASCII characters");
+        }
+    }
 
     /**
      * Checks if a directory exists at the specified location. For all file system types,

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
@@ -107,6 +107,13 @@ public final class CacheFileSystem
     }
 
     @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        return delegate.listFilesStartingFrom(location, startingFrom);
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionEnforcingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionEnforcingFileSystem.java
@@ -133,6 +133,13 @@ public class EncryptionEnforcingFileSystem
     }
 
     @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        return delegate.listFilesStartingFrom(location, startingFrom);
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/switching/SwitchingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/switching/SwitchingFileSystem.java
@@ -117,6 +117,13 @@ final class SwitchingFileSystem
     }
 
     @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        return fileSystem(location).listFilesStartingFrom(location, startingFrom);
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/FileSystemAttributes.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/FileSystemAttributes.java
@@ -27,4 +27,5 @@ public final class FileSystemAttributes
     public static final AttributeKey<Long> FILE_LOCATION_COUNT = longKey("trino.file.location_count");
     public static final AttributeKey<Long> FILE_READ_SIZE = longKey("trino.file.read_size");
     public static final AttributeKey<Long> FILE_READ_POSITION = longKey("trino.file.read_position");
+    public static final AttributeKey<String> FILE_LIST_STARTING_FROM = stringKey("trino.file.list_starting_from");
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
@@ -120,6 +120,17 @@ final class TracingFileSystem
     }
 
     @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.listFilesStartingFrom")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location.toString())
+                .setAttribute(FileSystemAttributes.FILE_LIST_STARTING_FROM, startingFrom)
+                .startSpan();
+        return withTracing(span, () -> delegate.listFilesStartingFrom(location, startingFrom));
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracking/TrackingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracking/TrackingFileSystem.java
@@ -96,6 +96,13 @@ public class TrackingFileSystem
     }
 
     @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        return delegate.listFilesStartingFrom(location, startingFrom);
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -1037,6 +1037,13 @@ public abstract class AbstractTestTrinoFileSystem
     }
 
     @Test
+    public void testListFilesStartingFrom()
+            throws IOException
+    {
+        testListFilesStartingFrom(isHierarchical());
+    }
+
+    @Test
     public void testPreSignedUris()
             throws IOException
     {
@@ -1148,6 +1155,177 @@ public abstract class AbstractTestTrinoFileSystem
                 // this lists a path in a directory with an empty name
                 assertThat(listPath("/")).isEmpty();
             }
+        }
+    }
+
+    protected void testListFilesStartingFrom(boolean hierarchicalNamingConstraints)
+            throws IOException
+    {
+        try (Closer closer = Closer.create()) {
+            createTestDirectoryStructure(closer, hierarchicalNamingConstraints);
+
+            ImmutableList.Builder<Location> rootAllBuilder = ImmutableList.<Location>builder()
+                    .add(
+                            createLocation("level0-file0"),
+                            createLocation("level0-file1"),
+                            createLocation("level0-file2"),
+                            createLocation("level0/level1-file0"),
+                            createLocation("level0/level1-file1"),
+                            createLocation("level0/level1-file2"),
+                            createLocation("level0/level1/level2-file0"),
+                            createLocation("level0/level1/level2-file1"),
+                            createLocation("level0/level1/level2-file2"));
+            if (!hierarchicalNamingConstraints) {
+                rootAllBuilder.add(
+                        createLocation("level0"),
+                        createLocation("level0/level1"),
+                        createLocation("level0/level1/level2"));
+            }
+            ImmutableList<Location> rootAll = rootAllBuilder.build();
+
+            ImmutableList.Builder<Location> rootStartingFromLevel1File1Builder = ImmutableList.<Location>builder()
+                    .add(
+                            createLocation("level0/level1-file1"),
+                            createLocation("level0/level1-file2"),
+                            createLocation("level0/level1/level2-file0"),
+                            createLocation("level0/level1/level2-file1"),
+                            createLocation("level0/level1/level2-file2"));
+            if (!hierarchicalNamingConstraints) {
+                rootStartingFromLevel1File1Builder.add(createLocation("level0/level1/level2"));
+            }
+            ImmutableList<Location> rootStartingFromLevel1File1 = rootStartingFromLevel1File1Builder.build();
+
+            ImmutableList.Builder<Location> level0AllBuilder = ImmutableList.<Location>builder()
+                    .add(
+                            createLocation("level0/level1-file0"),
+                            createLocation("level0/level1-file1"),
+                            createLocation("level0/level1-file2"),
+                            createLocation("level0/level1/level2-file0"),
+                            createLocation("level0/level1/level2-file1"),
+                            createLocation("level0/level1/level2-file2"));
+            if (!hierarchicalNamingConstraints) {
+                level0AllBuilder.add(
+                        createLocation("level0/level1"),
+                        createLocation("level0/level1/level2"));
+            }
+            ImmutableList<Location> level0All = level0AllBuilder.build();
+
+            ImmutableList.Builder<Location> level0StartingFromLevel1File0zBuilder = ImmutableList.<Location>builder()
+                    .add(
+                            createLocation("level0/level1-file1"),
+                            createLocation("level0/level1-file2"),
+                            createLocation("level0/level1/level2-file0"),
+                            createLocation("level0/level1/level2-file1"),
+                            createLocation("level0/level1/level2-file2"));
+            if (!hierarchicalNamingConstraints) {
+                level0StartingFromLevel1File0zBuilder.add(createLocation("level0/level1/level2"));
+            }
+            ImmutableList<Location> level0StartingFromLevel1File0z = level0StartingFromLevel1File0zBuilder.build();
+
+            ImmutableList<Location> level0StartingFromLevel1Level2File1 = ImmutableList.of(
+                    createLocation("level0/level1/level2-file1"),
+                    createLocation("level0/level1/level2-file2"));
+
+            ImmutableList.Builder<Location> level1AllBuilder = ImmutableList.<Location>builder()
+                    .add(
+                            createLocation("level0/level1/level2-file0"),
+                            createLocation("level0/level1/level2-file1"),
+                            createLocation("level0/level1/level2-file2"));
+            if (!hierarchicalNamingConstraints) {
+                level1AllBuilder.add(createLocation("level0/level1/level2"));
+            }
+            ImmutableList<Location> level1All = level1AllBuilder.build();
+
+            ImmutableList.Builder<Location> level1StartingFromLevel2Builder = ImmutableList.<Location>builder()
+                    .add(
+                            createLocation("level0/level1/level2-file0"),
+                            createLocation("level0/level1/level2-file1"),
+                            createLocation("level0/level1/level2-file2"));
+            if (!hierarchicalNamingConstraints) {
+                level1StartingFromLevel2Builder.add(createLocation("level0/level1/level2"));
+            }
+            ImmutableList<Location> level1StartingFromLevel2 = level1StartingFromLevel2Builder.build();
+
+            ImmutableList<Location> level1StartingFromLevel2File1 = ImmutableList.of(
+                    createLocation("level0/level1/level2-file1"),
+                    createLocation("level0/level1/level2-file2"));
+
+            assertThat(listPathStartingFrom("", ""))
+                    .containsExactlyInAnyOrderElementsOf(rootAll);
+            assertThat(listPathStartingFrom("", "level0/level1-file1"))
+                    .containsExactlyInAnyOrderElementsOf(rootStartingFromLevel1File1);
+            assertThat(listPathStartingFrom("", "zzz")).isEmpty();
+
+            assertThat(listPathStartingFrom("level0", ""))
+                    .containsExactlyInAnyOrderElementsOf(level0All);
+            assertThat(listPathStartingFrom("level0/", ""))
+                    .containsExactlyInAnyOrderElementsOf(level0All);
+            assertThat(listPathStartingFrom("level0", "level1"))
+                    .containsExactlyInAnyOrderElementsOf(level0All);
+            assertThat(listPathStartingFrom("level0", "level1-file0z"))
+                    .containsExactlyInAnyOrderElementsOf(level0StartingFromLevel1File0z);
+            assertThat(listPathStartingFrom("level0", "level1/level2-file1"))
+                    .containsExactlyInAnyOrderElementsOf(level0StartingFromLevel1Level2File1);
+            assertThat(listPathStartingFrom("level0/", "level1-file0z"))
+                    .containsExactlyInAnyOrderElementsOf(level0StartingFromLevel1File0z);
+            assertThat(listPathStartingFrom("level0", "zzz")).isEmpty();
+
+            assertThat(listPathStartingFrom("level0/level1/", ""))
+                    .containsExactlyInAnyOrderElementsOf(level1All);
+            assertThat(listPathStartingFrom("level0/level1", ""))
+                    .containsExactlyInAnyOrderElementsOf(level1All);
+            assertThat(listPathStartingFrom("level0/level1", "level2"))
+                    .containsExactlyInAnyOrderElementsOf(level1StartingFromLevel2);
+            assertThat(listPathStartingFrom("level0/level1", "level2-file1"))
+                    .containsExactlyInAnyOrderElementsOf(level1StartingFromLevel2File1);
+            assertThat(listPathStartingFrom("level0/level1", "zzz")).isEmpty();
+
+            assertThat(listPathStartingFrom("level0/level1/level2/", "")).isEmpty();
+            assertThat(listPathStartingFrom("level0/level1/level2", "")).isEmpty();
+            assertThat(listPathStartingFrom("level0/level1/level2", "zzz")).isEmpty();
+
+            assertThat(listPathStartingFrom("level0/level1/level2/level3", "")).isEmpty();
+            assertThat(listPathStartingFrom("level0/level1/level2/level3/", "")).isEmpty();
+
+            assertThat(listPathStartingFrom("unknown/", "")).isEmpty();
+
+            for (String directory : ImmutableList.of(
+                    "",
+                    "level0",
+                    "level0/level1",
+                    "level0/level1/level2",
+                    "level0/level1/level2/level3")) {
+                assertThat(listPathStartingFrom(directory, ""))
+                        .containsExactlyInAnyOrderElementsOf(listPath(directory));
+
+                if (!directory.isEmpty()) {
+                    assertThat(listPathStartingFrom(directory + "/", ""))
+                            .containsExactlyInAnyOrderElementsOf(listPath(directory + "/"));
+                }
+            }
+
+            if (isHierarchical()) {
+                assertThatThrownBy(() -> listPathStartingFrom("level0-file0", ""))
+                        .isInstanceOf(IOException.class)
+                        .hasMessageContaining(createLocation("level0-file0").toString());
+            }
+            else {
+                assertThat(listPathStartingFrom("level0-file0", "")).isEmpty();
+            }
+
+            if (!hierarchicalNamingConstraints && !normalizesListFilesResult()) {
+                assertThat(listPathStartingFrom("/", "")).isEmpty();
+            }
+
+            assertThatThrownBy(() -> listPathStartingFrom("", "é"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("ASCII");
+            assertThatThrownBy(() -> listPathStartingFrom("", "level0/é"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("ASCII");
+            assertThatThrownBy(() -> listPathStartingFrom("", "💡"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("ASCII");
         }
     }
 
@@ -1404,6 +1582,20 @@ public abstract class AbstractTestTrinoFileSystem
     {
         List<Location> locations = new ArrayList<>();
         FileIterator fileIterator = getFileSystem().listFiles(createListingLocation(path));
+        while (fileIterator.hasNext()) {
+            FileEntry fileEntry = fileIterator.next();
+            Location location = fileEntry.location();
+            assertThat(fileEntry.length()).isEqualTo(TEST_BLOB_CONTENT_PREFIX.length() + location.toString().length());
+            locations.add(location);
+        }
+        return locations;
+    }
+
+    private List<Location> listPathStartingFrom(String path, String startingFrom)
+            throws IOException
+    {
+        List<Location> locations = new ArrayList<>();
+        FileIterator fileIterator = getFileSystem().listFilesStartingFrom(createListingLocation(path), startingFrom);
         while (fileIterator.hasNext()) {
             FileEntry fileEntry = fileIterator.next();
             Location location = fileEntry.location();

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestEmulatedListFilesStartingFromIterator.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestEmulatedListFilesStartingFromIterator.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestEmulatedListFilesStartingFromIterator
+{
+    private static final Instant MODIFIED = Instant.ofEpochSecond(1234567890);
+
+    @Test
+    void testListFilesStartingFromUsesFullPathRemainder()
+            throws IOException
+    {
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///prefix/"),
+                "a/file-2",
+                List.of(
+                        entry("file:///prefix/a/file-1"),
+                        entry("file:///prefix/a/file-2"),
+                        entry("file:///prefix/a/sub/file-3"),
+                        entry("file:///prefix/b/file-4"))))
+                .containsExactly(
+                        Location.of("file:///prefix/a/file-2"),
+                        Location.of("file:///prefix/a/sub/file-3"),
+                        Location.of("file:///prefix/b/file-4"));
+    }
+
+    @Test
+    void testListFilesStartingFromNormalizesDirectoryLocationWithoutTrailingSlash()
+            throws IOException
+    {
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///prefix"),
+                "b",
+                List.of(
+                        entry("file:///prefix/a/file-1"),
+                        entry("file:///prefix/b/file-2"),
+                        entry("file:///prefix/c/file-3"))))
+                .containsExactly(
+                        Location.of("file:///prefix/b/file-2"),
+                        Location.of("file:///prefix/c/file-3"));
+    }
+
+    @Test
+    void testListFilesStartingFromSupportsRootListing()
+            throws IOException
+    {
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///"),
+                "b",
+                List.of(
+                        entry("file:///a/file-1"),
+                        entry("file:///b/file-2"),
+                        entry("file:///c/file-3"))))
+                .containsExactly(
+                        Location.of("file:///b/file-2"),
+                        Location.of("file:///c/file-3"));
+    }
+
+    @Test
+    void testListFilesStartingFromSupportsAuthorityRootListing()
+            throws IOException
+    {
+        assertThat(listFilesStartingFrom(
+                Location.of("memory://"),
+                "b/file-2",
+                List.of(
+                        entry("memory:///a/file-1"),
+                        entry("memory:///b/file-2"),
+                        entry("memory:///c/file-3"))))
+                .containsExactly(
+                        Location.of("memory:///b/file-2"),
+                        Location.of("memory:///c/file-3"));
+    }
+
+    @Test
+    void testListFilesStartingFromSupportsBarePaths()
+            throws IOException
+    {
+        assertThat(listFilesStartingFrom(
+                Location.of("/prefix/"),
+                "b",
+                List.of(
+                        entry("/prefix/a/file-1"),
+                        entry("/prefix/b/file-2"),
+                        entry("/prefix/c/file-3"))))
+                .containsExactly(
+                        Location.of("/prefix/b/file-2"),
+                        Location.of("/prefix/c/file-3"));
+    }
+
+    @Test
+    void testListFilesStartingFromEmptyStartingFromMatchesListFiles()
+            throws IOException
+    {
+        List<FileEntry> entries = List.of(
+                entry("file:///prefix/a/file-1"),
+                entry("file:///prefix/b/file-2"));
+
+        assertThat(listLocations(new EmulatedListFilesStartingFromIterator(
+                new ListFileIterator(entries),
+                Location.of("file:///prefix/"),
+                "")))
+                .isEqualTo(entries.stream()
+                        .map(FileEntry::location)
+                        .toList());
+    }
+
+    @Test
+    void testListFilesStartingFromAllowsSlashInStartingFrom()
+            throws IOException
+    {
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///prefix/"),
+                "a/file-1",
+                List.of(
+                        entry("file:///prefix/a/file-1"),
+                        entry("file:///prefix/a/file-2"),
+                        entry("file:///prefix/b/file-3"))))
+                .containsExactly(
+                        Location.of("file:///prefix/a/file-1"),
+                        Location.of("file:///prefix/a/file-2"),
+                        Location.of("file:///prefix/b/file-3"));
+    }
+
+    @Test
+    void testListFilesStartingFromLeadingSlashInStartingFromMatchesAllFiles()
+            throws IOException
+    {
+        // '/' (0x2F) is less than any printable filename-start character, so a startingFrom
+        // value beginning with '/' matches every file whose path remainder does not itself
+        // begin with '/' - i.e., every regular file under the directory.
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///prefix/"),
+                "/bar",
+                List.of(
+                        entry("file:///prefix/abc"),
+                        entry("file:///prefix/bar"),
+                        entry("file:///prefix/foo"))))
+                .containsExactly(
+                        Location.of("file:///prefix/abc"),
+                        Location.of("file:///prefix/bar"),
+                        Location.of("file:///prefix/foo"));
+    }
+
+    @Test
+    void testListFilesStartingFromDoubleSlashPathComponent()
+            throws IOException
+    {
+        // Blob stores allow keys with empty-name components (e.g. "double//slash"). The
+        // path remainder after the listing directory preserves the extra slash, so the
+        // slash participates in the comparison against startingFrom at its literal position.
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///double/"),
+                ".",
+                List.of(
+                        entry("file:///double//slash"),
+                        entry("file:///double/a"))))
+                .containsExactly(
+                        Location.of("file:///double//slash"),
+                        Location.of("file:///double/a"));
+
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///double/"),
+                "a",
+                List.of(
+                        entry("file:///double//slash"),
+                        entry("file:///double/a"))))
+                .containsExactly(
+                        Location.of("file:///double/a"));
+    }
+
+    @Test
+    void testListFilesStartingFromIncludesAllNonAsciiFilenames()
+            throws IOException
+    {
+        // Any non-ASCII code point is lexicographically greater than every ASCII character
+        // under UTF-8 byte, Java char, and Unicode code point comparisons, so an ASCII
+        // startingFrom must never exclude a file with a non-ASCII path remainder.
+        assertThat(listFilesStartingFrom(
+                Location.of("file:///prefix/"),
+                "a",
+                List.of(
+                        entry("file:///prefix/a-ascii"),
+                        entry("file:///prefix/é-latin1"),
+                        entry("file:///prefix/α-greek"),
+                        entry("file:///prefix/💡-supplementary"),
+                        entry("file:///prefix/Ａ-fullwidth"))))
+                .containsExactlyInAnyOrder(
+                        Location.of("file:///prefix/a-ascii"),
+                        Location.of("file:///prefix/é-latin1"),
+                        Location.of("file:///prefix/α-greek"),
+                        Location.of("file:///prefix/💡-supplementary"),
+                        Location.of("file:///prefix/Ａ-fullwidth"));
+    }
+
+    private static List<Location> listFilesStartingFrom(Location location, String startingFrom, List<FileEntry> entries)
+            throws IOException
+    {
+        return listLocations(new EmulatedListFilesStartingFromIterator(new ListFileIterator(entries), location, startingFrom));
+    }
+
+    private static FileEntry entry(String location)
+    {
+        return new FileEntry(Location.of(location), 1, MODIFIED, Optional.empty());
+    }
+
+    private static List<Location> listLocations(FileIterator iterator)
+            throws IOException
+    {
+        List<Location> locations = new ArrayList<>();
+        while (iterator.hasNext()) {
+            locations.add(iterator.next().location());
+        }
+        return List.copyOf(locations);
+    }
+
+    private static final class ListFileIterator
+            implements FileIterator
+    {
+        private final Iterator<FileEntry> iterator;
+
+        private ListFileIterator(List<FileEntry> entries)
+        {
+            iterator = entries.iterator();
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public FileEntry next()
+        {
+            return iterator.next();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Modern blob storage systems support performant APIs for enumerating objects starting from a user-provided cursor. This can be used to skip irrelevant objects when listing from large directories, which in turn can make the listing operation much faster and cheaper.

This PR introduces a `listFilesStartingFrom` method on `TrinoFileSystem`, with an emulated default implementation for file systems that don't support the operation natively. It includes native implementations for `AzureFileSystem`, `S3FileSystem`, and `GcsFileSystem`.

`startingFrom` is restricted to ASCII characters. Under that restriction, UTF-8 byte, Java char, and Unicode code point orderings all agree on which files to include, so the backend-native cursor (byte-ordered) and the client-side emulated filter (char-ordered) produce identical results regardless of what filenames exist in the directory.

This API was initially designed to accelerate operations on the `_delta_log` directory in Delta Lake tables. For large tables, `_delta_log` can grow to encompass tens of thousands of objects, so efficiently skipping irrelevant objects is critical to overall good performance. However, it may also be useful for optimizations on other file-based table formats as well.

## Additional context and related issues
This improvement came out of a previous PR, https://github.com/trinodb/trino/pull/28381, which accelerates reading Delta Lake metadata by identifying the latest available "checksum file" in the `_delta_log`. Since `_delta_log` may be enormous, it's only possible to do this performantly using `listFilesStartingFrom` or a similar API.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
```
