### PR TITLE
add `privateKey` as a JVM property for Snowflake JDBC Connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,7 +514,8 @@ jobs:
             - { modules: plugin/trino-resource-group-managers }
             - { modules: plugin/trino-singlestore }
             - { modules: plugin/trino-snowflake }
-            - { modules: plugin/trino-snowflake, profile: cloud-tests }
+            - { modules: plugin/trino-snowflake, profile: cloud-tests, auth: private-key }
+            - { modules: plugin/trino-snowflake, profile: cloud-tests, auth: password }
             - { modules: plugin/trino-sqlserver }
             - { modules: plugin/trino-vertica }
             - { modules: testing/trino-faulttolerant-tests, profile: default }
@@ -692,8 +693,26 @@ jobs:
         if: matrix.modules == 'plugin/trino-bigquery' && !contains(matrix.profile, 'cloud-tests-2') && (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests-case-insensitive-mapping -Dtesting.bigquery.credentials-key="${BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY}"
-      - name: Cloud Snowflake Tests
-        id: tests-snowflake
+      - name: Cloud Snowflake Tests (Private Key Auth)
+        id: tests-snowflake-private-key
+        env:
+          SNOWFLAKE_URL: ${{ vars.SNOWFLAKE_URL }}
+          SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
+          SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
+          SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
+          SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
+        if: matrix.modules == 'plugin/trino-snowflake' && contains(matrix.profile, 'cloud-tests') && matrix.auth == 'private-key' && (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.SNOWFLAKE_URL != '')
+        run: |
+          $MAVEN test ${MAVEN_TEST} -pl :trino-snowflake -Pcloud-tests \
+            -Dsnowflake.test.server.url="${SNOWFLAKE_URL}" \
+            -Dsnowflake.test.server.user="${SNOWFLAKE_USER}" \
+            -Dsnowflake.test.server.private-key="${SNOWFLAKE_PRIVATE_KEY}" \
+            -Dsnowflake.test.server.database="${SNOWFLAKE_DATABASE}" \
+            -Dsnowflake.test.server.role="${SNOWFLAKE_ROLE}" \
+            -Dsnowflake.test.server.warehouse="${SNOWFLAKE_WAREHOUSE}"
+      - name: Cloud Snowflake Tests (Password Auth)
+        id: tests-snowflake-password
         env:
           SNOWFLAKE_URL: ${{ vars.SNOWFLAKE_URL }}
           SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
@@ -701,7 +720,7 @@ jobs:
           SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
           SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
           SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
-        if: matrix.modules == 'plugin/trino-snowflake' && contains(matrix.profile, 'cloud-tests') && (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.SNOWFLAKE_URL != '')
+        if: matrix.modules == 'plugin/trino-snowflake' && contains(matrix.profile, 'cloud-tests') && matrix.auth == 'password' && (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.SNOWFLAKE_URL != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-snowflake -Pcloud-tests \
             -Dsnowflake.test.server.url="${SNOWFLAKE_URL}" \
@@ -818,7 +837,8 @@ jobs:
               || steps.tests-bq-smoke.outcome == 'failure'
               || steps.tests-iceberg.outcome == 'failure'
               || steps.tests-redshift.outcome == 'failure'
-              || steps.tests-snowflake.outcome == 'failure'
+              || steps.tests-snowflake-password.outcome == 'failure'
+              || steps.tests-snowflake-private-key.outcome == 'failure'
             }}
           upload-heap-dump: ${{ env.SECRETS_PRESENT == '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       - name: Update PR check
@@ -1023,6 +1043,7 @@ jobs:
           SNOWFLAKE_URL: ""
           SNOWFLAKE_USER: ""
           SNOWFLAKE_PASSWORD: ""
+          SNOWFLAKE_PRIVATE_KEY: ""
           SNOWFLAKE_DATABASE: ""
           SNOWFLAKE_ROLE: ""
           SNOWFLAKE_WAREHOUSE: ""
@@ -1096,6 +1117,7 @@ jobs:
           SNOWFLAKE_URL: ${{ vars.SNOWFLAKE_URL }}
           SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
           SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
           SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
           SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}

--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -26,12 +26,17 @@ connection properties as appropriate for your setup:
 connector.name=snowflake
 connection-url=jdbc:snowflake://<account>.snowflakecomputing.com
 connection-user=root
-connection-password=secret
+snowflake.private-key=unencrypted-private-key-content
 snowflake.account=account
 snowflake.database=database
 snowflake.role=role
 snowflake.warehouse=warehouse
 ```
+
+:::{note}
+The `snowflake.private-key` property accepts a Base64-encoded RSA private key in PKCS8 format.
+Alternatively, you can use `connection-password=secret` for password-based authentication.
+:::
 
 The Snowflake connector uses Apache Arrow as the serialization format when
 reading from Snowflake. Add the following required, additional JVM argument

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeConfig.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeConfig.java
@@ -25,6 +25,7 @@ public class SnowflakeConfig
     private String role;
     private String warehouse;
     private String httpProxy;
+    private String privateKey;
 
     public Optional<String> getAccount()
     {
@@ -84,6 +85,19 @@ public class SnowflakeConfig
     public SnowflakeConfig setHttpProxy(String httpProxy)
     {
         this.httpProxy = httpProxy;
+        return this;
+    }
+
+    public Optional<String> getPrivateKey()
+    {
+        return Optional.ofNullable(privateKey);
+    }
+
+    @Config("snowflake.private-key")
+    @ConfigSecuritySensitive
+    public SnowflakeConfig setPrivateKey(String privateKey)
+    {
+        this.privateKey = privateKey;
         return this;
     }
 }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
@@ -41,9 +42,16 @@ public final class SnowflakeQueryRunner
         Builder builder = new Builder()
                 .addConnectorProperty("connection-url", TestingSnowflakeServer.TEST_URL)
                 .addConnectorProperty("connection-user", TestingSnowflakeServer.TEST_USER)
-                .addConnectorProperty("connection-password", TestingSnowflakeServer.TEST_PASSWORD)
                 .addConnectorProperty("snowflake.database", TestingSnowflakeServer.TEST_DATABASE)
                 .addConnectorProperty("snowflake.warehouse", TestingSnowflakeServer.TEST_WAREHOUSE);
+
+        checkArgument(
+                TestingSnowflakeServer.TEST_PRIVATE_KEY.isPresent() ^ TestingSnowflakeServer.TEST_PASSWORD.isPresent(),
+                "Exactly one of PrivateKey or Password must be set");
+        TestingSnowflakeServer.TEST_PRIVATE_KEY
+                .ifPresent(privateKey -> builder.addConnectorProperty("snowflake.private-key", privateKey));
+        TestingSnowflakeServer.TEST_PASSWORD
+                .ifPresent(password -> builder.addConnectorProperty("connection-password", password));
         TestingSnowflakeServer.TEST_ROLE.ifPresent(role -> builder.addConnectorProperty("snowflake.role", role));
         return builder;
     }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConfig.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConfig.java
@@ -32,7 +32,8 @@ public class TestSnowflakeConfig
                 .setDatabase(null)
                 .setRole(null)
                 .setWarehouse(null)
-                .setHttpProxy(null));
+                .setHttpProxy(null)
+                .setPrivateKey(null));
     }
 
     @Test
@@ -44,6 +45,7 @@ public class TestSnowflakeConfig
                 .put("snowflake.role", "MYROLE")
                 .put("snowflake.warehouse", "MYWAREHOUSE")
                 .put("snowflake.http-proxy", "MYPROXY")
+                .put("snowflake.private-key", "MYPRIVATEKEY")
                 .buildOrThrow();
 
         SnowflakeConfig expected = new SnowflakeConfig()
@@ -51,7 +53,8 @@ public class TestSnowflakeConfig
                 .setDatabase("MYDATABASE")
                 .setRole("MYROLE")
                 .setWarehouse("MYWAREHOUSE")
-                .setHttpProxy("MYPROXY");
+                .setHttpProxy("MYPROXY")
+                .setPrivateKey("MYPRIVATEKEY");
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeSnowflakeWithPrivateKey.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeSnowflakeWithPrivateKey.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.env.environment;
+
+import com.google.inject.Inject;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentProvider;
+import io.trino.tests.product.launcher.env.common.Standard;
+import io.trino.tests.product.launcher.env.common.TestsEnvironment;
+
+import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
+import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_JVM_CONFIG;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+@TestsEnvironment
+public class EnvMultinodeSnowflakeWithPrivateKey
+        extends EnvironmentProvider
+{
+    private final DockerFiles.ResourceProvider configDir;
+
+    @Inject
+    public EnvMultinodeSnowflakeWithPrivateKey(DockerFiles dockerFiles, Standard standard)
+    {
+        super(standard);
+        configDir = requireNonNull(dockerFiles, "dockerFiles is null").getDockerFilesHostDirectory("conf/environment/multinode-snowflake-with-private-key");
+    }
+
+    @Override
+    public void extendEnvironment(Environment.Builder builder)
+    {
+        builder.configureContainers(container -> {
+            if (isTrinoContainer(container.getLogicalName())) {
+                container
+                        .withEnv("SNOWFLAKE_URL", requireEnv("SNOWFLAKE_URL"))
+                        .withEnv("SNOWFLAKE_USER", requireEnv("SNOWFLAKE_USER"))
+                        .withEnv("SNOWFLAKE_PRIVATE_KEY", requireEnv("SNOWFLAKE_PRIVATE_KEY"))
+                        .withEnv("SNOWFLAKE_DATABASE", requireEnv("SNOWFLAKE_DATABASE"))
+                        .withEnv("SNOWFLAKE_ROLE", requireEnv("SNOWFLAKE_ROLE"))
+                        .withEnv("SNOWFLAKE_WAREHOUSE", requireEnv("SNOWFLAKE_WAREHOUSE"));
+
+                container.withCopyFileToContainer(forHostPath(configDir.getPath("jvm.config")), CONTAINER_TRINO_JVM_CONFIG);
+            }
+        });
+
+        builder.addConnector("snowflake", forHostPath(configDir.getPath("snowflake.properties")));
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteSnowflake.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteSnowflake.java
@@ -16,6 +16,7 @@ package io.trino.tests.product.launcher.suite.suites;
 import com.google.common.collect.ImmutableList;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.environment.EnvMultinodeSnowflake;
+import io.trino.tests.product.launcher.env.environment.EnvMultinodeSnowflakeWithPrivateKey;
 import io.trino.tests.product.launcher.suite.Suite;
 import io.trino.tests.product.launcher.suite.SuiteTestRun;
 
@@ -31,6 +32,9 @@ public class SuiteSnowflake
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinodeSnowflake.class)
+                        .withGroups("configured_features", "snowflake")
+                        .build(),
+                testOnEnvironment(EnvMultinodeSnowflakeWithPrivateKey.class)
                         .withGroups("configured_features", "snowflake")
                         .build());
     }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-snowflake-with-private-key/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-snowflake-with-private-key/jvm.config
@@ -1,0 +1,19 @@
+-server
+--add-opens=java.base/java.nio=ALL-UNNAMED
+--sun-misc-unsafe-memory-access=allow
+-Xmx2G
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
+-XX:ReservedCodeCacheSize=150M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+# jdk.nio.maxCachedBufferSize controls what buffers can be allocated in per-thread "temporary buffer cache" (sun.nio.ch.Util). Value of 0 disables the cache.
+-Djdk.nio.maxCachedBufferSize=0
+-Duser.timezone=Asia/Kathmandu
+-XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-snowflake-with-private-key/snowflake.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-snowflake-with-private-key/snowflake.properties
@@ -1,0 +1,7 @@
+connector.name=snowflake
+connection-url=${ENV:SNOWFLAKE_URL}
+connection-user=${ENV:SNOWFLAKE_USER}
+snowflake.private-key=${ENV:SNOWFLAKE_PRIVATE_KEY}
+snowflake.database=${ENV:SNOWFLAKE_DATABASE}
+snowflake.role=${ENV:SNOWFLAKE_ROLE}
+snowflake.warehouse=${ENV:SNOWFLAKE_WAREHOUSE}

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
@@ -20,6 +20,7 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -64,5 +65,10 @@ public final class TestingProperties
         String value = System.getProperty(propertyName);
         checkArgument(!isNullOrEmpty(value), "System property %s must be non-empty", propertyName);
         return value;
+    }
+
+    public static Optional<String> optionalSystemProperty(String propertyName)
+    {
+        return Optional.ofNullable(System.getProperty(propertyName));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
* Adds support for the privateKey authentication property in the Snowflake connector.
* The Snowflake JDBC driver already supports this property, but Trino previously had no way to pass it through.
* With this change, users can configure key-pair authentication directly in the catalog instead of relying on file-based approaches.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
* Fixes #26514
* Provides a more secure and convenient alternative to using JDBC URL parameters with file paths and passwords.
* Particularly useful for dynamic catalog creation, where file system dependencies are harder to manage.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(&#x2713;) Release notes are required, with the following suggested text:

```markdown
## Snowflake connector
* Add support for the `privateKey` authentication property to enable key-pair authentication. (#26514)
```
