### PR TITLE
Add functions to convert IPADDRESS to 128 bits varchar

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
@@ -15,19 +15,28 @@ package io.trino.operator.scalar;
 
 import com.google.common.net.InetAddresses;
 import com.google.common.primitives.Ints;
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.util.OptionalLong;
 import java.util.regex.Pattern;
 
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.StandardTypes.INTEGER;
+import static io.trino.spi.type.StandardTypes.IPADDRESS;
+import static io.trino.spi.type.StandardTypes.VARCHAR;
 
 public final class IpAddressFunctions
 {
@@ -117,5 +126,101 @@ public final class IpAddressFunctions
         }
 
         return bytes;
+    }
+
+    @ScalarFunction("ip_to_bits")
+    @Description("Convert the IP address to its IPv4 32-bit or IPv6 128-bit representation")
+    @SqlType(VARCHAR)
+    public static Slice toBits(@SqlType(IPADDRESS) Slice slice)
+    {
+        return toBits(slice, OptionalLong.empty());
+    }
+
+    @ScalarFunction("ip_to_bits")
+    @Description("Convert the IP address to its IPv4 32-bit or IPv6 128-bit representation for a specific subnet")
+    @SqlType(VARCHAR)
+    public static Slice toBits(@SqlType(IPADDRESS) Slice slice, @SqlType(INTEGER) long subnet)
+    {
+        return toBits(slice, OptionalLong.of(subnet));
+    }
+
+    private static Slice toBits(Slice slice, OptionalLong optionalSubnet)
+    {
+        if (slice.length() != 16) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid IP address binary length, expected 16 but was " + slice.length());
+        }
+
+        boolean isIPv4 = ipVersion(slice) == 4;
+        int totalBits = isIPv4 ? 32 : 128;
+        long subnet = optionalSubnet.orElse(totalBits);
+
+        if (isIPv4) {
+            if (subnet < 0 || subnet > 32) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Subnet address must be between 0 and 32 for IPv4, but was " + subnet);
+            }
+        }
+        else if (subnet < 0 || subnet > 128) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Subnet address must be between 0 and 128 for IPv6, but was " + subnet);
+        }
+
+        int bit = 0;
+        byte[] result = new byte[totalBits];
+        for (int i = isIPv4 ? 12 : 0; i < 16 && bit < subnet; i++) {
+            int value = slice.getByte(i) & 0xFF;
+            for (int shift = 7; shift >= 0 && bit < subnet; shift--) {
+                result[bit] = (byte) (((value >>> shift) & 1) == 0 ? '0' : '1');
+                bit++;
+            }
+        }
+
+        while (bit < totalBits) {
+            result[bit++] = '0';
+        }
+
+        return Slices.wrappedBuffer(result);
+    }
+
+    @ScalarFunction("ip_from_bits")
+    @Description("Convert an IPv4 32-bit or IPv6 128-bit binary IP address to an IPADDRESS")
+    @SqlType(IPADDRESS)
+    public static Slice fromBits(@SqlType(VARCHAR) Slice slice)
+    {
+        boolean isIPv4 = slice.length() == 32;
+        if (!isIPv4 && slice.length() != 128) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid IP address bits length, expected 32 or 128 but was " + slice.length());
+        }
+
+        try (SliceOutput output = new DynamicSliceOutput(16)) {
+            if (isIPv4) {
+                output.writeZero(10);
+                output.writeShort(0xFFFF);
+            }
+
+            for (int i = isIPv4 ? 12 : 0, n = 0; i < 16; i++) {
+                int value = 0;
+                for (int j = 0; j < 8; j++, n++) {
+                    int bit = switch (slice.getByte(n)) {
+                        case '0' -> 0;
+                        case '1' -> 1;
+                        default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid IP address bits, expected only '0' and '1'");
+                    };
+                    value <<= 1;
+                    value |= bit;
+                }
+                output.writeByte((byte) value);
+            }
+            return output.slice();
+        }
+        catch (IOException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    @ScalarFunction("ip_version")
+    @Description("Returns 4 for IPv4 and 6 for IPv6")
+    @SqlType(INTEGER)
+    public static long ipVersion(@SqlType(IPADDRESS) Slice slice)
+    {
+        return slice.getLong(0) == 0 && slice.getInt(8) == 0xFFFF_0000 ? 4 : 6;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
@@ -21,7 +21,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static io.trino.type.IpAddressType.IPADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -531,5 +534,125 @@ public class TestIpAddressFunctions
                 .isEqualTo(true);
         assertThat(assertions.function("contains", "'127.0.0.1/32'", "IPADDRESS '::ffff:7f00:0002'"))
                 .isEqualTo(false);
+    }
+
+    @Test
+    public void testIpAddressToBits()
+    {
+        assertThat(assertions.expression("ip_to_bits(a)")
+                .binding("a", "IPADDRESS '192.172.1.20'"))
+                .hasType(VARCHAR)
+                .isEqualTo("11000000101011000000000100010100");
+
+        assertThat(assertions.expression("ip_to_bits(a)")
+                .binding("a", "IPADDRESS '4ffe:2900:5545:3210:2000:f8ff:fe21:67cf'"))
+                .hasType(VARCHAR)
+                .isEqualTo("01001111111111100010100100000000010101010100010100110010000100000010000000000000111110001111111111111110001000010110011111001111");
+    }
+
+    @Test
+    public void testIpAddressToBitsWithSubnet()
+    {
+        assertThat(assertions.expression("ip_to_bits(a, 96)")
+                .binding("a", "IPADDRESS '64:ff9b::'"))
+                .hasType(VARCHAR)
+                .isEqualTo("00000000011001001111111110011011000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+        assertThat(assertions.expression("ip_to_bits(a, 1)")
+                .binding("a", "IPADDRESS 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'"))
+                .hasType(VARCHAR)
+                .isEqualTo("10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+        assertThat(assertions.expression("ip_to_bits(a, 120)")
+                .binding("a", "IPADDRESS 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:00ff'"))
+                .hasType(VARCHAR)
+                .isEqualTo("11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110000000000000000");
+
+        assertThat(assertions.expression("ip_to_bits(a, 8)")
+                .binding("a", "IPADDRESS 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:00ff'"))
+                .hasType(VARCHAR)
+                .isEqualTo("11111111000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+        assertThat(assertions.expression("ip_to_bits(a, 9)")
+                .binding("a", "IPADDRESS 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'"))
+                .hasType(VARCHAR)
+                .isEqualTo("11111111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+        assertThat(assertions.expression("ip_to_bits(a, 32)")
+                .binding("a", "IPADDRESS '255.255.255.255'"))
+                .hasType(VARCHAR)
+                .isEqualTo("11111111111111111111111111111111");
+
+        assertThat(assertions.expression("ip_to_bits(a, 16)")
+                .binding("a", "IPADDRESS '255.255.255.255'"))
+                .hasType(VARCHAR)
+                .isEqualTo("11111111111111110000000000000000");
+
+        assertThat(assertions.expression("ip_to_bits(a, 0)")
+                .binding("a", "IPADDRESS '255.255.255.255'"))
+                .hasType(VARCHAR)
+                .isEqualTo("00000000000000000000000000000000");
+
+        // Roundtrips
+        assertThat(assertions.expression("ip_from_bits(ip_to_bits(a))")
+                .binding("a", "IPADDRESS '192.172.1.20'"))
+                .hasType(IPADDRESS)
+                .isEqualTo("192.172.1.20");
+
+        assertThat(assertions.expression("ip_from_bits(ip_to_bits(a, 24))")
+                .binding("a", "IPADDRESS '192.172.1.20'"))
+                .hasType(IPADDRESS)
+                .isEqualTo("192.172.1.0");
+
+        assertThat(assertions.expression("ip_from_bits(ip_to_bits(a, 112))")
+                .binding("a", "IPADDRESS '4ffe:2900:5545:3210:2000:f8ff:fe21:67cf'"))
+                .hasType(IPADDRESS)
+                .isEqualTo("4ffe:2900:5545:3210:2000:f8ff:fe21:0");
+    }
+
+    @Test
+    public void testIpAddressFromBits()
+    {
+        assertThat(assertions.expression("ip_from_bits(a)")
+                .binding("a", "'00000000000000000000000000000000000000000000000000000000000000000000000000000000111111111111111111000000101011000000000100010100'"))
+                .hasType(IPADDRESS)
+                .isEqualTo("192.172.1.20");
+
+        assertThat(assertions.expression("ip_from_bits(a)")
+                .binding("a", "'01001111111111100010100100000000010101010100010100110010000100000010000000000000111110001111111111111110001000010110011111001111'"))
+                .hasType(IPADDRESS)
+                .isEqualTo("4ffe:2900:5545:3210:2000:f8ff:fe21:67cf");
+
+        assertThat(assertions.expression("ip_from_bits(a)")
+                .binding("a", "'00000000000000000000000000000000000000000000000000000000000000000000000000000000111111111111111100000000000000000000000000000000'"))
+                .hasType(IPADDRESS)
+                .isEqualTo("0.0.0.0");
+    }
+
+    @Test
+    public void testIpAddressVersion()
+    {
+        assertThat(assertions.expression("ip_version(a)")
+                .binding("a", "IPADDRESS '192.172.1.20'"))
+                .hasType(INTEGER)
+                .isEqualTo(4);
+
+        assertThat(assertions.expression("ip_version(a)")
+                .binding("a", "IPADDRESS '64:ff9b::'"))
+                .hasType(INTEGER)
+                .isEqualTo(6);
+    }
+
+    @Test
+    public void testIpAddressBitsInvalidArguments()
+    {
+        assertTrinoExceptionThrownBy(assertions.function("ip_from_bits", "'0'")::evaluate)
+                .hasMessage("Invalid IP address bits length, expected 32 or 128 but was 1");
+        assertTrinoExceptionThrownBy(assertions.function("ip_from_bits", "'%s'".formatted("2".repeat(128)))::evaluate)
+                .hasMessage("Invalid IP address bits, expected only '0' and '1'");
+        assertTrinoExceptionThrownBy(assertions.function("ip_to_bits", "IPADDRESS '192.172.1.20'", "33")::evaluate)
+                .hasMessage("Subnet address must be between 0 and 32 for IPv4, but was 33");
+        assertTrinoExceptionThrownBy(assertions.function("ip_to_bits", "IPADDRESS '64:ff9b::'", "129")::evaluate)
+                .hasMessage("Subnet address must be between 0 and 128 for IPv6, but was 129");
     }
 }

--- a/docs/src/main/sphinx/functions/ipaddress.md
+++ b/docs/src/main/sphinx/functions/ipaddress.md
@@ -14,3 +14,59 @@ SELECT contains('2001:0db8:0:0:0:ff00:0042:8329/128', IPADDRESS '2001:0db8:0:0:0
 SELECT contains('2001:0db8:0:0:0:ff00:0042:8329/128', IPADDRESS '2001:0db8:0:0:0:ff00:0042:8328'); -- false
 ```
 :::
+
+:::{function} ip_version(ipaddress) -> integer
+Returns `4` for IPv4 and `6` for IPv6.
+```sql
+SELECT ip_version(IPADDRESS '192.172.1.20');
+-- 4
+```
+:::
+
+:::{function} ip_from_bits(varchar) -> ipaddress
+Convert a 32-bit binary IPv4 address to an IPADDRESS.
+```sql
+SELECT ip_from_bits('11000000101011000000000100010100');
+-- 192.172.1.20
+```
+
+Or convert a 128-bit binary IPv6 address to an IPADDRESS.
+```sql
+SELECT ip_from_bits(concat(
+    '01001111111111100010100100000000',
+    '01010101010001010011001000010000',
+    '00100000000000001111100011111111',
+    '11111110001000010110011111001111'));
+-- 4ffe:2900:5545:3210:2000:f8ff:fe21:67cf
+```
+:::
+
+:::{function} ip_to_bits(ipaddress) -> varchar
+Convert an IPv4 address to its 32-bit representation
+```sql
+SELECT ip_to_bits(IPADDRESS '192.172.1.20');
+-- 11000000101011000000000100010100
+```
+
+Or convert an IPv6 address to its 128-bit representation
+```sql
+SELECT ip_to_bits(IPADDRESS '4ffe:2900:5545:3210:2000:f8ff:fe21:67cf');
+-- 0100111111111110...0000000000111110001111111111111110001000010110011111001111
+```
+:::
+
+:::{function} ip_to_bits(ipaddress, integer) -> varchar
+:noindex: true
+Convert an IPv4 address to its 32-bit representation or an IPv6 address to its
+128-bit representation, keeping the first subnet bits but zeroes for the 
+remaining bits.
+```sql
+SELECT ip_to_bits(IPADDRESS '255.255.255.255', 16);
+-- 11111111111111110000000000000000
+```
+
+```sql
+SELECT ip_to_bits(IPADDRESS 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 112);
+-- 1111111111111111...1111111111111111111111111111111111111111110000000000000000
+```
+:::

--- a/docs/src/main/sphinx/functions/list-by-topic.md
+++ b/docs/src/main/sphinx/functions/list-by-topic.md
@@ -71,7 +71,7 @@ For more details, see {doc}`array`
 - {func}`cardinality`
 - {func}`combinations`
 - `concat()`
-- {func}`contains`
+- `contains()`
 - {func}`element_at`
 - {func}`filter`
 - {func}`flatten`
@@ -308,6 +308,15 @@ For more details, see {doc}`hyperloglog`
 - `cardinality()`
 - {func}`empty_approx_set`
 - {func}`merge`
+
+## IP Address
+
+For more details, see {doc}`ipaddress`
+
+- `contains()`
+- {func}`ip_from_bits`
+- {func}`ip_to_bits`
+- {func}`ip_version`
 
 ## JSON
 

--- a/docs/src/main/sphinx/functions/list.md
+++ b/docs/src/main/sphinx/functions/list.md
@@ -211,6 +211,9 @@
 - {func}`intersection_cardinality`
 - {func}`inverse_beta_cdf`
 - {func}`inverse_normal_cdf`
+- {func}`ip_from_bits`
+- {func}`ip_to_bits`
+- {func}`ip_version`
 - {func}`is_finite`
 - {func}`is_infinite`
 - {func}`is_json_scalar`


### PR DESCRIPTION
## Description
Add function `ip_to_bits` and `ip_from_bits` to convert an ip address to its 128 bit form and vice versa. These functions can be used to group ip addresses by subnet.
Add function `ip_version(ipaddress)` to get either 4 for ipv4 and 6 for ipv6

```sql
SELECT ip_from_bits('0100111111111110001010010000000001010101010...000010110011111001111');
-- 4ffe:2900:5545:3210:2000:f8ff:fe21:67cf
```

```sql
SELECT ip_from_bits('11000000101011000000000100010100');
-- 192.172.1.20
```

```sql
SELECT ip_to_bits(IPADDRESS '4ffe:2900:5545:3210:2000:f8ff:fe21:67cf');
-- 0100111111111110001010010000000001010101010...000010110011111001111
```

```sql
SELECT ip_to_bits(IPADDRESS 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 112);
-- 1111111111111111111111111111111111111111111...111110000000000000000
```

```sql
SELECT ip_to_bits(IPADDRESS '192.172.1.20');
-- 11000000101011000000000100010100
```

```sql
SELECT ip_version(IPADDRESS '192.172.1.20')
-- 4
```

```sql
SELECT ip_version(IPADDRESS '64:ff9b::')
-- 6
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Add functions to convert IPADDRESS to 128 bits varchar representation and vice versa: ip_to_bits and ip_from_bits. Add `ip_version(ipaddress)`
```
