### PR TITLE
Propagate split source metrics to QueryInputMetadata

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -538,8 +538,21 @@ public class QueryMonitor
             return;
         }
 
+        List<OperatorStats> operatorSummaries = stageInfo.stageStats().getOperatorSummaries();
+        Map<PlanNodeId, Metrics> splitSourceMetrics = stageInfo.stageStats().getSplitSourceMetrics();
+        ImmutableList.Builder<OperatorStats> operatorStats = ImmutableList.builderWithExpectedSize(operatorSummaries.size());
+        for (OperatorStats stats : operatorSummaries) {
+            if (stats.getSourceId().isPresent()) {
+                Metrics metrics = splitSourceMetrics.get(stats.getSourceId().get());
+                if (metrics != null && metrics != Metrics.EMPTY) {
+                    stats = stats.withConnectorSplitSourceMetrics(metrics);
+                }
+            }
+            operatorStats.add(stats);
+        }
+
         // Note: a plan node may be mapped to multiple operators
-        Map<PlanNodeId, Collection<OperatorStats>> allOperatorStats = Multimaps.index(stageInfo.stageStats().getOperatorSummaries(), OperatorStats::getPlanNodeId).asMap();
+        Map<PlanNodeId, Collection<OperatorStats>> allOperatorStats = Multimaps.index(operatorStats.build(), OperatorStats::getPlanNodeId).asMap();
 
         // Sometimes a plan node is merged with other nodes into a single operator, and in that case,
         // use the stats of the nearest parent node with stats.

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -180,6 +180,7 @@ public class MockConnector
     private final Optional<ConnectorAccessControl> accessControl;
     private final Function<SchemaTableName, List<List<?>>> data;
     private final Function<SchemaTableName, Metrics> metrics;
+    private final Function<SchemaTableName, Metrics> splitSourceMetrics;
     private final Set<Procedure> procedures;
     private final Set<TableProcedureMetadata> tableProcedures;
     private final Set<ConnectorTableFunction> tableFunctions;
@@ -236,6 +237,7 @@ public class MockConnector
             Optional<ConnectorAccessControl> accessControl,
             Function<SchemaTableName, List<List<?>>> data,
             Function<SchemaTableName, Metrics> metrics,
+            Function<SchemaTableName, Metrics> splitSourceMetrics,
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
@@ -291,6 +293,7 @@ public class MockConnector
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.data = requireNonNull(data, "data is null");
         this.metrics = requireNonNull(metrics, "metrics is null");
+        this.splitSourceMetrics = requireNonNull(splitSourceMetrics, "splitSourceMetrics is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
         this.tableProcedures = requireNonNull(tableProcedures, "tableProcedures is null");
         this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
@@ -351,7 +354,14 @@ public class MockConnector
                     DynamicFilter dynamicFilter,
                     Constraint constraint)
             {
-                return new FixedSplitSource(MOCK_CONNECTOR_SPLIT);
+                SchemaTableName tableName = ((MockConnectorTableHandle) table).getTableName();
+                return new FixedSplitSource(MOCK_CONNECTOR_SPLIT) {
+                    @Override
+                    public Metrics getMetrics()
+                    {
+                        return splitSourceMetrics.apply(tableName);
+                    }
+                };
             }
 
             @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -132,6 +132,7 @@ public class MockConnectorFactory
     private final Collection<String> branches;
     private final Function<SchemaTableName, List<List<?>>> data;
     private final Function<SchemaTableName, Metrics> metrics;
+    private final Function<SchemaTableName, Metrics> splitSourceMetrics;
     private final Set<Procedure> procedures;
     private final Set<TableProcedureMetadata> tableProcedures;
     private final Set<ConnectorTableFunction> tableFunctions;
@@ -192,6 +193,7 @@ public class MockConnectorFactory
             Collection<String> branches,
             Function<SchemaTableName, List<List<?>>> data,
             Function<SchemaTableName, Metrics> metrics,
+            Function<SchemaTableName, Metrics> splitSourceMetrics,
             Set<Procedure> procedures,
             Set<TableProcedureMetadata> tableProcedures,
             Set<ConnectorTableFunction> tableFunctions,
@@ -255,6 +257,7 @@ public class MockConnectorFactory
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.data = requireNonNull(data, "data is null");
         this.metrics = requireNonNull(metrics, "metrics is null");
+        this.splitSourceMetrics = requireNonNull(splitSourceMetrics, "splitSourceMetrics is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
         this.tableProcedures = requireNonNull(tableProcedures, "tableProcedures is null");
         this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
@@ -317,6 +320,7 @@ public class MockConnectorFactory
                 accessControl,
                 data,
                 metrics,
+                splitSourceMetrics,
                 procedures,
                 tableProcedures,
                 tableFunctions,
@@ -469,6 +473,7 @@ public class MockConnectorFactory
         private BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable = (session, tableName) -> Optional.empty();
         private Function<SchemaTableName, List<List<?>>> data = schemaTableName -> ImmutableList.of();
         private Function<SchemaTableName, Metrics> metrics = schemaTableName -> EMPTY;
+        private Function<SchemaTableName, Metrics> splitSourceMetrics = schemaTableName -> EMPTY;
         private Set<Procedure> procedures = ImmutableSet.of();
         private Set<TableProcedureMetadata> tableProcedures = ImmutableSet.of();
         private Set<ConnectorTableFunction> tableFunctions = ImmutableSet.of();
@@ -735,6 +740,12 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withSplitSourceMetrics(Function<SchemaTableName, Metrics> splitSourceMetrics)
+        {
+            this.splitSourceMetrics = requireNonNull(splitSourceMetrics, "splitSourceMetrics is null");
+            return this;
+        }
+
         public Builder withProcedures(Iterable<Procedure> procedures)
         {
             this.procedures = ImmutableSet.copyOf(procedures);
@@ -904,6 +915,7 @@ public class MockConnectorFactory
                     branches,
                     data,
                     metrics,
+                    splitSourceMetrics,
                     procedures,
                     tableProcedures,
                     tableFunctions,

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -118,6 +118,7 @@ public class TestEventListenerBasic
     private static final String VARCHAR_TYPE = "varchar(15)";
     private static final String BIGINT_TYPE = BIGINT.getDisplayName();
     private static final Metrics TEST_METRICS = new Metrics(ImmutableMap.of("test_metrics", new LongCount(1)));
+    private static final Metrics TEST_SPLIT_SOURCE_METRICS = new Metrics(ImmutableMap.of("test_split_source_metrics", new LongCount(2)));
 
     private EventsAwaitingQueries queries;
 
@@ -263,6 +264,12 @@ public class TestEventListenerBasic
                         .withMetrics(schemaTableName -> {
                             if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
                                 return TEST_METRICS;
+                            }
+                            return EMPTY;
+                        })
+                        .withSplitSourceMetrics(schemaTableName -> {
+                            if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
+                                return TEST_SPLIT_SOURCE_METRICS;
                             }
                             return EMPTY;
                         })
@@ -1428,7 +1435,7 @@ public class TestEventListenerBasic
         List<Metrics> connectorMetrics = event.getIoMetadata().getInputs().stream()
                 .map(QueryInputMetadata::getConnectorMetrics)
                 .collect(toImmutableList());
-        assertThat(connectorMetrics).containsExactly(TEST_METRICS);
+        assertThat(connectorMetrics).containsExactly(TEST_METRICS.mergeWith(TEST_SPLIT_SOURCE_METRICS));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/28870


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Event Listener
* Include connector split source metrics in io.trino.spi.eventlistener.QueryInputMetadata#connectorMetrics. ({issue}`28870`)
```
