### PR TITLE
Fix TestQueues flakiness: cancel queries after assertion

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/QueryRunnerUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/QueryRunnerUtil.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.execution.QueryState.RUNNING;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class QueryRunnerUtil
@@ -63,6 +64,16 @@ public final class QueryRunnerUtil
                 }
             }
             MILLISECONDS.sleep(100);
+            // Fail fast if query reached a terminal state we weren't expecting
+            QueryState currentState = dispatchManager.getQueryInfo(queryId).getState();
+            if (currentState.isDone() && !expectedQueryStates.contains(currentState)) {
+                throw new AssertionError(format(
+                        "Query %s reached unexpected terminal state %s (expected states: %s, error code: %s)",
+                        queryId,
+                        currentState,
+                        expectedQueryStates,
+                        dispatchManager.getQueryInfo(queryId).getErrorCode()));
+            }
         }
         while (!expectedQueryStates.contains(dispatchManager.getQueryInfo(queryId).getState()));
     }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
@@ -336,14 +336,20 @@ public class TestQueues
             throws InterruptedException
     {
         QueryId queryId = createQuery(queryRunner, session, query);
-        waitForQueryState(queryRunner, queryId, ImmutableSet.of(RUNNING, FINISHING, FINISHED));
-        Optional<ResourceGroupId> resourceGroupId = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getResourceGroupId();
-        assertThat(resourceGroupId.isPresent())
-                .describedAs("Query should have a resource group")
-                .isTrue();
-        assertThat(resourceGroupId.get())
-                .describedAs(format("Expected: '%s' resource group, found: %s", expectedResourceGroup, resourceGroupId.get()))
-                .isEqualTo(expectedResourceGroup);
+        try {
+            waitForQueryState(queryRunner, queryId, ImmutableSet.of(RUNNING, FINISHING, FINISHED));
+            Optional<ResourceGroupId> resourceGroupId = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getResourceGroupId();
+            assertThat(resourceGroupId.isPresent())
+                    .describedAs("Query should have a resource group")
+                    .isTrue();
+            assertThat(resourceGroupId.get())
+                    .describedAs(format("Expected: '%s' resource group, found: %s", expectedResourceGroup, resourceGroupId.get()))
+                    .isEqualTo(expectedResourceGroup);
+        }
+        finally {
+            cancelQuery(queryRunner, queryId);
+            waitForQueryState(queryRunner, queryId, ImmutableSet.of(FINISHED, FAILED));
+        }
     }
 
     private void testRejection()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`TestQueues.testSelectorResourceEstimateBasedSelection` or `TestQueues.testQueryTypeBasedSelection` (depending on the run) intermittently times out after 240 seconds waiting for a query to reach RUNNING state.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
`assertResourceGroup` creates queries but never cancels them. When running the full `TestQueues` class, earlier test methods spin up a full `DistributedQueryRunner`. By the time `testSelectorResourceEstimateBasedSelection` runs, its 5 sequential `assertResourceGroup` calls accumulate 5 concurrent `SELECT COUNT(*) FROM lineitem` queries on `sf100000` against a single-node cluster. Under JVM pressure, this leads to thread pool saturation (RejectedExecutionException), preventing later queries from progressing through their state machine.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
