### PR TITLE
Extend IcebergInputInfo

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergInputInfo.java
@@ -29,7 +29,9 @@ public record IcebergInputInfo(
         Optional<String> totalRecords,
         Optional<String> deletedRecords,
         Optional<String> totalDataFiles,
-        Optional<String> totalDeleteFiles)
+        Optional<String> totalDeleteFiles,
+        Optional<String> totalPositionDeletes,
+        Optional<String> totalEqualityDeletes)
 {
     public IcebergInputInfo
     {
@@ -40,5 +42,7 @@ public record IcebergInputInfo(
         requireNonNull(deletedRecords, "deletedRecords is null");
         requireNonNull(totalDataFiles, "totalDataFiles is null");
         requireNonNull(totalDeleteFiles, "totalDeleteFiles is null");
+        requireNonNull(totalPositionDeletes, "totalPositionDeletes is null");
+        requireNonNull(totalEqualityDeletes, "totalEqualityDeletes is null");
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -457,6 +457,8 @@ import static org.apache.iceberg.SnapshotSummary.REMOVED_EQ_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_POS_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DATA_FILES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DELETE_FILES_PROP;
+import static org.apache.iceberg.SnapshotSummary.TOTAL_EQ_DELETES_PROP;
+import static org.apache.iceberg.SnapshotSummary.TOTAL_POS_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_RECORDS_PROP;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
@@ -2718,6 +2720,8 @@ public class IcebergMetadata
         Optional<String> deletedRecords = Optional.ofNullable(summary.get(DELETED_RECORDS_PROP));
         Optional<String> totalDataFiles = Optional.ofNullable(summary.get(TOTAL_DATA_FILES_PROP));
         Optional<String> totalDeleteFiles = Optional.ofNullable(summary.get(TOTAL_DELETE_FILES_PROP));
+        Optional<String> totalPositionDeletes = Optional.ofNullable(summary.get(TOTAL_POS_DELETES_PROP));
+        Optional<String> totalEqualityDeletes = Optional.ofNullable(summary.get(TOTAL_EQ_DELETES_PROP));
 
         return Optional.of(new IcebergInputInfo(
                 icebergTableHandle.getFormatVersion(),
@@ -2727,7 +2731,9 @@ public class IcebergMetadata
                 totalRecords,
                 deletedRecords,
                 totalDataFiles,
-                totalDeleteFiles));
+                totalDeleteFiles,
+                totalPositionDeletes,
+                totalEqualityDeletes));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
@@ -14,18 +14,25 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
+import org.apache.iceberg.BaseTable;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergTestUtils.loadTable;
+import static io.trino.plugin.iceberg.util.EqualityDeleteUtils.writeEqualityDeleteForTable;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,7 +53,7 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_with_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey', 'truncate(name, 1)']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, ImmutableList.of("regionkey: identity", "name_trunc: truncate[1]"), "PARQUET", 9);
+        assertInputInfo(tableName, ImmutableList.of("regionkey: identity", "name_trunc: truncate[1]"), "PARQUET", 9, 0, 0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -55,7 +62,7 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_without_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1);
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 0, 0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -64,11 +71,38 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_with_orc_file_format_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'ORC') AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, ImmutableList.of(), "ORC", 1);
+        assertInputInfo(tableName, ImmutableList.of(), "ORC", 1, 0, 0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
-    private void assertInputInfo(String tableName, List<String> partitionFields, String expectedFileFormat, long dataFiles)
+    @Test
+    public void testInputWithPositionDeleteFile()
+    {
+        String tableName = "test_input_info_with_position_delete_file_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
+        assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 1", 1);
+
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 1, 0);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testInputWithEqualityDeleteFile()
+            throws Exception
+    {
+        String tableName = "test_input_info_with_equality_delete_file_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
+        TrinoFileSystemFactory fileSystemFactory = getFileSystemFactory(getQueryRunner());
+        BaseTable table = loadTable(tableName, getHiveMetastore(getQueryRunner()), fileSystemFactory, "iceberg", "tpch");
+        writeEqualityDeleteForTable(table, fileSystemFactory, Optional.empty(), Optional.empty(), ImmutableMap.of("nationkey", 1L), Optional.empty());
+
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 0, 1);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private void assertInputInfo(String tableName, List<String> partitionFields, String expectedFileFormat, long dataFiles, long positionDeleteFiles, long equalityDeleteFiles)
     {
         inTransaction(session -> {
             Metadata metadata = getQueryRunner().getPlannerContext().getMetadata();
@@ -89,7 +123,9 @@ public class TestIcebergInputInfo
                     Optional.of("10"),
                     Optional.empty(),
                     Optional.of(String.valueOf(dataFiles)),
-                    Optional.of("0")));
+                    Optional.of(String.valueOf(positionDeleteFiles + equalityDeleteFiles)),
+                    Optional.of(String.valueOf(positionDeleteFiles)),
+                    Optional.of(String.valueOf(equalityDeleteFiles))));
         });
     }
 }


### PR DESCRIPTION
## Description

Add separate information for equality and position deletes count

## Additional context and related issues

This will enhance visibility over table's delete file structure

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

Add information about position and equality delete files count to `IcebergInputInfo`
