### PR TITLE
Fix expected stacktrace in Iceberg BigLake tests

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -254,7 +254,7 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
     {
         assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
                 .hasMessageContaining("Failed to register table")
-                .hasStackTraceContaining("does not start with the expected prefix");
+                .hasStackTraceContaining("Malformed request: Invalid metadata location");
     }
 
     @Test
@@ -263,7 +263,7 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
     {
         assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
                 .hasMessageContaining("Failed to register table")
-                .hasStackTraceContaining("does not start with the expected prefix");
+                .hasStackTraceContaining("Malformed request: Invalid metadata location");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

https://github.com/trinodb/trino/actions/runs/23695008434/job/69028834232
```
Error:    TestIcebergBigLakeMetastoreConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation:266 
Expecting actual:
  "io.trino.testing.QueryFailedException: Failed to register table 'test_register_table_with_different_table_name_v93lq20atp_new'
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:591)
	at io.trino.testing.DistributedQueryRunner.executeWithPlan(DistributedQueryRunner.java:580)
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:111)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:65)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:59)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:416)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:411)
	at io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest.testRegisterTableWithDifferentTableName(BaseIcebergConnectorSmokeTest.java:364)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.lambda$testRegisterTableWithTrailingSpaceInLocation$0(TestIcebergBigLakeMetastoreConnectorSmokeTest.java:264)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:66)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:908)
	at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1476)
	at org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1319)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation(TestIcebergBigLakeMetastoreConnectorSmokeTest.java:264)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:701)
	at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:502)
	at org.junit.jupiter.engine.support.MethodReflectionUtils.invoke(MethodReflectionUtils.java:45)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:61)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:124)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:163)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:148)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:735)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:760)
	at io.trino.execution.CallTask.execute(CallTask.java:210)
	at io.trino.execution.CallTask.execute(CallTask.java:70)
	at io.trino.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:153)
	at io.trino.execution.QueryManager.createQuery(QueryManager.java:317)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:151)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$1(LocalDispatchQuery.java:135)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$0(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at io.trino.$gen.Trino_testversion____20260328_215410_537.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: org.apache.iceberg.exceptions.BadRequestException: Malformed request: Invalid metadata location: The path 'gs://trino-ci-test/test_iceberg_biglake_ryiepdygas/test_register_table_with_different_table_name_v93lq20atp/metadata/00002-69c73bc5-0000-2b94-be30-14c14ee7b1e8.metadata.json' does not end with '/<table_id>/metadata/<metadata_file>'.
	at org.apache.iceberg.rest.ErrorHandlers$DefaultErrorHandler.accept(ErrorHandlers.java:234)
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:124)
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:108)
	at org.apache.iceberg.rest.HTTPClient.throwFailure(HTTPClient.java:240)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:336)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:297)
	at org.apache.iceberg.rest.BaseHTTPClient.post(BaseHTTPClient.java:100)
	at org.apache.iceberg.rest.RESTSessionCatalog.registerTable(RESTSessionCatalog.java:514)
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.registerTable(TrinoRestCatalog.java:462)
	... 17 more
"
to contain:
  "does not start with the expected prefix" 
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
