### PR TITLE
Add support for cast from BOOLEAN to NUMBER

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/BooleanOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BooleanOperators.java
@@ -22,6 +22,9 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
@@ -76,6 +79,13 @@ public final class BooleanOperators
     public static long castToTinyint(@SqlType(StandardTypes.BOOLEAN) boolean value)
     {
         return value ? 1 : 0;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType(StandardTypes.BOOLEAN) boolean value)
+    {
+        return TrinoNumber.from(value ? BigDecimal.ONE : BigDecimal.ZERO);
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/test/java/io/trino/type/TestBooleanOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBooleanOperators.java
@@ -26,6 +26,7 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -254,6 +255,20 @@ public class TestBooleanOperators
         assertThat(assertions.expression("cast(a as real)")
                 .binding("a", "false"))
                 .isEqualTo(0.0f);
+    }
+
+    @Test
+    public void testCastToNumber()
+    {
+        assertThat(assertions.expression("cast(a as number)")
+                .binding("a", "true"))
+                .hasType(NUMBER)
+                .matches("NUMBER '1'");
+
+        assertThat(assertions.expression("cast(a as number)")
+                .binding("a", "false"))
+                .hasType(NUMBER)
+                .matches("NUMBER '0'");
     }
 
     @Test


### PR DESCRIPTION
Implements cast operator to convert BOOLEAN to NUMBER:
- true is converted to NUMBER 1
- false is converted to NUMBER 0

This follows the same pattern as existing casts from BOOLEAN to other numeric types (BIGINT, INTEGER, DOUBLE, etc).


### release notes

```
General
* Support casting BOOLEAN to NUMBER.
```