### PR TITLE
Require plugins to bind mbeans in namespace

### DIFF
--- a/.mvn/modernizer/violations.xml
+++ b/.mvn/modernizer/violations.xml
@@ -259,6 +259,12 @@
     </violation>
 
     <violation>
+        <name>org/weakref/jmx/guice/MBeanModule."&lt;init&gt;":()V</name>
+        <version>1.8</version>
+        <comment>MBeanModule by default binds mbeans into global namespace, which is great default in general, but not so great for Trino plugins. Use MBeanModule helper from trino-jmxutils</comment>
+    </violation>
+
+    <violation>
         <name>org/testng/annotations/BeforeTest</name>
         <version>1.8</version>
         <comment>Prefer org.testng.annotations.BeforeClass</comment>

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -265,6 +265,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-matching</artifactId>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -43,6 +43,7 @@ import io.trino.exchange.ExchangeManagerModule;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.resourcegroups.ResourceGroupManager;
 import io.trino.execution.warnings.WarningCollectorModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.node.Announcer;
 import io.trino.node.NodeManagerModule;
 import io.trino.security.AccessControlManager;
@@ -57,7 +58,6 @@ import io.trino.server.security.oauth2.OAuth2Client;
 import io.trino.spi.NodeVersion;
 import io.trino.transaction.TransactionManagerModule;
 import io.trino.util.EmbedVersion;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -95,7 +95,7 @@ public class Server
                 new HttpServerModule(),
                 new JsonModule(),
                 new JaxrsModule(),
-                new MBeanModule(),
+                MBeanModule.forMainServer(),
                 new PrefixObjectNameGeneratorModule("io.trino"),
                 new JmxModule(),
                 new JmxOpenMetricsModule(),

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -59,6 +59,7 @@ import io.trino.execution.QueryManager;
 import io.trino.execution.SqlTaskManager;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.resourcegroups.InternalResourceGroupManager;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.memory.ClusterMemoryManager;
 import io.trino.memory.LocalMemoryManager;
 import io.trino.metadata.CatalogManager;
@@ -118,7 +119,6 @@ import io.trino.tracing.TracingAccessControl;
 import io.trino.transaction.TransactionManager;
 import io.trino.transaction.TransactionManagerModule;
 import jakarta.servlet.Filter;
-import org.weakref.jmx.guice.MBeanModule;
 
 import javax.management.MBeanServer;
 
@@ -303,7 +303,7 @@ public class TestingTrinoServer
                 .add(new TestingHttpServerModule("testing-trino-" + instanceId, httpPort))
                 .add(new JsonModule())
                 .add(new JaxrsModule())
-                .add(new MBeanModule())
+                .add(MBeanModule.forMainServer())
                 .add(new PrefixObjectNameGeneratorModule("io.trino"))
                 .add(new TestingJmxModule())
                 .add(new JmxOpenMetricsModule())

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -104,6 +104,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystemManager.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystemManager.java
@@ -25,11 +25,11 @@ import io.trino.hdfs.azure.HiveAzureModule;
 import io.trino.hdfs.cos.HiveCosModule;
 import io.trino.hdfs.gcs.HiveGcsModule;
 import io.trino.hdfs.s3.HiveS3Module;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.ConnectorContext;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +53,7 @@ public final class HdfsFileSystemManager
     {
         List<Module> modules = new ArrayList<>();
 
-        modules.add(new MBeanModule());
+        modules.add(MBeanModule.forConnector());
         modules.add(new MBeanServerModule());
         modules.add(new ConnectorObjectNameGeneratorModule("", ""));
 

--- a/lib/trino-jmxutils/pom.xml
+++ b/lib/trino-jmxutils/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>481-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-jmxutils</artifactId>
+    <name>${project.artifactId}</name>
+    <description>Trino - JMX utils</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/lib/trino-jmxutils/src/main/java/io/trino/jmxutils/MBeanModule.java
+++ b/lib/trino-jmxutils/src/main/java/io/trino/jmxutils/MBeanModule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jmxutils;
+
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+import org.weakref.jmx.ObjectNameGenerator;
+
+import java.util.Optional;
+
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
+
+public final class MBeanModule
+{
+    private MBeanModule() {}
+
+    public static Module forMainServer()
+    {
+        return createMBeanModule();
+    }
+
+    public static Module forConnector()
+    {
+        return combine(
+                createMBeanModule(),
+                binder -> {
+                    // require binding for ObjectNameGenerator
+                    binder.bind(RequireObjectNameGenerator.class).asEagerSingleton();
+                });
+    }
+
+    @SuppressModernizer // MBeanModule::new is forbidden, advising to use this class as a safety-adding wrapper.
+    private static Module createMBeanModule()
+    {
+        return new org.weakref.jmx.guice.MBeanModule();
+    }
+
+    static class RequireObjectNameGenerator
+    {
+        @Inject
+        RequireObjectNameGenerator(Optional<ObjectNameGenerator> objectNameGenerator)
+        {
+            if (objectNameGenerator.isEmpty()) {
+                throw new IllegalStateException("ObjectNameGenerator must be explicitly bound");
+            }
+        }
+    }
+}

--- a/lib/trino-jmxutils/src/test/java/io/trino/jmxutils/TestDummy.java
+++ b/lib/trino-jmxutils/src/test/java/io/trino/jmxutils/TestDummy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jmxutils;
+
+import org.junit.jupiter.api.Test;
+
+public class TestDummy
+{
+    @Test
+    public void buildRequiresTestToExist() {}
+}

--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -88,6 +88,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-matching</artifactId>
         </dependency>
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
@@ -17,6 +17,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
@@ -58,6 +59,7 @@ public class JdbcConnectorFactory
                 "io.trino.bootstrap.catalog." + catalogName,
                 new ConnectorContextModule(catalogName, context),
                 new JdbcModule(),
+                new ConnectorObjectNameGeneratorModule("io.trino.plugin.jdbc", "trino.plugin." + name),
                 module.get());
 
         Injector injector = app

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDiagnosticModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDiagnosticModule.java
@@ -14,31 +14,31 @@
 package io.trino.plugin.jdbc;
 
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.log.Logger;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.util.LoggingInvocationHandler;
 import io.trino.plugin.jdbc.jmx.StatisticsAwareConnectionFactory;
 import io.trino.plugin.jdbc.jmx.StatisticsAwareJdbcClient;
 import io.trino.spi.catalog.CatalogName;
-import org.weakref.jmx.guice.MBeanModule;
 
 import static com.google.common.reflect.Reflection.newProxy;
 import static java.lang.String.format;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class JdbcDiagnosticModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
-        binder.install(new MBeanServerModule());
-        binder.install(new MBeanModule());
+        install(new MBeanServerModule());
+        install(MBeanModule.forConnector());
         binder.bind(StatisticsAwareConnectionFactory.class).in(Scopes.SINGLETON);
 
         Provider<CatalogName> catalogName = binder.getProvider(CatalogName.class);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJmxStats.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJmxStats.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
@@ -28,7 +27,6 @@ import javax.management.ObjectName;
 import java.util.Set;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
@@ -41,9 +39,7 @@ public class TestJmxStats
             throws Exception
     {
         String jmxBaseName = getClass().getSimpleName() + "_" + randomNameSuffix();
-        Plugin plugin = new JdbcPlugin(
-                "base_jdbc",
-                () -> combine(new TestingH2JdbcModule(), new ConnectorObjectNameGeneratorModule("io.trino.plugin.jdbc", "trino.plugin.jdbc")));
+        Plugin plugin = new JdbcPlugin("base_jdbc", TestingH2JdbcModule::new);
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         Connector connector = factory.create(
                 "test",

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -262,6 +262,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
@@ -16,13 +16,13 @@ package io.trino.plugin.bigquery;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -50,7 +50,7 @@ public class BigQueryConnectorFactory
                 new JsonModule(),
                 new BigQueryConnectorModule(),
                 new MBeanServerModule(),
-                new MBeanModule(),
+                MBeanModule.forConnector(),
                 new ConnectorObjectNameGeneratorModule("io.trino.plugin.bigquery", "trino.plugin.bigquery"),
                 new ConnectorContextModule(catalogName, context));
 

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -102,6 +102,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
@@ -114,11 +119,6 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
@@ -16,12 +16,13 @@ package io.trino.plugin.cassandra;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -46,7 +47,8 @@ public class CassandraConnectorFactory
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.catalog." + catalogName,
                 new ConnectorContextModule(catalogName, context),
-                new MBeanModule(),
+                MBeanModule.forConnector(),
+                new ConnectorObjectNameGeneratorModule("io.trino.plugin.cassandra", "trino.plugin.cassandra"),
                 new JsonModule(),
                 new CassandraClientModule(),
                 new MBeanServerModule());

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -115,6 +115,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-metastore</artifactId>
         </dependency>
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
@@ -21,6 +21,7 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.json.JsonModule;
 import io.trino.filesystem.manager.FileSystemModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorAccessControl;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
@@ -45,7 +46,6 @@ import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.Optional;
@@ -84,7 +84,7 @@ public class DeltaLakeConnectorFactory
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     "io.trino.bootstrap.catalog." + catalogName,
-                    new MBeanModule(),
+                    MBeanModule.forConnector(),
                     new ConnectorObjectNameGeneratorModule("io.trino.plugin.deltalake", "trino.plugin.deltalake"),
                     new JsonModule(),
                     new MBeanServerModule(),

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -82,6 +82,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.elasticsearch;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.TypeDeserializerModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
@@ -23,7 +24,6 @@ import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -50,7 +50,7 @@ public class ElasticsearchConnectorFactory
 
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.catalog." + catalogName,
-                new MBeanModule(),
+                MBeanModule.forConnector(),
                 new MBeanServerModule(),
                 new ConnectorObjectNameGeneratorModule("io.trino.plugin.elasticsearch", "trino.plugin.elasticsearch"),
                 new JsonModule(),

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -209,6 +209,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManagerFactory.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManagerFactory.java
@@ -17,12 +17,12 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.spi.exchange.ExchangeManager;
 import io.trino.spi.exchange.ExchangeManagerContext;
 import io.trino.spi.exchange.ExchangeManagerFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -46,7 +46,7 @@ public class FileSystemExchangeManagerFactory
 
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.exchange.filesystem",
-                new MBeanModule(),
+                MBeanModule.forConnector(),
                 new MBeanServerModule(),
                 new PrefixObjectNameGeneratorModule("io.trino.plugin.exchange.filesystem", "trino.plugin.exchange.filesystem"),
                 new FileSystemExchangeModule(),

--- a/plugin/trino-exchange-hdfs/pom.xml
+++ b/plugin/trino-exchange-hdfs/pom.xml
@@ -57,6 +57,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeManagerFactory.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeManagerFactory.java
@@ -17,13 +17,13 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeManager;
 import io.trino.spi.exchange.ExchangeManager;
 import io.trino.spi.exchange.ExchangeManagerContext;
 import io.trino.spi.exchange.ExchangeManagerFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class HdfsExchangeManagerFactory
 
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.exchange.hdfs",
-                new MBeanModule(),
+                MBeanModule.forConnector(),
                 new MBeanServerModule(),
                 new PrefixObjectNameGeneratorModule("io.trino.plugin.exchange.hdfs", "trino.plugin.exchange.hdfs"),
                 new HdfsExchangeModule(),

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -113,6 +113,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
@@ -22,6 +22,7 @@ import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.json.JsonModule;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.manager.FileSystemModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.TypeDeserializerModule;
@@ -48,7 +49,6 @@ import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.procedure.Procedure;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.Optional;
@@ -88,7 +88,7 @@ public class HiveConnectorFactory
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     "io.trino.bootstrap.catalog." + catalogName,
-                    new MBeanModule(),
+                    MBeanModule.forConnector(),
                     new ConnectorObjectNameGeneratorModule("io.trino.plugin.hive", "trino.plugin.hive"),
                     new JsonModule(),
                     new TypeDeserializerModule(),

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -84,6 +84,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConnectorFactory.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConnectorFactory.java
@@ -21,10 +21,12 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.json.JsonModule;
 import io.trino.filesystem.manager.FileSystemModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
 import io.trino.plugin.base.classloader.ClassLoaderSafeNodePartitioningProvider;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.metastore.HiveMetastoreModule;
@@ -35,7 +37,6 @@ import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.Optional;
@@ -70,7 +71,8 @@ public class HudiConnectorFactory
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     "io.trino.bootstrap.catalog." + catalogName,
-                    new MBeanModule(),
+                    MBeanModule.forConnector(),
+                    new ConnectorObjectNameGeneratorModule("io.trino.plugin.hudi", "trino.plugin.hudi"),
                     new JsonModule(),
                     new HudiModule(),
                     new HiveMetastoreModule(Optional.empty(), false),

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -145,6 +145,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
@@ -21,6 +21,7 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.json.JsonModule;
 import io.trino.filesystem.manager.FileSystemModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
@@ -30,7 +31,6 @@ import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.Optional;
@@ -67,7 +67,7 @@ public class IcebergConnectorFactory
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     "io.trino.bootstrap.catalog." + catalogName,
-                    new MBeanModule(),
+                    MBeanModule.forConnector(),
                     new ConnectorObjectNameGeneratorModule("io.trino.plugin.iceberg", "trino.plugin.iceberg"),
                     new JsonModule(),
                     new IcebergModule(),

--- a/plugin/trino-kafka-event-listener/pom.xml
+++ b/plugin/trino-kafka-event-listener/pom.xml
@@ -82,6 +82,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-kafka</artifactId>
             <exclusions>
                 <exclusion>

--- a/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerFactory.java
+++ b/plugin/trino-kafka-event-listener/src/main/java/io/trino/plugin/eventlistener/kafka/KafkaEventListenerFactory.java
@@ -18,10 +18,11 @@ import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.EventListenerFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -42,7 +43,8 @@ public class KafkaEventListenerFactory
     {
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.listener." + getName(),
-                new MBeanModule(),
+                MBeanModule.forConnector(),
+                new PrefixObjectNameGeneratorModule("io.trino.plugin.eventlistener.kafka", "trino.plugin.eventlistener.kafka"),
                 new MBeanServerModule(),
                 new KafkaProducerModule(),
                 binder -> {

--- a/plugin/trino-lakehouse/pom.xml
+++ b/plugin/trino-lakehouse/pom.xml
@@ -68,6 +68,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-metastore</artifactId>
         </dependency>
 

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseConnectorFactory.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseConnectorFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.lakehouse;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.TypeDeserializerModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
@@ -25,7 +26,6 @@ import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class LakehouseConnectorFactory
         try (var _ = new ThreadContextClassLoader(getClass().getClassLoader())) {
             Bootstrap app = new Bootstrap(
                     "io.trino.bootstrap.catalog." + catalogName,
-                    new MBeanModule(),
+                    MBeanModule.forConnector(),
                     new MBeanServerModule(),
                     new ConnectorObjectNameGeneratorModule("io.trino.plugin", "trino.plugin"),
                     new JsonModule(),

--- a/plugin/trino-opensearch/pom.xml
+++ b/plugin/trino-opensearch/pom.xml
@@ -83,6 +83,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchConnectorFactory.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchConnectorFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.opensearch;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.TypeDeserializerModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
@@ -23,7 +24,6 @@ import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -50,7 +50,7 @@ public class OpenSearchConnectorFactory
 
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.catalog." + catalogName,
-                new MBeanModule(),
+                MBeanModule.forConnector(),
                 new MBeanServerModule(),
                 new ConnectorObjectNameGeneratorModule("io.trino.plugin.opensearch", "trino.plugin.opensearch"),
                 new JsonModule(),

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -105,6 +105,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-matching</artifactId>
         </dependency>
 
@@ -325,11 +330,6 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
@@ -18,14 +18,15 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.TypeDeserializerModule;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.pinot.auth.PinotAuthenticationModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.Optional;
@@ -58,7 +59,8 @@ public class PinotConnectorFactory
 
         ImmutableList.Builder<Module> modulesBuilder = ImmutableList.<Module>builder()
                 .add(new JsonModule())
-                .add(new MBeanModule())
+                .add(MBeanModule.forConnector())
+                .add(new ConnectorObjectNameGeneratorModule("io.trino.plugin.pinot", "trino.plugin.pinot"))
                 .add(new MBeanServerModule())
                 .add(new TypeDeserializerModule())
                 .add(new ConnectorContextModule(catalogName, context))

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -84,6 +84,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -17,13 +17,13 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.spi.memory.ClusterMemoryPoolManager;
 import io.trino.spi.resourcegroups.ResourceGroupConfigurationManager;
 import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerContext;
 import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -44,11 +44,11 @@ public class DbResourceGroupConfigurationManagerFactory
         FlywayMigration.migrate(new ConfigurationFactory(replaceEnvironmentVariables(config)).build(DbResourceGroupConfig.class));
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.resource-group." + getName(),
-                new MBeanModule(),
+                MBeanModule.forConnector(),
+                new PrefixObjectNameGeneratorModule("io.trino.plugin.resourcegroups.db", "trino.plugin.resourcegroups.db"),
                 new MBeanServerModule(),
                 new JsonModule(),
                 new DbResourceGroupsModule(),
-                new PrefixObjectNameGeneratorModule("io.trino.plugin.resourcegroups.db", "trino.plugin.resourcegroups.db"),
                 binder -> binder.bind(String.class).annotatedWith(ForEnvironment.class).toInstance(context.getEnvironment()),
                 binder -> binder.bind(ClusterMemoryPoolManager.class).toInstance(context.getMemoryPoolManager()));
 

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -82,6 +82,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/db/DbSessionPropertyManagerFactory.java
+++ b/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/db/DbSessionPropertyManagerFactory.java
@@ -16,11 +16,12 @@ package io.trino.plugin.session.db;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.spi.resourcegroups.SessionPropertyConfigurationManagerContext;
 import io.trino.spi.session.SessionPropertyConfigurationManager;
 import io.trino.spi.session.SessionPropertyConfigurationManagerFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -41,7 +42,8 @@ public class DbSessionPropertyManagerFactory
         try {
             Bootstrap app = new Bootstrap(
                     "io.trino.bootstrap.session." + getName(),
-                    new MBeanModule(),
+                    MBeanModule.forConnector(),
+                    new PrefixObjectNameGeneratorModule("io.trino.plugin.session.db", "trino.plugin.session.db"),
                     new MBeanServerModule(),
                     new JsonModule(),
                     new DbSessionPropertyManagerModule());

--- a/plugin/trino-spooling-filesystem/pom.xml
+++ b/plugin/trino-spooling-filesystem/pom.xml
@@ -77,6 +77,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
@@ -88,11 +93,6 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-spooling-filesystem/src/main/java/io/trino/spooling/filesystem/FileSystemSpoolingManagerFactory.java
+++ b/plugin/trino-spooling-filesystem/src/main/java/io/trino/spooling/filesystem/FileSystemSpoolingManagerFactory.java
@@ -16,12 +16,13 @@ package io.trino.spooling.filesystem;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.spi.Node;
 import io.trino.spi.spool.SpoolingManager;
 import io.trino.spi.spool.SpoolingManagerContext;
 import io.trino.spi.spool.SpoolingManagerFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -43,7 +44,8 @@ public class FileSystemSpoolingManagerFactory
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.spooling." + getName(),
                 new FileSystemSpoolingModule(context.isCoordinator()),
-                new MBeanModule(),
+                MBeanModule.forConnector(),
+                new PrefixObjectNameGeneratorModule("io.trino.spooling.filesystem", "trino.spooling.filesystem"),
                 new MBeanServerModule(),
                 binder -> {
                     binder.bind(SpoolingManagerContext.class).toInstance(context);

--- a/plugin/trino-thrift/pom.xml
+++ b/plugin/trino-thrift/pom.xml
@@ -83,6 +83,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
@@ -17,13 +17,13 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.drift.transport.netty.client.DriftNettyClientModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -56,7 +56,7 @@ public class ThriftConnectorFactory
 
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.catalog." + catalogName,
-                new MBeanModule(),
+                MBeanModule.forConnector(),
                 new MBeanServerModule(),
                 new ConnectorObjectNameGeneratorModule("io.trino.plugin.thrift", "trino.plugin.thrift"),
                 new DriftNettyClientModule(),

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -52,17 +52,17 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.trino.tpch</groupId>
             <artifactId>tpch</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
@@ -16,12 +16,13 @@ package io.trino.plugin.tpch;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.trino.jmxutils.MBeanModule;
 import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
-import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -63,7 +64,8 @@ public class TpchConnectorFactory
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.catalog." + catalogName,
                 new ConnectorContextModule(catalogName, context),
-                new MBeanModule(),
+                MBeanModule.forConnector(),
+                new ConnectorObjectNameGeneratorModule("io.trino.plugin.tpch", "trino.plugin.tpch"),
                 new JsonModule(),
                 new TpchModule(defaultSplitsPerNode, predicatePushdownEnabled),
                 new MBeanServerModule());

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>lib/trino-geospatial-toolkit</module>
         <module>lib/trino-hdfs</module>
         <module>lib/trino-hive-formats</module>
+        <module>lib/trino-jmxutils</module>
         <module>lib/trino-matching</module>
         <module>lib/trino-memory-context</module>
         <module>lib/trino-metastore</module>
@@ -1177,6 +1178,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-jmx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-jmxutils</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/service/trino-proxy/pom.xml
+++ b/service/trino-proxy/pom.xml
@@ -121,6 +121,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
@@ -142,11 +147,6 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
         </dependency>
 
         <dependency>

--- a/service/trino-proxy/src/main/java/io/trino/proxy/TrinoProxy.java
+++ b/service/trino-proxy/src/main/java/io/trino/proxy/TrinoProxy.java
@@ -24,7 +24,7 @@ import io.airlift.log.LogJmxModule;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeModule;
 import io.airlift.tracing.TracingModule;
-import org.weakref.jmx.guice.MBeanModule;
+import io.trino.jmxutils.MBeanModule;
 
 import static java.util.Objects.requireNonNullElse;
 
@@ -41,7 +41,7 @@ public final class TrinoProxy
                 .add(new HttpServerModule())
                 .add(new JsonModule())
                 .add(new JaxrsModule())
-                .add(new MBeanModule())
+                .add(MBeanModule.forMainServer())
                 .add(new JmxModule())
                 .add(new LogJmxModule())
                 .add(new TracingModule("trino-proxy", VERSION))


### PR DESCRIPTION
`MBeanModule` is used by almost every connector. By default, it exports mbeans into global namespace, which is confusing. Disallow direct use of that module. Instead, require to use a wrapper that verifies an `ObjectNameGenerator` is properly bound.

 
- alternative to https://github.com/trinodb/trino/pull/27623