### PR TITLE
Cancel NIO on interrupt

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/BackpressureRestClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/BackpressureRestClient.java
@@ -26,11 +26,13 @@ import io.trino.plugin.elasticsearch.ElasticsearchConfig;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
+import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.rest.RestStatus;
 
@@ -38,6 +40,8 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
@@ -82,13 +86,79 @@ public class BackpressureRestClient
     public Response performRequest(String method, String endpoint, Header... headers)
             throws IOException
     {
-        return executeWithRetries(() -> delegate.performRequest(toRequest(method, endpoint, headers)));
+        return executeWithRetries(() -> {
+            CompletableFuture<Response> future = new CompletableFuture<>();
+            Cancellable cancellable = delegate.performRequestAsync(toRequest(method, endpoint, headers), new ResponseListener() {
+                @Override
+                public void onSuccess(Response response)
+                {
+                    future.complete(response);
+                }
+
+                @Override
+                public void onFailure(Exception exception)
+                {
+                    future.completeExceptionally(exception);
+                }
+            });
+            try {
+                return future.get();
+            }
+            catch (InterruptedException e) {
+                cancellable.cancel();
+                Thread.currentThread().interrupt();
+                throw new IOException("ES request interrupted", e);
+            }
+            catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IOException ioe) {
+                    throw ioe;
+                }
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new IOException(cause);
+            }
+        });
     }
 
     public Response performRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity, Header... headers)
             throws IOException
     {
-        return executeWithRetries(() -> delegate.performRequest(toRequest(method, endpoint, params, entity, headers)));
+        return executeWithRetries(() -> {
+            CompletableFuture<Response> future = new CompletableFuture<>();
+            Cancellable cancellable = delegate.performRequestAsync(toRequest(method, endpoint, params, entity, headers), new ResponseListener() {
+                @Override
+                public void onSuccess(Response response)
+                {
+                    future.complete(response);
+                }
+
+                @Override
+                public void onFailure(Exception exception)
+                {
+                    future.completeExceptionally(exception);
+                }
+            });
+            try {
+                return future.get();
+            }
+            catch (InterruptedException e) {
+                cancellable.cancel();
+                Thread.currentThread().interrupt();
+                throw new IOException("ES request interrupted", e);
+            }
+            catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IOException ioe) {
+                    throw ioe;
+                }
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new IOException(cause);
+            }
+        });
     }
 
     private static Request toRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity, Header... headers)

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/BackpressureRestHighLevelClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/BackpressureRestHighLevelClient.java
@@ -133,6 +133,12 @@ public class BackpressureRestHighLevelClient
             throwIfUnchecked(throwable);
             throw new RuntimeException("Unexpected cause from FailsafeException", throwable);
         }
+        catch (RuntimeException e) {
+            if (Thread.interrupted()) {
+                throw new IOException("ES request interrupted", e);
+            }
+            throw e;
+        }
     }
 
     private void onFailedAttempt(ExecutionAttemptedEvent<ActionResponse> executionAttemptedEvent)


### PR DESCRIPTION
Interrupted Elasticsearch requests now cancel the in-flight NIO call instead of only stopping the waiting thread.

This makes cancelled work release the backend request promptly instead of letting it continue in the background.

Related to #28927.