### PR TITLE
Add npm package cache to CI setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -71,6 +71,26 @@ runs:
           key: ${{ runner.os }}-nodejs-${{ env.NODE_VERSION }}
           restore-keys: |
             ${{ runner.os }}-nodejs-
+      - name: Cache and Restore npm packages
+        id: cache-npm
+        if: ${{ format('{0}', inputs.cache) == 'true' && env.NODE_VERSION != '' }}
+        uses: actions/cache@v5
+        with:
+          # Note: must be same set of paths as for cache:restore mode
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-
+      - name: Restore npm packages
+        id: cache-restore-npm
+        if: ${{ format('{0}', inputs.cache) == 'restore' && env.NODE_VERSION != '' }}
+        uses: actions/cache/restore@v5
+        with:
+          # Note: must be same set of paths as for cache:true mode
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-
       - name: Cache and Restore local Maven repo
         id: cache
         if: ${{ format('{0}', inputs.cache) == 'true' }}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/.npmrc
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/.npmrc
@@ -2,3 +2,4 @@ registry=https://registry.npmjs.org
 fetch-retries=4
 fetch-retry-mintimeout=10000
 fetch-retry-maxtimeout=120000
+prefer-offline=true

--- a/core/trino-web-ui/src/main/resources/webapp/src/.npmrc
+++ b/core/trino-web-ui/src/main/resources/webapp/src/.npmrc
@@ -2,3 +2,4 @@ registry=https://registry.npmjs.org
 fetch-retries=4
 fetch-retry-mintimeout=10000
 fetch-retry-maxtimeout=120000
+prefer-offline=true


### PR DESCRIPTION
## Add npm package cache to CI setup

Cache ~/.npm (npm's content-addressable tarball cache) in GitHub Actions
to avoid redundant network downloads during npm clean-install. The cache
is keyed on the OS, Node version, and a hash of all package-lock.json
files. The idea is to prevent ECONNRESET errors during NPM install.

- Add npm cache save/restore steps to .github/actions/setup/action.yml

- Add .npmrc with prefer-offline=true to both webapp
and webapp-preview. This tells npm: check the local ~/.npm cache first,
and only go to the registry if the package isn't cached.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
