### PR TITLE
Allow data_location without object store layout in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2576,12 +2576,6 @@ public class IcebergMetadata
         if (properties.containsKey(DATA_LOCATION_PROPERTY)) {
             String dataLocation = (String) properties.get(DATA_LOCATION_PROPERTY)
                     .orElseThrow(() -> new IllegalArgumentException("The data_location property cannot be empty"));
-            boolean objectStoreEnabled = (boolean) properties.getOrDefault(
-                    OBJECT_STORE_LAYOUT_ENABLED_PROPERTY,
-                    Optional.of(Boolean.parseBoolean(icebergTable.properties().get(OBJECT_STORE_ENABLED)))).orElseThrow();
-            if (!objectStoreEnabled) {
-                throw new TrinoException(INVALID_TABLE_PROPERTY, "Data location can only be set when object store layout is enabled");
-            }
             updateProperties.set(WRITE_DATA_LOCATION, dataLocation);
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -986,12 +986,7 @@ public final class IcebergUtil
             propertiesBuilder.put(OBJECT_STORE_ENABLED, "true");
         }
         Optional<String> dataLocation = IcebergTableProperties.getDataLocation(tableMetadata.getProperties());
-        dataLocation.ifPresent(location -> {
-            if (!objectStoreLayoutEnabled) {
-                throw new TrinoException(INVALID_TABLE_PROPERTY, "Data location can only be set when object store layout is enabled");
-            }
-            propertiesBuilder.put(WRITE_DATA_LOCATION, location);
-        });
+        dataLocation.ifPresent(location -> propertiesBuilder.put(WRITE_DATA_LOCATION, location));
 
         // iceberg ORC format bloom filter properties used by create table
         List<String> orcBloomFilterColumns = IcebergTableProperties.getOrcBloomFilterColumns(tableMetadata.getProperties());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -9838,11 +9838,16 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
-    public void testCreateTableWithDataLocationButObjectStoreLayoutDisabled()
+    public void testCreateTableWithDataLocationWithoutObjectStoreLayout()
     {
-        assertQueryFails(
-                "CREATE TABLE test_data_location WITH (data_location = 'local:///data-location/xyz') AS SELECT 1 AS val",
-                "Data location can only be set when object store layout is enabled");
+        String tableName = "test_data_location_no_object_store" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " WITH (data_location = 'local:///data-location/xyz') AS SELECT 1 AS val", 1);
+
+        assertQuery("SELECT * FROM " + tableName, "VALUES 1");
+        String filePath = (String) computeScalar("SELECT file_path FROM \"" + tableName + "$files\"");
+        assertThat(filePath).startsWith("local:///data-location/xyz/");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -229,9 +229,11 @@ public class TestIcebergV2
             assertThat(loadTable(table.getName()).properties())
                     .doesNotContainKey("write.data.path");
 
-            assertQueryFails(
-                    "ALTER TABLE " + table.getName() + " SET PROPERTIES data_location = 'local:///data-location'",
-                    "Data location can only be set when object store layout is enabled");
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES data_location = 'local:///data-location'");
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("data_location = 'local:///data-location'");
+            assertThat(loadTable(table.getName()).properties())
+                    .containsEntry("write.data.path", "local:///data-location");
 
             assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES object_store_layout_enabled = true, data_location = 'local:///data-location'");
             assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))


### PR DESCRIPTION
## Description
Previously, setting the `data_location` table property required `object_store_layout_enabled` to be `true`, otherwise Trino would reject the query with an error.

Remove this restriction so users can specify a custom data file location independently of the object store layout. The underlying Iceberg write.data.path property works without object store layout enabled, so the validation was unnecessarily limiting.


## Additional context and related issues
Previously, when using the Iceberg object store layout, it was not possible to specify an exact
location for data files — the layout adds a random prefix directory to file paths, making the
final location unpredictable.

The only workaround was to create the table in Spark with explicit data and metadata folder
locations, and then register it in Trino using `register_table`. This required an unnecessary
Spark dependency just for table creation.

With this change, data_location can be set independently of `object_store_layout_enabled`,
allowing tables to be created directly from Trino with a predictable data file location —
removing the need for the Spark workaround entirely.


## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Allow configuring `data_location` table property without enabling `object_store_layout_enabled`. ({issue}`28887`)
```
