### PR TITLE
Fix casting exception when writing value to IntegerType or RealType

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
@@ -45,6 +45,12 @@ public final class TypeUtils
         if (block.isNull(position)) {
             return null;
         }
+        if (type instanceof IntegerType integerType) {
+            return integerType.getInt(block, position);
+        }
+        if (type instanceof RealType realType) {
+            return realType.getFloat(block, position);
+        }
         if (javaType == long.class) {
             return type.getLong(block, position);
         }
@@ -79,10 +85,15 @@ public final class TypeUtils
             type.writeBoolean(blockBuilder, (Boolean) value);
         }
         else if (type.getJavaType() == double.class) {
-            type.writeDouble(blockBuilder, ((double) value));
+            type.writeDouble(blockBuilder, (double) value);
         }
-        else if (type.getJavaType() == long.class) {
-            type.writeLong(blockBuilder, ((long) value));
+        else if (type instanceof RealType realType) {
+            // Java type is long.class, but write as float
+            realType.writeFloat(blockBuilder, (float) value);
+        }
+        else if (type.getJavaType() == long.class && value instanceof Number number) {
+            // Works for Long and Integer
+            type.writeLong(blockBuilder, number.longValue());
         }
         else if (type.getJavaType() == Slice.class) {
             Slice slice;

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTypeUtils.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTypeUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTypeUtils
+{
+    @Test
+    public void testWriteNativeValueToAbstractIntType()
+    {
+        Map<Type, Object> values = ImmutableMap.of(
+                BIGINT, 123456789L,
+                DOUBLE, 1234.56789d,
+                INTEGER, 1337,
+                REAL, 1.23456f);
+
+        values.forEach((type, value) -> {
+            assertThat(readNativeValue(type, writeNativeValue(type, value), 0)).isEqualTo(value);
+        });
+    }
+}


### PR DESCRIPTION
## Description
```
writeNativeValue(INTEGER, 2);
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long

writeNativeValue(REAL, 2f);
java.lang.ClassCastException: class java.lang.Float cannot be cast to class java.lang.Long
```

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: