### PR TITLE
Extract testAbandonedQueries to a separate test class

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -29,15 +29,10 @@ import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.JsonMapperProvider;
-import io.airlift.units.Duration;
-import io.trino.client.ClientSession;
 import io.trino.client.QueryDataJacksonModule;
 import io.trino.client.QueryError;
 import io.trino.client.QueryResults;
 import io.trino.client.ResultRowsDecoder;
-import io.trino.client.StatementClient;
-import io.trino.client.StatementClientFactory;
-import io.trino.client.uri.TrinoUri;
 import io.trino.plugin.memory.MemoryPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.server.BasicQueryInfo;
@@ -45,7 +40,6 @@ import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.QueryId;
 import io.trino.spi.type.TimeZoneNotSupportedException;
 import io.trino.testing.TestingTrinoClient;
-import okhttp3.OkHttpClient;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,12 +48,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import java.net.URI;
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -88,7 +80,6 @@ import static io.trino.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static io.trino.client.ClientCapabilities.PATH;
 import static io.trino.client.ClientCapabilities.SESSION_AUTHORIZATION;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
-import static io.trino.client.uri.HttpClientFactory.toHttpClientBuilder;
 import static io.trino.spi.StandardErrorCode.INCOMPATIBLE_CLIENT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -122,7 +113,7 @@ public class TestServer
     public void setup()
     {
         server = TestingTrinoServer.builder()
-                .setProperties(ImmutableMap.of("http-server.process-forwarded", "true", "query.client.timeout", "1s"))
+                .setProperties(ImmutableMap.of("http-server.process-forwarded", "true"))
                 .build();
 
         server.installPlugin(new MemoryPlugin());
@@ -340,48 +331,6 @@ public class TestServer
         try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of(
                 SESSION_AUTHORIZATION.name())).build())) {
             testingClient.execute("SET SESSION AUTHORIZATION userA");
-        }
-    }
-
-    @Test
-    public void testAbandonedQueries()
-            throws InterruptedException
-    {
-        TrinoUri trinoUri = TrinoUri.builder()
-                .setUri(server.getBaseUrl())
-                .build();
-
-        OkHttpClient httpClient = toHttpClientBuilder(trinoUri, "Trino Test").build();
-        ClientSession session = ClientSession.builder()
-                .server(server.getBaseUrl())
-                .source("test")
-                .timeZone(ZoneId.of("UTC"))
-                .user(Optional.of("user"))
-                .heartbeatInterval(new Duration(1, TimeUnit.SECONDS))
-                .build();
-
-        try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
-            client.advance();
-            // heartbeat is expected every 1 second, the check runs every second, plus one second padding
-            Thread.sleep(3000);
-            client.advance();
-            assertThat(client.currentStatusInfo().getError().getMessage())
-                    .contains("was abandoned by the client, as it may have exited or stopped checking for query results");
-        }
-
-        // Test query is not abandoned when client iterates over rows, even when one batch of results takes more than client timeout
-        try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
-            while (client.advance()) {
-                client.currentRows().forEach(_ -> {
-                    try {
-                        Thread.sleep(100); // 25 rows * 100 ms = 2500 ms > client timeout
-                    }
-                    catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-                assertThat(client.currentStatusInfo().getError()).isNull();
-            }
         }
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServerAbandonedQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServerAbandonedQueries.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.client.ClientSession;
+import io.trino.client.StatementClient;
+import io.trino.client.StatementClientFactory;
+import io.trino.client.uri.TrinoUri;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.server.testing.TestingTrinoServer;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.client.uri.HttpClientFactory.toHttpClientBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestServerAbandonedQueries
+{
+    private TestingTrinoServer server;
+
+    @BeforeAll
+    public void setup()
+    {
+        server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.of("query.client.timeout", "1s"))
+                .build();
+
+        server.installPlugin(new TpchPlugin());
+        server.createCatalog("tpch", "tpch");
+    }
+
+    @Test
+    public void testAbandonedQueries()
+            throws InterruptedException
+    {
+        TrinoUri trinoUri = TrinoUri.builder()
+                .setUri(server.getBaseUrl())
+                .build();
+
+        OkHttpClient httpClient = toHttpClientBuilder(trinoUri, "Trino Test").build();
+        ClientSession session = ClientSession.builder()
+                .server(server.getBaseUrl())
+                .source("test")
+                .timeZone(ZoneId.of("UTC"))
+                .user(Optional.of("user"))
+                .heartbeatInterval(new Duration(1, TimeUnit.SECONDS))
+                .build();
+
+        try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
+            client.advance();
+            // heartbeat is expected every 1 second, the check runs every second, plus one second padding
+            Thread.sleep(3000);
+            client.advance();
+            assertThat(client.currentStatusInfo().getError().getMessage())
+                    .contains("was abandoned by the client, as it may have exited or stopped checking for query results");
+        }
+
+        // Test query is not abandoned when client iterates over rows, even when one batch of results takes more than client timeout
+        try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
+            while (client.advance()) {
+                client.currentRows().forEach(_ -> {
+                    try {
+                        Thread.sleep(100); // 25 rows * 100 ms = 2500 ms > client timeout
+                    }
+                    catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                assertThat(client.currentStatusInfo().getError()).isNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This test requires a specific client timeout that interferes with other tests like `TestServer.testVersionOnCompilerFailedError` that can fail with an abandoned client timeout:

```
Expecting actual:
  "io.trino.spi.TrinoException: Query 20260318_190211_00017_fxacu was abandoned by the client, as it may have exited or stopped checking for query results. Query results have not been accessed since 2026-03-18T19:02:12.074039520Z: currentTime 2026-03-18T19:02:13.575091194Z
	at io.trino.execution.QueryTracker.failAbandonedQueries(QueryTracker.java:276)
	at io.trino.execution.QueryTracker.lambda$start$0(QueryTracker.java:83)
	at com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask.run(MoreExecutors.java:639)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:369)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:310)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
"
to contain pattern:
  "TrinoException: Failed to execute query; (?s:.*)at io.trino.sql.gen.PageFunctionCompiler.compileProjectionInternal"
```

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Closes:
- https://github.com/trinodb/trino/issues/28013



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
