### PR TITLE
Fix HttpPageBufferClient double-close race

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
@@ -282,11 +282,11 @@ public final class HttpPageBufferClient
     @Override
     public void close()
     {
-        boolean shouldDestroyTaskResults;
         Future<?> future;
         synchronized (this) {
-            shouldDestroyTaskResults = !closed;
-
+            if (closed) {
+                return;
+            }
             closed = true;
 
             future = this.future;
@@ -301,9 +301,7 @@ public final class HttpPageBufferClient
         }
 
         // destroy task results on the remote node; response is ignored
-        if (shouldDestroyTaskResults) {
-            destroyTaskResults();
-        }
+        destroyTaskResults();
     }
 
     public synchronized void scheduleRequest()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Second close() call in HttpPageBufferClient was grabbing and potentially cancelling the
in-flight DELETE future set by destroyTaskResults(), defeating cleanup.

Simplify close() to return early if already closed, removing the
shouldDestroyTaskResults flag. The first close always calls
destroyTaskResults(); subsequent closes are no-ops.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
```
io.trino.operator.HttpPageBufferClient  Request to delete http://100.123.75.169:8080/v1/task/20260319_194134_08266_a8qwh.1.0.0/results/93 failed java.util.concurrent.CancellationException: Task was cancelled.
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
