### PR TITLE
Use Hive sentinel bucket count for unbucketed thrift tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -700,6 +700,9 @@ public final class ThriftMetastoreUtil
         sd.setOutputFormat(storage.getStorageFormat().getOutputFormatNullable());
         sd.setSkewedInfoIsSet(storage.isSkewed());
         sd.setParameters(ImmutableMap.of());
+        // Hive uses -1 as the sentinel value for "not bucketed". Leaving the Thrift default (0)
+        // can lead to divergent behavior for unbucketed tables created by Trino.
+        sd.setNumBuckets(-1);
 
         Optional<HiveBucketProperty> bucketProperty = storage.getBucketProperty();
         if (bucketProperty.isPresent()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -232,6 +232,27 @@ public class TestThriftMetastoreUtil
     }
 
     @Test
+    public void testUnbucketedTableUsesHiveSentinelBucketCount()
+    {
+        Table bucketed = ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE, TEST_SCHEMA);
+        Table.Builder builder = Table.builder(bucketed);
+        builder.getStorageBuilder().setBucketProperty(Optional.empty());
+        Table unbucketed = builder.build();
+
+        io.trino.hive.thrift.metastore.Table metastoreApiTable = ThriftMetastoreUtil.toMetastoreApiTable(unbucketed, NO_PRIVILEGES);
+        assertThat(metastoreApiTable.getSd().getNumBuckets()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testBucketedTablePreservesBucketCount()
+    {
+        Table table = ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE, TEST_SCHEMA);
+
+        io.trino.hive.thrift.metastore.Table metastoreApiTable = ThriftMetastoreUtil.toMetastoreApiTable(table, NO_PRIVILEGES);
+        assertThat(metastoreApiTable.getSd().getNumBuckets()).isEqualTo(TEST_TABLE.getSd().getNumBuckets());
+    }
+
+    @Test
     public void testHiveSchemaTable()
     {
         Map<String, String> actual = MetastoreUtil.getHiveSchema(ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE_WITH_UNSUPPORTED_FIELDS, TEST_SCHEMA));


### PR DESCRIPTION
## Description

Set the Hive thrift `StorageDescriptor.numBuckets` field to `-1` for
unbucketed tables created by Trino.

Hive uses `-1` as the sentinel value for "not bucketed". Leaving the
thrift default of `0` can lead to divergent behavior for unbucketed
tables created by Trino.

This change preserves the existing behavior for bucketed tables and adds
unit tests covering both cases.

## Additional context and related issues

This issue was observed while testing against Apache Hive 3.1.

Some Hive distributions appear to tolerate `numBuckets = 0` for
unbucketed tables, but Apache Hive 3.1 treats that differently from the
expected `-1` sentinel value. This change aligns Trino's thrift
serialization with Hive's expected contract without changing bucketed
table behavior.

Apache Hive itself uses `-1` for this case, for example in:

- [`Table.getEmptyTable()`](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java#L227)
- [`AlterTableNotClusteredOperation`](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/cluster/AlterTableNotClusteredOperation.java#L43)

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Fix creation of unbucketed Hive tables in HMS for Apache Hive 3.1.
```
