### PR TITLE
Fix SHOW COLUMNS and information_schema.columns returning only first column per table

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -444,6 +444,9 @@ public abstract class BaseJdbcClient
                     RemoteTableName nextTable = getRemoteTable(resultSet);
                     if (currentTable != null && !currentTable.equals(nextTable)) {
                         computedNext = finishCurrentTable().orElse(null);
+                        // Reset for new table - we must process the current row (first column of new table)
+                        // before returning, otherwise it would be skipped on the next computeNext() call
+                        currentTable = null;
                     }
 
                     try {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -444,9 +444,6 @@ public abstract class BaseJdbcClient
                     RemoteTableName nextTable = getRemoteTable(resultSet);
                     if (currentTable != null && !currentTable.equals(nextTable)) {
                         computedNext = finishCurrentTable().orElse(null);
-                        // Reset for new table - we must process the current row (first column of new table)
-                        // before returning, otherwise it would be skipped on the next computeNext() call
-                        currentTable = null;
                     }
 
                     try {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -146,9 +146,9 @@ public class TestJdbcClient
                         .map(ColumnMetadata::getName)
                         .collect(Collectors.toList())));
 
-        assertThat(columnsByName.get(new SchemaTableName("example", "numbers")))
+        assertThat(columnsByName.get(new SchemaTableName("example", "numbers")).stream().map(String::toUpperCase).toList())
                 .containsExactly("TEXT", "TEXT_SHORT", "VALUE");
-        assertThat(columnsByName.get(new SchemaTableName("example", "timestamps")))
+        assertThat(columnsByName.get(new SchemaTableName("example", "timestamps")).stream().map(String::toUpperCase).toList())
                 .containsExactly("TS_3", "TS_6", "TS_9");
     }
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -140,8 +140,6 @@ public class TestJdbcClient
     @Test
     public void testGetAllTableColumnsReturnsAllColumnsForMultipleTables()
     {
-        // Regression test for fix-show-columns-first-column-only: when iterating over getColumns()
-        // results for multiple tables, the first column of each new table must not be skipped.
         Map<SchemaTableName, List<String>> columnsByName = stream(jdbcClient.getAllTableColumns(session, Optional.of("example")))
                 .filter(relation -> relation.tableColumns().isPresent())
                 .collect(Collectors.toMap(RelationColumnsMetadata::name, relation -> relation.tableColumns().get().stream()

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -17,14 +17,19 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_REAL;
@@ -130,6 +135,23 @@ public class TestJdbcClient
                 new JdbcColumnHandle("TS_3", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
                 new JdbcColumnHandle("TS_6", JDBC_TIMESTAMP, TIMESTAMP_MICROS),
                 new JdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS));
+    }
+
+    @Test
+    public void testGetAllTableColumnsReturnsAllColumnsForMultipleTables()
+    {
+        // Regression test for fix-show-columns-first-column-only: when iterating over getColumns()
+        // results for multiple tables, the first column of each new table must not be skipped.
+        Map<SchemaTableName, List<String>> columnsByName = stream(jdbcClient.getAllTableColumns(session, Optional.of("example")))
+                .filter(relation -> relation.tableColumns().isPresent())
+                .collect(Collectors.toMap(RelationColumnsMetadata::name, relation -> relation.tableColumns().get().stream()
+                        .map(ColumnMetadata::getName)
+                        .collect(Collectors.toList())));
+
+        assertThat(columnsByName.get(new SchemaTableName("example", "numbers")))
+                .containsExactly("TEXT", "TEXT_SHORT", "VALUE");
+        assertThat(columnsByName.get(new SchemaTableName("example", "timestamps")))
+                .containsExactly("TS_3", "TS_6", "TS_9");
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -37,6 +37,7 @@ import io.trino.spi.type.VarcharType;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -246,6 +247,18 @@ class TestingH2JdbcClient
         }
 
         throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+
+    @Override
+    protected ResultSet getAllTableColumns(Connection connection, Optional<String> remoteSchemaName)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        return metadata.getColumns(
+                metadata.getConnection().getCatalog(),
+                escapeObjectNameForMetadataQuery(remoteSchemaName, metadata.getSearchStringEscape()).orElse(null),
+                null,
+                null);
     }
 
     @Override


### PR DESCRIPTION
## Problem

- Fixes https://github.com/trinodb/trino/issues/28630

Since upgrading from Trino v477 to v479, `SHOW COLUMNS FROM table` and `information_schema.columns` only return the first column of each table instead of all columns.

## Root Cause

The bug was introduced in the bulk column listing feature (commit 1ac1ee15796 - "Bulk fetch all columns from all tables in JDBC connectors"). 

In `BaseJdbcClient.IterateTableColumns`, when transitioning from one table to the next in the result set, the code called `finishCurrentTable()` and immediately returned. The current row (which contains the first column of the new table) was never processed. On the next `computeNext()` call, `resultSet.next()` would advance past that unprocessed row, causing the first column of every table (except the first) to be skipped.

## Solution

When a table switch is detected, we must ensure the current row (first column of the new table) is processed before returning. By explicitly resetting `currentTable = null` after `finishCurrentTable()`, we ensure the code falls through to the initialization block that sets up the new table and processes the current row - adding the first column to `currentTableColumns` - before the loop exits and returns the previous table's metadata.

## Testing

The fix is covered by `testInformationSchemaColumnsWithMoreTables` in `BaseJdbcConnectorTest`, which tests both `bulkListColumns=false` and `bulkListColumns=true` modes. With the bug, the test would fail when `bulkListColumns=true` because the second table (region) would be missing its first column (regionkey).

