### PR TITLE
Use wget and remove grep for health check

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN \
     dnf install --installroot /tmp/overlay --setopt install_weak_deps=false --nodocs -y \
       less \
       libstdc++ `# required by snappy and duckdb` \
-      curl-minimal grep `# required by health-check` \
+      wget `# required by health-check` \
       zlib `#required by java` \
       shadow-utils `# required by useradd` \
       tar `# required to support kubectl cp` && \

--- a/core/docker/bin/health-check
+++ b/core/docker/bin/health-check
@@ -3,7 +3,15 @@
 set -euo pipefail
 
 function get_property() {
-    grep "^$1=" "$2" | cut -d'=' -f2
+    local key="$1"
+    local file="$2"
+
+    while IFS='=' read -r k v; do
+        if [ "${k}" = "${key}" ]; then
+            printf '%s\n' "$v"
+            return
+        fi
+    done < "$file"
 }
 
 scheme=http
@@ -20,13 +28,14 @@ fi
 
 endpoint="$scheme://localhost:$port/v1/info"
 
-# add --insecure to disable certificate verification in curl, in case a self-signed certificate is being used
-if ! info=$(curl --fail --silent --show-error --insecure "$endpoint"); then
+# add --no-check-certificate to disable certificate verification in wget
+# in case a self-signed certificate is being used
+if ! info=$(wget -q --no-check-certificate -O- "$endpoint"); then
     echo >&2 "Server is not responding to requests"
     exit 1
 fi
 
-if ! grep -q '"starting":\s*false' <<<"$info" >/dev/null; then
+if ! [[ "$info" =~ '"starting":false' || "$info" =~ '"starting": false' ]]; then
     echo >&2 "Server is starting"
     exit 1
 fi

--- a/core/docker/bin/health-check
+++ b/core/docker/bin/health-check
@@ -24,13 +24,14 @@ fi
 
 endpoint="$scheme://localhost:$port/v1/info"
 
-# add --insecure to disable certificate verification in curl, in case a self-signed certificate is being used
-if ! info=$(curl --fail --silent --show-error --insecure "$endpoint"); then
+# add --no-check-certificate to disable certificate verification in wget
+# in case a self-signed certificate is being used
+if ! info=$(wget -q --no-check-certificate -O- "$endpoint"); then
     echo >&2 "Server is not responding to requests"
     exit 1
 fi
 
-if ! grep -q '"starting":\s*false' <<<"$info" >/dev/null; then
+if ! [[ "$info" =~ '"starting":false' || "$info" =~ '"starting": false' ]]; then
     echo >&2 "Server is starting"
     exit 1
 fi


### PR DESCRIPTION
It reduces the amount and surface of packages installed just to run health checks:

Before:

by severity: 0 critical, 1 high, 34 medium, 31 low, 0 negligible

After:

by severity: 0 critical, 0 high, 16 medium, 6 low, 0 negligible

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
