### PR TITLE
Fix Iceberg OPTIMIZE failing with ORC EOF checkpoint edge case

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
@@ -85,10 +85,6 @@ public final class CompressedOrcChunkLoader
         return lastCheckpoint;
     }
 
-    /**
-     * Seeks to the given checkpoint. A checkpoint may legitimately point to stream EOF when there
-     * is no payload in this stream for a row group (for example, all values are null or empty strings).
-     */
     @Override
     public void seekToCheckpoint(long checkpoint)
             throws IOException

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
@@ -85,6 +85,10 @@ public final class CompressedOrcChunkLoader
         return lastCheckpoint;
     }
 
+    /**
+     * Seeks to the given checkpoint. A checkpoint may legitimately point to stream EOF when there
+     * is no payload in this stream for a row group (for example, all values are null or empty strings).
+     */
     @Override
     public void seekToCheckpoint(long checkpoint)
             throws IOException
@@ -92,8 +96,6 @@ public final class CompressedOrcChunkLoader
         int compressedOffset = decodeCompressedBlockOffset(checkpoint);
         int decompressedOffset = decodeDecompressedOffset(checkpoint);
 
-        // A checkpoint may legitimately point to stream EOF when there is no payload in this stream
-        // for a row group (for example, all values are null or empty strings).
         if (compressedOffset > dataReader.getSize() || (compressedOffset == dataReader.getSize() && decompressedOffset != 0)) {
             throw new OrcCorruptionException(dataReader.getOrcDataSourceId(), "Seek past end of stream");
         }

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
@@ -90,7 +90,11 @@ public final class CompressedOrcChunkLoader
             throws IOException
     {
         int compressedOffset = decodeCompressedBlockOffset(checkpoint);
-        if (compressedOffset >= dataReader.getSize()) {
+        int decompressedOffset = decodeDecompressedOffset(checkpoint);
+
+        // A checkpoint may legitimately point to stream EOF when there is no payload in this stream
+        // for a row group (for example, all values are null or empty strings).
+        if (compressedOffset > dataReader.getSize() || (compressedOffset == dataReader.getSize() && decompressedOffset != 0)) {
             throw new OrcCorruptionException(dataReader.getOrcDataSourceId(), "Seek past end of stream");
         }
         // is the compressed offset within the current compressed buffer
@@ -102,7 +106,7 @@ public final class CompressedOrcChunkLoader
             compressedBufferStream = EMPTY_SLICE.getInput();
         }
 
-        nextUncompressedOffset = decodeDecompressedOffset(checkpoint);
+        nextUncompressedOffset = decompressedOffset;
         lastCheckpoint = checkpoint;
     }
 


### PR DESCRIPTION
When an ORC stream has a row group with no payload (e.g. all nulls or empty strings), the checkpoint can legitimately point to stream EOF. The previous check incorrectly threw OrcCorruptionException in this case.

Fixes #28636



<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
