### PR TITLE
Async + Cancellable in Elasticsearch page sources

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/CountQueryPageSource.java
@@ -16,6 +16,9 @@ package io.trino.plugin.elasticsearch;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.SourcePage;
+import org.elasticsearch.client.Cancellable;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
 import static java.lang.Math.toIntExact;
@@ -30,6 +33,7 @@ class CountQueryPageSource
     // TODO (https://github.com/trinodb/trino/issues/16824) allow connector to return pages of arbitrary row count and handle this gracefully in engine
     private static final int BATCH_SIZE = 10000;
 
+    private final AtomicReference<Cancellable> cancellable = new AtomicReference<>();
     private final long readTimeNanos;
     private long remaining;
 
@@ -43,7 +47,8 @@ class CountQueryPageSource
         long count = client.count(
                 split.index(),
                 split.shard(),
-                buildSearchQuery(table.constraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.query(), table.regexes()));
+                buildSearchQuery(table.constraint().transformKeys(ElasticsearchColumnHandle.class::cast), table.query(), table.regexes()),
+                cancellable);
         readTimeNanos = System.nanoTime() - start;
 
         if (table.limit().isPresent()) {
@@ -87,5 +92,11 @@ class CountQueryPageSource
     }
 
     @Override
-    public void close() {}
+    public void close()
+    {
+        Cancellable request = cancellable.get();
+        if (request != null) {
+            request.cancel();
+        }
+    }
 }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/PassthroughQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/PassthroughQueryPageSource.java
@@ -19,8 +19,10 @@ import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.SourcePage;
+import org.elasticsearch.client.Cancellable;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -28,6 +30,7 @@ import static java.util.Objects.requireNonNull;
 public class PassthroughQueryPageSource
         implements ConnectorPageSource
 {
+    private final AtomicReference<Cancellable> cancellable = new AtomicReference<>();
     private final long readTimeNanos;
     private final String result;
     private boolean done;
@@ -38,7 +41,7 @@ public class PassthroughQueryPageSource
         requireNonNull(table, "table is null");
 
         long start = System.nanoTime();
-        result = client.executeQuery(table.index(), table.query().get());
+        result = client.executeQuery(table.index(), table.query().get(), cancellable);
         readTimeNanos = System.nanoTime() - start;
     }
 
@@ -83,5 +86,11 @@ public class PassthroughQueryPageSource
 
     @Override
     public void close()
-            throws IOException {}
+            throws IOException
+    {
+        Cancellable request = cancellable.get();
+        if (request != null) {
+            request.cancel();
+        }
+    }
 }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/BackpressureRestClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/BackpressureRestClient.java
@@ -26,11 +26,13 @@ import io.trino.plugin.elasticsearch.ElasticsearchConfig;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
+import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.rest.RestStatus;
 
@@ -38,6 +40,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
@@ -89,6 +94,56 @@ public class BackpressureRestClient
             throws IOException
     {
         return executeWithRetries(() -> delegate.performRequest(toRequest(method, endpoint, params, entity, headers)));
+    }
+
+    public Response performRequest(String method, String endpoint, AtomicReference<Cancellable> cancellableRef, Header... headers)
+            throws IOException
+    {
+        return executeWithRetries(() -> performCancellable(toRequest(method, endpoint, headers), cancellableRef));
+    }
+
+    public Response performRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity, AtomicReference<Cancellable> cancellableRef, Header... headers)
+            throws IOException
+    {
+        return executeWithRetries(() -> performCancellable(toRequest(method, endpoint, params, entity, headers), cancellableRef));
+    }
+
+    private Response performCancellable(Request request, AtomicReference<Cancellable> cancellableRef)
+            throws IOException
+    {
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        Cancellable cancellable = delegate.performRequestAsync(request, new ResponseListener() {
+            @Override
+            public void onSuccess(Response response)
+            {
+                future.complete(response);
+            }
+
+            @Override
+            public void onFailure(Exception exception)
+            {
+                future.completeExceptionally(exception);
+            }
+        });
+        cancellableRef.set(cancellable);
+        try {
+            return future.get();
+        }
+        catch (InterruptedException e) {
+            cancellable.cancel();
+            Thread.currentThread().interrupt();
+            throw new IOException("ES request interrupted", e);
+        }
+        catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException ioe) {
+                throw ioe;
+            }
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new IOException(cause);
+        }
     }
 
     private static Request toRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity, Header... headers)

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -52,6 +52,7 @@ import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -577,6 +578,37 @@ public class ElasticsearchClient
         return body;
     }
 
+    public String executeQuery(String index, String query, AtomicReference<Cancellable> cancellableRef)
+    {
+        String path = format("/%s/_search", index);
+
+        Response response;
+        try {
+            response = client.getLowLevelClient()
+                    .performRequest(
+                            "GET",
+                            path,
+                            ImmutableMap.of(),
+                            new ByteArrayEntity(query.getBytes(UTF_8)),
+                            cancellableRef,
+                            new BasicHeader("Content-Type", "application/json"),
+                            new BasicHeader("Accept-Encoding", "application/json"));
+        }
+        catch (IOException e) {
+            throw new TrinoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+
+        String body;
+        try {
+            body = EntityUtils.toString(response.getEntity());
+        }
+        catch (IOException e) {
+            throw new TrinoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+        }
+
+        return body;
+    }
+
     public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields, Optional<String> sort, OptionalLong limit)
     {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
@@ -669,6 +701,46 @@ public class ElasticsearchClient
                                 format("/%s/_count?preference=_shards:%s", index, shard),
                                 ImmutableMap.of(),
                                 new StringEntity(sourceBuilder.toString(), UTF_8),
+                                new BasicHeader("Content-Type", "application/json"));
+            }
+            catch (ResponseException e) {
+                throw propagate(e);
+            }
+            catch (IOException e) {
+                throw new TrinoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+            }
+
+            try {
+                return COUNT_RESPONSE_CODEC.fromJson(response.getEntity().getContent())
+                        .getCount();
+            }
+            catch (IOException e) {
+                throw new TrinoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+            }
+        }
+        finally {
+            countStats.add(Duration.nanosSince(start));
+        }
+    }
+
+    public long count(String index, int shard, QueryBuilder query, AtomicReference<Cancellable> cancellableRef)
+    {
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
+                .query(query);
+
+        LOG.debug("Count: %s:%s, query: %s", index, shard, sourceBuilder);
+
+        long start = System.nanoTime();
+        try {
+            Response response;
+            try {
+                response = client.getLowLevelClient()
+                        .performRequest(
+                                "GET",
+                                format("/%s/_count?preference=_shards:%s", index, shard),
+                                ImmutableMap.of(),
+                                new StringEntity(sourceBuilder.toString(), UTF_8),
+                                cancellableRef,
                                 new BasicHeader("Content-Type", "application/json"));
             }
             catch (ResponseException e) {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchQueryTimeout.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchQueryTimeout.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.airlift.json.JsonMapperProvider;
+import io.trino.execution.QueryManager;
+import io.trino.server.BasicQueryInfo;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.execution.QueryState.RUNNING;
+import static io.trino.plugin.elasticsearch.ElasticsearchServer.ELASTICSEARCH_8_IMAGE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * When Trino cancels a query, ES should stop executing it.
+ *
+ * <pre>
+ * ./mvnw test -pl plugin/trino-elasticsearch -Dtest=TestElasticsearchQueryTimeout -Dair.check.skip-all=true
+ * </pre>
+ */
+final class TestElasticsearchQueryTimeout
+        extends AbstractTestQueryFramework
+{
+    private static final JsonMapper JSON = new JsonMapperProvider().get();
+
+    private RestClient esClient;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        ElasticsearchServer elasticsearch = closeAfterClass(new ElasticsearchServer(ELASTICSEARCH_8_IMAGE));
+        esClient = closeAfterClass(elasticsearch.getClient().getLowLevelClient());
+        return ElasticsearchQueryRunner.builder(elasticsearch).build();
+    }
+
+    @Test
+    void testCancelledQueryStopsRunningOnEs()
+            throws Exception
+    {
+        Request put = new Request("PUT", "/test/_doc/1?refresh");
+        put.setJsonEntity("{\"v\":1}");
+        esClient.performRequest(put);
+
+        try {
+            // O(n²) string concat in painless: runs for minutes on a single document.
+            String esQuery = """
+                    {
+                        "query": {
+                            "script_score": {
+                                "query": {"match_all": {}},
+                                "script": {
+                                    "source": "String s = new String(); for (int i = 0; i < 999999; i++) { s = s + Integer.toString(i % 10); } return s.length();"
+                                }
+                            }
+                        }
+                    }""".replace("\n", " ");
+
+            // Start the query in the background
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<?> future = executor.submit(() ->
+                    getQueryRunner().execute(
+                            testSessionBuilder()
+                                    .setCatalog("elasticsearch").setSchema("tpch")
+                                    .build(),
+                            "SELECT result FROM TABLE(elasticsearch.system.raw_query(" +
+                                    "schema => 'tpch', " +
+                                    "index => 'test', " +
+                                    "query => '" + esQuery + "'" +
+                                    "))"));
+
+            // Wait for ES to actually be executing the search
+            QueryManager queryManager = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getQueryManager();
+            while (getSearchTasks().isEmpty()) {
+                assertThat(future.isDone()).as("query should still be running").isFalse();
+                Thread.sleep(100);
+            }
+
+            // Cancel the query
+            for (BasicQueryInfo info : queryManager.getQueries()) {
+                if (!info.getState().isDone()) {
+                    System.out.println("Cancelling query " + info.getQueryId());
+                    queryManager.cancelQuery(info.getQueryId());
+                }
+            }
+            try { future.get(10, TimeUnit.SECONDS); }
+            catch (Exception _) { /* expected */ }
+            executor.shutdown();
+
+            Thread.sleep(5000);
+
+            List<String> tasks = getSearchTasks();
+            System.out.println("ES search tasks 5s after cancellation: " + tasks);
+
+            assertThat(tasks)
+                    .as("ES should have no active search tasks 5s after Trino cancelled the query")
+                    .isEmpty();
+        }
+        finally {
+            esClient.performRequest(new Request("DELETE", "/test"));
+        }
+    }
+
+    private List<String> getSearchTasks()
+            throws IOException
+    {
+        Request request = new Request("GET", "/_tasks");
+        request.addParameter("actions", "*search*");
+        request.addParameter("detailed", "true");
+        JsonNode nodes = JSON.readTree(
+                esClient.performRequest(request)
+                        .getEntity().getContent()).get("nodes");
+        List<String> descriptions = new ArrayList<>();
+        if (nodes != null) {
+            for (Iterator<JsonNode> it = nodes.elements(); it.hasNext(); ) {
+                JsonNode tasks = it.next().get("tasks");
+                if (tasks != null) {
+                    for (Iterator<JsonNode> taskIt = tasks.elements(); taskIt.hasNext(); ) {
+                        JsonNode task = taskIt.next();
+                        if (!task.path("cancelled").asBoolean(false)) {
+                            descriptions.add(task.get("description").asText());
+                        }
+                    }
+                }
+            }
+        }
+        return descriptions;
+    }
+}


### PR DESCRIPTION
Passthrough and count page sources now issue cancellable asynchronous Elasticsearch requests, so closing the page source can stop in-flight backend work.

This reduces the amount of Elasticsearch work that keeps running after Trino is no longer consuming the result.

Related to #28927.