### PR TITLE
Run Bloom filters test single-threaded

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
@@ -18,13 +18,17 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+// createParquetTableWithBloomFilter creates test data at fixed location
+@Execution(SAME_THREAD)
 public abstract class BaseTestParquetWithBloomFilters
         extends AbstractTestQueryFramework
 {


### PR DESCRIPTION
`createParquetTableWithBloomFilter` creates data at fixed location, so tests cannot execute concurrently.
- fixes https://github.com/trinodb/trino/issues/26424
- alternative to https://github.com/trinodb/trino/pull/28764