### PR TITLE
Fix OPA access denied to list only inaccessible columns

### DIFF
--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -772,10 +772,6 @@ public sealed class OpaAccessControl
                 OpaQueryInputResource.builder().table(new TrinoTable(table).withProperties(properties)).build());
     }
 
-    /**
-     * When access is denied, reports only the inaccessible columns (not all columns)
-     * by using filterColumns to determine which columns the user can access.
-     */
     private void checkTableAndColumnsOperation(SystemSecurityContext context, String actionName, CatalogSchemaTableName table, Set<String> columns, BiConsumer<String, Set<String>> deny)
     {
         opaHighLevelClient.queryAndEnforce(

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.opa;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimaps;
@@ -58,6 +59,7 @@ import java.util.function.Consumer;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.opa.OpaHighLevelClient.buildQueryInputForSimpleResource;
 import static io.trino.spi.security.AccessDeniedException.denyCreateCatalog;
@@ -775,7 +777,17 @@ public sealed class OpaAccessControl
         opaHighLevelClient.queryAndEnforce(
                 buildQueryContext(context),
                 actionName,
-                () -> deny.accept(table.toString(), columns),
+                () -> {
+                    // When access is denied, report only the inaccessible columns (not all columns)
+                    // by using filterColumns to determine which columns the user can access
+                    Set<String> allowedColumns = filterColumns(context, table.getCatalogName(),
+                            ImmutableMap.of(table.getSchemaTableName(), columns))
+                            .getOrDefault(table.getSchemaTableName(), ImmutableSet.of());
+                    Set<String> inaccessibleColumns = columns.stream()
+                            .filter(column -> !allowedColumns.contains(column))
+                            .collect(toImmutableSet());
+                    deny.accept(table.toString(), inaccessibleColumns.isEmpty() ? columns : inaccessibleColumns);
+                },
                 OpaQueryInputResource.builder().table(new TrinoTable(table).withColumns(columns)).build());
     }
 

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -772,14 +772,16 @@ public sealed class OpaAccessControl
                 OpaQueryInputResource.builder().table(new TrinoTable(table).withProperties(properties)).build());
     }
 
+    /**
+     * When access is denied, reports only the inaccessible columns (not all columns)
+     * by using filterColumns to determine which columns the user can access.
+     */
     private void checkTableAndColumnsOperation(SystemSecurityContext context, String actionName, CatalogSchemaTableName table, Set<String> columns, BiConsumer<String, Set<String>> deny)
     {
         opaHighLevelClient.queryAndEnforce(
                 buildQueryContext(context),
                 actionName,
                 () -> {
-                    // When access is denied, report only the inaccessible columns (not all columns)
-                    // by using filterColumns to determine which columns the user can access
                     Set<String> allowedColumns = filterColumns(context, table.getCatalogName(),
                             ImmutableMap.of(table.getSchemaTableName(), columns))
                             .getOrDefault(table.getSchemaTableName(), ImmutableSet.of());

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.opa;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimaps;
@@ -58,6 +59,7 @@ import java.util.function.Consumer;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.opa.OpaHighLevelClient.buildQueryInputForSimpleResource;
 import static io.trino.spi.security.AccessDeniedException.denyCreateCatalog;
@@ -775,7 +777,17 @@ public sealed class OpaAccessControl
         opaHighLevelClient.queryAndEnforce(
                 buildQueryContext(context),
                 actionName,
-                () -> deny.accept(table.toString(), columns),
+                () -> {
+                    Set<String> allowedColumns = filterColumns(
+                            context,
+                            table.getCatalogName(),
+                            ImmutableMap.of(table.getSchemaTableName(), columns))
+                            .getOrDefault(table.getSchemaTableName(), ImmutableSet.of());
+                    Set<String> inaccessibleColumns = columns.stream()
+                            .filter(column -> !allowedColumns.contains(column))
+                            .collect(toImmutableSet());
+                    deny.accept(table.toString(), inaccessibleColumns.isEmpty() ? columns : inaccessibleColumns);
+                },
                 OpaQueryInputResource.builder().table(new TrinoTable(table).withColumns(columns)).build());
     }
 

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -561,8 +561,6 @@ final class TestOpaAccessControl
                         table.getSchemaTableName().getSchemaName(),
                         table.getSchemaTableName().getTableName(),
                         dummyColumnName);
-        // When access is denied, filterColumns is called to determine inaccessible columns for the error message,
-        // causing the restrictive client to make additional FilterColumns requests
         assertAccessControlMethodBehaviour(wrappedMethod, ImmutableSet.of(expectedRequest), true);
     }
 

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -561,7 +561,9 @@ final class TestOpaAccessControl
                         table.getSchemaTableName().getSchemaName(),
                         table.getSchemaTableName().getTableName(),
                         dummyColumnName);
-        assertAccessControlMethodBehaviour(wrappedMethod, ImmutableSet.of(expectedRequest));
+        // When access is denied, filterColumns is called to determine inaccessible columns for the error message,
+        // causing the restrictive client to make additional FilterColumns requests
+        assertAccessControlMethodBehaviour(wrappedMethod, ImmutableSet.of(expectedRequest), true);
     }
 
     @Test
@@ -1094,12 +1096,22 @@ final class TestOpaAccessControl
 
     private static void assertAccessControlMethodBehaviour(MethodWrapper method, Set<String> expectedRequests)
     {
+        assertAccessControlMethodBehaviour(method, expectedRequests, false);
+    }
+
+    private static void assertAccessControlMethodBehaviour(MethodWrapper method, Set<String> expectedRequests, boolean allowRestrictiveExtraRequests)
+    {
         InstrumentedHttpClient permissiveMockClient = createMockHttpClient(OPA_SERVER_URI, buildValidatingRequestHandler(TEST_IDENTITY, OK_RESPONSE));
         InstrumentedHttpClient restrictiveMockClient = createMockHttpClient(OPA_SERVER_URI, buildValidatingRequestHandler(TEST_IDENTITY, NO_ACCESS_RESPONSE));
 
         assertThat(method.isAccessAllowed(createOpaAuthorizer(simpleOpaConfig(), permissiveMockClient))).isTrue();
         assertThat(method.isAccessAllowed(createOpaAuthorizer(simpleOpaConfig(), restrictiveMockClient))).isFalse();
-        assertThat(permissiveMockClient.getRequests()).containsExactlyInAnyOrderElementsOf(restrictiveMockClient.getRequests());
+        if (allowRestrictiveExtraRequests) {
+            assertThat(restrictiveMockClient.getRequests()).containsAll(permissiveMockClient.getRequests());
+        }
+        else {
+            assertThat(permissiveMockClient.getRequests()).containsExactlyInAnyOrderElementsOf(restrictiveMockClient.getRequests());
+        }
         assertStringRequestsEqual(expectedRequests, permissiveMockClient.getRequests(), "/input/action");
         assertAccessControlMethodThrowsForIllegalResponses(method::isAccessAllowed, simpleOpaConfig(), OPA_SERVER_URI);
     }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -562,7 +562,7 @@ final class TestOpaAccessControl
                         table.getSchemaTableName().getSchemaName(),
                         table.getSchemaTableName().getTableName(),
                         dummyColumnName);
-        assertAccessControlMethodBehaviour(wrappedMethod, ImmutableSet.of(expectedRequest));
+        assertAccessControlMethodBehaviour(wrappedMethod, ImmutableSet.of(expectedRequest), true);
     }
 
     @Test
@@ -1100,12 +1100,22 @@ final class TestOpaAccessControl
 
     private static void assertAccessControlMethodBehaviour(MethodWrapper method, Set<String> expectedRequests)
     {
+        assertAccessControlMethodBehaviour(method, expectedRequests, false);
+    }
+
+    private static void assertAccessControlMethodBehaviour(MethodWrapper method, Set<String> expectedRequests, boolean allowRestrictiveExtraRequests)
+    {
         InstrumentedHttpClient permissiveMockClient = createMockHttpClient(OPA_SERVER_URI, buildValidatingRequestHandler(TEST_IDENTITY, OK_RESPONSE));
         InstrumentedHttpClient restrictiveMockClient = createMockHttpClient(OPA_SERVER_URI, buildValidatingRequestHandler(TEST_IDENTITY, NO_ACCESS_RESPONSE));
 
         assertThat(method.isAccessAllowed(createOpaAuthorizer(simpleOpaConfig(), permissiveMockClient))).isTrue();
         assertThat(method.isAccessAllowed(createOpaAuthorizer(simpleOpaConfig(), restrictiveMockClient))).isFalse();
-        assertThat(permissiveMockClient.getRequests()).containsExactlyInAnyOrderElementsOf(restrictiveMockClient.getRequests());
+        if (allowRestrictiveExtraRequests) {
+            assertThat(restrictiveMockClient.getRequests()).containsAll(permissiveMockClient.getRequests());
+        }
+        else {
+            assertThat(permissiveMockClient.getRequests()).containsExactlyInAnyOrderElementsOf(restrictiveMockClient.getRequests());
+        }
         assertStringRequestsEqual(expectedRequests, permissiveMockClient.getRequests(), "/input/action");
         assertAccessControlMethodThrowsForIllegalResponses(method::isAccessAllowed, simpleOpaConfig(), OPA_SERVER_URI);
     }


### PR DESCRIPTION
## Description

When a user lacks permission for some (but not all) of the columns referenced in a query, the OPA access control's "access denied" message now lists only the inaccessible columns instead of every column of the table. `filterColumns` is used to determine which columns the user can access, and only the denied subset is reported.

## Additional context and related issues

- Fixes #28602

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## OPA
* Only list the inaccessible columns in the access denied error message. ({issue}`28602`)
```
