### PR TITLE
Use EmptyPageSource.empty() singleton instead of creating new instances

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -123,7 +123,7 @@ public class SystemPageSourceProvider
 
         TupleDomain<ColumnHandle> constraint = systemSplit.getConstraint();
         if (constraint.isNone()) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
         TupleDomain<Integer> newConstraint = systemSplit.getConstraint().transformKeys(columnHandle ->
                 columnsByName.get(((SystemColumnHandle) columnHandle).columnName()));

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -242,7 +242,7 @@ public class ScanFilterAndProjectOperator
 
             ConnectorPageSource source;
             if (split.getConnectorSplit() instanceof EmptySplit) {
-                source = new EmptyPageSource();
+                source = EmptyPageSource.EMPTY;
             }
             else {
                 source = pageSourceProvider.createPageSource(session, split, table, columns, dynamicFilter);

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -180,7 +180,7 @@ public class TableScanOperator
         blocked.set(null);
 
         if (split.getConnectorSplit() instanceof EmptySplit) {
-            source = new EmptyPageSource();
+            source = EmptyPageSource.EMPTY;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
@@ -72,7 +72,7 @@ public class PageSourceManager
 
             TupleDomain<ColumnHandle> constraint = dynamicFilter.getCurrentPredicate();
             if (constraint.isNone()) {
-                return new EmptyPageSource();
+                return EmptyPageSource.EMPTY;
             }
             if (!isAllowPushdownIntoConnectors(session)) {
                 dynamicFilter = DynamicFilter.EMPTY;

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -914,6 +914,15 @@
                                     <new>method io.trino.spi.function.FunctionMetadata io.trino.spi.function.FunctionMetadata::fromJson(io.trino.spi.function.FunctionId, io.trino.spi.function.Signature, java.lang.String, java.util.Set&lt;java.lang.String&gt;, io.trino.spi.function.FunctionNullability, boolean, boolean, boolean, java.lang.String, io.trino.spi.function.FunctionKind, boolean)</new>
                                     <justification>Function declares whether it never fails</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.connector.EmptyPageSource::&lt;init&gt;()</old>
+                                    <new>method void io.trino.spi.connector.EmptyPageSource::&lt;init&gt;()</new>
+                                    <oldVisibility>public</oldVisibility>
+                                    <newVisibility>private</newVisibility>
+                                    <justification>Introduced static EMPTY method to get an instance</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/EmptyPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/EmptyPageSource.java
@@ -16,6 +16,12 @@ package io.trino.spi.connector;
 public class EmptyPageSource
         implements ConnectorPageSource
 {
+    public static final EmptyPageSource EMPTY = new EmptyPageSource();
+
+    private EmptyPageSource()
+    {
+    }
+
     @Override
     public long getCompletedBytes()
     {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/BaseTransactionsTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/BaseTransactionsTable.java
@@ -128,7 +128,7 @@ public abstract class BaseTransactionsTable
         }
 
         if (startVersionExclusive.isPresent() && endVersionInclusive.isPresent() && startVersionExclusive.get() >= endVersionInclusive.get()) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         if (endVersionInclusive.isEmpty()) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -196,13 +196,13 @@ public class DeltaLakePageSourceProvider
                 split.getStatisticsPredicate(),
                 dynamicFilter.getCurrentPredicate().transformKeys(DeltaLakeColumnHandle.class::cast)));
         if (filteredSplitPredicate.isNone()) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
         Map<DeltaLakeColumnHandle, Domain> partitionColumnDomains = filteredSplitPredicate.getDomains().orElseThrow().entrySet().stream()
                 .filter(entry -> entry.getKey().columnType() == DeltaLakeColumnType.PARTITION_KEY)
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         if (!partitionMatchesPredicate(split.getPartitionKeys(), partitionColumnDomains)) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
         // Skip reading the file if none of the actual file columns are being read
         if (filteredSplitPredicate.isAll() &&

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePartitionsTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePartitionsTable.java
@@ -158,7 +158,7 @@ public class DeltaLakePartitionsTable
     public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
         if (partitionColumns.isEmpty()) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         return new FixedPageSource(buildPages(session));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -114,7 +114,7 @@ public class HivePageSourceProvider
         HiveSplit hiveSplit = (HiveSplit) split;
 
         if (shouldSkipBucket(hiveTable, hiveSplit, dynamicFilter)) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         List<HiveColumnHandle> hiveColumns = columns.stream()
@@ -137,7 +137,7 @@ public class HivePageSourceProvider
         // Perform dynamic partition pruning in case coordinator didn't prune split.
         // This can happen when dynamic filters are collected after partition splits were listed.
         if (shouldSkipSplit(columnMappings, dynamicFilter)) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         Optional<ConnectorPageSource> pageSource = createHivePageSource(
@@ -192,7 +192,7 @@ public class HivePageSourceProvider
             List<ColumnMapping> columnMappings)
     {
         if (effectivePredicate.isNone()) {
-            return Optional.of(new EmptyPageSource());
+            return Optional.of(EmptyPageSource.EMPTY);
         }
 
         List<ColumnMapping> regularAndInterimColumnMappings = ColumnMapping.extractRegularAndInterimColumnMappings(columnMappings);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroPageSourceFactory.java
@@ -108,7 +108,7 @@ public class AvroPageSourceFactory
 
         // Split may be empty now that the correct file size is known
         if (actualSplitSize <= 0) {
-            return Optional.of(new EmptyPageSource());
+            return Optional.of(EmptyPageSource.EMPTY);
         }
 
         return Optional.of(projectColumnDereferences(columns, baseColumns -> createPageSource(session, trinoFileSystem, inputFile, start, actualSplitSize, schema, baseColumns)));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/esri/EsriPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/esri/EsriPageSourceFactory.java
@@ -82,7 +82,7 @@ public class EsriPageSourceFactory
 
         // Skip empty inputs
         if (length == 0) {
-            return Optional.of(new EmptyPageSource());
+            return Optional.of(EmptyPageSource.EMPTY);
         }
 
         if (start != 0) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
@@ -146,13 +146,13 @@ public abstract class LinePageSourceFactory
 
             // Skip empty inputs
             if (length <= 0) {
-                return new EmptyPageSource();
+                return EmptyPageSource.EMPTY;
             }
 
             LineReader lineReader = lineReaderFactory.createLineReader(inputFile, start, length, headerCount, footerCount);
             // Split may be empty after discovering the real file size and skipping headers
             if (lineReader.isClosed()) {
-                return new EmptyPageSource();
+                return EmptyPageSource.EMPTY;
             }
             return new LinePageSource(lineReader, lineDeserializer, lineReaderFactory.createLineBuffer(), path, smallFileReadTimeNanos);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -265,7 +265,7 @@ public class OrcPageSourceFactory
         try {
             Optional<OrcReader> optionalOrcReader = OrcReader.createOrcReader(orcDataSource, options);
             if (optionalOrcReader.isEmpty()) {
-                return new EmptyPageSource();
+                return EmptyPageSource.EMPTY;
             }
             OrcReader reader = optionalOrcReader.get();
             if (!originalFile && acidInfo.isPresent() && !acidInfo.get().orcAcidVersionValidated()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSourceFactory.java
@@ -143,7 +143,7 @@ public class RcFilePageSourceFactory
 
         // Split may be empty now that the correct file size is known
         if (length <= 0) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -323,7 +323,7 @@ public class IcebergPageSourceProvider
                 unenforcedPredicate,
                 fileStatisticsDomain);
         if (effectivePredicate.isNone()) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         // exit early when only reading partition keys from a simple split

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSourceProvider.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSourceProvider.java
@@ -79,7 +79,7 @@ public class MongoPageSourceProvider
         }
 
         if (newTableHandle.constraint().isNone()) {
-            return new EmptyPageSource();
+            return EmptyPageSource.EMPTY;
         }
 
         return new MongoPageSource(mongoSession, newTableHandle, handles.build(), implicitPrefix);

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -626,7 +626,7 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
                             .describedAs("columns covered")
                             .isEqualTo(expectedDynamicFilterColumnsCovered);
 
-                    return new EmptyPageSource()
+                    return EmptyPageSource.EMPTY
                     {
                         @Override
                         public CompletableFuture<?> isBlocked()

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestBeginQuery.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestBeginQuery.java
@@ -204,7 +204,7 @@ public class TestBeginQuery
                         List<ColumnHandle> columns,
                         DynamicFilter dynamicFilter)
                 {
-                    return new EmptyPageSource();
+                    return EmptyPageSource.EMPTY;
                 }
             };
         }


### PR DESCRIPTION
## Description
I noticed the `new EmptyPageSource()` was invoked multiple times, I think a lazy singleton is more efficient.

## Release notes

(X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
