### PR TITLE
Increase value of node-scheduler.allowed-no-matching-node-period

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
@@ -52,7 +52,7 @@ public class NodeSchedulerConfig
     private boolean optimizedLocalScheduling = true;
     private SplitsBalancingPolicy splitsBalancingPolicy = SplitsBalancingPolicy.STAGE;
     private int maxUnacknowledgedSplitsPerTask = 2000;
-    private Duration allowedNoMatchingNodePeriod = new Duration(2, TimeUnit.MINUTES);
+    private Duration allowedNoMatchingNodePeriod = new Duration(10, TimeUnit.MINUTES);
     private Duration exhaustedNodeWaitPeriod = new Duration(2, TimeUnit.MINUTES);
 
     @NotNull

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
@@ -42,7 +42,7 @@ public class TestNodeSchedulerConfig
                 .setIncludeCoordinator(true)
                 .setSplitsBalancingPolicy(NodeSchedulerConfig.SplitsBalancingPolicy.STAGE)
                 .setOptimizedLocalScheduling(true)
-                .setAllowedNoMatchingNodePeriod(new Duration(2, MINUTES))
+                .setAllowedNoMatchingNodePeriod(new Duration(10, MINUTES))
                 .setExhaustedNodeWaitPeriod(new Duration(2, MINUTES)));
     }
 


### PR DESCRIPTION
The default value of 2 minutes was often not big enough. In single worker cluster in case of cluster failure we observed query failures if worker crashed, as replacement worker was not provisioned soon enough.

More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
