### PR TITLE
Add date partition predicate pushdown for Glue

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
@@ -22,7 +22,6 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.CharType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
@@ -79,7 +78,7 @@ public final class GlueExpressionUtil
 
     private static boolean canConvertSqlTypeToStringForGlue(Type type, boolean assumeCanonicalPartitionKeys)
     {
-        return !(type instanceof TimestampType) && !(type instanceof DateType) && (type instanceof CharType || type instanceof VarcharType || assumeCanonicalPartitionKeys);
+        return !(type instanceof TimestampType) && (type instanceof CharType || type instanceof VarcharType || assumeCanonicalPartitionKeys);
     }
 
     /**

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -273,7 +273,7 @@ public class GlueHiveMetastoreConfig
     }
 
     @Config("hive.metastore.glue.assume-canonical-partition-keys")
-    @ConfigDescription("Allow conversion of non-char types (eg BIGINT, timestamp) to canonical string formats")
+    @ConfigDescription("Allow conversion of non-char types (eg BIGINT, date) to canonical string formats")
     public GlueHiveMetastoreConfig setAssumeCanonicalPartitionKeys(boolean assumeCanonicalPartitionKeys)
     {
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/PartitionFilterBuilder.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/PartitionFilterBuilder.java
@@ -21,6 +21,7 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.BigintType;
+import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.VarcharType;
@@ -54,6 +55,13 @@ public class PartitionFilterBuilder
     public PartitionFilterBuilder addBigintValues(String columnName, Long... values)
     {
         Domain domain = Domain.multipleValues(BigintType.BIGINT, Arrays.asList(values));
+        domains.merge(columnName, domain, Domain::union);
+        return this;
+    }
+
+    public PartitionFilterBuilder addDateValues(String columnName, Long... values)
+    {
+        Domain domain = Domain.multipleValues(DateType.DATE, Arrays.asList(values));
         domains.merge(columnName, domain, Domain::union);
         return this;
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.DateType;
 import io.trino.spi.type.VarcharType;
 import org.junit.jupiter.api.Test;
 
@@ -235,5 +236,42 @@ public class TestGlueExpressionUtil
                 .build();
         String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
         assertThat(expression).isEqualTo(format("((col1 = %d))", Byte.MAX_VALUE));
+    }
+
+    @Test
+    public void testDateConversionWithCanonicalKeys()
+    {
+        TupleDomain<String> singleValue = new PartitionFilterBuilder()
+                .addDateValues("dt", 0L)
+                .build();
+        assertThat(buildGlueExpression(ImmutableList.of("dt"), singleValue, true))
+                .isEqualTo("((dt = '1970-01-01'))");
+
+        TupleDomain<String> range = new PartitionFilterBuilder()
+                .addRanges("dt", Range.greaterThanOrEqual(DateType.DATE, 0L))
+                .build();
+        assertThat(buildGlueExpression(ImmutableList.of("dt"), range, true))
+                .isEqualTo("((dt >= '1970-01-01'))");
+
+        TupleDomain<String> between = new PartitionFilterBuilder()
+                .addRanges("dt", Range.range(DateType.DATE, 0L, true, 6L, true))
+                .build();
+        assertThat(buildGlueExpression(ImmutableList.of("dt"), between, true))
+                .isEqualTo("((dt >= '1970-01-01' AND dt <= '1970-01-07'))");
+
+        TupleDomain<String> inClause = new PartitionFilterBuilder()
+                .addDateValues("dt", 0L, 1L)
+                .build();
+        assertThat(buildGlueExpression(ImmutableList.of("dt"), inClause, true))
+                .isEqualTo("((dt in ('1970-01-01', '1970-01-02')))");
+    }
+
+    @Test
+    public void testDateConversionWithoutCanonicalKeys()
+    {
+        TupleDomain<String> singleValue = new PartitionFilterBuilder()
+                .addDateValues("dt", 0L)
+                .build();
+        assertThat(buildGlueExpression(ImmutableList.of("dt"), singleValue, false)).isEmpty();
     }
 }


### PR DESCRIPTION
## Description

When using the Glue catalog, Trino doesn't push date partition predicates to Glue's `GetPartitions` API. This causes Trino to fetch all partitions and filter them locally, which is inefficient for large tables partitioned by date.

## Additional context and related issues

Currently, the `GlueExpressionUtil.canConvertSqlTypeToStringForGlue()` function sets `DateType` as unconvertible even when `hive.metastore.glue.assume-canonical-partition-keys=true` is set.

Thrift, on the other hand, already allows `DateType` when `assumeCanonicalPartitionKeys=true`, therefore the infrastructure to implement this feature for Glue already exists:

- `MetastoreUtil.sqlScalarToString()` converts epoch days to ISO strings (e.g. `2019-04-14`)
- `QUOTED_TYPES` in `GlueExpressionUtil` already includes `"date"`, so values are properly quoted as `'2019-04-14'`

## Proposal

Align Glue and Thrift: allow Trino to push `DateType` predicates to Glue when `assumeCanonicalPartitionKeys=true`.

Resolves #28817.

## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Improve performance of queries on Glue-backed tables by pushing down date partition predicates. {#28817}
```
