### PR TITLE
Coerce NUMBER to DOUBLE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
@@ -396,6 +396,10 @@ public final class TypeCoercion
                 case StandardTypes.NUMBER -> Optional.of(NumberType.NUMBER);
                 default -> Optional.empty();
             };
+            case StandardTypes.NUMBER -> switch (resultTypeBase) {
+                case StandardTypes.REAL, StandardTypes.DOUBLE -> Optional.of(DOUBLE);
+                default -> Optional.empty();
+            };
             case StandardTypes.REAL -> switch (resultTypeBase) {
                 case StandardTypes.DOUBLE -> Optional.of(DOUBLE);
                 default -> Optional.empty();

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -721,6 +721,13 @@ public abstract class AbstractTestEngineOnlyQueries
                 computeActual("SELECT ARRAY[CAST(282 AS DECIMAL(22,1)), CAST(282 AS DECIMAL(10,1))] || CAST(292 AS BIGINT)"),
                 computeActual("SELECT ARRAY[CAST(282 AS DECIMAL(22,1)), CAST(282 AS DECIMAL(10,1)), CAST(292 AS DECIMAL(19,0))]"));
 
+        // REAL - DOUBLE
+        assertThat(query("SELECT REAL '1.1' + DOUBLE '1.1'")).matches("VALUES DOUBLE '2.2'");
+        assertThat(query("SELECT REAL '1.1' = DOUBLE '1.1'")).matches("VALUES false");
+        assertThat(query("SELECT REAL '1.25' = DOUBLE '1.25'")).matches("VALUES true");
+        assertThat(query("SELECT ARRAY[REAL '282.1', REAL '283.2'] || DOUBLE '101.3'"))
+                .matches("SELECT ARRAY[DOUBLE '282.1', DOUBLE '283.2', DOUBLE '101.3']");
+
         // DECIMAL - DOUBLE
         assertQuery("SELECT CAST(1.1 AS DECIMAL(38,1)) + CAST(1.1 AS DOUBLE)");
         assertQuery("SELECT CAST(1.1 AS DECIMAL(38,1)) = CAST(1.1 AS DOUBLE)");
@@ -750,6 +757,20 @@ public abstract class AbstractTestEngineOnlyQueries
         assertThat(query("SELECT CAST(1.1 AS DECIMAL(38,1)) = CAST(1.1 AS NUMBER)")).matches("VALUES true");
         assertThat(query("SELECT ARRAY[CAST(282.1 AS NUMBER), CAST(283.2 AS NUMBER)] || CAST(101.3 AS DECIMAL(5,1))"))
                 .matches("SELECT ARRAY[CAST(282.1 AS NUMBER), CAST(283.2 AS NUMBER), CAST(101.3 AS NUMBER)]");
+
+        // NUMBER - REAL
+        assertThat(query("SELECT NUMBER '1.1' + REAL '1.1'")).matches("VALUES DOUBLE '2.2'");
+        assertThat(query("SELECT NUMBER '1.1' = REAL '1.1'")).matches("VALUES false");
+        assertThat(query("SELECT NUMBER '1.25' = REAL '1.25'")).matches("VALUES true");
+        assertThat(query("SELECT ARRAY[REAL '282.1', REAL '283.2'] || NUMBER '101.3'"))
+                .matches("SELECT ARRAY[DOUBLE '282.1', DOUBLE '283.2', DOUBLE '101.3']");
+
+        // NUMBER - DOUBLE
+        assertThat(query("SELECT NUMBER '1.1' + DOUBLE '1.1'")).matches("VALUES DOUBLE '2.2'");
+        assertThat(query("SELECT NUMBER '1.1' = DOUBLE '1.1'")).matches("VALUES true");
+        assertThat(query("SELECT sin(NUMBER '1.1')")).matches("VALUES sin(DOUBLE '1.1')");
+        assertThat(query("SELECT ARRAY[DOUBLE '282.1', DOUBLE '283.2'] || NUMBER '101.3'"))
+                .matches("SELECT ARRAY[DOUBLE '282.1', DOUBLE '283.2', DOUBLE '101.3']");
 
         // Complex coercions across joins
         assertQuery("SELECT * FROM (" +
@@ -831,25 +852,11 @@ public abstract class AbstractTestEngineOnlyQueries
                     String multiply = "SELECT CAST(CAST('3' AS " + left + ") * CAST('4' AS " + right + ") AS varchar)";
                     String divide = "SELECT CAST(CAST('12' AS " + left + ") / CAST('4' AS " + right + ") AS varchar)";
                     String modulus = "SELECT CAST(CAST('12' AS " + left + ") % CAST('7' AS " + right + ") AS varchar)";
-                    List<String> both = List.of(left, right);
-                    // There currently is no coercion between number and real/double/decimal
-                    boolean unsupported =
-                            both.contains("number") &&
-                            (both.contains("real") || both.contains("double"));
-                    if (unsupported) {
-                        assertThat(query(add)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* \\+ .*");
-                        assertThat(query(subtract)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* - .*");
-                        assertThat(query(multiply)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* \\* .*");
-                        assertThat(query(divide)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* / .*");
-                        assertThat(query(modulus)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* % .*");
-                    }
-                    else {
-                        assertThat((String) computeActual(add).getOnlyValue()).matches("7(\\.0E0|\\.0+)?");
-                        assertThat((String) computeActual(subtract).getOnlyValue()).matches("-1(\\.0E0|\\.0+)?");
-                        assertThat((String) computeActual(multiply).getOnlyValue()).matches("12(\\.0+)?|1.2E1");
-                        assertThat((String) computeActual(divide).getOnlyValue()).matches("3(\\.0E0|\\.0+)?");
-                        assertThat((String) computeActual(modulus).getOnlyValue()).matches("5(\\.0E0|\\.0+)?");
-                    }
+                    assertThat((String) computeActual(add).getOnlyValue()).matches("7(\\.0E0|\\.0+)?");
+                    assertThat((String) computeActual(subtract).getOnlyValue()).matches("-1(\\.0E0|\\.0+)?");
+                    assertThat((String) computeActual(multiply).getOnlyValue()).matches("12(\\.0+)?|1.2E1");
+                    assertThat((String) computeActual(divide).getOnlyValue()).matches("3(\\.0E0|\\.0+)?");
+                    assertThat((String) computeActual(modulus).getOnlyValue()).matches("5(\\.0E0|\\.0+)?");
                 }
                 catch (Throwable e) {
                     e.addSuppressed(new Exception("left = " + left));


### PR DESCRIPTION
Add coercion between NUMBER and DOUBLE so that, once again, all numeric types can be conveniently operated in queries without need for explicit casts.

The coercion is from NUMBER to DOUBLE and not the opposite direction because:
- when query uses DOUBLE type, it already has accepted approximate numeric semantics. Using "more exact" numeric semantics of the NUMBER will not help at this point
- DOUBLE type is much more performant
- this matches Oracle's semantics: they coerce NUMBER and BINARY_DOUBLE to BINARY_DOUBLE type (Oracle's NUMBER is similar to Trino's NUMBER and Oracle's BINARY_DOUBLE type is exactly same as Trino's DOUBLE type)

Caveat:
- DOUBLE has 11-bit exponent and currently NUMBER has 15-bit exponent, which means NUMBER type can represent non-infinite values which coerce to DOUBLE infinity.

The coercion between NUMBER and REAL is also added. When these types are used together, they coerce to DOUBLE.  This is different than e.g. Oracle's behavior (Oracle NUMBER and BINARY_FLOAT coerce to BINARY_FLOAT). Coercing to REAL seems not to have much benefits.

- fixes https://github.com/trinodb/trino/issues/28404