### PR TITLE
Prefer the most specific function overload during coercion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import io.trino.connector.CatalogHandle;
+import io.trino.metadata.FunctionSpecificityComparator.Specificity;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.CatalogSchemaFunctionName;
@@ -27,7 +28,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.sql.analyzer.TypeSignatureProvider;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -57,11 +57,13 @@ class FunctionBinder
 {
     private final Metadata metadata;
     private final TypeManager typeManager;
+    private final FunctionSpecificityComparator functionSpecificityComparator;
 
     public FunctionBinder(Metadata metadata, TypeManager typeManager)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.functionSpecificityComparator = new FunctionSpecificityComparator(metadata, typeManager);
     }
 
     CatalogFunctionBinding bindFunction(List<TypeSignatureProvider> parameterTypes, Collection<CatalogFunctionMetadata> candidates, String displayName)
@@ -233,25 +235,55 @@ class FunctionBinder
 
     private List<ApplicableFunction> selectMostSpecificFunctions(List<ApplicableFunction> candidates)
     {
-        // Provided `isMoreSpecificThan` is a partial order relation, this finds all the minimum values among candidates.
-        // TODO Warning: `isMoreSpecificThan` compares bound signature of the left with declared signature of the right (asymmetric) and it is *not* proper partial order relation.
-        //  the result depends on candidates order, and order in which `isMoreSpecificThan` is applied.
-
-        List<ApplicableFunction> representatives = new ArrayList<>();
-
-        for (ApplicableFunction current : candidates) {
-            if (representatives.removeIf(representative -> isMoreSpecificThan(current, representative))) {
-                representatives.add(current);
-                continue;
+        SpecificityComparisonCache comparisonCache = new SpecificityComparisonCache(candidates);
+        ImmutableList.Builder<ApplicableFunction> mostSpecificFunctions = ImmutableList.builder();
+        for (int currentIndex = 0; currentIndex < candidates.size(); currentIndex++) {
+            boolean lessSpecificThanAnother = false;
+            for (int otherIndex = 0; otherIndex < candidates.size(); otherIndex++) {
+                if (currentIndex == otherIndex) {
+                    continue;
+                }
+                if (comparisonCache.isMoreSpecific(otherIndex, currentIndex)) {
+                    lessSpecificThanAnother = true;
+                    break;
+                }
             }
-            if (representatives.stream().anyMatch(representative -> isMoreSpecificThan(representative, current))) {
-                // Current is less specific than one of the retained representatives.
-                continue;
+            if (!lessSpecificThanAnother) {
+                mostSpecificFunctions.add(candidates.get(currentIndex));
             }
-            representatives.add(current);
+        }
+        return mostSpecificFunctions.build();
+    }
+
+    private final class SpecificityComparisonCache
+    {
+        private final List<ApplicableFunction> candidates;
+        private final Specificity[][] cache;
+
+        private SpecificityComparisonCache(List<ApplicableFunction> candidates)
+        {
+            this.candidates = requireNonNull(candidates, "candidates is null");
+            this.cache = new Specificity[candidates.size()][candidates.size()];
         }
 
-        return representatives;
+        private boolean isMoreSpecific(int leftIndex, int rightIndex)
+        {
+            Specificity cachedSpecificity = cache[leftIndex][rightIndex];
+            if (cachedSpecificity != null) {
+                return cachedSpecificity == Specificity.MORE_SPECIFIC;
+            }
+
+            ApplicableFunction left = candidates.get(leftIndex);
+            ApplicableFunction right = candidates.get(rightIndex);
+            Specificity specificity = functionSpecificityComparator.compareSpecificity(
+                    left.boundSignature(),
+                    left.declaredSignature(),
+                    right.boundSignature(),
+                    right.declaredSignature());
+            cache[leftIndex][rightIndex] = specificity;
+            cache[rightIndex][leftIndex] = specificity.reverse();
+            return specificity == Specificity.MORE_SPECIFIC;
+        }
     }
 
     private static boolean someParameterIsUnknown(List<Type> parameters)
@@ -322,16 +354,6 @@ class FunctionBinder
             resultBuilder.add(typeManager.getType(typeSignatureProvider.getTypeSignature()));
         }
         return Optional.of(resultBuilder.build());
-    }
-
-    /**
-     * One method is more specific than another if invocation handled by the first method could be passed on to the other one
-     */
-    private boolean isMoreSpecificThan(ApplicableFunction left, ApplicableFunction right)
-    {
-        List<TypeSignatureProvider> resolvedTypes = fromTypeSignatures(left.boundSignature().getArgumentTypes());
-        return new SignatureBinder(metadata, typeManager, right.declaredSignature(), true)
-                .canBind(resolvedTypes);
     }
 
     private CatalogFunctionBinding toFunctionBinding(CatalogFunctionMetadata functionMetadata, Signature signature)

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionSpecificityComparator.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionSpecificityComparator.java
@@ -1,0 +1,474 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.function.Signature;
+import io.trino.spi.function.TypeVariableConstraint;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeParameter;
+import io.trino.spi.type.TypeSignature;
+import io.trino.sql.analyzer.TypeSignatureProvider;
+import io.trino.type.TypeCoercion;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Compares already-applicable functions to determine which one is more specific for overload
+ * selection in {@link FunctionBinder}.
+ * <p>
+ * This helper is intentionally specialized to FunctionBinder's current needs. It is not a general
+ * partial order over arbitrary signatures or bindings.
+ * <p>
+ * The comparison is performed in two phases:
+ * <ol>
+ * <li>Compare already-bound applicable functions using the existing forwardability rule: a bound
+ * call handled by one function is more specific if it can also bind to the other function's
+ * declared signature.</li>
+ * <li>If that relation is mutual, compare the declared signatures structurally to choose the
+ * narrower declaration deterministically.</li>
+ * </ol>
+ */
+final class FunctionSpecificityComparator
+{
+    enum Specificity
+    {
+        MORE_SPECIFIC,
+        LESS_SPECIFIC,
+        EQUIVALENT,
+        INCOMPARABLE;
+
+        Specificity reverse()
+        {
+            return switch (this) {
+                case MORE_SPECIFIC -> LESS_SPECIFIC;
+                case LESS_SPECIFIC -> MORE_SPECIFIC;
+                case EQUIVALENT, INCOMPARABLE -> this;
+            };
+        }
+    }
+
+    private final Metadata metadata;
+    private final TypeManager typeManager;
+    private final TypeCoercion typeCoercion;
+
+    FunctionSpecificityComparator(Metadata metadata, TypeManager typeManager)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.typeCoercion = new TypeCoercion(typeManager::getType);
+    }
+
+    /**
+     * Compares two already-applicable functions for overload selection in {@link FunctionBinder}.
+     * <p>
+     * The caller must provide both the bound signature selected for the actual call site and the
+     * original declared signature for each function. Usage outside this exact FunctionBinder flow
+     * has not been considered.
+     */
+    Specificity compareSpecificity(
+            Signature leftBoundSignature,
+            Signature leftDeclaredSignature,
+            Signature rightBoundSignature,
+            Signature rightDeclaredSignature)
+    {
+        requireNonNull(leftBoundSignature, "leftBoundSignature is null");
+        requireNonNull(leftDeclaredSignature, "leftDeclaredSignature is null");
+        requireNonNull(rightBoundSignature, "rightBoundSignature is null");
+        requireNonNull(rightDeclaredSignature, "rightDeclaredSignature is null");
+
+        int arity = leftBoundSignature.getArgumentTypes().size();
+        verify(arity == rightBoundSignature.getArgumentTypes().size(), "bound signatures have different arities");
+
+        boolean leftMoreSpecific = isMoreSpecificThan(leftBoundSignature, rightDeclaredSignature);
+        boolean rightMoreSpecific = isMoreSpecificThan(rightBoundSignature, leftDeclaredSignature);
+
+        if (leftMoreSpecific && !rightMoreSpecific) {
+            return Specificity.MORE_SPECIFIC;
+        }
+        if (rightMoreSpecific && !leftMoreSpecific) {
+            return Specificity.LESS_SPECIFIC;
+        }
+        if (!leftMoreSpecific) {
+            return Specificity.INCOMPARABLE;
+        }
+
+        return compareDeclaredSignatures(leftDeclaredSignature, rightDeclaredSignature, arity);
+    }
+
+    /**
+     * Compares two declared signatures structurally after applicability has already been
+     * established. This is only used as a deterministic tie-break for mutually specific bindings.
+     */
+    Specificity compareDeclaredSignatures(Signature left, Signature right, int arity)
+    {
+        requireNonNull(left, "left is null");
+        requireNonNull(right, "right is null");
+        checkArgument(arity >= 0, "arity is negative");
+
+        List<TypeSignature> leftArguments = expandArguments(left, arity);
+        List<TypeSignature> rightArguments = expandArguments(right, arity);
+
+        Map<String, TypeVariableConstraint> leftConstraints = constraintMap(left);
+        Map<String, TypeVariableConstraint> rightConstraints = constraintMap(right);
+
+        Specificity comparison = Specificity.EQUIVALENT;
+        // compare each argument position
+        for (int i = 0; i < arity; i++) {
+            comparison = combine(comparison, compareTypeSignatures(leftArguments.get(i), rightArguments.get(i), leftConstraints, rightConstraints));
+            if (comparison == Specificity.INCOMPARABLE) {
+                return Specificity.INCOMPARABLE;
+            }
+        }
+
+        comparison = combine(comparison, compareEqualityPatterns(leftArguments, rightArguments, leftConstraints, rightConstraints));
+        if (comparison == Specificity.INCOMPARABLE) {
+            return Specificity.INCOMPARABLE;
+        }
+
+        if (comparison == Specificity.EQUIVALENT && left.isVariableArity() != right.isVariableArity()) {
+            return left.isVariableArity() ? Specificity.LESS_SPECIFIC : Specificity.MORE_SPECIFIC;
+        }
+
+        return comparison;
+    }
+
+    private boolean isMoreSpecificThan(Signature boundSignature, Signature declaredSignature)
+    {
+        List<TypeSignatureProvider> resolvedTypes = TypeSignatureProvider.fromTypeSignatures(boundSignature.getArgumentTypes());
+        return new SignatureBinder(metadata, typeManager, declaredSignature, true)
+                .canBind(resolvedTypes);
+    }
+
+    /**
+     * Compares two type signatures structurally after applicability has already been established.
+     * Concrete types are always narrower than type variables at this stage.
+     */
+    private Specificity compareTypeSignatures(
+            TypeSignature left,
+            TypeSignature right,
+            Map<String, TypeVariableConstraint> leftConstraints,
+            Map<String, TypeVariableConstraint> rightConstraints)
+    {
+        boolean leftTypeVariable = isTypeVariable(left, leftConstraints);
+        boolean rightTypeVariable = isTypeVariable(right, rightConstraints);
+        if (leftTypeVariable && rightTypeVariable) {
+            return Specificity.EQUIVALENT;
+        }
+        if (leftTypeVariable) {
+            return Specificity.LESS_SPECIFIC;
+        }
+        if (rightTypeVariable) {
+            return Specificity.MORE_SPECIFIC;
+        }
+
+        if (left.equals(right)) {
+            return Specificity.EQUIVALENT;
+        }
+
+        Optional<Type> leftConcrete = resolveConcrete(left);
+        if (leftConcrete.isPresent()) {
+            Optional<Type> rightConcrete = resolveConcrete(right);
+            if (rightConcrete.isPresent()) {
+                return compareConcreteTypes(leftConcrete.get(), rightConcrete.get());
+            }
+        }
+        return compareParametricTypes(left, right, leftConstraints, rightConstraints);
+    }
+
+    private Specificity compareConcreteTypes(Type left, Type right)
+    {
+        if (left.equals(right)) {
+            return Specificity.EQUIVALENT;
+        }
+
+        boolean leftToRight = typeCoercion.canCoerce(left, right);
+        boolean rightToLeft = typeCoercion.canCoerce(right, left);
+        if (leftToRight && !rightToLeft) {
+            return Specificity.MORE_SPECIFIC;
+        }
+        if (rightToLeft && !leftToRight) {
+            return Specificity.LESS_SPECIFIC;
+        }
+        return Specificity.INCOMPARABLE;
+    }
+
+    private Specificity compareParametricTypes(TypeSignature left, TypeSignature right, Map<String, TypeVariableConstraint> leftConstraints, Map<String, TypeVariableConstraint> rightConstraints)
+    {
+        if (!left.getBase().equalsIgnoreCase(right.getBase())) {
+            return Specificity.INCOMPARABLE;
+        }
+        if (left.getParameters().size() != right.getParameters().size()) {
+            return Specificity.INCOMPARABLE;
+        }
+
+        Specificity comparison = Specificity.EQUIVALENT;
+        for (int i = 0; i < left.getParameters().size(); i++) {
+            comparison = combine(comparison, compareTypeParameters(left.getParameters().get(i), right.getParameters().get(i), leftConstraints, rightConstraints));
+            if (comparison == Specificity.INCOMPARABLE) {
+                return Specificity.INCOMPARABLE;
+            }
+        }
+        return comparison;
+    }
+
+    private Specificity compareTypeParameters(
+            TypeParameter left,
+            TypeParameter right,
+            Map<String, TypeVariableConstraint> leftConstraints,
+            Map<String, TypeVariableConstraint> rightConstraints)
+    {
+        return switch (left) {
+            case TypeParameter.Numeric leftNumeric -> switch (right) {
+                case TypeParameter.Numeric rightNumeric -> leftNumeric.value() == rightNumeric.value() ? Specificity.EQUIVALENT : Specificity.INCOMPARABLE;
+                case TypeParameter.Variable _ -> Specificity.MORE_SPECIFIC;
+                case TypeParameter.Type _ -> Specificity.INCOMPARABLE;
+            };
+            case TypeParameter.Variable _ -> switch (right) {
+                case TypeParameter.Numeric _ -> Specificity.LESS_SPECIFIC;
+                case TypeParameter.Variable _ -> Specificity.EQUIVALENT;
+                case TypeParameter.Type _ -> Specificity.INCOMPARABLE;
+            };
+            case TypeParameter.Type leftType -> switch (right) {
+                case TypeParameter.Numeric _, TypeParameter.Variable _ -> Specificity.INCOMPARABLE;
+                case TypeParameter.Type rightType -> compareTypeSignatures(leftType.type(), rightType.type(), leftConstraints, rightConstraints);
+            };
+        };
+    }
+
+    /**
+     * Compares the equality pairs required by two signatures.
+     * <p>
+     * The per-argument comparison only looks at each argument position independently. This method
+     * adds the missing cross-position constraints.
+     * <p>
+     * For example, {@code (T, T)} is narrower than {@code (T, U)} because it requires the two
+     * argument locations to be equal. Likewise, {@code decimal(p, s), decimal(p, s)} is narrower
+     * than {@code decimal(p1, s1), decimal(p2, s2)} because it requires both {@code p} locations
+     * to match and both {@code s} locations to match.
+     * <p>
+     * Each signature is reduced to the set of equality pairs returned by
+     * {@link #collectEqualityPatterns(List, Map)}. If one signature requires every equality pair
+     * required by the other, plus possibly more, it is more specific.
+     */
+    private static Specificity compareEqualityPatterns(
+            List<TypeSignature> leftArguments,
+            List<TypeSignature> rightArguments,
+            Map<String, TypeVariableConstraint> leftConstraints,
+            Map<String, TypeVariableConstraint> rightConstraints)
+    {
+        Set<EqualityPattern> leftEqualities = collectEqualityPatterns(leftArguments, leftConstraints);
+        Set<EqualityPattern> rightEqualities = collectEqualityPatterns(rightArguments, rightConstraints);
+
+        boolean leftImpliesRight = leftEqualities.containsAll(rightEqualities);
+        boolean rightImpliesLeft = rightEqualities.containsAll(leftEqualities);
+        if (leftImpliesRight && rightImpliesLeft) {
+            return Specificity.EQUIVALENT;
+        }
+        if (leftImpliesRight) {
+            return Specificity.MORE_SPECIFIC;
+        }
+        if (rightImpliesLeft) {
+            return Specificity.LESS_SPECIFIC;
+        }
+        return Specificity.INCOMPARABLE;
+    }
+
+    /**
+     * Returns every pair of locations in the expanded argument list that are required to be equal
+     * because they reuse the same type variable or calculated literal variable.
+     * <p>
+     * For example, {@code (T, T)} produces one equality pair between the two argument locations,
+     * while {@code decimal(p, s), decimal(p, s)} produces one pair for {@code p} and one pair for
+     * {@code s}. If the same variable appears in three locations, this returns all three pairwise
+     * equalities between those locations.
+     */
+    private static Set<EqualityPattern> collectEqualityPatterns(List<TypeSignature> argumentTypes, Map<String, TypeVariableConstraint> constraints)
+    {
+        Map<String, List<Occurrence>> occurrences = new HashMap<>();
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            collectOccurrences(argumentTypes.get(i), i, new IntArrayList(), constraints, occurrences);
+        }
+
+        Set<EqualityPattern> equalities = new HashSet<>();
+        for (List<Occurrence> paths : occurrences.values()) {
+            for (int i = 0; i < paths.size(); i++) {
+                for (int j = i + 1; j < paths.size(); j++) {
+                    equalities.add(new EqualityPattern(paths.get(i), paths.get(j)));
+                }
+            }
+        }
+        return equalities;
+    }
+
+    /**
+     * Records where each logical variable occurs in the expanded argument list.
+     * <p>
+     * Type variables are keyed by variable name, so repeated uses of the same variable contribute
+     * multiple paths to the same occurrence list. Calculated literal parameters are handled the
+     * same way. Concrete numeric parameters do not participate because they do not represent
+     * equality constraints; they are already compared directly in {@link #compareTypeParameters}.
+     */
+    private static void collectOccurrences(
+            TypeSignature signature,
+            int argumentIndex,
+            IntArrayList parameterPath,
+            Map<String, TypeVariableConstraint> constraints,
+            Map<String, List<Occurrence>> occurrences)
+    {
+        if (isTypeVariable(signature, constraints)) {
+            occurrences.computeIfAbsent("type:" + signature.getBase(), _ -> new ArrayList<>())
+                    .add(new Occurrence(argumentIndex, parameterPath));
+            return;
+        }
+
+        List<TypeParameter> parameters = signature.getParameters();
+        for (int i = 0; i < parameters.size(); i++) {
+            switch (parameters.get(i)) {
+                case TypeParameter.Numeric _ -> {}
+                case TypeParameter.Variable variable -> occurrences.computeIfAbsent("literal:" + variable.name(), _ -> new ArrayList<>())
+                        .add(new Occurrence(argumentIndex, parameterPath, i));
+                case TypeParameter.Type type -> {
+                    parameterPath.push(i);
+                    collectOccurrences(type.type(), argumentIndex, parameterPath, constraints, occurrences);
+                    parameterPath.popInt();
+                }
+            }
+        }
+    }
+
+    private record EqualityPattern(Occurrence left, Occurrence right)
+    {
+        private EqualityPattern
+        {
+            requireNonNull(left, "left is null");
+            requireNonNull(right, "right is null");
+            if (left.compareTo(right) > 0) {
+                Occurrence temporary = left;
+                left = right;
+                right = temporary;
+            }
+        }
+    }
+
+    private record Occurrence(int argumentIndex, IntArrayList parameterPath)
+            implements Comparable<Occurrence>
+    {
+        private Occurrence
+        {
+            parameterPath = new IntArrayList(requireNonNull(parameterPath, "parameterPath is null"));
+        }
+
+        private Occurrence(int argumentIndex, IntArrayList parameterPath, int parameter)
+        {
+            this(argumentIndex, parameterPath);
+            this.parameterPath.add(parameter);
+        }
+
+        @Override
+        public int compareTo(Occurrence other)
+        {
+            int comparison = Integer.compare(argumentIndex, other.argumentIndex);
+            if (comparison != 0) {
+                return comparison;
+            }
+            return parameterPath.compareTo(other.parameterPath);
+        }
+    }
+
+    private Optional<Type> resolveConcrete(TypeSignature signature)
+    {
+        if (signature.isCalculated()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(typeManager.getType(signature));
+        }
+        catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isTypeVariable(TypeSignature signature, Map<String, TypeVariableConstraint> constraints)
+    {
+        return signature.getParameters().isEmpty() && constraints.containsKey(signature.getBase());
+    }
+
+    private static Map<String, TypeVariableConstraint> constraintMap(Signature signature)
+    {
+        Map<String, TypeVariableConstraint> constraints = new TreeMap<>(CASE_INSENSITIVE_ORDER);
+        for (TypeVariableConstraint constraint : signature.getTypeVariableConstraints()) {
+            constraints.put(constraint.getName(), constraint);
+        }
+        return constraints;
+    }
+
+    private static List<TypeSignature> expandArguments(Signature signature, int arity)
+    {
+        List<TypeSignature> formalTypeSignatures = signature.getArgumentTypes();
+        if (!signature.isVariableArity()) {
+            verify(formalTypeSignatures.size() == arity);
+            return formalTypeSignatures;
+        }
+
+        verify(arity >= formalTypeSignatures.size() - 1);
+
+        int variableArityArgumentsCount = arity - formalTypeSignatures.size() + 1;
+        if (variableArityArgumentsCount == 0) {
+            return formalTypeSignatures.subList(0, formalTypeSignatures.size() - 1);
+        }
+        if (variableArityArgumentsCount == 1) {
+            return formalTypeSignatures;
+        }
+
+        ImmutableList.Builder<TypeSignature> builder = ImmutableList.builder();
+        builder.addAll(formalTypeSignatures);
+        TypeSignature lastTypeSignature = formalTypeSignatures.getLast();
+        for (int i = 1; i < variableArityArgumentsCount; i++) {
+            builder.add(lastTypeSignature);
+        }
+        return builder.build();
+    }
+
+    private static Specificity combine(Specificity current, Specificity next)
+    {
+        if (current == Specificity.INCOMPARABLE || next == Specificity.INCOMPARABLE) {
+            return Specificity.INCOMPARABLE;
+        }
+        if (current == Specificity.EQUIVALENT) {
+            return next;
+        }
+        if (next == Specificity.EQUIVALENT) {
+            return current;
+        }
+        if (current == next) {
+            return current;
+        }
+        return Specificity.INCOMPARABLE;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/TestFunctionSpecificityComparator.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestFunctionSpecificityComparator.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.function.Signature;
+import io.trino.spi.function.TypeVariableConstraint;
+import io.trino.spi.type.TypeSignature;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static io.trino.metadata.FunctionSpecificityComparator.Specificity.EQUIVALENT;
+import static io.trino.metadata.FunctionSpecificityComparator.Specificity.INCOMPARABLE;
+import static io.trino.metadata.FunctionSpecificityComparator.Specificity.LESS_SPECIFIC;
+import static io.trino.metadata.FunctionSpecificityComparator.Specificity.MORE_SPECIFIC;
+import static io.trino.spi.function.TypeVariableConstraint.typeVariable;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFunctionSpecificityComparator
+{
+    private static final Set<String> LITERAL_PARAMETERS = ImmutableSet.of("p", "s", "p1", "s1", "p2", "s2", "x", "y");
+
+    private final FunctionSpecificityComparator comparator = new FunctionSpecificityComparator(PLANNER_CONTEXT.getMetadata(), PLANNER_CONTEXT.getTypeManager());
+
+    @Test
+    void testCompareSpecificityPreservesConcreteCoercionOrdering()
+    {
+        Signature decimalAndDecimalBound = functionSignature(ImmutableList.of("decimal(19,0)", "decimal(19,0)"), "boolean").build();
+        Signature decimalAndDecimalDeclared = functionSignature(ImmutableList.of("decimal(p,s)", "decimal(p,s)"), "boolean").build();
+        Signature decimalAndDoubleBound = functionSignature(ImmutableList.of("decimal(19,0)", "double"), "boolean").build();
+        Signature decimalAndDoubleDeclared = functionSignature(ImmutableList.of("decimal(p,s)", "double"), "boolean").build();
+        Signature doubleAndDouble = functionSignature(ImmutableList.of("double", "double"), "boolean").build();
+
+        assertSpecificity(decimalAndDecimalBound, decimalAndDecimalDeclared, decimalAndDoubleBound, decimalAndDoubleDeclared, MORE_SPECIFIC);
+        assertSpecificity(decimalAndDecimalBound, decimalAndDecimalDeclared, doubleAndDouble, doubleAndDouble, MORE_SPECIFIC);
+        assertSpecificity(decimalAndDoubleBound, decimalAndDoubleDeclared, doubleAndDouble, doubleAndDouble, MORE_SPECIFIC);
+    }
+
+    @Test
+    void testCompareSpecificityUsesDeclaredSignaturesForExactVsGenericTie()
+    {
+        Signature exact = functionSignature(ImmutableList.of("boolean", "double"), "bigint").build();
+        Signature generic = functionSignature(ImmutableList.of("T", "double"), "bigint", ImmutableList.of(typeVariable("T"))).build();
+
+        assertSpecificity(exact, exact, exact, generic, MORE_SPECIFIC);
+    }
+
+    @Test
+    void testCompareSpecificityUsesDeclaredSignaturesForFixedArityVsVarargsTie()
+    {
+        Signature fixedArity = functionSignature(ImmutableList.of("boolean", "double", "double"), "boolean").build();
+        Signature varargsBound = fixedArity;
+        Signature varargsDeclared = functionSignature(ImmutableList.of("boolean", "double"), "boolean")
+                .variableArity()
+                .build();
+
+        assertSpecificity(fixedArity, fixedArity, varargsBound, varargsDeclared, MORE_SPECIFIC);
+    }
+
+    @Test
+    void testCompareSpecificityUsesDeclaredSignaturesForConcreteVsCalculatedTie()
+    {
+        Signature concrete = functionSignature(ImmutableList.of("decimal(3,1)", "double"), "boolean").build();
+        Signature calculated = functionSignature(ImmutableList.of("decimal(p,s)", "double"), "boolean").build();
+
+        assertSpecificity(concrete, concrete, concrete, calculated, MORE_SPECIFIC);
+    }
+
+    @Test
+    void testCompareSpecificityUsesDeclaredSignaturesForRepeatedVariablesTie()
+    {
+        Signature bound = functionSignature(ImmutableList.of("bigint", "bigint"), "boolean").build();
+        Signature repeated = functionSignature(ImmutableList.of("T", "T"), "boolean", ImmutableList.of(typeVariable("T"))).build();
+        Signature independent = functionSignature(ImmutableList.of("T", "U"), "boolean", ImmutableList.of(typeVariable("T"), typeVariable("U"))).build();
+
+        assertSpecificity(bound, repeated, bound, independent, MORE_SPECIFIC);
+    }
+
+    @Test
+    void testCompareSpecificityReturnsIncomparableWhenBoundFunctionsAreNotMutuallySpecific()
+    {
+        Signature bigint = functionSignature(ImmutableList.of("bigint"), "boolean").build();
+        Signature varchar = functionSignature(ImmutableList.of("varchar(3)"), "boolean").build();
+
+        assertSpecificity(bigint, bigint, varchar, varchar, INCOMPARABLE);
+    }
+
+    @Test
+    void testEquivalentSignatures()
+    {
+        Signature concrete = functionSignature(ImmutableList.of("bigint"), "boolean").build();
+        assertThat(comparator.compareDeclaredSignatures(concrete, concrete, 1)).isEqualTo(EQUIVALENT);
+
+        Signature genericLeft = functionSignature(ImmutableList.of("T"), "boolean", ImmutableList.of(typeVariable("T"))).build();
+        Signature genericRight = functionSignature(ImmutableList.of("U"), "boolean", ImmutableList.of(typeVariable("U"))).build();
+        assertThat(comparator.compareDeclaredSignatures(genericLeft, genericRight, 1)).isEqualTo(EQUIVALENT);
+
+        Signature calculatedLeft = functionSignature(ImmutableList.of("decimal(p,s)"), "boolean").build();
+        Signature calculatedRight = functionSignature(ImmutableList.of("decimal(x,y)"), "boolean").build();
+        assertThat(comparator.compareDeclaredSignatures(calculatedLeft, calculatedRight, 1)).isEqualTo(EQUIVALENT);
+    }
+
+    @Test
+    void testExactIsMoreSpecificThanGeneric()
+    {
+        Signature exact = functionSignature(ImmutableList.of("boolean", "double"), "bigint").build();
+        Signature generic = functionSignature(ImmutableList.of("T", "double"), "bigint", ImmutableList.of(typeVariable("T"))).build();
+
+        assertThat(comparator.compareDeclaredSignatures(exact, generic, 2)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(generic, exact, 2)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    @Test
+    void testApproxDistinctSpecializationShape()
+    {
+        Signature specialized = functionSignature(ImmutableList.of("boolean", "double"), "bigint").build();
+        Signature genericComparable = Signature.builder()
+                .returnType(typeSignature("bigint"))
+                .argumentType(typeSignature("T"))
+                .argumentType(typeSignature("double"))
+                .comparableTypeParameter("T")
+                .build();
+
+        assertThat(comparator.compareDeclaredSignatures(specialized, genericComparable, 2)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(genericComparable, specialized, 2)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    @Test
+    void testFixedArityIsMoreSpecificThanVarargs()
+    {
+        Signature fixedArity = functionSignature(ImmutableList.of("boolean", "double", "double"), "boolean").build();
+        Signature varargs = functionSignature(ImmutableList.of("boolean", "double"), "boolean")
+                .variableArity()
+                .build();
+
+        assertThat(comparator.compareDeclaredSignatures(fixedArity, varargs, 3)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(varargs, fixedArity, 3)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    @Test
+    void testConcreteIsMoreSpecificThanCalculated()
+    {
+        Signature concreteDecimal = functionSignature(ImmutableList.of("decimal(3,1)", "double"), "boolean").build();
+        Signature calculatedDecimal = functionSignature(ImmutableList.of("decimal(p,s)", "double"), "boolean").build();
+
+        assertThat(comparator.compareDeclaredSignatures(concreteDecimal, calculatedDecimal, 2)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(calculatedDecimal, concreteDecimal, 2)).isEqualTo(LESS_SPECIFIC);
+
+        Signature concreteVarchar = functionSignature(ImmutableList.of("varchar(3)"), "boolean").build();
+        Signature calculatedVarchar = functionSignature(ImmutableList.of("varchar(x)"), "boolean").build();
+
+        assertThat(comparator.compareDeclaredSignatures(concreteVarchar, calculatedVarchar, 1)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(calculatedVarchar, concreteVarchar, 1)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    @Test
+    void testConcreteCoercionSpecificity()
+    {
+        Signature bigint = functionSignature(ImmutableList.of("bigint"), "boolean").build();
+        Signature doubleType = functionSignature(ImmutableList.of("double"), "boolean").build();
+        Signature varchar = functionSignature(ImmutableList.of("varchar(3)"), "boolean").build();
+        Signature arrayBigint = functionSignature(ImmutableList.of("array(bigint)"), "boolean").build();
+        Signature arrayDouble = functionSignature(ImmutableList.of("array(double)"), "boolean").build();
+
+        assertThat(comparator.compareDeclaredSignatures(bigint, doubleType, 1)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(doubleType, bigint, 1)).isEqualTo(LESS_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(bigint, varchar, 1)).isEqualTo(INCOMPARABLE);
+        assertThat(comparator.compareDeclaredSignatures(arrayBigint, arrayDouble, 1)).isEqualTo(MORE_SPECIFIC);
+    }
+
+    @Test
+    void testTypeVariableConstraintsAreNotOrdered()
+    {
+        Signature unconstrained = Signature.builder()
+                .returnType(typeSignature("boolean"))
+                .argumentType(typeSignature("T"))
+                .typeVariable("T")
+                .build();
+        Signature comparable = Signature.builder()
+                .returnType(typeSignature("boolean"))
+                .argumentType(typeSignature("T"))
+                .comparableTypeParameter("T")
+                .build();
+        Signature orderable = Signature.builder()
+                .returnType(typeSignature("boolean"))
+                .argumentType(typeSignature("T"))
+                .orderableTypeParameter("T")
+                .build();
+
+        assertThat(comparator.compareDeclaredSignatures(orderable, comparable, 1)).isEqualTo(EQUIVALENT);
+        assertThat(comparator.compareDeclaredSignatures(comparable, orderable, 1)).isEqualTo(EQUIVALENT);
+        assertThat(comparator.compareDeclaredSignatures(comparable, unconstrained, 1)).isEqualTo(EQUIVALENT);
+        assertThat(comparator.compareDeclaredSignatures(unconstrained, comparable, 1)).isEqualTo(EQUIVALENT);
+    }
+
+    @Test
+    void testConcreteIsMoreSpecificThanConstrainedGenericAfterApplicability()
+    {
+        Signature json = functionSignature(ImmutableList.of("json"), "boolean").build();
+        Signature orderable = Signature.builder()
+                .returnType(typeSignature("boolean"))
+                .argumentType(typeSignature("T"))
+                .orderableTypeParameter("T")
+                .build();
+
+        assertThat(comparator.compareDeclaredSignatures(json, orderable, 1)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(orderable, json, 1)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    @Test
+    void testRepeatedTypeVariablesAreMoreSpecificThanIndependentOnes()
+    {
+        Signature repeated = functionSignature(ImmutableList.of("T", "T"), "boolean", ImmutableList.of(typeVariable("T"))).build();
+        Signature independent = functionSignature(ImmutableList.of("T", "U"), "boolean", ImmutableList.of(typeVariable("T"), typeVariable("U"))).build();
+
+        assertThat(comparator.compareDeclaredSignatures(repeated, independent, 2)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(independent, repeated, 2)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    @Test
+    void testRepeatedCalculatedVariablesAreMoreSpecificThanIndependentOnes()
+    {
+        Signature repeated = functionSignature(ImmutableList.of("decimal(p,s)", "decimal(p,s)"), "boolean").build();
+        Signature independent = functionSignature(ImmutableList.of("decimal(p1,s1)", "decimal(p2,s2)"), "boolean").build();
+
+        assertThat(comparator.compareDeclaredSignatures(repeated, independent, 2)).isEqualTo(MORE_SPECIFIC);
+        assertThat(comparator.compareDeclaredSignatures(independent, repeated, 2)).isEqualTo(LESS_SPECIFIC);
+    }
+
+    private static Signature.Builder functionSignature(List<String> arguments, String returnType)
+    {
+        return functionSignature(arguments, returnType, ImmutableList.of());
+    }
+
+    private static Signature.Builder functionSignature(List<String> arguments, String returnType, List<TypeVariableConstraint> typeVariableConstraints)
+    {
+        List<TypeSignature> argumentSignatures = arguments.stream()
+                .map(TestFunctionSpecificityComparator::typeSignature)
+                .toList();
+
+        return Signature.builder()
+                .returnType(typeSignature(returnType))
+                .argumentTypes(argumentSignatures)
+                .typeVariableConstraints(typeVariableConstraints);
+    }
+
+    private static TypeSignature typeSignature(String signature)
+    {
+        return parseTypeSignature(signature, LITERAL_PARAMETERS);
+    }
+
+    private void assertSpecificity(
+            Signature leftBoundSignature,
+            Signature leftDeclaredSignature,
+            Signature rightBoundSignature,
+            Signature rightDeclaredSignature,
+            FunctionSpecificityComparator.Specificity expectedSpecificity)
+    {
+        assertThat(comparator.compareSpecificity(leftBoundSignature, leftDeclaredSignature, rightBoundSignature, rightDeclaredSignature))
+                .isEqualTo(expectedSpecificity);
+        assertThat(comparator.compareSpecificity(rightBoundSignature, rightDeclaredSignature, leftBoundSignature, leftDeclaredSignature))
+                .isEqualTo(opposite(expectedSpecificity));
+    }
+
+    private static FunctionSpecificityComparator.Specificity opposite(FunctionSpecificityComparator.Specificity specificity)
+    {
+        return switch (specificity) {
+            case MORE_SPECIFIC -> LESS_SPECIFIC;
+            case LESS_SPECIFIC -> MORE_SPECIFIC;
+            case EQUIVALENT, INCOMPARABLE -> specificity;
+        };
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
@@ -27,6 +27,7 @@ import io.trino.spi.function.Signature;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
@@ -50,8 +51,10 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.function.TypeVariableConstraint.typeVariable;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static io.trino.spi.type.RealType.REAL;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
 import static java.util.Collections.nCopies;
@@ -177,6 +180,81 @@ public class TestGlobalFunctionCatalog
                         functionSignature("double", "decimal(p,s)"))
                 .forParameters(BIGINT, BIGINT)
                 .failsWithMessage("Could not choose a best candidate operator. Explicit type casts must be added.");
+    }
+
+    @Test
+    public void testResolveFunctionDoesNotDependOnCandidateOrderWhenSpecificityWasPreviouslyMutual()
+    {
+        // Both candidates are only reachable via coercion for (boolean, real). The exact declaration
+        // is narrower than the generic declaration, so candidate order must not affect the result.
+        Signature.Builder exactCandidate = functionSignature(ImmutableList.of("boolean", "double"), "boolean");
+        Signature.Builder genericCandidate = functionSignature(ImmutableList.of("T", "double"), "bigint", ImmutableList.of(typeVariable("T")));
+
+        assertThatResolveFunction()
+                .among(exactCandidate, genericCandidate)
+                .forParameters(BOOLEAN, REAL)
+                .returns(functionSignature(ImmutableList.of("boolean", "double"), "boolean"));
+
+        assertThatResolveFunction()
+                .among(genericCandidate, exactCandidate)
+                .forParameters(BOOLEAN, REAL)
+                .returns(functionSignature(ImmutableList.of("boolean", "double"), "boolean"));
+
+        // The same issue also exists for variable arity signatures. The fixed-arity declaration is
+        // narrower than the variable-arity declaration, so it must win regardless of candidate order.
+        Signature.Builder exactVarargsPeer = functionSignature(ImmutableList.of("boolean", "double", "double"), "boolean");
+        Signature.Builder varargsCandidate = functionSignature(ImmutableList.of("boolean", "double"), "bigint")
+                .variableArity();
+
+        assertThatResolveFunction()
+                .among(exactVarargsPeer, varargsCandidate)
+                .forParameters(BOOLEAN, REAL, REAL)
+                .returns(functionSignature(ImmutableList.of("boolean", "double", "double"), "boolean"));
+
+        assertThatResolveFunction()
+                .among(varargsCandidate, exactVarargsPeer)
+                .forParameters(BOOLEAN, REAL, REAL)
+                .returns(functionSignature(ImmutableList.of("boolean", "double", "double"), "boolean"));
+
+        // The same issue also exists for calculated signatures. The concrete decimal declaration is
+        // narrower than the calculated declaration, so it must win regardless of candidate order.
+        Signature.Builder exactDecimalCandidate = functionSignature(ImmutableList.of("decimal(3,1)", "double"), "boolean");
+        Signature.Builder calculatedCandidate = functionSignature(ImmutableList.of("decimal(p,s)", "double"), "bigint");
+
+        assertThatResolveFunction()
+                .among(exactDecimalCandidate, calculatedCandidate)
+                .forParameters(createDecimalType(3, 1), REAL)
+                .returns(functionSignature(ImmutableList.of("decimal(3,1)", "double"), "boolean"));
+
+        assertThatResolveFunction()
+                .among(calculatedCandidate, exactDecimalCandidate)
+                .forParameters(createDecimalType(3, 1), REAL)
+                .returns(functionSignature(ImmutableList.of("decimal(3,1)", "double"), "boolean"));
+    }
+
+    @Test
+    public void testResolveFunctionPrefersRepeatedTypeVariables()
+    {
+        assertThatResolveFunction()
+                .among(
+                        functionSignature(ImmutableList.of("decimal(p,s)", "decimal(p,s)"), "boolean"),
+                        functionSignature(ImmutableList.of("decimal(p1,s1)", "decimal(p2,s2)"), "boolean"))
+                .forParameters(BIGINT, BIGINT)
+                .returns(functionSignature("decimal(19,0)", "decimal(19,0)"));
+    }
+
+    @Test
+    public void testApproxDistinctPrefersSpecializedBooleanOverload()
+    {
+        BoundSignature resolvedFunction = new TestingFunctionResolution()
+                .resolveFunction("approx_distinct", fromTypeSignatures(BOOLEAN.getTypeSignature(), REAL.getTypeSignature()))
+                .signature();
+
+        assertThat(resolvedFunction.toSignature()).isEqualTo(Signature.builder()
+                .returnType(BIGINT.getTypeSignature())
+                .argumentType(BOOLEAN.getTypeSignature())
+                .argumentType(DoubleType.DOUBLE.getTypeSignature())
+                .build());
     }
 
     @Test


### PR DESCRIPTION
## Description

When overload resolution falls back to coercion, Trino should prefer the narrowest applicable
function declaration. The previous selection logic could still depend on candidate order because it
compared a bound signature of one candidate against another candidate's declared signature.

This change replaces that selection step with a deterministic specificity comparison.

The new logic:

- compares bound signatures first, preserving existing coercion behavior
- breaks ties using declared-signature specificity
- prefers narrower declarations such as exact over generic, fixed arity over varargs, concrete over
  calculated, and repeated equality constraints over independent ones

Type-variable constraints are still handled during applicability filtering, but they are not
considered during ranking.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve function overload resolution during coercion to prefer the most specific applicable function. ({issue}`28763`)
```
