### PR TITLE
Use StandardCharsets constants

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonInputFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonInputFunctions.java
@@ -25,11 +25,11 @@ import io.trino.spi.type.StandardTypes;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
 
 import static io.trino.json.JsonInputErrorNode.JSON_ERROR;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_32LE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -57,7 +57,6 @@ public final class JsonInputFunctions
     public static final String VARBINARY_UTF32_TO_JSON = "$varbinary_utf32_to_json";
 
     private static final JsonMapper MAPPER = new JsonMapper();
-    private static final Charset UTF_32LE = Charset.forName("UTF-32LE");
 
     private JsonInputFunctions() {}
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonOutputFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonOutputFunctions.java
@@ -73,9 +73,9 @@ public final class JsonOutputFunctions
             Slices.copiedBuffer(new ObjectNode(JsonNodeFactory.instance).asText(), StandardCharsets.UTF_16LE));
     private static final EncodingSpecificConstants UTF_32 = new EncodingSpecificConstants(
             JsonEncoding.UTF32_LE,
-            Charset.forName("UTF-32LE"),
-            Slices.copiedBuffer(new ArrayNode(JsonNodeFactory.instance).asText(), Charset.forName("UTF-32LE")),
-            Slices.copiedBuffer(new ObjectNode(JsonNodeFactory.instance).asText(), Charset.forName("UTF-32LE")));
+            StandardCharsets.UTF_32LE,
+            Slices.copiedBuffer(new ArrayNode(JsonNodeFactory.instance).asText(), StandardCharsets.UTF_32LE),
+            Slices.copiedBuffer(new ObjectNode(JsonNodeFactory.instance).asText(), StandardCharsets.UTF_32LE));
 
     private JsonOutputFunctions() {}
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonInputFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonInputFunctions.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.json.JsonInputErrorNode.JSON_ERROR;
@@ -164,13 +165,13 @@ public class TestJsonInputFunctions
     @Test
     public void testVarbinaryUtf32ToJson()
     {
-        assertThat(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, Charset.forName("UTF-32LE")) + ", true)"))
+        assertThat(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, StandardCharsets.UTF_32LE) + ", true)"))
                 .hasType(JSON_2016)
                 .isEqualTo(JSON_OBJECT);
 
         // wrong input encoding
 
-        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, Charset.forName("UTF-32BE")) + ", true)")::evaluate)
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, StandardCharsets.UTF_32BE) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -186,12 +187,12 @@ public class TestJsonInputFunctions
         // correct encoding, incorrect input
 
         // with unsuppressed input conversion error
-        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(ERROR_INPUT, Charset.forName("UTF-32LE")) + ", true)")::evaluate)
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(ERROR_INPUT, StandardCharsets.UTF_32LE) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
         // with input conversion error suppressed and converted to JSON_ERROR
-        assertThat(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(ERROR_INPUT, Charset.forName("UTF-32LE")) + ", false)"))
+        assertThat(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(ERROR_INPUT, StandardCharsets.UTF_32LE) + ", false)"))
                 .hasType(JSON_2016)
                 .isEqualTo(JSON_ERROR);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonOutputFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonOutputFunctions.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
@@ -81,7 +81,7 @@ public class TestJsonOutputFunctions
     public void testJsonToVarbinaryUtf32()
     {
         assertThat(assertions.expression("\"$json_to_varbinary_utf32\"(" + JSON_EXPRESSION + ", TINYINT '1', true)"))
-                .isEqualTo(new SqlVarbinary(OUTPUT.getBytes(Charset.forName("UTF-32LE"))));
+                .isEqualTo(new SqlVarbinary(OUTPUT.getBytes(StandardCharsets.UTF_32LE)));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
@@ -186,7 +186,7 @@ public class TestJsonArrayFunction
                 "SELECT json_array(true RETURNING varbinary FORMAT JSON ENCODING UTF16)"))
                 .matches("VALUES " + varbinaryLiteral);
 
-        bytes = output.getBytes(Charset.forName("UTF_32LE"));
+        bytes = output.getBytes(StandardCharsets.UTF_32LE);
         varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
         assertThat(assertions.query(
                 "SELECT json_array(true RETURNING varbinary FORMAT JSON ENCODING UTF32)"))

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonExistsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonExistsFunction.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.spi.StandardErrorCode.INVALID_PATH;
@@ -131,7 +131,7 @@ public class TestJsonExistsFunction
                 "SELECT json_exists(" + varbinaryLiteral + " FORMAT JSON ENCODING UTF16, 'lax $[1]')"))
                 .matches("VALUES true");
 
-        bytes = INPUT.getBytes(Charset.forName("UTF-32LE"));
+        bytes = INPUT.getBytes(StandardCharsets.UTF_32LE);
         varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
 
         assertThat(assertions.query(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonObjectFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonObjectFunction.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -243,7 +243,7 @@ public class TestJsonObjectFunction
                 "SELECT json_object('key' : 1 RETURNING varbinary FORMAT JSON ENCODING UTF16)"))
                 .matches("VALUES " + varbinaryLiteral);
 
-        bytes = output.getBytes(Charset.forName("UTF_32LE"));
+        bytes = output.getBytes(StandardCharsets.UTF_32LE);
         varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
         assertThat(assertions.query(
                 "SELECT json_object('key' : 1 RETURNING varbinary FORMAT JSON ENCODING UTF32)"))

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
@@ -174,7 +174,7 @@ public class TestJsonQueryFunction
                 "SELECT json_query(" + varbinaryLiteral + " FORMAT JSON ENCODING UTF16, 'lax $[1]')"))
                 .matches("VALUES VARCHAR '\"b\"'");
 
-        bytes = INPUT.getBytes(Charset.forName("UTF-32LE"));
+        bytes = INPUT.getBytes(StandardCharsets.UTF_32LE);
         varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
 
         assertThat(assertions.query(
@@ -322,7 +322,7 @@ public class TestJsonQueryFunction
                 "SELECT json_query('" + INPUT + "', 'lax $' RETURNING varbinary FORMAT JSON ENCODING UTF16)"))
                 .matches("VALUES " + varbinaryLiteral);
 
-        bytes = output.getBytes(Charset.forName("UTF_32LE"));
+        bytes = output.getBytes(StandardCharsets.UTF_32LE);
         varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
 
         assertThat(assertions.query(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.spi.StandardErrorCode.INVALID_PATH;
@@ -169,7 +169,7 @@ public class TestJsonValueFunction
                 "SELECT json_value(" + varbinaryLiteral + " FORMAT JSON ENCODING UTF16, 'lax $[1]')"))
                 .matches("VALUES VARCHAR 'b'");
 
-        bytes = INPUT.getBytes(Charset.forName("UTF-32LE"));
+        bytes = INPUT.getBytes(StandardCharsets.UTF_32LE);
         varbinaryLiteral = "X'" + base16().encode(bytes) + "'";
 
         assertThat(assertions.query(


### PR DESCRIPTION
Spotted during other work. UTF_32LE/UTF_32BE were added in JDK 22

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
