### PR TITLE
Update HiveMetadata to respect session timestamp precision when build…

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1917,7 +1917,7 @@ public class HiveMetadata
         }
 
         Map<String, Type> columnTypes = handle.getInputColumns().stream()
-                .collect(toImmutableMap(HiveColumnHandle::getName, column -> typeManager.getType(getTypeSignature(column.getHiveType()))));
+                .collect(toImmutableMap(HiveColumnHandle::getName, column -> getType(column.getHiveType(), typeManager, getTimestampPrecision(session))));
         Map<List<String>, ComputedStatistics> partitionComputedStatistics = createComputedStatisticsToPartitionMap(computedStatistics, handle.getPartitionedBy(), columnTypes);
 
         PartitionStatistics tableStatistics;
@@ -2296,7 +2296,7 @@ public class HiveMetadata
                 .map(Column::getName)
                 .collect(toImmutableList());
         Map<String, Type> columnTypes = handle.getInputColumns().stream()
-                .collect(toImmutableMap(HiveColumnHandle::getName, column -> typeManager.getType(getTypeSignature(column.getHiveType()))));
+                .collect(toImmutableMap(HiveColumnHandle::getName, column -> getType(column.getHiveType(), typeManager, getTimestampPrecision(session))));
         Map<List<String>, ComputedStatistics> partitionComputedStatistics = createComputedStatisticsToPartitionMap(computedStatistics, partitionedBy, columnTypes);
 
         ImmutableList.Builder<PartitionUpdateInfo> partitionUpdateInfosBuilder = ImmutableList.builder();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/Statistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/Statistics.java
@@ -26,7 +26,6 @@ import io.trino.plugin.hive.HiveColumnStatisticType;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.Fixed12Block;
 import io.trino.spi.statistics.ColumnStatisticMetadata;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.type.DecimalType;
@@ -68,7 +67,6 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -302,18 +300,11 @@ public final class Statistics
         if (block.isNull(0)) {
             return OptionalLong.empty();
         }
-        // TODO: https://github.com/trinodb/trino/issues/28835
-        //  The columnTypes map in HiveMetadata.finishChangingTable is built using the deprecated
-        //   getTypeSignature(HiveType) which always resolves TIMESTAMP to milliseconds,
-        //   ignoring the session's hive.timestamp-precision setting. The statistics
-        //   blocks however are computed by the engine using the session's precision.
-        //   The fix is to pass the session's timestamp precision when building columnTypes in HiveMetadata.
-        if (block instanceof Fixed12Block) {
-            LongTimestamp timestamp = (LongTimestamp) TIMESTAMP_NANOS.getObject(block, 0);
-            // Note: we're truncating even for the max value. Statistics are estimate so this should be fine.
-            return OptionalLong.of(timestamp.getEpochMicros());
+        if (((TimestampType) type).isShort()) {
+            return OptionalLong.of(type.getLong(block, 0));
         }
-        return OptionalLong.of(type.getLong(block, 0));
+        // Note: we're truncating even for the max value. Statistics are estimate so this should be fine.
+        return OptionalLong.of(((LongTimestamp) type.getObject(block, 0)).getEpochMicros());
     }
 
     private static Optional<BigDecimal> getDecimalValue(Type type, Block block)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -6681,6 +6681,31 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testCollectStatisticsOnInsertTimestampWithPrecision()
+    {
+        for (HiveTimestampPrecision precision : HiveTimestampPrecision.values()) {
+            Session session = withTimestampPrecision(getSession(), precision);
+            String tableName = "test_stats_on_insert_timestamp_precision_" + precision.name() + randomNameSuffix();
+            try {
+                assertUpdate(format("CREATE TABLE %s (c_timestamp TIMESTAMP)", tableName));
+                assertUpdate(session,
+                        format("INSERT INTO %s VALUES " +
+                                "TIMESTAMP '1988-04-08 02:03:04.111', " +
+                                "TIMESTAMP '1988-04-08 02:03:04.119'", tableName),
+                        2);
+
+                assertQuery("SHOW STATS FOR " + tableName,
+                        "SELECT * FROM VALUES " +
+                                "('c_timestamp', null, 2.0, 0.0, null, '1988-04-08 02:03:04.111', '1988-04-08 02:03:04.119'), " +
+                                "(null, null, null, null, 2.0, null, null)");
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            }
+        }
+    }
+
+    @Test
     public void testCollectColumnStatisticsOnInsert()
     {
         String tableName = "test_collect_column_statistics_on_insert" + randomNameSuffix();


### PR DESCRIPTION
- Fix https://github.com/trinodb/trino/issues/28835

Using session timestamp precision when building columnTypes

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
