### PR TITLE
Update styfle/cancel-workflow-action to 0.13.1

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: 'Cancel Runs For Closed PRs'
-        uses: styfle/cancel-workflow-action@3155a141048f8f89c06b4cdae32e7853e97536bc # 0.13.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
         with:
           # Cancel workflow when PR closed. https://github.com/styfle/cancel-workflow-action#advanced-ignore-sha
           ignore_sha: true


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Update styfle/cancel-workflow-action to [0.13.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.13.1)
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: styfle/cancel-workflow-action@3155a141048f8f89c06b4cdae32e7853e97536bc. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
https://github.com/trinodb/trino/actions/runs/23233412391

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
