### PR TITLE
Store NUMBER in Iceberg MV

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -95,6 +95,7 @@ import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
@@ -409,6 +410,9 @@ public abstract class AbstractTrinoCatalog
     {
         if (type == TINYINT || type == SMALLINT) {
             return INTEGER;
+        }
+        if (type == NUMBER) {
+            return VARCHAR;
         }
         if (type instanceof CharType) {
             return VARCHAR;

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1457,6 +1457,8 @@ public abstract class BaseConnectorTest
                     DOUBLE '12345.678901234' a_double,
                     CAST('1234567.8901' AS decimal(11, 4)) a_short_decimal,
                     CAST('1234567890123456789.0123456' AS decimal(26, 7)) a_long_decimal,
+                    NUMBER '1234567890123456789012345678901234567890.123456789012345678901234567890123456789' a_number,
+                    NUMBER '+Infinity' an_infinite_number,
                     CHAR 'few chars  ' a_char,
                     CAST('some string' AS varchar(33)) a_bounded_varchar,
                     CAST('some longer string' AS varchar) an_unbounded_varchar,


### PR DESCRIPTION
Add support for storing NUMBER type in Iceberg MATERIALIZED VIEW.  Since Iceberg does not have a corresponding numeric type, the values as stored as Iceberg `string`. This is consistent with how other unsupported types are handled.

- fixes https://github.com/trinodb/trino/issues/28399

### Release notes

```
Iceberg
* Add support for creation of materialized views with `number` column type. ({issue}`28399`)
```