### PR TITLE
Fix Cassandra INT partition key full scan when IN clause uses consecutive  values

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -58,6 +58,8 @@ public class CassandraPartitionManager
      */
     private static final int MAX_PARTITION_KEY_RANGE_EXPANSION = 1000;
 
+    private static final Set<CassandraType.Kind> INTEGER_PARTITION_KEY_TYPES = ImmutableSet.of(INT, BIGINT, SMALLINT, TINYINT);
+
     private final CassandraSession cassandraSession;
     private final CassandraTypeManager cassandraTypeManager;
 
@@ -232,6 +234,6 @@ public class CassandraPartitionManager
 
     private static boolean isIntegerPartitionKeyType(CassandraType.Kind kind)
     {
-        return kind == INT || kind == BIGINT || kind == SMALLINT || kind == TINYINT;
+        return INTEGER_PARTITION_KEY_TYPES.contains(kind);
     }
 }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -23,7 +23,9 @@ import io.trino.plugin.cassandra.util.CassandraCqlUtils;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.Ranges;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.Type;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +39,24 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.cassandra.CassandraType.Kind.BIGINT;
+import static io.trino.plugin.cassandra.CassandraType.Kind.INT;
+import static io.trino.plugin.cassandra.CassandraType.Kind.SMALLINT;
+import static io.trino.plugin.cassandra.CassandraType.Kind.TINYINT;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class CassandraPartitionManager
 {
     private static final Logger log = Logger.get(CassandraPartitionManager.class);
+
+    /**
+     * Maximum number of partition key values to expand from a range predicate.
+     * Cassandra cannot use BETWEEN for INT/BIGINT partition keys, so we expand
+     * consecutive ranges (e.g. IN (1,2,3,4) simplified to BETWEEN 1 AND 4) to discrete
+     * values for partition pruning. Ranges exceeding this limit fall back to full scan.
+     */
+    private static final int MAX_PARTITION_KEY_RANGE_EXPANSION = 1000;
 
     private final CassandraSession cassandraSession;
     private final CassandraTypeManager cassandraTypeManager;
@@ -151,22 +165,7 @@ public class CassandraPartitionManager
             }
 
             Set<Object> values = domain.getValues().getValuesProcessor().transform(
-                    ranges -> {
-                        ImmutableSet.Builder<Object> columnValues = ImmutableSet.builder();
-                        for (Range range : ranges.getOrderedRanges()) {
-                            // if the range is not a single value, we cannot perform partition pruning
-                            if (!range.isSingleValue()) {
-                                return ImmutableSet.of();
-                            }
-                            Object value = range.getSingleValue();
-
-                            CassandraType valueType = columnHandle.cassandraType();
-                            if (valueType.kind().isSupportedPartitionKey()) {
-                                columnValues.add(value);
-                            }
-                        }
-                        return columnValues.build();
-                    },
+                    ranges -> extractPartitionKeyValues(columnHandle, ranges),
                     discreteValues -> {
                         if (discreteValues.isInclusive()) {
                             return ImmutableSet.copyOf(discreteValues.getValues());
@@ -177,5 +176,62 @@ public class CassandraPartitionManager
             partitionColumnValues.add(values);
         }
         return partitionColumnValues.build();
+    }
+
+    /**
+     * Extracts partition key values from a domain's ranges. For single-value ranges, the value is used directly.
+     * For multi-value ranges on INT/BIGINT/SMALLINT/TINYINT partition keys, the range is expanded to discrete
+     * values (since Cassandra cannot use BETWEEN for partition key filtering but supports IN).
+     */
+    private ImmutableSet<Object> extractPartitionKeyValues(CassandraColumnHandle columnHandle, Ranges ranges)
+    {
+        ImmutableSet.Builder<Object> columnValues = ImmutableSet.builder();
+        CassandraType valueType = columnHandle.cassandraType();
+
+        if (!valueType.kind().isSupportedPartitionKey()) {
+            return ImmutableSet.of();
+        }
+
+        for (Range range : ranges.getOrderedRanges()) {
+            if (range.isSingleValue()) {
+                columnValues.add(range.getSingleValue());
+                continue;
+            }
+
+            // For non-single-value ranges, Cassandra cannot use BETWEEN on partition keys.
+            // Expand to discrete values for integer types (INT, BIGINT, SMALLINT, TINYINT).
+            if (range.isLowUnbounded() || range.isHighUnbounded()) {
+                return ImmutableSet.of();
+            }
+
+            if (!isIntegerPartitionKeyType(valueType.kind())) {
+                return ImmutableSet.of();
+            }
+
+            Type trinoType = valueType.trinoType();
+            Optional<Stream<?>> discreteValuesOpt = trinoType.getDiscreteValues(
+                    new Type.Range(range.getLowBoundedValue(), range.getHighBoundedValue()));
+
+            if (discreteValuesOpt.isEmpty()) {
+                return ImmutableSet.of();
+            }
+
+            List<Object> expandedValues = discreteValuesOpt.get()
+                    .limit(MAX_PARTITION_KEY_RANGE_EXPANSION + 1)
+                    .map(Object.class::cast)
+                    .collect(toList());
+
+            if (expandedValues.size() > MAX_PARTITION_KEY_RANGE_EXPANSION) {
+                return ImmutableSet.of();
+            }
+
+            columnValues.addAll(expandedValues);
+        }
+        return columnValues.build();
+    }
+
+    private static boolean isIntegerPartitionKeyType(CassandraType.Kind kind)
+    {
+        return kind == INT || kind == BIGINT || kind == SMALLINT || kind == TINYINT;
     }
 }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -200,8 +200,6 @@ public class CassandraPartitionManager
                 continue;
             }
 
-            // For non-single-value ranges, Cassandra cannot use BETWEEN on partition keys.
-            // Expand to discrete values for integer types (INT, BIGINT, SMALLINT, TINYINT).
             if (range.isLowUnbounded() || range.isHighUnbounded()) {
                 return ImmutableSet.of();
             }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -50,12 +50,6 @@ public class CassandraPartitionManager
 {
     private static final Logger log = Logger.get(CassandraPartitionManager.class);
 
-    /**
-     * Maximum number of partition key values to expand from a range predicate.
-     * Cassandra cannot use BETWEEN for INT/BIGINT partition keys, so we expand
-     * consecutive ranges (e.g. IN (1,2,3,4) simplified to BETWEEN 1 AND 4) to discrete
-     * values for partition pruning. Ranges exceeding this limit fall back to full scan.
-     */
     private static final int MAX_PARTITION_KEY_RANGE_EXPANSION = 1000;
 
     private static final Set<CassandraType.Kind> INTEGER_PARTITION_KEY_TYPES = ImmutableSet.of(INT, BIGINT, SMALLINT, TINYINT);
@@ -180,11 +174,6 @@ public class CassandraPartitionManager
         return partitionColumnValues.build();
     }
 
-    /**
-     * Extracts partition key values from a domain's ranges. For single-value ranges, the value is used directly.
-     * For multi-value ranges on INT/BIGINT/SMALLINT/TINYINT partition keys, the range is expanded to discrete
-     * values (since Cassandra cannot use BETWEEN for partition key filtering but supports IN).
-     */
     private ImmutableSet<Object> extractPartitionKeyValues(CassandraColumnHandle columnHandle, Ranges ranges)
     {
         ImmutableSet.Builder<Object> columnValues = ImmutableSet.builder();

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
@@ -17,8 +17,11 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,7 @@ import java.util.Optional;
 import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.plugin.cassandra.CassandraTestingUtils.CASSANDRA_TYPE_MANAGER;
 import static io.trino.plugin.cassandra.CassandraTestingUtils.createKeyspace;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -101,6 +105,51 @@ final class TestCassandraSplitManager
             assertThat(((CassandraSplit) splits.get(0)).partitionId()).isEqualTo("\"partition_key\" in (0,1)");
             assertThat(((CassandraSplit) splits.get(1)).partitionId()).isEqualTo("\"partition_key\" in (2)");
         }
+
+        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+    }
+
+    @Test
+    void testIntPartitionKeyRangeExpansionForConsecutiveValues()
+            throws Exception
+    {
+        String tableName = "int_partition_key_range_table";
+
+        session.execute(format(
+                """
+                CREATE TABLE %s.%s (
+                      partition_key int,
+                      data text,
+                      PRIMARY KEY(partition_key))
+                """,
+                KEYSPACE,
+                tableName));
+
+        for (int i = 1; i <= 5; i++) {
+            session.execute(format("INSERT INTO %s.%s (partition_key, data) VALUES (%d, 'value_%d')", KEYSPACE, tableName, i, i));
+        }
+
+        CassandraColumnHandle columnHandle = new CassandraColumnHandle("partition_key", 0, CassandraTypes.INT, true, false, false, false);
+        // Simulate planner producing a range (e.g. IN (1,2,3,4,5) simplified to BETWEEN 1 AND 5)
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                Map.of(columnHandle,
+                        Domain.create(ValueSet.ofRanges(Range.range(INTEGER, 1L, true, 5L, true)), false)));
+
+        CassandraPartitionManager partitionManager = new CassandraPartitionManager(session, CASSANDRA_TYPE_MANAGER);
+        CassandraNamedRelationHandle tableHandle = new CassandraNamedRelationHandle(KEYSPACE, tableName);
+        CassandraPartitionResult result = partitionManager.getPartitions(tableHandle, tupleDomain);
+
+        // Range should be expanded to discrete values [1,2,3,4,5] for partition pruning
+        assertThat(result.partitions()).hasSize(5);
+        assertThat(result.partitions().stream()
+                .map(p -> p.getPartitionId())
+                .toList())
+                .containsExactlyInAnyOrder(
+                        "\"partition_key\" = 1",
+                        "\"partition_key\" = 2",
+                        "\"partition_key\" = 3",
+                        "\"partition_key\" = 4",
+                        "\"partition_key\" = 5");
 
         session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
     }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplitManager.java
@@ -130,7 +130,6 @@ final class TestCassandraSplitManager
         }
 
         CassandraColumnHandle columnHandle = new CassandraColumnHandle("partition_key", 0, CassandraTypes.INT, true, false, false, false);
-        // Simulate planner producing a range (e.g. IN (1,2,3,4,5) simplified to BETWEEN 1 AND 5)
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
                 Map.of(columnHandle,
                         Domain.create(ValueSet.ofRanges(Range.range(INTEGER, 1L, true, 5L, true)), false)));
@@ -139,7 +138,6 @@ final class TestCassandraSplitManager
         CassandraNamedRelationHandle tableHandle = new CassandraNamedRelationHandle(KEYSPACE, tableName);
         CassandraPartitionResult result = partitionManager.getPartitions(tableHandle, tupleDomain);
 
-        // Range should be expanded to discrete values [1,2,3,4,5] for partition pruning
         assertThat(result.partitions()).hasSize(5);
         assertThat(result.partitions().stream()
                 .map(p -> p.getPartitionId())


### PR DESCRIPTION


When partition keys are INT or BIGINT, specifying consecutive values in IN (e.g. IN (1,2,3,4)) gets optimized to BETWEEN by SimplifyContinuousInValues. Cassandra cannot use BETWEEN for partition key filtering, causing a full scan.

Expand integer range predicates to discrete values for partition pruning, using IN clause which Cassandra supports. Limit expansion to 1000 values for safety.

Fixes #28624



<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
