### PR TITLE
Fix MERGE statement formatting in SqlFormatter

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1111,7 +1111,12 @@ public final class SqlFormatter
 
             append(indent + 1, "USING ");
 
-            processRelation(node.getSource(), indent + 2);
+            if (node.getSource() instanceof Table table) {
+                builder.append(formatName(table.getName()));
+            }
+            else {
+                processRelation(node.getSource(), indent + 2);
+            }
 
             builder.append("\n");
             append(indent + 1, "ON ");

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -677,6 +677,41 @@ public class TestSqlFormatter
     }
 
     @Test
+    void testMerge()
+    {
+        assertThat(formatSql(new Merge(
+                new NodeLocation(1, 1),
+                new Table(new NodeLocation(1, 1), QualifiedName.of("t")),
+                table(QualifiedName.of("changes")),
+                new BooleanLiteral(new NodeLocation(1, 1), "true"),
+                ImmutableList.of(new MergeDelete(new NodeLocation(1, 1), Optional.empty())))))
+                .isEqualTo(
+                        """
+                        MERGE INTO t
+                           USING changes
+                           ON true
+                        WHEN MATCHED
+                           THEN DELETE\
+                        """);
+
+        // with alias for the source table
+        assertThat(formatSql(new Merge(
+                new NodeLocation(1, 1),
+                new Table(new NodeLocation(1, 1), QualifiedName.of("t")),
+                aliased(table(QualifiedName.of("changes")), "s"),
+                new BooleanLiteral(new NodeLocation(1, 1), "true"),
+                ImmutableList.of(new MergeDelete(new NodeLocation(1, 1), Optional.empty())))))
+                .isEqualTo(
+                        """
+                        MERGE INTO t
+                           USING changes s
+                           ON true
+                        WHEN MATCHED
+                           THEN DELETE\
+                        """);
+    }
+
+    @Test
     void testInsertWithBranch()
     {
         assertThat(formatSql(new Insert(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Currently, `SqlFormatter` formats MERGE statement wrongly if the source table is specified without alias.

Original query:
```sql
MERGE INTO t
  USING changes
  ON true
WHEN MATCHED
  THEN DELETE
```

Formatted:
```sql
MERGE INTO t
  USING TABLE changes

  ON true
WHEN MATCHED
  THEN DELETE
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.