### PR TITLE
Document truncate(x, n) two-argument variant

### DIFF
--- a/docs/src/main/sphinx/functions/math.md
+++ b/docs/src/main/sphinx/functions/math.md
@@ -114,6 +114,12 @@ Returns the square root of `x`.
 Returns `x` rounded to integer by dropping digits after decimal point.
 :::
 
+:::{function} truncate(x, n) -> [same as input]
+:noindex: true
+
+Returns `x` truncated to `n` decimal places.
+:::
+
 :::{function} width_bucket(x, bound1, bound2, n) -> bigint
 Returns the bin number of `x` in an equi-width histogram with the
 specified `bound1` and `bound2` bounds and `n` number of buckets.


### PR DESCRIPTION
## Summary

- Add documentation for `truncate(x, n)` which truncates `x` to `n` decimal places
- The two-argument variant exists for decimal types but was missing from the docs
- Follows the same pattern as the existing `round(x, d)` documentation

Fixes #28765

## Test plan

- [ ] Verify the docs render correctly with the new function signature
- [ ] Confirm the `:noindex: true` directive prevents duplicate index entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)