### PR TITLE
Make function loading deterministic

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
@@ -50,6 +50,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
 import static io.trino.operator.annotations.ImplementationDependency.isImplementationDependencyAnnotation;
@@ -65,6 +66,7 @@ import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Comparator.comparing;
 
 public final class FunctionsParserHelper
 {
@@ -204,20 +206,27 @@ public final class FunctionsParserHelper
     }
 
     @SafeVarargs
-    public static Set<Method> findPublicMethodsWithAnnotation(Class<?> clazz, Class<? extends Annotation>... annotationClasses)
+    public static List<Method> findPublicMethodsWithAnnotation(Class<?> clazz, Class<? extends Annotation>... annotationClasses)
     {
-        ImmutableSet.Builder<Method> methods = ImmutableSet.builder();
-        for (Method method : clazz.getDeclaredMethods()) {
-            for (Annotation annotation : method.getAnnotations()) {
-                for (Class<?> annotationClass : annotationClasses) {
-                    if (annotationClass.isInstance(annotation)) {
-                        checkArgument(Modifier.isPublic(method.getModifiers()), "Method [%s] annotated with @%s must be public", method, annotationClass.getSimpleName());
-                        methods.add(method);
-                    }
-                }
+        return Stream.of(clazz.getDeclaredMethods())
+                // Make function loading deterministic
+                .sorted(comparing(Method::toString))
+                .flatMap(method -> firstAnnotationPresent(method, annotationClasses)
+                        .map(annotated -> {
+                            checkArgument(Modifier.isPublic(method.getModifiers()), "Method [%s] annotated with @%s must be public", method, annotated.getSimpleName());
+                            return method;
+                        }).stream())
+                .collect(toImmutableList());
+    }
+
+    private static Optional<Class<? extends Annotation>> firstAnnotationPresent(AnnotatedElement annotatedElement, Class<? extends Annotation>[] annotationClasses)
+    {
+        for (Class<? extends Annotation> annotationClass : annotationClasses) {
+            if (annotatedElement.isAnnotationPresent(annotationClass)) {
+                return Optional.of(annotationClass);
             }
         }
-        return methods.build();
+        return Optional.empty();
     }
 
     public static Optional<Constructor<?>> findConstructor(Class<?> clazz)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ScalarFromAnnotationsParser.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ScalarFromAnnotationsParser.java
@@ -14,7 +14,6 @@
 package io.trino.operator.scalar.annotations;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.operator.ParametricImplementationsGroup;
 import io.trino.operator.annotations.FunctionsParserHelper;
@@ -32,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.operator.scalar.annotations.OperatorValidator.validateOperator;
@@ -72,7 +70,7 @@ public final class ScalarFromAnnotationsParser
         checkArgument(!classHeaders.isEmpty(), "Class [%s] that defines function must be annotated with @ScalarFunction or @ScalarOperator", annotated.getName());
 
         for (ScalarHeader header : classHeaders) {
-            Set<Method> methods = FunctionsParserHelper.findPublicMethodsWithAnnotation(annotated, SqlType.class, ScalarFunction.class, ScalarOperator.class);
+            List<Method> methods = FunctionsParserHelper.findPublicMethodsWithAnnotation(annotated, SqlType.class, ScalarFunction.class, ScalarOperator.class);
             checkCondition(!methods.isEmpty(), FUNCTION_IMPLEMENTATION_ERROR, "Parametric class [%s] does not have any annotated methods", annotated.getName());
             for (Method method : methods) {
                 checkArgument(method.getAnnotation(ScalarFunction.class) == null, "Parametric class method [%s] is annotated with @ScalarFunction", method);
@@ -87,11 +85,11 @@ public final class ScalarFromAnnotationsParser
     private static List<ScalarHeaderAndMethods> findScalarsInFunctionSetClass(Class<?> annotated)
     {
         ImmutableList.Builder<ScalarHeaderAndMethods> builder = ImmutableList.builder();
-        for (Method method : FunctionsParserHelper.findPublicMethodsWithAnnotation(annotated, SqlType.class, ScalarFunction.class, ScalarOperator.class)) {
+        for (Method method : FunctionsParserHelper.findPublicMethodsWithAnnotation(annotated, ScalarFunction.class, ScalarOperator.class, SqlType.class)) {
             checkCondition((method.getAnnotation(ScalarFunction.class) != null) || (method.getAnnotation(ScalarOperator.class) != null),
                     FUNCTION_IMPLEMENTATION_ERROR, "Method [%s] annotated with @SqlType is missing @ScalarFunction or @ScalarOperator", method);
             for (ScalarHeader header : ScalarHeader.fromAnnotatedElement(method)) {
-                builder.add(new ScalarHeaderAndMethods(header, ImmutableSet.of(method)));
+                builder.add(new ScalarHeaderAndMethods(header, ImmutableList.of(method)));
             }
         }
         List<ScalarHeaderAndMethods> methods = builder.build();
@@ -132,7 +130,7 @@ public final class ScalarFromAnnotationsParser
         return new ParametricScalar(scalarSignature, scalar.header(), implementations, deprecated);
     }
 
-    private record ScalarHeaderAndMethods(ScalarHeader header, Set<Method> methods)
+    private record ScalarHeaderAndMethods(ScalarHeader header, List<Method> methods)
     {
         private ScalarHeaderAndMethods
         {


### PR DESCRIPTION
See this issue for information about function overload selection non-determinism:
- https://github.com/trinodb/trino/issues/28763

This PR improves "`selectMostSpecificFunctions` is deterministic but input is not" situation by making input more deterministic. While it's not the solution for the root problem, it's still reasonable to eliminate undesired non-determinism. 

For example, we defensively use LinkedHashMap a lot in the query analyzer and planner, even though in many cases we don't have _strong_ reasons to do so. In many other places we use `ImmutableMap` / `ImmutableSet` and they do guarantee iteration order for same reasons: system non-determinism just makes reproducing and fixing bugs harder.


When reviewing, see also past discussion
- https://github.com/trinodb/trino/pull/28703#discussion_r2951347169

.

- for https://github.com/trinodb/trino/issues/28763