### PR TITLE
Fix invalid subtree reading

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientTypeSignatureParameter.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientTypeSignatureParameter.java
@@ -171,7 +171,7 @@ public class ClientTypeSignatureParameter
         public ClientTypeSignatureParameter deserialize(JsonParser jp, DeserializationContext ctxt)
                 throws IOException
         {
-            JsonNode node = jp.getCodec().readTree(jp);
+            JsonNode node = ctxt.readTree(jp);
             ParameterKind kind = MAPPER.readValue(MAPPER.treeAsTokens(node.get("kind")), ParameterKind.class);
             JsonParser jsonValue = MAPPER.treeAsTokens(node.get("value"));
             Object value;

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataJacksonModule.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataJacksonModule.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -44,8 +43,6 @@ import java.io.IOException;
 public class QueryDataJacksonModule
         extends SimpleModule
 {
-    private static final TypeReference<EncodedQueryData> ENCODED_FORMAT = new TypeReference<>() {};
-
     public QueryDataJacksonModule()
     {
         super(QueryDataJacksonModule.class.getSimpleName(), Version.unknownVersion());
@@ -68,9 +65,9 @@ public class QueryDataJacksonModule
         {
             // If this is not JSON_ARRAY we are dealing with direct data encoding
             if (jsonParser.currentToken().equals(JsonToken.START_ARRAY)) {
-                return new JsonQueryData(jsonParser.readValueAsTree());
+                return new JsonQueryData(deserializationContext.readTree(jsonParser));
             }
-            return jsonParser.readValueAs(ENCODED_FORMAT);
+            return deserializationContext.readValue(jsonParser, EncodedQueryData.class);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestLocalProperties.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestLocalProperties.java
@@ -704,7 +704,7 @@ public class TestLocalProperties
                             public ColumnHandle deserialize(JsonParser parser, DeserializationContext context)
                                     throws IOException
                             {
-                                return parser.readValueAs(TestingColumnHandle.class);
+                                return context.readValue(parser, TestingColumnHandle.class);
                             }
                         }))
                 .get();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Found invalid deserializers while testing https://github.com/airlift/airlift/pull/1811

Correct way of decoding (sub)trees is by using DeserializationContext which is aware
whether decoded tree is a part of a bigger document. If FAIL_ON_TRAILING_TOKENS
is enabled, decoding without context will fail if the decoded tree is a substree in a bigger
object as the parser will check for next token that exists for the outer object.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
