### PR TITLE
Move npm retry settings to .npmrc to ensure consistency in CI

### DIFF
--- a/core/trino-web-ui/pom.xml
+++ b/core/trino-web-ui/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <frontend.package.goal>package</frontend.package.goal>
         <frontend.check.goal>check</frontend.check.goal>
-        <frontend.npm.retries>--fetch-retries=4 --fetch-retry-mintimeout=10000 --fetch-retry-maxtimeout=120000</frontend.npm.retries>
     </properties>
 
     <dependencies>
@@ -101,7 +100,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>run ${frontend.package.goal} ${frontend.npm.retries}</arguments>
+                            <arguments>run ${frontend.package.goal}</arguments>
                             <workingDirectory>src/main/resources/webapp/src</workingDirectory>
                         </configuration>
                     </execution>
@@ -134,7 +133,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>run ${frontend.package.goal} ${frontend.npm.retries}</arguments>
+                            <arguments>run ${frontend.package.goal}</arguments>
                             <workingDirectory>src/main/resources/webapp-preview</workingDirectory>
                         </configuration>
                     </execution>

--- a/core/trino-web-ui/src/main/resources/webapp-preview/.npmrc
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/.npmrc
@@ -1,1 +1,4 @@
 registry=https://registry.npmjs.org
+fetch-retries=4
+fetch-retry-mintimeout=10000
+fetch-retry-maxtimeout=120000

--- a/core/trino-web-ui/src/main/resources/webapp/src/.npmrc
+++ b/core/trino-web-ui/src/main/resources/webapp/src/.npmrc
@@ -1,1 +1,4 @@
 registry=https://registry.npmjs.org
+fetch-retries=4
+fetch-retry-mintimeout=10000
+fetch-retry-maxtimeout=120000


### PR DESCRIPTION
## Problem
This build flakes on master CI due to a network connectivity issue during npm package installation in the trino-web-ui module. The failure occurs during the 'npm run package:clean' command which runs 'npm clean-install && npm run build'.

Network flake where npm registry connection is reset (ECONNRESET) while downloading packages during clean-install. This is an intermittent network issue between the CI environment and the npm registry.

```
npm error code ECONNRESET
npm error network aborted
npm error network This is a problem related to network connectivity.
npm error network In most cases you are behind a proxy or have bad network settings.
npm error network
npm error network If you are behind a proxy, please make sure that the
npm error network 'proxy' config is set properly.  See: 'npm help config'

[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:2.0.0:npm (package (webapp-preview)) on project trino-web-ui: Failed to run task: 'npm run package:clean --fetch-retries=4 --fetch-retry-mintimeout=10000 --fetch-retry-maxtimeout=120000' failed. org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)

Full error context from logs:
[INFO] Running 'npm run package:clean --fetch-retries=4 --fetch-retry-mintimeout=10000 --fetch-retry-maxtimeout=120000' in /home/ubuntu/actions-runner/_work/cork/cork/core/trino-web-ui/src/main/resources/webapp-preview
[INFO] > webapp-preview@0.0.0 package:clean
[INFO] > npm clean-install && npm run build
[INFO] npm warn deprecated babel-merge@3.0.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
[INFO] npm error code ECONNRESET
[INFO] npm error network aborted
[INFO] npm error network This is a problem related to network connectivity.
[INFO] npm error A complete log of this run can be found in: /home/ubuntu/.npm/_logs/2026-03-05T06_31_09_639Z-debug-0.log

Build Summary: trino-web-ui FAILURE [01:09 min]
```
## Solution

In npm v6 and earlier, CLI flags like --fetch-retries passed to npm run were exported as npm_config_* environment variables, so child npm processes (e.g., npm clean-install inside scripts) would inherit them.

In npm v7+ (we use v11.7.0), this behavior was removed: CLI flags passed to npm run are no longer forwarded to lifecycle scripts, so nested npm commands run with defaults (2 retries, 60s max timeout).

By putting retry settings in .npmrc, every npm process—including nested installs in npm run scripts—uses the correct values, avoiding issues caused by the flag-forwarding change.

Fixes #27458