### PR TITLE
Fix failure when column names contain uppercase letters in table procedures

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -59,12 +59,10 @@ import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.SaveMode.REPLACE;
 import static io.trino.spi.expression.Constant.FALSE;
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Locale.ENGLISH;
 import static java.util.function.Function.identity;
-import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -149,17 +147,8 @@ public interface ConnectorMetadata
      */
     default Set<ColumnHandle> getColumnHandlesForTableExecute(ConnectorSession connectorSession, ConnectorTableHandle tableHandle, ConnectorTableExecuteHandle connectorTableExecuteHandle)
     {
-        Map<String, ColumnHandle> columnHandles = getColumnHandles(connectorSession, tableHandle);
-        return getTableMetadata(connectorSession, tableHandle).getColumns().stream()
-                .filter(not(ColumnMetadata::isHidden))
-                .map(ColumnMetadata::getName)
-                .map(columnName -> {
-                    ColumnHandle columnHandle = columnHandles.get(columnName);
-                    if (columnHandle == null) {
-                        throw new TrinoException(GENERIC_INTERNAL_ERROR, format("No handle found for column '%s' in table execute", columnName));
-                    }
-                    return columnHandle;
-                })
+        return getColumnHandles(connectorSession, tableHandle).values().stream()
+                .filter(column -> !getColumnMetadata(connectorSession, tableHandle, column).isHidden())
                 .collect(toUnmodifiableSet());
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2897,7 +2897,7 @@ public class DeltaLakeMetadata
             return Optional.empty();
         }
         Map<String, DeltaLakeColumnHandle> columnsByName = optimizeHandle.getTableColumns().stream()
-                .collect(toImmutableMap(DeltaLakeColumnHandle::columnName, identity()));
+                .collect(toImmutableMap(column -> column.columnName().toLowerCase(ENGLISH), identity()));
         ImmutableList.Builder<DeltaLakeColumnHandle> partitioningColumns = ImmutableList.builder();
         for (String columnName : partitionColumnNames) {
             partitioningColumns.add(columnsByName.get(columnName));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -878,6 +878,26 @@ public class TestDeltaLakeBasic
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test // regression test for https://github.com/trinodb/trino/issues/28970
+    void testOptimizeWithUppercaseColumnName()
+            throws Exception
+    {
+        String tableName = "test_optimize_with_uppercase_column_name_" + randomNameSuffix();
+        Path tableLocation = catalogDir.resolve(tableName);
+        copyDirectoryContents(new File(Resources.getResource("deltalake/case_sensitive").toURI()).toPath(), tableLocation);
+
+        assertUpdate("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')".formatted(tableName, tableLocation.toUri()));
+        assertQueryReturnsEmptyResult("SELECT * FROM " + tableName);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, 11)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, 22)", 1);
+
+        assertUpdate("ALTER TABLE " + tableName + " EXECUTE optimize");
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("VALUES (1, 11), (2, 22)");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     @Test
     public void testAppendOnly()
             throws Exception

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2018,32 +2018,23 @@ public class IcebergMetadata
         IcebergTableExecuteHandle executeHandle = (IcebergTableExecuteHandle) tableExecuteHandle;
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         return switch (executeHandle.procedureId()) {
-            case OPTIMIZE -> getColumnHandlesForOptimize(session, icebergTableHandle, icebergTableHandle.getFormatVersion());
+            case OPTIMIZE -> getColumnHandlesForOptimize(icebergTableHandle);
             case OPTIMIZE_MANIFESTS, DROP_EXTENDED_STATS, ROLLBACK_TO_SNAPSHOT, EXPIRE_SNAPSHOTS, REMOVE_ORPHAN_FILES, ADD_FILES, ADD_FILES_FROM_TABLE ->
                     throw new IllegalArgumentException("Unknown procedure '" + executeHandle.procedureId() + "'");
         };
     }
 
-    private Set<ColumnHandle> getColumnHandlesForOptimize(ConnectorSession session, IcebergTableHandle tableHandle, int formatVersion)
+    private Set<ColumnHandle> getColumnHandlesForOptimize(IcebergTableHandle table)
     {
-        Map<String, ColumnHandle> columnHandles = getColumnHandles(session, tableHandle);
-        return getTableMetadata(session, tableHandle).getColumns().stream()
-                .filter(column -> isOptimizeReadColumn(formatVersion, column))
-                .map(ColumnMetadata::getName)
-                .map(columnName -> requireNonNull(columnHandles.get(columnName), "Cannot find column handle for " + columnName))
-                .collect(toImmutableSet());
-    }
-
-    private static boolean isOptimizeReadColumn(int formatVersion, ColumnMetadata column)
-    {
-        if (!column.isHidden()) {
-            return true;
+        ImmutableSet.Builder<ColumnHandle> columnHandles = ImmutableSet.builder();
+        for (IcebergColumnHandle columnHandle : getTopLevelColumns(SchemaParser.fromJson(table.getTableSchemaJson()), typeManager)) {
+            columnHandles.add(columnHandle);
         }
-        if (formatVersion < 3) {
-            return false;
+        if (table.getFormatVersion() >= 3) {
+            columnHandles.add(rowIdColumnHandle());
+            columnHandles.add(lastUpdatedSequenceNumberColumnHandle());
         }
-        String columnName = column.getName();
-        return columnName.equals(ROW_ID.getColumnName()) || columnName.equals(LAST_UPDATED_SEQUENCE_NUMBER.getColumnName());
+        return columnHandles.build();
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -3065,6 +3065,25 @@ public class TestIcebergSparkCompatibility
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
 
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}) // regression test for https://github.com/trinodb/trino/issues/28970
+    public void testTrinoOptimizeWithNonLowercaseColumnName()
+    {
+        String baseTableName = "test_trino_optimize_with_uppercase_field" + randomNameSuffix();
+        String trinoTableName = trinoTableName(baseTableName);
+        String sparkTableName = sparkTableName(baseTableName);
+
+        onSpark().executeQuery("CREATE TABLE " + sparkTableName + "(col1 INT, COL2 INT) USING ICEBERG");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (1, 1)");
+        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES (2, 2)");
+        onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE optimize");
+
+        List<Row> expected = ImmutableList.of(row(1, 1), row(2, 2));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+
+        onSpark().executeQuery("DROP TABLE " + sparkTableName);
+    }
+
     @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "storageFormats")
     public void testRegisterTableWithTableLocation(StorageFormat storageFormat)
             throws TException


### PR DESCRIPTION
## Description

1536db9 introduced this bug. The getColumnHandles method may return uppercase keys, while getTableMetadata internally lowercases column names.

* Fixes #28970

## Release notes

```markdown
## General, Iceberg, Delta Lake
* Fix failure when executing table procedures on tables with uppercase column names. ({issue}`28970`)
```
