### PR TITLE
Do not allocate lambda on every scheduleLeafSplit

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -79,6 +79,9 @@ public class ThreadPerDriverTaskExecutor
     @GuardedBy("this")
     private int runningLeafDrivers;
 
+    // Do not inline this field to avoid creating lambdas that cannot be cached by JVM.
+    private final Runnable leafSplitDoneCallback = this::leafSplitDone;
+
     @Inject
     public ThreadPerDriverTaskExecutor(TaskManagerConfig config, Tracer tracer, VersionEmbedder versionEmbedder)
     {
@@ -177,7 +180,7 @@ public class ThreadPerDriverTaskExecutor
 
     private boolean scheduleLeafSplit(TaskEntry task)
     {
-        boolean scheduled = task.dequeueAndRunLeafSplit(this::leafSplitDone);
+        boolean scheduled = task.dequeueAndRunLeafSplit(leafSplitDoneCallback);
         if (scheduled) {
             runningLeafDrivers++;
         }


### PR DESCRIPTION
Since this lambda captures this, JVM is unable to cache it. By hosting it out of the loop where it is called, lambda allocations are removed.

Before:

<img width="2652" height="466" alt="CleanShot 2026-03-10 at 11 48 47@2x" src="https://github.com/user-attachments/assets/983a8355-fbcf-486b-9d6b-9a87b84d9b7a" />

After:

<img width="2600" height="444" alt="CleanShot 2026-03-10 at 11 49 14@2x" src="https://github.com/user-attachments/assets/def13afe-1127-4151-aa6c-6c4be515bd4f" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
