### PR TITLE
Fix flaky Iceberg testBloomFilterColumnWithDictionaryPage

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFiltersMixedCase.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFiltersMixedCase.java
@@ -34,6 +34,7 @@ import static io.trino.testing.containers.Minio.MINIO_REGION;
 import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
 import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -73,12 +74,14 @@ public class TestIcebergParquetWithBloomFiltersMixedCase
     @Override
     protected CatalogSchemaTableName createParquetTableWithBloomFilter(String columnName, List<Integer> testValues)
     {
-        minio.copyResources("iceberg/mixed_case_bloom_filter", BUCKET_NAME, "mixed_case_bloom_filter");
-        String tableName = "test_iceberg_write_mixed_case_bloom_filter" + randomNameSuffix();
+        String tableLocation = "mixed_case_bloom_filter_" + randomNameSuffix();
+        String s3Location = "s3://%s/%s".formatted(BUCKET_NAME, tableLocation);
+        minio.processAndCopyResources("iceberg/mixed_case_bloom_filter", rewriteMetadataJson(s3Location), BUCKET_NAME, tableLocation);
+        String tableName = "test_iceberg_write_mixed_case_bloom_filter_" + randomNameSuffix();
         assertUpdate(format(
                 "CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')",
                 tableName,
-                format("s3://%s/mixed_case_bloom_filter", BUCKET_NAME)));
+                s3Location));
 
         CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName("iceberg", new SchemaTableName("tpch", tableName));
         assertUpdate(format("INSERT INTO %s SELECT * FROM (VALUES %s) t(%s)", catalogSchemaTableName, Joiner.on(", ").join(testValues), columnName), testValues.size());
@@ -106,5 +109,18 @@ public class TestIcebergParquetWithBloomFiltersMixedCase
             throws Exception
     {
         minio = null; // closed by closeAfterClass
+    }
+
+    public Minio.ResourcePreProcessor rewriteMetadataJson(String newLocation)
+    {
+        return (fileName, data) -> {
+            if (!fileName.endsWith(".metadata.json")) {
+                return data;
+            }
+
+            return new String(data, UTF_8)
+                    .replaceAll("s3://test-bucket-mixed-case/mixed_case_bloom_filter", newLocation)
+                    .getBytes(UTF_8);
+        };
     }
 }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -134,12 +134,17 @@ public class Minio
 
     public void copyResources(String resourcePath, String bucketName, String target)
     {
+        processAndCopyResources(resourcePath, (_, bytes) -> bytes, bucketName, target);
+    }
+
+    public void processAndCopyResources(String resourcePath, ResourcePreProcessor processor, String bucketName, String target)
+    {
         try (MinioClient minioClient = createMinioClient()) {
             for (ClassPath.ResourceInfo resourceInfo : ClassPath.from(getClass().getClassLoader())
                     .getResources()) {
                 if (resourceInfo.getResourceName().startsWith(resourcePath)) {
                     String fileName = resourceInfo.getResourceName().replaceFirst("^" + Pattern.quote(resourcePath), quoteReplacement(target));
-                    minioClient.putObject(bucketName, resourceInfo.asByteSource().read(), fileName);
+                    minioClient.putObject(bucketName, processor.process(fileName, resourceInfo.asByteSource().read()), fileName);
                 }
             }
         }
@@ -182,5 +187,10 @@ public class Minio
         {
             return new Minio(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
         }
+    }
+
+    public interface ResourcePreProcessor
+    {
+        byte[] process(String name, byte[] data);
     }
 }


### PR DESCRIPTION
By making sure that test tables are independent from each other. This requires a copied manifest to be patched for unique table location.

Fixes https://github.com/trinodb/trino/issues/26424

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
