### PR TITLE
Fix OPTIMIZE failing with uppercase Iceberg column names

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2018,32 +2018,23 @@ public class IcebergMetadata
         IcebergTableExecuteHandle executeHandle = (IcebergTableExecuteHandle) tableExecuteHandle;
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         return switch (executeHandle.procedureId()) {
-            case OPTIMIZE -> getColumnHandlesForOptimize(session, icebergTableHandle, icebergTableHandle.getFormatVersion());
+            case OPTIMIZE -> getColumnHandlesForOptimize(icebergTableHandle);
             case OPTIMIZE_MANIFESTS, DROP_EXTENDED_STATS, ROLLBACK_TO_SNAPSHOT, EXPIRE_SNAPSHOTS, REMOVE_ORPHAN_FILES, ADD_FILES, ADD_FILES_FROM_TABLE ->
                     throw new IllegalArgumentException("Unknown procedure '" + executeHandle.procedureId() + "'");
         };
     }
 
-    private Set<ColumnHandle> getColumnHandlesForOptimize(ConnectorSession session, IcebergTableHandle tableHandle, int formatVersion)
+    private Set<ColumnHandle> getColumnHandlesForOptimize(IcebergTableHandle table)
     {
-        Map<String, ColumnHandle> columnHandles = getColumnHandles(session, tableHandle);
-        return getTableMetadata(session, tableHandle).getColumns().stream()
-                .filter(column -> isOptimizeReadColumn(formatVersion, column))
-                .map(ColumnMetadata::getName)
-                .map(columnName -> requireNonNull(columnHandles.get(columnName), "Cannot find column handle for " + columnName))
-                .collect(toImmutableSet());
-    }
-
-    private static boolean isOptimizeReadColumn(int formatVersion, ColumnMetadata column)
-    {
-        if (!column.isHidden()) {
-            return true;
+        ImmutableSet.Builder<ColumnHandle> columnHandles = ImmutableSet.builder();
+        for (IcebergColumnHandle columnHandle : getTopLevelColumns(SchemaParser.fromJson(table.getTableSchemaJson()), typeManager)) {
+            columnHandles.add(columnHandle);
         }
-        if (formatVersion < 3) {
-            return false;
+        if (table.getFormatVersion() >= 3) {
+            columnHandles.add(rowIdColumnHandle());
+            columnHandles.add(lastUpdatedSequenceNumberColumnHandle());
         }
-        String columnName = column.getName();
-        return columnName.equals(ROW_ID.getColumnName()) || columnName.equals(LAST_UPDATED_SEQUENCE_NUMBER.getColumnName());
+        return columnHandles.build();
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -3065,6 +3065,25 @@ public class TestIcebergSparkCompatibility
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
 
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testTrinoOptimizeWithNonLowercaseColumnName()
+    {
+        String baseTableName = "test_trino_optimize_with_uppercase_field" + randomNameSuffix();
+        String trinoTableName = trinoTableName(baseTableName);
+        String sparkTableName = sparkTableName(baseTableName);
+
+        onSpark().executeQuery("CREATE TABLE " + sparkTableName + "(col1 INT, COL2 INT) USING ICEBERG");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (1, 1)");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (2, 2)");
+        onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE optimize");
+
+        List<Row> expected = ImmutableList.of(row(1, 1), row(2, 2));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+
+        onSpark().executeQuery("DROP TABLE " + sparkTableName);
+    }
+
     @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "storageFormats")
     public void testRegisterTableWithTableLocation(StorageFormat storageFormat)
             throws TException


### PR DESCRIPTION
## Description

IcebergMetadata.getColumnHandles() stored data column handles with original-case keys from the Iceberg schema, but ColumnMetadata lowercases all names in its constructor. When getColumnHandlesForOptimize() (introduced in 480) looked up columns by their ColumnMetadata names, the case-insensitive lookup failed for tables with uppercase column names.

The fix lowercases the key in getColumnHandles() to match the convention already enforced by MetadataManager at the engine boundary, and to match what ColumnMetadata.getName() returns.

## Release notes

```markdown
## Iceberg
* Fix failure when column name contains uppercase characters in OPTIMIZE procedure. ({issue}`28888`)
```
