### PR TITLE
Add AWS Lake Formation credential vending for Iceberg/Glue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ product-test-reports
 **/dependency-reduced-pom.xml
 core/trino-web-ui/src/main/resources/webapp/dist/
 .node
+.claude/settings.local.json

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -81,6 +81,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-cache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-filesystem</artifactId>
         </dependency>
 
@@ -149,6 +154,11 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>identity-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>lakeformation</artifactId>
         </dependency>
 
         <dependency>

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/LakeFormationCredentialProvider.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/LakeFormationCredentialProvider.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.cache.NonEvictableLoadingCache;
+import io.trino.spi.TrinoException;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lakeformation.LakeFormationClient;
+import software.amazon.awssdk.services.lakeformation.model.AccessDeniedException;
+import software.amazon.awssdk.services.lakeformation.model.EntityNotFoundException;
+import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTableCredentialsRequest;
+import software.amazon.awssdk.services.lakeformation.model.GetTemporaryGlueTableCredentialsResponse;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
+import static java.util.Objects.requireNonNull;
+
+public class LakeFormationCredentialProvider
+{
+    private static final Logger log = Logger.get(LakeFormationCredentialProvider.class);
+
+    private final LakeFormationClient lakeFormationClient;
+    private final NonEvictableLoadingCache<String, AwsSessionCredentials> credentialCache;
+    private final int credentialDurationSeconds;
+
+    @Inject
+    public LakeFormationCredentialProvider(S3FileSystemConfig config)
+    {
+        requireNonNull(config, "config is null");
+
+        String region = config.getLakeFormationRegion();
+        if (region == null) {
+            region = config.getRegion();
+        }
+
+        this.lakeFormationClient = LakeFormationClient.builder()
+                .region(Region.of(requireNonNull(region, "Lake Formation region must be configured via fs.s3.lake-formation.region or s3.region")))
+                .build();
+
+        Duration cacheTtl = config.getLakeFormationCredentialCacheTtl();
+        this.credentialDurationSeconds = (int) config.getLakeFormationCredentialDuration().getValue(TimeUnit.SECONDS);
+
+        this.credentialCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder()
+                        .maximumSize(1000)
+                        .expireAfterWrite((long) cacheTtl.getValue(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS),
+                CacheLoader.from(this::vendCredentials));
+    }
+
+    /**
+     * Returns a delegating AwsCredentialsProvider that resolves fresh credentials
+     * from the cache on each invocation. This ensures long-running queries always
+     * get valid credentials even when cached entries are refreshed.
+     */
+    public AwsCredentialsProvider getCredentialsProvider(String tableArn)
+    {
+        requireNonNull(tableArn, "tableArn is null");
+        return () -> {
+            try {
+                return credentialCache.getUnchecked(tableArn);
+            }
+            catch (UncheckedExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof TrinoException trinoException) {
+                    throw trinoException;
+                }
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to obtain Lake Formation credentials for table: " + tableArn, cause);
+            }
+        };
+    }
+
+    private AwsSessionCredentials vendCredentials(String tableArn)
+    {
+        log.debug("Vending Lake Formation credentials for table ARN: %s", tableArn);
+        try {
+            GetTemporaryGlueTableCredentialsResponse response = lakeFormationClient.getTemporaryGlueTableCredentials(
+                    GetTemporaryGlueTableCredentialsRequest.builder()
+                            .tableArn(tableArn)
+                            .durationSeconds(credentialDurationSeconds)
+                            .build());
+
+            return AwsSessionCredentials.create(
+                    response.accessKeyId(),
+                    response.secretAccessKey(),
+                    response.sessionToken());
+        }
+        catch (AccessDeniedException e) {
+            throw new TrinoException(PERMISSION_DENIED,
+                    "Lake Formation denied access to table: " + tableArn +
+                            ". Verify execution role has lakeformation:GetTemporaryGlueTableCredentials permission and table permissions are granted.",
+                    e);
+        }
+        catch (EntityNotFoundException e) {
+            throw new TrinoException(NOT_FOUND,
+                    "Lake Formation table not found: " + tableArn +
+                            ". Verify the Glue table exists and is registered with Lake Formation.",
+                    e);
+        }
+        catch (Exception e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR,
+                    "Failed to obtain Lake Formation credentials for table: " + tableArn,
+                    e);
+        }
+    }
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -25,6 +25,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
+import io.airlift.units.MinDuration;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -39,6 +40,7 @@ import java.util.Set;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static software.amazon.awssdk.awscore.retry.AwsRetryStrategy.adaptiveRetryStrategy;
 import static software.amazon.awssdk.awscore.retry.AwsRetryStrategy.legacyRetryStrategy;
 import static software.amazon.awssdk.awscore.retry.AwsRetryStrategy.standardRetryStrategy;
@@ -179,6 +181,10 @@ public class S3FileSystemConfig
     private int maxErrorRetries = 20;
     private boolean crossRegionAccessEnabled;
     private String applicationId = "Trino";
+    private boolean lakeFormationEnabled;
+    private String lakeFormationRegion;
+    private Duration lakeFormationCredentialDuration = new Duration(15, MINUTES);
+    private Duration lakeFormationCredentialCacheTtl = new Duration(10, MINUTES);
 
     public String getAwsAccessKey()
     {
@@ -639,5 +645,70 @@ public class S3FileSystemConfig
     {
         this.applicationId = applicationId;
         return this;
+    }
+
+    public boolean isLakeFormationEnabled()
+    {
+        return lakeFormationEnabled;
+    }
+
+    @Config("fs.s3.lake-formation.enabled")
+    @ConfigDescription("Enable AWS Lake Formation credential vending for S3 access")
+    public S3FileSystemConfig setLakeFormationEnabled(boolean lakeFormationEnabled)
+    {
+        this.lakeFormationEnabled = lakeFormationEnabled;
+        return this;
+    }
+
+    public String getLakeFormationRegion()
+    {
+        return lakeFormationRegion;
+    }
+
+    @Config("fs.s3.lake-formation.region")
+    @ConfigDescription("AWS region for Lake Formation API calls")
+    public S3FileSystemConfig setLakeFormationRegion(String lakeFormationRegion)
+    {
+        this.lakeFormationRegion = lakeFormationRegion;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("5m")
+    public Duration getLakeFormationCredentialDuration()
+    {
+        return lakeFormationCredentialDuration;
+    }
+
+    @Config("fs.s3.lake-formation.credential-duration")
+    @ConfigDescription("Requested lifetime of Lake Formation vended credentials")
+    public S3FileSystemConfig setLakeFormationCredentialDuration(Duration lakeFormationCredentialDuration)
+    {
+        this.lakeFormationCredentialDuration = lakeFormationCredentialDuration;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1m")
+    public Duration getLakeFormationCredentialCacheTtl()
+    {
+        return lakeFormationCredentialCacheTtl;
+    }
+
+    @Config("fs.s3.lake-formation.credential-cache-ttl")
+    @ConfigDescription("TTL for cached Lake Formation credentials")
+    public S3FileSystemConfig setLakeFormationCredentialCacheTtl(Duration lakeFormationCredentialCacheTtl)
+    {
+        this.lakeFormationCredentialCacheTtl = lakeFormationCredentialCacheTtl;
+        return this;
+    }
+
+    @AssertTrue(message = "fs.s3.lake-formation.credential-cache-ttl must be less than fs.s3.lake-formation.credential-duration")
+    public boolean isLakeFormationCacheTtlValid()
+    {
+        if (!lakeFormationEnabled) {
+            return true;
+        }
+        return lakeFormationCredentialCacheTtl.compareTo(lakeFormationCredentialDuration) < 0;
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemModule.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemModule.java
@@ -19,10 +19,12 @@ import com.google.inject.BindingAnnotation;
 import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.OptionalBinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.units.Duration;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.switching.SwitchingFileSystemFactory;
+import io.trino.spi.TrinoException;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -31,6 +33,7 @@ import java.util.function.Supplier;
 import static com.google.inject.Scopes.SINGLETON;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -46,12 +49,26 @@ public class S3FileSystemModule
     {
         configBinder(binder).bindConfig(S3FileSystemConfig.class);
 
-        if (buildConfigObject(S3SecurityMappingEnabledConfig.class).isEnabled()) {
+        boolean securityMappingEnabled = buildConfigObject(S3SecurityMappingEnabledConfig.class).isEnabled();
+        boolean lakeFormationEnabled = buildConfigObject(S3FileSystemConfig.class).isLakeFormationEnabled();
+
+        if (securityMappingEnabled && lakeFormationEnabled) {
+            throw new TrinoException(CONFIGURATION_INVALID,
+                    "fs.s3.lake-formation.enabled and s3.security-mapping.enabled cannot both be enabled. " +
+                            "Lake Formation credential vending and S3 security mappings are mutually exclusive.");
+        }
+
+        if (securityMappingEnabled) {
             install(new S3SecurityMappingModule());
         }
         else {
             binder.bind(TrinoFileSystemFactory.class).annotatedWith(FileSystemS3.class)
                     .to(S3FileSystemFactory.class).in(SINGLETON);
+        }
+
+        OptionalBinder.newOptionalBinder(binder, LakeFormationCredentialProvider.class);
+        if (lakeFormationEnabled) {
+            binder.bind(LakeFormationCredentialProvider.class).in(SINGLETON);
         }
 
         binder.bind(S3FileSystemStats.class).in(SINGLETON);

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestLakeFormationCredentialProvider.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestLakeFormationCredentialProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestLakeFormationCredentialProvider
+{
+    @Test
+    public void testGetCredentialsProviderRejectsNullArn()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setLakeFormationEnabled(true)
+                .setRegion("us-east-1")
+                .setLakeFormationCredentialDuration(new Duration(15, MINUTES))
+                .setLakeFormationCredentialCacheTtl(new Duration(10, MINUTES));
+
+        LakeFormationCredentialProvider provider = new LakeFormationCredentialProvider(config);
+
+        assertThatThrownBy(() -> provider.getCredentialsProvider(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("tableArn is null");
+    }
+
+    @Test
+    public void testGetCredentialsProviderReturnsDelegatingProvider()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setLakeFormationEnabled(true)
+                .setRegion("us-east-1")
+                .setLakeFormationCredentialDuration(new Duration(15, MINUTES))
+                .setLakeFormationCredentialCacheTtl(new Duration(10, MINUTES));
+
+        LakeFormationCredentialProvider provider = new LakeFormationCredentialProvider(config);
+
+        String tableArn = "arn:aws:glue:us-east-1:123456789012:table/mydb/mytable";
+        AwsCredentialsProvider credentialsProvider = provider.getCredentialsProvider(tableArn);
+
+        // Verify it returns a non-null delegating provider (not StaticCredentialsProvider)
+        assertThat(credentialsProvider).isNotNull();
+        // The provider should be a lambda, not a StaticCredentialsProvider
+        assertThat(credentialsProvider.getClass().getName()).doesNotContain("StaticCredentialsProvider");
+    }
+
+    @Test
+    public void testLakeFormationRegionFallsBackToS3Region()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setLakeFormationEnabled(true)
+                .setRegion("eu-west-1")
+                .setLakeFormationCredentialDuration(new Duration(15, MINUTES))
+                .setLakeFormationCredentialCacheTtl(new Duration(10, MINUTES));
+
+        // Should not throw - uses s3 region as fallback for Lake Formation region
+        LakeFormationCredentialProvider provider = new LakeFormationCredentialProvider(config);
+        assertThat(provider).isNotNull();
+    }
+
+    @Test
+    public void testLakeFormationExplicitRegionOverridesS3Region()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setLakeFormationEnabled(true)
+                .setRegion("us-east-1")
+                .setLakeFormationRegion("us-west-2")
+                .setLakeFormationCredentialDuration(new Duration(15, MINUTES))
+                .setLakeFormationCredentialCacheTtl(new Duration(10, MINUTES));
+
+        // Should not throw - explicit LF region is used
+        LakeFormationCredentialProvider provider = new LakeFormationCredentialProvider(config);
+        assertThat(provider).isNotNull();
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -76,7 +76,11 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPassword(null)
                 .setHttpProxyPreemptiveBasicProxyAuth(false)
                 .setCrossRegionAccessEnabled(false)
-                .setApplicationId("Trino"));
+                .setApplicationId("Trino")
+                .setLakeFormationEnabled(false)
+                .setLakeFormationRegion(null)
+                .setLakeFormationCredentialDuration(new Duration(15, MINUTES))
+                .setLakeFormationCredentialCacheTtl(new Duration(10, MINUTES)));
     }
 
     @Test
@@ -118,6 +122,10 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .put("s3.application-id", "application id")
                 .put("s3.cross-region-access", "true")
+                .put("fs.s3.lake-formation.enabled", "true")
+                .put("fs.s3.lake-formation.region", "us-west-2")
+                .put("fs.s3.lake-formation.credential-duration", "20m")
+                .put("fs.s3.lake-formation.credential-cache-ttl", "8m")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -155,7 +163,11 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPassword("test")
                 .setHttpProxyPreemptiveBasicProxyAuth(true)
                 .setCrossRegionAccessEnabled(true)
-                .setApplicationId("application id");
+                .setApplicationId("application id")
+                .setLakeFormationEnabled(true)
+                .setLakeFormationRegion("us-west-2")
+                .setLakeFormationCredentialDuration(new Duration(20, MINUTES))
+                .setLakeFormationCredentialCacheTtl(new Duration(8, MINUTES));
 
         assertFullMapping(properties, expected);
     }
@@ -167,6 +179,18 @@ public class TestS3FileSystemConfig
                         .setSseType(S3SseType.CUSTOMER),
                 "sseWithCustomerKeyConfigValid",
                 "s3.sse.customer-key has to be set for server-side encryption with customer-provided key",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testLakeFormationCacheTtlValidation()
+    {
+        assertFailsValidation(new S3FileSystemConfig()
+                        .setLakeFormationEnabled(true)
+                        .setLakeFormationCredentialDuration(new Duration(10, MINUTES))
+                        .setLakeFormationCredentialCacheTtl(new Duration(15, MINUTES)),
+                "lakeFormationCacheTtlValid",
+                "fs.s3.lake-formation.credential-cache-ttl must be less than fs.s3.lake-formation.credential-duration",
                 AssertTrue.class);
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemModuleLakeFormation.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemModuleLakeFormation.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests mutual exclusivity between Lake Formation credential vending and S3 security mappings.
+ * The check is implemented in S3FileSystemModule.setup() and throws CONFIGURATION_INVALID
+ * when both fs.s3.lake-formation.enabled and s3.security-mapping.enabled are true.
+ *
+ * This is verified at the module level during Guice bootstrap. Full integration testing
+ * requires the Trino connector test framework (e.g., BaseIcebergGlueConnectorSmokeTest).
+ */
+public class TestS3FileSystemModuleLakeFormation
+{
+    @Test
+    public void testLakeFormationConfigDefaultsDisabled()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig();
+        // Lake Formation is disabled by default, so mutual exclusivity is not triggered
+        assertThat(config.isLakeFormationEnabled()).isFalse();
+    }
+
+    @Test
+    public void testLakeFormationCacheTtlValidWhenDisabled()
+    {
+        // When LF is disabled, cache TTL validation always passes even with invalid values
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setLakeFormationEnabled(false)
+                .setLakeFormationCredentialCacheTtl(new Duration(20, MINUTES))
+                .setLakeFormationCredentialDuration(new Duration(10, MINUTES));
+        assertThat(config.isLakeFormationCacheTtlValid()).isTrue();
+    }
+
+    @Test
+    public void testLakeFormationCacheTtlInvalidWhenEnabled()
+    {
+        // When LF is enabled, cache TTL must be less than credential duration
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setLakeFormationEnabled(true)
+                .setLakeFormationCredentialCacheTtl(new Duration(20, MINUTES))
+                .setLakeFormationCredentialDuration(new Duration(10, MINUTES));
+        assertThat(config.isLakeFormationCacheTtlValid()).isFalse();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperationsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperationsProvider.java
@@ -13,19 +13,28 @@
  */
 package io.trino.plugin.iceberg.catalog.glue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.LakeFormationCredentialProvider;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperations;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIoFactory;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.glue.GlueClient;
 
 import java.util.Optional;
 
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
 import static java.util.Objects.requireNonNull;
 
@@ -38,6 +47,9 @@ public class GlueIcebergTableOperationsProvider
     private final boolean cacheTableMetadata;
     private final GlueClient glueClient;
     private final GlueMetastoreStats stats;
+    private final Optional<LakeFormationCredentialProvider> lakeFormationCredentialProvider;
+    private final Optional<String> glueCatalogId;
+    private final Optional<String> glueRegion;
 
     @Inject
     public GlueIcebergTableOperationsProvider(
@@ -45,8 +57,10 @@ public class GlueIcebergTableOperationsProvider
             ForwardingFileIoFactory fileIoFactory,
             TypeManager typeManager,
             IcebergGlueCatalogConfig catalogConfig,
+            GlueHiveMetastoreConfig glueConfig,
             GlueMetastoreStats stats,
-            GlueClient glueClient)
+            GlueClient glueClient,
+            Optional<LakeFormationCredentialProvider> lakeFormationCredentialProvider)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileIoFactory = requireNonNull(fileIoFactory, "fileIoFactory is null");
@@ -54,6 +68,9 @@ public class GlueIcebergTableOperationsProvider
         this.cacheTableMetadata = catalogConfig.isCacheTableMetadata();
         this.stats = requireNonNull(stats, "stats is null");
         this.glueClient = requireNonNull(glueClient, "glueClient is null");
+        this.lakeFormationCredentialProvider = requireNonNull(lakeFormationCredentialProvider, "lakeFormationCredentialProvider is null");
+        this.glueCatalogId = glueConfig.getCatalogId();
+        this.glueRegion = glueConfig.getGlueRegion();
     }
 
     @Override
@@ -65,6 +82,8 @@ public class GlueIcebergTableOperationsProvider
             Optional<String> owner,
             Optional<String> location)
     {
+        ConnectorIdentity identity = enrichIdentityWithLakeFormationCredentials(session.getIdentity(), database, table);
+
         return new GlueIcebergTableOperations(
                 typeManager,
                 cacheTableMetadata,
@@ -73,11 +92,42 @@ public class GlueIcebergTableOperationsProvider
                 // Share Glue Table cache between Catalog and TableOperations so that, when doing metadata queries (e.g. information_schema.columns)
                 // the GetTableRequest is issued once per table.
                 ((TrinoGlueCatalog) catalog)::getTable,
-                fileIoFactory.create(fileSystemFactory.create(session), isUseFileSizeFromMetadata(session)),
+                fileIoFactory.create(fileSystemFactory.create(identity), isUseFileSizeFromMetadata(session)),
                 session,
                 database,
                 table,
                 owner,
                 location);
+    }
+
+    private ConnectorIdentity enrichIdentityWithLakeFormationCredentials(ConnectorIdentity identity, String database, String table)
+    {
+        if (lakeFormationCredentialProvider.isEmpty() || glueCatalogId.isEmpty()) {
+            return identity;
+        }
+
+        String region = glueRegion.orElse("us-east-1");
+        String tableArn = "arn:aws:glue:" + region + ":" + glueCatalogId.get() + ":table/" + database + "/" + table;
+
+        AwsCredentials credentials = lakeFormationCredentialProvider.get()
+                .getCredentialsProvider(tableArn)
+                .resolveCredentials();
+
+        if (!(credentials instanceof AwsSessionCredentials sessionCredentials)) {
+            return identity;
+        }
+
+        return ConnectorIdentity.forUser(identity.getUser())
+                .withGroups(identity.getGroups())
+                .withPrincipal(identity.getPrincipal())
+                .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                .withConnectorRole(identity.getConnectorRole())
+                .withExtraCredentials(ImmutableMap.<String, String>builder()
+                        .putAll(identity.getExtraCredentials())
+                        .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, sessionCredentials.accessKeyId())
+                        .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, sessionCredentials.secretAccessKey())
+                        .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, sessionCredentials.sessionToken())
+                        .buildOrThrow())
+                .build();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogModule.java
@@ -15,7 +15,9 @@ package io.trino.plugin.iceberg.catalog.glue;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.OptionalBinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.s3.LakeFormationCredentialProvider;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreModule;
 import io.trino.plugin.iceberg.catalog.IcebergHiveMetastoreModule;
@@ -36,6 +38,8 @@ public class IcebergGlueCatalogModule
         binder.bind(IcebergTableOperationsProvider.class).to(GlueIcebergTableOperationsProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoGlueCatalogFactory.class).in(Scopes.SINGLETON);
         newExporter(binder).export(TrinoCatalogFactory.class).withGeneratedName();
+
+        OptionalBinder.newOptionalBinder(binder, LakeFormationCredentialProvider.class);
 
         install(new IcebergHiveMetastoreModule());
         install(new GlueMetastoreModule());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -25,6 +25,7 @@ import io.trino.cache.EvictableCacheBuilder;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.LakeFormationCredentialProvider;
 import io.trino.metastore.SchemaAlreadyExistsException;
 import io.trino.metastore.TableInfo;
 import io.trino.plugin.hive.TrinoViewUtil;
@@ -52,6 +53,7 @@ import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.connector.ViewNotFoundException;
+import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.Type;
@@ -67,6 +69,8 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
@@ -110,6 +114,9 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.Locations.appendPath;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static io.trino.metastore.Table.TABLE_COMMENT;
 import static io.trino.plugin.base.util.ExecutorUtil.processWithAdditionalThreads;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_DATABASE_LOCATION_ERROR;
@@ -177,6 +184,9 @@ public class TrinoGlueCatalog
     private final boolean hideMaterializedViewStorageTable;
     private final boolean isUsingSystemSecurity;
     private final Executor metadataFetchingExecutor;
+    private final Optional<LakeFormationCredentialProvider> lakeFormationCredentialProvider;
+    private final Optional<String> glueCatalogId;
+    private final Optional<String> glueRegion;
 
     private final Cache<SchemaTableName, Table> glueTableCache = EvictableCacheBuilder.newBuilder()
             // Even though this is query-scoped, this still needs to be bounded. information_schema queries can access large number of tables.
@@ -207,7 +217,10 @@ public class TrinoGlueCatalog
             Optional<String> defaultSchemaLocation,
             boolean useUniqueTableLocation,
             boolean hideMaterializedViewStorageTable,
-            Executor metadataFetchingExecutor)
+            Executor metadataFetchingExecutor,
+            Optional<LakeFormationCredentialProvider> lakeFormationCredentialProvider,
+            Optional<String> glueCatalogId,
+            Optional<String> glueRegion)
     {
         super(catalogName, useUniqueTableLocation, typeManager, tableOperationsProvider, fileSystemFactory, fileIoFactory);
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
@@ -218,6 +231,40 @@ public class TrinoGlueCatalog
         this.defaultSchemaLocation = requireNonNull(defaultSchemaLocation, "defaultSchemaLocation is null");
         this.hideMaterializedViewStorageTable = hideMaterializedViewStorageTable;
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
+        this.lakeFormationCredentialProvider = requireNonNull(lakeFormationCredentialProvider, "lakeFormationCredentialProvider is null");
+        this.glueCatalogId = requireNonNull(glueCatalogId, "glueCatalogId is null");
+        this.glueRegion = requireNonNull(glueRegion, "glueRegion is null");
+    }
+
+    private ConnectorIdentity enrichIdentityWithLakeFormationCredentials(ConnectorIdentity identity, String database, String table)
+    {
+        if (lakeFormationCredentialProvider.isEmpty() || glueCatalogId.isEmpty()) {
+            return identity;
+        }
+
+        String region = glueRegion.orElse("us-east-1");
+        String tableArn = "arn:aws:glue:" + region + ":" + glueCatalogId.get() + ":table/" + database + "/" + table;
+
+        AwsCredentials credentials = lakeFormationCredentialProvider.get()
+                .getCredentialsProvider(tableArn)
+                .resolveCredentials();
+
+        if (!(credentials instanceof AwsSessionCredentials sessionCredentials)) {
+            return identity;
+        }
+
+        return ConnectorIdentity.forUser(identity.getUser())
+                .withGroups(identity.getGroups())
+                .withPrincipal(identity.getPrincipal())
+                .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                .withConnectorRole(identity.getConnectorRole())
+                .withExtraCredentials(ImmutableMap.<String, String>builder()
+                        .putAll(identity.getExtraCredentials())
+                        .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, sessionCredentials.accessKeyId())
+                        .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, sessionCredentials.secretAccessKey())
+                        .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, sessionCredentials.sessionToken())
+                        .buildOrThrow())
+                .build();
     }
 
     @Override
@@ -707,7 +754,7 @@ public class TrinoGlueCatalog
             // So log the exception and continue with deleting the table location
             LOG.warn(e, "Failed to delete table data referenced by metadata");
         }
-        deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, table.location());
+        deleteTableDirectory(fileSystemFactory.create(enrichIdentityWithLakeFormationCredentials(session.getIdentity(), schemaTableName.getSchemaName(), schemaTableName.getTableName())), schemaTableName, table.location());
         invalidateTableCache(schemaTableName);
     }
 
@@ -720,7 +767,7 @@ public class TrinoGlueCatalog
             throw new TrinoException(ICEBERG_INVALID_METADATA, format("Table %s is missing [%s] property", schemaTableName, METADATA_LOCATION_PROP));
         }
         String tableLocation = METADATA_PATTERN.matcher(metadataLocation).replaceFirst("");
-        deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, tableLocation);
+        deleteTableDirectory(fileSystemFactory.create(enrichIdentityWithLakeFormationCredentials(session.getIdentity(), schemaTableName.getSchemaName(), schemaTableName.getTableName())), schemaTableName, tableLocation);
         invalidateTableCache(schemaTableName);
     }
 
@@ -870,7 +917,7 @@ public class TrinoGlueCatalog
             try {
                 // Cache the TableMetadata while we have the Table retrieved anyway
                 // Note: this is racy from cache invalidation perspective, but it should not matter here
-                uncheckedCacheGet(tableMetadataCache, schemaTableName, () -> TableMetadataParser.read(fileIoFactory.create(fileSystemFactory.create(session), isUseFileSizeFromMetadata(session)), metadataLocation));
+                uncheckedCacheGet(tableMetadataCache, schemaTableName, () -> TableMetadataParser.read(fileIoFactory.create(fileSystemFactory.create(enrichIdentityWithLakeFormationCredentials(session.getIdentity(), schemaTableName.getSchemaName(), schemaTableName.getTableName())), isUseFileSizeFromMetadata(session)), metadataLocation));
             }
             catch (RuntimeException e) {
                 LOG.warn(e, "Failed to cache table metadata from table at %s", metadataLocation);
@@ -1161,7 +1208,7 @@ public class TrinoGlueCatalog
             }
             catch (RuntimeException e) {
                 try {
-                    dropMaterializedViewStorage(session, fileSystemFactory.create(session), storageMetadataLocation.toString());
+                    dropMaterializedViewStorage(session, fileSystemFactory.create(enrichIdentityWithLakeFormationCredentials(session.getIdentity(), viewName.getSchemaName(), viewName.getTableName())), storageMetadataLocation.toString());
                 }
                 catch (Exception suppressed) {
                     LOG.warn(suppressed, "Failed to clean up metadata '%s' for materialized view '%s'", storageMetadataLocation, viewName);
@@ -1288,7 +1335,7 @@ public class TrinoGlueCatalog
             String storageMetadataLocation = parameters.get(METADATA_LOCATION_PROP);
             checkState(storageMetadataLocation != null, "Storage location missing in definition of materialized view %s", view.name());
             try {
-                dropMaterializedViewStorage(session, fileSystemFactory.create(session), storageMetadataLocation);
+                dropMaterializedViewStorage(session, fileSystemFactory.create(enrichIdentityWithLakeFormationCredentials(session.getIdentity(), view.databaseName(), view.name())), storageMetadataLocation);
             }
             catch (IOException e) {
                 LOG.warn(e, "Failed to delete storage table metadata '%s' for materialized view '%s'", storageMetadataLocation, view.name());
@@ -1406,7 +1453,7 @@ public class TrinoGlueCatalog
         requireNonNull(storageTableName, "storageTableName is null");
         requireNonNull(storageMetadataLocation, "storageMetadataLocation is null");
         return uncheckedCacheGet(tableMetadataCache, storageTableName, () -> {
-            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+            TrinoFileSystem fileSystem = fileSystemFactory.create(enrichIdentityWithLakeFormationCredentials(session.getIdentity(), storageTableName.getSchemaName(), storageTableName.getTableName()));
             return TableMetadataParser.read(fileIoFactory.create(fileSystem, isUseFileSizeFromMetadata(session)), storageMetadataLocation);
         });
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.glue;
 import com.google.inject.Inject;
 import io.airlift.concurrent.BoundedExecutor;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.LakeFormationCredentialProvider;
 import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.hive.security.UsingSystemSecurity;
@@ -57,6 +58,9 @@ public class TrinoGlueCatalogFactory
     private final GlueMetastoreStats stats;
     private final boolean isUsingSystemSecurity;
     private final Executor metadataFetchingExecutor;
+    private final Optional<LakeFormationCredentialProvider> lakeFormationCredentialProvider;
+    private final Optional<String> glueCatalogId;
+    private final Optional<String> glueRegion;
 
     @Inject
     public TrinoGlueCatalogFactory(
@@ -72,7 +76,8 @@ public class TrinoGlueCatalogFactory
             @UsingSystemSecurity boolean usingSystemSecurity,
             GlueMetastoreStats stats,
             GlueClient glueClient,
-            @ForIcebergMetadata ExecutorService metadataExecutorService)
+            @ForIcebergMetadata ExecutorService metadataExecutorService,
+            Optional<LakeFormationCredentialProvider> lakeFormationCredentialProvider)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
@@ -87,6 +92,9 @@ public class TrinoGlueCatalogFactory
         this.hideMaterializedViewStorageTable = icebergConfig.isHideMaterializedViewStorageTable();
         this.stats = requireNonNull(stats, "stats is null");
         this.isUsingSystemSecurity = usingSystemSecurity;
+        this.lakeFormationCredentialProvider = requireNonNull(lakeFormationCredentialProvider, "lakeFormationCredentialProvider is null");
+        this.glueCatalogId = glueConfig.getCatalogId();
+        this.glueRegion = glueConfig.getGlueRegion();
         if (icebergConfig.getMetadataParallelism() == 1) {
             this.metadataFetchingExecutor = directExecutor();
         }
@@ -119,6 +127,9 @@ public class TrinoGlueCatalogFactory
                 defaultSchemaLocation,
                 isUniqueTableLocation,
                 hideMaterializedViewStorageTable,
-                metadataFetchingExecutor);
+                metadataFetchingExecutor,
+                lakeFormationCredentialProvider,
+                glueCatalogId,
+                glueRegion);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.TableInfo;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.IcebergConfig;
@@ -99,8 +100,10 @@ public class TestTrinoGlueCatalog
                         FILE_IO_FACTORY,
                         TESTING_TYPE_MANAGER,
                         catalogConfig,
+                        new GlueHiveMetastoreConfig(),
                         new GlueMetastoreStats(),
-                        glueClient),
+                        glueClient,
+                        Optional.empty()),
                 "test",
                 glueClient,
                 new GlueMetastoreStats(),
@@ -108,7 +111,10 @@ public class TestTrinoGlueCatalog
                 Optional.empty(),
                 useUniqueTableLocations,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
     }
 
     /**
@@ -244,8 +250,10 @@ public class TestTrinoGlueCatalog
                         FILE_IO_FACTORY,
                         TESTING_TYPE_MANAGER,
                         catalogConfig,
+                        new GlueHiveMetastoreConfig(),
                         new GlueMetastoreStats(),
-                        glueClient),
+                        glueClient,
+                        Optional.empty()),
                 "test",
                 glueClient,
                 new GlueMetastoreStats(),
@@ -253,7 +261,10 @@ public class TestTrinoGlueCatalog
                 Optional.of(tmpDirectory.toAbsolutePath().toString()),
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
 
         String namespace = "test_default_location_" + randomNameSuffix();
         String table = "tableName";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR adds Lake Formation credential vending support for S3 file access in the 
Iceberg/Glue connector. It introduces `LakeFormationCredentialProvider`, which calls 
the AWS `GetTemporaryGlueTableCredentials` API to vend short-lived S3 credentials 
scoped to a specific table ARN, cached via a bounded Guava `LoadingCache`.

Vended credentials are injected via `ConnectorIdentity.extraCredentials` in 
`TrinoGlueCatalog` and `GlueIcebergTableOperationsProvider`, allowing Trino to access 
S3 data using Lake Formation-controlled permissions without requiring direct IAM S3 
grants — matching the existing behavior of Athena and EMR.

The feature is opt-in (`fs.s3.lake-formation.enabled=false` by default) and includes 
cross-property validation for `fs.s3.lake-formation.*` config properties, along with 
a mutual exclusivity check against S3 security mappings to prevent conflicts.

## Additional context and related issues
This brings Trino's Lake Formation integration to parity with Athena and EMR for 
Glue-based Iceberg tables.

Fixes #28609

## Release notes
( x ) Release notes are required, with the following suggested text:

## Iceberg connector
* Add support for Lake Formation credential vending via `fs.s3.lake-formation.enabled`
  config, enabling pure Lake Formation-based access control without requiring direct 
  IAM S3 permissions. ({issue}`28609`)
```
