### PR TITLE
Hive: Preserve custom partition locations during INSERT OVERWRITE

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -403,7 +403,7 @@ public class HiveWriterFactory
                     compressionCodec = selectCompressionCodec(session, partitionStorageFormat);
                     schema.putAll(getHiveSchema(table));
 
-                    writeInfo = locationService.getPartitionWriteInfo(locationHandle, Optional.empty(), partitionName.get());
+                    writeInfo = locationService.getPartitionWriteInfo(locationHandle, partition, partitionName.get());
                     break;
                 case ERROR:
                     throw new TrinoException(HIVE_PARTITION_READ_ONLY, "Cannot insert into an existing partition of Hive table: " + partitionName.get());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -108,6 +108,7 @@ abstract class BaseTestHiveOnDataLake
                 .setHiveProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("hive.insert-existing-partitions-behavior", "OVERWRITE")
+                                .put("hive.allow-register-partition-procedure", "true")
                                 .put("hive.non-managed-table-writes-enabled", "true")
                                 // Below are required to enable caching on metastore
                                 .put("hive.metastore-cache-ttl", "1d")
@@ -2621,5 +2622,63 @@ abstract class BaseTestHiveOnDataLake
         assertInsertFailure(
                 testTable,
                 "Overwriting existing partition in transactional tables doesn't support DIRECT_TO_TARGET_EXISTING_DIRECTORY write mode");
+    }
+
+    @Test
+    public void testInsertOverwriteWithCustomPartitionLocation()
+    {
+        String tableName = "test_insert_overwrite_custom_partition_" + randomNameSuffix();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+        String tableLocation = format("s3://%s/%s/%s/", bucketName, HIVE_TEST_SCHEMA, tableName);
+
+        // Create external partitioned table
+        assertUpdate(format(
+                "CREATE TABLE %s (v integer, k varchar) WITH (" +
+                        "partitioned_by = ARRAY['k']," +
+                        "external_location = '%s')",
+                fullyQualifiedTestTableName,
+                tableLocation));
+
+        // Create custom partition directory (register_partition requires the directory to exist)
+        String customPartitionPath = HIVE_TEST_SCHEMA + "/" + tableName + "/k=k1_plus";
+        hiveMinioDataLake.getMinioClient().putObject(bucketName, "".getBytes(UTF_8), customPartitionPath + "/.keep");
+
+        // Register partition k=k1 with custom location k=k1_plus
+        String customPartitionLocation = format("s3://%s/%s/", bucketName, customPartitionPath);
+        assertUpdate(format(
+                "CALL system.register_partition('%s', '%s', ARRAY['k'], ARRAY['k1'], '%s')",
+                HIVE_TEST_SCHEMA, tableName, customPartitionLocation));
+
+        // First insert: add data to custom partition (k1) and normal partition (k2)
+        Session appendSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty("hive", "insert_existing_partitions_behavior", "APPEND")
+                .build();
+        assertUpdate(appendSession, format("INSERT INTO %s VALUES (1, 'k1'), (2, 'k2')", fullyQualifiedTestTableName), 2);
+        assertQuery("SELECT v, k FROM " + fullyQualifiedTestTableName + " ORDER BY v", "VALUES (1, 'k1'), (2, 'k2')");
+        // Paths before overwrite: k1 in custom location, k2 in default location
+        assertQuery(
+                format("SELECT \"$path\" LIKE '%%k=k1_plus%%' FROM %s WHERE k='k1' LIMIT 1", fullyQualifiedTestTableName),
+                "VALUES true");
+        assertQuery(
+                format("SELECT \"$path\" LIKE '%%k=k2%%' FROM %s WHERE k='k2' LIMIT 1", fullyQualifiedTestTableName),
+                "VALUES true");
+
+        // Set session to OVERWRITE and insert again with different data
+        Session overwriteSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty("hive", "insert_existing_partitions_behavior", "OVERWRITE")
+                .build();
+        assertUpdate(overwriteSession, format("INSERT INTO %s VALUES (10, 'k1'), (20, 'k2')", fullyQualifiedTestTableName), 2);
+
+        // After overwrite: only new data should exist, previous data is lost
+        assertQuery("SELECT v, k FROM " + fullyQualifiedTestTableName + " ORDER BY v", "VALUES (10, 'k1'), (20, 'k2')");
+        // Paths after overwrite: k1 still in custom location, k2 in default location
+        assertQuery(
+                format("SELECT \"$path\" LIKE '%%k=k1_plus%%' FROM %s WHERE k='k1' LIMIT 1", fullyQualifiedTestTableName),
+                "VALUES true");
+        assertQuery(
+                format("SELECT \"$path\" LIKE '%%k=k2%%' FROM %s WHERE k='k2' LIMIT 1", fullyQualifiedTestTableName),
+                "VALUES true");
+
+        assertUpdate("DROP TABLE " + fullyQualifiedTestTableName);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartition.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartition.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.trino.plugin.hive.HiveQueryRunner.HIVE_CATALOG;
+import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
+import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+
+public class TestHivePartition
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setHiveProperties(ImmutableMap.of(
+                        "hive.non-managed-table-writes-enabled", "true",
+                        "hive.allow-register-partition-procedure", "true"))
+                .build();
+    }
+
+    @Test
+    public void testInsertOverwriteWithCustomPartitionLocation()
+            throws Exception
+    {
+        String tableName = "test_insert_overwrite_custom_partition_" + randomNameSuffix();
+        TrinoFileSystem fileSystem = getConnectorService(getQueryRunner(), TrinoFileSystemFactory.class)
+                .create(ConnectorIdentity.ofUser("test"));
+
+        Location tableLocation = Location.of("local:///test_insert_overwrite_" + UUID.randomUUID());
+        fileSystem.createDirectory(tableLocation);
+
+        Location customPartitionDir = tableLocation.appendPath("k=k1_plus");
+        fileSystem.createDirectory(customPartitionDir);
+
+        try {
+            assertUpdate(format(
+                    "CREATE TABLE %s.%s.%s (v integer, k varchar) WITH (" +
+                            "partitioned_by = ARRAY['k']," +
+                            "external_location = '%s')",
+                    HIVE_CATALOG, TPCH_SCHEMA, tableName,
+                    tableLocation));
+
+            assertUpdate(format(
+                    "CALL system.register_partition('%s', '%s', ARRAY['k'], ARRAY['k1'], '%s')",
+                    TPCH_SCHEMA, tableName, customPartitionDir.toString()));
+
+            Session appendSession = Session.builder(getQueryRunner().getDefaultSession())
+                    .setCatalogSessionProperty("hive", "insert_existing_partitions_behavior", "APPEND")
+                    .build();
+            assertUpdate(appendSession, format("INSERT INTO %s.%s.%s VALUES (1, 'k1'), (2, 'k2')", HIVE_CATALOG, TPCH_SCHEMA, tableName), 2);
+            assertQuery("SELECT v, k FROM " + tableName + " ORDER BY v", "VALUES (1, 'k1'), (2, 'k2')");
+            assertQuery(
+                    format("SELECT \"$path\" LIKE '%%k=k1_plus%%' FROM %s WHERE k='k1' LIMIT 1", tableName),
+                    "VALUES true");
+            assertQuery(
+                    format("SELECT \"$path\" LIKE '%%k=k2%%' FROM %s WHERE k='k2' LIMIT 1", tableName),
+                    "VALUES true");
+
+            Session overwriteSession = Session.builder(getQueryRunner().getDefaultSession())
+                    .setCatalogSessionProperty("hive", "insert_existing_partitions_behavior", "OVERWRITE")
+                    .build();
+            assertUpdate(overwriteSession, format("INSERT INTO %s.%s.%s VALUES (10, 'k1'), (20, 'k2')", HIVE_CATALOG, TPCH_SCHEMA, tableName), 2);
+
+            assertQuery("SELECT v, k FROM " + tableName + " ORDER BY v", "VALUES (10, 'k1'), (20, 'k2')");
+            assertQuery(
+                    format("SELECT \"$path\" LIKE '%%k=k1_plus%%' FROM %s WHERE k='k1' LIMIT 1", tableName),
+                    "VALUES true");
+            assertQuery(
+                    format("SELECT \"$path\" LIKE '%%k=k2%%' FROM %s WHERE k='k2' LIMIT 1", tableName),
+                    "VALUES true");
+
+            assertUpdate("DROP TABLE " + tableName);
+        }
+        finally {
+            fileSystem.deleteDirectory(tableLocation);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #27271

Hive: Fix custom partition location on overwrite

Description
When using insert_existing_partitions_behavior='OVERWRITE', Trino incorrectly ignored custom partition locations registered via system.register_partition. Instead of replacing data in the custom URI, it reverted to the default partition path.

This caused cross-directory rename failures on object stores like S3 (IOException: S3 does not support renames), and silent data movement to the wrong directory on HDFS, breaking the custom partition registration entirely.

This PR ensures the overwrite logic correctly resolves and respects existing custom partition URIs, maintaining the integrity of external data pipelines.

Additional context and related issues
Previously, when evaluating the write path for an OVERWRITE operation, the code passed an empty Optional for the partition into the getPartitionWriteInfo() function. This caused the function to treat the partition as brand new, returning a path that used the default directory nomenclature and abandoning the actual custom directory.

In this change, we pass the existing partition as a parameter instead. This allows getPartitionWriteInfo() to correctly determine and return the custom directory. Because there is already existing logic to safely clean up the target directory during an OVERWRITE, passing the existing partition correctly resolves the location without accidentally triggering APPEND behavior.

Release notes
( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Code snippet
## Bug Fixes
* Hive
  * Fix an issue where `INSERT OVERWRITE` ignores custom partition locations and incorrectly moves data to the default partition path. ({issue}`#27271`)