### PR TITLE
Map ClickHouse high-precision DECIMAL to Trino NUMBER

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.md
+++ b/docs/src/main/sphinx/connector/clickhouse.md
@@ -217,8 +217,8 @@ to the following table:
   - `DOUBLE`
   - `DOUBLE` is an alias of `Float64`
 * - `Decimal`
-  - `DECIMAL`
-  -
+  - `DECIMAL` or `NUMBER`
+  - Maps to Trino `DECIMAL` when `p ≤ 38`. Otherwise, maps to `NUMBER`.
 * - `FixedString`
   - `VARBINARY`
   - Enabling `clickhouse.map-string-as-varchar` config property changes the

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -74,6 +74,7 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.NumberType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -128,7 +129,6 @@ import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT16;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT32;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT64;
 import static io.trino.plugin.clickhouse.TrinoToClickHouseWriteChecker.UINT8;
-import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRoundingMode;
@@ -147,6 +147,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.numberReadFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.numberWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
@@ -706,21 +708,32 @@ public class ClickHouseClient
             case Types.DECIMAL:
                 int decimalDigits = typeHandle.requiredDecimalDigits();
                 int precision = typeHandle.requiredColumnSize();
-
-                ColumnMapping decimalColumnMapping;
-                if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
-                    int scale = Math.min(decimalDigits, getDecimalDefaultScale(session));
-                    decimalColumnMapping = decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session));
+                if (precision <= Decimals.MAX_PRECISION) {
+                    return Optional.of(ColumnMapping.mapping(
+                            createDecimalType(precision, max(decimalDigits, 0)),
+                            decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))).getReadFunction(),
+                            decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))).getWriteFunction(),
+                            // TODO (https://github.com/trinodb/trino/issues/7100) fix, enable and test decimal pushdown
+                            DISABLE_PUSHDOWN));
                 }
-                else {
-                    decimalColumnMapping = decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0)));
+                switch (getDecimalRounding(session)) {
+                    case MAP_TO_NUMBER -> {
+                        return Optional.of(numberColumnMapping());
+                    }
+                    case STRICT -> {
+                        // skipped (unhandled type)
+                    }
+                    case ALLOW_OVERFLOW -> {
+                        int scale = Math.min(max(decimalDigits, 0), getDecimalDefaultScale(session));
+                        return Optional.of(ColumnMapping.mapping(
+                                createDecimalType(Decimals.MAX_PRECISION, scale),
+                                decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)).getReadFunction(),
+                                decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)).getWriteFunction(),
+                                // TODO (https://github.com/trinodb/trino/issues/7100) fix, enable and test decimal pushdown
+                                DISABLE_PUSHDOWN));
+                    }
                 }
-                return Optional.of(ColumnMapping.mapping(
-                        decimalColumnMapping.getType(),
-                        decimalColumnMapping.getReadFunction(),
-                        decimalColumnMapping.getWriteFunction(),
-                        // TODO (https://github.com/trinodb/trino/issues/7100) fix, enable and test decimal pushdown
-                        DISABLE_PUSHDOWN));
+                break;
 
             case Types.DATE:
                 return Optional.of(dateColumnMappingUsingLocalDate(version));
@@ -884,6 +897,16 @@ public class ClickHouseClient
                     UINT64.validate(version, bigDecimal);
                     statement.setBigDecimal(index, bigDecimal);
                 });
+    }
+
+    private static ColumnMapping numberColumnMapping()
+    {
+        return ColumnMapping.objectMapping(
+                NumberType.NUMBER,
+                numberReadFunction(),
+                numberWriteFunction(),
+                // TODO (https://github.com/trinodb/trino/issues/7100) fix, enable and test decimal pushdown
+                DISABLE_PUSHDOWN);
     }
 
     private static ColumnMapping dateColumnMappingUsingLocalDate(ClickHouseVersionUtils version)

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClientModule.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClientModule.java
@@ -39,6 +39,7 @@ import static com.clickhouse.jdbc.JdbcConfig.PROP_EXTERNAL_DATABASE;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.clickhouse.ClickHouseClient.DEFAULT_DOMAIN_COMPACTION_THRESHOLD;
+import static io.trino.plugin.jdbc.DecimalModule.MappingToNumber.ON_BY_DEFAULT;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
 
@@ -53,7 +54,7 @@ public class ClickHouseClientModule
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(ClickHouseClient.class).in(Scopes.SINGLETON);
         bindTablePropertiesProvider(binder, ClickHouseTableProperties.class);
         configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setDomainCompactionThreshold(DEFAULT_DOMAIN_COMPACTION_THRESHOLD));
-        binder.install(new DecimalModule());
+        binder.install(DecimalModule.withNumberMapping(ON_BY_DEFAULT));
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
     }
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -48,6 +48,7 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.createTimestampType;
@@ -59,6 +60,7 @@ import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.type.IpAddressType.IPADDRESS;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -471,6 +473,79 @@ public abstract class BaseClickHouseTypeMapping
                 .addRoundTrip("Nullable(decimal(3, 1))", "NULL", createDecimalType(3, 1), "CAST(NULL AS decimal(3,1))")
                 .addRoundTrip("Nullable(decimal(30, 5))", "NULL", createDecimalType(30, 5), "CAST(NULL AS decimal(30,5))")
                 .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_nullable_decimal"));
+    }
+
+    @Test
+    public void testDecimalExceedingPrecisionMax()
+    {
+        // Test that DECIMAL types with precision > 38 map to NUMBER type
+        // ClickHouse uses Decimal256 for precision from 39 to 76 digits
+        // Scale range: [0 : P] where P is the precision
+
+        // Test precision 39 (minimum for Decimal256, just above Trino's MAX_PRECISION of 38)
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(39, 0)", "123456789012345678901234567890123456789", NUMBER, "NUMBER '123456789012345678901234567890123456789'")
+                .addRoundTrip("decimal(39, 0)", "-123456789012345678901234567890123456789", NUMBER, "NUMBER '-123456789012345678901234567890123456789'")
+                .addRoundTrip("Nullable(decimal(39, 0))", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p39"));
+
+        // Test precision 40, scale 5
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(40, 5)", "12345678901234567890123456789012345.12345", NUMBER, "NUMBER '12345678901234567890123456789012345.12345'")
+                .addRoundTrip("decimal(40, 5)", "-12345678901234567890123456789012345.12345", NUMBER, "NUMBER '-12345678901234567890123456789012345.12345'")
+                .addRoundTrip("decimal(40, 5)", "123.45", NUMBER, "NUMBER '123.45'")
+                .addRoundTrip("decimal(40, 5)", "-123.45", NUMBER, "NUMBER '-123.45'")
+                .addRoundTrip("Nullable(decimal(40, 5))", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p40"));
+
+        // Test precision 50, scale 10
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(50, 10)", "1234567890123456789012345678901234567890.1234567890", NUMBER, "NUMBER '1234567890123456789012345678901234567890.1234567890'")
+                .addRoundTrip("decimal(50, 10)", "-1234567890123456789012345678901234567890.1234567890", NUMBER, "NUMBER '-1234567890123456789012345678901234567890.1234567890'")
+                .addRoundTrip("Nullable(decimal(50, 10))", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p50"));
+
+        // Test precision 60, scale 20
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(60, 20)", "1234567890123456789012345678901234567890.12345678901234567890", NUMBER, "NUMBER '1234567890123456789012345678901234567890.12345678901234567890'")
+                .addRoundTrip("decimal(60, 20)", "-1234567890123456789012345678901234567890.12345678901234567890", NUMBER, "NUMBER '-1234567890123456789012345678901234567890.12345678901234567890'")
+                .addRoundTrip("Nullable(decimal(60, 20))", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p60"));
+
+        // Test precision 76 (ClickHouse Decimal256's max), scale 30
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(76, 30)", "1234567890123456789012345678901234567890123456.123456789012345678901234567890", NUMBER, "NUMBER '1234567890123456789012345678901234567890123456.123456789012345678901234567890'")
+                .addRoundTrip("decimal(76, 30)", "-1234567890123456789012345678901234567890123456.123456789012345678901234567890", NUMBER, "NUMBER '-1234567890123456789012345678901234567890123456.123456789012345678901234567890'")
+                .addRoundTrip("Nullable(decimal(76, 30))", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p76"));
+
+        // Test precision 76 (ClickHouse Decimal256's max), scale 76 (ClickHouse Decimal256's max)
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(76, 76)", "0.0123456789012345678901234567890123456789012345689012345678901234567890123456", NUMBER, "NUMBER '0.0123456789012345678901234567890123456789012345689012345678901234567890123456'")
+                .addRoundTrip("decimal(76, 76)", "-0.0123456789012345678901234567890123456789012345689012345678901234567890123456", NUMBER, "NUMBER '-0.0123456789012345678901234567890123456789012345689012345678901234567890123456'")
+                .addRoundTrip("Nullable(decimal(76, 76))", "NULL", NUMBER, "CAST(NULL AS NUMBER)")
+                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_decimal_exceeding_precision_max_p76_s76"));
+    }
+
+    @Test
+    public void testClickHouseDecimalUnsupportedPrecision()
+    {
+        assertThatThrownBy(() -> clickhouseServer.execute("CREATE TABLE verify_negative_scale_not_supported(a decimal(77, 0)) ENGINE=Log"))
+                .hasStackTraceContaining("Wrong precision");
+    }
+
+    @Test
+    public void testClickHouseDecimalNegativeScale()
+    {
+        assertThatThrownBy(() -> clickhouseServer.execute("CREATE TABLE verify_negative_scale_not_supported(a decimal(5, -1)) ENGINE=Log"))
+                .hasStackTraceContaining("Negative scales and scales larger than precision are not supported");
+    }
+
+    @Test
+    public void testClickHouseDecimalScaleExceedingPrecision()
+    {
+        assertThatThrownBy(() -> clickhouseServer.execute("CREATE TABLE verify_negative_scale_not_supported(a decimal(76, 77)) ENGINE=Log"))
+                .hasStackTraceContaining("Negative scales and scales larger than precision are not supported");
     }
 
     @Test


### PR DESCRIPTION
## Description

Trino's `DECIMAL` has precision of 1-38 decimal digits. ClickHouse's `DECIMAL` supports precision up to 76 digits with scale up to 30. Previously it was impossible to reasonably map high precision ClickHouse `DECIMAL` to Trino. Mapping required agreeing to lossy conversion using `decimal-mapping=ALLOW_OVERFLOW` config and perhaps tuning the behavior further with `decimal-default-scale` and `decimal-rounding-mode` configs. These configs, along with supporting session properties, are provided by `DecimalModule` and reused across multiple connectors.

After the changes, the connector maps high-precision DECIMAL (precision 39-76) to NUMBER, the new Trino high precision decimal type. The decimal configs such as `decimal-mapping`, `decimal-default-scale` are deprecated in the connector. They remain non-deprecated from the perspective of all other connectors using `DecimalModule`.

For backwards compatibility, when `decimal-mapping` is set to `STRICT` or `ALLOW_OVERFLOW`, the mapping to NUMBER is *not* used.

Note on backwards incompatible behavior when `unsupported-type-handling` is used. Previously, when connector was configured with `unsupported-type-handling=CONVERT_TO_VARCHAR` (and without `decimal-mapping`), ClickHouse's high precision decimals were mapped to VARCHAR. Now they are properly supported and mapped to NUMBER, which constitutes a backward incompatible change. This backwards incompatibility is intrinsic nature of `unsupported-type-handling` though and not specific to this new mapping. `unsupported-type-handling` very nature is future incompatibility so anyone configuring this config signs up for a breaking change like this.

This change adds read mapping only. Write mapping may be added separately.

https://clickhouse.com/docs/sql-reference/data-types/decimal

- for https://github.com/trinodb/trino/issues/28405

## Release notes

```markdown
## ClickHouse
* Add support for reading all ClickHouse `DECIMAL` columns. ({issue}`28873`)
```
