### PR TITLE
Remove unused CachingKerberosAuthentication method

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/authentication/CachingKerberosAuthentication.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/authentication/CachingKerberosAuthentication.java
@@ -46,16 +46,6 @@ public class CachingKerberosAuthentication
         return subject;
     }
 
-    public synchronized void reauthenticateIfSoonWillBeExpired()
-    {
-        requireNonNull(subject, "subject is null, getSubject() must be called before reauthenticate()");
-        if (ticketNeedsRefresh()) {
-            kerberosAuthentication.attemptLogin(subject);
-            KerberosTicket tgtTicket = getTicketGrantingTicket(subject);
-            nextRefreshTime = KerberosTicketUtils.getRefreshTime(tgtTicket);
-        }
-    }
-
     @GuardedBy("this")
     private boolean ticketNeedsRefresh()
     {


### PR DESCRIPTION
`reauthenticateIfSoonWillBeExpired` is a left over after bc5d4fd6a4868efe05b6485d681e863ff41cb11a commit.
