### PR TITLE
Support vended SSE encryption keys from Iceberg REST catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,6 +562,11 @@ jobs:
         if: contains(matrix.modules, 'trino-hdfs')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-hdfs -P test-isolated-jvm-suites
+      - name: Iceberg isolated JVM tests
+        id: tests-iceberg-isolated
+        if: contains(matrix.modules, 'trino-iceberg') && matrix.profile == ''
+        run: |
+          $MAVEN test ${MAVEN_TEST} -pl :trino-iceberg -P test-isolated-jvm-suites
       - name: FileSystem Exchange Storage Cloud Tests
         id: tests-filesystem-exchange
         env:
@@ -812,6 +817,7 @@ jobs:
           has-failed-tests: >-
             ${{ steps.tests.outcome == 'failure'
               || steps.tests-hdfs-isolated.outcome == 'failure'
+              || steps.tests-iceberg-isolated.outcome == 'failure'
               || steps.tests-s3.outcome == 'failure'
               || steps.tests-azure.outcome == 'failure'
               || steps.tests-filesystem-exchange.outcome == 'failure'

--- a/docs/src/main/sphinx/object-storage/file-system-gcs.md
+++ b/docs/src/main/sphinx/object-storage/file-system-gcs.md
@@ -57,6 +57,30 @@ Storage file system support:
     for all requests sent to Google Cloud Storage. Defaults to `Trino`.
 :::
 
+## Encryption
+
+Trino supports [customer-supplied encryption keys
+(CSEK)](https://cloud.google.com/storage/docs/encryption/customer-supplied-keys)
+to encrypt objects written to Google Cloud Storage and decrypt objects read from
+Google Cloud Storage. Separate encryption and decryption key properties are
+supported so that you can rotate keys: configure the new key for encryption and
+keep the previous key for decryption until all objects are re-encrypted.
+
+:::{list-table}
+:widths: 40, 60
+:header-rows: 1
+
+* - Property
+  - Description
+* - `gcs.encryption-key`
+  - The 256-bit, Base64-encoded AES-256 customer-supplied encryption key used
+    to encrypt objects written to Google Cloud Storage.
+* - `gcs.decryption-key`
+  - The 256-bit, Base64-encoded AES-256 customer-supplied encryption key used
+    to decrypt objects read from Google Cloud Storage. Typically set to the
+    same value as `gcs.encryption-key` unless rotating keys.
+:::
+
 ## Authentication
 
 Use one of the following properties to configure the authentication to Google

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -82,8 +82,10 @@ public class GcsFileSystem
     private final int pageSize;
     private final int batchSize;
     private final Optional<String> endpoint;
+    private final Optional<EncryptionKey> encryptionKey;
+    private final Optional<EncryptionKey> decryptionKey;
 
-    public GcsFileSystem(ListeningExecutorService executorService, Storage storage, int readBlockSizeBytes, long writeBlockSizeBytes, int pageSize, int batchSize, Optional<String> endpoint)
+    public GcsFileSystem(ListeningExecutorService executorService, Storage storage, int readBlockSizeBytes, long writeBlockSizeBytes, int pageSize, int batchSize, Optional<String> endpoint, Optional<EncryptionKey> encryptionKey, Optional<EncryptionKey> decryptionKey)
     {
         this.executorService = requireNonNull(executorService, "executorService is null");
         this.storage = requireNonNull(storage, "storage is null");
@@ -92,6 +94,8 @@ public class GcsFileSystem
         this.pageSize = pageSize;
         this.batchSize = batchSize;
         this.endpoint = requireNonNull(endpoint, "endpoint is null");
+        this.encryptionKey = requireNonNull(encryptionKey, "encryptionKey is null");
+        this.decryptionKey = requireNonNull(decryptionKey, "decryptionKey is null");
     }
 
     @Override
@@ -99,7 +103,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.empty(), Optional.empty(), Optional.empty());
+        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.empty(), Optional.empty(), decryptionKey);
     }
 
     @Override
@@ -115,7 +119,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.empty(), Optional.empty());
+        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.empty(), decryptionKey);
     }
 
     @Override
@@ -131,7 +135,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.of(lastModified), Optional.empty());
+        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.of(lastModified), decryptionKey);
     }
 
     @Override
@@ -147,7 +151,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsOutputFile(gcsLocation, storage, writeBlockSizeBytes, Optional.empty());
+        return new GcsOutputFile(gcsLocation, storage, writeBlockSizeBytes, encryptionKey);
     }
 
     @Override
@@ -357,7 +361,7 @@ public class GcsFileSystem
     public Optional<UriLocation> preSignedUri(Location location, Duration ttl)
             throws IOException
     {
-        return preSignedUri(location, ttl, Optional.empty());
+        return preSignedUri(location, ttl, decryptionKey);
     }
 
     @Override

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConfig.java
@@ -15,6 +15,7 @@ package io.trino.filesystem.gcs;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -56,6 +57,8 @@ public class GcsFileSystemConfig
     // Note: there is no benefit to setting this much higher as the rpc quota is 1x per second: https://cloud.google.com/storage/docs/retry-strategy#java
     private Duration maxBackoffDelay = new Duration(2000, TimeUnit.MILLISECONDS);
     private String applicationId = "Trino";
+    private String encryptionKey;
+    private String decryptionKey;
 
     @NotNull
     public DataSize getReadBlockSize()
@@ -236,6 +239,36 @@ public class GcsFileSystemConfig
     public GcsFileSystemConfig setApplicationId(String applicationId)
     {
         this.applicationId = applicationId;
+        return this;
+    }
+
+    @Nullable
+    public String getEncryptionKey()
+    {
+        return encryptionKey;
+    }
+
+    @Config("gcs.encryption-key")
+    @ConfigDescription("Base64-encoded AES-256 customer-supplied encryption key used to encrypt objects written to Google Cloud Storage")
+    @ConfigSecuritySensitive
+    public GcsFileSystemConfig setEncryptionKey(String encryptionKey)
+    {
+        this.encryptionKey = encryptionKey;
+        return this;
+    }
+
+    @Nullable
+    public String getDecryptionKey()
+    {
+        return decryptionKey;
+    }
+
+    @Config("gcs.decryption-key")
+    @ConfigDescription("Base64-encoded AES-256 customer-supplied encryption key used to decrypt objects read from Google Cloud Storage")
+    @ConfigSecuritySensitive
+    public GcsFileSystemConfig setDecryptionKey(String decryptionKey)
+    {
+        this.decryptionKey = decryptionKey;
         return this;
     }
 

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemFactory.java
@@ -17,13 +17,17 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.encryption.EncryptionKey;
 import io.trino.spi.security.ConnectorIdentity;
 import jakarta.annotation.PreDestroy;
 
+import java.util.Base64;
 import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -36,6 +40,8 @@ public class GcsFileSystemFactory
     private final int pageSize;
     private final int batchSize;
     private final Optional<String> endpoint;
+    private final Optional<EncryptionKey> configuredEncryptionKey;
+    private final Optional<EncryptionKey> configuredDecryptionKey;
     private final ListeningExecutorService executorService;
     private final GcsStorageFactory storageFactory;
 
@@ -47,6 +53,8 @@ public class GcsFileSystemFactory
         this.pageSize = config.getPageSize();
         this.batchSize = config.getBatchSize();
         this.endpoint = config.getEndpoint();
+        this.configuredEncryptionKey = toEncryptionKey(config.getEncryptionKey());
+        this.configuredDecryptionKey = toEncryptionKey(config.getDecryptionKey());
         this.storageFactory = requireNonNull(storageFactory, "storageFactory is null");
         this.executorService = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("trino-filesystem-gcs-%S")));
     }
@@ -60,6 +68,18 @@ public class GcsFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
-        return new GcsFileSystem(executorService, storageFactory.create(identity), readBlockSizeBytes, writeBlockSizeBytes, pageSize, batchSize, endpoint);
+        Optional<EncryptionKey> encryptionKey = toEncryptionKey(identity.getExtraCredentials().get(EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY))
+                .or(() -> configuredEncryptionKey);
+        Optional<EncryptionKey> decryptionKey = toEncryptionKey(identity.getExtraCredentials().get(EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY))
+                .or(() -> configuredDecryptionKey);
+        return new GcsFileSystem(executorService, storageFactory.create(identity), readBlockSizeBytes, writeBlockSizeBytes, pageSize, batchSize, endpoint, encryptionKey, decryptionKey);
+    }
+
+    private static Optional<EncryptionKey> toEncryptionKey(String base64Key)
+    {
+        if (base64Key == null) {
+            return Optional.empty();
+        }
+        return Optional.of(EncryptionKey.ofAes256(Base64.getDecoder().decode(base64Key)));
     }
 }

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
@@ -49,7 +49,9 @@ public class TestGcsFileSystemConfig
                 .setMaxRetryTime(new Duration(25, SECONDS))
                 .setMinBackoffDelay(new Duration(10, MILLISECONDS))
                 .setMaxBackoffDelay(new Duration(2000, MILLISECONDS))
-                .setApplicationId("Trino"));
+                .setApplicationId("Trino")
+                .setEncryptionKey(null)
+                .setDecryptionKey(null));
     }
 
     @Test
@@ -69,6 +71,8 @@ public class TestGcsFileSystemConfig
                 .put("gcs.client.min-backoff-delay", "20ms")
                 .put("gcs.client.max-backoff-delay", "20ms")
                 .put("gcs.application-id", "application id")
+                .put("gcs.encryption-key", "encryptionKey")
+                .put("gcs.decryption-key", "decryptionKey")
                 .buildOrThrow();
 
         GcsFileSystemConfig expected = new GcsFileSystemConfig()
@@ -84,7 +88,9 @@ public class TestGcsFileSystemConfig
                 .setMaxRetryTime(new Duration(10, SECONDS))
                 .setMinBackoffDelay(new Duration(20, MILLISECONDS))
                 .setMaxBackoffDelay(new Duration(20, MILLISECONDS))
-                .setApplicationId("application id");
+                .setApplicationId("application id")
+                .setEncryptionKey("encryptionKey")
+                .setDecryptionKey("decryptionKey");
         assertFullMapping(properties, expected);
     }
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -31,6 +31,7 @@ import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.KMS;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY;
 import static java.util.Objects.requireNonNull;
 
 record S3Context(
@@ -62,14 +63,19 @@ record S3Context(
 
     public S3Context withCredentials(ConnectorIdentity identity)
     {
+        S3Context context = this;
         if (identity.getExtraCredentials().containsKey(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY)) {
             AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(AwsSessionCredentials.create(
                     identity.getExtraCredentials().get(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY),
                     identity.getExtraCredentials().get(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY),
                     identity.getExtraCredentials().get(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY)));
-            return withCredentialsProviderOverride(credentialsProvider);
+            context = context.withCredentialsProviderOverride(credentialsProvider);
         }
-        return this;
+        String sseCustomerKey = identity.getExtraCredentials().get(EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY);
+        if (sseCustomerKey != null) {
+            context = context.withSseCustomerKey(sseCustomerKey);
+        }
+        return context;
     }
 
     public S3Context withSseCustomerKey(String key)

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionKey.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionKey.java
@@ -17,6 +17,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public record EncryptionKey(byte[] key, String algorithm)
@@ -36,8 +37,10 @@ public record EncryptionKey(byte[] key, String algorithm)
         return ofAes256(key);
     }
 
-    private static EncryptionKey ofAes256(byte[] key)
+    public static EncryptionKey ofAes256(byte[] key)
     {
+        requireNonNull(key, "key is null");
+        checkArgument(key.length == 32, "AES-256 key must be 32 bytes, got %s", key.length);
         return new EncryptionKey(key, "AES256");
     }
 

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConstants.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConstants.java
@@ -18,6 +18,8 @@ public final class GcsFileSystemConstants
     public static final String EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY = "internal$gcs_oauth2_token";
     public static final String EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY = "internal$gcs_oauth2_token_expires_at";
     public static final String EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY = "internal$gcs_project_id";
+    public static final String EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY = "internal$gcs_encryption_key";
+    public static final String EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY = "internal$gcs_decryption_key";
 
     private GcsFileSystemConstants() {}
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/s3/S3FileSystemConstants.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/s3/S3FileSystemConstants.java
@@ -18,6 +18,7 @@ public final class S3FileSystemConstants
     public static final String EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY = "internal$s3_aws_access_key";
     public static final String EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY = "internal$s3_aws_secret_key";
     public static final String EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY = "internal$s3_aws_session_token";
+    public static final String EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY = "internal$s3_sse_customer_key";
 
     private S3FileSystemConstants() {}
 }

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -969,12 +969,14 @@
                                 <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java</exclude>
+                                <exclude>**/TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey.java</exclude>
                                 <exclude>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
                                 <exclude>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestTrinoSnowflakeCatalog.java</exclude>
+                                <exclude>**/TestIcebergS3VendingRestCatalogServerSideEncryptionCustomerKey.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -1032,12 +1034,32 @@
                                 <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java</include>
+                                <include>**/TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey.java</include>
                                 <include>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestTrinoSnowflakeCatalog.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>test-isolated-jvm-suites</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestIcebergS3VendingRestCatalogServerSideEncryptionCustomerKey.java</include>
+                            </includes>
+                            <reuseForks>false</reuseForks>
+                            <forkCount>1</forkCount>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -36,7 +36,10 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.HOURS;
 
@@ -119,26 +122,36 @@ public class IcebergRestCatalogFileSystemFactory
 
     private TrinoFileSystem getTrinoFileSystem(Location location, ConnectorIdentity identity, CachedVendedCredentialsProviders cached)
     {
-        // Derive the vended credentials to load from the location scheme
+        // Derive the vended credentials to load from the location scheme. Schemes without vended credentials
+        // (default) yield no credentials and fall through to the delegate filesystem with the original identity.
         Optional<VendedCredentials> vendedCredentials = switch (location.scheme().get()) {
             case "s3", "s3a", "s3n" -> findVendedCredentialsForLocation(cached.s3VendedCredentialsProviders(), location);
             case "gs" -> findVendedCredentialsForLocation(cached.gcsVendedCredentialsProviders(), location);
             case "abfs", "abfss", "wasb", "wasbs" -> cached.azureVendedCredentialsProvider().map(AzureVendedCredentialsProvider::getCredentials);
-            default -> throw new IllegalArgumentException("Unsupported location scheme for vended credentials: " + location);
+            default -> Optional.empty();
         };
-        if (vendedCredentials.isEmpty()) {
-            throw new IllegalStateException("Failed to initialize the vended credentials from the provided fileIoProperties");
+
+        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.<String, String>builder()
+                .putAll(cached.extraCredentials());
+        vendedCredentials.ifPresent(credentials -> extraCredentialsBuilder.putAll(credentials.toExtraCredentials()));
+        Map<String, String> injectedExtraCredentials = extraCredentialsBuilder.buildOrThrow();
+        if (injectedExtraCredentials.isEmpty()) {
+            // No vended credentials or static extras to inject — delegate with the original identity.
+            return fileSystemFactory.create(identity);
         }
+
+        // Preserve the identity's existing extra credentials; injected vended/static values take precedence on conflict.
+        Map<String, String> extraCredentials = ImmutableMap.<String, String>builder()
+                .putAll(identity.getExtraCredentials())
+                .putAll(injectedExtraCredentials)
+                .buildKeepingLast();
 
         ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
                 .withGroups(identity.getGroups())
                 .withPrincipal(identity.getPrincipal())
                 .withEnabledSystemRoles(identity.getEnabledSystemRoles())
                 .withConnectorRole(identity.getConnectorRole())
-                .withExtraCredentials(ImmutableMap.<String, String>builder()
-                        .putAll(cached.extraCredentials())
-                        .putAll(ImmutableMap.copyOf(vendedCredentials.map(VendedCredentials::toExtraCredentials).orElse(ImmutableMap.of())))
-                        .buildOrThrow())
+                .withExtraCredentials(extraCredentials)
                 .build();
 
         return fileSystemFactory.create(identityWithExtraCredentials);
@@ -150,7 +163,8 @@ public class IcebergRestCatalogFileSystemFactory
                 identity.getUser(),
                 createS3VendedCredentials(fileIoProperties, storageCredentials),
                 createGcsVendedCredentials(fileIoProperties, storageCredentials),
-                createAzureVendedCredentials(fileIoProperties));
+                createAzureVendedCredentials(fileIoProperties),
+                collectStaticExtraCredentials(fileIoProperties));
     }
 
     private static Map<String, S3VendedCredentials> createS3VendedCredentials(Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentialsList)
@@ -222,7 +236,6 @@ public class IcebergRestCatalogFileSystemFactory
     {
         ImmutableMap.Builder<String, S3VendedCredentialsProvider> s3ProvidersBuilder = ImmutableMap.builder();
         ImmutableMap.Builder<String, GcsVendedCredentialsProvider> gcsProvidersBuilder = ImmutableMap.builder();
-        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
 
         // Root-prefix providers built from fileIoProperties — act as catch-all fallback, matching any S3/GCS path
         createVendedCredentialsProviderIfPresent(
@@ -237,9 +250,6 @@ public class IcebergRestCatalogFileSystemFactory
                 () -> new GcsVendedCredentialsProvider(catalogProperties, fileIoProperties),
                 GCPProperties.GCS_OAUTH2_TOKEN)
                 .ifPresent(vendedCredentialsProvider -> gcsProvidersBuilder.put("gs", vendedCredentialsProvider));
-        if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
-            addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
-        }
 
         // Per-prefix providers built from merged config (storage credential config overrides fileIoProperties)
         for (IcebergStorageCredentials storageCredentials : storageCredentialsList) {
@@ -259,14 +269,32 @@ public class IcebergRestCatalogFileSystemFactory
                 s3ProvidersBuilder.buildKeepingLast(),
                 gcsProvidersBuilder.buildKeepingLast(),
                 azureVendedCredentialsProvider,
-                extraCredentialsBuilder.buildOrThrow());
+                collectStaticExtraCredentials(fileIoProperties));
+    }
+
+    private static Map<String, String> collectStaticExtraCredentials(Map<String, String> fileIoProperties)
+    {
+        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
+        // handle GCS project id
+        if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
+            addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
+        }
+        // handle s3 SSE-C encryption key
+        if (S3FileIOProperties.SSE_TYPE_CUSTOM.equals(fileIoProperties.get(S3FileIOProperties.SSE_TYPE))) {
+            addOptionalProperty(extraCredentialsBuilder, fileIoProperties, S3FileIOProperties.SSE_KEY, EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY);
+        }
+        // handle gcs CSEK encryption keys
+        addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_ENCRYPTION_KEY, EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY);
+        addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_DECRYPTION_KEY, EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY);
+        return extraCredentialsBuilder.buildOrThrow();
     }
 
     private record VendedCredentialsCacheKey(
             String user,
             Map<String, S3VendedCredentials> s3VendedCredentials,
             Map<String, GcsVendedCredentials> gcsVendedCredentials,
-            Optional<AzureVendedCredentials> azureVendedCredentials)
+            Optional<AzureVendedCredentials> azureVendedCredentials,
+            Map<String, String> staticExtraCredentials)
     {
         public VendedCredentialsCacheKey
         {
@@ -274,6 +302,7 @@ public class IcebergRestCatalogFileSystemFactory
             s3VendedCredentials = ImmutableMap.copyOf(s3VendedCredentials);
             gcsVendedCredentials = ImmutableMap.copyOf(gcsVendedCredentials);
             requireNonNull(azureVendedCredentials, "azureVendedCredentials is null");
+            staticExtraCredentials = ImmutableMap.copyOf(requireNonNull(staticExtraCredentials, "staticExtraCredentials is null"));
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/RestCatalogTestingHttpServers.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/RestCatalogTestingHttpServers.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.http.server.HttpConfig;
+import io.airlift.http.server.HttpServer.ClientCertificate;
+import io.airlift.http.server.HttpServerConfig;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.ServerFeature;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.node.NodeInfo;
+import org.apache.iceberg.rest.RESTCatalogServlet;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Helpers for building a {@link TestingHttpServer} that hosts a
+ * {@link RESTCatalogServlet} (or subclass) on an arbitrary local port.
+ * Shared by the Iceberg REST catalog tests to avoid duplicating HTTP
+ * server configuration.
+ */
+public final class RestCatalogTestingHttpServers
+{
+    private RestCatalogTestingHttpServers() {}
+
+    public static TestingHttpServer create(RESTCatalogServlet servlet)
+            throws IOException
+    {
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerConfig config = new HttpServerConfig()
+                .setMinThreads(4)
+                .setMaxThreads(8)
+                .setHttpEnabled(true);
+        HttpConfig httpConfig = new HttpConfig()
+                .setHttpPort(0)
+                .setHttpAcceptorThreads(4)
+                .setAcceptQueueSize(10);
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(httpConfig), Optional.empty(), nodeInfo);
+
+        return new TestingHttpServer(
+                "rest-catalog",
+                httpServerInfo,
+                nodeInfo,
+                config,
+                Optional.of(httpConfig),
+                Optional.empty(),
+                servlet,
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                ServerFeature.builder()
+                        // Required due to URIs like: HEAD /v1/namespaces/level_1%1Flevel_2
+                        .withLegacyUriCompliance(true)
+                        .build(),
+                ClientCertificate.NONE);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.log.Logger;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.gcs.GcsFileSystemConfig;
+import io.trino.filesystem.gcs.GcsFileSystemFactory;
+import io.trino.filesystem.gcs.GcsServiceAccountAuth;
+import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
+import io.trino.filesystem.gcs.GcsStorageFactory;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.rest.RESTCatalogServlet;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies that {@link GcsFileSystem} transparently encrypts and decrypts
+ * objects when the Iceberg REST catalog vends a customer-supplied encryption
+ * key via the {@code gcs.encryption-key}/{@code gcs.decryption-key} properties.
+ */
+final class TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey
+        extends AbstractTestQueryFramework
+{
+    private static final Logger log = Logger.get(TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey.class);
+
+    // 32-byte AES-256 customer-supplied encryption key encoded in Base64
+    private static final String BASE64_ENCRYPTION_KEY = randomBase64AesKey();
+
+    private static String randomBase64AesKey()
+    {
+        byte[] key = new byte[32];
+        new SecureRandom().nextBytes(key);
+        return Base64.getEncoder().encodeToString(key);
+    }
+
+    private final String gcpCredentialKey;
+    private final String warehouseLocation;
+
+    private GcsFileSystemFactory gcsFileSystemFactory;
+
+    TestIcebergGcsVendingRestCatalogCustomerSuppliedEncryptionKey()
+    {
+        gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
+        String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+        warehouseLocation = "gs://%s/gcs-vending-rest-encryption-%s".formatted(gcpStorageBucket, randomNameSuffix());
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
+                .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        AccessToken accessToken = credentials.refreshAccessToken();
+
+        JsonNode jsonKey = new JsonMapper().readTree(gcpCredentials);
+        String gcpProjectId = jsonKey.get("project_id").asText();
+
+        GcsFileSystemConfig fsConfig = new GcsFileSystemConfig();
+        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(gcpCredentials);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(fsConfig, new GcsServiceAccountAuth(authConfig));
+        gcsFileSystemFactory = new GcsFileSystemFactory(fsConfig, storageFactory);
+        // register factory shutdown first so it runs last, after cleanup below
+        closeAfterClass(gcsFileSystemFactory::stop);
+        closeAfterClass(this::cleanupWarehouse);
+
+        JdbcCatalog backend = closeAfterClass(createGcsBackendCatalog(gcpProjectId, accessToken));
+
+        Map<String, String> vendedConfig = ImmutableMap.of(
+                GCPProperties.GCS_ENCRYPTION_KEY, BASE64_ENCRYPTION_KEY,
+                GCPProperties.GCS_DECRYPTION_KEY, BASE64_ENCRYPTION_KEY);
+        TestingHttpServer testServer = RestCatalogTestingHttpServers.create(
+                new RESTCatalogServlet(new VendingRESTCatalogAdapter(backend, vendedConfig)));
+        testServer.start();
+        closeAfterClass(testServer::stop);
+
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
+                                .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                                .put("fs.native-gcs.enabled", "true")
+                                .put("gcs.json-key", gcpCredentials)
+                                .buildOrThrow())
+                .build();
+    }
+
+    private void cleanupWarehouse()
+    {
+        try {
+            gcsFileSystemFactory.create(ConnectorIdentity.ofUser("test"))
+                    .deleteDirectory(Location.of(warehouseLocation));
+        }
+        catch (IOException e) {
+            // The GCS bucket should be configured to expire objects automatically;
+            // leaked objects from the test do not need to fail the teardown.
+            log.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+        }
+    }
+
+    private JdbcCatalog createGcsBackendCatalog(String gcpProjectId, AccessToken accessToken)
+            throws IOException
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put(CatalogProperties.URI, "jdbc:h2:file:" + Files.createTempFile(null, null).toAbsolutePath())
+                .put(JdbcCatalog.PROPERTY_PREFIX + "username", "user")
+                .put(JdbcCatalog.PROPERTY_PREFIX + "password", "password")
+                .put(JdbcCatalog.PROPERTY_PREFIX + "schema-version", "V1")
+                .put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation)
+                .put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.gcp.gcs.GCSFileIO")
+                .put(GCPProperties.GCS_OAUTH2_TOKEN, accessToken.getTokenValue())
+                .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(accessToken.getExpirationTime().getTime()))
+                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_ENCRYPTION_KEY, BASE64_ENCRYPTION_KEY)
+                .put(GCPProperties.GCS_DECRYPTION_KEY, BASE64_ENCRYPTION_KEY)
+                .buildOrThrow();
+
+        JdbcCatalog catalog = new JdbcCatalog();
+        catalog.initialize("backend_jdbc", properties);
+        return catalog;
+    }
+
+    @Test
+    void testWriteAndReadWithVendedEncryptionKey()
+    {
+        String tableName = "test_gcs_csek_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x, VARCHAR 'hello' y", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'hello')");
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'world')", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY x", "VALUES (1, 'hello'), (2, 'world')");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    void testDataFilesAreEncrypted()
+            throws IOException
+    {
+        String tableName = "test_gcs_csek_encrypted_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES 1");
+
+            String dataFilePath = (String) computeScalar(
+                    "SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1");
+            assertThat(dataFilePath).startsWith("gs://");
+
+            // Reading the object content without the encryption key must fail,
+            // proving the data is actually encrypted on storage.
+            // Note: GCS allows HEAD/metadata operations without the key, so we must
+            // attempt to read content (not just length) to exercise the decryption path.
+            TrinoFileSystem plainFileSystem = gcsFileSystemFactory.create(ConnectorIdentity.ofUser("test"));
+            TrinoInputFile plainInputFile = plainFileSystem.newInputFile(Location.of(dataFilePath));
+            assertThatThrownBy(() -> {
+                try (InputStream stream = plainInputFile.newStream()) {
+                    stream.readAllBytes();
+                }
+            }).isInstanceOf(IOException.class);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -44,17 +45,31 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.filesystem.azure.AzureFileSystemConstants.EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class TestIcebergRestCatalogFileSystemFactory
 {
+    // 32-byte AES-256 keys encoded in Base64
+    private static final String BASE64_KEY_A = aes256KeyWithFirstByte((byte) 0);
+    private static final String BASE64_KEY_B = aes256KeyWithFirstByte((byte) 1);
+
+    private static String aes256KeyWithFirstByte(byte firstByte)
+    {
+        byte[] key = new byte[32];
+        key[0] = firstByte;
+        return Base64.getEncoder().encodeToString(key);
+    }
+
     @Test
     void testS3VendedCredentials()
     {
@@ -156,15 +171,271 @@ final class TestIcebergRestCatalogFileSystemFactory
     }
 
     @Test
+    void testS3SseCVendedEncryptionKey()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_CUSTOM,
+                S3FileIOProperties.SSE_KEY, BASE64_KEY_A);
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("s3://bucket/path"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY, BASE64_KEY_A);
+    }
+
+    @Test
+    void testS3SseKmsIsNotWrapped()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new NoOpTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        // SSE-KMS uses server-managed keys; no client-side encryption key needed
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_KMS,
+                S3FileIOProperties.SSE_KEY, "arn:aws:kms:us-east-1:123456789:key/test-key");
+
+        TrinoFileSystem fileSystem = factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        // Trigger lazy loader; SSE-KMS adds nothing, so the original identity should pass through unchanged.
+        assertThatThrownBy(() -> fileSystem.newInputFile(Location.of("s3://bucket/path/file")))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .doesNotContainKey(EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY);
+    }
+
+    @Test
+    void testGcsCsekBothKeys()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        // GCS key rotation: different encryption and decryption keys
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                GCPProperties.GCS_ENCRYPTION_KEY, BASE64_KEY_A,
+                GCPProperties.GCS_DECRYPTION_KEY, BASE64_KEY_B);
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY, BASE64_KEY_A)
+                .containsEntry(EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY, BASE64_KEY_B);
+    }
+
+    @Test
+    void testGcsCsekEncryptionKeyOnly()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        // Only encryption key: new writes are encrypted, reads are unencrypted
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                GCPProperties.GCS_ENCRYPTION_KEY, BASE64_KEY_A);
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY, BASE64_KEY_A)
+                .doesNotContainKey(EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY);
+    }
+
+    @Test
+    void testGcsCsekDecryptionKeyOnly()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        // Only decryption key: reads use the key, writes are unencrypted
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                GCPProperties.GCS_DECRYPTION_KEY, BASE64_KEY_B);
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .doesNotContainKey(EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY)
+                .containsEntry(EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY, BASE64_KEY_B);
+    }
+
+    @Test
+    void testEncryptionKeysNotAppliedWhenVendedCredentialsDisabled()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new NoOpTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, false);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_CUSTOM,
+                S3FileIOProperties.SSE_KEY, BASE64_KEY_A,
+                GCPProperties.GCS_ENCRYPTION_KEY, BASE64_KEY_A);
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .doesNotContainKey(EXTRA_CREDENTIALS_SSE_CUSTOMER_KEY_PROPERTY)
+                .doesNotContainKey(EXTRA_CREDENTIALS_GCS_ENCRYPTION_KEY_PROPERTY)
+                .doesNotContainKey(EXTRA_CREDENTIALS_GCS_DECRYPTION_KEY_PROPERTY);
+    }
+
+    @Test
     void testNoVendedCredentialsInProperties()
     {
-        IcebergRestCatalogFileSystemFactory factory = createFactory(_ -> new MockTrinoFileSystem(), true);
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new NoOpTrinoFileSystem();
+        };
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
         TrinoFileSystem fileSystem = factory.create(originalIdentity, ImmutableMap.of());
-
+        // Trigger the lazy loader: with no vended creds and no extras, the original identity should pass through unchanged.
         assertThatThrownBy(() -> fileSystem.newInputFile(Location.of("s3://bucket/path/file")))
-                .hasMessage("Failed to initialize the vended credentials from the provided fileIoProperties");
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThat(capturedIdentity.get()).isSameAs(originalIdentity);
+    }
+
+    @Test
+    void testUnsupportedSchemeDelegatesWithOriginalIdentity()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new NoOpTrinoFileSystem();
+        };
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
+        TrinoFileSystem fileSystem = factory.create(originalIdentity, ImmutableMap.of());
+        // A scheme without vended credentials (for example an HDFS location handled by the delegate) must fall through
+        // to the delegate filesystem with the original identity rather than failing on the credential scheme switch.
+        assertThatThrownBy(() -> fileSystem.newInputFile(Location.of("hdfs://namenode/path/file")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThat(capturedIdentity.get()).isSameAs(originalIdentity);
+    }
+
+    private static class NoOpTrinoFileSystem
+            implements TrinoFileSystem
+    {
+        @Override
+        public TrinoInputFile newInputFile(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TrinoOutputFile newOutputFile(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteFile(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteDirectory(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void renameFile(Location source, Location target)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FileIterator listFiles(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<Boolean> directoryExists(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void createDirectory(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void renameDirectory(Location source, Location target)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Location> listDirectories(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<Location> createTemporaryDirectory(Location targetPath, String temporaryPrefix, String relativePrefix)
+        {
+            throw new UnsupportedOperationException();
+        }
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3VendingRestCatalogServerSideEncryptionCustomerKey.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3VendingRestCatalogServerSideEncryptionCustomerKey.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.s3.S3FileSystemConfig;
+import io.trino.filesystem.s3.S3FileSystemFactory;
+import io.trino.filesystem.s3.S3FileSystemStats;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.containers.MinioTls;
+import io.trino.testing.containers.TlsCertificate;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.rest.RESTCatalogServlet;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestIcebergS3VendingRestCatalogServerSideEncryptionCustomerKey
+        extends AbstractTestQueryFramework
+{
+    private static final byte[] SSE_KEY = randomSseKey();
+    private static final String BASE64_SSE_KEY = Base64.getEncoder().encodeToString(SSE_KEY);
+    private static final String BASE64_SSE_KEY_MD5 = base64Md5(SSE_KEY);
+
+    private static byte[] randomSseKey()
+    {
+        byte[] key = new byte[32];
+        new SecureRandom().nextBytes(key);
+        return key;
+    }
+
+    private static String base64Md5(byte[] bytes)
+    {
+        try {
+            return Base64.getEncoder().encodeToString(MessageDigest.getInstance("MD5").digest(bytes));
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("MD5 is always available", e);
+        }
+    }
+
+    private final String bucketName = "test-sse-c-" + randomNameSuffix();
+    private S3FileSystemFactory s3FileSystemFactory;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TlsCertificate certificate = TlsCertificate.generate();
+        closeAfterClass(certificate);
+        certificate.installAsDefaultTrustStore();
+
+        MinioTls minioContainer = MinioTls.builder()
+                .withCertificate(certificate)
+                .build();
+        minioContainer.start();
+        closeAfterClass(minioContainer);
+
+        String minioAddress = minioContainer.getMinioHttpsEndpoint();
+
+        createBucket(minioAddress, bucketName);
+
+        s3FileSystemFactory = new S3FileSystemFactory(
+                OpenTelemetry.noop(),
+                new S3FileSystemConfig()
+                        .setRegion(MINIO_REGION)
+                        .setEndpoint(minioAddress)
+                        .setPathStyleAccess(true)
+                        .setAwsAccessKey(MINIO_ROOT_USER)
+                        .setAwsSecretKey(MINIO_ROOT_PASSWORD),
+                new S3FileSystemStats());
+        closeAfterClass(s3FileSystemFactory::destroy);
+
+        JdbcCatalog backend = closeAfterClass(createS3BackendCatalog(minioAddress));
+
+        Map<String, String> vendedConfig = ImmutableMap.of(
+                S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_CUSTOM,
+                S3FileIOProperties.SSE_KEY, BASE64_SSE_KEY);
+        TestingHttpServer testServer = RestCatalogTestingHttpServers.create(
+                new RESTCatalogServlet(new VendingRESTCatalogAdapter(backend, vendedConfig)));
+        testServer.start();
+        closeAfterClass(testServer::stop);
+
+        return IcebergQueryRunner.builder()
+                .setIcebergProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
+                                .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                                .put("fs.native-s3.enabled", "true")
+                                .put("s3.region", MINIO_REGION)
+                                .put("s3.endpoint", minioAddress)
+                                .put("s3.path-style-access", "true")
+                                .put("s3.aws-access-key", MINIO_ROOT_USER)
+                                .put("s3.aws-secret-key", MINIO_ROOT_PASSWORD)
+                                .buildOrThrow())
+                .build();
+    }
+
+    private JdbcCatalog createS3BackendCatalog(String minioAddress)
+            throws IOException
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put(CatalogProperties.URI, "jdbc:h2:file:" + Files.createTempFile(null, null).toAbsolutePath())
+                .put(JdbcCatalog.PROPERTY_PREFIX + "username", "user")
+                .put(JdbcCatalog.PROPERTY_PREFIX + "password", "password")
+                .put(JdbcCatalog.PROPERTY_PREFIX + "schema-version", "V1")
+                .put(CatalogProperties.WAREHOUSE_LOCATION, "s3://" + bucketName + "/iceberg_data")
+                .put(CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.aws.s3.S3FileIO")
+                .put(S3FileIOProperties.ENDPOINT, minioAddress)
+                .put(S3FileIOProperties.ACCESS_KEY_ID, MINIO_ROOT_USER)
+                .put(S3FileIOProperties.SECRET_ACCESS_KEY, MINIO_ROOT_PASSWORD)
+                .put(S3FileIOProperties.PATH_STYLE_ACCESS, "true")
+                .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                .put(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_CUSTOM)
+                .put(S3FileIOProperties.SSE_KEY, BASE64_SSE_KEY)
+                .put(S3FileIOProperties.SSE_MD5, BASE64_SSE_KEY_MD5)
+                .buildOrThrow();
+
+        JdbcCatalog catalog = new JdbcCatalog();
+        catalog.initialize("backend_jdbc", properties);
+        return catalog;
+    }
+
+    private static void createBucket(String endpoint, String bucketName)
+    {
+        try (S3Client s3Client = S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD)))
+                .region(Region.of(MINIO_REGION))
+                .forcePathStyle(true)
+                .build()) {
+            s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+        }
+    }
+
+    @Test
+    void testWriteAndReadWithVendedSseCKey()
+    {
+        String tableName = "test_sse_c_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x, VARCHAR 'hello' y", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 'hello')");
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'world')", 1);
+            assertQuery("SELECT * FROM " + tableName + " ORDER BY x", "VALUES (1, 'hello'), (2, 'world')");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    void testDataFilesAreEncrypted()
+            throws IOException
+    {
+        String tableName = "test_sse_c_encrypted_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 x", 1);
+            assertQuery("SELECT * FROM " + tableName, "VALUES 1");
+
+            String dataFilePath = (String) computeScalar(
+                    "SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1");
+            assertThat(dataFilePath).startsWith("s3://");
+
+            // Reading the data file without the SSE-C key must fail,
+            // proving the data is actually encrypted on storage
+            TrinoFileSystem plainFileSystem = s3FileSystemFactory.create(ConnectorIdentity.ofUser("test"));
+            TrinoInputFile plainInputFile = plainFileSystem.newInputFile(Location.of(dataFilePath));
+            assertThatThrownBy(plainInputFile::length)
+                    .isInstanceOf(IOException.class);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendingRESTCatalogAdapter.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendingRESTCatalogAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Test-only {@link RESTCatalogAdapter} that injects a fixed set of {@code
+ * fileIoProperties} entries into every {@link LoadTableResponse}. Simulates a
+ * REST catalog that vends per-table storage configuration such as access
+ * credentials or server-side encryption keys.
+ */
+public class VendingRESTCatalogAdapter
+        extends RESTCatalogAdapter
+{
+    private final Map<String, String> vendedConfig;
+
+    public VendingRESTCatalogAdapter(Catalog catalog, Map<String, String> vendedConfig)
+    {
+        super(catalog);
+        this.vendedConfig = ImmutableMap.copyOf(requireNonNull(vendedConfig, "vendedConfig is null"));
+    }
+
+    @Override
+    protected <T extends RESTResponse> T execute(
+            HTTPRequest request,
+            Class<T> responseType,
+            Consumer<ErrorResponse> errorHandler,
+            Consumer<Map<String, String>> responseHeaders)
+    {
+        T response = super.execute(request, responseType, errorHandler, responseHeaders);
+        if (response instanceof LoadTableResponse loadTableResponse && !vendedConfig.isEmpty()) {
+            return responseType.cast(
+                    LoadTableResponse.builder()
+                            .withTableMetadata(loadTableResponse.tableMetadata())
+                            .addAllConfig(loadTableResponse.config())
+                            .addAllConfig(vendedConfig)
+                            .build());
+        }
+        return response;
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
@@ -13,19 +13,12 @@
  */
 package org.apache.iceberg.rest;
 
-import com.google.common.collect.ImmutableSet;
-import io.airlift.http.server.HttpConfig;
-import io.airlift.http.server.HttpServer.ClientCertificate;
-import io.airlift.http.server.HttpServerConfig;
-import io.airlift.http.server.HttpServerInfo;
-import io.airlift.http.server.ServerFeature;
 import io.airlift.http.server.testing.TestingHttpServer;
-import io.airlift.node.NodeInfo;
+import io.trino.plugin.iceberg.catalog.rest.RestCatalogTestingHttpServers;
 import org.apache.iceberg.catalog.Catalog;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,33 +53,7 @@ public class DelegatingRestSessionCatalog
     public TestingHttpServer testServer()
             throws IOException
     {
-        NodeInfo nodeInfo = new NodeInfo("test");
-        HttpServerConfig config = new HttpServerConfig()
-                .setMinThreads(4)
-                .setMaxThreads(8)
-                .setHttpEnabled(true);
-        HttpConfig httpConfig = new HttpConfig()
-                .setHttpPort(0)
-                .setHttpAcceptorThreads(4)
-                .setAcceptQueueSize(10);
-        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(httpConfig), Optional.empty(), nodeInfo);
-        RESTCatalogServlet servlet = new RESTCatalogServlet(adapter);
-
-        return new TestingHttpServer(
-                "rest-catalog",
-                httpServerInfo,
-                nodeInfo,
-                config,
-                Optional.of(httpConfig),
-                Optional.empty(),
-                servlet,
-                ImmutableSet.of(),
-                ImmutableSet.of(),
-                ServerFeature.builder()
-                        // Required due to URIs like: HEAD /v1/namespaces/level_1%1Flevel_2
-                        .withLegacyUriCompliance(true)
-                        .build(),
-                ClientCertificate.NONE);
+        return RestCatalogTestingHttpServers.create(new RESTCatalogServlet(adapter));
     }
 
     public static Builder builder()

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MinioTls.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MinioTls.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.testing.containers.Minio.DEFAULT_IMAGE;
+import static io.trino.testing.containers.Minio.MINIO_API_PORT;
+import static io.trino.testing.containers.Minio.MINIO_CONSOLE_PORT;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * MinIO test container configured for HTTPS using a caller-supplied
+ * {@link TlsCertificate}. Modeled after {@link Minio} but exposes an
+ * {@code https://} endpoint, as required by features such as S3 server-side
+ * encryption with customer-provided keys (SSE-C).
+ */
+public class MinioTls
+        extends BaseTestContainer
+{
+    private static final Logger log = Logger.get(MinioTls.class);
+
+    private static final String CONTAINER_CERTS_DIR = "/certs";
+    private static final String CONTAINER_CERTS_PUBLIC = CONTAINER_CERTS_DIR + "/public.crt";
+    private static final String CONTAINER_CERTS_PRIVATE = CONTAINER_CERTS_DIR + "/private.key";
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private MinioTls(
+            String image,
+            String hostName,
+            Set<Integer> exposePorts,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int retryLimit)
+    {
+        super(image,
+                hostName,
+                exposePorts,
+                filesToMount,
+                envVars,
+                network,
+                retryLimit);
+    }
+
+    @Override
+    protected void setupContainer()
+    {
+        super.setupContainer();
+        withRunCommand(ImmutableList.of(
+                "server",
+                "--address",
+                "0.0.0.0:" + MINIO_API_PORT,
+                "--console-address",
+                "0.0.0.0:" + MINIO_CONSOLE_PORT,
+                "--certs-dir",
+                CONTAINER_CERTS_DIR,
+                "/data"));
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        log.info("MinIO TLS container started with address for api: %s and console: %s", getMinioHttpsEndpoint(), getMinioConsoleEndpoint());
+    }
+
+    public String getMinioHttpsEndpoint()
+    {
+        return "https://" + getMappedHostAndPortForExposedPort(MINIO_API_PORT);
+    }
+
+    public String getMinioConsoleEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(MINIO_CONSOLE_PORT).toString();
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<Builder, MinioTls>
+    {
+        private TlsCertificate certificate;
+
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = "minio-tls";
+            this.exposePorts = ImmutableSet.of(MINIO_API_PORT, MINIO_CONSOLE_PORT);
+            this.envVars = ImmutableMap.<String, String>builder()
+                    .put("MINIO_ROOT_USER", MINIO_ROOT_USER)
+                    .put("MINIO_ROOT_PASSWORD", MINIO_ROOT_PASSWORD)
+                    .buildOrThrow();
+        }
+
+        public Builder withCertificate(TlsCertificate certificate)
+        {
+            this.certificate = requireNonNull(certificate, "certificate is null");
+            return self;
+        }
+
+        @Override
+        public MinioTls build()
+        {
+            requireNonNull(certificate, "certificate must be set via withCertificate()");
+            Map<String, String> mounts = ImmutableMap.<String, String>builder()
+                    .putAll(filesToMount)
+                    .put(CONTAINER_CERTS_PUBLIC, certificate.publicCertificate().toString())
+                    .put(CONTAINER_CERTS_PRIVATE, certificate.privateKey().toString())
+                    .buildOrThrow();
+            return new MinioTls(image, hostName, exposePorts, mounts, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TlsCertificate.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TlsCertificate.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.util.Base64;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Generates a self-signed TLS certificate suitable for testing HTTPS servers
+ * such as {@link MinioTls}. The resulting directory contains the PEM-encoded
+ * certificate and private key (which can be mounted into a container), and a
+ * PKCS#12 trust store usable by the JVM's default SSL context.
+ */
+public final class TlsCertificate
+        implements AutoCloseable
+{
+    private static final String DEFAULT_ALIAS = "trino-testing";
+    private static final String DEFAULT_PASSWORD = "changeit";
+    private static final String PUBLIC_CERTIFICATE_FILE = "public.crt";
+    private static final String PRIVATE_KEY_FILE = "private.key";
+    private static final String TRUST_STORE_FILE = "truststore.p12";
+
+    private final Path directory;
+    private final String password;
+    private final boolean ownsDirectory;
+    private PreviousTrustStoreSettings previousTrustStore;
+    private SSLContext previousDefaultSslContext;
+
+    private TlsCertificate(Path directory, String password, boolean ownsDirectory)
+    {
+        this.directory = requireNonNull(directory, "directory is null");
+        this.password = requireNonNull(password, "password is null");
+        this.ownsDirectory = ownsDirectory;
+    }
+
+    /**
+     * Generate a new self-signed certificate valid for {@code localhost}/127.0.0.1
+     * into a fresh temporary directory that is deleted on {@link #close()}.
+     */
+    public static TlsCertificate generate()
+            throws Exception
+    {
+        Path directory = Files.createTempDirectory("trino-tls");
+        try {
+            generateInternal(directory, DEFAULT_ALIAS, DEFAULT_PASSWORD);
+        }
+        catch (Exception | Error e) {
+            MoreFiles.deleteRecursively(directory, RecursiveDeleteOption.ALLOW_INSECURE);
+            throw e;
+        }
+        return new TlsCertificate(directory, DEFAULT_PASSWORD, true);
+    }
+
+    public Path publicCertificate()
+    {
+        return directory.resolve(PUBLIC_CERTIFICATE_FILE);
+    }
+
+    public Path privateKey()
+    {
+        return directory.resolve(PRIVATE_KEY_FILE);
+    }
+
+    public Path trustStore()
+    {
+        return directory.resolve(TRUST_STORE_FILE);
+    }
+
+    public String trustStorePassword()
+    {
+        return password;
+    }
+
+    /**
+     * Install this certificate as the JVM default trust store so that HTTPS
+     * connections to a server presenting it succeed. Any previous values are
+     * captured and automatically restored by {@link #close()}, preventing the
+     * JVM-wide trust store configuration from leaking into subsequent tests.
+     *
+     * <p>In addition to setting the {@code javax.net.ssl.trustStore} system
+     * properties (which are only consulted on first SSL initialization), this
+     * also installs a freshly-built {@link SSLContext} as the JVM default via
+     * {@link SSLContext#setDefault(SSLContext)}. Without that override, an
+     * earlier test in a forked-but-reused JVM (Surefire {@code reuseForks=true})
+     * may have already locked in the original JRE {@code cacerts} as the
+     * default {@code SSLContext}, causing later HTTPS clients (e.g. AWS SDK
+     * v2 Apache HTTP client) to fail PKIX validation against this self-signed
+     * certificate.
+     */
+    public void installAsDefaultTrustStore()
+    {
+        if (previousTrustStore == null) {
+            previousTrustStore = PreviousTrustStoreSettings.capture();
+        }
+
+        // Capture the existing default SSLContext BEFORE mutating system
+        // properties. If nothing has initialized SSL yet, this call lazily
+        // initializes the default using the still-unmodified system
+        // properties, so the captured context represents the JVM's pristine
+        // defaults and can be safely restored on close().
+        SSLContext previous;
+        try {
+            previous = SSLContext.getDefault();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to read existing default SSLContext", e);
+        }
+        if (previousDefaultSslContext == null) {
+            previousDefaultSslContext = previous;
+        }
+
+        System.setProperty("javax.net.ssl.trustStore", trustStore().toString());
+        System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword());
+        System.setProperty("javax.net.ssl.trustStoreType", "PKCS12");
+
+        SSLContext.setDefault(buildSslContext());
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (previousDefaultSslContext != null) {
+            SSLContext.setDefault(previousDefaultSslContext);
+            previousDefaultSslContext = null;
+        }
+        if (previousTrustStore != null) {
+            previousTrustStore.restore();
+            previousTrustStore = null;
+        }
+        if (ownsDirectory) {
+            MoreFiles.deleteRecursively(directory, RecursiveDeleteOption.ALLOW_INSECURE);
+        }
+    }
+
+    private SSLContext buildSslContext()
+    {
+        try {
+            KeyStore trustStore = KeyStore.getInstance("PKCS12");
+            try (InputStream in = Files.newInputStream(trustStore())) {
+                trustStore.load(in, password.toCharArray());
+            }
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, trustManagerFactory.getTrustManagers(), null);
+            return context;
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to build SSLContext from " + trustStore(), e);
+        }
+    }
+
+    private static void generateInternal(Path directory, String alias, String password)
+            throws Exception
+    {
+        Path keyStorePath = directory.resolve("keystore.p12");
+
+        Process process = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", "keytool").toString(),
+                "-genkeypair",
+                "-alias",
+                alias,
+                "-keyalg",
+                "RSA",
+                "-keysize",
+                "2048",
+                "-validity",
+                "1",
+                "-keystore",
+                keyStorePath.toString(),
+                "-storetype",
+                "PKCS12",
+                "-storepass",
+                password,
+                "-keypass",
+                password,
+                "-dname",
+                "CN=localhost",
+                "-ext",
+                "SAN=DNS:localhost,IP:127.0.0.1")
+                .inheritIO()
+                .start();
+        int exitCode = process.waitFor();
+        checkArgument(exitCode == 0, "keytool failed with exit code %s", exitCode);
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream in = Files.newInputStream(keyStorePath)) {
+            keyStore.load(in, password.toCharArray());
+        }
+
+        Certificate certificate = keyStore.getCertificate(alias);
+        writePem(directory.resolve(PUBLIC_CERTIFICATE_FILE),
+                "CERTIFICATE",
+                certificate.getEncoded());
+
+        PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, password.toCharArray());
+        writePem(directory.resolve(PRIVATE_KEY_FILE),
+                "PRIVATE KEY",
+                privateKey.getEncoded());
+
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        trustStore.load(null, null);
+        trustStore.setCertificateEntry(alias, certificate);
+        try (OutputStream out = Files.newOutputStream(directory.resolve(TRUST_STORE_FILE), CREATE_NEW)) {
+            trustStore.store(out, password.toCharArray());
+        }
+    }
+
+    private static void writePem(Path target, String type, byte[] contents)
+            throws IOException
+    {
+        String pem = "-----BEGIN " + type + "-----\n" +
+                Base64.getMimeEncoder(64, new byte[] {'\n'}).encodeToString(contents) +
+                "\n-----END " + type + "-----\n";
+        Files.writeString(target, pem, CREATE_NEW);
+    }
+
+    private record PreviousTrustStoreSettings(String trustStore, String password, String type)
+    {
+        private static PreviousTrustStoreSettings capture()
+        {
+            return new PreviousTrustStoreSettings(
+                    System.getProperty("javax.net.ssl.trustStore"),
+                    System.getProperty("javax.net.ssl.trustStorePassword"),
+                    System.getProperty("javax.net.ssl.trustStoreType"));
+        }
+
+        void restore()
+        {
+            restoreProperty("javax.net.ssl.trustStore", trustStore);
+            restoreProperty("javax.net.ssl.trustStorePassword", password);
+            restoreProperty("javax.net.ssl.trustStoreType", type);
+        }
+
+        private static void restoreProperty(String key, String value)
+        {
+            if (value == null) {
+                System.clearProperty(key);
+            }
+            else {
+                System.setProperty(key, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

Iceberg REST catalogs can vend more than just access credentials — they can also vend
server-side encryption keys as part of the `fileIoProperties` response. This is how a
catalog enforces encryption policy centrally: it hands you the key along with the
credentials, so every write goes out encrypted with a customer-managed key.

Trino already forwards vended S3 and GCS credentials to the right filesystem. But if
the catalog also vended an SSE key alongside those credentials, Trino just dropped it.
The result: writes go out unencrypted even though the catalog intended them to be
encrypted, or reads fail because the data was written with a key Trino didn't apply.

For organizations that require customer-managed encryption (data sovereignty, compliance,
catalog-enforced encryption policy

## Description

Two things:

**1. `DualKeyEncryptionFileSystem`** — a new `TrinoFileSystem` wrapper in
`lib/trino-filesystem` that supports separate encryption and decryption keys. GCS
supports this for key rotation: you write new data with a new key while old data is
still readable with the previous key. The existing `EncryptionEnforcingFileSystem` only
handles one key for both directions, so it can't model this. Either key can be absent —
that direction just uses unencrypted I/O.

**2. Encryption key wiring in `IcebergRestCatalogFileSystemFactory`** — after the base
filesystem is created with vended credentials, we now check for encryption keys and wrap
the filesystem if they're present:

- `s3.sse.type=custom` + `s3.sse.key` → S3 SSE-C, wrapped with the existing
  `EncryptionEnforcingFileSystem` (same key for reads and writes)
- `gcs.encryption-key` / `gcs.decryption-key` → GCS CSEK, wrapped with the new
  `DualKeyEncryptionFileSystem` (either key can be absent for partial rotation)


When an Iceberg REST catalog vends fileIoProperties containing server-side encryption keys, Trino now applies them transparently via filesystem wrappers rather than silently ignoring them.

- Add DualKeyEncryptionFileSystem: a generic TrinoFileSystem wrapper that supports separate encryption (write) and decryption (read) keys, enabling GCS CSEK key rotation scenarios.

- Wire S3 SSE-C (s3.sse.type=custom + s3.sse.key) into IcebergRestCatalogFileSystemFactory using the existing EncryptionEnforcingFileSystem (same key for reads and writes).

- Wire GCS CSEK (gcs.encryption-key / gcs.decryption-key) using the new DualKeyEncryptionFileSystem (either key may be absent).

- S3 SSE-KMS is intentionally deferred: KMS key ARNs do not fit the current EncryptionKey byte-key abstraction and require a separate design. Azure CPK is deferred until the Iceberg spec defines Azure encryption properties.


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Wire server-side encryption keys vended by Iceberg REST catalogs (as part of the `fileIoProperties` response on `loadTable` / `loadView`) into Trino's storage layer, so that writes go out encrypted and reads decrypt correctly when a catalog enforces customer-managed encryption. See **Why** and **What** above for motivation, design, and the list of supported mechanisms.

The GCS filesystem configuration properties referenced above — `gcs.encryption-key` and `gcs.decryption-key`, along with their `internal$gcs_encryption_key` / `internal$gcs_decryption_key` per-identity extra-credential hooks — are introduced by the stacked base PR #29207. This PR consumes them from the Iceberg REST catalog vending path. The corresponding S3 properties (`s3.sse.customer-key`, `s3.sse.type`) already exist in the S3 filesystem; this PR only adds the `internal$s3_sse_customer_key` extra credential and the `S3Context` wiring to accept an identity-scoped override.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This PR is the top of a three-PR stack that progressively adds Iceberg REST catalog SSE key vending support:

1. #29186 — *Delegate encrypted file operations in `CacheFileSystem`* (base)
2. #29207 — *Add customer-supplied encryption key (CSEK) support to GCS filesystem* (stacked on #29186, introduces the `gcs.encryption-key` / `gcs.decryption-key` configuration properties and their `internal$gcs_*_key` extra-credential hooks)
3. **#28793 (this PR)** — *Support vended SSE encryption keys from Iceberg REST catalog* (stacked on #29207)


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Support server-side encryption keys vended by the Iceberg REST catalog, including S3 SSE-C and GCS customer-supplied encryption keys (CSEK). ({issue}`28793`)
```