### PR TITLE
Map SingleStore high-precision DECIMAL to Trino NUMBER

### DIFF
--- a/docs/src/main/sphinx/connector/singlestore.md
+++ b/docs/src/main/sphinx/connector/singlestore.md
@@ -176,8 +176,8 @@ this table:
   - `DOUBLE`
   -
 * - `DECIMAL(p, s)`
-  - `DECIMAL(p, s)`
-  -
+  - `DECIMAL(p, s)` or `NUMBER`
+  - Maps to Trino `DECIMAL` when `p ≤ 38`. Otherwise, maps to `NUMBER`.
 * - `CHAR(n)`
   - `CHAR(n)`
   -

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -2092,6 +2092,11 @@ public abstract class BaseJdbcConnectorTest
     public void testNativeQuerySelectUnsupportedType()
     {
         skipTestUnless(hasBehavior(SUPPORTS_NATIVE_QUERY));
+        testNativeQuerySelectUnsupportedType(false);
+    }
+
+    protected void testNativeQuerySelectUnsupportedType(boolean expectSuccess)
+    {
         try (TestTable testTable = createTableWithUnsupportedColumn()) {
             String unqualifiedTableName = testTable.getName().replaceAll("^\\w+\\.", "");
             // Check that column 'two' is not supported.
@@ -2099,9 +2104,17 @@ public abstract class BaseJdbcConnectorTest
                     "SELECT column_name FROM information_schema.columns WHERE table_schema = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + unqualifiedTableName + "'",
                     "VALUES 'one', 'three'");
             assertUpdate("INSERT INTO " + testTable.getName() + " (one, three) VALUES (123, 'test')", 1);
-            assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT * FROM %s'))", testTable.getName())))
-                    // TODO should be TrinoException
-                    .nonTrinoExceptionFailure().hasMessageContaining("Unsupported type");
+            QueryAssert queryAssert = assertThat(query(format("SELECT * FROM TABLE(system.query(query => 'SELECT * FROM %s'))", testTable.getName())));
+            if (expectSuccess) {
+                // For some connectors, the type introspection for regular tables (usually done via JDBC DatabaseMetaData)
+                // is not the same as the type introspection for queries (usually done via JDBC ResultSetMetaData).
+                // Sometimes there is no type that is unsupported on the table level and still not supported when introspecting a query.
+                queryAssert.skippingTypesCheck().matches("VALUES (BIGINT '123', null, 'test')");
+            }
+            else {
+                // TODO should be TrinoException
+                queryAssert.nonTrinoExceptionFailure().hasMessageContaining("Unsupported type");
+            }
         }
     }
 

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -79,7 +79,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
-import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRoundingMode;
@@ -99,6 +98,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.doubleWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.numberColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
@@ -331,14 +331,23 @@ public class SingleStoreClient
             case Types.DECIMAL:
                 int precision = typeHandle.requiredColumnSize();
                 int decimalDigits = typeHandle.requiredDecimalDigits();
-                if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
-                    int scale = min(decimalDigits, getDecimalDefaultScale(session));
-                    return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
+                if (precision <= Decimals.MAX_PRECISION) {
+                    return Optional.of(decimalColumnMapping(createDecimalType(precision, decimalDigits)));
                 }
-                if (precision > Decimals.MAX_PRECISION) {
-                    break;
+                // precision > MAX_PRECISION
+                switch (getDecimalRounding(session)) {
+                    case MAP_TO_NUMBER -> {
+                        return Optional.of(numberColumnMapping());
+                    }
+                    case STRICT -> {
+                        // skipped (unhandled type)
+                    }
+                    case ALLOW_OVERFLOW -> {
+                        int scale = min(max(decimalDigits, 0), getDecimalDefaultScale(session));
+                        return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
+                    }
                 }
-                return Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
+                break;
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClientModule.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClientModule.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.jdbc.DecimalModule.MappingToNumber.ON_BY_DEFAULT;
 
 public class SingleStoreClientModule
         implements Module
@@ -45,7 +46,7 @@ public class SingleStoreClientModule
         configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setBulkListColumns(true));
         configBinder(binder).bindConfig(SingleStoreJdbcConfig.class);
         configBinder(binder).bindConfig(SingleStoreConfig.class);
-        binder.install(new DecimalModule());
+        binder.install(DecimalModule.withNumberMapping(ON_BY_DEFAULT));
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
     }
 

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/BaseSingleStoreTypeMapping.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/BaseSingleStoreTypeMapping.java
@@ -54,6 +54,7 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MICROS;
@@ -282,7 +283,38 @@ public abstract class BaseSingleStoreTypeMapping
     @Test
     public void testDecimalExceedingPrecisionMax()
     {
-        testUnsupportedDataType("decimal(50,0)");
+        // Test that DECIMAL types with precision > 38 map to NUMBER type
+        // SingleStore supports DECIMAL up to precision 65 with scale up to 30
+
+        // Test precision 40, scale 5 (just above the 38 threshold)
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(40,5)", "12345678901234567890123456789012345.12345", NUMBER, "NUMBER '12345678901234567890123456789012345.12345'")
+                .addRoundTrip("decimal(40,5)", "-12345678901234567890123456789012345.12345", NUMBER, "NUMBER '-12345678901234567890123456789012345.12345'")
+                .addRoundTrip("decimal(40,5)", "123.45", NUMBER, "NUMBER '123.45'")
+                .addRoundTrip("decimal(40,5)", "-123.45", NUMBER, "NUMBER '-123.45'")
+                .addRoundTrip("decimal(40,5)", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), singleStoreCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p40"));
+
+        // Test precision 50, scale 0
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(50,0)", "12345678901234567890123456789012345678901234567890", NUMBER, "NUMBER '12345678901234567890123456789012345678901234567890'")
+                .addRoundTrip("decimal(50,0)", "-12345678901234567890123456789012345678901234567890", NUMBER, "NUMBER '-12345678901234567890123456789012345678901234567890'")
+                .addRoundTrip("decimal(50,0)", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), singleStoreCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p50"));
+
+        // Test precision 60, scale 10
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(60,10)", "12345678901234567890123456789012345678901234567890.1234567890", NUMBER, "NUMBER '12345678901234567890123456789012345678901234567890.1234567890'")
+                .addRoundTrip("decimal(60,10)", "-12345678901234567890123456789012345678901234567890.1234567890", NUMBER, "NUMBER '-12345678901234567890123456789012345678901234567890.1234567890'")
+                .addRoundTrip("decimal(60,10)", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), singleStoreCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p60"));
+
+        // Test precision 65 (SingleStore's max), scale 30
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(65,30)", "12345678901234567890123456789012345.123456789012345678901234567890", NUMBER, "NUMBER '12345678901234567890123456789012345.123456789012345678901234567890'")
+                .addRoundTrip("decimal(65,30)", "-12345678901234567890123456789012345.123456789012345678901234567890", NUMBER, "NUMBER '-12345678901234567890123456789012345.123456789012345678901234567890'")
+                .addRoundTrip("decimal(65,30)", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), singleStoreCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p65"));
     }
 
     @Test

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
@@ -112,7 +112,15 @@ public class TestSingleStoreConnectorTest
         return new TestTable(
                 onRemoteDatabase(),
                 "tpch.test_unsupported_column_present",
-                "(one bigint, two decimal(50,0), three varchar(10))");
+                "(one bigint, two bit(10), three varchar(10))");
+    }
+
+    @Override
+    @Test
+    public void testNativeQuerySelectUnsupportedType()
+    {
+        // No SingleStore type is found to be unsupported by the connector and also unsupported when type introspection is done via ResultSetMetaData.
+        super.testNativeQuerySelectUnsupportedType(true);
     }
 
     @Override


### PR DESCRIPTION
Trino's `DECIMAL` has precision of 1-38 decimal digits. SingleStore's `DECIMAL` supports precision up to 65 digits with scale up to 30. Previously it was impossible to reasonably map high precision SingleStore `DECIMAL` to Trino. Mapping required agreeing to lossy conversion using `decimal-mapping=ALLOW_OVERFLOW` config and perhaps tuning the behavior further with `decimal-default-scale` and `decimal-rounding-mode` configs. These configs, along with supporting session properties, are provided by `DecimalModule` and reused across multiple connectors.

After the changes, the connector maps high-precision DECIMAL (precision 39-65) to NUMBER, the new Trino high precision decimal type. The decimal configs such as `decimal-mapping`, `decimal-default-scale` are deprecated in the connector. They remain non-deprecated from the perspective of all other connectors using `DecimalModule`.

For backwards compatibility, when `decimal-mapping` is set to `STRICT` or `ALLOW_OVERFLOW`, the mapping to NUMBER is *not* used.

Note on backwards incompatible behavior when `unsupported-type-handling` is used. Previously, when connector was configured with `unsupported-type-handling=CONVERT_TO_VARCHAR` (and without `decimal-mapping`), SingleStore's high precision decimals were mapped to VARCHAR. Now they are properly supported and mapped to NUMBER, which constitutes a backward incompatible change. This backwards incompatibility is intrinsic nature of `unsupported-type-handling` though and not specific to this new mapping. `unsupported-type-handling` very nature is future incompatibility so anyone configuring this config signs up for a breaking change like this.

This change adds read mapping only. Write mapping may be added separately.

