### PR TITLE
Add support to NUMBER to Python UDFs

### DIFF
--- a/plugin/trino-functions-python/pom.xml
+++ b/plugin/trino-functions-python/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-wasm-python</artifactId>
-            <version>3.13-5</version>
+            <version>3.13-6</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-functions-python/src/main/java/io/trino/plugin/functions/python/TrinoType.java
+++ b/plugin/trino-functions-python/src/main/java/io/trino/plugin/functions/python/TrinoType.java
@@ -38,6 +38,7 @@ enum TrinoType
     JSON(20),
     UUID(21),
     IPADDRESS(22),
+    NUMBER(23),
     /**/;
 
     private final int id;

--- a/plugin/trino-functions-python/src/main/java/io/trino/plugin/functions/python/TrinoTypes.java
+++ b/plugin/trino-functions-python/src/main/java/io/trino/plugin/functions/python/TrinoTypes.java
@@ -35,9 +35,11 @@ import io.trino.spi.type.LongTimeWithTimeZone;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.MapType;
+import io.trino.spi.type.NumberType;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.SqlNumber;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeWithTimeZoneType;
@@ -45,6 +47,7 @@ import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.TrinoNumber;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -169,6 +172,7 @@ final class TrinoTypes
             case StandardTypes.JSON -> TrinoType.JSON;
             case StandardTypes.UUID -> TrinoType.UUID;
             case StandardTypes.IPADDRESS -> TrinoType.IPADDRESS;
+            case StandardTypes.NUMBER -> TrinoType.NUMBER;
             default -> throw new TrinoException(NOT_SUPPORTED, "Unsupported type: " + type);
         };
     }
@@ -200,6 +204,15 @@ final class TrinoTypes
                         ? Decimals.toString((long) value, decimalType.getScale())
                         : Decimals.toString((Int128) value, decimalType.getScale());
                 writeVariableSlice(utf8Slice(decimalString), output);
+            }
+            case NumberType _ -> {
+                TrinoNumber number = (TrinoNumber) value;
+                String stringValue = switch (number.toBigDecimal()) {
+                    case TrinoNumber.BigDecimalValue(BigDecimal bigDecimal) -> bigDecimal.toString();
+                    case TrinoNumber.Infinity(boolean negative) -> negative ? "-Infinity" : "+Infinity";
+                    case TrinoNumber.NotANumber() -> "NaN";
+                };
+                writeVariableSlice(utf8Slice(stringValue), output);
             }
             case TimeWithTimeZoneType timeType -> {
                 if (timeType.isShort()) {
@@ -282,6 +295,15 @@ final class TrinoTypes
                         ? Decimals.toString(decimalType.getLong(block, position), decimalType.getScale())
                         : Decimals.toString((Int128) decimalType.getObject(block, position), decimalType.getScale());
                 writeVariableSlice(utf8Slice(decimalString), output);
+            }
+            case NumberType numberType -> {
+                SqlNumber value = (SqlNumber) numberType.getObjectValue(block, position);
+                String stringValue = switch (value.value()) {
+                    case TrinoNumber.BigDecimalValue(BigDecimal bigDecimal) -> bigDecimal.toString();
+                    case TrinoNumber.Infinity(boolean negative) -> negative ? "-Infinity" : "+Infinity";
+                    case TrinoNumber.NotANumber() -> "NaN";
+                };
+                writeVariableSlice(utf8Slice(stringValue), output);
             }
             case DateType dateType -> output.writeInt(dateType.getInt(block, position));
             case TimeType timeType -> output.writeLong(picosToMicros(timeType.getLong(block, position)));
@@ -384,6 +406,16 @@ final class TrinoTypes
                 yield decimalType.isShort()
                         ? encodeShortScaledValue(decimal, decimalType.getScale(), HALF_UP)
                         : encodeScaledValue(decimal, decimalType.getScale(), HALF_UP);
+            }
+            case NumberType _ -> {
+                String stringUtf8 = input.readSlice(input.readInt()).toStringUtf8();
+                TrinoNumber.AsBigDecimal number = switch (stringUtf8) {
+                    case "NaN" -> new TrinoNumber.NotANumber();
+                    case "+Infinity" -> new TrinoNumber.Infinity(false);
+                    case "-Infinity" -> new TrinoNumber.Infinity(true);
+                    default -> new TrinoNumber.BigDecimalValue(new BigDecimal(stringUtf8));
+                };
+                yield TrinoNumber.from(number);
             }
             case TimeType timeType -> {
                 long micros = roundMicros(input.readLong(), timeType.getPrecision()) % MICROSECONDS_PER_DAY;

--- a/plugin/trino-functions-python/src/test/java/io/trino/plugin/functions/python/TestPythonFunctions.java
+++ b/plugin/trino-functions-python/src/test/java/io/trino/plugin/functions/python/TestPythonFunctions.java
@@ -35,6 +35,7 @@ import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -749,6 +750,56 @@ public class TestPythonFunctions
                 .hasErrorCode(FUNCTION_IMPLEMENTATION_ERROR)
                 .hasMessage("Failed to convert Python result type 'str' to Trino type BIGINT: " +
                         "TypeError: 'str' object cannot be interpreted as an integer");
+    }
+
+    @Test
+    public void testTypeNumber()
+    {
+        String query =
+                """
+                WITH FUNCTION multiply(x number, y number)
+                RETURNS number
+                LANGUAGE PYTHON
+                WITH (handler = 'multiply')
+                AS $$
+                from decimal import Decimal
+                def multiply(x, y):
+                    return x * y
+                $$
+                """;
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER '1.12345000000000123456789', NUMBER '2.5432100000000000000000000000000000000000001')"))
+                .matches("VALUES NUMBER '2.857169274500003139765403527'");
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER 'NaN', NUMBER '3.14')"))
+                .matches("VALUES NUMBER 'NaN'");
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER '-Infinity', NUMBER '3.14')"))
+                .matches("VALUES NUMBER '-Infinity'");
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER '+Infinity', NUMBER '3.14')"))
+                .matches("VALUES NUMBER '+Infinity'");
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER '+Infinity', NUMBER '-Infinity')"))
+                .matches("VALUES NUMBER '-Infinity'");
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER '-Infinity', NUMBER '-Infinity')"))
+                .matches("VALUES NUMBER '+Infinity'");
+
+        assertThat(assertions.query(
+                query + "SELECT multiply(NUMBER '-Infinity', NUMBER 'NaN')"))
+                .matches("VALUES NUMBER 'NaN'");
+
+        assertThatThrownBy(() -> assertThat(assertions.query(
+                query + "SELECT multiply(NULL, NUMBER '2.54321')"))
+                .matches("VALUES NUMBER 'NaN'"))
+                .hasMessageContaining("TypeError: unsupported operand type(s) for *: 'NoneType' and 'decimal.Decimal'");
     }
 
     @Test


### PR DESCRIPTION
Resubmitted after accidental merge

## Description

- Requires https://github.com/trinodb/trino-wasm-python/pull/11 to correctly pass NaN and Infinity values

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support to `NUMBER` type in Python UDF ({issue}`issuenumber`)
```
