### PR TITLE
Fix expected error pattern in Iceberg BigLake test

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -199,6 +199,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
@@ -2075,7 +2076,7 @@ public class IcebergMetadata
         try {
             commit(update, session);
         }
-        catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException e) {
+        catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException | RESTException e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, format("Failed to commit during %s: %s", operation, requireNonNullElse(e.getMessage(), e)), e);
         }
     }
@@ -2085,7 +2086,7 @@ public class IcebergMetadata
         try {
             transaction.commitTransaction();
         }
-        catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException e) {
+        catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException | RESTException e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, format("Failed to commit the transaction during %s: %s", operation, requireNonNullElse(e.getMessage(), e)), e);
         }
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -243,7 +243,7 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
     }
 
     @Test
-    @Override // Override because BigLake metastore requires table location to start with the prefix with the table name without following spaces
+    @Override // Override because BigLake metastore doesn't allow changing a table location
     public void testCreateTableWithTrailingSpaceInLocation()
     {
         String tableName = "test_create_table_with_trailing_space_" + randomNameSuffix();
@@ -251,8 +251,8 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
         String tableLocationWithTrailingSpace = tableLocationWithoutTrailingSpace + " ";
 
         assertThat(query(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS a, 'INDIA' AS b, true AS c", tableName, tableLocationWithTrailingSpace))).failure()
-                .hasMessage("Failed to create transaction")
-                .hasStackTraceContaining("Malformed request: The table `location` property must point to a location in the catalog.");
+                .hasMessageStartingWith("Failed to commit the transaction during insert")
+                .hasMessageContaining("Malformed request: Table location is immutable");
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix a broken test: https://github.com/trinodb/trino/actions/runs/23107141092/job/67118283741
```
Error:  Failures: 
Error:    TestIcebergBigLakeMetastoreConnectorSmokeTest.testCreateTableWithTrailingSpaceInLocation:254 
Expecting message to be:
  "Failed to create transaction"
but was:
  "Failed to commit the transaction during insert: Malformed request: Table location is immutable. Expected: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb, actual: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb "

Throwable that failed the check:

io.trino.testing.QueryFailedException: Failed to commit the transaction during insert: Malformed request: Table location is immutable. Expected: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb, actual: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb 
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:642)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:618)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:317)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:201)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:66)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:908)
	at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1476)
	at io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy(TrinoExceptionAssert.java:67)
	at io.trino.sql.query.QueryAssertions$QueryAssert.failure(QueryAssertions.java:400)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.testCreateTableWithTrailingSpaceInLocation(TestIcebergBigLakeMetastoreConnectorSmokeTest.java:253)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:701)
	at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:502)
	at org.junit.jupiter.engine.support.MethodReflectionUtils.invoke(MethodReflectionUtils.java:45)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:61)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:124)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:163)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:148)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:123)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:99)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:66)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:47)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:39)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:98)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invokeVoid(InterceptingExecutableInvoker.java:71)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$0(TestMethodTestDescriptor.java:219)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:215)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:157)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:176)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.exec(ForkJoinPoolHierarchicalTestExecutorService.java:253)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:666)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.joinConcurrentTasksInReverseOrderToEnableWorkStealing(ForkJoinPoolHierarchicalTestExecutorService.java:175)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:141)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.exec(ForkJoinPoolHierarchicalTestExecutorService.java:253)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: CREATE TABLE test_create_table_with_trailing_space_cicubvetkb WITH (location = 'gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb ') AS SELECT 1 AS a, 'INDIA' AS b, true AS c
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:649)
		... 62 more
Caused by: io.trino.spi.TrinoException: Failed to commit the transaction during insert: Malformed request: Table location is immutable. Expected: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb, actual: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb 
	at io.trino.plugin.iceberg.IcebergMetadata.commitTransaction(IcebergMetadata.java:2538)
	at io.trino.plugin.iceberg.IcebergMetadata.finishInsert(IcebergMetadata.java:1912)
	at io.trino.plugin.iceberg.IcebergMetadata.finishCreateTable(IcebergMetadata.java:1647)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.finishCreateTable(ClassLoaderSafeConnectorMetadata.java:596)
	at io.trino.tracing.TracingConnectorMetadata.finishCreateTable(TracingConnectorMetadata.java:663)
	at io.trino.metadata.MetadataManager.finishCreateTable(MetadataManager.java:1215)
	at io.trino.tracing.TracingMetadata.finishCreateTable(TracingMetadata.java:650)
	at io.trino.sql.planner.LocalExecutionPlanner.lambda$createTableFinisher$0(LocalExecutionPlanner.java:4426)
	at io.trino.operator.TableFinishOperator.getOutput(TableFinishOperator.java:315)
	at io.trino.operator.Driver.processInternal(Driver.java:400)
	at io.trino.operator.Driver.lambda$process$0(Driver.java:303)
	at io.trino.operator.Driver.tryWithLock(Driver.java:706)
	at io.trino.operator.Driver.process(Driver.java:295)
	at io.trino.operator.Driver.processForDuration(Driver.java:266)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:853)
	at io.trino.execution.executor.timesharing.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:189)
	at io.trino.execution.executor.timesharing.TimeSharingTaskExecutor$TaskRunner.run(TimeSharingTaskExecutor.java:651)
	at io.trino.$gen.Trino_testversion____20260316_012129_1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: org.apache.iceberg.exceptions.BadRequestException: Malformed request: Table location is immutable. Expected: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb, actual: gs://***/test_iceberg_biglake_ihdrut2e62/test_create_table_with_trailing_space_cicubvetkb 
	at org.apache.iceberg.rest.ErrorHandlers$DefaultErrorHandler.accept(ErrorHandlers.java:234)
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:124)
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:108)
	at org.apache.iceberg.rest.HTTPClient.throwFailure(HTTPClient.java:240)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:336)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:297)
	at org.apache.iceberg.rest.BaseHTTPClient.post(BaseHTTPClient.java:100)
	at org.apache.iceberg.rest.RESTClient.post(RESTClient.java:126)
	at org.apache.iceberg.rest.RESTTableOperations.commit(RESTTableOperations.java:159)
	at org.apache.iceberg.BaseTransaction.commitCreateTransaction(BaseTransaction.java:281)
	at org.apache.iceberg.BaseTransaction.commitTransaction(BaseTransaction.java:260)
	at io.trino.plugin.iceberg.IcebergMetadata.commitTransaction(IcebergMetadata.java:2535)
	... 20 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
