### PR TITLE
Added retryable tests pattern

### DIFF
--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -366,6 +366,23 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ProductTestRetryAnalyzer.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ProductTestRetryAnalyzer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product;
+
+import io.airlift.log.Logger;
+import io.trino.testng.services.FlakyTestRetryAnalyzer;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static io.trino.testng.services.FlakyTestRetryAnalyzer.ALLOWED_RETRIES_COUNT;
+import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_MATCH;
+
+/**
+ * Retries convention-based product tests that fail due to known transient
+ * infrastructure failures that cannot be fixed in the test itself.
+ */
+public class ProductTestRetryAnalyzer
+        implements IRetryAnalyzer
+{
+    private static final Logger log = Logger.get(ProductTestRetryAnalyzer.class);
+
+    private static final String DISABLED_SYSTEM_PROPERTY = "io.trino.tests.product.ProductTestRetryAnalyzer.disabled";
+
+    private static final Pattern INFRASTRUCTURE_FAILURE_PATTERN = Pattern.compile(RETRYABLE_FAILURES_MATCH);
+
+    private final Map<String, Long> retryCounter = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean retry(ITestResult result)
+    {
+        if (result.isSuccess()) {
+            return false;
+        }
+
+        if (Boolean.getBoolean(DISABLED_SYSTEM_PROPERTY)) {
+            log.info("ProductTestRetryAnalyzer disabled via system property '%s'", DISABLED_SYSTEM_PROPERTY);
+            return false;
+        }
+
+        if (result.getThrowable() == null) {
+            return false;
+        }
+
+        String stackTrace = getStackTraceAsString(result.getThrowable());
+        if (!INFRASTRUCTURE_FAILURE_PATTERN.matcher(stackTrace).find()) {
+            return false;
+        }
+
+        ITestNGMethod method = result.getMethod();
+        String testId = FlakyTestRetryAnalyzer.testId(method, result.getParameters());
+        long retryCount = retryCounter.merge(testId, 1L, Long::sum);
+        if (retryCount > ALLOWED_RETRIES_COUNT) {
+            return false;
+        }
+        log.warn(
+                result.getThrowable(),
+                "Test %s::%s attempt %s failed due to infrastructure failure, retrying...,",
+                result.getTestClass().getName(),
+                method.getMethodName(),
+                retryCount);
+        return true;
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ProductTestRetryListener.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ProductTestRetryListener.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product;
+
+import io.airlift.log.Logger;
+import io.trino.tempto.internal.convention.ConventionBasedTestProxyGenerator;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+import org.testng.ITestNGMethod;
+
+public class ProductTestRetryListener
+        implements IClassListener
+{
+    private static final Logger log = Logger.get(ProductTestRetryListener.class);
+
+    @Override
+    public void onBeforeClass(ITestClass testClass)
+    {
+        Class<?> realClass = testClass.getRealClass();
+        if (isConventionBasedTest(realClass)) {
+            for (ITestNGMethod method : testClass.getTestMethods()) {
+                log.debug("Instrumenting method %s with %s.", method.getMethodName(), ProductTestRetryAnalyzer.class.getSimpleName());
+                method.setRetryAnalyzer(new ProductTestRetryAnalyzer());
+            }
+        }
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {}
+
+    private static boolean isConventionBasedTest(Class<?> realClass)
+    {
+        return ConventionBasedTestProxyGenerator.ConventionBasedTestProxy.class.isAssignableFrom(realClass);
+    }
+}

--- a/testing/trino-product-tests/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-product-tests/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,1 @@
+io.trino.tests.product.ProductTestRetryListener

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestProductTestRetryAnalyzer.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestProductTestRetryAnalyzer.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product;
+
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+import org.testng.internal.NoOpTestClass;
+import org.testng.internal.TestResult;
+
+import java.lang.reflect.Proxy;
+
+import static io.trino.testng.services.FlakyTestRetryAnalyzer.ALLOWED_RETRIES_COUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestProductTestRetryAnalyzer
+{
+    @Test
+    public void testRetryOnHadoopReplicationFailure()
+    {
+        ProductTestRetryAnalyzer analyzer = new ProductTestRetryAnalyzer();
+        ITestResult result = failedResult("testMethod", new RuntimeException(
+                "could only be replicated to 0 nodes instead of minReplication"));
+
+        for (int i = 0; i < ALLOWED_RETRIES_COUNT; i++) {
+            assertThat(analyzer.retry(result))
+                    .describedAs("retry attempt %d", i + 1)
+                    .isTrue();
+        }
+        assertThat(analyzer.retry(result))
+                .describedAs("should not retry beyond allowed count")
+                .isFalse();
+    }
+
+    @Test
+    public void testRetryOnHadoopWriteFailure()
+    {
+        ProductTestRetryAnalyzer analyzer = new ProductTestRetryAnalyzer();
+        ITestResult result = failedResult("testMethod", new RuntimeException(
+                "could only be written to 0 of the 1 minReplication"));
+
+        assertThat(analyzer.retry(result)).isTrue();
+    }
+
+    @Test
+    public void testRetryOnHadoopMapReduceFailure()
+    {
+        ProductTestRetryAnalyzer analyzer = new ProductTestRetryAnalyzer();
+        ITestResult result = failedResult("testMethod", new RuntimeException(
+                "return code 1 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask"));
+
+        assertThat(analyzer.retry(result)).isTrue();
+    }
+
+    @Test
+    public void testNoRetryOnUnknownFailure()
+    {
+        ProductTestRetryAnalyzer analyzer = new ProductTestRetryAnalyzer();
+        ITestResult result = failedResult("testMethod", new RuntimeException(
+                "some unknown failure"));
+
+        assertThat(analyzer.retry(result)).isFalse();
+    }
+
+    @Test
+    public void testNoRetryOnSuccess()
+    {
+        ProductTestRetryAnalyzer analyzer = new ProductTestRetryAnalyzer();
+        ITestResult result = successResult("testMethod");
+
+        assertThat(analyzer.retry(result)).isFalse();
+    }
+
+    @Test
+    public void testNoRetryWhenDisabled()
+    {
+        System.setProperty("io.trino.tests.product.ProductTestRetryAnalyzer.disabled", "true");
+        try {
+            ProductTestRetryAnalyzer analyzer = new ProductTestRetryAnalyzer();
+            ITestResult result = failedResult("testMethod", new RuntimeException(
+                    "could only be replicated to 0 nodes instead of minReplication"));
+
+            assertThat(analyzer.retry(result)).isFalse();
+        }
+        finally {
+            System.clearProperty("io.trino.tests.product.ProductTestRetryAnalyzer.disabled");
+        }
+    }
+
+    private static ITestResult failedResult(String methodName, Throwable throwable)
+    {
+        return testResult(methodName, ITestResult.FAILURE, throwable);
+    }
+
+    private static ITestResult successResult(String methodName)
+    {
+        return testResult(methodName, ITestResult.SUCCESS, null);
+    }
+
+    private static ITestResult testResult(String methodName, int status, Throwable throwable)
+    {
+        NoOpTestClass testClass = new StubTestClass();
+        ITestNGMethod method = stubMethod(methodName, testClass);
+
+        TestResult result = new TestResult();
+        result.setStatus(status);
+        result.setThrowable(throwable);
+        result.setMethod(method);
+        result.setTestClass(testClass);
+        return result;
+    }
+
+    private static ITestNGMethod stubMethod(String methodName, NoOpTestClass testClass)
+    {
+        return (ITestNGMethod) Proxy.newProxyInstance(
+                ITestNGMethod.class.getClassLoader(),
+                new Class<?>[] {ITestNGMethod.class},
+                (proxy, method, args) ->
+                        switch (method.getName()) {
+                            case "getMethodName" -> methodName;
+                            case "getTestClass" -> testClass;
+                            default -> throw new UnsupportedOperationException(method.getName());
+                        });
+    }
+
+    private static class StubTestClass
+            extends NoOpTestClass
+    {
+        StubTestClass()
+        {
+            super();
+            setTestClass(TestProductTestRetryAnalyzer.class);
+        }
+    }
+}

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/FlakyTestRetryAnalyzer.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/FlakyTestRetryAnalyzer.java
@@ -13,7 +13,6 @@
  */
 package io.trino.testng.services;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.log.Logger;
@@ -40,8 +39,7 @@ public class FlakyTestRetryAnalyzer
     // TODO replace pom.xml property with explicit invocation of a testng runner (test suite with a test) and amend the retryer behavior on that level
     private static final String ENABLED_SYSTEM_PROPERTY = "io.trino.testng.services.FlakyTestRetryAnalyzer.enabled";
 
-    @VisibleForTesting
-    static final int ALLOWED_RETRIES_COUNT = 2;
+    public static final int ALLOWED_RETRIES_COUNT = 2;
 
     @GuardedBy("this")
     private final Map<String, Long> retryCounter = new HashMap<>();
@@ -88,13 +86,13 @@ public class FlakyTestRetryAnalyzer
         long retryCount;
         ITestNGMethod method = result.getMethod();
         synchronized (this) {
-            String name = getName(method, result.getParameters());
-            retryCount = retryCounter.getOrDefault(name, 0L);
+            String testId = testId(method, result.getParameters());
+            retryCount = retryCounter.getOrDefault(testId, 0L);
             retryCount++;
             if (retryCount > ALLOWED_RETRIES_COUNT) {
                 return false;
             }
-            retryCounter.put(name, retryCount);
+            retryCounter.put(testId, retryCount);
         }
         log.warn(
                 result.getThrowable(),
@@ -105,7 +103,7 @@ public class FlakyTestRetryAnalyzer
         return true;
     }
 
-    private static String getName(ITestNGMethod method, Object[] parameters)
+    public static String testId(ITestNGMethod method, Object[] parameters)
     {
         String actualTestClass = method.getTestClass().getName();
         if (parameters.length != 0) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Added a `RetryableFailurePattern` SPI for automatically retrying tests that fail due to known transient infrastructure issues.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
### Motivation
Currently, tests that fail due to transient infrastructure problems (e.g., Databricks JDBC communication failures, Hadoop HDFS replication issues) can only be retried if they are individually annotated with `@Flaky`. This has two problems:
  1. Every test interacting with flaky infrastructure must carry its own `@Flaky` annotation with duplicated regex patterns - this is tedious and error-prone.
  2. New tests are not flaky at the start and are easily forgotten. It may lead to spurious CI failures that waste developer time and erode trust in the test suite. Non flaky tests can become ones.
 
### Approach
Instead of requiring per-test annotations, this PR introduces a `RetryableFailurePattern` interface discovered via Java `ServiceLoader`. Each implementation provides a regex pattern that is matched against the failure stacktrace. When any registered pattern matches, `FlakyTestRetryAnalyzer` retries the test (up to the `ALLOWED_RETRIES_COUNT` times) - regardless of whether `@Flaky` is present. This means known infrastructure failure patterns are defined once in the appropriate module and automatically apply to all TestNG tests on the classpath.

### Documentation
Updated docs/src/main/sphinx/develop/tests.md with usage instructions

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
