### PR TITLE
Expose add files metrics in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2253,11 +2253,9 @@ public class IcebergMetadata
             case REMOVE_ORPHAN_FILES:
                 return executeRemoveOrphanFiles(session, executeHandle);
             case ADD_FILES:
-                executeAddFiles(session, executeHandle);
-                return ImmutableMap.of();
+                return executeAddFiles(session, executeHandle);
             case ADD_FILES_FROM_TABLE:
-                executeAddFilesFromTable(session, executeHandle);
-                return ImmutableMap.of();
+                return executeAddFilesFromTable(session, executeHandle);
             default:
                 throw new IllegalArgumentException("Unknown procedure '" + executeHandle.procedureId() + "'");
         }
@@ -2626,12 +2624,12 @@ public class IcebergMetadata
                 "deleted_files_count", result.deletedFilesCount());
     }
 
-    public void executeAddFiles(ConnectorSession session, IcebergTableExecuteHandle executeHandle)
+    public Map<String, Long> executeAddFiles(ConnectorSession session, IcebergTableExecuteHandle executeHandle)
     {
         IcebergAddFilesHandle addFilesHandle = (IcebergAddFilesHandle) executeHandle.procedureHandle();
         Table table = catalog.loadTable(session, executeHandle.schemaTableName());
         TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
-        addFiles(
+        long addedDataFiles = addFiles(
                 session,
                 fileSystem,
                 catalog,
@@ -2640,14 +2638,15 @@ public class IcebergMetadata
                 addFilesHandle.format(),
                 addFilesHandle.recursiveDirectory(),
                 icebergScanExecutor);
+        return ImmutableMap.of("added_data_files", addedDataFiles);
     }
 
-    public void executeAddFilesFromTable(ConnectorSession session, IcebergTableExecuteHandle executeHandle)
+    public Map<String, Long> executeAddFilesFromTable(ConnectorSession session, IcebergTableExecuteHandle executeHandle)
     {
         IcebergAddFilesFromTableHandle addFilesHandle = (IcebergAddFilesFromTableHandle) executeHandle.procedureHandle();
         Table table = catalog.loadTable(session, executeHandle.schemaTableName());
         TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
-        addFilesFromTable(
+        long addedDataFiles = addFilesFromTable(
                 session,
                 fileSystem,
                 metastoreFactory.orElseThrow(),
@@ -2656,6 +2655,7 @@ public class IcebergMetadata
                 addFilesHandle.partitionFilter(),
                 addFilesHandle.recursiveDirectory(),
                 icebergScanExecutor);
+        return ImmutableMap.of("added_data_files", addedDataFiles);
     }
 
     private ScanAndDeleteResult scanAndDeleteInvalidFiles(Table table, ConnectorSession session, SchemaTableName schemaTableName, Instant expiration, Set<String> validFiles, Map<String, String> fileIoProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
@@ -163,7 +163,7 @@ public final class MigrationUtils
         }
     }
 
-    public static void addFiles(
+    public static long addFiles(
             ConnectorSession session,
             TrinoFileSystem fileSystem,
             TrinoCatalog catalog,
@@ -180,7 +180,7 @@ public final class MigrationUtils
 
         try {
             List<DataFile> dataFiles = buildDataFilesFromLocation(fileSystem, recursiveDirectory, format, location, partitionSpec, Optional.empty(), table.schema());
-            addFiles(session, table, dataFiles, icebergScanExecutor);
+            return addFiles(session, table, dataFiles, icebergScanExecutor);
         }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add files: " + requireNonNullElse(e.getMessage(), e), e);
@@ -210,7 +210,7 @@ public final class MigrationUtils
         throw new TrinoException(NOT_FOUND, "Location not found: " + location);
     }
 
-    public static void addFilesFromTable(
+    public static long addFilesFromTable(
             ConnectorSession session,
             TrinoFileSystem fileSystem,
             HiveMetastoreFactory metastoreFactory,
@@ -255,7 +255,7 @@ public final class MigrationUtils
                         .set(DEFAULT_NAME_MAPPING, toJson(nameMapping))
                         .commit();
             }
-            addFiles(session, targetTable, dataFilesBuilder.build(), icebergScanExecutor);
+            return addFiles(session, targetTable, dataFilesBuilder.build(), icebergScanExecutor);
         }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add files: " + requireNonNullElse(e.getMessage(), e), e);
@@ -273,7 +273,7 @@ public final class MigrationUtils
         return dataFile.build();
     }
 
-    public static void addFiles(ConnectorSession session, Table table, List<DataFile> dataFiles, ExecutorService icebergScanExecutor)
+    public static long addFiles(ConnectorSession session, Table table, List<DataFile> dataFiles, ExecutorService icebergScanExecutor)
     {
         Schema schema = table.schema();
         Set<Integer> requiredFields = schema.columns().stream()
@@ -326,6 +326,7 @@ public final class MigrationUtils
             appendFiles.commit();
             transaction.commitTransaction();
             log.debug("Successfully added files to %s table", table.name());
+            return dataFiles.size();
         }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add files: " + requireNonNullElse(e.getMessage(), e), e);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java
@@ -84,7 +84,9 @@ final class TestIcebergAddFilesProcedure
         assertUpdate("CREATE TABLE hive.tpch." + hiveTableName + " AS SELECT 1 x", 1);
         assertUpdate("CREATE TABLE iceberg.tpch." + icebergTableName + " AS SELECT 2 x", 1);
 
-        assertUpdate("ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table('tpch', '" + hiveTableName + "')");
+        assertUpdate(
+                "ALTER TABLE " + icebergTableName + " EXECUTE add_files_from_table('tpch', '" + hiveTableName + "')",
+                "VALUES ('added_data_files', 1)");
 
         assertQuery("SELECT * FROM hive.tpch." + hiveTableName, "VALUES 1");
         assertQuery("SELECT * FROM iceberg.tpch." + icebergTableName, "VALUES 1, 2");
@@ -484,7 +486,9 @@ final class TestIcebergAddFilesProcedure
 
         String path = (String) computeScalar("SELECT \"$path\" FROM hive.tpch." + hiveTableName);
 
-        assertUpdate("ALTER TABLE " + icebergTableName + " EXECUTE add_files('" + path + "', 'ORC')");
+        assertUpdate(
+                "ALTER TABLE " + icebergTableName + " EXECUTE add_files('" + path + "', 'ORC')",
+                "VALUES ('added_data_files', 1)");
 
         assertQuery("SELECT * FROM iceberg.tpch." + icebergTableName, "VALUES 1, 2");
 


### PR DESCRIPTION
## Release notes

```markdown
## Iceberg
* Return execution metrics while running the `add_files` and `add_files_from_table` commands. ({issue}`28996`)
```
