### PR TITLE
Include actual parameter types in ambiguous function call error

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -167,6 +167,9 @@ class FunctionBinder
 
         StringBuilder errorMessageBuilder = new StringBuilder();
         errorMessageBuilder.append("Could not choose a best candidate operator. Explicit type casts must be added.\n");
+        errorMessageBuilder.append("Actual types: (");
+        Joiner.on(", ").appendTo(errorMessageBuilder, parameters);
+        errorMessageBuilder.append(")\n");
         errorMessageBuilder.append("Candidates are:\n");
         for (ApplicableFunction function : applicableFunctions) {
             errorMessageBuilder.append("\t * ");

--- a/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
@@ -176,7 +176,14 @@ public class TestGlobalFunctionCatalog
                         functionSignature("decimal(p,s)", "double"),
                         functionSignature("double", "decimal(p,s)"))
                 .forParameters(BIGINT, BIGINT)
-                .failsWithMessage("Could not choose a best candidate operator. Explicit type casts must be added.");
+                .failsWithMessage(
+                        """
+                        Could not choose a best candidate operator. Explicit type casts must be added.
+                        Actual types: (bigint, bigint)
+                        Candidates are:
+                        \t * (decimal(19,0),double):boolean
+                        \t * (double,decimal(19,0)):boolean
+                        """);
     }
 
     @Test
@@ -266,7 +273,14 @@ public class TestGlobalFunctionCatalog
                         functionSignature(ImmutableList.of("JoniRegExp"), "JoniRegExp"),
                         functionSignature(ImmutableList.of("integer"), "integer"))
                 .forParameters(UnknownType.UNKNOWN)
-                .failsWithMessage("Could not choose a best candidate operator. Explicit type casts must be added.");
+                .failsWithMessage(
+                        """
+                        Could not choose a best candidate operator. Explicit type casts must be added.
+                        Actual types: (unknown)
+                        Candidates are:
+                        \t * (joniregexp):joniregexp
+                        \t * (integer):integer
+                        """);
     }
 
     private static List<FunctionMetadata> listOperators(TestingFunctionResolution functionResolution)
@@ -334,11 +348,11 @@ public class TestGlobalFunctionCatalog
             return this;
         }
 
-        public ResolveFunctionAssertion failsWithMessage(String... messages)
+        public ResolveFunctionAssertion failsWithMessage(String message)
         {
             assertThatThrownBy(this::resolveSignature)
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessageContainingAll(messages);
+                    .hasMessage(message);
             return this;
         }
 


### PR DESCRIPTION
Fixes #28702.

## Description

When `Could not choose a best candidate operator. Explicit type casts must be added.` error is raised, the error message now includes the actual parameter types at the call site.

### Before

```
Could not choose a best candidate operator. Explicit type casts must be added.
Candidates are:
	 * (decimal(19,0),double):boolean
	 * (double,decimal(19,0)):boolean
```

### After

```
Could not choose a best candidate operator. Explicit type casts must be added.
Actual types: (bigint, bigint)
Candidates are:
	 * (decimal(19,0),double):boolean
	 * (double,decimal(19,0)):boolean
```

This helps users understand which explicit cast to add by showing the types they actually passed.

## Changes

- **`FunctionBinder.java`**: Added `Actual types: (...)` line to the error message in `matchFunction()`, using `Joiner.on(", ").join(parameters)` which is consistent with how `functionNotFound()` already formats parameter types.
- **`TestGlobalFunctionCatalog.java`**: Updated two `failsWithMessage` assertions to verify the new `Actual types` information is present.