### PR TITLE
Test Ignite handling of decimal type with negative scale

### DIFF
--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -259,6 +259,19 @@ public class TestIgniteTypeMapping
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // IgniteClient.toColumnMapping claims support for decimal(p, -s) mapping to decimal(p+s, 0)
+        // Verify whether Ignite actually supports creating and reading such columns
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(5, -1)", "123450", createDecimalType(6, 0), "DECIMAL '123450'")
+                .addRoundTrip("decimal(5, -3)", "12345000", createDecimalType(8, 0), "DECIMAL '12345000'")
+                .addRoundTrip("decimal(9, -7)", "1234567890000000", createDecimalType(16, 0), "DECIMAL '1234567890000000'")
+                .addRoundTrip("decimal(27, -11)", "12345678901234567890123456700000000000", createDecimalType(38, 0), "DECIMAL '12345678901234567890123456700000000000'")
+                .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
+    }
+
+    @Test
     public void testBinary()
     {
         binaryTest("binary")


### PR DESCRIPTION
## Description

Add test coverage for Ignite connector handling of decimal columns with negative scale.

`IgniteClient.toColumnMapping` has code at line 253 that claims to support mapping `decimal(p, -s)` to `decimal(p+s, 0)`, but this code path is untested.

This PR adds `testDecimalNegativeScale()` to `TestIgniteTypeMapping` following the same pattern established in #28414 for the PostgreSQL connector.

## Additional context and related issues

- Fixes #28416
- See #28388 for the original PostgreSQL negative scale issue
- See #28414 for the PostgreSQL fix and test pattern

## Release notes

( ) This is not user-visible or docs-only