### PR TITLE
Migrate away from deprecated assertj's `@CheckReturnValue`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/assertions/TrinoExceptionAssert.java
+++ b/core/trino-main/src/main/java/io/trino/testing/assertions/TrinoExceptionAssert.java
@@ -17,6 +17,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import io.trino.cache.SafeCaches;
 import io.trino.client.ErrorInfo;
 import io.trino.client.FailureException;
@@ -31,7 +32,6 @@ import io.trino.sql.parser.ParsingException;
 import io.trino.testing.QueryFailedException;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.util.CheckReturnValue;
 
 import java.util.Optional;
 import java.util.stream.Stream;

--- a/core/trino-main/src/test/java/io/trino/operator/window/matcher/MatchAssert.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/matcher/MatchAssert.java
@@ -14,6 +14,7 @@
 package io.trino.operator.window.matcher;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.window.pattern.LabelEvaluator;
@@ -25,7 +26,6 @@ import io.trino.sql.planner.rowpattern.ir.IrLabel;
 import io.trino.sql.planner.rowpattern.ir.IrRowPattern;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AssertProvider;
-import org.assertj.core.util.CanIgnoreReturnValue;
 
 import java.util.List;
 import java.util.Map;

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.trino.Session;
 import io.trino.cost.StatsAndCosts;
@@ -55,7 +56,6 @@ import org.assertj.core.description.Description;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.core.util.CanIgnoreReturnValue;
 import org.intellij.lang.annotations.Language;
 
 import java.io.Closeable;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/S3Assert.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/S3Assert.java
@@ -13,8 +13,8 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.assertj.core.api.AssertProvider;
-import org.assertj.core.util.CanIgnoreReturnValue;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 


### PR DESCRIPTION
By convention, we use errorprone's annotations for `@CheckReturnValue` and `@CanIgnoreReturnValue`.
