### PR TITLE
Do not expose JMX beans over http

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -145,11 +145,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>jmx-http</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>joni</artifactId>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -26,7 +26,6 @@ import io.airlift.compress.v3.snappy.SnappyNativeCompressor;
 import io.airlift.compress.v3.zstd.ZstdNativeCompressor;
 import io.airlift.http.server.HttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
-import io.airlift.jmx.JmxHttpModule;
 import io.airlift.jmx.JmxModule;
 import io.airlift.json.JsonModule;
 import io.airlift.log.LogJmxModule;
@@ -99,7 +98,6 @@ public class Server
                 new MBeanModule(),
                 new PrefixObjectNameGeneratorModule("io.trino"),
                 new JmxModule(),
-                new JmxHttpModule(),
                 new JmxOpenMetricsModule(),
                 new LogJmxModule(),
                 new TracingModule("trino", trinoVersion),

--- a/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
@@ -22,7 +22,6 @@ import com.google.inject.multibindings.MapBinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.airlift.http.server.HttpServerConfig;
-import io.airlift.jmx.MBeanResource;
 import io.airlift.openmetrics.MetricsResource;
 import io.trino.server.security.jwt.JwtAuthenticator;
 import io.trino.server.security.jwt.JwtAuthenticatorSupportModule;
@@ -56,7 +55,6 @@ public class ServerSecurityModule
         jaxrsBinder(binder).bind(ResourceSecurityDynamicFeature.class);
 
         resourceSecurityBinder(binder)
-                .managementReadResource(MBeanResource.class)
                 .managementReadResource(MetricsResource.class);
 
         newOptionalBinder(binder, PasswordAuthenticatorManager.class);


### PR DESCRIPTION
JmxHttpModule exposes all mbeans along with the embededded UI that allows to browse MBeans.

This is obsolete way of monitoring Trino that was already
replaced by much modern approach like openmetrics and opentracing.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
