### PR TITLE
Assert join symbols type in SemiJoinNode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SemiJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SemiJoinNode.java
@@ -58,6 +58,7 @@ public class SemiJoinNode
 
         checkArgument(source.getOutputSymbols().contains(sourceJoinSymbol), "Source does not contain join symbol");
         checkArgument(filteringSource.getOutputSymbols().contains(filteringSourceJoinSymbol), "Filtering source does not contain filtering join symbol");
+        checkArgument(sourceJoinSymbol.type().equals(filteringSourceJoinSymbol.type()), "Type mismatch between source and filtering source join symbols");
     }
 
     public enum DistributionType


### PR DESCRIPTION
Join symbols from source and filtering source must have the same type.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
