### PR TITLE
Add exponential backoff handling for Google Sheets API requests

### DIFF
--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsClient.java
@@ -15,9 +15,12 @@ package io.trino.plugin.google.sheets;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.SheetsScopes;
 import com.google.api.services.sheets.v4.model.ValueRange;
@@ -68,6 +71,13 @@ public class SheetsClient
     public static final String DEFAULT_RANGE = "$1:$10000";
     public static final String RANGE_SEPARATOR = "#";
     private static final Logger log = Logger.get(SheetsClient.class);
+
+    public static final ExponentialBackOff BACKOFF = new ExponentialBackOff.Builder()
+            .setInitialIntervalMillis(500)
+            .setMaxIntervalMillis(10_000)
+            .setMaxElapsedTimeMillis(60_000)
+            .setMultiplier(1.5)
+            .build();
 
     private static final String APPLICATION_NAME = "trino google sheets integration";
     private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
@@ -333,6 +343,8 @@ public class SheetsClient
             httpRequest.setConnectTimeout(toIntExact(config.getConnectionTimeout().toMillis()));
             httpRequest.setReadTimeout(toIntExact(config.getReadTimeout().toMillis()));
             httpRequest.setWriteTimeout(toIntExact(config.getWriteTimeout().toMillis()));
+            httpRequest.setUnsuccessfulResponseHandler(new HttpBackOffUnsuccessfulResponseHandler(BACKOFF));
+            httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(BACKOFF));
         };
     }
 }

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.google.sheets;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.sheets.v4.Sheets;
@@ -36,6 +38,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.api.client.googleapis.javanet.GoogleNetHttpTransport.newTrustedTransport;
+import static io.trino.plugin.google.sheets.SheetsClient.BACKOFF;
 import static io.trino.plugin.google.sheets.TestSheetsPlugin.DATA_SHEET_ID;
 import static io.trino.plugin.google.sheets.TestSheetsPlugin.getTestCredentialsPath;
 import static io.trino.testing.assertions.Assert.assertEventually;
@@ -329,6 +332,8 @@ public class TestGoogleSheets
             requestInitializer.initialize(httpRequest);
             httpRequest.setConnectTimeout(toIntExact(TimeUnit.MINUTES.toMillis(1)));
             httpRequest.setReadTimeout(toIntExact(TimeUnit.MINUTES.toMillis(1)));
+            httpRequest.setUnsuccessfulResponseHandler(new HttpBackOffUnsuccessfulResponseHandler(BACKOFF));
+            httpRequest.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(BACKOFF));
         };
     }
 }


### PR DESCRIPTION
## Description

Hope this change mitigates a flaky issue: 
```
com.google.api.client.googleapis.json.GoogleJsonResponseException: 
503 Service Unavailable
POST https://sheets.googleapis.com/v4/spreadsheets?fields=spreadsheetId
{
  "code" : 503,
  "errors" : [ {
    "domain" : "global",
    "message" : "The service is currently unavailable.",
    "reason" : "backendError"
  } ],
  "message" : "The service is currently unavailable.",
  "status" : "UNAVAILABLE"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$3.interceptResponse(AbstractGoogleClientRequest.java:479)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:565)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:506)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:616)
	at io.trino.plugin.google.sheets.TestGoogleSheets.createSpreadsheetWithTestdata(TestGoogleSheets.java:81)
	at io.trino.plugin.google.sheets.TestGoogleSheets.createQueryRunner(TestGoogleSheets.java:59)

[ERROR] Tests run: 12, Failures: 0, Errors: 1, Skipped: 0
[ERROR] TestGoogleSheets.createQueryRunner:59->createSpreadsheetWithTestdata:81 - GoogleJsonResponse 503 Service Unavailable
CI job: google-sheets-tests | Run: 23673083486 | Job: 68970575570
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
