### PR TITLE
Increase hive.max-split-size to 128MB

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -71,7 +71,7 @@ public class HiveConfig
 {
     private boolean singleStatementWritesOnly;
 
-    private DataSize maxSplitSize = DataSize.of(64, MEGABYTE);
+    private DataSize maxSplitSize = DataSize.of(128, MEGABYTE);
     private int maxPartitionsPerScan = 1_000_000;
     private int maxPartitionsForEagerLoad = 100_000;
     private int maxOutstandingSplits = 3_000;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -42,7 +42,7 @@ public class TestHiveConfig
     {
         assertRecordedDefaults(recordDefaults(HiveConfig.class)
                 .setSingleStatementWritesOnly(false)
-                .setMaxSplitSize(DataSize.of(64, Unit.MEGABYTE))
+                .setMaxSplitSize(DataSize.of(128, Unit.MEGABYTE))
                 .setMaxPartitionsPerScan(1_000_000)
                 .setMaxPartitionsForEagerLoad(100_000)
                 .setMaxOutstandingSplits(3_000)
@@ -52,7 +52,7 @@ public class TestHiveConfig
                 .setMinPartitionBatchSize(10)
                 .setMaxPartitionBatchSize(100)
                 .setMaxInitialSplits(200)
-                .setMaxInitialSplitSize(DataSize.of(32, Unit.MEGABYTE))
+                .setMaxInitialSplitSize(DataSize.of(64, Unit.MEGABYTE))
                 .setSplitLoaderConcurrency(64)
                 .setMaxSplitsPerSecond(null)
                 .setDomainCompactionThreshold(1000)


### PR DESCRIPTION
## Description
Reduces overheads from many small splits, especially on parquet where the default row-group size is 128MB



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
