### PR TITLE
Refresh vended credentials during long-running Iceberg REST catalog queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/MemoryTrackingRemoteTaskFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
 import io.opentelemetry.api.trace.Span;
@@ -53,7 +54,7 @@ public class MemoryTrackingRemoteTaskFactory
             InternalNode node,
             boolean speculative,
             PlanFragment fragment,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials,
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
@@ -68,7 +69,7 @@ public class MemoryTrackingRemoteTaskFactory
                 node,
                 speculative,
                 fragment,
-                tableCredentials,
+                tableCredentialSuppliers,
                 initialSplits,
                 outputBuffers,
                 partitionedSplitCountTracker,

--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTaskFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
 import io.opentelemetry.api.trace.Span;
@@ -39,7 +40,7 @@ public interface RemoteTaskFactory
             InternalNode node,
             boolean speculative,
             PlanFragment fragment,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials,
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,

--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.errorprone.annotations.ThreadSafe;
@@ -77,7 +78,7 @@ public final class SqlStage
 {
     private final Session session;
     private final StageStateMachine stateMachine;
-    private final Map<PlanNodeId, ConnectorTableCredentials> tableCredentials;
+    private final Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers;
     private final RemoteTaskFactory remoteTaskFactory;
     private final NodeTaskMap nodeTaskMap;
     private final boolean summarizeTaskInfo;
@@ -135,7 +136,7 @@ public final class SqlStage
                 nodeTaskMap,
                 summarizeTaskInfo,
                 bucketCountProvider,
-                extractTableCredentials(session, metadata, fragment));
+                extractTableCredentialSuppliers(session, metadata, fragment));
         sqlStage.initialize();
         return sqlStage;
     }
@@ -147,7 +148,7 @@ public final class SqlStage
             NodeTaskMap nodeTaskMap,
             boolean summarizeTaskInfo,
             LocalExchangeBucketCountProvider bucketCountProvider,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials)
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers)
     {
         this.session = requireNonNull(session, "session is null");
         this.stateMachine = stateMachine;
@@ -157,12 +158,12 @@ public final class SqlStage
         this.bucketCountProvider = requireNonNull(bucketCountProvider, "bucketCountProvider is null");
 
         this.outboundDynamicFilterIds = getOutboundDynamicFilters(stateMachine.getFragment());
-        this.tableCredentials = ImmutableMap.copyOf(tableCredentials);
+        this.tableCredentialSuppliers = ImmutableMap.copyOf(tableCredentialSuppliers);
     }
 
-    private static Map<PlanNodeId, ConnectorTableCredentials> extractTableCredentials(Session session, Metadata metadata, PlanFragment fragment)
+    private static Map<PlanNodeId, Supplier<ConnectorTableCredentials>> extractTableCredentialSuppliers(Session session, Metadata metadata, PlanFragment fragment)
     {
-        ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> tableCredentialsBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialsBuilder = ImmutableMap.builder();
         ConnectorTableCredentialsVisitor visitor = new ConnectorTableCredentialsVisitor(session, metadata, tableCredentialsBuilder);
         fragment.getRoot().accept(visitor, null);
         return tableCredentialsBuilder.buildOrThrow();
@@ -308,7 +309,7 @@ public final class SqlStage
                 node,
                 speculative,
                 fragment,
-                tableCredentials,
+                tableCredentialSuppliers,
                 splits,
                 outputBuffers,
                 nodeTaskMap.createPartitionedSplitCountTracker(node, taskId),
@@ -455,9 +456,9 @@ public final class SqlStage
     {
         private final Metadata metadata;
         private final Session session;
-        private final ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder;
+        private final ImmutableMap.Builder<PlanNodeId, Supplier<ConnectorTableCredentials>> builder;
 
-        public ConnectorTableCredentialsVisitor(Session session, Metadata metadata, ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder)
+        public ConnectorTableCredentialsVisitor(Session session, Metadata metadata, ImmutableMap.Builder<PlanNodeId, Supplier<ConnectorTableCredentials>> builder)
         {
             this.session = requireNonNull(session, "session is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
@@ -468,7 +469,7 @@ public final class SqlStage
         public Void visitMergeWriter(MergeWriterNode node, Void context)
         {
             TableWriterNode.MergeTarget target = node.getTarget();
-            extract(builder, node, metadata.getTableCredentials(session, target.getHandle().catalogHandle(), target.getHandle().connectorHandle()));
+            extract(builder, node, () -> metadata.getTableCredentials(session, target.getHandle().catalogHandle(), target.getHandle().connectorHandle()));
             return null;
         }
 
@@ -476,7 +477,7 @@ public final class SqlStage
         public Void visitTableExecute(TableExecuteNode node, Void context)
         {
             TableWriterNode.TableExecuteTarget target = node.getTarget();
-            extract(builder, node, metadata.getTableCredentials(session, target.getExecuteHandle().catalogHandle(), target.getExecuteHandle().connectorHandle()));
+            extract(builder, node, () -> metadata.getTableCredentials(session, target.getExecuteHandle().catalogHandle(), target.getExecuteHandle().connectorHandle()));
             return null;
         }
 
@@ -485,15 +486,15 @@ public final class SqlStage
         {
             switch (node.getTarget()) {
                 case TableWriterNode.MergeTarget mergeTarget ->
-                        extract(builder, node, metadata.getTableCredentials(session, mergeTarget.getHandle().catalogHandle(), mergeTarget.getHandle().connectorHandle()));
+                        extract(builder, node, () -> metadata.getTableCredentials(session, mergeTarget.getHandle().catalogHandle(), mergeTarget.getHandle().connectorHandle()));
                 case TableWriterNode.RefreshMaterializedViewTarget materializedViewTarget ->
-                        extract(builder, node, metadata.getTableCredentials(session, materializedViewTarget.getTableHandle().catalogHandle(), materializedViewTarget.getTableHandle().connectorHandle()));
+                        extract(builder, node, () -> metadata.getTableCredentials(session, materializedViewTarget.getTableHandle().catalogHandle(), materializedViewTarget.getTableHandle().connectorHandle()));
                 case TableWriterNode.TableExecuteTarget tableExecuteTarget ->
-                        extract(builder, node, metadata.getTableCredentials(session, tableExecuteTarget.getExecuteHandle().catalogHandle(), tableExecuteTarget.getExecuteHandle().connectorHandle()));
+                        extract(builder, node, () -> metadata.getTableCredentials(session, tableExecuteTarget.getExecuteHandle().catalogHandle(), tableExecuteTarget.getExecuteHandle().connectorHandle()));
                 case TableWriterNode.CreateTarget createTarget ->
-                        extract(builder, node, metadata.getTableCredentials(session, createTarget.getHandle().catalogHandle(), createTarget.getHandle().connectorHandle()));
+                        extract(builder, node, () -> metadata.getTableCredentials(session, createTarget.getHandle().catalogHandle(), createTarget.getHandle().connectorHandle()));
                 case TableWriterNode.InsertTarget insertTarget ->
-                        extract(builder, node, metadata.getTableCredentials(session, insertTarget.getHandle().catalogHandle(), insertTarget.getHandle().connectorHandle()));
+                        extract(builder, node, () -> metadata.getTableCredentials(session, insertTarget.getHandle().catalogHandle(), insertTarget.getHandle().connectorHandle()));
                 default -> throw new IllegalArgumentException("Unsupported table writer node: " + node.getClass().getSimpleName());
             }
             return null;
@@ -503,7 +504,7 @@ public final class SqlStage
         public Void visitTableScan(TableScanNode node, Void context)
         {
             TableHandle table = node.getTable();
-            extract(builder, node, metadata.getTableCredentials(session, table.catalogHandle(), table.connectorHandle()));
+            extract(builder, node, () -> metadata.getTableCredentials(session, table.catalogHandle(), table.connectorHandle()));
             return null;
         }
 
@@ -511,13 +512,15 @@ public final class SqlStage
         public Void visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
         {
             TableFunctionHandle handle = node.getHandle();
-            extract(builder, node, metadata.getTableCredentials(session, handle.catalogHandle(), handle.functionHandle()));
+            extract(builder, node, () -> metadata.getTableCredentials(session, handle.catalogHandle(), handle.functionHandle()));
             return null;
         }
 
-        private static void extract(ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder, PlanNode node, Optional<ConnectorTableCredentials> credentials)
+        private static void extract(ImmutableMap.Builder<PlanNodeId, Supplier<ConnectorTableCredentials>> builder, PlanNode node, Supplier<Optional<ConnectorTableCredentials>> credentialSupplier)
         {
-            credentials.ifPresent(connectorTableCredentials -> builder.put(node.getId(), connectorTableCredentials));
+            Optional<ConnectorTableCredentials> initial = credentialSupplier.get();
+            initial.ifPresent(credentials ->
+                    builder.put(node.getId(), () -> credentialSupplier.get().orElse(credentials)));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -539,6 +539,7 @@ public class SqlTask
             }
             // taskExecution can still be null if the creation was skipped
             if (taskExecution != null) {
+                taskExecution.getTaskContext().updateTableCredentials(tableCredentials);
                 taskExecution.getTaskContext().addDynamicFilter(dynamicFilterDomains);
                 taskExecution.addSplitAssignments(splitAssignments);
             }

--- a/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LeafTableFunctionOperator.java
@@ -147,7 +147,8 @@ public class LeafTableFunctionOperator
                 // ignore close exceptions, as this is a best-effort cleanup
             }
         }
-        this.processor = tableFunctionProvider.getSplitProcessor(session, functionHandle, tableCredentials, nextSplit);
+        Optional<ConnectorTableCredentials> freshCredentials = operatorContext.getDriverContext().getPipelineContext().getTaskContext().getTableCredentials(sourceId);
+        this.processor = tableFunctionProvider.getSplitProcessor(session, functionHandle, freshCredentials.or(() -> tableCredentials), nextSplit);
         this.processorFinishedSplit = false;
         this.processorBlocked = NOT_BLOCKED;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
@@ -79,7 +79,8 @@ public class MergeWriterOperator
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext context = driverContext.addOperatorContext(operatorId, planNodeId, MergeWriterOperator.class.getSimpleName());
-            ConnectorMergeSink mergeSink = pageSinkManager.createMergeSink(session, target.getMergeHandle().orElseThrow(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
+            Optional<ConnectorTableCredentials> freshCredentials = driverContext.getPipelineContext().getTaskContext().getTableCredentials(planNodeId);
+            ConnectorMergeSink mergeSink = pageSinkManager.createMergeSink(session, target.getMergeHandle().orElseThrow(), freshCredentials.or(() -> tableCredentials), PageSinkId.fromTaskId(driverContext.getTaskId()));
             return new MergeWriterOperator(context, mergeSink, pagePreprocessor);
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -449,6 +449,7 @@ public class ScanFilterAndProjectOperator
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> split)
         {
+            Optional<ConnectorTableCredentials> freshCredentials = operatorContext.getDriverContext().getPipelineContext().getTaskContext().getTableCredentials(sourceId);
             return new ScanFilterAndProjectOperator(
                     operatorContext.getSession(),
                     memoryTrackingContext,
@@ -457,7 +458,7 @@ public class ScanFilterAndProjectOperator
                     pageSourceProvider,
                     pageProcessor.apply(dynamicFilter),
                     table,
-                    tableCredentials,
+                    freshCredentials.or(() -> tableCredentials),
                     columns,
                     dynamicFilter,
                     types,

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -278,7 +278,8 @@ public class TableScanOperator
             if (!dynamicFilter.getCurrentPredicate().isAll()) {
                 operatorContext.recordDynamicFilterSplitProcessed(1L);
             }
-            source = pageSourceProvider.createPageSource(operatorContext.getSession(), split, table, tableCredentials, columns, dynamicFilter);
+            Optional<ConnectorTableCredentials> freshCredentials = operatorContext.getDriverContext().getPipelineContext().getTaskContext().getTableCredentials(sourceId);
+            source = pageSourceProvider.createPageSource(operatorContext.getSession(), split, table, freshCredentials.or(() -> tableCredentials), columns, dynamicFilter);
         }
 
         SourcePage sourcePage = source.getNextSourcePage();

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -139,17 +139,19 @@ public class TableWriterOperator
 
         private ConnectorPageSink createPageSink(DriverContext driverContext)
         {
+            Optional<ConnectorTableCredentials> freshCredentials = driverContext.getPipelineContext().getTaskContext().getTableCredentials(planNodeId);
+            Optional<ConnectorTableCredentials> credentials = freshCredentials.or(() -> tableCredentials);
             if (target instanceof CreateTarget createTarget) {
-                return pageSinkManager.createPageSink(session, createTarget.getHandle(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
+                return pageSinkManager.createPageSink(session, createTarget.getHandle(), credentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
             }
             if (target instanceof InsertTarget insertTarget) {
-                return pageSinkManager.createPageSink(session, insertTarget.getHandle(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
+                return pageSinkManager.createPageSink(session, insertTarget.getHandle(), credentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
             }
             if (target instanceof TableWriterNode.RefreshMaterializedViewTarget refreshMaterializedViewTarget) {
-                return pageSinkManager.createPageSink(session, refreshMaterializedViewTarget.getInsertHandle(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
+                return pageSinkManager.createPageSink(session, refreshMaterializedViewTarget.getInsertHandle(), credentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
             }
             if (target instanceof TableWriterNode.TableExecuteTarget tableExecuteTarget) {
-                return pageSinkManager.createPageSink(session, tableExecuteTarget.getExecuteHandle(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
+                return pageSinkManager.createPageSink(session, tableExecuteTarget.getExecuteHandle(), credentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
             }
             throw new UnsupportedOperationException("Unhandled target type: " + target.getClass().getName());
         }

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -71,7 +71,7 @@ public class TaskContext
 {
     private final QueryContext queryContext;
     private final TaskStateMachine taskStateMachine;
-    private final Map<PlanNodeId, ConnectorTableCredentials> tableCredentials;
+    private volatile Map<PlanNodeId, ConnectorTableCredentials> tableCredentials;
     private final GcMonitor gcMonitor;
     private final Executor notificationExecutor;
     private final ScheduledExecutorService yieldExecutor;
@@ -196,6 +196,11 @@ public class TaskContext
     public Optional<ConnectorTableCredentials> getTableCredentials(PlanNodeId planNodeId)
     {
         return Optional.ofNullable(tableCredentials.get(planNodeId));
+    }
+
+    public void updateTableCredentials(Map<PlanNodeId, ConnectorTableCredentials> tableCredentials)
+    {
+        this.tableCredentials = ImmutableMap.copyOf(tableCredentials);
     }
 
     public PipelineContext addPipelineContext(int pipelineId, boolean inputPipeline, boolean outputPipeline, boolean partitioned)

--- a/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import io.airlift.concurrent.BoundedExecutor;
@@ -143,7 +144,7 @@ public class HttpRemoteTaskFactory
             InternalNode node,
             boolean speculative,
             PlanFragment fragment,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials,
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
@@ -159,7 +160,7 @@ public class HttpRemoteTaskFactory
                 speculative,
                 locationFactory.createTaskLocation(node, taskId),
                 fragment,
-                tableCredentials,
+                tableCredentialSuppliers,
                 initialSplits,
                 outputBuffers,
                 httpClient,

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -146,7 +146,7 @@ public final class HttpRemoteTask
     private final String nodeId;
     private final AtomicBoolean speculative;
     private final PlanFragment planFragment;
-    private final Map<PlanNodeId, ConnectorTableCredentials> tableCredentials;
+    private final Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers;
 
     private final AtomicLong nextSplitId = new AtomicLong();
 
@@ -220,7 +220,7 @@ public final class HttpRemoteTask
             boolean speculative,
             URI location,
             PlanFragment planFragment,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials,
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             HttpClient httpClient,
@@ -250,7 +250,7 @@ public final class HttpRemoteTask
         requireNonNull(node, "node is null");
         requireNonNull(location, "location is null");
         requireNonNull(planFragment, "planFragment is null");
-        requireNonNull(tableCredentials, "tableCredentials is null");
+        requireNonNull(tableCredentialSuppliers, "tableCredentialSuppliers is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
         requireNonNull(httpClient, "httpClient is null");
         requireNonNull(executor, "executor is null");
@@ -269,7 +269,7 @@ public final class HttpRemoteTask
             this.nodeId = node.getNodeIdentifier();
             this.speculative = new AtomicBoolean(speculative);
             this.planFragment = planFragment;
-            this.tableCredentials = ImmutableMap.copyOf(tableCredentials);
+            this.tableCredentialSuppliers = ImmutableMap.copyOf(tableCredentialSuppliers);
             this.outputBuffers.set(outputBuffers);
             this.httpClient = httpClient;
             this.executor = executor;
@@ -733,6 +733,16 @@ public final class HttpRemoteTask
         return false;
     }
 
+    private Map<PlanNodeId, ConnectorTableCredentials> resolveTableCredentials()
+    {
+        ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder = ImmutableMap.builder();
+        for (Map.Entry<PlanNodeId, Supplier<ConnectorTableCredentials>> entry : tableCredentialSuppliers.entrySet()) {
+            Supplier<ConnectorTableCredentials> credentialSupplier = entry.getValue();
+            builder.put(entry.getKey(), credentialSupplier.get());
+        }
+        return builder.buildOrThrow();
+    }
+
     private void sendUpdate()
     {
         try {
@@ -773,7 +783,7 @@ public final class HttpRemoteTask
                 session.getIdentity().getExtraCredentials(),
                 stageSpan,
                 fragment,
-                tableCredentials,
+                resolveTableCredentials(),
                 splitAssignments,
                 outputBuffers.get(),
                 dynamicFilterDomains.getDynamicFilterDomains(),

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -163,7 +164,7 @@ public class MockRemoteTaskFactory
             InternalNode node,
             boolean speculative,
             PlanFragment fragment,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials,
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -78,7 +79,7 @@ public class TestingRemoteTaskFactory
             InternalNode node,
             boolean speculative,
             PlanFragment fragment,
-            Map<PlanNodeId, ConnectorTableCredentials> tableCredentials,
+            Map<PlanNodeId, Supplier<ConnectorTableCredentials>> tableCredentialSuppliers,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -13,12 +13,12 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.base.Suppliers;
 import com.google.common.base.VerifyException;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.concurrent.MoreFutures;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -34,7 +33,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.trino.cache.NonEvictableCache;
 import io.trino.filesystem.FileEntry;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
@@ -269,7 +267,6 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -280,8 +277,6 @@ import static com.google.common.collect.Iterables.size;
 import static com.google.common.collect.Maps.transformValues;
 import static com.google.common.collect.Sets.difference;
 import static io.airlift.units.Duration.ZERO;
-import static io.trino.cache.CacheUtils.uncheckedCacheGet;
-import static io.trino.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.filesystem.Locations.isS3Tables;
 import static io.trino.plugin.base.filter.UtcConstraintExtractor.extractTupleDomain;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
@@ -524,7 +519,6 @@ public class IcebergMetadata
     private static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
     // Value should be ISO-8601 formatted time instant
     private static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
-
     private final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
     private final TrinoCatalog catalog;
@@ -541,7 +535,9 @@ public class IcebergMetadata
     private final int materializedViewRefreshMaxSnapshotsToExpire;
     private final Duration materializedViewRefreshSnapshotRetentionPeriod;
     private final Map<IcebergTableHandle, AtomicReference<TableStatistics>> tableStatisticsCache = new ConcurrentHashMap<>();
-    private final NonEvictableCache<SchemaTableName, IcebergTableCredentials> tableCredentialsCache;
+    // Unbounded ConcurrentHashMap is acceptable here: IcebergMetadata is per-query,
+    // so entries only accumulate for tables accessed within a single query lifetime.
+    private final ConcurrentHashMap<SchemaTableName, IcebergTableCredentials> tableCredentialsCache = new ConcurrentHashMap<>();
     private final DeletionVectorWriter deletionVectorWriter;
 
     private Transaction transaction;
@@ -581,7 +577,6 @@ public class IcebergMetadata
         this.deletionVectorWriter = requireNonNull(deletionVectorWriter, "deletionVectorWriter is null");
         this.materializedViewRefreshMaxSnapshotsToExpire = materializedViewRefreshMaxSnapshotsToExpire;
         this.materializedViewRefreshSnapshotRetentionPeriod = materializedViewRefreshSnapshotRetentionPeriod;
-        this.tableCredentialsCache = buildNonEvictableCache(CacheBuilder.newBuilder());
     }
 
     @Override
@@ -605,18 +600,49 @@ public class IcebergMetadata
     private Optional<ConnectorTableCredentials> getOrLoadTableCredentials(ConnectorSession session, SchemaTableName schemaTableName)
     {
         try {
-            return Optional.of(uncheckedCacheGet(
-                tableCredentialsCache,
-                schemaTableName,
-                () -> {
-                    BaseTable baseTable = catalog.loadTable(session, schemaTableName);
-                    return new IcebergTableCredentials(baseTable.io().properties());
-                }));
+            // Check if existing cached entry is still fresh (per-entry expiry).
+            // Each IcebergTableCredentials carries its own expiresAt, so entries with
+            // different token lifetimes are handled correctly without a cache-wide static TTL.
+            IcebergTableCredentials cached = tableCredentialsCache.get(schemaTableName);
+            if (cached != null && !cached.shouldRefresh()) {
+                return Optional.of(cached);
+            }
+            // When refreshing an expired entry, invalidate the catalog-level table cache
+            // so loadTable() fetches a fresh BaseTable with updated vended credentials.
+            // Skip invalidation on initial load — the catalog cache already has the table.
+            if (cached != null) {
+                catalog.invalidateTableCache(schemaTableName);
+            }
+            IcebergTableCredentials fresh = loadTableCredentials(session, schemaTableName);
+            if (cached != null) {
+                tableCredentialsCache.replace(schemaTableName, cached, fresh);
+            }
+            else {
+                tableCredentialsCache.putIfAbsent(schemaTableName, fresh);
+            }
+            return Optional.of(fresh);
         }
-        catch (UncheckedExecutionException e) {
-            throwIfUnchecked(e.getCause());
-            throw e;
+        catch (TableNotFoundException e) {
+            // Table may not exist yet (e.g. during CREATE TABLE AS SELECT);
+            // no credentials to vend in that case.
+            return Optional.empty();
         }
+    }
+
+    private IcebergTableCredentials loadTableCredentials(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        BaseTable baseTable = catalog.loadTable(session, schemaTableName);
+        return IcebergTableCredentials.forFileIO(baseTable.io());
+    }
+
+    @VisibleForTesting
+    public void invalidateTableCredentialsCache()
+    {
+        // Replace each entry with an immediately-expired copy so the next
+        // getOrLoadTableCredentials() call sees cached != null with shouldRefresh() == true,
+        // triggering catalog cache invalidation and a fresh credential fetch.
+        tableCredentialsCache.replaceAll((_, value) ->
+                new IcebergTableCredentials(value.fileIoProperties(), Optional.of(Instant.EPOCH)));
     }
 
     private static SchemaTableName getSchemaTableName(ConnectorTableHandle tableHandle)
@@ -627,14 +653,6 @@ public class IcebergMetadata
         throw new IllegalArgumentException("Unsupported ConnectorTableHandle type: " + tableHandle.getClass().getName());
     }
 
-    private static SchemaTableName getSchemaTableName(ConnectorTableFunctionHandle tableFunctionHandle)
-    {
-        if (tableFunctionHandle instanceof TableChangesFunctionHandle handle) {
-            return handle.schemaTableName();
-        }
-        throw new IllegalArgumentException("Unsupported ConnectorTableFunctionHandle type: " + tableFunctionHandle.getClass().getName());
-    }
-
     private static SchemaTableName getSchemaTableName(ConnectorWritableTableHandle tableHandle)
     {
         return switch (tableHandle) {
@@ -642,6 +660,14 @@ public class IcebergMetadata
             case IcebergWritableTableHandle handle -> handle.name();
             default -> throw new IllegalArgumentException("Unsupported ConnectorWritableTableHandle type: " + tableHandle.getClass().getName());
         };
+    }
+
+    private static SchemaTableName getSchemaTableName(ConnectorTableFunctionHandle tableFunctionHandle)
+    {
+        if (tableFunctionHandle instanceof TableChangesFunctionHandle handle) {
+            return handle.schemaTableName();
+        }
+        throw new IllegalArgumentException("Unsupported ConnectorTableFunctionHandle type: " + tableFunctionHandle.getClass().getName());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentials.java
@@ -15,20 +15,93 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ConnectorTableCredentials;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.FileIO;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
 
-public record IcebergTableCredentials(Map<String, String> fileIoProperties)
+import static java.util.Objects.requireNonNull;
+
+public record IcebergTableCredentials(Map<String, String> fileIoProperties, Optional<Instant> expiresAt)
         implements ConnectorTableCredentials
 {
+    // S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS is package-private in Iceberg,
+    // so we duplicate the string here. See apache/iceberg#11389.
+    private static final String S3_SESSION_TOKEN_EXPIRES_AT_MS = "s3.session-token-expires-at-ms";
+    // Default credential TTL when vended credentials are present but no expiry timestamp
+    // property is found. Matches the default AWS STS session token lifetime (1 hour).
+    private static final long DEFAULT_CREDENTIAL_TTL_MINUTES = 60;
+    // Prefetch buffer before credential expiry, matching Iceberg's VendedCredentialsProvider pattern.
+    private static final long PREFETCH_BUFFER_MINUTES = 5;
+
     public IcebergTableCredentials
     {
         fileIoProperties = ImmutableMap.copyOf(fileIoProperties);
+        requireNonNull(expiresAt, "expiresAt is null");
+    }
+
+    public boolean shouldRefresh()
+    {
+        return expiresAt.map(expiry -> Instant.now().isAfter(expiry)).orElse(false);
     }
 
     public static IcebergTableCredentials forFileIO(FileIO io)
     {
-        return new IcebergTableCredentials(io.properties());
+        return forProperties(io.properties());
+    }
+
+    static IcebergTableCredentials forProperties(Map<String, String> properties)
+    {
+        // Only compute an expiry when actual vended credentials are present.
+        // Empty expiresAt means credentials never expire, so catalogs that do not vend
+        // credentials are unaffected even if getTableCredentials() is called.
+        if (!hasVendedCredentials(properties)) {
+            return new IcebergTableCredentials(properties, Optional.empty());
+        }
+        // Extract the actual credential expiry from the properties, following the pattern in
+        // Iceberg's VendedCredentialsProvider (apache/iceberg#11389, #11577, #11282).
+        // Prefetch PREFETCH_BUFFER_MINUTES before actual expiry so shouldRefresh() triggers
+        // proactive refresh on lazy access (CachingKerberosAuthentication pattern).
+        OptionalLong expiresAtMs = extractExpiresAtMs(properties);
+        Instant expiresAt = expiresAtMs.isPresent()
+                ? Instant.ofEpochMilli(expiresAtMs.getAsLong()).minus(PREFETCH_BUFFER_MINUTES, ChronoUnit.MINUTES)
+                : Instant.now().plus(DEFAULT_CREDENTIAL_TTL_MINUTES - PREFETCH_BUFFER_MINUTES, ChronoUnit.MINUTES);
+        return new IcebergTableCredentials(properties, Optional.of(expiresAt));
+    }
+
+    private static OptionalLong extractExpiresAtMs(Map<String, String> properties)
+    {
+        // S3: s3.session-token-expires-at-ms (apache/iceberg#11389)
+        String s3Expiry = properties.get(S3_SESSION_TOKEN_EXPIRES_AT_MS);
+        if (s3Expiry != null) {
+            return OptionalLong.of(Long.parseLong(s3Expiry));
+        }
+        // GCS: gcs.oauth2.token-expires-at (apache/iceberg#11282)
+        String gcsExpiry = properties.get(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT);
+        if (gcsExpiry != null) {
+            return OptionalLong.of(Long.parseLong(gcsExpiry));
+        }
+        // Azure: adls.sas-token-expires-at-ms.<account> — use earliest expiry across all accounts
+        OptionalLong azureExpiry = properties.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX))
+                .mapToLong(entry -> Long.parseLong(entry.getValue()))
+                .min();
+        if (azureExpiry.isPresent()) {
+            return azureExpiry;
+        }
+        return OptionalLong.empty();
+    }
+
+    private static boolean hasVendedCredentials(Map<String, String> properties)
+    {
+        return properties.containsKey(S3FileIOProperties.ACCESS_KEY_ID) ||
+                properties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN) ||
+                properties.keySet().stream().anyMatch(key -> key.startsWith(AzureProperties.ADLS_SAS_TOKEN_PREFIX));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -507,5 +507,6 @@ public abstract class AbstractTrinoCatalog
                 .buildOrThrow();
     }
 
-    protected abstract void invalidateTableCache(SchemaTableName schemaTableName);
+    @Override
+    public abstract void invalidateTableCache(SchemaTableName schemaTableName);
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -151,6 +151,17 @@ public interface TrinoCatalog
     BaseTable loadTable(ConnectorSession session, SchemaTableName schemaTableName);
 
     /**
+     * Invalidate any catalog-level cache entry for the given table, so that
+     * a subsequent {@link #loadTable} call fetches a fresh instance from the
+     * underlying catalog. The default implementation is a no-op for catalogs
+     * that do not maintain a per-query table cache.
+     */
+    default void invalidateTableCache(SchemaTableName schemaTableName)
+    {
+        // no-op by default
+    }
+
+    /**
      * Bulk load column metadata. The returned map may contain fewer entries then asked for.
      */
     Map<SchemaTableName, List<ColumnMetadata>> tryGetColumnMetadata(ConnectorSession session, List<SchemaTableName> tables);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -1456,7 +1456,7 @@ public class TrinoGlueCatalog
     }
 
     @Override
-    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    public void invalidateTableCache(SchemaTableName schemaTableName)
     {
         tableMetadataCache.invalidate(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -890,7 +890,7 @@ public class TrinoHiveCatalog
     }
 
     @Override
-    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    public void invalidateTableCache(SchemaTableName schemaTableName)
     {
         tableMetadataCache.invalidate(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -625,7 +625,7 @@ public class TrinoJdbcCatalog
     }
 
     @Override
-    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    public void invalidateTableCache(SchemaTableName schemaTableName)
     {
         tableMetadataCache.invalidate(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -455,7 +455,7 @@ public class TrinoNessieCatalog
     }
 
     @Override
-    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    public void invalidateTableCache(SchemaTableName schemaTableName)
     {
         tableMetadataCache.invalidate(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -911,7 +911,8 @@ public class TrinoRestCatalog
         };
     }
 
-    private void invalidateTableCache(SchemaTableName schemaTableName)
+    @Override
+    public void invalidateTableCache(SchemaTableName schemaTableName)
     {
         tableCache.invalidate(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/snowflake/TrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/snowflake/TrinoSnowflakeCatalog.java
@@ -419,7 +419,7 @@ public class TrinoSnowflakeCatalog
     }
 
     @Override
-    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    public void invalidateTableCache(SchemaTableName schemaTableName)
     {
         tableMetadataCache.invalidate(schemaTableName);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableCredentials.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableCredentials.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestIcebergTableCredentials
+{
+    @Test
+    void testNoVendedCredentials()
+    {
+        Map<String, String> properties = ImmutableMap.of("warehouse", "s3://bucket/path");
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        assertThat(credentials.expiresAt()).isEmpty();
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testS3VendedCredentialsWithExpiry()
+    {
+        Instant actualExpiry = Instant.now().plus(Duration.ofMinutes(30));
+        Map<String, String> properties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "FAKE_ACCESS_KEY",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "FAKE_SECRET_KEY",
+                S3FileIOProperties.SESSION_TOKEN, "FAKE_SESSION_TOKEN",
+                "s3.session-token-expires-at-ms", Long.toString(actualExpiry.toEpochMilli()));
+
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        // expiresAt should be 5 minutes before the actual expiry (prefetch buffer)
+        assertThat(credentials.expiresAt()).isPresent();
+        assertThat(credentials.expiresAt().get()).isBefore(actualExpiry);
+        assertThat(credentials.expiresAt().get()).isAfter(Instant.now().plus(Duration.ofMinutes(20)));
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testS3VendedCredentialsWithoutExpiry()
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "FAKE_ACCESS_KEY",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "FAKE_SECRET_KEY",
+                S3FileIOProperties.SESSION_TOKEN, "FAKE_SESSION_TOKEN");
+
+        Instant before = Instant.now();
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+        Instant after = Instant.now();
+
+        // Falls back to default TTL (60 min) minus prefetch buffer (5 min) = ~55 minutes
+        assertThat(credentials.expiresAt()).isPresent();
+        assertThat(credentials.expiresAt().get()).isAfter(before.plus(Duration.ofMinutes(54)));
+        assertThat(credentials.expiresAt().get()).isBefore(after.plus(Duration.ofMinutes(56)));
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testGcsVendedCredentialsWithExpiry()
+    {
+        Instant actualExpiry = Instant.now().plus(Duration.ofMinutes(45));
+        Map<String, String> properties = ImmutableMap.of(
+                GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token",
+                GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(actualExpiry.toEpochMilli()));
+
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        assertThat(credentials.expiresAt()).isPresent();
+        assertThat(credentials.expiresAt().get()).isBefore(actualExpiry);
+        assertThat(credentials.expiresAt().get()).isAfter(Instant.now().plus(Duration.ofMinutes(35)));
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testGcsVendedCredentialsWithoutExpiry()
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token");
+
+        Instant before = Instant.now();
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        assertThat(credentials.expiresAt()).isPresent();
+        assertThat(credentials.expiresAt().get()).isAfter(before.plus(Duration.ofMinutes(54)));
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testFileIoPropertiesPreservedThroughForProperties()
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "FAKE_KEY",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "FAKE_SECRET",
+                S3FileIOProperties.SESSION_TOKEN, "FAKE_TOKEN",
+                "s3.session-token-expires-at-ms", Long.toString(Instant.now().plus(Duration.ofMinutes(30)).toEpochMilli()),
+                "s3.endpoint", "https://s3.example.com");
+
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        assertThat(credentials.fileIoProperties()).containsAllEntriesOf(properties);
+        assertThat(credentials.fileIoProperties()).hasSize(properties.size());
+    }
+
+    @Test
+    void testS3ExpiryPrefetchBufferIsExactlyFiveMinutes()
+    {
+        Instant actualExpiry = Instant.ofEpochMilli(Instant.now().plus(Duration.ofMinutes(30)).toEpochMilli());
+        Map<String, String> properties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "KEY",
+                "s3.session-token-expires-at-ms", Long.toString(actualExpiry.toEpochMilli()));
+
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        Instant expected = actualExpiry.minus(Duration.ofMinutes(5));
+        assertThat(credentials.expiresAt()).isEqualTo(Optional.of(expected));
+    }
+
+    @Test
+    void testShouldRefreshWithExpiredCredentials()
+    {
+        IcebergTableCredentials expired = new IcebergTableCredentials(
+                ImmutableMap.of(S3FileIOProperties.ACCESS_KEY_ID, "expired-key"),
+                Optional.of(Instant.now().minus(Duration.ofMinutes(1))));
+
+        assertThat(expired.shouldRefresh()).isTrue();
+    }
+
+    @Test
+    void testShouldRefreshWithFreshCredentials()
+    {
+        IcebergTableCredentials fresh = new IcebergTableCredentials(
+                ImmutableMap.of(S3FileIOProperties.ACCESS_KEY_ID, "fresh-key"),
+                Optional.of(Instant.now().plus(Duration.ofMinutes(25))));
+
+        assertThat(fresh.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testShouldRefreshWithEmptyExpiry()
+    {
+        IcebergTableCredentials nonVended = new IcebergTableCredentials(
+                ImmutableMap.of("warehouse", "s3://bucket"),
+                Optional.empty());
+
+        assertThat(nonVended.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testAzureVendedCredentialsWithExpiry()
+    {
+        Instant actualExpiry = Instant.now().plus(Duration.ofMinutes(40));
+        Map<String, String> properties = ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + "mystorageaccount", Long.toString(actualExpiry.toEpochMilli()));
+
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        assertThat(credentials.expiresAt()).isPresent();
+        assertThat(credentials.expiresAt().get()).isBefore(actualExpiry);
+        assertThat(credentials.expiresAt().get()).isAfter(Instant.now().plus(Duration.ofMinutes(30)));
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testAzureVendedCredentialsWithoutExpiry()
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
+
+        Instant before = Instant.now();
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        assertThat(credentials.expiresAt()).isPresent();
+        assertThat(credentials.expiresAt().get()).isAfter(before.plus(Duration.ofMinutes(54)));
+        assertThat(credentials.shouldRefresh()).isFalse();
+    }
+
+    @Test
+    void testAzureMultipleAccountsUsesEarliestExpiry()
+    {
+        Instant earlierExpiry = Instant.ofEpochMilli(Instant.now().plus(Duration.ofMinutes(20)).toEpochMilli());
+        Instant laterExpiry = Instant.ofEpochMilli(Instant.now().plus(Duration.ofMinutes(50)).toEpochMilli());
+        Map<String, String> properties = ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account1", "sas-token-1",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + "account1", Long.toString(earlierExpiry.toEpochMilli()),
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account2", "sas-token-2",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + "account2", Long.toString(laterExpiry.toEpochMilli()));
+
+        IcebergTableCredentials credentials = IcebergTableCredentials.forProperties(properties);
+
+        // Should use the earliest expiry (account1) minus prefetch buffer
+        assertThat(credentials.expiresAt()).isPresent();
+        Instant expected = earlierExpiry.minus(Duration.ofMinutes(5));
+        assertThat(credentials.expiresAt().get()).isEqualTo(expected);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergMetadataCredentialCacheWithRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergMetadataCredentialCacheWithRestCatalog.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.cache.EvictableCacheBuilder;
+import io.trino.plugin.hive.orc.OrcReaderConfig;
+import io.trino.plugin.hive.orc.OrcWriterConfig;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.plugin.hive.parquet.ParquetWriterConfig;
+import io.trino.plugin.iceberg.CommitTaskData;
+import io.trino.plugin.iceberg.DefaultIcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergConfig;
+import io.trino.plugin.iceberg.IcebergMetadata;
+import io.trino.plugin.iceberg.IcebergSessionProperties;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
+import io.trino.plugin.iceberg.TableStatisticsWriter;
+import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.Security;
+import io.trino.spi.NodeVersion;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.PrincipalType;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.testing.TestingConnectorSession;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.CredentialVendingRESTCatalogAdapter;
+import org.apache.iceberg.rest.CredentialVendingRESTCatalogAdapter.Bundle;
+import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.units.Duration.ZERO;
+import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.plugin.iceberg.IcebergTestUtils.TABLE_STATISTICS_READER;
+import static io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType.NONE;
+import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
+import static io.trino.plugin.iceberg.delete.DeletionVectorWriter.UNSUPPORTED_DELETION_VECTOR_WRITER;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+/**
+ * End-to-end test for the coordinator's evictable {@code tableCredentialsCache} in {@link IcebergMetadata},
+ * using a {@link CredentialVendingRESTCatalogAdapter} that injects fake S3 vended credentials into
+ * every {@code loadTable} REST response. Each call returns a unique access key, so the test can
+ * verify that cache eviction triggers a genuine re-fetch from the REST catalog.
+ * <p>
+ * This validates the full credential flow:
+ * REST catalog (RESTCatalogAdapter) → TrinoRestCatalog → IcebergMetadata.getTableCredentials()
+ * <p>
+ * The evictable coordinator cache is the primary mechanism for credential refresh: when the cache
+ * TTL expires, the next {@code getTableCredentials()} call transparently re-fetches fresh credentials.
+ * The coordinator uses {@code Supplier}-based credential resolution (via {@code SqlStage}) so that
+ * every task update receives the latest credentials.
+ */
+@TestInstance(PER_CLASS)
+class TestIcebergMetadataCredentialCacheWithRestCatalog
+{
+    private static final String NAMESPACE = "test_ns_" + randomNameSuffix();
+    private static final String TABLE_NAME = "test_table_" + randomNameSuffix();
+    private static final SchemaTableName SCHEMA_TABLE = new SchemaTableName(NAMESPACE, TABLE_NAME);
+    private static final ConnectorSession SESSION = TestingConnectorSession.builder()
+            .setPropertyMetadata(new IcebergSessionProperties(
+                    new IcebergConfig(),
+                    new OrcReaderConfig(),
+                    new OrcWriterConfig(),
+                    new ParquetReaderConfig(),
+                    new ParquetWriterConfig())
+                    .getSessionProperties())
+            .build();
+
+    private Path warehouseLocation;
+    private DelegatingRestSessionCatalog restSessionCatalog;
+    private CredentialVendingRESTCatalogAdapter vendingAdapter;
+    private TrinoRestCatalog trinoCatalog;
+
+    @BeforeAll
+    void setUp()
+            throws IOException
+    {
+        warehouseLocation = Files.createTempDirectory("iceberg-credential-cache-test");
+        warehouseLocation.toFile().deleteOnExit();
+
+        Catalog backendCatalog = backendCatalog(warehouseLocation);
+        Bundle bundle = CredentialVendingRESTCatalogAdapter.createBundle(backendCatalog);
+        restSessionCatalog = bundle.catalog();
+        vendingAdapter = bundle.adapter();
+        restSessionCatalog.initialize("test_catalog", ImmutableMap.of());
+
+        trinoCatalog = new TrinoRestCatalog(
+                new DefaultIcebergFileSystemFactory(HDFS_FILE_SYSTEM_FACTORY),
+                restSessionCatalog,
+                new CatalogName("test_catalog"),
+                Security.NONE,
+                NONE,
+                ImmutableMap.of(),
+                false,
+                "test",
+                TESTING_TYPE_MANAGER,
+                false,
+                false,
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
+                true);
+
+        trinoCatalog.createNamespace(SESSION, NAMESPACE, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+        String tableLocation = warehouseLocation.resolve("iceberg_data").resolve(NAMESPACE).resolve(TABLE_NAME).toFile().getAbsolutePath();
+        trinoCatalog.newCreateTableTransaction(
+                        SESSION,
+                        SCHEMA_TABLE,
+                        new Schema(Types.NestedField.required(1, "id", Types.LongType.get())),
+                        PartitionSpec.unpartitioned(),
+                        SortOrder.unsorted(),
+                        Optional.of(tableLocation),
+                        ImmutableMap.of())
+                .commitTransaction();
+    }
+
+    @AfterAll
+    void tearDown()
+            throws Exception
+    {
+        if (restSessionCatalog != null) {
+            restSessionCatalog.close();
+        }
+    }
+
+    @Test
+    void testVendedCredentialsFlowThroughRestCatalog()
+    {
+        ConnectorMetadata metadata = createIcebergMetadata();
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, SCHEMA_TABLE, Optional.empty(), Optional.empty());
+        assertThat(tableHandle).isNotNull();
+
+        Optional<ConnectorTableCredentials> credentials = metadata.getTableCredentials(SESSION, tableHandle);
+        assertThat(credentials).isPresent();
+        assertThat(credentials.get()).isInstanceOf(IcebergTableCredentials.class);
+
+        IcebergTableCredentials icebergCredentials = (IcebergTableCredentials) credentials.get();
+        // Verify vended S3 credentials flowed through the REST → Trino pipeline
+        assertThat(icebergCredentials.fileIoProperties()).containsKey("s3.access-key-id");
+        assertThat(icebergCredentials.fileIoProperties().get("s3.access-key-id")).startsWith("FAKE_ACCESS_KEY_");
+        assertThat(icebergCredentials.fileIoProperties()).containsKey("s3.secret-access-key");
+        assertThat(icebergCredentials.fileIoProperties()).containsKey("s3.session-token");
+        // Because S3 credentials are present, expiresAt should be present (not empty)
+        assertThat(icebergCredentials.expiresAt()).isPresent();
+        // The adapter was called at least once (during setUp or this test)
+        assertThat(vendingAdapter.getLoadTableCount()).isGreaterThan(0);
+    }
+
+    @Test
+    void testCredentialsAreCachedAcrossMultipleCalls()
+    {
+        ConnectorMetadata metadata = createIcebergMetadata();
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, SCHEMA_TABLE, Optional.empty(), Optional.empty());
+        assertThat(tableHandle).isNotNull();
+
+        Optional<ConnectorTableCredentials> first = metadata.getTableCredentials(SESSION, tableHandle);
+        Optional<ConnectorTableCredentials> second = metadata.getTableCredentials(SESSION, tableHandle);
+
+        assertThat(first).isPresent();
+        assertThat(second).isPresent();
+        // Same cached object from IcebergMetadata.tableCredentialsCache — no re-fetch
+        assertThat(first.get()).isSameAs(second.get());
+    }
+
+    @Test
+    void testExpiredEntryTriggersRefreshWithNewCredentials()
+    {
+        IcebergMetadata metadata = createIcebergMetadata();
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, SCHEMA_TABLE, Optional.empty(), Optional.empty());
+        assertThat(tableHandle).isNotNull();
+
+        Optional<ConnectorTableCredentials> first = metadata.getTableCredentials(SESSION, tableHandle);
+        assertThat(first).isPresent();
+        IcebergTableCredentials firstCredentials = (IcebergTableCredentials) first.get();
+        String firstAccessKey = firstCredentials.fileIoProperties().get("s3.access-key-id");
+        int loadsAfterFirst = vendingAdapter.getLoadTableCount();
+
+        // Mark all cached credentials as expired to simulate token expiry.
+        // getOrLoadTableCredentials() detects cached != null with shouldRefresh() == true,
+        // invalidates TrinoRestCatalog.tableCache, and re-fetches via a fresh REST call.
+        metadata.invalidateTableCredentialsCache();
+
+        Optional<ConnectorTableCredentials> second = metadata.getTableCredentials(SESSION, tableHandle);
+        assertThat(second).isPresent();
+        IcebergTableCredentials secondCredentials = (IcebergTableCredentials) second.get();
+        String secondAccessKey = secondCredentials.fileIoProperties().get("s3.access-key-id");
+
+        // After per-entry expiry: different credential instance with a new access key from a fresh REST call
+        assertThat(first.get()).isNotSameAs(second.get());
+        assertThat(secondAccessKey).isNotEqualTo(firstAccessKey);
+        assertThat(vendingAdapter.getLoadTableCount()).isGreaterThan(loadsAfterFirst);
+    }
+
+    @Test
+    void testShouldRefreshEnabledForVendedCredentials()
+    {
+        ConnectorMetadata metadata = createIcebergMetadata();
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, SCHEMA_TABLE, Optional.empty(), Optional.empty());
+        assertThat(tableHandle).isNotNull();
+
+        Optional<ConnectorTableCredentials> credentials = metadata.getTableCredentials(SESSION, tableHandle);
+        assertThat(credentials).isPresent();
+
+        IcebergTableCredentials icebergCredentials = (IcebergTableCredentials) credentials.get();
+        // Freshly fetched credentials should NOT need refresh yet (they were just created)
+        assertThat(icebergCredentials.shouldRefresh()).isFalse();
+        // expiresAt is present because S3 credentials are vended
+        assertThat(icebergCredentials.expiresAt()).isPresent();
+        assertThat(icebergCredentials.expiresAt().get()).isAfter(Instant.now());
+    }
+
+    private IcebergMetadata createIcebergMetadata()
+    {
+        return new IcebergMetadata(
+                PLANNER_CONTEXT.getTypeManager(),
+                jsonCodec(CommitTaskData.class),
+                trinoCatalog,
+                (connectorIdentity, fileIoProperties) -> {
+                    throw new UnsupportedOperationException();
+                },
+                TABLE_STATISTICS_READER,
+                new TableStatisticsWriter(new NodeVersion("test-version")),
+                UNSUPPORTED_DELETION_VECTOR_WRITER,
+                Optional.empty(),
+                false,
+                _ -> false,
+                newDirectExecutorService(),
+                directExecutor(),
+                newDirectExecutorService(),
+                newDirectExecutorService(),
+                0,
+                ZERO);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/CredentialVendingRESTCatalogAdapter.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/CredentialVendingRESTCatalogAdapter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.rest;
+
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A test adapter that wraps {@link RESTCatalogAdapter} and injects fake S3 vended credentials
+ * into every {@link LoadTableResponse}. Each call receives a unique access key so tests can
+ * verify that a cache miss triggers a genuine re-fetch.
+ * <p>
+ * This lives in the {@code org.apache.iceberg.rest} package so it can access the
+ * package-private {@link DelegatingRestSessionCatalog} constructor.
+ */
+public class CredentialVendingRESTCatalogAdapter
+        extends RESTCatalogAdapter
+{
+    private final AtomicInteger loadTableCount = new AtomicInteger();
+
+    public CredentialVendingRESTCatalogAdapter(Catalog delegate)
+    {
+        super(delegate);
+    }
+
+    public int getLoadTableCount()
+    {
+        return loadTableCount.get();
+    }
+
+    @Override
+    protected <T extends RESTResponse> T execute(
+            HTTPRequest request,
+            Class<T> responseType,
+            Consumer<ErrorResponse> errorHandler,
+            Consumer<Map<String, String>> responseHeaders)
+    {
+        T response = super.execute(request, responseType, errorHandler, responseHeaders);
+        if (response instanceof LoadTableResponse loadTableResponse) {
+            int count = loadTableCount.incrementAndGet();
+            TableMetadata metadata = loadTableResponse.tableMetadata();
+            LoadTableResponse modified = LoadTableResponse.builder()
+                    .withTableMetadata(metadata)
+                    .addAllConfig(loadTableResponse.config())
+                    .addConfig("s3.access-key-id", "FAKE_ACCESS_KEY_" + count)
+                    .addConfig("s3.secret-access-key", "FAKE_SECRET_KEY_" + count)
+                    .addConfig("s3.session-token", "FAKE_SESSION_TOKEN_" + count)
+                    .addConfig("s3.session-token-expires-at-ms", Long.toString(Instant.now().plus(30, ChronoUnit.MINUTES).toEpochMilli()))
+                    .build();
+            return responseType.cast(modified);
+        }
+        return response;
+    }
+
+    /**
+     * Creates a {@link DelegatingRestSessionCatalog} backed by this credential-vending adapter.
+     */
+    public static Bundle createBundle(Catalog delegate)
+    {
+        requireNonNull(delegate, "delegate is null");
+        CredentialVendingRESTCatalogAdapter adapter = new CredentialVendingRESTCatalogAdapter(delegate);
+        DelegatingRestSessionCatalog catalog = new DelegatingRestSessionCatalog(adapter, delegate);
+        return new Bundle(catalog, adapter);
+    }
+
+    public record Bundle(DelegatingRestSessionCatalog catalog, CredentialVendingRESTCatalogAdapter adapter) {}
+}


### PR DESCRIPTION
# Refresh vended credentials during long-running Iceberg REST catalog queries

## Problem

When a query against an Iceberg REST catalog exceeds the STS token lifetime (typically 30–60 minutes), workers fail with `ICEBERG_CURSOR_ERROR` because the vended credentials (S3 access key, secret key, session token) have expired:

```
Query failed: com.amazonaws.services.s3.model.AmazonS3Exception:
  The provided token has expired. (Service: Amazon S3; Status Code: 400)
```

This affects any long-running workload: large table scans over hundreds of partitions, `INSERT INTO ... SELECT` with expensive transformations, multi-table JOINs, and ETL jobs running 30–60+ minutes.

The root cause is that `SqlStage.extractTableCredentials()` fetches credentials **once at stage creation** and freezes them into an `ImmutableMap` shared across all tasks in that stage. Later tasks reuse the same stale snapshot — the coordinator never re-fetches for already-dispatched stages.

## Solution

Three-layer fix: coordinator cache → transport refresh → worker-side update.

### 1. Coordinator cache (`IcebergMetadata`)

`tableCredentialsCache` (`ConcurrentHashMap`) stores `IcebergTableCredentials` per table. Each entry carries its own `Optional<Instant> expiresAt` derived from the vended token's expiry property (S3, GCS, or Azure). On access, `shouldRefresh()` checks if the entry is within 5 minutes of expiry and reloads from the catalog if needed. Updates use `ConcurrentMap.replace(K, old, new)` for atomic swap.

`TableNotFoundException` during `CREATE TABLE AS SELECT` returns empty credentials instead of failing — the table doesn't exist yet.

### 2. Coordinator → Worker transport (`SqlStage` / `HttpRemoteTask`)

Changed `SqlStage.extractTableCredentials()` from returning a resolved `ImmutableMap<PlanNodeId, ConnectorTableCredentials>` to `extractTableCredentialSuppliers()` returning `Map<PlanNodeId, Supplier<ConnectorTableCredentials>>`. Each supplier calls back into `IcebergMetadata.getOrLoadTableCredentials()`.

`HttpRemoteTask` stores these suppliers and calls `resolveTableCredentials()` on **every** `sendUpdate()`, so each `TaskUpdateRequest` carries the freshest credentials available.

### 3. Worker-side update (`TaskContext` / Operators)

`TaskContext.tableCredentials` changed from `final ImmutableMap` to `volatile` with an `updateTableCredentials()` method. `SqlTask.updateTask()` calls it on every incoming `TaskUpdateRequest` — credentials are updated before splits or dynamic filters are processed.

All five credential-consuming operators re-read from `TaskContext` at the point of use instead of relying on captured fields:

- `TableScanOperator.getOutput()` — per-split, when creating page source
- `ScanFilterAndProjectOperatorFactory.create()` — per-driver creation
- `TableWriterOperator.createPageSink()` — when creating page sink
- `MergeWriterOperator.createOperator()` — when creating merge sink
- `LeafTableFunctionOperator.resetProcessor()` — per-split

Pattern: `freshCredentials.or(() -> tableCredentials)` — reads from `TaskContext` first, falls back to captured value.

### Multi-cloud credential detection

`IcebergTableCredentials.forProperties()` detects vended credentials from all three providers:

- **S3**: `s3.access-key-id`, expiry from `s3.session-token-expires-at-ms`
- **GCS**: `gcs.oauth2.token`, expiry from `gcs.oauth2.token-expires-at`
- **Azure ADLS**: `adls.sas-token.*` prefix, expiry from `adls.sas-token-expires-at-ms.*` (uses earliest across accounts)

When no vended credentials are detected, `expiresAt` is `Optional.empty()` — refresh is disabled entirely.

When expiry is present, `shouldRefresh()` triggers 5 minutes before the actual expiry (matching Iceberg's `VendedCredentialsProvider` pattern). When vended credentials are present but no expiry timestamp is found, a conservative 55-minute TTL is assumed (1 hour default STS lifetime minus 5-minute buffer).



### Multi-cloud credential detection

`IcebergTableCredentials.forProperties()` detects vended credentials from all three providers:

- **S3**: `s3.access-key-id`, expiry from `s3.session-token-expires-at-ms`
- **GCS**: `gcs.oauth2.token`, expiry from `gcs.oauth2.token-expires-at`
- **Azure ADLS**: `adls.sas-token.*` prefix, expiry from `adls.sas-token-expires-at-ms.*` (uses earliest across accounts)

When no vended credentials are detected, `expiresAt` is `Optional.empty()` — refresh is disabled entirely.

When expiry is present, `shouldRefresh()` triggers 5 minutes before the actual expiry (matching Iceberg's `VendedCredentialsProvider` pattern). When vended credentials are present but no expiry timestamp is found, a conservative 55-minute TTL is assumed (1 hour default STS lifetime minus 5-minute buffer).


## Known limitations

- An already-open page source reading a single large file cannot refresh mid-read. In practice, individual splits complete in minutes, not hours — the refresh granularity is per-split, which covers the vast majority of real-world cases.
- Long-running single writes exceeding the token TTL are similarly constrained. This would require credential rotation support in the underlying file system client.


## Release notes

(x) Release notes are required, with the following suggested text:

```
## Iceberg connector
* Add credential refresh for long-running queries against Iceberg REST catalogs that vend temporary cloud credentials. Credentials are now automatically refreshed on both coordinator and worker sides before they expire, preventing query failures due to expired STS tokens.
* Add configurable TTL properties: `iceberg.credential-cache-ttl`, `iceberg.coordinator-credential-prefetch`
```


  
Fixes #25827

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
