### PR TITLE
Add Databricks connector

### DIFF
--- a/docs/src/main/sphinx/connector.md
+++ b/docs/src/main/sphinx/connector.md
@@ -12,6 +12,7 @@ BigQuery        <connector/bigquery>
 Black Hole      <connector/blackhole>
 Cassandra       <connector/cassandra>
 ClickHouse      <connector/clickhouse>
+Databricks      <connector/databricks>
 Delta Lake      <connector/delta-lake>
 Druid           <connector/druid>
 DuckDB          <connector/duckdb>

--- a/docs/src/main/sphinx/connector/databricks.md
+++ b/docs/src/main/sphinx/connector/databricks.md
@@ -1,0 +1,291 @@
+---
+myst:
+  substitutions:
+    default_domain_compaction_threshold: "`256`"
+---
+# Databricks connector
+
+The Databricks connector allows querying and creating tables in an external
+[Databricks](https://www.databricks.com/) workspace. This can be used to join
+data between different systems like Databricks and Hive, or between two
+different Databricks workspaces.
+
+## Configuration
+
+The connector can query a Databricks SQL warehouse. Create a catalog properties
+file that specifies the Databricks connector by setting the `connector.name` to
+`databricks`.
+
+For example, to access a Databricks workspace as the `example` catalog, create
+the file `etc/catalog/example.properties`. Replace the connection properties as
+appropriate for your setup:
+
+```none
+connector.name=databricks
+connection-url=jdbc:databricks://<hostname>:443/default;transportMode=http;ssl=1;AuthMech=3;httpPath=<http-path>;
+connection-user=token
+connection-password=<access-token>
+```
+
+The `connection-url` defines the connection information and parameters to pass
+to the Databricks JDBC driver. The supported URL format is documented in the
+[Databricks JDBC driver documentation](https://docs.databricks.com/en/integrations/jdbc/index.html).
+
+Replace `<hostname>` with your Databricks workspace hostname (e.g.
+`dbc-xxxxxxxx-xxxx.cloud.databricks.com`), `<http-path>` with the HTTP path of
+your SQL warehouse (e.g. `/sql/1.0/warehouses/xxxxxxxxxxxx`), and
+`<access-token>` with your Databricks personal access token.
+
+### Connector properties
+
+The following configuration properties are available:
+
+:::{list-table}
+:widths: 40, 40, 20
+:header-rows: 1
+
+* - Property name
+  - Description
+  - Default
+* - `databricks.http-path`
+  - The HTTP path of the Databricks SQL warehouse.
+  - (none)
+* - `databricks.catalog`
+  - The Databricks Unity Catalog catalog to use.
+  - (none)
+* - `databricks.schema`
+  - The Databricks schema (database) to use.
+  - (none)
+:::
+
+### Multiple Databricks catalogs
+
+The Databricks connector can access a single Unity Catalog catalog within a
+Databricks workspace. If you need to access multiple catalogs, configure
+multiple instances of the Databricks connector with different
+`databricks.catalog` values.
+
+```{include} jdbc-common-configurations.fragment
+```
+
+```{include} query-comment-format.fragment
+```
+
+```{include} jdbc-domain-compaction-threshold.fragment
+```
+
+(databricks-type-mapping)=
+## Type mapping
+
+Because Trino and Databricks each support types that the other does not, this
+connector {ref}`modifies some types <type-mapping-overview>` when reading or
+writing data. Data types may not map the same way in both directions between
+Trino and the data source. Refer to the following sections for type mapping in
+each direction.
+
+List of [Databricks SQL data types](https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html).
+
+### Databricks type to Trino type mapping
+
+The connector maps Databricks types to the corresponding Trino types following
+this table:
+
+:::{list-table} Databricks type to Trino type mapping
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - Databricks type
+  - Trino type
+  - Notes
+* - `BOOLEAN`
+  - `BOOLEAN`
+  -
+* - `TINYINT`
+  - `TINYINT`
+  -
+* - `SMALLINT`
+  - `SMALLINT`
+  -
+* - `INT`
+  - `INTEGER`
+  -
+* - `BIGINT`
+  - `BIGINT`
+  -
+* - `FLOAT`
+  - `REAL`
+  -
+* - `DOUBLE`
+  - `DOUBLE`
+  -
+* - `DECIMAL`
+  - `DECIMAL`
+  - Default precision and scale are (10,0).
+* - `STRING`
+  - `VARCHAR`
+  -
+* - `VARCHAR`
+  - `VARCHAR`
+  -
+* - `DATE`
+  - `DATE`
+  -
+* - `TIMESTAMP`
+  - `TIMESTAMP(3)`
+  -
+* - `TIMESTAMP_NTZ`
+  - `TIMESTAMP(3)`
+  -
+:::
+
+No other types are supported.
+
+### Trino type to Databricks type mapping
+
+The connector maps Trino types to the corresponding Databricks types following
+this table:
+
+:::{list-table} Trino type to Databricks type mapping
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - Trino type
+  - Databricks type
+  - Notes
+* - `BOOLEAN`
+  - `BOOLEAN`
+  -
+* - `TINYINT`
+  - `TINYINT`
+  -
+* - `SMALLINT`
+  - `SMALLINT`
+  -
+* - `INTEGER`
+  - `INTEGER`
+  -
+* - `BIGINT`
+  - `BIGINT`
+  -
+* - `REAL`
+  - `FLOAT`
+  -
+* - `DOUBLE`
+  - `DOUBLE`
+  -
+* - `DECIMAL`
+  - `DECIMAL`
+  -
+* - `CHAR`
+  - `STRING`
+  -
+* - `VARCHAR`
+  - `STRING`
+  -
+* - `DATE`
+  - `DATE`
+  -
+* - `TIMESTAMP`
+  - `TIMESTAMP`
+  -
+:::
+
+No other types are supported.
+
+```{include} jdbc-type-mapping.fragment
+```
+
+(databricks-sql-support)=
+## SQL support
+
+The connector provides read access and write access to data and metadata in a
+Databricks SQL warehouse. In addition to the {ref}`globally available
+<sql-globally-available>` and {ref}`read operation <sql-read-operations>`
+statements, the connector supports the following features:
+
+- {doc}`/sql/insert`
+- {doc}`/sql/delete`
+- {doc}`/sql/truncate`
+- {doc}`/sql/create-table`
+- {doc}`/sql/create-table-as`
+- {doc}`/sql/drop-table`
+- {doc}`/sql/alter-table`
+- {doc}`/sql/create-schema`
+- {doc}`/sql/drop-schema`
+
+### Procedures
+
+```{include} jdbc-procedures-flush.fragment
+```
+```{include} procedures-execute.fragment
+```
+
+### Table functions
+
+The connector provides specific [table functions](/functions/table) to
+access Databricks.
+
+(databricks-query-function)=
+#### `query(varchar) -> table`
+
+The `query` function allows you to query the underlying database directly. It
+requires syntax native to Databricks SQL, because the full query is pushed down
+and processed in Databricks. This can be useful for accessing native features
+which are not available in Trino or for improving query performance in
+situations where running a query natively may be faster.
+
+Find details about the SQL support of Databricks that you can use in the query
+in the [Databricks SQL language
+reference](https://docs.databricks.com/en/sql/language-manual/index.html).
+
+```{include} query-passthrough-warning.fragment
+```
+
+As a simple example, query the `example` catalog and select an entire table:
+
+```
+SELECT
+  *
+FROM
+  TABLE(
+    example.system.query(
+      query => 'SELECT
+        *
+      FROM
+        tpch.nation'
+    )
+  );
+```
+
+```{include} query-table-function-ordering.fragment
+```
+
+## Performance
+
+The connector includes a number of performance improvements, detailed in the
+following sections.
+
+(databricks-pushdown)=
+### Pushdown
+
+The connector supports pushdown for a number of operations:
+
+- [](limit-pushdown)
+- [](topn-pushdown)
+
+{ref}`Aggregate pushdown <aggregation-pushdown>` for the following functions:
+
+- {func}`avg`
+- {func}`count`
+- {func}`max`
+- {func}`min`
+- {func}`sum`
+- {func}`stddev`
+- {func}`stddev_pop`
+- {func}`stddev_samp`
+- {func}`variance`
+- {func}`var_pop`
+- {func}`var_samp`
+
+```{include} pushdown-correctness-behavior.fragment
+```

--- a/plugin/trino-databricks/pom.xml
+++ b/plugin/trino-databricks/pom.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>481-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-databricks</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - Databricks Connector</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>databricks-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <!-- Trino SPI -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api-incubator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-base-jdbc</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredResourcePatterns>
+                            <ignoredResourcePattern>mime.types</ignoredResourcePattern>
+                            <ignoredResourcePattern>TypeCalculation\.tokens</ignoredResourcePattern>
+                            <ignoredResourcePattern>TypeCalculationLexer\.tokens</ignoredResourcePattern>
+                        </ignoredResourcePatterns>
+                        <ignoredDependencies>
+                            <dependency>
+                                <groupId>com.databricks</groupId>
+                                <artifactId>databricks-jdbc</artifactId>
+                            </dependency>
+                        </ignoredDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TestDatabricksConnectorTest.java</exclude>
+                                <exclude>**/TestDatabricksTypeMapping.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- Tests which require third party cloud services are separated from the main test profile -->
+            <id>cloud-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestDatabricksConnectorTest.java</include>
+                                <include>**/TestDatabricksTypeMapping.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksClient.java
+++ b/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksClient.java
@@ -1,0 +1,463 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
+import io.trino.plugin.base.aggregation.AggregateFunctionRule;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.mapping.IdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcClient;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcSortItem;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.ObjectReadFunction;
+import io.trino.plugin.jdbc.ObjectWriteFunction;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.RemoteTableName;
+import io.trino.plugin.jdbc.SliceWriteFunction;
+import io.trino.plugin.jdbc.StandardColumnMappings;
+import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.aggregation.ImplementAvgDecimal;
+import io.trino.plugin.jdbc.aggregation.ImplementAvgFloatingPoint;
+import io.trino.plugin.jdbc.aggregation.ImplementCorr;
+import io.trino.plugin.jdbc.aggregation.ImplementCount;
+import io.trino.plugin.jdbc.aggregation.ImplementCountAll;
+import io.trino.plugin.jdbc.aggregation.ImplementCountDistinct;
+import io.trino.plugin.jdbc.aggregation.ImplementCovariancePop;
+import io.trino.plugin.jdbc.aggregation.ImplementCovarianceSamp;
+import io.trino.plugin.jdbc.aggregation.ImplementMinMax;
+import io.trino.plugin.jdbc.aggregation.ImplementRegrIntercept;
+import io.trino.plugin.jdbc.aggregation.ImplementRegrSlope;
+import io.trino.plugin.jdbc.aggregation.ImplementStddevPop;
+import io.trino.plugin.jdbc.aggregation.ImplementStddevSamp;
+import io.trino.plugin.jdbc.aggregation.ImplementSum;
+import io.trino.plugin.jdbc.aggregation.ImplementVariancePop;
+import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
+import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Chars;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Timestamps;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.function.BiFunction;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.emptyToNull;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.decimalColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.toTrinoTimestamp;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.math.RoundingMode.UNNECESSARY;
+
+public class DatabricksClient
+        extends BaseJdbcClient
+{
+    private static final int MAX_SUPPORTED_TEMPORAL_PRECISION = 9;
+
+    private static final DateTimeFormatter DATABRICKS_DATE_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd");
+    private static final DateTimeFormatter DATABRICKS_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("u-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+    private static final TimeZone UTC_TZ = TimeZone.getTimeZone(ZoneId.of("UTC"));
+    private final AggregateFunctionRewriter<JdbcExpression, ?> aggregateFunctionRewriter;
+
+    @Inject
+    public DatabricksClient(
+            BaseJdbcConfig config,
+            ConnectionFactory connectionFactory,
+            QueryBuilder queryBuilder,
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier remoteQueryModifier)
+    {
+        super("`", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, remoteQueryModifier, false);
+
+        JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
+                .addStandardRules(this::quoted)
+                .build();
+
+        this.aggregateFunctionRewriter = new AggregateFunctionRewriter<>(
+                connectorExpressionRewriter,
+                ImmutableSet.<AggregateFunctionRule<JdbcExpression, ParameterizedExpression>>builder()
+                        .add(new ImplementCountAll(bigintTypeHandle))
+                        .add(new ImplementCount(bigintTypeHandle))
+                        .add(new ImplementCountDistinct(bigintTypeHandle, false))
+                        .add(new ImplementMinMax(false))
+                        .add(new ImplementSum(DatabricksClient::decimalTypeHandle))
+                        .add(new ImplementAvgFloatingPoint())
+                        .add(new ImplementAvgDecimal())
+                        .add(new ImplementAvgBigint())
+                        .add(new ImplementStddevSamp())
+                        .add(new ImplementStddevPop())
+                        .add(new ImplementVarianceSamp())
+                        .add(new ImplementVariancePop())
+                        .add(new ImplementCovarianceSamp())
+                        .add(new ImplementCovariancePop())
+                        .add(new ImplementCorr())
+                        .add(new ImplementRegrIntercept())
+                        .add(new ImplementRegrSlope())
+                        .build());
+    }
+
+    @Override
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
+        if (mapping.isPresent()) {
+            return mapping;
+        }
+        int type = typeHandle.jdbcType();
+
+        switch (type) {
+            case Types.BOOLEAN, Types.BIT -> {
+                return Optional.of(booleanColumnMapping());
+            }
+            case Types.TINYINT -> {
+                return Optional.of(tinyintColumnMapping());
+            }
+            case Types.SMALLINT -> {
+                return Optional.of(smallintColumnMapping());
+            }
+            case Types.INTEGER -> {
+                return Optional.of(integerColumnMapping());
+            }
+            case Types.BIGINT -> {
+                return Optional.of(bigintColumnMapping());
+            }
+            case Types.REAL, Types.FLOAT -> {
+                return Optional.of(realColumnMapping());
+            }
+            case Types.DOUBLE -> {
+                return Optional.of(doubleColumnMapping());
+            }
+            case Types.NUMERIC, Types.DECIMAL -> {
+                int precision = typeHandle.requiredColumnSize();
+                int scale = typeHandle.requiredDecimalDigits();
+                if (precision <= 38) {
+                    DecimalType decimalType = createDecimalType(precision, scale);
+                    return Optional.of(decimalColumnMapping(decimalType, UNNECESSARY));
+                }
+            }
+            case Types.CHAR, Types.NCHAR -> {
+                int columnSize = typeHandle.requiredColumnSize();
+                if (columnSize > CharType.MAX_LENGTH) {
+                    return Optional.of(varcharColumnMapping(createUnboundedVarcharType(), false));
+                }
+                return Optional.of(varcharColumnMapping(createVarcharType(columnSize), false));
+            }
+            case Types.VARCHAR, Types.NVARCHAR, Types.LONGVARCHAR, Types.LONGNVARCHAR -> {
+                int columnSize = typeHandle.requiredColumnSize();
+                if (columnSize > VarcharType.MAX_LENGTH || columnSize == 0) {
+                    return Optional.of(varcharColumnMapping(createUnboundedVarcharType(), false));
+                }
+                return Optional.of(varcharColumnMapping(createVarcharType(columnSize), false));
+            }
+            case Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY -> {
+                return Optional.of(varbinaryColumnMapping());
+            }
+            case Types.DATE -> {
+                return Optional.of(ColumnMapping.longMapping(DateType.DATE, ResultSet::getLong, databricksDateWriteFunction()));
+            }
+            case Types.TIMESTAMP -> {
+                return Optional.of(timestampColumnMapping(typeHandle.requiredDecimalDigits()));
+            }
+        }
+        if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
+            return mapToUnboundedVarchar(typeHandle);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        if (type == BOOLEAN) {
+            return WriteMapping.booleanMapping("BOOLEAN", booleanWriteFunction());
+        }
+        if (type == TINYINT) {
+            return WriteMapping.longMapping("TINYINT", tinyintWriteFunction());
+        }
+        if (type == SMALLINT) {
+            return WriteMapping.longMapping("SMALLINT", smallintWriteFunction());
+        }
+        if (type == INTEGER) {
+            return WriteMapping.longMapping("INT", integerWriteFunction());
+        }
+        if (type == BIGINT) {
+            return WriteMapping.longMapping("BIGINT", bigintWriteFunction());
+        }
+        if (type == REAL) {
+            return WriteMapping.longMapping("FLOAT", realWriteFunction());
+        }
+        if (type == DOUBLE) {
+            return WriteMapping.doubleMapping("DOUBLE", doubleWriteFunction());
+        }
+        if (type instanceof DecimalType decimalType) {
+            String dataType = format("DECIMAL(%s, %s)", decimalType.getPrecision(), decimalType.getScale());
+            if (decimalType.isShort()) {
+                return WriteMapping.longMapping(dataType, shortDecimalWriteFunction(decimalType));
+            }
+            return WriteMapping.objectMapping(dataType, longDecimalWriteFunction(decimalType));
+        }
+        if (type instanceof CharType charType) {
+            return WriteMapping.sliceMapping("STRING", charWriteFunction(charType));
+        }
+        if (type instanceof VarcharType varcharType) {
+            String dataType;
+            if (varcharType.isUnbounded()) {
+                dataType = "STRING";
+            }
+            else {
+                dataType = "STRING";
+            }
+            return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
+        }
+        if (type == VARBINARY) {
+            return WriteMapping.sliceMapping("BINARY", varbinaryWriteFunction());
+        }
+        if (type == DATE) {
+            return WriteMapping.longMapping("DATE", databricksDateWriteFunction());
+        }
+        if (type instanceof TimestampType timestampType) {
+            return databricksTimestampWriteMapping(timestampType.getPrecision());
+        }
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+
+    @Override
+    public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
+    {
+        return aggregateFunctionRewriter.rewrite(session, aggregate, assignments);
+    }
+
+    @Override
+    public boolean supportsAggregationPushdown(ConnectorSession session, JdbcTableHandle table, List<AggregateFunction> aggregates, Map<String, ColumnHandle> assignments, List<List<ColumnHandle>> groupingSets)
+    {
+        return preventTextualTypeAggregationPushdown(groupingSets);
+    }
+
+    private static Optional<JdbcTypeHandle> decimalTypeHandle(DecimalType decimalType)
+    {
+        return Optional.of(new JdbcTypeHandle(
+                Types.NUMERIC,
+                Optional.of("DECIMAL"),
+                Optional.of(decimalType.getPrecision()),
+                Optional.of(decimalType.getScale()),
+                Optional.empty(),
+                Optional.empty()));
+    }
+
+    @Override
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
+    {
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
+    }
+
+    @Override
+    public boolean isLimitGuaranteed(ConnectorSession session)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<JdbcSortItem> sortOrder)
+    {
+        for (JdbcSortItem sortItem : sortOrder) {
+            Type sortItemType = sortItem.column().getColumnType();
+            if (sortItemType instanceof CharType || sortItemType instanceof VarcharType) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    protected Optional<TopNFunction> topNFunction()
+    {
+        return Optional.of(TopNFunction.sqlStandard(this::quoted));
+    }
+
+    @Override
+    public boolean isTopNGuaranteed(ConnectorSession session)
+    {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getTableComment(ResultSet resultSet)
+            throws SQLException
+    {
+        return Optional.ofNullable(emptyToNull(resultSet.getString("REMARKS")));
+    }
+
+    @Override
+    protected List<String> createTableSqls(RemoteTableName remoteTableName, List<String> columns, ConnectorTableMetadata tableMetadata)
+    {
+        checkArgument(tableMetadata.getProperties().isEmpty(), "Unsupported table properties: %s", tableMetadata.getProperties());
+        return ImmutableList.of(format("CREATE TABLE %s (%s)", quoted(remoteTableName), join(", ", columns)));
+    }
+
+    @Override
+    public void setColumnType(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle column, Type type)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support setting column types");
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session)
+            throws SQLException
+    {
+        // Databricks JDBC driver does not support readOnly mode
+        return connectionFactory.openConnection(session);
+    }
+
+    private static ColumnMapping timestampColumnMapping(int precision)
+    {
+        int effectivePrecision = Math.min(precision, MAX_SUPPORTED_TEMPORAL_PRECISION);
+        if (effectivePrecision <= TimestampType.MAX_SHORT_PRECISION) {
+            return ColumnMapping.longMapping(createTimestampType(effectivePrecision), (resultSet, columnIndex) -> toTrinoTimestamp(createTimestampType(effectivePrecision), toLocalDateTime(resultSet, columnIndex)), shortTimestampWriteFunction());
+        }
+        return ColumnMapping.objectMapping(createTimestampType(effectivePrecision), longTimestampReader(), longTimestampWriteFunction(effectivePrecision));
+    }
+
+    private static LocalDateTime toLocalDateTime(ResultSet resultSet, int columnIndex)
+            throws SQLException
+    {
+        Calendar calendar = new GregorianCalendar(UTC_TZ, Locale.ENGLISH);
+        calendar.setTime(new Date(0));
+        Timestamp ts = resultSet.getTimestamp(columnIndex, calendar);
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(ts.getTime()), ZoneOffset.UTC);
+    }
+
+    private static ObjectReadFunction longTimestampReader()
+    {
+        return ObjectReadFunction.of(LongTimestamp.class, (resultSet, columnIndex) -> {
+            Calendar calendar = new GregorianCalendar(UTC_TZ, Locale.ENGLISH);
+            calendar.setTime(new Date(0));
+            Timestamp ts = resultSet.getTimestamp(columnIndex, calendar);
+            long epochMillis = ts.getTime();
+            int nanosInTheSecond = ts.getNanos();
+            int nanosInTheMilli = nanosInTheSecond % NANOSECONDS_PER_MILLISECOND;
+            long micro = epochMillis * Timestamps.MICROSECONDS_PER_MILLISECOND + (nanosInTheMilli / Timestamps.NANOSECONDS_PER_MICROSECOND);
+            int picosOfMicro = nanosInTheMilli % 1000 * 1000;
+            return new LongTimestamp(micro, picosOfMicro);
+        });
+    }
+
+    private static LongWriteFunction databricksDateWriteFunction()
+    {
+        return (statement, index, day) -> statement.setString(index, DATABRICKS_DATE_FORMATTER.format(LocalDate.ofEpochDay(day)));
+    }
+
+    private static SliceWriteFunction charWriteFunction(CharType charType)
+    {
+        return (statement, index, value) -> statement.setString(index, Chars.padSpaces(value, charType).toStringUtf8());
+    }
+
+    private static WriteMapping databricksTimestampWriteMapping(int precision)
+    {
+        checkArgument(precision <= MAX_SUPPORTED_TEMPORAL_PRECISION, "The max timestamp precision in Databricks is " + MAX_SUPPORTED_TEMPORAL_PRECISION);
+        if (precision <= TimestampType.MAX_SHORT_PRECISION) {
+            return WriteMapping.longMapping("TIMESTAMP", shortTimestampWriteFunction());
+        }
+        return WriteMapping.objectMapping("TIMESTAMP", longTimestampWriteFunction(precision));
+    }
+
+    private static LongWriteFunction shortTimestampWriteFunction()
+    {
+        return (statement, index, value) -> statement.setString(index, StandardColumnMappings.fromTrinoTimestamp(value).toString());
+    }
+
+    private static ObjectWriteFunction longTimestampWriteFunction(int precision)
+    {
+        return ObjectWriteFunction.of(
+                LongTimestamp.class,
+                (statement, index, value) -> statement.setString(index, DATABRICKS_TIMESTAMP_FORMATTER.format(StandardColumnMappings.fromLongTrinoTimestamp(value, precision))));
+    }
+}

--- a/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksClientModule.java
+++ b/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksClientModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import com.databricks.client.jdbc.Driver;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.TypeHandlingJdbcConfig;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.plugin.jdbc.ptf.Query;
+import io.trino.spi.function.table.ConnectorTableFunction;
+
+import java.util.Properties;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class DatabricksClientModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(DatabricksClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(DatabricksConfig.class);
+        configBinder(binder).bindConfig(TypeHandlingJdbcConfig.class);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
+    }
+
+    @Singleton
+    @Provides
+    @ForBaseJdbc
+    public ConnectionFactory getConnectionFactory(BaseJdbcConfig baseJdbcConfig, DatabricksConfig databricksConfig, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
+    {
+        Properties properties = new Properties();
+        databricksConfig.getHttpPath().ifPresent(httpPath -> properties.setProperty("httpPath", httpPath));
+        databricksConfig.getCatalog().ifPresent(catalog -> properties.setProperty("ConnCatalog", catalog));
+        databricksConfig.getSchema().ifPresent(schema -> properties.setProperty("ConnSchema", schema));
+
+        return DriverConnectionFactory.builder(new Driver(), baseJdbcConfig.getConnectionUrl(), credentialProvider)
+                .setConnectionProperties(properties)
+                .setOpenTelemetry(openTelemetry)
+                .build();
+    }
+}

--- a/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksConfig.java
+++ b/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import java.util.Optional;
+
+public class DatabricksConfig
+{
+    private String httpPath;
+    private String catalog;
+    private String schema;
+
+    public Optional<String> getHttpPath()
+    {
+        return Optional.ofNullable(httpPath);
+    }
+
+    @Config("databricks.http-path")
+    public DatabricksConfig setHttpPath(String httpPath)
+    {
+        this.httpPath = httpPath;
+        return this;
+    }
+
+    public Optional<String> getCatalog()
+    {
+        return Optional.ofNullable(catalog);
+    }
+
+    @Config("databricks.catalog")
+    public DatabricksConfig setCatalog(String catalog)
+    {
+        this.catalog = catalog;
+        return this;
+    }
+
+    public Optional<String> getSchema()
+    {
+        return Optional.ofNullable(schema);
+    }
+
+    @Config("databricks.schema")
+    @ConfigSecuritySensitive
+    public DatabricksConfig setSchema(String schema)
+    {
+        this.schema = schema;
+        return this;
+    }
+}

--- a/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksPlugin.java
+++ b/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/DatabricksPlugin.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import io.trino.plugin.jdbc.JdbcPlugin;
+
+public class DatabricksPlugin
+        extends JdbcPlugin
+{
+    public DatabricksPlugin()
+    {
+        super("databricks", DatabricksClientModule::new);
+    }
+}

--- a/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/ImplementAvgBigint.java
+++ b/plugin/trino-databricks/src/main/java/io/trino/plugin/databricks/ImplementAvgBigint.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import io.trino.plugin.jdbc.aggregation.BaseImplementAvgBigint;
+
+public class ImplementAvgBigint
+        extends BaseImplementAvgBigint
+{
+    @Override
+    protected String getRewriteFormatExpression()
+    {
+        return "avg(CAST(%s AS DOUBLE))";
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/DatabricksQueryRunner.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/DatabricksQueryRunner.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.airlift.log.Logger;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.tpch.TpchTable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+
+public final class DatabricksQueryRunner
+{
+    private DatabricksQueryRunner() {}
+
+    public static final String TPCH_SCHEMA = "default";
+
+    public static Builder builder()
+    {
+        return new Builder()
+                .addConnectorProperty("connection-url", TestingDatabricksServer.TEST_URL)
+                .addConnectorProperty("connection-user", "token")
+                .addConnectorProperty("connection-password", TestingDatabricksServer.TEST_TOKEN);
+    }
+
+    public static final class Builder
+            extends DistributedQueryRunner.Builder<Builder>
+    {
+        private final Map<String, String> connectorProperties = new HashMap<>();
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
+
+        private Builder()
+        {
+            super(testSessionBuilder()
+                    .setCatalog("databricks")
+                    .setSchema(TPCH_SCHEMA)
+                    .build());
+        }
+
+        @CanIgnoreReturnValue
+        public Builder addConnectorProperty(String key, String value)
+        {
+            this.connectorProperties.put(key, value);
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new DatabricksPlugin());
+                queryRunner.createCatalog("databricks", "databricks", connectorProperties);
+
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, initialTables);
+
+                return queryRunner;
+            }
+            catch (Throwable e) {
+                closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+        }
+    }
+
+    static void main()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = builder()
+                .addCoordinatorProperty("http-server.http.port", "8080")
+                .build();
+
+        Logger log = Logger.get(DatabricksQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksClient.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksClient.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Variable;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDatabricksClient
+{
+    private static final JdbcColumnHandle BIGINT_COLUMN =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_bigint")
+                    .setColumnType(BIGINT)
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("int8"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    private static final JdbcColumnHandle DOUBLE_COLUMN =
+            JdbcColumnHandle.builder()
+                    .setColumnName("c_double")
+                    .setColumnType(DOUBLE)
+                    .setJdbcTypeHandle(new JdbcTypeHandle(Types.DOUBLE, Optional.of("double"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                    .build();
+
+    private static final JdbcClient JDBC_CLIENT = new DatabricksClient(
+            new BaseJdbcConfig(),
+            _ -> { throw new UnsupportedOperationException(); },
+            new DefaultQueryBuilder(RemoteQueryModifier.NONE),
+            new DefaultIdentifierMapping(),
+            RemoteQueryModifier.NONE);
+
+    @Test
+    public void testImplementCount()
+    {
+        Variable bigintVariable = new Variable("v_bigint", BIGINT);
+        Variable doubleVariable = new Variable("v_double", BIGINT);
+        Optional<ConnectorExpression> filter = Optional.of(new Variable("a_filter", BOOLEAN));
+
+        // count(*)
+        testImplementAggregation(
+                new AggregateFunction("count", BIGINT, List.of(), List.of(), false, Optional.empty()),
+                Map.of(),
+                Optional.of("count(*)"));
+
+        // count(bigint)
+        testImplementAggregation(
+                new AggregateFunction("count", BIGINT, List.of(bigintVariable), List.of(), false, Optional.empty()),
+                Map.of(bigintVariable.getName(), BIGINT_COLUMN),
+                Optional.of("count(`c_bigint`)"));
+
+        // count(DISTINCT bigint)
+        testImplementAggregation(
+                new AggregateFunction("count", BIGINT, List.of(bigintVariable), List.of(), true, Optional.empty()),
+                Map.of(bigintVariable.getName(), BIGINT_COLUMN),
+                Optional.of("count(DISTINCT `c_bigint`)"));
+
+        // count(double)
+        testImplementAggregation(
+                new AggregateFunction("count", BIGINT, List.of(doubleVariable), List.of(), false, Optional.empty()),
+                Map.of(doubleVariable.getName(), DOUBLE_COLUMN),
+                Optional.of("count(`c_double`)"));
+
+        // count() FILTER (WHERE ...)
+        testImplementAggregation(
+                new AggregateFunction("count", BIGINT, List.of(), List.of(), false, filter),
+                Map.of(),
+                Optional.empty());
+
+        // count(bigint) FILTER (WHERE ...)
+        testImplementAggregation(
+                new AggregateFunction("count", BIGINT, List.of(bigintVariable), List.of(), false, filter),
+                Map.of(bigintVariable.getName(), BIGINT_COLUMN),
+                Optional.empty());
+    }
+
+    @Test
+    public void testImplementSum()
+    {
+        Variable bigintVariable = new Variable("v_bigint", BIGINT);
+        Variable doubleVariable = new Variable("v_double", DOUBLE);
+        Optional<ConnectorExpression> filter = Optional.of(new Variable("a_filter", BOOLEAN));
+
+        // sum(bigint)
+        testImplementAggregation(
+                new AggregateFunction("sum", BIGINT, List.of(bigintVariable), List.of(), false, Optional.empty()),
+                Map.of(bigintVariable.getName(), BIGINT_COLUMN),
+                Optional.of("sum(`c_bigint`)"));
+
+        // sum(double)
+        testImplementAggregation(
+                new AggregateFunction("sum", DOUBLE, List.of(doubleVariable), List.of(), false, Optional.empty()),
+                Map.of(doubleVariable.getName(), DOUBLE_COLUMN),
+                Optional.of("sum(`c_double`)"));
+
+        // sum(DISTINCT bigint)
+        testImplementAggregation(
+                new AggregateFunction("sum", BIGINT, List.of(bigintVariable), List.of(), true, Optional.empty()),
+                Map.of(bigintVariable.getName(), BIGINT_COLUMN),
+                Optional.of("sum(DISTINCT `c_bigint`)"));
+
+        // sum(bigint) FILTER (WHERE ...)
+        testImplementAggregation(
+                new AggregateFunction("sum", BIGINT, List.of(bigintVariable), List.of(), false, filter),
+                Map.of(bigintVariable.getName(), BIGINT_COLUMN),
+                Optional.empty()); // filter not supported
+    }
+
+    private static void testImplementAggregation(AggregateFunction aggregateFunction, Map<String, ColumnHandle> assignments, Optional<String> expectedExpression)
+    {
+        Optional<JdbcExpression> result = JDBC_CLIENT.implementAggregation(SESSION, aggregateFunction, assignments);
+        if (expectedExpression.isEmpty()) {
+            assertThat(result).isEmpty();
+        }
+        else {
+            assertThat(result).isPresent();
+            assertThat(result.get().getExpression()).isEqualTo(expectedExpression.get());
+            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toColumnMapping(SESSION, null, result.get().getJdbcTypeHandle());
+            assertThat(columnMapping.isPresent())
+                    .describedAs("No mapping for: " + result.get().getJdbcTypeHandle())
+                    .isTrue();
+            assertThat(columnMapping.get().getType()).isEqualTo(aggregateFunction.getOutputType());
+        }
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksConfig.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestDatabricksConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DatabricksConfig.class)
+                .setHttpPath(null)
+                .setCatalog(null)
+                .setSchema(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("databricks.http-path", "/sql/1.0/warehouses/abc123")
+                .put("databricks.catalog", "my_catalog")
+                .put("databricks.schema", "my_schema")
+                .buildOrThrow();
+
+        DatabricksConfig expected = new DatabricksConfig()
+                .setHttpPath("/sql/1.0/warehouses/abc123")
+                .setCatalog("my_catalog")
+                .setSchema("my_schema");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksConnectorTest.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksConnectorTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.trino.plugin.databricks.TestingDatabricksServer.TEST_SCHEMA;
+import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestDatabricksConnectorTest
+        extends BaseJdbcConnectorTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DatabricksQueryRunner.builder()
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    @Override
+    protected SqlExecutor onRemoteDatabase()
+    {
+        return TestingDatabricksServer::execute;
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_ADD_COLUMN_WITH_COMMENT,
+                 SUPPORTS_ADD_COLUMN_WITH_POSITION,
+                 SUPPORTS_ARRAY,
+                 SUPPORTS_COMMENT_ON_COLUMN,
+                 SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT,
+                 SUPPORTS_MAP_TYPE,
+                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY,
+                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
+                 SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
+                 SUPPORTS_ROW_TYPE,
+                 SUPPORTS_SET_COLUMN_TYPE,
+                 SUPPORTS_MERGE,
+                 SUPPORTS_ROW_LEVEL_UPDATE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected TestTable createTableWithDefaultColumns()
+    {
+        return new TestTable(
+                onRemoteDatabase(),
+                TEST_SCHEMA,
+                "(col_required BIGINT NOT NULL," +
+                        "col_nullable BIGINT," +
+                        "col_default BIGINT DEFAULT 43," +
+                        "col_nonnull_default BIGINT NOT NULL DEFAULT 42," +
+                        "col_required2 BIGINT NOT NULL)");
+    }
+
+    @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        return new TestTable(
+                onRemoteDatabase(),
+                "test_unsupported_col",
+                "(one bigint, two binary, three varchar(10))");
+    }
+
+    @Override
+    protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
+    {
+        String typeName = dataMappingTestSetup.getTrinoTypeName();
+        if (typeName.equals("real")) {
+            return Optional.empty();
+        }
+        if (typeName.equals("timestamp(6)")) {
+            return Optional.empty();
+        }
+        if (typeName.equals("char(3)")) {
+            return Optional.empty();
+        }
+        return Optional.of(dataMappingTestSetup);
+    }
+
+    @Override
+    protected boolean isColumnNameRejected(Exception exception, String columnName, boolean delimited)
+    {
+        return false;
+    }
+
+    @Override
+    protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
+    {
+        assertThatThrownBy(() -> { throw e; })
+                .hasMessageContaining("NOT NULL");
+    }
+
+    @Override
+    protected String errorMessageForInsertIntoNotNullColumn(String columnName)
+    {
+        return "NULL result in a non-nullable column";
+    }
+
+    @Test
+    @Override
+    public void testDeleteWithLike()
+    {
+        assertThatThrownBy(super::testDeleteWithLike)
+                .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
+    }
+
+    @Test
+    @Override
+    public void testInsertRowConcurrently()
+    {
+        abort("Databricks JDBC driver does not support concurrent inserts reliably");
+    }
+
+    @Override
+    protected OptionalInt maxSchemaNameLength()
+    {
+        return OptionalInt.of(255);
+    }
+
+    @Override
+    protected void verifySchemaNameLengthFailurePermissible(Throwable e)
+    {
+        assertThatThrownBy(() -> { throw e; })
+                .hasMessageContaining("exceeds");
+    }
+
+    @Override
+    protected OptionalInt maxTableNameLength()
+    {
+        return OptionalInt.of(255);
+    }
+
+    @Override
+    protected void verifyTableNameLengthFailurePermissible(Throwable e)
+    {
+        assertThatThrownBy(() -> { throw e; })
+                .hasMessageContaining("exceeds");
+    }
+
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.of(255);
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksPlugin.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestDatabricksPlugin
+{
+    @Test
+    public void testCreateConnector()
+    {
+        Plugin plugin = new DatabricksPlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:databricks://test:443/default"), new TestingConnectorContext()).shutdown();
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksTypeMapping.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestDatabricksTypeMapping.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.datatype.CreateAndInsertDataSetup;
+import io.trino.testing.datatype.CreateAsSelectDataSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.datatype.SqlDataTypeTest;
+import io.trino.testing.sql.TrinoSqlExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestDatabricksTypeMapping
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DatabricksQueryRunner.builder()
+                .build();
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("boolean", "true", BOOLEAN, "true")
+                .addRoundTrip("boolean", "false", BOOLEAN, "false")
+                .addRoundTrip("boolean", "NULL", BOOLEAN, "CAST(NULL AS BOOLEAN)")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_boolean"))
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_boolean"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_boolean"));
+    }
+
+    @Test
+    public void testTinyint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("tinyint", "NULL", TINYINT, "CAST(NULL AS TINYINT)")
+                .addRoundTrip("tinyint", "-128", TINYINT, "TINYINT '-128'")
+                .addRoundTrip("tinyint", "5", TINYINT, "TINYINT '5'")
+                .addRoundTrip("tinyint", "127", TINYINT, "TINYINT '127'")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_tinyint"));
+    }
+
+    @Test
+    public void testSmallint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("smallint", "NULL", SMALLINT, "CAST(NULL AS SMALLINT)")
+                .addRoundTrip("smallint", "-32768", SMALLINT, "SMALLINT '-32768'")
+                .addRoundTrip("smallint", "32767", SMALLINT, "SMALLINT '32767'")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_smallint"));
+    }
+
+    @Test
+    public void testInteger()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("int", "NULL", INTEGER, "CAST(NULL AS INTEGER)")
+                .addRoundTrip("int", "-2147483648", INTEGER, "INTEGER '-2147483648'")
+                .addRoundTrip("int", "2147483647", INTEGER, "INTEGER '2147483647'")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_integer"));
+    }
+
+    @Test
+    public void testBigint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("bigint", "NULL", BIGINT, "CAST(NULL AS BIGINT)")
+                .addRoundTrip("bigint", "-9223372036854775808", BIGINT, "BIGINT '-9223372036854775808'")
+                .addRoundTrip("bigint", "9223372036854775807", BIGINT, "BIGINT '9223372036854775807'")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_bigint"));
+    }
+
+    @Test
+    public void testFloat()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("float", "NULL", REAL, "CAST(NULL AS REAL)")
+                .addRoundTrip("float", "3.14", REAL, "REAL '3.14'")
+                .addRoundTrip("float", "CAST('NaN' AS float)", REAL, "nan()")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_float"));
+    }
+
+    @Test
+    public void testDouble()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("double", "NULL", DOUBLE, "CAST(NULL AS DOUBLE)")
+                .addRoundTrip("double", "3.14", DOUBLE, "DOUBLE '3.14'")
+                .addRoundTrip("double", "1.0E100", DOUBLE, "1.0E100")
+                .addRoundTrip("double", "CAST('NaN' AS DOUBLE)", DOUBLE, "nan()")
+                .addRoundTrip("double", "CAST('Infinity' AS DOUBLE)", DOUBLE, "+infinity()")
+                .addRoundTrip("double", "CAST('-Infinity' AS DOUBLE)", DOUBLE, "-infinity()")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_double"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_double"));
+    }
+
+    @Test
+    public void testDecimal()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(3, 0)", "NULL", createDecimalType(3, 0), "CAST(NULL AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, 0)", "CAST('193' AS decimal(3, 0))", createDecimalType(3, 0), "CAST('193' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, 1)", "CAST('10.1' AS decimal(3, 1))", createDecimalType(3, 1), "CAST('10.1' AS decimal(3, 1))")
+                .addRoundTrip("decimal(30, 5)", "CAST('3141592653589793238462643.38327' AS decimal(30, 5))", createDecimalType(30, 5), "CAST('3141592653589793238462643.38327' AS decimal(30, 5))")
+                .addRoundTrip("decimal(38, 0)", "CAST('99999999999999999999999999999999999999' AS decimal(38, 0))", createDecimalType(38, 0), "CAST('99999999999999999999999999999999999999' AS decimal(38, 0))")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_decimal"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_decimal"));
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("string", "''\''test string'\\'''", createUnboundedVarcharType(), "CAST('test string'' AS VARCHAR)")
+                .addRoundTrip("string", "'NULL'", createUnboundedVarcharType(), "CAST('NULL' AS VARCHAR)")
+                .execute(getQueryRunner(), databricksCreateAndInsert("test_varchar"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("varchar", "NULL", createUnboundedVarcharType(), "CAST(NULL AS VARCHAR)")
+                .addRoundTrip("varchar", "'hello'", createUnboundedVarcharType(), "CAST('hello' AS VARCHAR)")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_varchar"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_varchar"));
+    }
+
+    @Test
+    public void testDate()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("date", "NULL", DATE, "CAST(NULL AS DATE)")
+                .addRoundTrip("date", "DATE '2017-07-01'", DATE, "DATE '2017-07-01'")
+                .addRoundTrip("date", "DATE '2017-01-01'", DATE, "DATE '2017-01-01'")
+                .addRoundTrip("date", "DATE '1983-04-01'", DATE, "DATE '1983-04-01'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_date"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_date"));
+    }
+
+    @Test
+    public void testTimestamp()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("timestamp(3)", "TIMESTAMP '2019-03-18 10:01:17.987'", createTimestampType(3), "TIMESTAMP '2019-03-18 10:01:17.987'")
+                .addRoundTrip("timestamp(3)", "TIMESTAMP '2018-10-28 01:33:17.456'", createTimestampType(3), "TIMESTAMP '2018-10-28 01:33:17.456'")
+                .addRoundTrip("timestamp(3)", "TIMESTAMP '2038-01-19 03:14:07.000'", createTimestampType(3), "TIMESTAMP '2038-01-19 03:14:07.000'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_timestamp"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_timestamp"));
+    }
+
+    private DataSetup trinoCreateAsSelect(String tableNamePrefix)
+    {
+        return trinoCreateAsSelect(getSession(), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAsSelect(Session session, String tableNamePrefix)
+    {
+        return new CreateAsSelectDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAndInsert(String tableNamePrefix)
+    {
+        return trinoCreateAndInsert(getSession(), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAndInsert(Session session, String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+    }
+
+    private DataSetup databricksCreateAndInsert(String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(TestingDatabricksServer::execute, tableNamePrefix);
+    }
+}

--- a/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestingDatabricksServer.java
+++ b/plugin/trino-databricks/src/test/java/io/trino/plugin/databricks/TestingDatabricksServer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.databricks;
+
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+
+public final class TestingDatabricksServer
+{
+    private TestingDatabricksServer() {}
+
+    public static final String TEST_URL = requiredNonEmptySystemProperty("databricks.test.server.url");
+    public static final String TEST_TOKEN = requiredNonEmptySystemProperty("databricks.test.server.token");
+    public static final String TEST_SCHEMA = "default";
+
+    public static void execute(@Language("SQL") String sql)
+    {
+        execute(TEST_URL, getProperties(), sql);
+    }
+
+    private static void execute(String url, Properties properties, String sql)
+    {
+        try (Connection connection = DriverManager.getConnection(url, properties);
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Properties getProperties()
+    {
+        Properties properties = new Properties();
+        properties.setProperty("PWD", TEST_TOKEN);
+        properties.setProperty("UID", "token");
+        return properties;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <module>plugin/trino-blackhole</module>
         <module>plugin/trino-cassandra</module>
         <module>plugin/trino-clickhouse</module>
+        <module>plugin/trino-databricks</module>
         <module>plugin/trino-datasketches</module>
         <module>plugin/trino-delta-lake</module>
         <module>plugin/trino-druid</module>
@@ -410,6 +411,12 @@
                         <artifactId>listenablefuture</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.databricks</groupId>
+                <artifactId>databricks-jdbc</artifactId>
+                <version>3.3.1</version>
             </dependency>
 
             <dependency>
@@ -985,6 +992,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-databricks</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Description

Add a new JDBC-based connector for [Databricks](https://www.databricks.com/) SQL warehouses. The connector connects using the [Databricks JDBC driver](https://docs.databricks.com/en/integrations/jdbc/index.html) and supports querying data through Databricks Unity Catalog.

## Additional context and related issues

The connector follows the same patterns as the existing Snowflake connector, using `BaseJdbcClient` with:

- Token-based authentication via the Databricks JDBC driver
- Type mappings for Databricks SQL types (BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE, DECIMAL, STRING, VARCHAR, DATE, TIMESTAMP)
- Aggregation pushdown (avg, count, min, max, sum, stddev, variance, covariance, correlation, regression)
- Limit and TopN pushdown
- Backtick quoting for Databricks SQL compatibility
- Unity Catalog support via `databricks.catalog` and `databricks.schema` config properties
- `query()` table function for pass-through native SQL queries

The Databricks JDBC driver does not support `readOnly` mode, so `getConnection()` is overridden to skip `setReadOnly(true)`.

### Files included

- `plugin/trino-databricks/` — connector plugin with Java sources, tests, and pom.xml
- `docs/src/main/sphinx/connector/databricks.md` — connector documentation
- `docs/src/main/sphinx/connector.md` — connector index entry
- `pom.xml` — root POM changes (module, dependency management)

## Testing

- Unit tests: `TestDatabricksPlugin` (plugin smoke test), `TestDatabricksConfig` (config property mapping)
- Tested locally against a live Databricks SQL warehouse on Trino 479:
  - `SHOW SCHEMAS` ✅
  - `SHOW TABLES` ✅
  - `DESCRIBE` ✅
  - `SELECT * FROM ... LIMIT` ✅
  - `SELECT count(*)` ✅
  - `SELECT ... GROUP BY ... ORDER BY` with `sum()` and `avg()` ✅

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# General
* Add Databricks connector.
```
