### PR TITLE
Add configurable view resolution to OpenLineage event listener

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-openlineage.md
+++ b/docs/src/main/sphinx/admin/event-listeners-openlineage.md
@@ -164,6 +164,13 @@ event-listener.config-files=etc/openlineage-event-listener.properties,...
       variables: `$QUERY_ID`, `$USER`, `$SOURCE`, `$CLIENT_IP`.
       For example: `As $USER from $CLIENT_IP via $SOURCE`.
     - `$QUERY_ID`.
+*
+    - openlineage-event-listener.resolve-views
+    - When set to `true`, input datasets report the underlying base tables
+      instead of the view name. This resolves views at any nesting depth,
+      including views over joins with multiple base tables. When `false`,
+      views are reported as input datasets directly.
+    - `false`
 
 :::
 

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
@@ -34,6 +34,7 @@ import io.trino.plugin.base.logging.FormatInterpolator;
 import io.trino.plugin.openlineage.job.OpenLineageJobContext;
 import io.trino.plugin.openlineage.job.OpenLineageJobInterpolatedValues;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.eventlistener.BaseViewReferenceInfo;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.OutputColumnMetadata;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
@@ -76,6 +77,7 @@ public class OpenLineageListener
     private final String jobNamespace;
     private final String datasetNamespace;
     private final Set<QueryType> includeQueryTypes;
+    private final boolean resolveViews;
     private final FormatInterpolator<OpenLineageJobContext> interpolator;
 
     @Inject
@@ -88,6 +90,7 @@ public class OpenLineageListener
         this.jobNamespace = listenerConfig.getNamespace().orElse(trinoURI.toString());
         this.datasetNamespace = trinoURI.toString();
         this.includeQueryTypes = ImmutableSet.copyOf(listenerConfig.getIncludeQueryTypes());
+        this.resolveViews = listenerConfig.isResolveViews();
         this.interpolator = new FormatInterpolator<>(listenerConfig.getJobNameFormat(), OpenLineageJobInterpolatedValues.values());
     }
 
@@ -296,10 +299,10 @@ public class OpenLineageListener
 
     private List<InputDataset> buildInputs(QueryMetadata queryMetadata)
     {
-        return queryMetadata
-                .getTables()
+        List<TableInfo> allTables = queryMetadata.getTables();
+        return allTables
                 .stream()
-                .filter(TableInfo::isDirectlyReferenced)
+                .filter(table -> resolveViews ? shouldIncludeWhenResolvingViews(table, allTables) : table.isDirectlyReferenced())
                 .map(table -> {
                     String datasetName = getDatasetName(table);
                     InputDatasetBuilder inputDatasetBuilder = openLineage
@@ -327,6 +330,21 @@ public class OpenLineageListener
                             .build();
                 })
                 .collect(toImmutableList());
+    }
+
+    private static boolean shouldIncludeWhenResolvingViews(TableInfo table, List<TableInfo> allTables)
+    {
+        if (table.getViewText().isEmpty()) {
+            return true;
+        }
+        boolean hasResolvedBaseTables = allTables.stream()
+                .filter(other -> other.getViewText().isEmpty())
+                .flatMap(other -> other.getReferenceChain().stream())
+                .anyMatch(ref -> ref instanceof BaseViewReferenceInfo viewRef &&
+                        viewRef.catalogName().equals(table.getCatalog()) &&
+                        viewRef.schemaName().equals(table.getSchema()) &&
+                        viewRef.viewName().equals(table.getTable()));
+        return !hasResolvedBaseTables;
     }
 
     private List<OutputDataset> buildOutputs(QueryIOMetadata ioMetadata)

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListenerConfig.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListenerConfig.java
@@ -35,6 +35,8 @@ public class OpenLineageListenerConfig
     private Optional<String> namespace = Optional.empty();
     private String jobNameFormat = "$QUERY_ID";
 
+    private boolean resolveViews;
+
     private Set<QueryType> includeQueryTypes = ImmutableSet.<QueryType>builder()
             .add(QueryType.ALTER_TABLE_EXECUTE)
             .add(QueryType.DELETE)
@@ -82,6 +84,19 @@ public class OpenLineageListenerConfig
             throws RuntimeException
     {
         this.disabledFacets = ImmutableSet.copyOf(disabledFacets);
+        return this;
+    }
+
+    public boolean isResolveViews()
+    {
+        return resolveViews;
+    }
+
+    @Config("openlineage-event-listener.resolve-views")
+    @ConfigDescription("When enabled, report underlying base tables instead of views as input datasets")
+    public OpenLineageListenerConfig setResolveViews(boolean resolveViews)
+    {
+        this.resolveViews = resolveViews;
         return this;
     }
 

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
@@ -192,6 +192,352 @@ final class TestOpenLineageListener
                 .isEqualTo("queryId-user-some-trino-client-127.0.0.1-abc123");
     }
 
+    @Test
+    void testResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.my_view");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.base_table");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testResolveNestedViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithNestedView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.v2");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testResolveNestedViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithNestedView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.base_table");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testDirectTableResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithDirectTable);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.orders");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("orderkey", "custkey");
+                });
+    }
+
+    @Test
+    void testDirectTableResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithDirectTable);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.orders");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("orderkey", "custkey");
+                });
+    }
+
+    @Test
+    void testMixedInputsResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithMixedInputs);
+
+        assertThat(result.getInputs())
+                .hasSize(2)
+                .satisfiesExactlyInAnyOrder(
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.orders");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("orderkey");
+                        },
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.my_view");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("nationkey");
+                        });
+    }
+
+    @Test
+    void testMixedInputsResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithMixedInputs);
+
+        assertThat(result.getInputs())
+                .hasSize(2)
+                .satisfiesExactlyInAnyOrder(
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.orders");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("orderkey");
+                        },
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.nation");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("nationkey");
+                        });
+    }
+
+    @Test
+    void testViewMultipleBaseTablesResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithViewMultipleBaseTables);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.join_view");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("col_a", "col_b");
+                });
+    }
+
+    @Test
+    void testViewMultipleBaseTablesResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithViewMultipleBaseTables);
+
+        assertThat(result.getInputs())
+                .hasSize(2)
+                .satisfiesExactlyInAnyOrder(
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.t1");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("col_a");
+                        },
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.t2");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("col_b");
+                        });
+    }
+
+    @Test
+    void testNestedViewComplexJoinResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithNestedViewComplexJoin);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.v_outer");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "regionkey", "orderkey");
+                });
+    }
+
+    @Test
+    void testNestedViewComplexJoinResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithNestedViewComplexJoin);
+
+        assertThat(result.getInputs())
+                .hasSize(3)
+                .satisfiesExactlyInAnyOrder(
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.orders");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("orderkey");
+                        },
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.nation");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("nationkey");
+                        },
+                        input -> {
+                            assertThat(input.getName()).isEqualTo("marquez.default.region");
+                            assertThat(input.getFacets().getSchema().getFields())
+                                    .extracting(field -> field.getName())
+                                    .containsExactly("regionkey");
+                        });
+    }
+
+    @Test
+    void testFreshMaterializedViewResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithFreshMaterializedView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.mv_fresh");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testFreshMaterializedViewResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithFreshMaterializedView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.mv_fresh");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testStaleMaterializedViewResolveViewsDisabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithStaleMaterializedView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.mv_stale");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
+    @Test
+    void testStaleMaterializedViewResolveViewsEnabled()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost",
+                "openlineage-event-listener.resolve-views", "true"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithStaleMaterializedView);
+
+        assertThat(result.getInputs())
+                .hasSize(1)
+                .satisfiesExactly(input -> {
+                    assertThat(input.getName()).isEqualTo("marquez.default.nation");
+                    assertThat(input.getFacets().getSchema().getFields())
+                            .extracting(field -> field.getName())
+                            .containsExactly("nationkey", "name");
+                });
+    }
+
     private static EventListener createEventListener(Map<String, String> config)
     {
         return new OpenLineageListenerFactory().create(ImmutableMap.copyOf(config), new TestingEventListenerContext());

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListenerConfig.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListenerConfig.java
@@ -46,6 +46,7 @@ final class TestOpenLineageListenerConfig
                 .setNamespace(null)
                 .setJobNameFormat("$QUERY_ID")
                 .setDisabledFacets(ImmutableSet.of())
+                .setResolveViews(false)
                 .setIncludeQueryTypes(ImmutableSet.of(
                         ALTER_TABLE_EXECUTE,
                         DELETE,
@@ -65,6 +66,7 @@ final class TestOpenLineageListenerConfig
                 .put("openlineage-event-listener.disabled-facets", "trino_metadata,trino_query_statistics")
                 .put("openlineage-event-listener.namespace", "testnamespace")
                 .put("openlineage-event-listener.job.name-format", "$QUERY_ID-$USER-$SOURCE-$CLIENT_IP-abc123")
+                .put("openlineage-event-listener.resolve-views", "true")
                 .buildOrThrow();
 
         OpenLineageListenerConfig expected = new OpenLineageListenerConfig()
@@ -72,6 +74,7 @@ final class TestOpenLineageListenerConfig
                 .setIncludeQueryTypes(ImmutableSet.of(SELECT, DELETE))
                 .setDisabledFacets(ImmutableSet.of(TRINO_METADATA, TRINO_QUERY_STATISTICS))
                 .setNamespace("testnamespace")
+                .setResolveViews(true)
                 .setJobNameFormat("$QUERY_ID-$USER-$SOURCE-$CLIENT_IP-abc123");
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
@@ -15,6 +15,8 @@ package io.trino.plugin.openlineage;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.operator.RetryPolicy;
+import io.trino.spi.eventlistener.ColumnInfo;
+import io.trino.spi.eventlistener.MaterializedViewReferenceInfo;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryContext;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
@@ -22,6 +24,8 @@ import io.trino.spi.eventlistener.QueryIOMetadata;
 import io.trino.spi.eventlistener.QueryMetadata;
 import io.trino.spi.eventlistener.QueryStatistics;
 import io.trino.spi.eventlistener.StageOutputBufferUtilization;
+import io.trino.spi.eventlistener.TableInfo;
+import io.trino.spi.eventlistener.ViewReferenceInfo;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.session.ResourceEstimates;
@@ -46,6 +50,22 @@ public class TrinoEventData
     public static final QueryStatistics queryStatistics;
     public static final QueryCompletedEvent queryCompleteEvent;
     public static final QueryCreatedEvent queryCreatedEvent;
+    public static final QueryMetadata queryMetadataWithView;
+    public static final QueryCompletedEvent queryCompleteEventWithView;
+    public static final QueryMetadata queryMetadataWithNestedView;
+    public static final QueryCompletedEvent queryCompleteEventWithNestedView;
+    public static final QueryMetadata queryMetadataWithDirectTable;
+    public static final QueryCompletedEvent queryCompleteEventWithDirectTable;
+    public static final QueryMetadata queryMetadataWithMixedInputs;
+    public static final QueryCompletedEvent queryCompleteEventWithMixedInputs;
+    public static final QueryMetadata queryMetadataWithViewMultipleBaseTables;
+    public static final QueryCompletedEvent queryCompleteEventWithViewMultipleBaseTables;
+    public static final QueryMetadata queryMetadataWithNestedViewComplexJoin;
+    public static final QueryCompletedEvent queryCompleteEventWithNestedViewComplexJoin;
+    public static final QueryMetadata queryMetadataWithFreshMaterializedView;
+    public static final QueryCompletedEvent queryCompleteEventWithFreshMaterializedView;
+    public static final QueryMetadata queryMetadataWithStaleMaterializedView;
+    public static final QueryCompletedEvent queryCompleteEventWithStaleMaterializedView;
 
     private TrinoEventData()
     {
@@ -159,5 +179,502 @@ public class TrinoEventData
                 Instant.parse("2025-04-28T11:23:55.384424Z"),
                 queryContext,
                 queryMetadata);
+
+        // View: my_view (directly referenced, has viewText)
+        TableInfo viewTable = new TableInfo(
+                "marquez",
+                "default",
+                "my_view",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM base_table"),
+                List.of());
+
+        // Base table: base_table (not directly referenced, resolved from view)
+        TableInfo baseTable = new TableInfo(
+                "marquez",
+                "default",
+                "base_table",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(new ViewReferenceInfo("marquez", "default", "my_view")));
+
+        queryMetadataWithView = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "create table b.c as select * from my_view",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(viewTable, baseTable),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithView = new QueryCompletedEvent(
+                queryMetadataWithView,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Nested view scenario: SELECT * FROM v2, where v2 -> v1 -> base_table
+        // v2: directly referenced, has viewText, empty referenceChain
+        TableInfo nestedViewV2 = new TableInfo(
+                "marquez",
+                "default",
+                "v2",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM v1"),
+                List.of());
+
+        // v1: not directly referenced, has viewText, referenceChain points to v2
+        TableInfo nestedViewV1 = new TableInfo(
+                "marquez",
+                "default",
+                "v1",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                false,
+                Optional.of("SELECT * FROM base_table"),
+                List.of(new ViewReferenceInfo("marquez", "default", "v2")));
+
+        // base_table: not directly referenced, no viewText, referenceChain points through v2 -> v1
+        TableInfo nestedBaseTable = new TableInfo(
+                "marquez",
+                "default",
+                "base_table",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(
+                        new ViewReferenceInfo("marquez", "default", "v2"),
+                        new ViewReferenceInfo("marquez", "default", "v1")));
+
+        queryMetadataWithNestedView = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "create table b.c as select * from v2",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(nestedViewV2, nestedViewV1, nestedBaseTable),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithNestedView = new QueryCompletedEvent(
+                queryMetadataWithNestedView,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Scenario: Direct table query (no views involved)
+        // SELECT * FROM orders
+        TableInfo directTable = new TableInfo(
+                "marquez",
+                "default",
+                "orders",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("orderkey", Optional.empty()),
+                        new ColumnInfo("custkey", Optional.empty())),
+                true,
+                Optional.empty(),
+                List.of());
+
+        queryMetadataWithDirectTable = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "select * from orders",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(directTable),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithDirectTable = new QueryCompletedEvent(
+                queryMetadataWithDirectTable,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Scenario: Mixed inputs - query joins a direct table and a view
+        // SELECT * FROM orders JOIN my_view ON ...
+        // where my_view is defined as SELECT * FROM nation
+        TableInfo mixedDirectTable = new TableInfo(
+                "marquez",
+                "default",
+                "orders",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("orderkey", Optional.empty())),
+                true,
+                Optional.empty(),
+                List.of());
+
+        TableInfo mixedView = new TableInfo(
+                "marquez",
+                "default",
+                "my_view",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("nationkey", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM nation"),
+                List.of());
+
+        TableInfo mixedViewBaseTable = new TableInfo(
+                "marquez",
+                "default",
+                "nation",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("nationkey", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(new ViewReferenceInfo("marquez", "default", "my_view")));
+
+        queryMetadataWithMixedInputs = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "select * from orders join my_view on orders.orderkey = my_view.nationkey",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(mixedDirectTable, mixedView, mixedViewBaseTable),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithMixedInputs = new QueryCompletedEvent(
+                queryMetadataWithMixedInputs,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Scenario: View with multiple base tables
+        // SELECT * FROM join_view, where join_view = SELECT * FROM t1 JOIN t2
+        TableInfo multiBaseView = new TableInfo(
+                "marquez",
+                "default",
+                "join_view",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("col_a", Optional.empty()),
+                        new ColumnInfo("col_b", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id"),
+                List.of());
+
+        TableInfo multiBaseT1 = new TableInfo(
+                "marquez",
+                "default",
+                "t1",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("col_a", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(new ViewReferenceInfo("marquez", "default", "join_view")));
+
+        TableInfo multiBaseT2 = new TableInfo(
+                "marquez",
+                "default",
+                "t2",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("col_b", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(new ViewReferenceInfo("marquez", "default", "join_view")));
+
+        queryMetadataWithViewMultipleBaseTables = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "select * from join_view",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(multiBaseView, multiBaseT1, multiBaseT2),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithViewMultipleBaseTables = new QueryCompletedEvent(
+                queryMetadataWithViewMultipleBaseTables,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Scenario: 2-level nested view with complex joins
+        // SELECT * FROM v_outer
+        // v_outer = SELECT * FROM v_inner JOIN orders ON v_inner.nationkey = orders.orderkey
+        // v_inner = SELECT * FROM nation JOIN region ON nation.regionkey = region.regionkey
+        // Resolved base tables: nation, region (depth 2), orders (depth 1)
+
+        // v_outer: directly referenced, has viewText, referenceChain = []
+        TableInfo complexOuterView = new TableInfo(
+                "marquez",
+                "default",
+                "v_outer",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("regionkey", Optional.empty()),
+                        new ColumnInfo("orderkey", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM v_inner JOIN orders ON v_inner.nationkey = orders.orderkey"),
+                List.of());
+
+        // v_inner: not directly referenced, has viewText, referenceChain = [v_outer]
+        TableInfo complexInnerView = new TableInfo(
+                "marquez",
+                "default",
+                "v_inner",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("regionkey", Optional.empty())),
+                false,
+                Optional.of("SELECT * FROM nation JOIN region ON nation.regionkey = region.regionkey"),
+                List.of(new ViewReferenceInfo("marquez", "default", "v_outer")));
+
+        // orders: not directly referenced, no viewText, referenceChain = [v_outer] (depth 1)
+        TableInfo complexOrders = new TableInfo(
+                "marquez",
+                "default",
+                "orders",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("orderkey", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(new ViewReferenceInfo("marquez", "default", "v_outer")));
+
+        // nation: not directly referenced, no viewText, referenceChain = [v_outer, v_inner] (depth 2)
+        TableInfo complexNation = new TableInfo(
+                "marquez",
+                "default",
+                "nation",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("nationkey", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(
+                        new ViewReferenceInfo("marquez", "default", "v_outer"),
+                        new ViewReferenceInfo("marquez", "default", "v_inner")));
+
+        // region: not directly referenced, no viewText, referenceChain = [v_outer, v_inner] (depth 2)
+        TableInfo complexRegion = new TableInfo(
+                "marquez",
+                "default",
+                "region",
+                "user",
+                List.of(),
+                List.of(new ColumnInfo("regionkey", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(
+                        new ViewReferenceInfo("marquez", "default", "v_outer"),
+                        new ViewReferenceInfo("marquez", "default", "v_inner")));
+
+        queryMetadataWithNestedViewComplexJoin = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "select * from v_outer",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(complexOuterView, complexInnerView, complexOrders, complexNation, complexRegion),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithNestedViewComplexJoin = new QueryCompletedEvent(
+                queryMetadataWithNestedViewComplexJoin,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Scenario: Fresh materialized view (storage table is up-to-date)
+        // SELECT * FROM mv_fresh
+        // Only the MV entry is in the tables list — no base tables resolved
+        TableInfo freshMvTable = new TableInfo(
+                "marquez",
+                "default",
+                "mv_fresh",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM nation"),
+                List.of());
+
+        queryMetadataWithFreshMaterializedView = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "select * from mv_fresh",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(freshMvTable),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithFreshMaterializedView = new QueryCompletedEvent(
+                queryMetadataWithFreshMaterializedView,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
+
+        // Scenario: Stale materialized view (storage table is outdated, query falls back to base tables)
+        // SELECT * FROM mv_stale
+        // MV entry + base table entry with MaterializedViewReferenceInfo in referenceChain
+        TableInfo staleMvTable = new TableInfo(
+                "marquez",
+                "default",
+                "mv_stale",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                true,
+                Optional.of("SELECT * FROM nation"),
+                List.of());
+
+        TableInfo staleMvBaseTable = new TableInfo(
+                "marquez",
+                "default",
+                "nation",
+                "user",
+                List.of(),
+                List.of(
+                        new ColumnInfo("nationkey", Optional.empty()),
+                        new ColumnInfo("name", Optional.empty())),
+                false,
+                Optional.empty(),
+                List.of(new MaterializedViewReferenceInfo("marquez", "default", "mv_stale")));
+
+        queryMetadataWithStaleMaterializedView = new QueryMetadata(
+                "queryId",
+                Optional.of("transactionId"),
+                Optional.empty(),
+                "select * from mv_stale",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "COMPLETED",
+                List.of(staleMvTable, staleMvBaseTable),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("queryPlan"),
+                Optional.empty(),
+                Optional.empty());
+
+        queryCompleteEventWithStaleMaterializedView = new QueryCompletedEvent(
+                queryMetadataWithStaleMaterializedView,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->

# Add configurable view resolution to OpenLineage event listener

## Description

The OpenLineage Trino plugin currently reports views as input datasets when a query references them. For example, `CREATE TABLE t AS SELECT * FROM my_view` emits `my_view` as the input — not the underlying base table that actually holds the data. This breaks the lineage graph for downstream consumers  because views don't represent physical storage.

This PR adds a new configuration property `openlineage-event-listener.resolve-views` that, when enabled, reports the underlying base tables instead of views as input datasets.

## Problem

When Trino analyzes a query that references a view, `QueryMetadata.getTables()` returns entries for both the view and its underlying base tables. Each entry carries metadata:
- Views have `isDirectlyReferenced() = true` and `getViewText()` present
- Base tables have `isDirectlyReferenced() = false` and `getViewText()` empty

The existing `buildInputs()` method filters on `TableInfo::isDirectlyReferenced`, which means only views are reported and base tables are discarded. This is correct from an access-control perspective but loses physical lineage information.

## Solution

A new boolean config property `openlineage-event-listener.resolve-views` (default `false`) controls which tables are emitted as inputs:

- `false` (default): existing behavior — filter on `isDirectlyReferenced()`, report views
- `true`: filter on `getViewText().isEmpty()`, report only physical base tables

The `viewText` check is the right discriminator because Trino's analyzer sets `viewText` on every view and materialized view entry, regardless of nesting depth. A table that is not a view will always have `viewText = Optional.empty()`.

This handles all cases correctly:
- Single view → base table
- Nested views (v2 → v1 → base_table) — intermediate views filtered out
- View over a JOIN (join_view → t1, t2) — both base tables reported
- Mixed queries (direct table JOIN view) — direct table kept, view replaced by its base table
- Direct table queries — no change in behavior




<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
