### PR TITLE
Fix failing bucket number parsing in transactional Hive tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -614,7 +614,7 @@ public class BackgroundHiveSplitLoader
 
         for (FileEntry entry : acidState.originalFiles()) {
             // Hive requires "original" files of transactional tables to conform to the bucketed tables naming pattern, to match them with delete deltas.
-            acidInfoBuilder.addOriginalFile(entry.location(), entry.length(), getRequiredBucketNumber(entry.location()));
+            getBucketNumber(entry.location()).ifPresent(bucketId -> acidInfoBuilder.addOriginalFile(entry.location(), entry.length(), bucketId));
         }
 
         if (tableBucketInfo.isPresent()) {
@@ -662,7 +662,7 @@ public class BackgroundHiveSplitLoader
 
     private static Optional<AcidInfo> acidInfoForOriginalFiles(boolean fullAcid, AcidInfo.Builder builder, Location location)
     {
-        return fullAcid ? Optional.of(builder.buildWithRequiredOriginalFiles(getRequiredBucketNumber(location))) : Optional.empty();
+        return fullAcid ? getBucketNumber(location).map(builder::buildWithRequiredOriginalFiles) : Optional.empty();
     }
 
     private Iterator<InternalHiveSplit> createInternalHiveSplitIterator(TrinoFileSystem fileSystem, Location location, InternalHiveSplitFactory splitFactory, boolean splittable, Optional<AcidInfo> acidInfo)
@@ -718,9 +718,9 @@ public class BackgroundHiveSplitLoader
         ListMultimap<Integer, TrinoFileStatus> bucketFiles = ArrayListMultimap.create();
         for (TrinoFileStatus file : files) {
             String fileName = Location.of(file.getPath()).fileName();
-            OptionalInt bucket = getBucketNumber(fileName);
+            Optional<Integer> bucket = getBucketNumber(fileName);
             if (bucket.isPresent()) {
-                bucketFiles.put(bucket.getAsInt(), file);
+                bucketFiles.put(bucket.get(), file);
                 continue;
             }
 
@@ -814,22 +814,21 @@ public class BackgroundHiveSplitLoader
         }
     }
 
-    private static int getRequiredBucketNumber(Location location)
+    private static Optional<Integer> getBucketNumber(Location location)
     {
-        return getBucketNumber(location.fileName())
-                .orElseThrow(() -> new IllegalStateException("Cannot get bucket number from location: " + location));
+        return getBucketNumber(location.fileName());
     }
 
     @VisibleForTesting
-    static OptionalInt getBucketNumber(String name)
+    static Optional<Integer> getBucketNumber(String name)
     {
         for (Pattern pattern : BUCKET_PATTERNS) {
             Matcher matcher = pattern.matcher(name);
             if (matcher.matches()) {
-                return OptionalInt.of(parseInt(matcher.group(1)));
+                return Optional.of(parseInt(matcher.group(1)));
             }
         }
-        return OptionalInt.empty();
+        return Optional.empty();
     }
 
     public static boolean hasAttemptId(String bucketFilename)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -68,7 +68,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -413,27 +412,27 @@ public class TestBackgroundHiveSplitLoader
     public void testGetBucketNumber()
     {
         // legacy Presto naming pattern
-        assertThat(getBucketNumber("20190526_072952_00009_fn7s5_bucket-00234")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("20190526_072952_00009_fn7s5_bucket-00234.txt")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("20190526_235847_87654_fn7s5_bucket-56789")).isEqualTo(OptionalInt.of(56789));
+        assertThat(getBucketNumber("20190526_072952_00009_fn7s5_bucket-00234")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("20190526_072952_00009_fn7s5_bucket-00234.txt")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("20190526_235847_87654_fn7s5_bucket-56789")).isEqualTo(Optional.of(56789));
 
         // Hive
-        assertThat(getBucketNumber("0234_0")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("000234_0")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("0234_99")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("0234_0.txt")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("0234_0_copy_1")).isEqualTo(OptionalInt.of(234));
+        assertThat(getBucketNumber("0234_0")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("000234_0")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("0234_99")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("0234_0.txt")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("0234_0_copy_1")).isEqualTo(Optional.of(234));
         // starts with non-zero
-        assertThat(getBucketNumber("234_99")).isEqualTo(OptionalInt.of(234));
-        assertThat(getBucketNumber("1234_0_copy_1")).isEqualTo(OptionalInt.of(1234));
+        assertThat(getBucketNumber("234_99")).isEqualTo(Optional.of(234));
+        assertThat(getBucketNumber("1234_0_copy_1")).isEqualTo(Optional.of(1234));
 
         // Hive ACID
-        assertThat(getBucketNumber("bucket_1234")).isEqualTo(OptionalInt.of(1234));
-        assertThat(getBucketNumber("bucket_01234")).isEqualTo(OptionalInt.of(1234));
+        assertThat(getBucketNumber("bucket_1234")).isEqualTo(Optional.of(1234));
+        assertThat(getBucketNumber("bucket_01234")).isEqualTo(Optional.of(1234));
 
         // not matching
-        assertThat(getBucketNumber("0234.txt")).isEqualTo(OptionalInt.empty());
-        assertThat(getBucketNumber("0234.txt")).isEqualTo(OptionalInt.empty());
+        assertThat(getBucketNumber("0234.txt")).isEqualTo(Optional.empty());
+        assertThat(getBucketNumber("0234.txt")).isEqualTo(Optional.empty());
     }
 
     @Test
@@ -630,6 +629,42 @@ public class TestBackgroundHiveSplitLoader
         List<String> splits = drain(hiveSplitSource);
         assertThat(splits).contains(originalFile.toString());
         assertThat(splits).contains(fileLocations.get(1).toString());
+    }
+
+    @Test
+    public void testFullAcidTableWithOriginalFilesWithoutBuckets()
+            throws Exception
+    {
+        TrinoFileSystemFactory fileSystemFactory = new MemoryFileSystemFactory();
+        TrinoFileSystem fileSystem = fileSystemFactory.create(ConnectorIdentity.ofUser("test"));
+        Location tableLocation = Location.of("memory:///my_table");
+
+        Table table = table(
+                tableLocation.toString(),
+                List.of(),
+                Optional.empty(),
+                Map.of(TRANSACTIONAL, "true"));
+
+        Location originalFile = tableLocation.appendPath("data.csv");
+        try (OutputStream outputStream = fileSystem.newOutputFile(originalFile).create()) {
+            outputStream.write("test".getBytes(UTF_8));
+        }
+
+        // ValidWriteIdsList is of format <currentTxn>$<schema>.<table>:<highWatermark>:<minOpenWriteId>::<AbortedTxns>
+        // This writeId list has high watermark transaction=3
+        ValidWriteIdList validWriteIdsList = new ValidWriteIdList(format("4$%s.%s:3:9223372036854775807::", table.getDatabaseName(), table.getTableName()));
+
+        BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
+                fileSystemFactory,
+                TupleDomain.all(),
+                Optional.empty(),
+                table,
+                Optional.empty(),
+                Optional.of(validWriteIdsList));
+        HiveSplitSource hiveSplitSource = hiveSplitSource(backgroundHiveSplitLoader);
+        backgroundHiveSplitLoader.start(hiveSplitSource);
+        List<String> splits = drain(hiveSplitSource);
+        assertThat(splits).contains(originalFile.toString());
     }
 
     @Test


### PR DESCRIPTION
## Description
Given a hive table backed by multiple files (for example `part1.csv, part2.csv`). The table was created in Hive with the default `TBLPROPERTIES`, resulting in `'transactional'='true', 'transaction_properties'='insert_only'`. Accessing this table via Trino results in the exception `Cannot get bucket number from location: part1.csv`. This PR fixes the issue.

## Additional context and related issues
The journey starts on line [492](https://github.com/trinodb/trino/blob/master/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java#L492) and invokes the method `getTransactionalSplits(...)`. Later on in that method, on line [615](https://github.com/trinodb/trino/blob/master/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java#L615) the original files are added to the acidInfoBuilder, but this fails as the file names do not match the bucket pattern `0000_1` (match patterns can be found [here](https://github.com/trinodb/trino/blob/master/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java#L140).

The code in this PR makes sure the original file is only added when a bucketId can be determined. When the original file has a file name like `part1.csv`, this should not be treated as a bucket. This is similar to the code in Hive: [AcidUtils.js](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java#L505), where it doesn't throw an exception but returns `-1` as bucketId which is later on omitted.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## HIve
* Fixed bug in Hive connector where bucket number parsing failed on table backed by files without bucket name
```
