### PR TITLE
Document truncate(x, d) in math functions docs

### DIFF
--- a/docs/src/main/sphinx/functions/math.md
+++ b/docs/src/main/sphinx/functions/math.md
@@ -117,7 +117,7 @@ Returns `x` rounded to integer by dropping digits after decimal point.
 :::{function} truncate(x, d) -> [same as input]
 :noindex: true
 
-Returns `x` rounded to `d` decimal places by dropping digits after decimal point.
+Returns `x` truncated to `d` decimal places.
 :::
 
 :::{function} width_bucket(x, bound1, bound2, n) -> bigint


### PR DESCRIPTION
## Description

Document the missing `truncate(x, d)` overload in `math.md`.

## Additional context and related issues

The existing docs describe `truncate(x)` but omit the two-argument overload. This update follows the existing `round(x, d)` entry and closes #28765.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
