### PR TITLE
Fix CREATE OR REPLACE TABLE partition name conflict

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1457,6 +1457,8 @@ public class IcebergMetadata
                 }
                 validateNotModifyingOldSnapshot(table, icebergTable);
                 tableLocation = icebergTable.location();
+                List<PartitionField> existingPartitionFields = getAllPartitionFields(icebergTable);
+                transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, existingPartitionFields);
             }
         }
 
@@ -1464,7 +1466,10 @@ public class IcebergMetadata
             tableLocation = getTableLocation(tableMetadata.getProperties())
                     .orElseGet(() -> catalog.defaultTableLocation(session, tableMetadata.getTable()));
         }
-        transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties);
+
+        if (transaction == null) {
+            transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, ImmutableList.of());
+        }
         Location location = Location.of(transaction.table().location());
         try {
             // S3 Tables internally assigns a unique location for each table

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -908,11 +908,18 @@ public final class IcebergUtil
                 .toList();
     }
 
-    public static Transaction newCreateTableTransaction(TrinoCatalog catalog, ConnectorTableMetadata tableMetadata, ConnectorSession session, boolean replace, String tableLocation, Predicate<String> allowedExtraProperties)
+    public static Transaction newCreateTableTransaction(
+            TrinoCatalog catalog,
+            ConnectorTableMetadata tableMetadata,
+            ConnectorSession session,
+            boolean replace,
+            String tableLocation,
+            Predicate<String> allowedExtraProperties,
+            List<PartitionField> existingPartitionFields)
     {
         SchemaTableName schemaTableName = tableMetadata.getTable();
         Schema schema = schemaFromMetadata(tableMetadata.getColumns());
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()), existingPartitionFields);
         SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
 
         Transaction transaction;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
@@ -351,7 +352,7 @@ public abstract class AbstractTrinoCatalog
         ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(storageTable, columns, materializedViewProperties, Optional.empty());
         String tableLocation = getTableLocation(tableMetadata.getProperties())
                 .orElseGet(() -> defaultTableLocation(session, tableMetadata.getTable()));
-        Transaction transaction = IcebergUtil.newCreateTableTransaction(this, tableMetadata, session, false, tableLocation, _ -> false);
+        Transaction transaction = IcebergUtil.newCreateTableTransaction(this, tableMetadata, session, false, tableLocation, _ -> false, ImmutableList.of());
         AppendFiles appendFiles = transaction.newAppend();
         commit(appendFiles, session);
         transaction.commitTransaction();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7722,6 +7722,29 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testCreateOrReplaceTableChangePartitionBucketCount()
+    {
+        try (TestTable table = newTrinoTable("test_create_or_replace_", "(a int, b varchar) WITH (partitioning = ARRAY['bucket(a, 10)'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 'v1')", 1);
+            long v1SnapshotId = getCurrentSnapshotId(table.getName());
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (partitioning = ARRAY['bucket(a, 11)']) AS SELECT 2 a, 'v2' b", 1);
+            assertThat(query("SELECT a, b FROM " + table.getName()))
+                    .matches("VALUES (2, CAST('v2' AS VARCHAR))");
+
+            // Reading $files must not throw "Invalid schema: multiple fields for name partition.*_bucket"
+            assertThat(query("SELECT count(*) FROM \"" + table.getName() + "$files\""))
+                    .matches("VALUES BIGINT '1'");
+
+            assertThat(query("SELECT a, b FROM " + table.getName() + " FOR VERSION AS OF " + v1SnapshotId))
+                    .matches("VALUES (1, CAST('v1' AS VARCHAR))");
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("partitioning = ARRAY['bucket(a, 11)']");
+        }
+    }
+
+    @Test
     public void testCreateOrReplaceTableChangePartitionedTableIntoUnpartitioned()
     {
         try (TestTable table = newTrinoTable("test_create_or_replace_", " WITH (partitioning=ARRAY['a']) AS SELECT BIGINT '42' a, 'some data' b UNION ALL SELECT BIGINT '43' a, 'another data' b")) {


### PR DESCRIPTION
## Description

When replacing a table with a different bucket count (e.g., `bucket(a, 10)` -> `bucket(a, 11)`), `parsePartitionFields()` was called without the existing partition fields. Both the old and new specs ended up with the same name `a_bucket`, causing a duplicate field error when reading `$files`.

Fix by passing existing partition fields from the original table to `parsePartitionFields()` so the width-suffix deduplication logic in `PartitionFields` applies correctly (e.g., the new spec gets named `a_bucket_11` instead of `a_bucket`).

## Additional context and related issues

Fixes #25339 (1st part)

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix partition name conflict in `CREATE OR REPLACE TABLE` when changing bucket count. ({issue}`25339`)
```