### PR TITLE
Add retry to BigQuerySqlExecutor

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/RetryOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/RetryOptionsConfigurer.java
@@ -17,6 +17,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import io.trino.spi.connector.ConnectorSession;
 
@@ -77,7 +78,8 @@ public class RetryOptionsConfigurer
         }
     }
 
-    private RetrySettings retrySettings()
+    @VisibleForTesting
+    RetrySettings retrySettings()
     {
         long maxDelay = retryDelay.toMillis() * (long) pow(retryMultiplier, retries);
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -29,6 +29,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Level;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
+import io.airlift.units.Duration;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -195,6 +196,12 @@ public final class BigQueryQueryRunner
                 InputStream jsonKey = new ByteArrayInputStream(Base64.getDecoder().decode(BIGQUERY_CREDENTIALS_KEY));
                 return BigQueryOptions.newBuilder()
                         .setCredentials(ServiceAccountCredentials.fromStream(jsonKey))
+                        .setRetrySettings(new RetryOptionsConfigurer(new BigQueryRpcConfig()
+                                .setRetries(10)
+                                .setRetryDelay(Duration.valueOf("200ms"))
+                                .setRetryMultiplier(1.5)
+                                .setTimeout(Duration.valueOf("30s")))
+                                .retrySettings())
                         .build()
                         .getService();
             }


### PR DESCRIPTION
## Description

The relevant CI failure:
```
Error:  io.trino.plugin.bigquery.TestBigQueryCaseInsensitiveMapping.testNonLowerCaseTableName -- Time elapsed: 53.28 s <<< ERROR!
com.google.cloud.bigquery.BigQueryException: Visibility check was unavailable. Please retry the request and contact support if the problem persists
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:71)
	at com.google.cloud.bigquery.BigQueryImpl.getJob(BigQueryImpl.java:1787)
	at com.google.cloud.bigquery.BigQueryImpl.queryRpc(BigQueryImpl.java:1997)
	at com.google.cloud.bigquery.BigQueryImpl.queryWithTimeout(BigQueryImpl.java:2103)
	at com.google.cloud.bigquery.BigQueryImpl.query(BigQueryImpl.java:2042)
	at com.google.cloud.bigquery.BigQueryImpl.query(BigQueryImpl.java:1931)
	at io.trino.plugin.bigquery.BigQueryQueryRunner$BigQuerySqlExecutor.executeQuery(BigQueryQueryRunner.java:157)
	at io.trino.plugin.bigquery.BigQueryQueryRunner$BigQuerySqlExecutor.execute(BigQueryQueryRunner.java:151)
	at io.trino.plugin.bigquery.BaseBigQueryCaseInsensitiveMapping.lambda$withTable$0(BaseBigQueryCaseInsensitiveMapping.java:263)
	at io.trino.plugin.bigquery.BaseBigQueryCaseInsensitiveMapping.testNonLowerCaseTableName(BaseBigQueryCaseInsensitiveMapping.java:101)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 503 Service Unavailable
GET https://bigquery.googleapis.com/bigquery/v2/projects/sep-bq-cicd-case-insensitive/jobs/job_SrY_Veds-hW4g0ubLubXS3BKqLeE?location=US&prettyPrint=false
{
  "code": 503,
  "errors": [
    {
      "domain": "global",
      "message": "Visibility check was unavailable. Please retry the request and contact support if the problem persists",
      "reason": "backendError"
    }
  ],
  "message": "Visibility check was unavailable. Please retry the request and contact support if the problem persists",
  "status": "UNAVAILABLE"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$3.interceptResponse(AbstractGoogleClientRequest.java:479)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:565)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:506)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:616)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.getJobSkipExceptionTranslation(HttpBigQueryRpc.java:1411)
	at com.google.cloud.bigquery.BigQueryImpl$31.call(BigQueryImpl.java:1791)
	at com.google.cloud.bigquery.BigQueryImpl$31.call(BigQueryImpl.java:1788)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:102)
	at com.google.cloud.bigquery.BigQueryRetryHelper.run(BigQueryRetryHelper.java:108)
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:62)
	... 14 more
```
https://github.com/trinodb/trino/actions/runs/22742339012/job/65958498601

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.