### PR TITLE
Document truncate(x, d) function

### DIFF
--- a/docs/src/main/sphinx/functions/math.md
+++ b/docs/src/main/sphinx/functions/math.md
@@ -114,6 +114,12 @@ Returns the square root of `x`.
 Returns `x` rounded to integer by dropping digits after decimal point.
 :::
 
+:::{function} truncate(x, d) -> [same as input]
+:noindex: true
+
+Returns `x` truncated to `d` decimal places.
+:::
+
 :::{function} width_bucket(x, bound1, bound2, n) -> bigint
 Returns the bin number of `x` in an equi-width histogram with the
 specified `bound1` and `bound2` bounds and `n` number of buckets.


### PR DESCRIPTION
## Summary
Document the two-argument form of the `truncate` function, which truncates a number to `d` decimal places.

Fixes issue #28765

## Details
- Added `truncate(x, d) -> [same as input]` entry to `docs/src/main/sphinx/functions/math.md`
- Follows the same pattern as the existing `round(x, d)` documentation
- Marked `:noindex: true` to match the `round(x, d)` style

## Testing
- Documentation-only change (no code changes)
- Verifiable by building the docs locally or checking the rendered output at https://trino.io/docs/current/functions/math.html#truncate

## Risk
- **Minimal**: Pure documentation addition, no code logic affected
- **Rollback**: Single-commit PR, revert to delete the entry

## External note
Trino requires a signed CLA before merging. Contributor needs to sign the Individual CLA at https://github.com/trinodb/cla before this PR can be merged.