### PR TITLE
Evaluate JSON_VALUE defaults lazily

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TryFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TryFunction.java
@@ -142,7 +142,7 @@ public final class TryFunction
         }
     }
 
-    private static void propagateIfUnhandled(TrinoException e)
+    public static void propagateIfUnhandled(TrinoException e)
             throws TrinoException
     {
         int errorCode = e.getErrorCode().getCode();

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TryFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TryFunction.java
@@ -28,7 +28,12 @@ import static io.trino.operator.scalar.TryFunction.NAME;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.INVALID_JSON_LITERAL;
+import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
+import static io.trino.spi.StandardErrorCode.JSON_OUTPUT_CONVERSION_ERROR;
+import static io.trino.spi.StandardErrorCode.JSON_VALUE_RESULT_ERROR;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.trino.spi.StandardErrorCode.PATH_EVALUATION_ERROR;
 
 @Description("Internal try function for desugaring TRY")
 @ScalarFunction(value = NAME, hidden = true, deterministic = false)
@@ -144,7 +149,12 @@ public final class TryFunction
         if (errorCode == DIVISION_BY_ZERO.toErrorCode().getCode()
                 || errorCode == INVALID_CAST_ARGUMENT.toErrorCode().getCode()
                 || errorCode == INVALID_FUNCTION_ARGUMENT.toErrorCode().getCode()
-                || errorCode == NUMERIC_VALUE_OUT_OF_RANGE.toErrorCode().getCode()) {
+                || errorCode == NUMERIC_VALUE_OUT_OF_RANGE.toErrorCode().getCode()
+                || errorCode == INVALID_JSON_LITERAL.toErrorCode().getCode()
+                || errorCode == JSON_INPUT_CONVERSION_ERROR.toErrorCode().getCode()
+                || errorCode == JSON_OUTPUT_CONVERSION_ERROR.toErrorCode().getCode()
+                || errorCode == JSON_VALUE_RESULT_ERROR.toErrorCode().getCode()
+                || errorCode == PATH_EVALUATION_ERROR.toErrorCode().getCode()) {
             return;
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
@@ -16,6 +16,7 @@ package io.trino.operator.scalar.json;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
 import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.json.JsonPathEvaluator;
@@ -31,47 +32,57 @@ import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.operator.scalar.ChoicesSpecializedSqlScalarFunction;
 import io.trino.operator.scalar.SpecializedSqlScalarFunction;
+import io.trino.operator.scalar.TryFunction;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
 import io.trino.sql.InterpretedFunctionInvoker;
+import io.trino.sql.gen.lambda.LambdaFunctionInterface;
 import io.trino.sql.tree.JsonValue.EmptyOrErrorBehavior;
+import io.trino.type.FunctionType;
 import io.trino.type.JsonPath2016Type;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.json.JsonInputErrorNode.JSON_ERROR;
 import static io.trino.json.ir.SqlJsonLiteralConverter.getTypedValue;
 import static io.trino.operator.scalar.json.ParameterUtil.getParametersArray;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
+import static io.trino.spi.type.TypeSignature.functionType;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.dropArguments;
 import static java.util.Objects.requireNonNull;
 
 public class JsonValueFunction
         extends SqlScalarFunction
 {
     public static final String JSON_VALUE_FUNCTION_NAME = "$json_value";
-    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(JsonValueFunction.class, "jsonValueLong", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, Long.class, long.class, Long.class);
-    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(JsonValueFunction.class, "jsonValueDouble", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, Double.class, long.class, Double.class);
-    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(JsonValueFunction.class, "jsonValueBoolean", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, Boolean.class, long.class, Boolean.class);
-    private static final MethodHandle METHOD_HANDLE_SLICE = methodHandle(JsonValueFunction.class, "jsonValueSlice", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, Slice.class, long.class, Slice.class);
-    private static final MethodHandle METHOD_HANDLE = methodHandle(JsonValueFunction.class, "jsonValue", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, Object.class, long.class, Object.class);
+    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(JsonValueFunction.class, "jsonValueLong", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, MethodHandle.class, MethodHandle.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, DefaultValueLambda.class, long.class, DefaultValueLambda.class);
+    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(JsonValueFunction.class, "jsonValueDouble", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, MethodHandle.class, MethodHandle.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, DefaultValueLambda.class, long.class, DefaultValueLambda.class);
+    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(JsonValueFunction.class, "jsonValueBoolean", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, MethodHandle.class, MethodHandle.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, DefaultValueLambda.class, long.class, DefaultValueLambda.class);
+    private static final MethodHandle METHOD_HANDLE_SLICE = methodHandle(JsonValueFunction.class, "jsonValueSlice", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, MethodHandle.class, MethodHandle.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, DefaultValueLambda.class, long.class, DefaultValueLambda.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(JsonValueFunction.class, "jsonValue", FunctionManager.class, Metadata.class, TypeManager.class, Type.class, Type.class, MethodHandle.class, MethodHandle.class, JsonPathInvocationContext.class, ConnectorSession.class, JsonNode.class, IrJsonPath.class, SqlRow.class, long.class, DefaultValueLambda.class, long.class, DefaultValueLambda.class);
 
     private final FunctionManager functionManager;
     private final Metadata metadata;
@@ -83,18 +94,21 @@ public class JsonValueFunction
                 .signature(Signature.builder()
                         .typeVariable("R")
                         .typeVariable("T")
+                        .typeVariable("E")
+                        .typeVariable("D")
                         .returnType(new TypeSignature("R"))
                         .argumentTypes(ImmutableList.of(
                                 new TypeSignature(JSON_2016),
                                 new TypeSignature(JsonPath2016Type.NAME),
                                 new TypeSignature("T"),
-                                new TypeSignature(TINYINT),
                                 new TypeSignature("R"),
                                 new TypeSignature(TINYINT),
-                                new TypeSignature("R")))
+                                functionType(new TypeSignature("E")),
+                                new TypeSignature(TINYINT),
+                                functionType(new TypeSignature("D"))))
                         .build())
                 .nullable()
-                .argumentNullability(false, false, true, false, true, false, true)
+                .argumentNullability(false, false, true, true, false, false, false, false)
                 .hidden()
                 .description("Extracts an SQL scalar from a JSON value")
                 .build());
@@ -109,6 +123,11 @@ public class JsonValueFunction
     {
         Type parametersRowType = boundSignature.getArgumentType(2);
         Type returnType = boundSignature.getReturnType();
+        Type emptyDefaultType = ((FunctionType) boundSignature.getArgumentType(5)).getReturnType();
+        Type errorDefaultType = ((FunctionType) boundSignature.getArgumentType(7)).getReturnType();
+        MethodHandle emptyDefaultCoercion = createDefaultCoercion(functionManager, metadata, emptyDefaultType, returnType);
+        MethodHandle errorDefaultCoercion = createDefaultCoercion(functionManager, metadata, errorDefaultType, returnType);
+
         MethodHandle handle;
         if (returnType.getJavaType().equals(long.class)) {
             handle = METHOD_HANDLE_LONG;
@@ -131,12 +150,16 @@ public class JsonValueFunction
                 .bindTo(metadata)
                 .bindTo(typeManager)
                 .bindTo(parametersRowType)
-                .bindTo(returnType);
+                .bindTo(returnType)
+                .bindTo(emptyDefaultCoercion)
+                .bindTo(errorDefaultCoercion);
+        methodHandle = dropArguments(methodHandle, 5, Primitives.wrap(boundSignature.getArgumentType(3).getJavaType()));
         MethodHandle instanceFactory = constructorMethodHandle(JsonPathInvocationContext.class);
         return new ChoicesSpecializedSqlScalarFunction(
                 boundSignature,
                 NULLABLE_RETURN,
-                ImmutableList.of(BOXED_NULLABLE, BOXED_NULLABLE, BOXED_NULLABLE, NEVER_NULL, BOXED_NULLABLE, NEVER_NULL, BOXED_NULLABLE),
+                ImmutableList.of(BOXED_NULLABLE, BOXED_NULLABLE, BOXED_NULLABLE, BOXED_NULLABLE, NEVER_NULL, FUNCTION, NEVER_NULL, FUNCTION),
+                ImmutableList.of(DefaultValueLambda.class, DefaultValueLambda.class),
                 methodHandle,
                 Optional.of(instanceFactory));
     }
@@ -148,17 +171,19 @@ public class JsonValueFunction
             TypeManager typeManager,
             Type parametersRowType,
             Type returnType,
+            MethodHandle emptyDefaultCoercion,
+            MethodHandle errorDefaultCoercion,
             JsonPathInvocationContext invocationContext,
             ConnectorSession session,
             JsonNode inputExpression,
             IrJsonPath jsonPath,
             SqlRow parametersRow,
             long emptyBehavior,
-            Long emptyDefault,
+            DefaultValueLambda emptyDefault,
             long errorBehavior,
-            Long errorDefault)
+            DefaultValueLambda errorDefault)
     {
-        return (Long) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
+        return (Long) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, emptyDefaultCoercion, errorDefaultCoercion, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
     }
 
     @UsedByGeneratedCode
@@ -168,17 +193,19 @@ public class JsonValueFunction
             TypeManager typeManager,
             Type parametersRowType,
             Type returnType,
+            MethodHandle emptyDefaultCoercion,
+            MethodHandle errorDefaultCoercion,
             JsonPathInvocationContext invocationContext,
             ConnectorSession session,
             JsonNode inputExpression,
             IrJsonPath jsonPath,
             SqlRow parametersRow,
             long emptyBehavior,
-            Double emptyDefault,
+            DefaultValueLambda emptyDefault,
             long errorBehavior,
-            Double errorDefault)
+            DefaultValueLambda errorDefault)
     {
-        return (Double) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
+        return (Double) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, emptyDefaultCoercion, errorDefaultCoercion, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
     }
 
     @UsedByGeneratedCode
@@ -188,17 +215,19 @@ public class JsonValueFunction
             TypeManager typeManager,
             Type parametersRowType,
             Type returnType,
+            MethodHandle emptyDefaultCoercion,
+            MethodHandle errorDefaultCoercion,
             JsonPathInvocationContext invocationContext,
             ConnectorSession session,
             JsonNode inputExpression,
             IrJsonPath jsonPath,
             SqlRow parametersRow,
             long emptyBehavior,
-            Boolean emptyDefault,
+            DefaultValueLambda emptyDefault,
             long errorBehavior,
-            Boolean errorDefault)
+            DefaultValueLambda errorDefault)
     {
-        return (Boolean) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
+        return (Boolean) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, emptyDefaultCoercion, errorDefaultCoercion, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
     }
 
     @UsedByGeneratedCode
@@ -208,17 +237,19 @@ public class JsonValueFunction
             TypeManager typeManager,
             Type parametersRowType,
             Type returnType,
+            MethodHandle emptyDefaultCoercion,
+            MethodHandle errorDefaultCoercion,
             JsonPathInvocationContext invocationContext,
             ConnectorSession session,
             JsonNode inputExpression,
             IrJsonPath jsonPath,
             SqlRow parametersRow,
             long emptyBehavior,
-            Slice emptyDefault,
+            DefaultValueLambda emptyDefault,
             long errorBehavior,
-            Slice errorDefault)
+            DefaultValueLambda errorDefault)
     {
-        return (Slice) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
+        return (Slice) jsonValue(functionManager, metadata, typeManager, parametersRowType, returnType, emptyDefaultCoercion, errorDefaultCoercion, invocationContext, session, inputExpression, jsonPath, parametersRow, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
     }
 
     @UsedByGeneratedCode
@@ -228,23 +259,25 @@ public class JsonValueFunction
             TypeManager typeManager,
             Type parametersRowType,
             Type returnType,
+            MethodHandle emptyDefaultCoercion,
+            MethodHandle errorDefaultCoercion,
             JsonPathInvocationContext invocationContext,
             ConnectorSession session,
             JsonNode inputExpression,
             IrJsonPath jsonPath,
             SqlRow parametersRow,
             long emptyBehavior,
-            Object emptyDefault,
+            DefaultValueLambda emptyDefault,
             long errorBehavior,
-            Object errorDefault)
+            DefaultValueLambda errorDefault)
     {
         if (inputExpression.equals(JSON_ERROR)) {
-            return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonInputConversionException("malformed input argument to JSON_VALUE function")); // ERROR ON ERROR was already handled by the input function
+            return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonInputConversionException("malformed input argument to JSON_VALUE function")); // ERROR ON ERROR was already handled by the input function
         }
         Object[] parameters = getParametersArray(parametersRowType, parametersRow);
         for (Object parameter : parameters) {
             if (parameter.equals(JSON_ERROR)) {
-                return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonInputConversionException("malformed JSON path parameter to JSON_VALUE function")); // ERROR ON ERROR was already handled by the input function
+                return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonInputConversionException("malformed JSON path parameter to JSON_VALUE function")); // ERROR ON ERROR was already handled by the input function
             }
         }
         // The jsonPath argument is constant for every row. We use the first incoming jsonPath argument to initialize
@@ -260,17 +293,16 @@ public class JsonValueFunction
             pathResult = evaluator.evaluate(inputExpression, parameters);
         }
         catch (PathEvaluationException e) {
-            return handleSpecialCase(errorBehavior, errorDefault, () -> e); // TODO by spec, we should cast the defaults only if they are used
+            return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> e);
         }
 
         if (pathResult.isEmpty()) {
-            return handleSpecialCase(emptyBehavior, emptyDefault, () -> new JsonValueResultException("JSON path found no items"));
+            return handleEmpty(session, emptyBehavior, emptyDefaultCoercion, emptyDefault, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonValueResultException("JSON path found no items"));
         }
 
         if (pathResult.size() > 1) {
-            return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonValueResultException("JSON path found multiple items"));
+            return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonValueResultException("JSON path found multiple items"));
         }
-
         Object item = getOnlyElement(pathResult);
         TypedValue typedValue;
         if (item instanceof JsonNode jsonNode) {
@@ -282,10 +314,10 @@ public class JsonValueFunction
                 itemValue = getTypedValue(jsonNode);
             }
             catch (JsonLiteralConversionException e) {
-                return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonValueResultException("JSON path found an item that cannot be converted to an SQL value", e));
+                return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonValueResultException("JSON path found an item that cannot be converted to an SQL value", e));
             }
             if (itemValue.isEmpty()) {
-                return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonValueResultException("JSON path found an item that cannot be converted to an SQL value"));
+                return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonValueResultException("JSON path found an item that cannot be converted to an SQL value"));
             }
             typedValue = itemValue.get();
         }
@@ -300,7 +332,7 @@ public class JsonValueFunction
             coercion = metadata.getCoercion(typedValue.getType(), returnType);
         }
         catch (OperatorNotFoundException e) {
-            return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonValueResultException(format(
+            return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonValueResultException(format(
                     "Cannot cast value of type %s to declared return type of function JSON_VALUE: %s",
                     typedValue.getType(),
                     returnType)));
@@ -309,19 +341,90 @@ public class JsonValueFunction
             return new InterpretedFunctionInvoker(functionManager).invoke(coercion, session, ImmutableList.of(typedValue.getValueAsObject()));
         }
         catch (RuntimeException e) {
-            return handleSpecialCase(errorBehavior, errorDefault, () -> new JsonValueResultException(format(
+            return handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> new JsonValueResultException(format(
                     "Cannot cast value of type %s to declared return type of function JSON_VALUE: %s",
                     typedValue.getType(),
                     returnType)));
         }
     }
 
-    private static Object handleSpecialCase(long behavior, Object defaultValue, Supplier<TrinoException> error)
+    private static Object handleEmpty(
+            ConnectorSession session,
+            long emptyBehavior,
+            MethodHandle emptyDefaultCoercion,
+            DefaultValueLambda emptyDefault,
+            long errorBehavior,
+            MethodHandle errorDefaultCoercion,
+            DefaultValueLambda errorDefault,
+            Supplier<RuntimeException> error)
+    {
+        return switch (EmptyOrErrorBehavior.values()[(int) emptyBehavior]) {
+            case NULL -> null;
+            case ERROR -> throw error.get();
+            case DEFAULT -> {
+                try {
+                    yield evaluateDefault(session, emptyDefaultCoercion, emptyDefault);
+                }
+                catch (TrinoException defaultError) {
+                    // Only handle evaluation errors (e.g., division by zero, cast overflow) by cascading
+                    // to the ON ERROR clause. Other errors indicate unexpected failures and should propagate.
+                    TryFunction.propagateIfUnhandled(defaultError);
+                    yield handleError(session, errorBehavior, errorDefaultCoercion, errorDefault, () -> defaultError);
+                }
+            }
+        };
+    }
+
+    private static Object handleError(
+            ConnectorSession session,
+            long behavior,
+            MethodHandle defaultCoercion,
+            DefaultValueLambda defaultValue,
+            Supplier<RuntimeException> error)
     {
         return switch (EmptyOrErrorBehavior.values()[(int) behavior]) {
             case NULL -> null;
             case ERROR -> throw error.get();
-            case DEFAULT -> defaultValue;
+            case DEFAULT -> evaluateDefault(session, defaultCoercion, defaultValue);
         };
+    }
+
+    private static Object evaluateDefault(ConnectorSession session, MethodHandle defaultCoercion, DefaultValueLambda defaultValue)
+    {
+        Object defaultResult = defaultValue.apply();
+        if (defaultResult == null) {
+            return null;
+        }
+        try {
+            return defaultCoercion.invoke(session, defaultResult);
+        }
+        catch (Throwable t) {
+            throwIfUnchecked(t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    private static MethodHandle createDefaultCoercion(FunctionManager functionManager, Metadata metadata, Type defaultType, Type returnType)
+    {
+        if (defaultType.equals(returnType)) {
+            // identity: (ConnectorSession, Object) -> Object, returns the value as-is
+            return dropArguments(MethodHandles.identity(Object.class), 0, ConnectorSession.class);
+        }
+        ResolvedFunction coercion = metadata.getCoercion(defaultType, returnType);
+        MethodHandle coercionHandle = functionManager.getScalarFunctionImplementation(
+                coercion,
+                new InvocationConvention(ImmutableList.of(BOXED_NULLABLE), NULLABLE_RETURN, true, false))
+                .getMethodHandle();
+        if (!coercionHandle.type().parameterType(0).equals(ConnectorSession.class)) {
+            coercionHandle = dropArguments(coercionHandle, 0, ConnectorSession.class);
+        }
+        return coercionHandle.asType(MethodType.methodType(Object.class, ConnectorSession.class, Object.class));
+    }
+
+    @FunctionalInterface
+    public interface DefaultValueLambda
+            extends LambdaFunctionInterface
+    {
+        Object apply();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/table/json/JsonTable.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/json/JsonTable.java
@@ -29,6 +29,7 @@ import io.trino.spi.function.table.TableFunctionProcessorState;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.sql.gen.PageFunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -82,6 +83,7 @@ public final class JsonTable
 
     public static TableFunctionProcessorProvider getJsonTableFunctionProcessorProvider(Metadata metadata, TypeManager typeManager, FunctionManager functionManager)
     {
+        PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(functionManager, metadata, typeManager, 0);
         return new TableFunctionProcessorProvider()
         {
             @Override
@@ -93,11 +95,11 @@ public final class JsonTable
                         jsonTableFunctionHandle.processingPlan(),
                         newRow,
                         jsonTableFunctionHandle.errorOnError(),
-                        jsonTableFunctionHandle.outputTypes(),
                         session,
                         metadata,
                         typeManager,
-                        functionManager);
+                        functionManager,
+                        pageFunctionCompiler);
                 return new JsonTableFunctionProcessor(executionPlan, newRow, jsonTableFunctionHandle.outputTypes(), (RowType) jsonTableFunctionHandle.parametersType(), jsonTableFunctionHandle.outer());
             }
         };

--- a/core/trino-main/src/main/java/io/trino/operator/table/json/JsonTableValueColumn.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/json/JsonTableValueColumn.java
@@ -15,7 +15,12 @@ package io.trino.operator.table.json;
 
 import io.trino.json.ir.IrJsonPath;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.planner.Symbol;
 
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public record JsonTableValueColumn(
@@ -23,14 +28,16 @@ public record JsonTableValueColumn(
         ResolvedFunction function,
         IrJsonPath path,
         long emptyBehavior,
-        int emptyDefaultInput, // channel number or -1 when default not specified
+        Expression emptyDefault, // evaluated lazily against the current input row
         long errorBehavior,
-        int errorDefaultInput) // channel number or -1 when default not specified
+        Expression errorDefault, // evaluated lazily against the current input row
+        List<Symbol> defaultInputLayout) // input channel layout for default expression evaluation
         implements JsonTableColumn
 {
     public JsonTableValueColumn
     {
         requireNonNull(function, "function is null");
         requireNonNull(path, "path is null");
+        defaultInputLayout = defaultInputLayout.stream().collect(toImmutableList());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/table/json/execution/ExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/json/execution/ExecutionPlanner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.json.JsonPathInvocationContext;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
+import io.trino.operator.project.PageProjection;
 import io.trino.operator.table.json.JsonTableColumn;
 import io.trino.operator.table.json.JsonTableOrdinalityColumn;
 import io.trino.operator.table.json.JsonTablePlanCross;
@@ -29,13 +30,21 @@ import io.trino.operator.table.json.JsonTableValueColumn;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.ScalarFunctionImplementation;
-import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.planner.Symbol;
+import io.trino.type.FunctionType;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 
@@ -47,18 +56,18 @@ public final class ExecutionPlanner
             JsonTablePlanNode plan,
             Object[] newRow,
             boolean errorOnError,
-            Type[] outputTypes,
             ConnectorSession session,
             Metadata metadata,
             TypeManager typeManager,
-            FunctionManager functionManager)
+            FunctionManager functionManager,
+            PageFunctionCompiler pageFunctionCompiler)
     {
         switch (plan) {
             case JsonTablePlanLeaf planLeaf -> {
                 return new FragmentLeaf(
                         planLeaf.path(),
                         planLeaf.columns().stream()
-                                .map(column -> getColumn(column, outputTypes, session, functionManager))
+                                .map(column -> getColumn(column, session, functionManager, pageFunctionCompiler))
                                 .collect(toImmutableList()),
                         errorOnError,
                         newRow,
@@ -71,11 +80,11 @@ public final class ExecutionPlanner
                 return new FragmentSingle(
                         planSingle.path(),
                         planSingle.columns().stream()
-                                .map(column -> getColumn(column, outputTypes, session, functionManager))
+                                .map(column -> getColumn(column, session, functionManager, pageFunctionCompiler))
                                 .collect(toImmutableList()),
                         errorOnError,
                         planSingle.outer(),
-                        getExecutionPlan(planSingle.child(), newRow, errorOnError, outputTypes, session, metadata, typeManager, functionManager),
+                        getExecutionPlan(planSingle.child(), newRow, errorOnError, session, metadata, typeManager, functionManager, pageFunctionCompiler),
                         newRow,
                         session,
                         metadata,
@@ -84,27 +93,27 @@ public final class ExecutionPlanner
             }
             case JsonTablePlanCross planCross -> {
                 return new FragmentCross(planCross.siblings().stream()
-                        .map(sibling -> getExecutionPlan(sibling, newRow, errorOnError, outputTypes, session, metadata, typeManager, functionManager))
+                        .map(sibling -> getExecutionPlan(sibling, newRow, errorOnError, session, metadata, typeManager, functionManager, pageFunctionCompiler))
                         .collect(toImmutableList()));
             }
             case JsonTablePlanUnion planUnion -> {
                 return new FragmentUnion(
                         planUnion.siblings().stream()
-                                .map(sibling -> getExecutionPlan(sibling, newRow, errorOnError, outputTypes, session, metadata, typeManager, functionManager))
+                                .map(sibling -> getExecutionPlan(sibling, newRow, errorOnError, session, metadata, typeManager, functionManager, pageFunctionCompiler))
                                 .collect(toImmutableList()),
                         newRow);
             }
         }
     }
 
-    private static Column getColumn(JsonTableColumn column, Type[] outputTypes, ConnectorSession session, FunctionManager functionManager)
+    private static Column getColumn(JsonTableColumn column, ConnectorSession session, FunctionManager functionManager, PageFunctionCompiler pageFunctionCompiler)
     {
         return switch (column) {
             case JsonTableValueColumn valueColumn -> {
                 ScalarFunctionImplementation implementation = functionManager.getScalarFunctionImplementation(
                         valueColumn.function(),
                         new InvocationConvention(
-                                ImmutableList.of(BOXED_NULLABLE, BOXED_NULLABLE, BOXED_NULLABLE, NEVER_NULL, BOXED_NULLABLE, NEVER_NULL, BOXED_NULLABLE),
+                                ImmutableList.of(BOXED_NULLABLE, BOXED_NULLABLE, BOXED_NULLABLE, BOXED_NULLABLE, NEVER_NULL, FUNCTION, NEVER_NULL, FUNCTION),
                                 NULLABLE_RETURN,
                                 true,
                                 true));
@@ -117,17 +126,26 @@ public final class ExecutionPlanner
                     throwIfUnchecked(throwable);
                     throw new RuntimeException(throwable);
                 }
+                Map<Symbol, Integer> defaultInputLayout = valueColumn.defaultInputLayout().isEmpty()
+                        ? Map.of()
+                        : IntStream.range(0, valueColumn.defaultInputLayout().size())
+                                .boxed()
+                                .collect(toImmutableMap(valueColumn.defaultInputLayout()::get, i -> i));
+                PageProjection emptyDefaultProjection = valueColumn.emptyDefault() == null ? null : pageFunctionCompiler.compileProjection(valueColumn.emptyDefault(), defaultInputLayout, Optional.empty()).get();
+                PageProjection errorDefaultProjection = valueColumn.errorDefault() == null ? null : pageFunctionCompiler.compileProjection(valueColumn.errorDefault(), defaultInputLayout, Optional.empty()).get();
                 yield new ValueColumn(
                         valueColumn.outputIndex(),
                         implementation.getMethodHandle()
                                 .bindTo(context)
                                 .bindTo(session),
+                        session,
                         valueColumn.path(),
                         valueColumn.emptyBehavior(),
-                        valueColumn.emptyDefaultInput(),
+                        emptyDefaultProjection,
+                        valueColumn.emptyDefault() == null ? ((FunctionType) valueColumn.function().signature().getArgumentType(5)).getReturnType() : valueColumn.emptyDefault().type(),
                         valueColumn.errorBehavior(),
-                        valueColumn.errorDefaultInput(),
-                        outputTypes[valueColumn.outputIndex()]);
+                        errorDefaultProjection,
+                        valueColumn.errorDefault() == null ? ((FunctionType) valueColumn.function().signature().getArgumentType(7)).getReturnType() : valueColumn.errorDefault().type());
             }
             case JsonTableQueryColumn queryColumn -> {
                 ScalarFunctionImplementation implementation = functionManager.getScalarFunctionImplementation(

--- a/core/trino-main/src/main/java/io/trino/operator/table/json/execution/ValueColumn.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/json/execution/ValueColumn.java
@@ -15,7 +15,12 @@ package io.trino.operator.table.json.execution;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.trino.json.ir.IrJsonPath;
+import io.trino.operator.project.PageProjection;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.operator.scalar.json.JsonValueFunction.DefaultValueLambda;
 import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SourcePage;
 import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
@@ -29,54 +34,49 @@ public class ValueColumn
 {
     private final int outputIndex;
     private final MethodHandle methodHandle;
+    private final ConnectorSession session;
     private final IrJsonPath path;
     private final long emptyBehavior;
-    private final int emptyDefaultInput;
+    private final PageProjection emptyDefaultProjection;
+    private final Type emptyDefaultType;
     private final long errorBehavior;
-    private final int errorDefaultInput;
-    private final Type resultType;
+    private final PageProjection errorDefaultProjection;
+    private final Type errorDefaultType;
 
     public ValueColumn(
             int outputIndex,
             MethodHandle methodHandle,
+            ConnectorSession session,
             IrJsonPath path,
             long emptyBehavior,
-            int emptyDefaultInput,
+            PageProjection emptyDefaultProjection,
+            Type emptyDefaultType,
             long errorBehavior,
-            int errorDefaultInput,
-            Type resultType)
+            PageProjection errorDefaultProjection,
+            Type errorDefaultType)
     {
         this.outputIndex = outputIndex;
         this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
+        this.session = requireNonNull(session, "session is null");
         this.path = requireNonNull(path, "path is null");
         this.emptyBehavior = emptyBehavior;
-        this.emptyDefaultInput = emptyDefaultInput;
+        this.emptyDefaultProjection = emptyDefaultProjection;
+        this.emptyDefaultType = requireNonNull(emptyDefaultType, "emptyDefaultType is null");
         this.errorBehavior = errorBehavior;
-        this.errorDefaultInput = errorDefaultInput;
-        this.resultType = requireNonNull(resultType, "resultType is null");
+        this.errorDefaultProjection = errorDefaultProjection;
+        this.errorDefaultType = requireNonNull(errorDefaultType, "errorDefaultType is null");
     }
 
     @Override
     public Object evaluate(long sequentialNumber, JsonNode item, Page input, int position)
     {
-        Object emptyDefault;
-        if (emptyDefaultInput == -1) {
-            emptyDefault = null;
-        }
-        else {
-            emptyDefault = readNativeValue(resultType, input.getBlock(emptyDefaultInput), position);
-        }
-
-        Object errorDefault;
-        if (errorDefaultInput == -1) {
-            errorDefault = null;
-        }
-        else {
-            errorDefault = readNativeValue(resultType, input.getBlock(errorDefaultInput), position);
-        }
+        SourcePage sourcePage = SourcePage.create(input);
+        SelectedPositions selectedPosition = SelectedPositions.positionsRange(position, 1);
+        DefaultValueLambda emptyDefault = () -> emptyDefaultProjection == null ? null : readNativeValue(emptyDefaultType, emptyDefaultProjection.project(session, emptyDefaultProjection.getInputChannels().getInputChannels(sourcePage), selectedPosition), 0);
+        DefaultValueLambda errorDefault = () -> errorDefaultProjection == null ? null : readNativeValue(errorDefaultType, errorDefaultProjection.project(session, errorDefaultProjection.getInputChannels().getInputChannels(sourcePage), selectedPosition), 0);
 
         try {
-            return methodHandle.invoke(item, path, null, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
+            return methodHandle.invoke(item, path, null, null, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
         }
         catch (Throwable throwable) {
             // According to ISO/IEC 9075-2:2016(E) 7.11 <JSON table> p.462 General rules 1) e) ii) 2) D) any exception thrown by column evaluation should be propagated.

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -234,6 +234,7 @@ import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.spi.StandardErrorCode.TOO_MANY_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.StandardErrorCode.TYPE_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.UNSUPPORTED_SUBQUERY;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.SUBSCRIPT;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
@@ -549,6 +550,7 @@ public class ExpressionAnalyzer
         Visitor visitor = new Visitor(scope, warningCollector);
         List<Type> pathInvocationArgumentTypes = ImmutableList.of(JSON_2016, plannerContext.getTypeManager().getType(TypeId.of(JsonPath2016Type.NAME)), JSON_NO_PARAMETERS_ROW_TYPE);
         return visitor.analyzeJsonValueExpression(
+                "JSON_TABLE",
                 column,
                 pathAnalysis,
                 Optional.of(column.getType()),
@@ -2718,6 +2720,7 @@ public class ExpressionAnalyzer
         {
             List<Type> pathInvocationArgumentTypes = analyzeJsonPathInvocation("JSON_VALUE", node, node.getJsonPathInvocation(), context);
             Type returnedType = analyzeJsonValueExpression(
+                    "JSON_VALUE",
                     node,
                     jsonPathAnalyses.get(NodeRef.of(node)),
                     node.getReturnedType(),
@@ -2731,6 +2734,7 @@ public class ExpressionAnalyzer
         }
 
         private Type analyzeJsonValueExpression(
+                String callerName,
                 Node node,
                 JsonPathAnalysis pathAnalysis,
                 Optional<DataType> declaredReturnedType,
@@ -2772,16 +2776,18 @@ public class ExpressionAnalyzer
             }
 
             // validate default values for empty and error behavior
+            Type emptyDefaultType = returnedType;
             if (declaredEmptyDefault.isPresent()) {
                 Expression emptyDefault = declaredEmptyDefault.get();
                 if (emptyBehavior != DEFAULT) {
                     throw semanticException(INVALID_FUNCTION_ARGUMENT, emptyDefault, "Default value specified for %s ON EMPTY behavior", emptyBehavior);
                 }
-                Type type = process(emptyDefault, context);
-                // this would normally be done after function resolution, but we know that the default expression is always coerced to the returnedType
-                coerceType(emptyDefault, type, returnedType, "Function JSON_VALUE default ON EMPTY result");
+                verifyNoSubqueriesInDefault(emptyDefault, callerName);
+                emptyDefaultType = process(emptyDefault, context);
+                verifyDefaultCoercion(emptyDefault, emptyDefaultType, returnedType, "Function %s default ON EMPTY result".formatted(callerName));
             }
 
+            Type errorDefaultType = returnedType;
             if (declaredErrorDefault.isPresent()) {
                 Expression errorDefault = declaredErrorDefault.get();
                 if (errorBehavior.isEmpty()) {
@@ -2790,18 +2796,19 @@ public class ExpressionAnalyzer
                 if (errorBehavior.orElseThrow() != DEFAULT) {
                     throw semanticException(INVALID_FUNCTION_ARGUMENT, errorDefault, "Default value specified for %s ON ERROR behavior", errorBehavior.orElseThrow());
                 }
-                Type type = process(errorDefault, context);
-                // this would normally be done after function resolution, but we know that the default expression is always coerced to the returnedType
-                coerceType(errorDefault, type, returnedType, "Function JSON_VALUE default ON ERROR result");
+                verifyNoSubqueriesInDefault(errorDefault, callerName);
+                errorDefaultType = process(errorDefault, context);
+                verifyDefaultCoercion(errorDefault, errorDefaultType, returnedType, "Function %s default ON ERROR result".formatted(callerName));
             }
 
             // pass remaining information in the node : empty behavior, empty default, error behavior, error default
             List<Type> argumentTypes = ImmutableList.<Type>builder()
                     .addAll(pathInvocationArgumentTypes)
+                    .add(returnedType) // return type anchor
                     .add(TINYINT) // empty behavior: enum encoded as integer value
-                    .add(returnedType) // empty default
+                    .add(new FunctionType(ImmutableList.of(), emptyDefaultType)) // empty default
                     .add(TINYINT) // error behavior: enum encoded as integer value
-                    .add(returnedType) // error default
+                    .add(new FunctionType(ImmutableList.of(), errorDefaultType)) // error default
                     .build();
 
             // resolve function
@@ -2818,6 +2825,27 @@ public class ExpressionAnalyzer
             resolvedFunctions.put(NodeRef.of(node), function);
 
             return function.signature().getReturnType();
+        }
+
+        private void verifyDefaultCoercion(Expression defaultValue, Type defaultType, Type returnedType, String message)
+        {
+            if (defaultType.equals(returnedType)) {
+                return;
+            }
+            try {
+                plannerContext.getMetadata().getCoercion(defaultType, returnedType);
+            }
+            catch (OperatorNotFoundException e) {
+                throw semanticException(TYPE_MISMATCH, defaultValue, "%s must evaluate to a %s (actual: %s)", message, returnedType, defaultType);
+            }
+        }
+
+        private static void verifyNoSubqueriesInDefault(Expression expression, String callerName)
+        {
+            List<SubqueryExpression> subqueries = extractExpressions(ImmutableList.of(expression), SubqueryExpression.class);
+            if (!subqueries.isEmpty()) {
+                throw semanticException(UNSUPPORTED_SUBQUERY, subqueries.getFirst(), "Subqueries are not supported in %s default expressions", callerName);
+            }
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4354,7 +4354,6 @@ class StatementAnalyzer
                                 analysis,
                                 warningCollector,
                                 correlationSupport);
-                        // default values can contain subqueries - the subqueries are recorded under the enclosing JsonTable node
                         analysis.recordSubqueries(jsonTable, typeAndAnalysis.analysis());
                         outputFields.add(Field.newUnqualified(name, typeAndAnalysis.type()));
                         orderedOutputColumns.add(NodeRef.of(valueColumn));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -1472,16 +1472,15 @@ class RelationPlanner
         PlanBuilder planBuilder = leftPlan;
 
         // extract input expressions
-        ImmutableList.Builder<io.trino.sql.tree.Expression> builder = ImmutableList.builder();
         io.trino.sql.tree.Expression inputExpression = jsonTable.getJsonPathInvocation().getInputExpression();
-        builder.add(inputExpression);
         List<JsonPathParameter> pathParameters = jsonTable.getJsonPathInvocation().getPathParameters();
-        pathParameters.stream()
-                .map(JsonPathParameter::getParameter)
-                .forEach(builder::add);
         List<io.trino.sql.tree.Expression> defaultExpressions = getDefaultExpressions(jsonTable.getColumns());
-        builder.addAll(defaultExpressions);
-        List<io.trino.sql.tree.Expression> inputExpressions = builder.build();
+        List<io.trino.sql.tree.Expression> inputExpressions = ImmutableList.<io.trino.sql.tree.Expression>builder()
+                .add(inputExpression)
+                .addAll(pathParameters.stream()
+                        .map(JsonPathParameter::getParameter)
+                        .collect(toImmutableList()))
+                .build();
 
         planBuilder = subqueryPlanner.handleSubqueries(planBuilder, inputExpressions, analysis.getSubqueries(jsonTable));
         planBuilder = planBuilder.appendProjections(inputExpressions, symbolAllocator, idAllocator);
@@ -1522,21 +1521,23 @@ class RelationPlanner
         planBuilder = planBuilder.withNewRoot(appended);
 
         // identify the required symbols
+        Map<NodeRef<io.trino.sql.tree.Expression>, Expression> rewrittenDefaultExpressions = new HashMap<>();
+        ImmutableList.Builder<Symbol> defaultSymbolsBuilder = ImmutableList.builder();
+        for (io.trino.sql.tree.Expression defaultExpression : defaultExpressions) {
+            Expression rewritten = coerceIfNecessary(analysis, defaultExpression, planBuilder.rewrite(defaultExpression));
+            rewrittenDefaultExpressions.put(NodeRef.of(defaultExpression), rewritten);
+            defaultSymbolsBuilder.addAll(SymbolsExtractor.extractUnique(rewritten));
+        }
+
         ImmutableList.Builder<Symbol> requiredSymbolsBuilder = ImmutableList.<Symbol>builder()
                 .add(inputJsonSymbol)
                 .add(parametersRowSymbol);
-        defaultExpressions.stream()
-                .map(coerced::get)
+        defaultSymbolsBuilder.build().stream()
                 .distinct()
                 .forEach(requiredSymbolsBuilder::add);
         List<Symbol> requiredSymbols = requiredSymbolsBuilder.build();
 
-        // map the default expressions of value columns to indexes in the required columns list
-        // use a HashMap because there might be duplicate expressions
-        Map<io.trino.sql.tree.Expression, Integer> defaultExpressionsMapping = new HashMap<>();
-        for (io.trino.sql.tree.Expression defaultExpression : defaultExpressions) {
-            defaultExpressionsMapping.put(defaultExpression, requiredSymbols.indexOf(coerced.get(defaultExpression)));
-        }
+        Map<NodeRef<io.trino.sql.tree.Expression>, Expression> defaultExpressionsMapping = rewrittenDefaultExpressions;
 
         // rewrite the root JSON path to IR using parameters
         IrJsonPath rootPath = new JsonPathTranslator(session, plannerContext).rewriteToIr(analysis.getJsonPathAnalysis(jsonTable), orderedParameters.parametersOrder());
@@ -1549,13 +1550,13 @@ class RelationPlanner
         JsonTablePlanNode executionPlan;
         boolean defaultErrorOnError = jsonTable.getErrorBehavior().map(errorBehavior -> errorBehavior == JsonTable.ErrorBehavior.ERROR).orElse(false);
         if (jsonTable.getPlan().isEmpty()) {
-            executionPlan = getPlanFromDefaults(rootPath, jsonTable.getColumns(), OUTER, UNION, defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping);
+            executionPlan = getPlanFromDefaults(rootPath, jsonTable.getColumns(), OUTER, UNION, defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping, requiredSymbols);
         }
         else if (jsonTable.getPlan().orElseThrow() instanceof JsonTableDefaultPlan defaultPlan) {
-            executionPlan = getPlanFromDefaults(rootPath, jsonTable.getColumns(), defaultPlan.getParentChild(), defaultPlan.getSiblings(), defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping);
+            executionPlan = getPlanFromDefaults(rootPath, jsonTable.getColumns(), defaultPlan.getParentChild(), defaultPlan.getSiblings(), defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping, requiredSymbols);
         }
         else {
-            executionPlan = getPlanFromSpecification(rootPath, jsonTable.getColumns(), (JsonTableSpecificPlan) jsonTable.getPlan().orElseThrow(), defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping);
+            executionPlan = getPlanFromSpecification(rootPath, jsonTable.getColumns(), (JsonTableSpecificPlan) jsonTable.getPlan().orElseThrow(), defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping, requiredSymbols);
         }
 
         // create new symbols for json_table function's proper columns
@@ -1675,7 +1676,8 @@ class RelationPlanner
             SiblingsPlanType siblingsPlanType,
             boolean defaultErrorOnError,
             Map<NodeRef<JsonTableColumnDefinition>, Integer> outputIndexMapping,
-            Map<io.trino.sql.tree.Expression, Integer> defaultExpressionsMapping)
+            Map<NodeRef<io.trino.sql.tree.Expression>, Expression> defaultExpressionsMapping,
+            List<Symbol> defaultInputLayout)
     {
         ImmutableList.Builder<JsonTableColumn> columns = ImmutableList.builder();
         ImmutableList.Builder<JsonTablePlanNode> childrenBuilder = ImmutableList.builder();
@@ -1690,10 +1692,11 @@ class RelationPlanner
                         siblingsPlanType,
                         defaultErrorOnError,
                         outputIndexMapping,
-                        defaultExpressionsMapping));
+                        defaultExpressionsMapping,
+                        defaultInputLayout));
             }
             else {
-                columns.add(getColumn(columnDefinition, defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping));
+                columns.add(getColumn(columnDefinition, defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping, defaultInputLayout));
             }
         }
 
@@ -1722,7 +1725,8 @@ class RelationPlanner
             JsonTableSpecificPlan specificPlan,
             boolean defaultErrorOnError,
             Map<NodeRef<JsonTableColumnDefinition>, Integer> outputIndexMapping,
-            Map<io.trino.sql.tree.Expression, Integer> defaultExpressionsMapping)
+            Map<NodeRef<io.trino.sql.tree.Expression>, Expression> defaultExpressionsMapping,
+            List<Symbol> defaultInputLayout)
     {
         ImmutableList.Builder<JsonTableColumn> columns = ImmutableList.builder();
         ImmutableMap.Builder<String, JsonTablePlanNode> childrenBuilder = ImmutableMap.builder();
@@ -1744,11 +1748,12 @@ class RelationPlanner
                         planSiblings.get(nestedPathName),
                         defaultErrorOnError,
                         outputIndexMapping,
-                        defaultExpressionsMapping);
+                        defaultExpressionsMapping,
+                        defaultInputLayout);
                 childrenBuilder.put(nestedPathName, child);
             }
             else {
-                columns.add(getColumn(columnDefinition, defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping));
+                columns.add(getColumn(columnDefinition, defaultErrorOnError, outputIndexMapping, defaultExpressionsMapping, defaultInputLayout));
             }
         }
 
@@ -1783,7 +1788,8 @@ class RelationPlanner
             JsonTableColumnDefinition columnDefinition,
             boolean defaultErrorOnError,
             Map<NodeRef<JsonTableColumnDefinition>, Integer> outputIndexMapping,
-            Map<io.trino.sql.tree.Expression, Integer> defaultExpressionsMapping)
+            Map<NodeRef<io.trino.sql.tree.Expression>, Expression> defaultExpressionsMapping,
+            List<Symbol> defaultInputLayout)
     {
         int index = outputIndexMapping.get(NodeRef.of(columnDefinition));
 
@@ -1802,12 +1808,14 @@ class RelationPlanner
                     queryColumn.getErrorBehavior().orElse(defaultErrorOnError ? JsonQuery.EmptyOrErrorBehavior.ERROR : JsonQuery.EmptyOrErrorBehavior.NULL).ordinal());
         }
         if (columnDefinition instanceof ValueColumn valueColumn) {
-            int emptyDefault = valueColumn.getEmptyDefault()
+            Expression emptyDefault = valueColumn.getEmptyDefault()
+                    .map(NodeRef::of)
                     .map(defaultExpressionsMapping::get)
-                    .orElse(-1);
-            int errorDefault = valueColumn.getErrorDefault()
+                    .orElse(null);
+            Expression errorDefault = valueColumn.getErrorDefault()
+                    .map(NodeRef::of)
                     .map(defaultExpressionsMapping::get)
-                    .orElse(-1);
+                    .orElse(null);
             return new JsonTableValueColumn(
                     index,
                     columnFunction.get(),
@@ -1815,7 +1823,8 @@ class RelationPlanner
                     valueColumn.getEmptyBehavior().ordinal(),
                     emptyDefault,
                     valueColumn.getErrorBehavior().orElse(defaultErrorOnError ? JsonValue.EmptyOrErrorBehavior.ERROR : JsonValue.EmptyOrErrorBehavior.NULL).ordinal(),
-                    errorDefault);
+                    errorDefault,
+                    defaultInputLayout);
         }
         throw new IllegalStateException("unexpected column definition: " + columnDefinition.getClass().getSimpleName());
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -1057,19 +1057,27 @@ public class TranslationMap
 
         IrJsonPath path = new JsonPathTranslator(session, plannerContext).rewriteToIr(analysis.getJsonPathAnalysis(node), orderedParameters.parametersOrder());
         io.trino.sql.ir.Expression pathExpression = new Constant(plannerContext.getTypeManager().getType(TypeId.of(JsonPath2016Type.NAME)), path);
+        Type returnType = resolvedFunction.get().signature().getReturnType();
 
         ImmutableList.Builder<io.trino.sql.ir.Expression> arguments = ImmutableList.<io.trino.sql.ir.Expression>builder()
                 .add(input)
                 .add(pathExpression)
                 .add(orderedParameters.parametersRow())
+                .add(new Constant(returnType, null))
                 .add(new Constant(TINYINT, (long) node.getEmptyBehavior().ordinal()))
                 .add(node.getEmptyDefault()
                         .map(this::translateExpression)
-                        .orElseGet(() -> new Constant(resolvedFunction.get().signature().getReturnType(), null)))
+                        .map(expression -> new Lambda(ImmutableList.of(), expression))
+                        .orElseGet(() -> new Lambda(
+                                ImmutableList.of(),
+                                new Constant(((FunctionType) resolvedFunction.get().signature().getArgumentType(5)).getReturnType(), null))))
                 .add(new Constant(TINYINT, (long) node.getErrorBehavior().ordinal()))
                 .add(node.getErrorDefault()
                         .map(this::translateExpression)
-                        .orElseGet(() -> new Constant(resolvedFunction.get().signature().getReturnType(), null)));
+                        .map(expression -> new Lambda(ImmutableList.of(), expression))
+                        .orElseGet(() -> new Lambda(
+                                ImmutableList.of(),
+                                new Constant(((FunctionType) resolvedFunction.get().signature().getArgumentType(7)).getReturnType(), null))));
 
         return new Call(resolvedFunction.get(), arguments.build());
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonFunctions.java
@@ -36,9 +36,11 @@ import io.trino.spi.type.TypeId;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import io.trino.testing.TestingSession;
+import io.trino.type.FunctionType;
 import io.trino.type.JsonPath2016Type;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -189,19 +191,21 @@ public class BenchmarkJsonFunctions
                                     JSON_2016,
                                     jsonPath2016Type,
                                     JSON_NO_PARAMETERS_ROW_TYPE,
-                                    TINYINT,
                                     VARCHAR,
                                     TINYINT,
-                                    VARCHAR))),
+                                    new FunctionType(ImmutableList.of(), VARCHAR),
+                                    TINYINT,
+                                    new FunctionType(ImmutableList.of(), VARCHAR)))),
                     ImmutableList.of(
                             call(functionResolution.resolveFunction(VARCHAR_TO_JSON, fromTypes(VARCHAR, BOOLEAN)),
                                     new Reference(VARCHAR, "$col_0"), new Constant(BOOLEAN, true)),
                             new Constant(jsonPath2016Type, new IrJsonPath(false, pathRoot)),
                             constantNull(JSON_NO_PARAMETERS_ROW_TYPE),
-                            new Constant(TINYINT, 0L),
                             constantNull(VARCHAR),
                             new Constant(TINYINT, 0L),
-                            constantNull(VARCHAR))));
+                            new Lambda(ImmutableList.of(), constantNull(VARCHAR)),
+                            new Constant(TINYINT, 0L),
+                            new Lambda(ImmutableList.of(), constantNull(VARCHAR)))));
 
             return functionResolution.getExpressionCompiler()
                     .compilePageProcessor(Optional.empty(), jsonValueProjection, ImmutableMap.of(new Symbol(VARCHAR, "$col_0"), 0))

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonPathBinaryOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkJsonPathBinaryOperators.java
@@ -38,9 +38,11 @@ import io.trino.spi.type.TypeId;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import io.trino.testing.TestingSession;
+import io.trino.type.FunctionType;
 import io.trino.type.JsonPath2016Type;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -158,19 +160,21 @@ public class BenchmarkJsonPathBinaryOperators
                                     JSON_2016,
                                     jsonPath2016Type,
                                     JSON_NO_PARAMETERS_ROW_TYPE,
-                                    TINYINT,
                                     VARCHAR,
                                     TINYINT,
-                                    VARCHAR))),
+                                    new FunctionType(ImmutableList.of(), VARCHAR),
+                                    TINYINT,
+                                    new FunctionType(ImmutableList.of(), VARCHAR)))),
                     ImmutableList.of(
                             call(functionResolution.resolveFunction(VARCHAR_TO_JSON, fromTypes(VARCHAR, BOOLEAN)),
                                     new Reference(VARCHAR, "$col_0"), new Constant(BOOLEAN, true)),
                             new Constant(jsonPath2016Type, new IrJsonPath(false, path)),
                             constantNull(JSON_NO_PARAMETERS_ROW_TYPE),
-                            new Constant(TINYINT, 0L),
                             constantNull(VARCHAR),
                             new Constant(TINYINT, 0L),
-                            constantNull(VARCHAR))));
+                            new Lambda(ImmutableList.of(), constantNull(VARCHAR)),
+                            new Constant(TINYINT, 0L),
+                            new Lambda(ImmutableList.of(), constantNull(VARCHAR)))));
 
             return functionResolution.getExpressionCompiler()
                     .compilePageProcessor(Optional.empty(), jsonValueProjection, ImmutableMap.of(new Symbol(VARCHAR, "$col_0"), 0))

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestTryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestTryFunction.java
@@ -26,10 +26,13 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static io.trino.type.JsonType.JSON;
@@ -117,8 +120,28 @@ public class TestTryFunction
                 .binding("a", "-9223372036854775807 - 1"))
                 .isNull(BIGINT);
 
+        // JSON path evaluation error (strict path miss)
+        assertThat(assertions.expression("try(json_value('[1, 2, 3]', 'strict $[100]' ERROR ON ERROR))"))
+                .isNull(VARCHAR);
+
+        // JSON_VALUE result error (path returns multiple items)
+        assertThat(assertions.expression("try(json_value('[1, 2, 3]', 'lax $[0 to 2]' ERROR ON ERROR))"))
+                .isNull(VARCHAR);
+
+        // JSON input conversion error (malformed input)
+        assertThat(assertions.expression("try(json_value('[...', 'lax $[0]' ERROR ON ERROR))"))
+                .isNull(VARCHAR);
+
+        // JSON output conversion error (JSON_QUERY with empty path)
+        assertThat(assertions.expression("try(json_query('[1, 2, 3]', 'lax $[100]' ERROR ON EMPTY))"))
+                .isNull(VARCHAR);
+
         // Exceptions that should not be suppressed
         assertTrinoExceptionThrownBy(assertions.expression("try(throw_error())")::evaluate)
                 .hasErrorCode(GENERIC_INTERNAL_ERROR);
+        assertTrinoExceptionThrownBy(assertions.expression("try(fail('boom'))")::evaluate)
+                .hasErrorCode(GENERIC_USER_ERROR);
+        assertTrinoExceptionThrownBy(assertions.expression("try(json_object('a' : 1, 'a' : 2))")::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -6472,14 +6472,12 @@ public class TestAnalyzer
                 "                   DEFAULT 1.0 ON EMPTY) " +
                 "       FROM (VALUES '-1', 'ala') t(json_column)");
 
-        assertFails("SELECT JSON_VALUE( " +
+        analyze("SELECT JSON_VALUE( " +
                 "                   json_column, " +
                 "                   'lax $.double()'" +
                 "                   RETURNING double" +
                 "                   DEFAULT 'text' ON EMPTY) " +
-                "       FROM (VALUES '-1', 'ala') t(json_column)")
-                .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:149: Function JSON_VALUE default ON EMPTY result must evaluate to a double (actual: varchar(4))");
+                "       FROM (VALUES '-1', 'ala') t(json_column)");
 
         // default value has the same type as the declared returned type
         analyze("SELECT JSON_VALUE( " +
@@ -6497,14 +6495,32 @@ public class TestAnalyzer
                 "                   DEFAULT 1.0 ON ERROR) " +
                 "       FROM (VALUES '-1', 'ala') t(json_column)");
 
-        assertFails("SELECT JSON_VALUE( " +
+        analyze("SELECT JSON_VALUE( " +
                 "                   json_column, " +
                 "                   'lax $.double()'" +
                 "                   RETURNING double" +
                 "                   DEFAULT 'text' ON ERROR) " +
-                "       FROM (VALUES '-1', 'ala') t(json_column)")
+                "       FROM (VALUES '-1', 'ala') t(json_column)");
+
+        assertFails("""
+                SELECT *
+                FROM JSON_TABLE(
+                    '1',
+                    'lax $'
+                    COLUMNS(x DATE DEFAULT true ON EMPTY))
+                """)
                 .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:149: Function JSON_VALUE default ON ERROR result must evaluate to a double (actual: varchar(4))");
+                .hasMessageContaining("Function JSON_TABLE default ON EMPTY result must evaluate to a date");
+
+        assertFails("""
+                SELECT *
+                FROM JSON_TABLE(
+                    '1',
+                    'strict $'
+                    COLUMNS(x DATE DEFAULT true ON ERROR))
+                """)
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("Function JSON_TABLE default ON ERROR result must evaluate to a date");
     }
 
     @Test
@@ -7801,9 +7817,20 @@ public class TestAnalyzer
                 FROM JSON_TABLE(
                     (SELECT '[1, 2, 3]'),
                     'lax $[2]' PASSING (SELECT 1) AS parameter_name
+                    COLUMNS(x BIGINT))
+                """);
+
+        assertFails(
+                """
+                SELECT *
+                FROM JSON_TABLE(
+                    (SELECT '[1, 2, 3]'),
+                    'lax $[2]' PASSING (SELECT 1) AS parameter_name
                     COLUMNS(
                         x BIGINT DEFAULT (SELECT 2) ON EMPTY))
-                """);
+                """)
+                .hasErrorCode(UNSUPPORTED_SUBQUERY)
+                .hasMessageContaining("Subqueries are not supported in JSON_TABLE default expressions");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/JsonTablePlanComparator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/JsonTablePlanComparator.java
@@ -25,6 +25,7 @@ import io.trino.operator.table.json.JsonTableValueColumn;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -118,8 +119,8 @@ public class JsonTablePlanComparator
                 leftColumn.function().equals(rightColumn.function()) &&
                 leftColumn.path().equals(rightColumn.path()) &&
                 leftColumn.emptyBehavior() == rightColumn.emptyBehavior() &&
-                leftColumn.emptyDefaultInput() == rightColumn.emptyDefaultInput() &&
+                Objects.equals(leftColumn.emptyDefault(), rightColumn.emptyDefault()) &&
                 leftColumn.errorBehavior() == rightColumn.errorBehavior() &&
-                leftColumn.errorDefaultInput() == rightColumn.errorDefaultInput();
+                Objects.equals(leftColumn.errorDefault(), rightColumn.errorDefault());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestJsonTable.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestJsonTable.java
@@ -29,9 +29,11 @@ import io.trino.operator.table.json.JsonTablePlanSingle;
 import io.trino.operator.table.json.JsonTablePlanUnion;
 import io.trino.operator.table.json.JsonTableQueryColumn;
 import io.trino.operator.table.json.JsonTableValueColumn;
+import io.trino.spi.type.Type;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
 import io.trino.sql.planner.assertions.BasePlanTest;
@@ -39,6 +41,7 @@ import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.plan.TableFunctionNode;
 import io.trino.sql.tree.JsonQuery;
 import io.trino.sql.tree.JsonValue;
+import io.trino.type.FunctionType;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
@@ -78,9 +81,7 @@ public class TestJsonTable
 {
     private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
 
-    private static final ResolvedFunction JSON_VALUE_FUNCTION = FUNCTIONS.resolveFunction(
-            JSON_VALUE_FUNCTION_NAME,
-            fromTypes(JSON_2016, JSON_PATH_2016, JSON_NO_PARAMETERS_ROW_TYPE, TINYINT, BIGINT, TINYINT, BIGINT));
+    private static final ResolvedFunction JSON_VALUE_FUNCTION = jsonValueFunction(BIGINT, BIGINT, BIGINT);
 
     private static final ResolvedFunction JSON_QUERY_FUNCTION = FUNCTIONS.resolveFunction(
             JSON_QUERY_FUNCTION_NAME,
@@ -122,16 +123,13 @@ public class TestJsonTable
                                                         ImmutableMap.of(
                                                                 "context_item", expression(new Call(VARCHAR_TO_JSON, ImmutableList.of(new Reference(VARCHAR, "json_col_coerced"), FALSE))), // apply input function to context item
                                                                 "parameters_row", expression(new Cast(new Row(ImmutableList.of(new Reference(INTEGER, "int_col"), new Call(VARCHAR_TO_JSON, ImmutableList.of(new Reference(VARCHAR, "name_coerced"), FALSE)))), rowType(field("id", INTEGER), field("name", JSON_2016))))), // apply input function to formatted path parameter and gather path parameters in a row
-                                                        project(// coerce context item, path parameters and default expressions
+                                                        project(// coerce context item and path parameters (default expressions are evaluated lazily inside $json_value)
                                                                 ImmutableMap.of(
                                                                         "name_coerced", expression(new Cast(new Reference(createVarcharType(5), "name"), VARCHAR)), // cast formatted path parameter to VARCHAR for the input function
-                                                                        "default_value_coerced", expression(new Cast(new Reference(INTEGER, "default_value"), BIGINT)), // cast default value to BIGINT to match declared return type for the column
-                                                                        "json_col_coerced", expression(new Cast(new Reference(createVarcharType(9), "json_col"), VARCHAR)), // cast context item to VARCHAR for the input function
-                                                                        "int_col_coerced", expression(new Cast(new Reference(INTEGER, "int_col"), BIGINT))), // cast default value to BIGINT to match declared return type for the column
-                                                                project(// pre-project context item, path parameters and default expressions
+                                                                        "json_col_coerced", expression(new Cast(new Reference(createVarcharType(9), "json_col"), VARCHAR))), // cast context item to VARCHAR for the input function
+                                                                project(// pre-project path parameter
                                                                         ImmutableMap.of(
-                                                                                "name", expression(new Constant(createVarcharType(5), Slices.utf8Slice("[ala]"))),
-                                                                                "default_value", expression(new Constant(INTEGER, 5L))),
+                                                                                "name", expression(new Constant(createVarcharType(5), Slices.utf8Slice("[ala]")))),
                                                                         anyTree(
                                                                                 project(
                                                                                         ImmutableMap.of(
@@ -241,23 +239,24 @@ public class TestJsonTable
                                         0,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "A")),
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1,
+                                        null,
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1),
+                                        null),
                                 valueColumn(
                                         1,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "B")),
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1,
+                                        null,
                                         JsonValue.EmptyOrErrorBehavior.ERROR,
-                                        -1),
+                                        null),
                                 valueColumn(
                                         2,
+                                        jsonValueFunction(BIGINT, INTEGER, INTEGER),
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "C")),
                                         JsonValue.EmptyOrErrorBehavior.DEFAULT,
-                                        2,
+                                        new Constant(INTEGER, 1L),
                                         JsonValue.EmptyOrErrorBehavior.DEFAULT,
-                                        3),
+                                        new Constant(INTEGER, 2L)),
                                 queryColumn(
                                         3,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "D")),
@@ -298,9 +297,9 @@ public class TestJsonTable
                                         0,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "A")),
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1,
+                                        null,
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1))));
+                                        null))));
 
         // the column has no explicit error behavior, and json_table has explicit ERROR ON ERROR. The default behavior for column is ERROR ON ERROR.
         assertJsonTablePlan(
@@ -320,9 +319,9 @@ public class TestJsonTable
                                         0,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "A")),
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1,
+                                        null,
                                         JsonValue.EmptyOrErrorBehavior.ERROR,
-                                        -1))));
+                                        null))));
 
         // the column has no explicit error behavior, and json_table has explicit EMPTY ON ERROR. The default behavior for column is NULL ON ERROR.
         assertJsonTablePlan(
@@ -342,9 +341,9 @@ public class TestJsonTable
                                         0,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "A")),
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1,
+                                        null,
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1))));
+                                        null))));
 
         // the column has  explicit NULL ON ERROR behavior, and json_table has no explicit ERROR ON ERROR. The behavior for column is the one explicitly specified.
         assertJsonTablePlan(
@@ -364,9 +363,9 @@ public class TestJsonTable
                                         0,
                                         new IrJsonPath(true, memberAccessor(contextVariable(), "A")),
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1,
+                                        null,
                                         JsonValue.EmptyOrErrorBehavior.NULL,
-                                        -1))));
+                                        null))));
     }
 
     @Test
@@ -532,17 +531,37 @@ public class TestJsonTable
 
     private static JsonTableValueColumn valueColumn(int outputIndex, IrJsonPath path)
     {
-        return valueColumn(outputIndex, path, JsonValue.EmptyOrErrorBehavior.NULL, -1, JsonValue.EmptyOrErrorBehavior.NULL, -1);
+        return valueColumn(outputIndex, JSON_VALUE_FUNCTION, path, JsonValue.EmptyOrErrorBehavior.NULL, null, JsonValue.EmptyOrErrorBehavior.NULL, null);
     }
 
-    private static JsonTableValueColumn valueColumn(int outputIndex, IrJsonPath path, JsonValue.EmptyOrErrorBehavior emptyBehavior, int emptyDefaultInput, JsonValue.EmptyOrErrorBehavior errorBehavior, int errorDefaultInput)
+    private static JsonTableValueColumn valueColumn(int outputIndex, IrJsonPath path, JsonValue.EmptyOrErrorBehavior emptyBehavior, Expression emptyDefault, JsonValue.EmptyOrErrorBehavior errorBehavior, Expression errorDefault)
     {
-        return new JsonTableValueColumn(outputIndex, JSON_VALUE_FUNCTION, path, emptyBehavior.ordinal(), emptyDefaultInput, errorBehavior.ordinal(), errorDefaultInput);
+        return valueColumn(outputIndex, JSON_VALUE_FUNCTION, path, emptyBehavior, emptyDefault, errorBehavior, errorDefault);
+    }
+
+    private static JsonTableValueColumn valueColumn(int outputIndex, ResolvedFunction function, IrJsonPath path, JsonValue.EmptyOrErrorBehavior emptyBehavior, Expression emptyDefault, JsonValue.EmptyOrErrorBehavior errorBehavior, Expression errorDefault)
+    {
+        return new JsonTableValueColumn(outputIndex, function, path, emptyBehavior.ordinal(), emptyDefault, errorBehavior.ordinal(), errorDefault, ImmutableList.of());
     }
 
     private static JsonTableQueryColumn queryColumn(int outputIndex, IrJsonPath path, JsonQuery.ArrayWrapperBehavior wrapperBehavior, JsonQuery.EmptyOrErrorBehavior emptyBehavior, JsonQuery.EmptyOrErrorBehavior errorBehavior)
     {
         return new JsonTableQueryColumn(outputIndex, JSON_QUERY_FUNCTION, path, wrapperBehavior.ordinal(), emptyBehavior.ordinal(), errorBehavior.ordinal());
+    }
+
+    private static ResolvedFunction jsonValueFunction(Type returnType, Type emptyDefaultType, Type errorDefaultType)
+    {
+        return FUNCTIONS.resolveFunction(
+                JSON_VALUE_FUNCTION_NAME,
+                fromTypes(
+                        JSON_2016,
+                        JSON_PATH_2016,
+                        JSON_NO_PARAMETERS_ROW_TYPE,
+                        returnType,
+                        TINYINT,
+                        new FunctionType(ImmutableList.of(), emptyDefaultType),
+                        TINYINT,
+                        new FunctionType(ImmutableList.of(), errorDefaultType)));
     }
 
     private void assertJsonTablePlan(@Language("SQL") String sql, JsonTablePlanNode expectedPlan)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonTable.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonTable.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import static com.google.common.io.BaseEncoding.base16;
+import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.PATH_EVALUATION_ERROR;
+import static io.trino.spi.StandardErrorCode.UNSUPPORTED_SUBQUERY;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -96,7 +98,7 @@ public class TestJsonTable
     @Test
     public void testSubqueries()
     {
-        // test subqueries in: context item, value of path parameter "index", empty default, error default
+        // subqueries are supported in the context item and path parameter value
         assertThat(assertions.query(
                 """
                  SELECT empty_default, error_default
@@ -104,10 +106,23 @@ public class TestJsonTable
                      (SELECT json_col),
                      'lax $[$index]' PASSING (SELECT 0) AS "index"
                      COLUMNS(
-                         empty_default bigint PATH 'lax $[-42]' DEFAULT (SELECT -42) ON EMPTY,
-                         error_default bigint PATH 'strict $[42]' DEFAULT (SELECT 42) ON ERROR))
+                         empty_default bigint PATH 'lax $[-42]' DEFAULT -42 ON EMPTY,
+                         error_default bigint PATH 'strict $[42]' DEFAULT 42 ON ERROR))
                 """))
                 .matches("VALUES (BIGINT '-42', BIGINT '42')");
+
+        assertThat(assertions.query(
+                """
+                 SELECT empty_default
+                 FROM (SELECT '[[1, 2, 3], [4, 5, 6]]') t(json_col), JSON_TABLE(
+                     (SELECT json_col),
+                     'lax $[$index]' PASSING (SELECT 0) AS "index"
+                     COLUMNS(
+                         empty_default bigint PATH 'lax $[-42]' DEFAULT (SELECT -42) ON EMPTY))
+                """))
+                .failure()
+                .hasErrorCode(UNSUPPORTED_SUBQUERY)
+                .hasMessage("line 6:57: Subqueries are not supported in JSON_TABLE default expressions");
     }
 
     @Test
@@ -743,6 +758,33 @@ public class TestJsonTable
                      COLUMNS(a integer PATH 'strict $[42]' DEFAULT -1 ON EMPTY DEFAULT error_default ON ERROR))
                 """))
                 .matches("VALUES CAST(null AS integer)");
+    }
+
+    @Test
+    public void testDefaultExpressionEvaluationIsLazy()
+    {
+        assertThat(assertions.query(
+                """
+                 SELECT a
+                 FROM (SELECT CAST(x AS integer) - CAST(x AS integer) AS divisor FROM UNNEST(sequence(1, 1)) u(x)) t,
+                 JSON_TABLE(
+                     '[1, 2, 3]',
+                     'lax $'
+                     COLUMNS(a integer PATH 'lax $[0]' DEFAULT 1 / divisor ON EMPTY ERROR ON ERROR))
+                """))
+                .matches("VALUES 1");
+
+        assertThat(assertions.query(
+                """
+                 SELECT a
+                 FROM (SELECT CAST(x AS integer) - CAST(x AS integer) AS divisor FROM UNNEST(sequence(1, 1)) u(x)) t,
+                 JSON_TABLE(
+                     '[1, 2, 3]',
+                     'lax $'
+                     COLUMNS(a integer PATH 'lax $[42]' DEFAULT 1 / divisor ON EMPTY ERROR ON ERROR))
+                """))
+                .failure()
+                .hasErrorCode(DIVISION_BY_ZERO);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
@@ -21,11 +21,13 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
+import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_PATH;
 import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
 import static io.trino.spi.StandardErrorCode.JSON_VALUE_RESULT_ERROR;
 import static io.trino.spi.StandardErrorCode.PATH_EVALUATION_ERROR;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static io.trino.spi.StandardErrorCode.UNSUPPORTED_SUBQUERY;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -285,10 +287,106 @@ public class TestJsonValueFunction
                 "SELECT json_value('" + INPUT + "', 'lax 1000' RETURNING tinyint DEFAULT TINYINT '-1' ON ERROR)"))
                 .matches("VALUES TINYINT '-1'");
 
+        assertThat(assertions.query(
+                "SELECT json_value('" + INPUT + "', 'lax 1' RETURNING tinyint DEFAULT 1000 ON EMPTY)"))
+                .matches("VALUES TINYINT '1'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('" + INPUT + "', 'lax 1' RETURNING tinyint DEFAULT 1000 ON ERROR)"))
+                .matches("VALUES TINYINT '1'");
+
         // default value cast to the expected returned type
         assertThat(assertions.query(
                 "SELECT json_value('" + INPUT + "', 'lax 1000000000000 * 1000000000000' RETURNING bigint DEFAULT TINYINT '-1' ON ERROR)"))
                 .matches("VALUES BIGINT '-1'");
+    }
+
+    @Test
+    public void testDefaultExpressionEvaluationIsLazy()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax $[100]' RETURNING tinyint DEFAULT 100 / divisor ON EMPTY)
+                FROM (VALUES 2) t(divisor)
+                """))
+                .matches("VALUES TINYINT '50'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax 1' RETURNING tinyint DEFAULT 100 / divisor ON EMPTY)
+                FROM (VALUES 2) t(divisor)
+                """))
+                .matches("VALUES TINYINT '1'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax 1' RETURNING tinyint DEFAULT 100 / divisor ON EMPTY)
+                FROM (VALUES 0) t(divisor)
+                """))
+                .matches("VALUES TINYINT '1'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax $[100]' RETURNING tinyint DEFAULT 100 / divisor ON EMPTY DEFAULT TINYINT '9' ON ERROR)
+                FROM (VALUES 0) t(divisor)
+                """))
+                .matches("VALUES TINYINT '9'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax $[100]' RETURNING tinyint DEFAULT 100 / divisor ON EMPTY ERROR ON ERROR)
+                FROM (VALUES 0) t(divisor)
+                """))
+                .failure()
+                .hasErrorCode(DIVISION_BY_ZERO);
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax 1000' RETURNING tinyint DEFAULT 100 / divisor ON ERROR)
+                FROM (VALUES 2) t(divisor)
+                """))
+                .matches("VALUES TINYINT '50'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax 1' RETURNING tinyint DEFAULT 100 / divisor ON ERROR)
+                FROM (VALUES 2) t(divisor)
+                """))
+                .matches("VALUES TINYINT '1'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax 1' RETURNING tinyint DEFAULT 100 / divisor ON ERROR)
+                FROM (VALUES 0) t(divisor)
+                """))
+                .matches("VALUES TINYINT '1'");
+
+        assertThat(assertions.query(
+                """
+                SELECT json_value('[1, 2, 3]', 'lax 1000' RETURNING tinyint DEFAULT 100 / divisor ON ERROR)
+                FROM (VALUES 0) t(divisor)
+                """))
+                .failure()
+                .hasErrorCode(DIVISION_BY_ZERO);
+    }
+
+    @Test
+    public void testSubqueriesInDefaultExpressionAreRejected()
+    {
+        // Lazy evaluation requires that nested scalar subqueries only run when the default branch is taken
+        // (SQL:2023 subclause 9.48 defers VE evaluation inside CAST(VE AS DT) to the selected branch).
+        // Trino cannot evaluate scalar subqueries inside a scalar function, so defaults containing subqueries are rejected.
+        assertThat(assertions.query(
+                "SELECT json_value('[1, 2, 3]', 'lax $[100]' RETURNING bigint DEFAULT (SELECT 42) ON EMPTY)"))
+                .failure()
+                .hasErrorCode(UNSUPPORTED_SUBQUERY)
+                .hasMessageContaining("Subqueries are not supported in JSON_VALUE default expressions");
+
+        assertThat(assertions.query(
+                "SELECT json_value('[1, 2, 3]', 'strict $[100]' RETURNING bigint DEFAULT (SELECT 42) ON ERROR)"))
+                .failure()
+                .hasErrorCode(UNSUPPORTED_SUBQUERY)
+                .hasMessageContaining("Subqueries are not supported in JSON_VALUE default expressions");
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/conditional.md
+++ b/docs/src/main/sphinx/functions/conditional.md
@@ -132,6 +132,10 @@ The following errors are handled by `TRY`:
 - Division by zero
 - Invalid cast or function argument
 - Numeric value out of range
+- Invalid JSON literal
+- JSON input or output conversion errors
+- JSON path evaluation errors
+- JSON value function result errors
 
 ### Examples
 

--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -1054,6 +1054,11 @@ to the `ON ERROR` clause are:
 - JSON path evaluation errors, e.g. division by zero
 - Returned scalar not convertible to the desired type
 
+The `DEFAULT` expression in `ON EMPTY` and `ON ERROR` is only evaluated when
+the corresponding branch is taken. If evaluation of the `ON EMPTY` default
+itself raises a data exception, the failure cascades to the `ON ERROR` clause.
+Subqueries are not supported in `DEFAULT` expressions.
+
 ### Examples
 
 Let `customers` be a table containing two columns: `id:bigint`,
@@ -1229,6 +1234,12 @@ data.
 
 `ON ERROR` specifies how to handle processing errors. `ERROR ON ERROR` throws an
 error. `EMPTY ON ERROR` returns an empty result set.
+
+For each value column with `DEFAULT` in its `ON EMPTY` or `ON ERROR` clause,
+the default expression is only evaluated when the corresponding branch is
+taken, and if the `ON EMPTY` default itself raises a data exception, the
+failure cascades to the `ON ERROR` clause. Subqueries are not supported in
+`json_table` `DEFAULT` expressions.
 
 `column_name` specifies a column name.
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6585,10 +6585,19 @@ public abstract class AbstractTestEngineOnlyQueries
     @Test
     public void testSubqueryInJsonFunctions()
     {
-        // subqueries as: input item, passed parameter, empty default, error default
-        assertThat(query("SELECT json_value((SELECT json_input), 'strict $?(@ < $var)' PASSING (SELECT 3) AS \"var\" DEFAULT (SELECT 'x') ON EMPTY DEFAULT (SELECT 'y') ON ERROR) result " +
+        // subqueries as: input item, passed parameter
+        assertThat(query("SELECT json_value((SELECT json_input), 'strict $?(@ < $var)' PASSING (SELECT 3) AS \"var\" DEFAULT 'x' ON EMPTY DEFAULT 'y' ON ERROR) result " +
                 "              FROM (SELECT format('%s', regionkey) FROM region) t(json_input)")) // JSON number
                 .matches("VALUES VARCHAR '0', '1', '2', 'x', 'x'");
+
+        // subqueries are not supported in default expressions; the analyzer rejects them so the spec-mandated
+        // lazy evaluation of CAST(VE AS DT) is not subverted by pre-planning the subquery at the outer level
+        assertQueryFails(
+                "SELECT json_value('{}', 'lax $' DEFAULT (SELECT 'x') ON EMPTY)",
+                ".*Subqueries are not supported in JSON_VALUE default expressions");
+        assertQueryFails(
+                "SELECT json_value('{}', 'lax $' DEFAULT (SELECT 'x') ON ERROR)",
+                ".*Subqueries are not supported in JSON_VALUE default expressions");
     }
 
     @Test


### PR DESCRIPTION
SQL:2023 subclause 9.48 says JSON_VALUE evaluates and casts `DEFAULT <value expression>` ON EMPTY/ON ERROR only when the selected branch is taken.

Trino currently evaluates JSON_VALUE defaults eagerly because the hidden $json_value function receives them as ordinary arguments. That can fail even when the corresponding branch is never used, and it prevents ON EMPTY default failures from being handled by ON ERROR.

Pass the default expressions to $json_value as zero-argument lambdas, evaluate them only in the selected branch, and cast them to the declared return type there. 

## Release notes

```markdown
## General
* Evaluate {func}`json_value` and {func}`json_table` `ON EMPTY`/`ON ERROR` clauses lazily. ({issue}`TBD`)
```
