### PR TITLE
Improve ambiguous operator error with call-site types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -167,6 +167,12 @@ class FunctionBinder
 
         StringBuilder errorMessageBuilder = new StringBuilder();
         errorMessageBuilder.append("Could not choose a best candidate operator. Explicit type casts must be added.\n");
+        errorMessageBuilder.append("Call site parameter types are:\n");
+        for (TypeSignatureProvider parameter : parameters) {
+            errorMessageBuilder.append("\t * ");
+            errorMessageBuilder.append(parameter);
+            errorMessageBuilder.append("\n");
+        }
         errorMessageBuilder.append("Candidates are:\n");
         for (ApplicableFunction function : applicableFunctions) {
             errorMessageBuilder.append("\t * ");

--- a/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
@@ -176,7 +176,15 @@ public class TestGlobalFunctionCatalog
                         functionSignature("decimal(p,s)", "double"),
                         functionSignature("double", "decimal(p,s)"))
                 .forParameters(BIGINT, BIGINT)
-                .failsWithMessage("Could not choose a best candidate operator. Explicit type casts must be added.");
+                .failsWithMessage("""
+                        Could not choose a best candidate operator. Explicit type casts must be added.
+                        Call site parameter types are:
+                        \t * bigint
+                        \t * bigint
+                        Candidates are:
+                        \t * (decimal(19,0),double):boolean
+                        \t * (double,decimal(19,0)):boolean
+                        """);
     }
 
     @Test
@@ -266,7 +274,14 @@ public class TestGlobalFunctionCatalog
                         functionSignature(ImmutableList.of("JoniRegExp"), "JoniRegExp"),
                         functionSignature(ImmutableList.of("integer"), "integer"))
                 .forParameters(UnknownType.UNKNOWN)
-                .failsWithMessage("Could not choose a best candidate operator. Explicit type casts must be added.");
+                .failsWithMessage("""
+                        Could not choose a best candidate operator. Explicit type casts must be added.
+                        Call site parameter types are:
+                        \t * unknown
+                        Candidates are:
+                        \t * (joniregexp):joniregexp
+                        \t * (integer):integer
+                        """);
     }
 
     private static List<FunctionMetadata> listOperators(TestingFunctionResolution functionResolution)


### PR DESCRIPTION
## Summary

Adds call-site parameter types to the ambiguous operator error so users can see both the candidate overloads and the actual types that triggered the ambiguity.

## Testing

- `./mvnw -pl core/trino-main -Dtest=TestGlobalFunctionCatalog -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -Dfrontend.check.goal=package -Dair.check.skip-all test`

Closes #28702
