### PR TITLE
Do not hide errors, which trigger manual delta check point file read

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.json.JsonMapperProvider;
@@ -33,10 +34,12 @@ import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.nio.file.NoSuchFileException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -287,8 +290,21 @@ public final class TransactionLogParser
             // _last_checkpoint file was not found, we need to find latest checkpoint manually
             // ideally, we'd detect the condition by catching FileNotFoundException, but some file system implementations
             // will throw different exceptions if the checkpoint is not found
+            if (isFileNotFoundException(e)) {
+                return Optional.empty();
+            }
+            // it could be situation, like access deny or other permission failure error, which actually should not trigger manual check point read
+            // because we can not be sure, which exceptions could appear here, at least we should not silently hide them
+            // TODO after we collect more of such situations we could add exclusion rules here
+            log.warn(e, "Failed to read Delta Lake last checkpoint file %s, falling back to manual checkpoint discovery", checkpointPath);
             return Optional.empty();
         }
+    }
+
+    private static boolean isFileNotFoundException(Throwable throwable)
+    {
+        return Throwables.getCausalChain(throwable).stream()
+                .anyMatch(cause -> cause instanceof FileNotFoundException || cause instanceof NoSuchFileException);
     }
 
     public static long getMandatoryCurrentVersion(TrinoFileSystem fileSystem, String tableLocation, long readVersion)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

It could be situation, like access deny or other permission failure error, which actually should not trigger manual check point read, because we can not be sure, which exceptions could appear here - at least we should not silently hide them, after we collect more of such situations we could add exclusion rules here


```
io.trino.plugin.deltalake.DeltaLakeMetadata.getTableHandle (DeltaLakeMetadata.java:831)
io.trino.plugin.deltalake.DeltaLakeMetadata.getTableHandle (DeltaLakeMetadata.java:406)
io.trino.plugin.objectstore.TracingObjectStoreConnectorMetadata.getTableHandle (TracingObjectStoreConnectorMetadata.java:157)
io.trino.plugin.objectstore.ObjectStoreMetadata.getTableHandleInOrder (ObjectStoreMetadata.java:250)
io.trino.plugin.objectstore.ObjectStoreMetadata.getTableHandle (ObjectStoreMetadata.java:278)
io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getTableHandle (ClassLoaderSafeConnectorMetadata.java:1342)
io.trino.tracing.TracingConnectorMetadata.getTableHandle (TracingConnectorMetadata.java:144)
io.trino.metadata.MetadataManager.lambda$getTableHandle$0 (MetadataManager.java:303)
java.util.Optional.flatMap (Optional.java:289)
io.trino.metadata.MetadataManager.getTableHandle (MetadataManager.java:294)
io.trino.metadata.MetadataManager.getRedirectionAwareTableHandle (MetadataManager.java:2017)
io.trino.tracing.TracingMetadata.getRedirectionAwareTableHandle (TracingMetadata.java:1639)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.getTableHandle (StatementAnalyzer.java:6084)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable (StatementAnalyzer.java:2334)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable (StatementAnalyzer.java:534)
io.trino.sql.tree.Table.accept (Table.java:70)
io.trino.sql.tree.AstVisitor.process (AstVisitor.java:27)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:553)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom (StatementAnalyzer.java:5108)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification (StatementAnalyzer.java:3181)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification (StatementAnalyzer.java:534)
io.trino.sql.tree.QuerySpecification.accept (QuerySpecification.java:155)
io.trino.sql.tree.AstVisitor.process (AstVisitor.java:27)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:553)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:561)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery (StatementAnalyzer.java:1607)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery (StatementAnalyzer.java:534)
io.trino.sql.tree.Query.accept (Query.java:130)
io.trino.sql.tree.AstVisitor.process (AstVisitor.java:27)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:553)
io.trino.sql.analyzer.StatementAnalyzer.analyze (StatementAnalyzer.java:513)
io.trino.sql.analyzer.StatementAnalyzer.analyze (StatementAnalyzer.java:502)
io.trino.sql.analyzer.Analyzer.analyze (Analyzer.java:102)
io.trino.sql.analyzer.Analyzer.lambda$analyze$0 (Analyzer.java:91)
io.trino.sql.analyzer.Analyzer.analyze (Analyzer.java:91)
io.trino.execution.SqlQueryExecution.analyze (SqlQueryExecution.java:359)
io.trino.execution.SqlQueryExecution.<init> (SqlQueryExecution.java:253)
io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution (SqlQueryExecution.java:1033)
io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0 (LocalDispatchQueryFactory.java:163)
...
com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly (TrustedListenableFutureTask.java:128)
com.google.common.util.concurrent.InterruptibleTask.run (InterruptibleTask.java:74)
com.google.common.util.concurrent.TrustedListenableFutureTask.run (TrustedListenableFutureTask.java:80)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1090)
java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:614)
java.lang.Thread.run (Thread.java:1474)


io.trino.plugin.deltalake.CorruptedDeltaLakeTableHandle.createException (CorruptedDeltaLakeTableHandle.java:44)
io.trino.plugin.deltalake.DeltaLakeMetadata.checkValidTableHandle (DeltaLakeMetadata.java:5142)
io.trino.plugin.deltalake.DeltaLakeMetadata.getTableMetadata (DeltaLakeMetadata.java:973)
io.trino.plugin.objectstore.TracingObjectStoreConnectorMetadata.getTableMetadata (TracingObjectStoreConnectorMetadata.java:256)
io.trino.plugin.objectstore.ObjectStoreMetadata.getTableMetadata (ObjectStoreMetadata.java:593)
io.trino.spi.connector.ConnectorMetadata.getTableSchema (ConnectorMetadata.java:237)
io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getTableSchema (ClassLoaderSafeConnectorMetadata.java:271)
io.trino.tracing.TracingConnectorMetadata.getTableSchema (TracingConnectorMetadata.java:234)
io.trino.metadata.MetadataManager.getTableSchema (MetadataManager.java:489)
io.trino.tracing.TracingMetadata.getTableSchema (TracingMetadata.java:311)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable (StatementAnalyzer.java:2346)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable (StatementAnalyzer.java:534)
io.trino.sql.tree.Table.accept (Table.java:70)
io.trino.sql.tree.AstVisitor.process (AstVisitor.java:27)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:553)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom (StatementAnalyzer.java:5108)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification (StatementAnalyzer.java:3181)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification (StatementAnalyzer.java:534)
io.trino.sql.tree.QuerySpecification.accept (QuerySpecification.java:155)
io.trino.sql.tree.AstVisitor.process (AstVisitor.java:27)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:553)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:561)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery (StatementAnalyzer.java:1607)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery (StatementAnalyzer.java:534)
io.trino.sql.tree.Query.accept (Query.java:130)
io.trino.sql.tree.AstVisitor.process (AstVisitor.java:27)
io.trino.sql.analyzer.StatementAnalyzer$Visitor.process (StatementAnalyzer.java:553)
io.trino.sql.analyzer.StatementAnalyzer.analyze (StatementAnalyzer.java:513)
io.trino.sql.analyzer.StatementAnalyzer.analyze (StatementAnalyzer.java:502)
io.trino.sql.analyzer.Analyzer.analyze (Analyzer.java:102)
io.trino.sql.analyzer.Analyzer.lambda$analyze$0 (Analyzer.java:91)
io.trino.sql.analyzer.Analyzer.analyze (Analyzer.java:91)
io.trino.execution.SqlQueryExecution.analyze (SqlQueryExecution.java:359)
io.trino.execution.SqlQueryExecution.<init> (SqlQueryExecution.java:253)
io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution (SqlQueryExecution.java:1033)
io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0 (LocalDispatchQueryFactory.java:163)
...
com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly (TrustedListenableFutureTask.java:128)
com.google.common.util.concurrent.InterruptibleTask.run (InterruptibleTask.java:74)
com.google.common.util.concurrent.TrustedListenableFutureTask.run (TrustedListenableFutureTask.java:80)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1090)
java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:614)
java.lang.Thread.run (Thread.java:1474)
```



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.