### PR TITLE
Mitigate Glue `ThrottlingException` via backoff retry strategy

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -44,6 +44,7 @@ import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
+import software.amazon.awssdk.services.glue.model.ThrottlingException;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -151,7 +152,7 @@ public final class GlueMetastoreModule
         glue.overrideConfiguration(builder -> builder
                 .executionInterceptors(ImmutableList.copyOf(executionInterceptors))
                 .retryStrategy(retryBuilder -> retryBuilder
-                        .retryOnException(throwable -> throwable instanceof ConcurrentModificationException)
+                        .retryOnException(throwable -> throwable instanceof ConcurrentModificationException || throwable instanceof ThrottlingException)
                         .backoffStrategy(BackoffStrategy.exponentialDelay(
                                 java.time.Duration.ofMillis(20),
                                 java.time.Duration.ofMillis(1500)))

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -454,6 +454,11 @@
             <artifactId>kms</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-spi</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -35,12 +35,17 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
+import software.amazon.awssdk.services.glue.model.ThrottlingException;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -86,7 +91,7 @@ public class TestTrinoGlueCatalog
 
     private TrinoCatalog createGlueTrinoCatalog(boolean useUniqueTableLocations, boolean useSystemSecurity)
     {
-        GlueClient glueClient = GlueClient.create();
+        GlueClient glueClient = createGlueClient();
         IcebergGlueCatalogConfig catalogConfig = new IcebergGlueCatalogConfig();
         return new TrinoGlueCatalog(
                 new CatalogName("catalog_name"),
@@ -108,6 +113,18 @@ public class TestTrinoGlueCatalog
                 useUniqueTableLocations,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
                 directExecutor());
+    }
+
+    private static GlueClient createGlueClient()
+    {
+        GlueClientBuilder glue = GlueClient.builder();
+
+        glue.overrideConfiguration(builder -> builder
+                .retryStrategy(retryBuilder -> retryBuilder
+                        .retryOnException(throwable -> throwable instanceof ConcurrentModificationException || throwable instanceof ThrottlingException)
+                        .backoffStrategy(BackoffStrategy.exponentialDelay(Duration.ofMillis(20), Duration.ofMillis(1500)))
+                        .maxAttempts(10)));
+        return glue.build();
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
Retry on AWS SDK’s ThrottlingException to mitigate intermittent (flaky) issues:

```
Error:  io.trino.plugin.iceberg.catalog.glue.TestTrinoGlueCatalog.testTableWithVariantColumn -- Time elapsed: 52.78 s <<< ERROR!
java.lang.RuntimeException: io.trino.spi.TrinoException: Rate exceeded (Service: Glue, Status Code: 400, Request ID: 242257bb-5fdc-49e5-834d-2befa425645a) (SDK Attempt Count: 4)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.listTables(TrinoGlueCatalog.java:399)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.listTables(TrinoGlueCatalog.java:371)
	at io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest.testTableWithVariantColumn(BaseTrinoCatalogTest.java:624)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:666)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:666)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: io.trino.spi.TrinoException: Rate exceeded (Service: Glue, Status Code: 400, Request ID: 242257bb-5fdc-49e5-834d-2befa425645a) (SDK Attempt Count: 4)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog$1.computeNext(TrinoGlueCatalog.java:1698)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog$1.computeNext(TrinoGlueCatalog.java:1668)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:141)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:136)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:132)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.lambda$listTables$2(TrinoGlueCatalog.java:391)
	at io.trino.plugin.base.util.ExecutorUtil.lambda$processWithAdditionalThreads$0(ExecutorUtil.java:70)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
	at java.base/java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:187)
	at io.trino.plugin.base.util.ExecutorUtil.processWithAdditionalThreads(ExecutorUtil.java:65)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog.listTables(TrinoGlueCatalog.java:394)
	... 17 more
Caused by: software.amazon.awssdk.services.glue.model.ThrottlingException: Rate exceeded (Service: Glue, Status Code: 400, Request ID: 242257bb-5fdc-49e5-834d-2befa425645a) (SDK Attempt Count: 4)
	at software.amazon.awssdk.services.glue.model.ThrottlingException$BuilderImpl.build(ThrottlingException.java:150)
	at software.amazon.awssdk.services.glue.model.ThrottlingException$BuilderImpl.build(ThrottlingException.java:98)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.retryPolicyDisallowedRetryException(RetryableStageHelper.java:168)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:73)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:53)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:35)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:82)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:62)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:43)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:50)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:32)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
	at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:210)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:173)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:80)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:182)
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:74)
	at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:53)
	at software.amazon.awssdk.services.glue.DefaultGlueClient.getTables(DefaultGlueClient.java:32587)
	at software.amazon.awssdk.services.glue.paginators.GetTablesIterable$GetTablesResponseFetcher.nextPage(GetTablesIterable.java:111)
	at software.amazon.awssdk.services.glue.paginators.GetTablesIterable$GetTablesResponseFetcher.nextPage(GetTablesIterable.java:102)
	at software.amazon.awssdk.core.pagination.sync.PaginatedResponsesIterator.next(PaginatedResponsesIterator.java:58)
	at java.base/java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1950)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:297)
	at java.base/java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
	at java.base/java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:161)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:303)
	at java.base/java.util.Spliterators$1Adapter.hasNext(Spliterators.java:669)
	at io.trino.plugin.iceberg.catalog.glue.TrinoGlueCatalog$1.computeNext(TrinoGlueCatalog.java:1681)
	... 36 more
	Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 1 failure: Rate exceeded (Service: Glue, Status Code: 400, Request ID: 9bc91de6-b35a-4de6-8335-8fecf7d8aede)
	Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 2 failure: Rate exceeded (Service: Glue, Status Code: 400, Request ID: b73a78ab-0fc0-4f6b-8465-66c728a5bd43)
	Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 3 failure: Rate exceeded (Service: Glue, Status Code: 400, Request ID: b7c722e6-d623-45b2-b834-5d7460ad27c3)
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
