### PR TITLE
Update actions/github-script to v8

### DIFF
--- a/.github/actions/update-check/action.yml
+++ b/.github/actions/update-check/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v8
       id: update-check-run
       if: inputs.check_name != '' && inputs.conclusion != ''
       env:
@@ -61,7 +61,7 @@ runs:
             conclusion: process.env.conclusion
           });
           return result;
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v8
       id: comment
       if: always()
       env:


### PR DESCRIPTION
## Description

Update actions/github-script to [v8](https://github.com/actions/github-script/releases/tag/v8).

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
https://github.com/trinodb/trino/actions/runs/23233392161

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.