### PR TITLE
Allow hyphen in Azure OneLake account name URI

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
@@ -28,7 +28,7 @@ class AzureLocation
 
     // https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
     private static final CharMatcher CONTAINER_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9')).or(CharMatcher.is('-'));
-    private static final CharMatcher STORAGE_ACCOUNT_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9'));
+    private static final CharMatcher STORAGE_ACCOUNT_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9')).or(CharMatcher.is('-'));
 
     private final Location location;
     private final String scheme;

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
@@ -28,6 +28,7 @@ class TestAzureLocation
     {
         assertValid("abfs://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfs", "core.windows.net");
         assertValid("abfss://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfss", "core.windows.net");
+        assertValid("abfss://container@account-onelake.dfs.fabric.microsoft.com/some/path/file", "account-onelake", "container", "some/path/file", "abfss", "fabric.microsoft.com");
         assertValid("wasb://container@account.blob.core.windows.net/some/path/file", "account", "container", "some/path/file", "wasb", "core.windows.net");
         assertValid("wasbs://container@account.blob.core.windows.net/some/path/file", "account", "container", "some/path/file", "wasbs", "core.windows.net");
 
@@ -73,8 +74,7 @@ class TestAzureLocation
         assertInvalid("abfs://con---tainer@account.dfs.core.windows.net/some/path/file");
         assertInvalid("abfs://con--tainer@account.dfs.core.windows.net/some/path/file");
 
-        // account is only a-z and 0-9
-        assertInvalid("abfs://container@ac-count.dfs.core.windows.net/some/path/file");
+        // account is only a-z, 0-9 and -
         assertInvalid("abfs://container@ac_count.dfs.core.windows.net/some/path/file");
         assertInvalid("abfs://container@ac$count.dfs.core.windows.net/some/path/file");
 


### PR DESCRIPTION
## Description

Allow hyphen in Azure OneLake account name URI.

- Fixes https://github.com/trinodb/trino/issues/28983

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
