### PR TITLE
Manage empty result sets from Pinot

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -610,12 +610,27 @@ public class PinotClient
                 .boxed()
                 // Pinot lower cases column names which use aggregate functions, ex. min(my_Col) becomes min(my_col)
                 .collect(toImmutableMap(i -> columnNames[i].toLowerCase(ENGLISH), identity()));
-        int[] indices = new int[columnNames.length];
+        int[] indices = new int[columnHandles.size()];
         int[] inverseIndices = new int[columnNames.length];
+        boolean isEmptyResultSet = resultTable.getRows().isEmpty();
         for (int i = 0; i < columnHandles.size(); i++) {
             String columnName = columnHandles.get(i).getColumnName().toLowerCase(ENGLISH);
-            indices[i] = requireNonNull(columnIndices.get(columnName), format("column index for '%s' was not found", columnName));
-            inverseIndices[indices[i]] = i;
+            Integer columnIndex = columnIndices.get(columnName);
+            if (columnIndex == null) {
+                if (isEmptyResultSet) {
+                    indices[i] = 0;
+                }
+                else {
+                    throw new PinotException(
+                            PINOT_EXCEPTION,
+                            Optional.empty(),
+                            format("column index for '%s' was not found", columnName));
+                }
+            }
+            else {
+                indices[i] = columnIndex;
+                inverseIndices[columnIndex] = i;
+            }
         }
         List<Object[]> rows = resultTable.getRows();
         // If returning from a global aggregation (no grouping columns) over an empty table, NULL-out all aggregation function results except for `count()`

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestBrokerQueries.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestBrokerQueries.java
@@ -172,4 +172,25 @@ public class TestBrokerQueries
                 .isThrownBy(pageSource::getNextSourcePage)
                 .withMessage("Broker query returned '3' rows, maximum allowed is '2' rows. with query \"SELECT col_1, col_2, col_3 FROM test_table\"");
     }
+
+    @Test
+    public void testEmptyResultSetWithAliases()
+    {
+        DataSchema emptyDataSchema = new DataSchema(
+                new String[] {"user"},
+                new ColumnDataType[] {STRING});
+        ResultTable emptyResultTable = new ResultTable(emptyDataSchema, ImmutableList.of());
+        BrokerResponseNative emptyResponse = new BrokerResponseNative();
+        emptyResponse.setResultTable(emptyResultTable);
+        emptyResponse.setNumServersQueried(1);
+        emptyResponse.setNumServersResponded(1);
+        emptyResponse.setNumDocsScanned(0);
+
+        List<PinotColumnHandle> columnHandles = ImmutableList.of(
+                new PinotColumnHandle("user", VARCHAR),
+                new PinotColumnHandle("no. of msg", BIGINT));
+
+        ResultsIterator iterator = fromResultTable(emptyResponse, columnHandles, 1);
+        assertThat(iterator.hasNext()).isFalse();
+    }
 }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorSmokeTest.java
@@ -1280,6 +1280,14 @@ public class TestPinotConnectorSmokeTest
     }
 
     @Test
+    public void testPassthroughQueryWithAliasesReturningEmptyResult()
+    {
+        assertQueryReturnsEmptyResult("SELECT * FROM \"SELECT string_col AS user, COUNT(*) AS 'No. of msg' FROM " + ALL_TYPES_TABLE + " WHERE string_col = 'nonexistent_value' GROUP BY string_col\"");
+        assertQueryReturnsEmptyResult("SELECT \"user\", \"No. of msg\" FROM \"SELECT string_col AS user, COUNT(*) AS 'No. of msg' FROM " + ALL_TYPES_TABLE + " WHERE long_col > 9999999999 GROUP BY string_col\"");
+        assertQueryReturnsEmptyResult("SELECT * FROM \"SELECT int_col, SUM(long_col) AS total FROM " + ALL_TYPES_TABLE + " WHERE int_col = -999999 GROUP BY int_col\"");
+    }
+
+    @Test
     public void testNullBehavior()
     {
         assertThat(query("SELECT int_col FROM alltypes_nullable WHERE string_col IS NULL"))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Issue
When Pinot returns empty result sets, the original code threw - "column index for 'no. of msg' was not found"

## Solution
1. Detect the empty result sets, an use dummy indices
2. For non-empty results, throw an exception
3. Fixed array size bug: `indices = new int[columnNames.length]` (wrong) -> `indices = new int[columnHandles.size()]`

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- Closes #28538 

## Tests
with Empty result with aliased column - no exception
Column not found case - throw exception for missing column

## Unit tests
Added -  `testEmptyResultSetWithAliases()` to `TestBrokerQueries.java`