### PR TITLE
Document Vertica connector removal in 480 release note

### DIFF
--- a/docs/src/main/sphinx/release/release-480.md
+++ b/docs/src/main/sphinx/release/release-480.md
@@ -218,8 +218,7 @@
 
 ## Vertica connector
 
-* Fix failure when creating a table if a prior `CREATE TABLE ... AS SELECT`
-  operation for the same table failed. ({issue}`27702`)
+* {{breaking}} Remove the Vertica connector. ({issue}`26904`)
 
 ## SPI
 


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
