### PR TITLE
Recommend json_query alternative in json_array_get docs

### DIFF
--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -1826,9 +1826,8 @@ and any interior quotes will not be escaped).
 We recommend against using this function. It cannot be fixed without
 impacting existing usages and may be removed in a future release.
 
-Use {ref}`json_query<json-query>` or {func}`json_extract` instead with
-JSONPath array indexing syntax, e.g., `json_query(json_array, 'lax $[0]')`
-or `json_extract(json_array, '$[0]')`.
+Use {ref}`json_query<json-query>` instead with JSONPath array indexing
+syntax, e.g., `json_query(json_array, 'lax $[0]')`.
 :::
 
 Returns the element at the specified index into the `json_array`.


### PR DESCRIPTION
The json_array_get function has a warning that it's broken and may be removed, but didn't provide guidance on what to use instead. Now recommends using json_query with JSONPath array indexing syntax.
