### PR TITLE
Add SHOW COLUMNS support for nested ROW fields

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -51,6 +51,7 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.SqlEnvironmentConfig;
 import io.trino.sql.analyzer.AnalyzerFactory;
@@ -127,6 +128,7 @@ import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.metadata.MetadataUtil.processRoleCommandCatalog;
 import static io.trino.metadata.PropertyUtil.toSqlProperties;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_DEFAULT_COLUMN_VALUE;
 import static io.trino.spi.StandardErrorCode.INVALID_MATERIALIZED_VIEW_PROPERTY;
@@ -450,10 +452,41 @@ public final class ShowQueriesRewrite
         @Override
         protected Node visitShowColumns(ShowColumns showColumns, Void context)
         {
-            QualifiedObjectName tableName = createQualifiedObjectName(session, showColumns, showColumns.getTable());
+            List<String> parts = showColumns.getTable().getParts();
+            Optional<String> nestedFieldName = Optional.empty();
+            QualifiedObjectName tableName;
+
+            if (parts.size() == 4) {
+                tableName = new QualifiedObjectName(parts.get(0), parts.get(1), parts.get(2));
+                nestedFieldName = Optional.of(parts.get(3));
+            }
+            else {
+                tableName = createQualifiedObjectName(session, showColumns, showColumns.getTable());
+                if (!relationExists(tableName)) {
+                    if (parts.size() == 2 && session.getCatalog().isPresent() && session.getSchema().isPresent()) {
+                        QualifiedObjectName fallbackTableName = new QualifiedObjectName(session.getCatalog().get(), session.getSchema().get(), parts.get(0));
+                        if (relationExists(fallbackTableName)) {
+                            tableName = fallbackTableName;
+                            nestedFieldName = Optional.of(parts.get(1));
+                        }
+                    }
+                    else if (parts.size() == 3 && session.getCatalog().isPresent()) {
+                        QualifiedObjectName fallbackTableName = new QualifiedObjectName(session.getCatalog().get(), parts.get(0), parts.get(1));
+                        if (relationExists(fallbackTableName)) {
+                            tableName = fallbackTableName;
+                            nestedFieldName = Optional.of(parts.get(2));
+                        }
+                    }
+                }
+            }
+
             getRequiredCatalogHandle(metadata, session, showColumns, tableName.catalogName());
             if (!metadata.schemaExists(session, new CatalogSchemaName(tableName.catalogName(), tableName.schemaName()))) {
                 throw semanticException(SCHEMA_NOT_FOUND, showColumns, "Schema '%s' does not exist", tableName.schemaName());
+            }
+
+            if (nestedFieldName.isPresent()) {
+                return visitShowColumnsNested(showColumns, tableName, nestedFieldName.get());
             }
 
             boolean isMaterializedView = metadata.isMaterializedView(session, tableName);
@@ -514,6 +547,95 @@ public final class ShowQueriesRewrite
                     from(targetTableName.catalogName(), COLUMNS.getSchemaTableName()),
                     predicate,
                     ordering(ascending("ordinal_position")));
+        }
+
+        private Query visitShowColumnsNested(ShowColumns showColumns, QualifiedObjectName tableName, String nestedFieldName)
+        {
+            if (metadata.isMaterializedView(session, tableName) || metadata.isView(session, tableName)) {
+                throw semanticException(NOT_SUPPORTED, showColumns,
+                        "SHOW COLUMNS for nested fields is not supported for views and materialized views");
+            }
+
+            RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
+            TableHandle tableHandle = redirection.tableHandle()
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, showColumns, "Table '%s' does not exist", tableName));
+            QualifiedObjectName targetTableName = redirection.redirectedTableName().orElse(tableName);
+
+            ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle).metadata();
+            var columnMetadata = MetadataUtil.findColumnMetadata(tableMetadata, nestedFieldName);
+            if (columnMetadata == null) {
+                throw semanticException(COLUMN_NOT_FOUND, showColumns, "Column '%s' does not exist in table '%s'", nestedFieldName, tableName);
+            }
+
+            if (!(columnMetadata.getType() instanceof RowType rowType)) {
+                throw semanticException(NOT_SUPPORTED, showColumns,
+                        "Column '%s' is not of type ROW. SHOW COLUMNS for nested fields only supports ROW types.", nestedFieldName);
+            }
+
+            accessControl.checkCanShowColumns(session.toSecurityContext(), targetTableName.asCatalogSchemaTableName());
+
+            List<RowType.Field> fields = rowType.getFields();
+            List<Expression> rows = new ArrayList<>();
+            int ordinal = 0;
+            Optional<String> likePattern = showColumns.getLikePattern();
+            if (likePattern.isPresent() && showColumns.getEscape().isPresent()) {
+                throw semanticException(NOT_SUPPORTED, showColumns,
+                        "ESCAPE clause for LIKE is not supported for SHOW COLUMNS on nested ROW fields");
+            }
+
+            for (RowType.Field field : fields) {
+                String fieldName = field.getName().orElse("field" + ordinal);
+                if (likePattern.isPresent() && !likeMatches(fieldName, likePattern.get())) {
+                    continue;
+                }
+                rows.add(row(
+                        new StringLiteral(fieldName),
+                        new StringLiteral(field.getType().getDisplayName()),
+                        new StringLiteral(""),
+                        new StringLiteral("")));
+                ordinal++;
+            }
+
+            return simpleQuery(
+                    selectList(
+                            aliasedName("column_name", "Column"),
+                            aliasedName("data_type", "Type"),
+                            aliasedNullToEmpty("extra_info", "Extra"),
+                            aliasedNullToEmpty("comment", "Comment")),
+                    aliased(new Values(rows), "columns", ImmutableList.of("column_name", "data_type", "extra_info", "comment")),
+                    Optional.empty(),
+                    Optional.of(ordering(ascending("column_name"))));
+        }
+
+        private boolean relationExists(QualifiedObjectName name)
+        {
+            try {
+                if (!metadata.schemaExists(session, new CatalogSchemaName(name.catalogName(), name.schemaName()))) {
+                    return false;
+                }
+                return metadata.isMaterializedView(session, name) ||
+                       metadata.isView(session, name) ||
+                       metadata.getRedirectionAwareTableHandle(session, name).tableHandle().isPresent();
+            }
+            catch (RuntimeException e) {
+                return false;
+            }
+        }
+
+        private boolean likeMatches(String value, String pattern)
+        {
+            if (pattern.equals("%")) {
+                return true;
+            }
+            if (!pattern.contains("%") && !pattern.contains("_")) {
+                return value.equals(pattern);
+            }
+            String regex = pattern
+                    .replace("\\", "\\\\")
+                    .replace(".", "\\.")
+                    .replace("%", ".*")
+                    .replace("_", ".");
+            return value.matches(regex);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -41,6 +41,8 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
@@ -93,6 +95,17 @@ public class TestShowQueries
                                 .add(columnMetadata("col_long_timestamptz", createTimestampWithTimeZoneType(12), "TIMESTAMP '1970-01-01 00:00:00.000000000000 UTC'"))
                                 .build();
                     }
+                    if (schemaTableName.getTableName().equals("tablewithrow")) {
+                        return ImmutableList.of(
+                                ColumnMetadata.builder()
+                                        .setName("id")
+                                        .setType(BIGINT)
+                                        .build(),
+                                ColumnMetadata.builder()
+                                        .setName("complex")
+                                        .setType(rowType(field("a", BIGINT), field("b", VARCHAR)))
+                                        .build());
+                    }
                     return ImmutableList.of(
                             ColumnMetadata.builder()
                                     .setName("colaa")
@@ -108,7 +121,7 @@ public class TestShowQueries
                                     .build());
                 })
                 .withListSchemaNames(session -> ImmutableList.of("mockschema"))
-                .withListTables((session, schemaName) -> ImmutableList.of("mockTable"))
+                .withListTables((session, schemaName) -> ImmutableList.of("mockTable", "tablewithrow"))
                 .withTableFunctions(ImmutableList.of(new SimpleTableFunction()))
                 .withGetTableHandle((session, schemaTableName) -> {
                     if (schemaTableName.getTableName().equals("mockview")) {
@@ -269,6 +282,19 @@ public class TestShowQueries
                 .failure().hasMessage("Escape string must be a single character");
         assertThat(assertions.query("SHOW COLUMNS FROM mock.mockSchema.mockTable LIKE 'cola$_' ESCAPE '$'"))
                 .matches("VALUES (VARCHAR 'cola_', VARCHAR 'bigint' , VARCHAR '', VARCHAR '')");
+    }
+
+    @Test
+    public void testShowColumnsFromNestedField()
+    {
+        assertThat(assertions.query("SHOW COLUMNS FROM mock.mockSchema.tablewithrow.complex"))
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "(VARCHAR 'a', VARCHAR 'bigint', VARCHAR '', VARCHAR '')," +
+                        "(VARCHAR 'b', VARCHAR 'varchar', VARCHAR '', VARCHAR '')");
+        assertThat(assertions.query("SHOW COLUMNS FROM mock.mockSchema.tablewithrow.complex LIKE 'a'"))
+                .skippingTypesCheck()
+                .matches("VALUES (VARCHAR 'a', VARCHAR 'bigint', VARCHAR '', VARCHAR '')");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1667,6 +1667,17 @@ public class TestSqlParser
                         QualifiedName.of(ImmutableList.of(new Identifier(location(1, 19), "a", false), new Identifier(location(1, 21), "b", false))),
                         Optional.of("%$_%"),
                         Optional.of("$")));
+        // SHOW COLUMNS FROM table.complex for nested ROW fields (4-part: catalog.schema.table.column)
+        assertThat(statement("SHOW COLUMNS FROM a.b.c.d"))
+                .isEqualTo(new ShowColumns(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(
+                                new Identifier(location(1, 19), "a", false),
+                                new Identifier(location(1, 21), "b", false),
+                                new Identifier(location(1, 23), "c", false),
+                                new Identifier(location(1, 25), "d", false))),
+                        Optional.empty(),
+                        Optional.empty()));
 
         assertStatementIsInvalid("SHOW COLUMNS FROM a.b LIKE null")
                 .withMessage("line 1:28: mismatched input 'null'. Expecting: <string>");


### PR DESCRIPTION
- Fixes https://github.com/trinodb/trino/issues/19131

Supports:
- SHOW COLUMNS FROM table.column (2 parts, uses session catalog/schema)
- SHOW COLUMNS FROM catalog.schema.table.column (4 parts)

Shows the nested fields of a ROW type column when the column name is specified after the table name.



<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
