### PR TITLE
Support parameterized prepared statements in versioned table

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ConstantEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ConstantEvaluator.java
@@ -23,8 +23,11 @@ import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.planner.TranslationMap;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.Parameter;
 import io.trino.type.TypeCoercion;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_CONSTANT;
@@ -35,6 +38,10 @@ public final class ConstantEvaluator
 {
     private ConstantEvaluator() {}
 
+    /**
+     * @deprecated Use {@link #evaluateConstant(Expression, Type, Map, PlannerContext, Session, AccessControl)} instead to pass parameters explicitly.
+     */
+    @Deprecated // TODO https://github.com/trinodb/trino/issues/28708 Remove after all calls are updated to pass parameters explicitly
     public static Object evaluateConstant(
             Expression expression,
             Type expectedType,
@@ -42,7 +49,24 @@ public final class ConstantEvaluator
             Session session,
             AccessControl accessControl)
     {
-        Analysis analysis = new Analysis(null, ImmutableMap.of(), QueryType.OTHERS);
+        return evaluateConstant(
+                expression,
+                expectedType,
+                ImmutableMap.of(),
+                plannerContext,
+                session,
+                accessControl);
+    }
+
+    public static Object evaluateConstant(
+            Expression expression,
+            Type expectedType,
+            Map<NodeRef<Parameter>, Expression> parameters,
+            PlannerContext plannerContext,
+            Session session,
+            AccessControl accessControl)
+    {
+        Analysis analysis = new Analysis(null, parameters, QueryType.OTHERS);
         Scope scope = Scope.create();
         ExpressionAnalyzer.analyzeExpressionWithoutSubqueries(
                 session,

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -6074,6 +6074,9 @@ class StatementAnalyzer
             if (version.isEmpty()) {
                 return tableVersion;
             }
+            if (analysis.isDescribe()) {
+                throw semanticException(NOT_SUPPORTED, table, "DESCRIBE is not supported if a versioned table uses parameters");
+            }
             ExpressionAnalysis expressionAnalysis = analyzeExpression(version.get(), scope.get());
             analysis.recordSubqueries(table, expressionAnalysis);
 
@@ -6083,7 +6086,7 @@ class StatementAnalyzer
             if (versionType == UNKNOWN) {
                 throw semanticException(INVALID_ARGUMENTS, table.getQueryPeriod().get(), "Pointer value cannot be NULL");
             }
-            Object evaluatedVersion = evaluateConstant(version.get(), versionType, plannerContext, session, accessControl);
+            Object evaluatedVersion = evaluateConstant(version.get(), versionType, analysis.getParameters(), plannerContext, session, accessControl);
             TableVersion extractedVersion = new TableVersion(pointerType, versionType, evaluatedVersion);
             validateVersionPointer(table.getQueryPeriod().get(), extractedVersion);
             return Optional.of(extractedVersion);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -362,6 +362,23 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitTable(Table node, C context)
+    {
+        node.getQueryPeriod().ifPresent(period -> process(period, context));
+
+        return null;
+    }
+
+    @Override
+    protected Void visitQueryPeriod(QueryPeriod node, C context)
+    {
+        node.getStart().ifPresent(start -> process(start, context));
+        node.getEnd().ifPresent(end -> process(end, context));
+
+        return null;
+    }
+
+    @Override
     protected Void visitInListExpression(InListExpression node, C context)
     {
         for (Expression value : node.getValues()) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7635,6 +7635,21 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testPreparedStatementWithParameterizedVersionedTable()
+    {
+        Session session = Session.builder(getSession())
+                .addPreparedStatement("my_query", "SELECT * FROM region FOR VERSION AS OF ?")
+                .build();
+        long snapshotId = getCurrentSnapshotId("region");
+
+        assertThat(query(session, "EXECUTE my_query USING " + snapshotId))
+                .matches("TABLE region");
+
+        assertQueryFails(session, "EXECUTE my_query USING " + (snapshotId - 1), "Iceberg snapshot ID does not exists: .*");
+        assertQueryFails(session, "DESCRIBE OUTPUT my_query", ".* DESCRIBE is not supported if a versioned table uses parameters");
+    }
+
+    @Test
     public void testDeleteRetainsTableHistory()
     {
         String tableName = "test_delete_retains_table_history_" + randomNameSuffix();


### PR DESCRIPTION
## Description

Fixes the following failure: 
```
io.trino.testing.QueryFailedException: line 1:1: Incorrect number of parameters: expected 0 but found 1

	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:591)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:574)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:318)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:201)
	at io.trino.sql.query.QueryAssertions$QueryAssert.result(QueryAssertions.java:437)
	at io.trino.sql.query.QueryAssertions$QueryAssert.matches(QueryAssertions.java:358)
	at io.trino.plugin.iceberg.BaseIcebergConnectorTest.testPreparedStatementWithParameterizedVersionedTable(BaseIcebergConnectorTest.java:7646)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: EXECUTE my_query USING 233880898577629041
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:598)
		... 12 more
Caused by: io.trino.spi.TrinoException: line 1:1: Incorrect number of parameters: expected 0 but found 1
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:58)
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:52)
	at io.trino.execution.QueryPreparer.validateParameters(QueryPreparer.java:96)
	at io.trino.execution.QueryPreparer.prepareQuery(QueryPreparer.java:87)
	at io.trino.execution.QueryPreparer.prepareQuery(QueryPreparer.java:55)
	at io.trino.dispatcher.DispatchManager.createQueryInternal(DispatchManager.java:225)
	at io.trino.dispatcher.DispatchManager.lambda$createQuery$0(DispatchManager.java:194)
	at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:241)
	at io.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:79)
	at io.trino.$gen.Trino_testversion____20260317_031748_1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```

## Release notes

```markdown
## General
* Allow prepared statement parameters for versioned tables. ({issue}`28681`)
```
