### PR TITLE
Add getExecutingQueries to QueryTracker to filter active non-finishing queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
@@ -39,8 +39,6 @@ import static java.util.Objects.requireNonNull;
 public interface QueryExecution
         extends TrackedQuery
 {
-    QueryState getState();
-
     ListenableFuture<QueryState> getStateChange(QueryState currentState);
 
     void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener);

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
@@ -58,7 +58,6 @@ import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.trino.SystemSessionProperties.getQueryMaxCpuTime;
 import static io.trino.SystemSessionProperties.getQueryMaxScanPhysicalBytes;
 import static io.trino.SystemSessionProperties.getQueryMaxWritePhysicalSize;
-import static io.trino.execution.QueryState.FINISHING;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.tracing.ScopedSpan.scopedSpan;
@@ -394,7 +393,7 @@ public class QueryManager
      */
     private void enforceCpuLimits()
     {
-        for (QueryExecution query : queryTracker.getAllQueries()) {
+        for (QueryExecution query : queryTracker.getExecutingQueries()) {
             Duration cpuTime = query.getTotalCpuTime();
             Duration sessionLimit = getQueryMaxCpuTime(query.getSession());
             Duration limit = Ordering.natural().min(maxQueryCpuTime, sessionLimit);
@@ -409,7 +408,7 @@ public class QueryManager
      */
     private void enforceScanLimits()
     {
-        for (QueryExecution query : queryTracker.getAllQueries()) {
+        for (QueryExecution query : queryTracker.getExecutingQueries()) {
             Optional<DataSize> limitOpt = getQueryMaxScanPhysicalBytes(query.getSession());
             if (maxQueryScanPhysicalBytes.isPresent()) {
                 limitOpt = limitOpt
@@ -431,10 +430,7 @@ public class QueryManager
      */
     private void enforceWriteLimits()
     {
-        for (QueryExecution query : queryTracker.getAllQueries()) {
-            if (query.isDone() || query.getState() == FINISHING) {
-                continue;
-            }
+        for (QueryExecution query : queryTracker.getExecutingQueries()) {
             Optional<DataSize> limitOpt = getQueryMaxWritePhysicalSize(query.getSession());
             if (maxQueryWritePhysicalSize.isPresent()) {
                 limitOpt = limitOpt

--- a/core/trino-main/src/main/java/io/trino/execution/QueryTracker.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryTracker.java
@@ -25,6 +25,7 @@ import org.weakref.jmx.Managed;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Queue;
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SystemSessionProperties.getQueryMaxExecutionTime;
 import static io.trino.SystemSessionProperties.getQueryMaxPlanningTime;
 import static io.trino.SystemSessionProperties.getQueryMaxRunTime;
@@ -46,6 +48,7 @@ import static io.trino.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableCollection;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
 
 @ThreadSafe
 public class QueryTracker<T extends TrackedQuery>
@@ -140,6 +143,15 @@ public class QueryTracker<T extends TrackedQuery>
     public Collection<T> getAllQueries()
     {
         return unmodifiableCollection(queries.values());
+    }
+
+    public List<T> getExecutingQueries()
+    {
+        return queries.values().stream()
+                .filter(not(TrackedQuery::isDone))
+                .filter(query -> query.getState() != QueryState.FINISHING)
+                .filter(query -> query.getExecutionStartTime().isPresent())
+                .collect(toImmutableList());
     }
 
     public T getQuery(QueryId queryId)
@@ -317,6 +329,8 @@ public class QueryTracker<T extends TrackedQuery>
         QueryId getQueryId();
 
         boolean isDone();
+
+        QueryState getState();
 
         Session getSession();
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Move getState() to TrackedQuery interface and introduce getExecutingQueries() which filters out done/finishing queries and those without an execution start time. Update QueryManager enforce* methods to use the new filtered view instead of iterating all queries with manual guards.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
seeing query monitor checking queries already finished.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
