### PR TITLE
Rethrow TableNotFoundException in ThriftHiveMetastore.alterTable

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -992,6 +992,13 @@ public final class ThriftHiveMetastore
         catch (NoSuchObjectException e) {
             throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
         }
+        catch (InvalidOperationException e) {
+            // Use text matching because InvalidOperationException doesn't provide an error code
+            if (e.isSetMessage() && e.getMessage().contains("table not found")) {
+                throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            }
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
         }


### PR DESCRIPTION
## Description

The example failure:
```
2026-03-04T21:34:07.2987899Z io.trino.spi.TrinoException: hive.test_schema.test_rename_column_show_stats_for_column_mapping_mode_tjc6kmpdiy table not found
2026-03-04T21:34:07.2991068Z 	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.alterTable(ThriftHiveMetastore.java:996)
2026-03-04T21:34:07.2994800Z 	at io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore.alterTable(BridgingHiveMetastore.java:380)
2026-03-04T21:34:07.2997991Z 	at io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore.replaceTable(BridgingHiveMetastore.java:259)
2026-03-04T21:34:07.3000903Z 	at io.trino.metastore.tracing.TracingHiveMetastore.lambda$replaceTable$0(TracingHiveMetastore.java:256)
2026-03-04T21:34:07.3004024Z 	at io.trino.metastore.tracing.Tracing.lambda$withTracing$0(Tracing.java:35)
2026-03-04T21:34:07.3007158Z 	at io.trino.metastore.tracing.Tracing.withTracing(Tracing.java:43)
2026-03-04T21:34:07.3010156Z 	at io.trino.metastore.tracing.Tracing.withTracing(Tracing.java:34)
2026-03-04T21:34:07.3026032Z 	at io.trino.metastore.tracing.TracingHiveMetastore.replaceTable(TracingHiveMetastore.java:256)
2026-03-04T21:34:07.3029262Z 	at io.trino.metastore.MeasuredHiveMetastore.lambda$replaceTable$0(MeasuredHiveMetastore.java:179)
2026-03-04T21:34:07.3032513Z 	at io.trino.metastore.MeasuredHiveMetastore.lambda$wrap$0(MeasuredHiveMetastore.java:437)
2026-03-04T21:34:07.3035396Z 	at io.trino.metastore.MeasuredHiveMetastore.wrap(MeasuredHiveMetastore.java:447)
2026-03-04T21:34:07.3037954Z 	at io.trino.metastore.MeasuredHiveMetastore.wrap(MeasuredHiveMetastore.java:436)
2026-03-04T21:34:07.3040399Z 	at io.trino.metastore.MeasuredHiveMetastore.replaceTable(MeasuredHiveMetastore.java:179)
2026-03-04T21:34:07.3043522Z 	at io.trino.metastore.cache.CachingHiveMetastore.replaceTable(CachingHiveMetastore.java:669)
2026-03-04T21:34:07.3048225Z 	at io.trino.plugin.deltalake.metastore.thrift.DeltaLakeThriftMetastoreTableOperations.commitToExistingTable(DeltaLakeThriftMetastoreTableOperations.java:69)
2026-03-04T21:34:07.3052922Z 	at io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.updateTable(DeltaLakeTableMetadataScheduler.java:177)
2026-03-04T21:34:07.3056638Z 	at io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.lambda$process$0(DeltaLakeTableMetadataScheduler.java:155)
2026-03-04T21:34:07.3060707Z 	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
2026-03-04T21:34:07.3064488Z 	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
2026-03-04T21:34:07.3067639Z 	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
2026-03-04T21:34:07.3070760Z 	at com.google.common.util.concurrent.DirectExecutorService.execute(DirectExecutorService.java:52)
2026-03-04T21:34:07.3074676Z 	at java.base/java.util.concurrent.AbstractExecutorService.invokeAll(AbstractExecutorService.java:271)
2026-03-04T21:34:07.3078000Z 	at io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.process(DeltaLakeTableMetadataScheduler.java:164)
2026-03-04T21:34:07.3082458Z 	at io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.lambda$start$0(DeltaLakeTableMetadataScheduler.java:125)
2026-03-04T21:34:07.3085607Z 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
2026-03-04T21:34:07.3088241Z 	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:369)
2026-03-04T21:34:07.3091225Z 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:310)
2026-03-04T21:34:07.3094684Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
2026-03-04T21:34:07.3097504Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
2026-03-04T21:34:07.3120190Z 	at java.base/java.lang.Thread.run(Thread.java:1474)
2026-03-04T21:34:07.3123325Z Caused by: InvalidOperationException(message:hive.test_schema.test_rename_column_show_stats_for_column_mapping_mode_tjc6kmpdiy table not found)
2026-03-04T21:34:07.3127306Z 	at io.trino.hive.thrift.metastore.ThriftHiveMetastore$alter_table_with_environment_context_result$alter_table_with_environment_context_resultStandardScheme.read(ThriftHiveMetastore.java)
2026-03-04T21:34:07.3131931Z 	at io.trino.hive.thrift.metastore.ThriftHiveMetastore$alter_table_with_environment_context_result$alter_table_with_environment_context_resultStandardScheme.read(ThriftHiveMetastore.java)
2026-03-04T21:34:07.3135639Z 	at io.trino.hive.thrift.metastore.ThriftHiveMetastore$alter_table_with_environment_context_result.read(ThriftHiveMetastore.java)
2026-03-04T21:34:07.3138492Z 	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:93)
2026-03-04T21:34:07.3142334Z 	at io.trino.hive.thrift.metastore.ThriftHiveMetastore$Client.recvAlterTableWithEnvironmentContext(ThriftHiveMetastore.java:2308)
2026-03-04T21:34:07.3146137Z 	at io.trino.hive.thrift.metastore.ThriftHiveMetastore$Client.alterTableWithEnvironmentContext(ThriftHiveMetastore.java:2292)
2026-03-04T21:34:07.3157616Z 	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient.alterTableWithEnvironmentContext(ThriftHiveMetastoreClient.java:301)
2026-03-04T21:34:07.3162721Z 	at io.trino.plugin.hive.metastore.thrift.FailureAwareThriftMetastoreClient.lambda$alterTableWithEnvironmentContext$0(FailureAwareThriftMetastoreClient.java:142)
2026-03-04T21:34:07.3167113Z 	at io.trino.plugin.hive.metastore.thrift.FailureAwareThriftMetastoreClient.runWithHandle(FailureAwareThriftMetastoreClient.java:484)
2026-03-04T21:34:07.3171690Z 	at io.trino.plugin.hive.metastore.thrift.FailureAwareThriftMetastoreClient.alterTableWithEnvironmentContext(FailureAwareThriftMetastoreClient.java:142)
2026-03-04T21:34:07.3176788Z 	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.lambda$alterTable$0(ThriftHiveMetastore.java:987)
2026-03-04T21:34:07.3180532Z 	at io.trino.plugin.hive.metastore.thrift.ThriftMetastoreApiStats.lambda$wrap$0(ThriftMetastoreApiStats.java:41)
2026-03-04T21:34:07.3183797Z 	at io.trino.plugin.hive.metastore.thrift.RetryDriver.run(RetryDriver.java:117)
2026-03-04T21:34:07.3186407Z 	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.alterTable(ThriftHiveMetastore.java:977)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.