### PR TITLE
ElasticSearch: Add timeout parameter to _search

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -122,6 +122,7 @@ public class ElasticsearchClient
     private final BackpressureRestHighLevelClient client;
     private final int scrollSize;
     private final Duration scrollTimeout;
+    private final Duration requestTimeout;
 
     private final AtomicReference<Set<ElasticsearchNode>> nodes = new AtomicReference<>(ImmutableSet.of());
     private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("NodeRefresher"));
@@ -146,6 +147,7 @@ public class ElasticsearchClient
         this.ignorePublishAddress = config.isIgnorePublishAddress();
         this.scrollSize = config.getScrollSize();
         this.scrollTimeout = config.getScrollTimeout();
+        this.requestTimeout = config.getRequestTimeout();
         this.refreshInterval = config.getNodeRefreshInterval();
         this.tlsEnabled = config.isTlsEnabled();
     }
@@ -580,7 +582,8 @@ public class ElasticsearchClient
     public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields, Optional<String> sort, OptionalLong limit)
     {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
-                .query(query);
+                .query(query)
+                .timeout(new TimeValue(requestTimeout.toMillis()));
 
         if (limit.isPresent() && limit.getAsLong() < scrollSize) {
             // Safe to cast it to int because scrollSize is int.
@@ -612,7 +615,11 @@ public class ElasticsearchClient
 
         long start = System.nanoTime();
         try {
-            return client.search(request);
+            SearchResponse response = client.search(request);
+            if (response.isTimedOut()) {
+                throw new TrinoException(ELASTICSEARCH_CONNECTION_ERROR, "Elasticsearch query timed out");
+            }
+            return response;
         }
         catch (IOException e) {
             throw new TrinoException(ELASTICSEARCH_CONNECTION_ERROR, e);
@@ -642,7 +649,11 @@ public class ElasticsearchClient
 
         long start = System.nanoTime();
         try {
-            return client.searchScroll(request);
+            SearchResponse response = client.searchScroll(request);
+            if (response.isTimedOut()) {
+                throw new TrinoException(ELASTICSEARCH_CONNECTION_ERROR, "Elasticsearch query timed out");
+            }
+            return response;
         }
         catch (IOException e) {
             throw new TrinoException(ELASTICSEARCH_CONNECTION_ERROR, e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Elasticsearch _search requests now carry the configured request timeout, and Trino fails the query when Elasticsearch reports that the search timed out.

This makes Elasticsearch aware of the timeout, so that it cancels the query on its side even if the Trino node is too slow and does not cut the HTTP connection on time.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related to #28927.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

Release notes are required, with the following suggested text:

```markdown
## fixes
* elasticsearch connector: propagate query timeout information to elasticsearch ({issue}`28927`)
```
