### PR TITLE
Increase lock timeout from 30s in H2

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcModule.java
@@ -78,7 +78,7 @@ public class TestingH2JdbcModule
 
     public static String createH2ConnectionUrl()
     {
-        return format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=10000", System.nanoTime() + ThreadLocalRandom.current().nextLong());
+        return format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=30000", System.nanoTime() + ThreadLocalRandom.current().nextLong());
     }
 
     public interface TestingH2JdbcClientFactory


### PR DESCRIPTION
This is additional increase after
https://github.com/trinodb/trino/pull/27690
to mitigate new occurrences of flaky
```
Error Stack Trace:
org.h2.jdbc.JdbcSQLTimeoutException: Timeout trying to lock table "SYS"; SQL statement:
CREATE SCHEMA "TPCHRRG81O1CRD_TODROP" [50200-240]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:572)
	at org.h2.mvstore.db.MVTable.doLock1(MVTable.java:232)
	at org.h2.mvstore.db.MVTable.lock(MVTable.java:191)
	at org.h2.engine.Database.lockMeta(Database.java:792)
	at org.h2.engine.Database.addDatabaseObject(Database.java:961)
	at org.h2.command.ddl.CreateSchema.update(CreateSchema.java:53)
```

Related PR:
- https://github.com/trinodb/trino/pull/27690
