### PR TITLE
Add support for refreshable vended credentials refresh for Iceberg REST catalog (S3, GCS, Azure)

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -838,7 +838,9 @@
                                 <exclude>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
+                                <exclude>**/TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.java</exclude>
                                 <exclude>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</exclude>
+                                <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
                                 <exclude>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</exclude>
@@ -907,7 +909,9 @@
                                 <include>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
+                                <include>**/TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.java</include>
                                 <include>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</include>
+                                <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestTrinoSnowflakeCatalog.java</include>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AbstractIcebergRestVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AbstractIcebergRestVendedCredentialsProvider.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.rest.ErrorHandlers;
+import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for storage-specific vended credential providers that refresh
+ * credentials by calling the Iceberg REST catalog's credentials endpoint
+ * 5 minutes before they expire, similar to {@code org.apache.iceberg.aws.s3.VendedCredentialsProvider}.
+ */
+abstract class AbstractIcebergRestVendedCredentialsProvider<T extends VendedCredentials>
+        implements VendedCredentialsProvider<T>
+{
+    static final long PREFETCH_MINUTES = 5;
+
+    private final Map<String, String> properties;
+    private final String catalogEndpoint;
+    private final boolean refreshCredentialsEnabled;
+    private final Optional<String> credentialsEndpoint;
+    private volatile T cached;
+
+    AbstractIcebergRestVendedCredentialsProvider(
+            Map<String, String> catalogProperties,
+            Map<String, String> fileIoProperties,
+            boolean refreshCredentialsEnabled,
+            Optional<String> credentialsEndpoint,
+            T initialCredentials)
+    {
+        requireNonNull(catalogProperties, "catalogProperties is null");
+        requireNonNull(fileIoProperties, "fileIoProperties is null");
+        // Follows the merge logic of catalog & table properties from org.apache.iceberg.rest.RESTSessionCatalog.tableFileIO
+        // https://github.com/apache/iceberg/blob/b25cb522ccaddacc4e7be4dcf48fc80dd7b823dd/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L1216
+        this.properties = RESTUtil.merge(catalogProperties, fileIoProperties);
+        this.catalogEndpoint = requireNonNull(properties.get(CatalogProperties.URI), "catalog endpoint is null");
+        this.refreshCredentialsEnabled = refreshCredentialsEnabled;
+        this.credentialsEndpoint = requireNonNull(credentialsEndpoint, "credentialsEndpoint is null");
+        this.cached = requireNonNull(initialCredentials, "initialCredentials is null");
+    }
+
+    @Override
+    public T getCredentials()
+    {
+        T current = cached;
+        if (shouldRefresh(current)) {
+            synchronized (this) {
+                current = cached;
+                if (shouldRefresh(current)) {
+                    current = refreshCachedState();
+                    cached = current;
+                }
+            }
+        }
+        return current;
+    }
+
+    private boolean shouldRefresh(T vendedCredentials)
+    {
+        return refreshCredentialsEnabled &&
+                credentialsEndpoint.isPresent() &&
+                isStale(vendedCredentials);
+    }
+
+    private boolean isStale(T vendedCredentials)
+    {
+        Optional<Instant> expiresAt = vendedCredentials.expiresAt();
+        return expiresAt.isPresent() && Instant.now().isAfter(expiresAt.get().minus(PREFETCH_MINUTES, ChronoUnit.MINUTES));
+    }
+
+    private T refreshCachedState()
+    {
+        LoadCredentialsResponse response = fetchCredentials();
+        return applyRefreshedCredentials(response.credentials());
+    }
+
+    private LoadCredentialsResponse fetchCredentials()
+    {
+        try (AuthManager authManager = AuthManagers.loadAuthManager("credentials-refresh", properties);
+                HTTPClient httpClient = HTTPClient.builder(properties)
+                        .uri(catalogEndpoint)
+                        .withHeaders(RESTUtil.configHeaders(properties))
+                        .build()) {
+            AuthSession authSession = authManager.catalogSession(httpClient, properties);
+            return httpClient.withAuthSession(authSession).get(
+                    credentialsEndpoint.orElseThrow(),
+                    null,
+                    LoadCredentialsResponse.class,
+                    Map.of(),
+                    ErrorHandlers.defaultErrorHandler());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to fetch vended credentials", e);
+        }
+    }
+
+    protected abstract T applyRefreshedCredentials(List<Credential> credentials);
+
+    protected static boolean parseBoolean(Map<String, String> properties, String key, boolean defaultValue)
+    {
+        String value = properties.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
+            return Boolean.parseBoolean(value);
+        }
+        throw new IllegalArgumentException("Invalid boolean value for property '%s': %s".formatted(key, value));
+    }
+
+    protected static Optional<Instant> parseInstantEpochMillis(Map<String, String> properties, String key)
+    {
+        String value = properties.get(key);
+        if (value == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Instant.ofEpochMilli(Long.parseLong(value)));
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid epoch millis value for property '%s': %s".formatted(key, value), e);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentials.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static io.trino.filesystem.azure.AzureFileSystemConstants.EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX;
+import static java.util.Objects.requireNonNull;
+
+record AzureVendedCredentials(Map<String, String> sasTokens, Optional<Instant> expirationTime)
+        implements VendedCredentials
+{
+    public AzureVendedCredentials
+    {
+        sasTokens = ImmutableMap.copyOf(sasTokens);
+        requireNonNull(expirationTime, "expirationTime is null");
+    }
+
+    @Override
+    public Map<String, String> toExtraCredentials()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (Entry<String, String> entry : sasTokens.entrySet()) {
+            builder.put(EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX + entry.getKey(), entry.getValue());
+        }
+        return builder.buildOrThrow();
+    }
+
+    @Override
+    public Optional<Instant> expiresAt()
+    {
+        return expirationTime;
+    }
+
+    /**
+     * Returns the SAS token for the given storage account, or {@code null} if none is present.
+     */
+    public String get(String storageAccount)
+    {
+        return sasTokens.get(storageAccount);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
@@ -49,7 +49,7 @@ final class AzureVendedCredentialsProvider
                 .collect(toImmutableList()));
     }
 
-    private static AzureVendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
+    public static AzureVendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
     {
         return parseAzureVendedCredentials(fileIoProperties.entrySet());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.credentials.Credential;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.apache.iceberg.azure.AzureProperties.ADLS_REFRESH_CREDENTIALS_ENABLED;
+import static org.apache.iceberg.azure.AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT;
+import static org.apache.iceberg.azure.AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX;
+import static org.apache.iceberg.azure.AzureProperties.ADLS_SAS_TOKEN_PREFIX;
+
+final class AzureVendedCredentialsProvider
+        extends AbstractIcebergRestVendedCredentialsProvider<AzureVendedCredentials>
+{
+    AzureVendedCredentialsProvider(Map<String, String> catalogProperties, Map<String, String> fileIoProperties)
+    {
+        super(
+                catalogProperties,
+                fileIoProperties,
+                parseBoolean(fileIoProperties, ADLS_REFRESH_CREDENTIALS_ENABLED, true),
+                Optional.ofNullable(fileIoProperties.get(ADLS_REFRESH_CREDENTIALS_ENDPOINT)),
+                createVendedCredentials(fileIoProperties));
+    }
+
+    @Override
+    protected AzureVendedCredentials applyRefreshedCredentials(List<Credential> credentials)
+    {
+        return parseAzureVendedCredentials(credentials.stream()
+                .flatMap(credential -> credential.config().entrySet().stream())
+                .collect(toImmutableList()));
+    }
+
+    private static AzureVendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
+    {
+        return parseAzureVendedCredentials(fileIoProperties.entrySet());
+    }
+
+    private static AzureVendedCredentials parseAzureVendedCredentials(Iterable<Entry<String, String>> properties)
+    {
+        ImmutableMap.Builder<String, String> sasTokensBuilder = ImmutableMap.builder();
+        Instant earliest = null;
+        for (Entry<String, String> entry : properties) {
+            if (entry.getKey().startsWith(ADLS_SAS_TOKEN_PREFIX)) {
+                String account = entry.getKey().substring(ADLS_SAS_TOKEN_PREFIX.length());
+                sasTokensBuilder.put(account, entry.getValue());
+            }
+            if (entry.getKey().startsWith(ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX)) {
+                Instant expiresAt = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));
+                if (earliest == null || expiresAt.isBefore(earliest)) {
+                    earliest = expiresAt;
+                }
+            }
+        }
+        return new AzureVendedCredentials(sasTokensBuilder.buildOrThrow(), Optional.ofNullable(earliest));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GcsVendedCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GcsVendedCredentials.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
+import static java.util.Objects.requireNonNull;
+
+record GcsVendedCredentials(String token, Optional<Instant> expirationTime)
+        implements VendedCredentials
+{
+    public GcsVendedCredentials
+    {
+        requireNonNull(token, "token is null");
+        requireNonNull(expirationTime, "expirationTime is null");
+    }
+
+    @Override
+    public Map<String, String> toExtraCredentials()
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        builder.put(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, token);
+        expirationTime.ifPresent(expirationTime -> builder.put(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY, String.valueOf(expirationTime.toEpochMilli())));
+        return builder.buildOrThrow();
+    }
+
+    @Override
+    public Optional<Instant> expiresAt()
+    {
+        return expirationTime;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GcsVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GcsVendedCredentialsProvider.java
@@ -53,7 +53,7 @@ final class GcsVendedCredentialsProvider
         return createVendedCredentials(config);
     }
 
-    private static GcsVendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
+    public static GcsVendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
     {
         return new GcsVendedCredentials(
                 fileIoProperties.get(GCS_OAUTH2_TOKEN),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GcsVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GcsVendedCredentialsProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.rest.credentials.Credential;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT;
+
+final class GcsVendedCredentialsProvider
+        extends AbstractIcebergRestVendedCredentialsProvider<GcsVendedCredentials>
+{
+    GcsVendedCredentialsProvider(
+            Map<String, String> catalogProperties,
+            Map<String, String> fileIoProperties)
+    {
+        super(
+                catalogProperties,
+                fileIoProperties,
+                parseBoolean(fileIoProperties, GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, true),
+                Optional.ofNullable(fileIoProperties.get(GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT)),
+                createVendedCredentials(fileIoProperties));
+    }
+
+    @Override
+    protected GcsVendedCredentials applyRefreshedCredentials(List<Credential> credentials)
+    {
+        Credential gcsCredential = credentials.stream()
+                .filter(credential -> credential.prefix().startsWith("gs"))
+                .reduce((_, _) -> {
+                    throw new IllegalStateException("Multiple GCS credentials returned");
+                })
+                .orElseThrow(() -> new IllegalStateException("No GCS credentials in refresh response"));
+
+        Map<String, String> config = gcsCredential.config();
+        return createVendedCredentials(config);
+    }
+
+    private static GcsVendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
+    {
+        return new GcsVendedCredentials(
+                fileIoProperties.get(GCS_OAUTH2_TOKEN),
+                parseInstantEpochMillis(fileIoProperties, GCS_OAUTH2_TOKEN_EXPIRES_AT));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.airlift.units.Duration;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.filesystem.UriLocation;
+import io.trino.filesystem.encryption.EncryptionKey;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
+
+public class IcebergRestCatalogFileSystem
+        implements TrinoFileSystem
+{
+    private final Function<Location, TrinoFileSystem> loader;
+
+    public IcebergRestCatalogFileSystem(Function<Location, TrinoFileSystem> loader)
+    {
+        this.loader = requireNonNull(loader, "loader is null");
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location)
+    {
+        return fileSystem(location).newInputFile(location);
+    }
+
+    @Override
+    public TrinoInputFile newEncryptedInputFile(Location location, EncryptionKey key)
+    {
+        return fileSystem(location).newEncryptedInputFile(location, key);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length)
+    {
+        return fileSystem(location).newInputFile(location, length);
+    }
+
+    @Override
+    public TrinoInputFile newEncryptedInputFile(Location location, long length, EncryptionKey key)
+    {
+        return fileSystem(location).newEncryptedInputFile(location, length, key);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return fileSystem(location).newInputFile(location, length, lastModified);
+    }
+
+    @Override
+    public TrinoInputFile newEncryptedInputFile(Location location, long length, Instant lastModified, EncryptionKey key)
+    {
+        return fileSystem(location).newEncryptedInputFile(location, length, lastModified, key);
+    }
+
+    @Override
+    public TrinoOutputFile newOutputFile(Location location)
+    {
+        return fileSystem(location).newOutputFile(location);
+    }
+
+    @Override
+    public TrinoOutputFile newEncryptedOutputFile(Location location, EncryptionKey key)
+    {
+        return fileSystem(location).newEncryptedOutputFile(location, key);
+    }
+
+    @Override
+    public void deleteFile(Location location)
+            throws IOException
+    {
+        fileSystem(location).deleteFile(location);
+    }
+
+    @Override
+    public void deleteFiles(Collection<Location> locations)
+            throws IOException
+    {
+        Map<TrinoFileSystem, List<Location>> groups = locations.stream().collect(groupingBy(loader));
+        for (var entry : groups.entrySet()) {
+            entry.getKey().deleteFiles(entry.getValue());
+        }
+    }
+
+    @Override
+    public void deleteDirectory(Location location)
+            throws IOException
+    {
+        fileSystem(location).deleteDirectory(location);
+    }
+
+    @Override
+    public void renameFile(Location source, Location target)
+            throws IOException
+    {
+        fileSystem(source).renameFile(source, target);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location)
+            throws IOException
+    {
+        return fileSystem(location).listFiles(location);
+    }
+
+    @Override
+    public Optional<Boolean> directoryExists(Location location)
+            throws IOException
+    {
+        return fileSystem(location).directoryExists(location);
+    }
+
+    @Override
+    public void createDirectory(Location location)
+            throws IOException
+    {
+        fileSystem(location).createDirectory(location);
+    }
+
+    @Override
+    public void renameDirectory(Location source, Location target)
+            throws IOException
+    {
+        fileSystem(source).renameDirectory(source, target);
+    }
+
+    @Override
+    public Set<Location> listDirectories(Location location)
+            throws IOException
+    {
+        return fileSystem(location).listDirectories(location);
+    }
+
+    @Override
+    public Optional<Location> createTemporaryDirectory(Location targetPath, String temporaryPrefix, String relativePrefix)
+            throws IOException
+    {
+        return fileSystem(targetPath).createTemporaryDirectory(targetPath, temporaryPrefix, relativePrefix);
+    }
+
+    @Override
+    public Optional<UriLocation> preSignedUri(Location location, Duration ttl)
+            throws IOException
+    {
+        return fileSystem(location).preSignedUri(location, ttl);
+    }
+
+    @Override
+    public Optional<UriLocation> encryptedPreSignedUri(Location location, Duration ttl, EncryptionKey key)
+            throws IOException
+    {
+        return fileSystem(location).encryptedPreSignedUri(location, ttl, key);
+    }
+
+    private TrinoFileSystem fileSystem(Location location)
+    {
+        return loader.apply(location);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -24,15 +24,10 @@ import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
 
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Supplier;
 
-import static io.trino.filesystem.azure.AzureFileSystemConstants.EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX;
-import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
-import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
-import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
-import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
-import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergRestCatalogFileSystemFactory
@@ -40,59 +35,96 @@ public class IcebergRestCatalogFileSystemFactory
 {
     private final TrinoFileSystemFactory fileSystemFactory;
     private final boolean vendedCredentialsEnabled;
+    private final Map<String, String> catalogProperties;
 
     @Inject
-    public IcebergRestCatalogFileSystemFactory(TrinoFileSystemFactory fileSystemFactory, IcebergRestCatalogConfig config)
+    public IcebergRestCatalogFileSystemFactory(
+            TrinoFileSystemFactory fileSystemFactory,
+            IcebergRestCatalogConfig config,
+            IcebergRestCatalogPropertiesProvider catalogPropertiesProvider)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.vendedCredentialsEnabled = config.isVendedCredentialsEnabled();
+        this.catalogProperties = ImmutableMap.copyOf(catalogPropertiesProvider.catalogProperties());
     }
 
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
         if (vendedCredentialsEnabled) {
+            Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+                    fileIoProperties,
+                    () -> new S3VendedCredentialsProvider(catalogProperties, fileIoProperties),
+                    S3FileIOProperties.ACCESS_KEY_ID, S3FileIOProperties.SECRET_ACCESS_KEY, S3FileIOProperties.SESSION_TOKEN);
+            Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+                    fileIoProperties,
+                    () -> new GcsVendedCredentialsProvider(catalogProperties, fileIoProperties),
+                    GCPProperties.GCS_OAUTH2_TOKEN);
+            Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
+
             ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
-
-            // handle s3
-            if (fileIoProperties.containsKey(S3FileIOProperties.ACCESS_KEY_ID) &&
-                    fileIoProperties.containsKey(S3FileIOProperties.SECRET_ACCESS_KEY) &&
-                    fileIoProperties.containsKey(S3FileIOProperties.SESSION_TOKEN)) {
-                extraCredentialsBuilder
-                        .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, fileIoProperties.get(S3FileIOProperties.ACCESS_KEY_ID))
-                        .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, fileIoProperties.get(S3FileIOProperties.SECRET_ACCESS_KEY))
-                        .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, fileIoProperties.get(S3FileIOProperties.SESSION_TOKEN));
-            }
-
-            // handle gcs
+            // handle GCS
             if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
-                extraCredentialsBuilder.put(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, fileIoProperties.get(GCPProperties.GCS_OAUTH2_TOKEN));
-                addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY);
                 addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
             }
-
-            // handle azure
-            for (Entry<String, String> entry : fileIoProperties.entrySet()) {
-                if (entry.getKey().startsWith(AzureProperties.ADLS_SAS_TOKEN_PREFIX)) {
-                    String account = entry.getKey().substring(AzureProperties.ADLS_SAS_TOKEN_PREFIX.length());
-                    extraCredentialsBuilder.put(EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX + account, entry.getValue());
-                }
-            }
-
             Map<String, String> extraCredentials = extraCredentialsBuilder.buildOrThrow();
-            if (!extraCredentials.isEmpty()) {
-                ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
-                        .withGroups(identity.getGroups())
-                        .withPrincipal(identity.getPrincipal())
-                        .withEnabledSystemRoles(identity.getEnabledSystemRoles())
-                        .withConnectorRole(identity.getConnectorRole())
-                        .withExtraCredentials(extraCredentials)
-                        .build();
-                return fileSystemFactory.create(identityWithExtraCredentials);
+
+            if (s3VendedCredentialsProvider.isPresent() || gcsVendedCredentialsProvider.isPresent() || azureVendedCredentialsProvider.isPresent()) {
+                return new IcebergRestCatalogFileSystem(
+                        location -> {
+                            if (location.scheme().isEmpty()) {
+                                throw new IllegalArgumentException("Location scheme is empty: " + location);
+                            }
+                            // Derive the vended credentials to load from the location scheme
+                            Optional<VendedCredentials> vendedCredentials = switch (location.scheme().get()) {
+                                case "s3", "s3a", "s3n" -> s3VendedCredentialsProvider.map(S3VendedCredentialsProvider::getCredentials);
+                                case "gs" -> gcsVendedCredentialsProvider.map(GcsVendedCredentialsProvider::getCredentials);
+                                case "abfs", "abfss", "wasb", "wasbs" -> azureVendedCredentialsProvider.map(AzureVendedCredentialsProvider::getCredentials);
+                                default -> throw new IllegalArgumentException("Unsupported location scheme for vended credentials: " + location);
+                            };
+                            if (vendedCredentials.isEmpty()) {
+                                throw new IllegalStateException("Failed to initialize the vended credentials from the provided fileIoProperties");
+                            }
+
+                            ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
+                                    .withGroups(identity.getGroups())
+                                    .withPrincipal(identity.getPrincipal())
+                                    .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                                    .withConnectorRole(identity.getConnectorRole())
+                                    .withExtraCredentials(ImmutableMap.<String, String>builder()
+                                            .putAll(extraCredentials)
+                                            .putAll(ImmutableMap.copyOf(vendedCredentials.map(VendedCredentials::toExtraCredentials).orElse(ImmutableMap.of())))
+                                            .buildOrThrow())
+                                    .build();
+
+                            return fileSystemFactory.create(identityWithExtraCredentials);
+                        });
             }
         }
-
         return fileSystemFactory.create(identity);
+    }
+
+    private static <T> Optional<T> createVendedCredentialsProviderIfPresent(
+            Map<String, String> fileIoProperties,
+            Supplier<T> providerFactory,
+            String... requiredKeys)
+    {
+        for (String key : requiredKeys) {
+            if (!fileIoProperties.containsKey(key)) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(providerFactory.get());
+    }
+
+    private Optional<AzureVendedCredentialsProvider> createAzureVendedCredentialsProvider(Map<String, String> fileIoProperties)
+    {
+        for (String key : fileIoProperties.keySet()) {
+            if (key.startsWith(AzureProperties.ADLS_SAS_TOKEN_PREFIX)) {
+                return Optional.of(new AzureVendedCredentialsProvider(catalogProperties, fileIoProperties));
+            }
+        }
+        return Optional.empty();
     }
 
     private static void addOptionalProperty(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -13,8 +13,10 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.trino.cache.EvictableCacheBuilder;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
@@ -27,8 +29,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.HOURS;
 
 public class IcebergRestCatalogFileSystemFactory
         implements IcebergFileSystemFactory
@@ -36,6 +40,10 @@ public class IcebergRestCatalogFileSystemFactory
     private final TrinoFileSystemFactory fileSystemFactory;
     private final boolean vendedCredentialsEnabled;
     private final Map<String, String> catalogProperties;
+    private final Cache<VendedCredentialsCacheKey, CachedVendedCredentialsProviders> vendedCredentialsProvidersCache = EvictableCacheBuilder.newBuilder()
+            .maximumSize(1_000)
+            .expireAfterWrite(1, HOURS)
+            .build();
 
     @Inject
     public IcebergRestCatalogFileSystemFactory(
@@ -52,24 +60,12 @@ public class IcebergRestCatalogFileSystemFactory
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
         if (vendedCredentialsEnabled) {
-            Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
-                    fileIoProperties,
-                    () -> new S3VendedCredentialsProvider(catalogProperties, fileIoProperties),
-                    S3FileIOProperties.ACCESS_KEY_ID, S3FileIOProperties.SECRET_ACCESS_KEY, S3FileIOProperties.SESSION_TOKEN);
-            Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
-                    fileIoProperties,
-                    () -> new GcsVendedCredentialsProvider(catalogProperties, fileIoProperties),
-                    GCPProperties.GCS_OAUTH2_TOKEN);
-            Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
+            CachedVendedCredentialsProviders cached = uncheckedCacheGet(
+                    vendedCredentialsProvidersCache,
+                    createVendedCredentialsCacheKey(identity, fileIoProperties),
+                    () -> createVendedCredentialsProviders(fileIoProperties));
 
-            ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
-            // handle GCS
-            if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
-                addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
-            }
-            Map<String, String> extraCredentials = extraCredentialsBuilder.buildOrThrow();
-
-            if (s3VendedCredentialsProvider.isPresent() || gcsVendedCredentialsProvider.isPresent() || azureVendedCredentialsProvider.isPresent()) {
+            if (cached.s3VendedCredentialsProvider().isPresent() || cached.gcsVendedCredentialsProvider().isPresent() || cached.azureVendedCredentialsProvider().isPresent()) {
                 return new IcebergRestCatalogFileSystem(
                         location -> {
                             if (location.scheme().isEmpty()) {
@@ -77,9 +73,9 @@ public class IcebergRestCatalogFileSystemFactory
                             }
                             // Derive the vended credentials to load from the location scheme
                             Optional<VendedCredentials> vendedCredentials = switch (location.scheme().get()) {
-                                case "s3", "s3a", "s3n" -> s3VendedCredentialsProvider.map(S3VendedCredentialsProvider::getCredentials);
-                                case "gs" -> gcsVendedCredentialsProvider.map(GcsVendedCredentialsProvider::getCredentials);
-                                case "abfs", "abfss", "wasb", "wasbs" -> azureVendedCredentialsProvider.map(AzureVendedCredentialsProvider::getCredentials);
+                                case "s3", "s3a", "s3n" -> cached.s3VendedCredentialsProvider().map(S3VendedCredentialsProvider::getCredentials);
+                                case "gs" -> cached.gcsVendedCredentialsProvider().map(GcsVendedCredentialsProvider::getCredentials);
+                                case "abfs", "abfss", "wasb", "wasbs" -> cached.azureVendedCredentialsProvider().map(AzureVendedCredentialsProvider::getCredentials);
                                 default -> throw new IllegalArgumentException("Unsupported location scheme for vended credentials: " + location);
                             };
                             if (vendedCredentials.isEmpty()) {
@@ -92,7 +88,7 @@ public class IcebergRestCatalogFileSystemFactory
                                     .withEnabledSystemRoles(identity.getEnabledSystemRoles())
                                     .withConnectorRole(identity.getConnectorRole())
                                     .withExtraCredentials(ImmutableMap.<String, String>builder()
-                                            .putAll(extraCredentials)
+                                            .putAll(cached.extraCredentials())
                                             .putAll(ImmutableMap.copyOf(vendedCredentials.map(VendedCredentials::toExtraCredentials).orElse(ImmutableMap.of())))
                                             .buildOrThrow())
                                     .build();
@@ -102,6 +98,99 @@ public class IcebergRestCatalogFileSystemFactory
             }
         }
         return fileSystemFactory.create(identity);
+    }
+
+    private static VendedCredentialsCacheKey createVendedCredentialsCacheKey(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    {
+        Optional<S3VendedCredentials> s3VendedCredentials = createVendedCredentialsIfPresent(
+                fileIoProperties,
+                () -> S3VendedCredentialsProvider.createVendedCredentials(fileIoProperties),
+                S3FileIOProperties.ACCESS_KEY_ID, S3FileIOProperties.SECRET_ACCESS_KEY, S3FileIOProperties.SESSION_TOKEN);
+        Optional<GcsVendedCredentials> gcsVendedCredentials = createVendedCredentialsIfPresent(
+                fileIoProperties,
+                () -> GcsVendedCredentialsProvider.createVendedCredentials(fileIoProperties),
+                GCPProperties.GCS_OAUTH2_TOKEN);
+        Optional<AzureVendedCredentials> azureVendedCredentials = createAzureVendedCredentials(fileIoProperties);
+
+        return new VendedCredentialsCacheKey(identity.getUser(), s3VendedCredentials, gcsVendedCredentials, azureVendedCredentials);
+    }
+
+    private static <T> Optional<T> createVendedCredentialsIfPresent(
+            Map<String, String> fileIoProperties,
+            Supplier<T> providerFactory,
+            String... requiredKeys)
+    {
+        for (String key : requiredKeys) {
+            if (!fileIoProperties.containsKey(key)) {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(providerFactory.get());
+    }
+
+    private static Optional<AzureVendedCredentials> createAzureVendedCredentials(Map<String, String> fileIoProperties)
+    {
+        for (String key : fileIoProperties.keySet()) {
+            if (key.startsWith(AzureProperties.ADLS_SAS_TOKEN_PREFIX)) {
+                return Optional.of(AzureVendedCredentialsProvider.createVendedCredentials(fileIoProperties));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private CachedVendedCredentialsProviders createVendedCredentialsProviders(Map<String, String> fileIoProperties)
+    {
+        Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+                fileIoProperties,
+                () -> new S3VendedCredentialsProvider(catalogProperties, fileIoProperties),
+                S3FileIOProperties.ACCESS_KEY_ID, S3FileIOProperties.SECRET_ACCESS_KEY, S3FileIOProperties.SESSION_TOKEN);
+        Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+                fileIoProperties,
+                () -> new GcsVendedCredentialsProvider(catalogProperties, fileIoProperties),
+                GCPProperties.GCS_OAUTH2_TOKEN);
+        Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
+
+        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
+        // handle GCS
+        if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
+            addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
+        }
+
+        return new CachedVendedCredentialsProviders(
+                s3VendedCredentialsProvider,
+                gcsVendedCredentialsProvider,
+                azureVendedCredentialsProvider,
+                extraCredentialsBuilder.buildOrThrow());
+    }
+
+    private record VendedCredentialsCacheKey(
+            String user,
+            Optional<S3VendedCredentials> s3VendedCredentials,
+            Optional<GcsVendedCredentials> gcsVendedCredentials,
+            Optional<AzureVendedCredentials> azureVendedCredentials)
+    {
+        public VendedCredentialsCacheKey
+        {
+            requireNonNull(user, "user is null");
+            requireNonNull(s3VendedCredentials, "s3VendedCredentials is null");
+            requireNonNull(gcsVendedCredentials, "gcsVendedCredentials is null");
+            requireNonNull(azureVendedCredentials, "azureVendedCredentials is null");
+        }
+    }
+
+    private record CachedVendedCredentialsProviders(
+            Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider,
+            Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider,
+            Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider,
+            Map<String, String> extraCredentials)
+    {
+        public CachedVendedCredentialsProviders
+        {
+            requireNonNull(s3VendedCredentialsProvider, "s3VendedCredentialsProvider is null");
+            requireNonNull(gcsVendedCredentialsProvider, "gcsVendedCredentialsProvider is null");
+            requireNonNull(azureVendedCredentialsProvider, "azureVendedCredentialsProvider is null");
+            requireNonNull(extraCredentials, "extraCredentials is null");
+        }
     }
 
     private static <T> Optional<T> createVendedCredentialsProviderIfPresent(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
@@ -39,6 +39,7 @@ public class IcebergRestCatalogModule
             case NONE -> new NoneSecurityModule();
         });
 
+        binder.bind(IcebergRestCatalogPropertiesProvider.class).in(Scopes.SINGLETON);
         binder.bind(TrinoCatalogFactory.class).to(TrinoIcebergRestCatalogFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, IcebergFileSystemFactory.class).setBinding().to(IcebergRestCatalogFileSystemFactory.class).in(Scopes.SINGLETON);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogPropertiesProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogPropertiesProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.spi.NodeVersion;
+import org.apache.iceberg.CatalogProperties;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.CatalogProperties.AUTH_SESSION_TIMEOUT_MS;
+
+public class IcebergRestCatalogPropertiesProvider
+{
+    private final Map<String, String> catalogProperties;
+
+    @Inject
+    public IcebergRestCatalogPropertiesProvider(
+            IcebergRestCatalogConfig restConfig,
+            SecurityProperties securityProperties,
+            NodeVersion nodeVersion)
+    {
+        requireNonNull(restConfig, "restConfig is null");
+        requireNonNull(securityProperties, "securityProperties is null");
+        requireNonNull(nodeVersion, "nodeVersion is null");
+
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        properties.put(CatalogProperties.URI, restConfig.getBaseUri().toString());
+        restConfig.getWarehouse().ifPresent(location -> properties.put(CatalogProperties.WAREHOUSE_LOCATION, location));
+        restConfig.getPrefix().ifPresent(aPrefix -> properties.put("prefix", aPrefix));
+        properties.put("view-endpoints-supported", Boolean.toString(restConfig.isViewEndpointsEnabled()));
+        properties.put("trino-version", nodeVersion.toString());
+        properties.put(AUTH_SESSION_TIMEOUT_MS, String.valueOf(restConfig.getSessionTimeout().toMillis()));
+        restConfig.getConnectionTimeout().ifPresent(duration -> properties.put("rest.client.connection-timeout-ms", String.valueOf(duration.toMillis())));
+        restConfig.getSocketTimeout().ifPresent(timeout -> properties.put("rest.client.socket-timeout-ms", String.valueOf(timeout.toMillis())));
+        properties.putAll(securityProperties.get());
+        if (restConfig.isVendedCredentialsEnabled()) {
+            properties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
+        }
+        catalogProperties = properties.buildOrThrow();
+    }
+
+    public Map<String, String> catalogProperties()
+    {
+        return catalogProperties;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/S3VendedCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/S3VendedCredentials.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
+import static java.util.Objects.requireNonNull;
+
+record S3VendedCredentials(String accessKey, String secretKey, String sessionToken, Optional<Instant> expirationTime)
+        implements VendedCredentials
+{
+    public S3VendedCredentials
+    {
+        requireNonNull(accessKey, "accessKey is null");
+        requireNonNull(secretKey, "secretKey is null");
+        requireNonNull(sessionToken, "sessionToken is null");
+        requireNonNull(expirationTime, "expirationTime is null");
+    }
+
+    @Override
+    public Optional<Instant> expiresAt()
+    {
+        return expirationTime;
+    }
+
+    @Override
+    public Map<String, String> toExtraCredentials()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, accessKey)
+                .put(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, secretKey)
+                .put(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, sessionToken)
+                .buildOrThrow();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/S3VendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/S3VendedCredentialsProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.rest.credentials.Credential;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.iceberg.aws.AwsClientProperties.REFRESH_CREDENTIALS_ENABLED;
+import static org.apache.iceberg.aws.AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT;
+import static org.apache.iceberg.aws.s3.S3FileIOProperties.ACCESS_KEY_ID;
+import static org.apache.iceberg.aws.s3.S3FileIOProperties.SECRET_ACCESS_KEY;
+import static org.apache.iceberg.aws.s3.S3FileIOProperties.SESSION_TOKEN;
+
+final class S3VendedCredentialsProvider
+        extends AbstractIcebergRestVendedCredentialsProvider<S3VendedCredentials>
+{
+    // Copy org.apache.iceberg.aws.s3.S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS because the apache/iceberg constant is package-private
+    static final String SESSION_TOKEN_EXPIRES_AT_MS = "s3.session-token-expires-at-ms";
+
+    S3VendedCredentialsProvider(
+            Map<String, String> catalogProperties,
+            Map<String, String> fileIoProperties)
+    {
+        super(
+                catalogProperties,
+                fileIoProperties,
+                parseBoolean(fileIoProperties, REFRESH_CREDENTIALS_ENABLED, true),
+                Optional.ofNullable(fileIoProperties.get(REFRESH_CREDENTIALS_ENDPOINT)),
+                createVendedCredentials(fileIoProperties));
+    }
+
+    @Override
+    protected S3VendedCredentials applyRefreshedCredentials(List<Credential> credentials)
+    {
+        Credential s3Credential = credentials.stream()
+                .filter(c -> c.prefix().startsWith("s3"))
+                .reduce((a, b) -> {
+                    throw new IllegalStateException("Multiple S3 credentials returned");
+                })
+                .orElseThrow(() -> new IllegalStateException("No S3 credentials in refresh response"));
+
+        Map<String, String> config = s3Credential.config();
+        return createVendedCredentials(config);
+    }
+
+    private static S3VendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
+    {
+        return new S3VendedCredentials(
+                fileIoProperties.get(ACCESS_KEY_ID),
+                fileIoProperties.get(SECRET_ACCESS_KEY),
+                fileIoProperties.get(SESSION_TOKEN),
+                parseInstantEpochMillis(fileIoProperties, SESSION_TOKEN_EXPIRES_AT_MS));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/S3VendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/S3VendedCredentialsProvider.java
@@ -57,7 +57,7 @@ final class S3VendedCredentialsProvider
         return createVendedCredentials(config);
     }
 
-    private static S3VendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
+    public static S3VendedCredentials createVendedCredentials(Map<String, String> fileIoProperties)
     {
         return new S3VendedCredentials(
                 fileIoProperties.get(ACCESS_KEY_ID),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -14,11 +14,9 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.cache.Cache;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
-import io.airlift.units.Duration;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
@@ -38,14 +36,11 @@ import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.RESTUtil;
 
-import java.net.URI;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.iceberg.CatalogProperties.AUTH_SESSION_TIMEOUT_MS;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 
@@ -56,18 +51,12 @@ public class TrinoIcebergRestCatalogFactory
     private final ForwardingFileIoFactory fileIoFactory;
     private final CatalogName catalogName;
     private final String trinoVersion;
-    private final URI serverUri;
-    private final Optional<String> prefix;
-    private final Optional<String> warehouse;
     private final boolean nestedNamespaceEnabled;
     private final Security security;
     private final SessionType sessionType;
-    private final Optional<Duration> connectionTimeout;
-    private final Optional<Duration> socketTimeout;
-    private final Duration sessionTimeout;
-    private final boolean vendedCredentialsEnabled;
     private final boolean viewEndpointsEnabled;
     private final SecurityProperties securityProperties;
+    private final IcebergRestCatalogPropertiesProvider catalogPropertiesProvider;
     private final boolean uniqueTableLocation;
     private final TypeManager typeManager;
     private final boolean caseInsensitiveNameMatching;
@@ -84,6 +73,7 @@ public class TrinoIcebergRestCatalogFactory
             CatalogName catalogName,
             IcebergRestCatalogConfig restConfig,
             SecurityProperties securityProperties,
+            IcebergRestCatalogPropertiesProvider catalogPropertiesProvider,
             IcebergConfig icebergConfig,
             TypeManager typeManager,
             NodeVersion nodeVersion)
@@ -93,18 +83,12 @@ public class TrinoIcebergRestCatalogFactory
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         requireNonNull(restConfig, "restConfig is null");
-        this.serverUri = restConfig.getBaseUri();
-        this.prefix = restConfig.getPrefix();
-        this.warehouse = restConfig.getWarehouse();
         this.nestedNamespaceEnabled = restConfig.isNestedNamespaceEnabled();
         this.security = restConfig.getSecurity();
         this.sessionType = restConfig.getSessionType();
-        this.connectionTimeout = restConfig.getConnectionTimeout();
-        this.socketTimeout = restConfig.getSocketTimeout();
-        this.sessionTimeout = restConfig.getSessionTimeout();
-        this.vendedCredentialsEnabled = restConfig.isVendedCredentialsEnabled();
         this.viewEndpointsEnabled = restConfig.isViewEndpointsEnabled();
         this.securityProperties = requireNonNull(securityProperties, "securityProperties is null");
+        this.catalogPropertiesProvider = requireNonNull(catalogPropertiesProvider, "catalogPropertiesProvider is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
         this.uniqueTableLocation = icebergConfig.isUniqueTableLocation();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -125,21 +109,6 @@ public class TrinoIcebergRestCatalogFactory
         // Creation of the RESTSessionCatalog is lazy due to required network calls
         // for authorization and config route
         if (icebergCatalog == null) {
-            ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
-            properties.put(CatalogProperties.URI, serverUri.toString());
-            warehouse.ifPresent(location -> properties.put(CatalogProperties.WAREHOUSE_LOCATION, location));
-            prefix.ifPresent(prefix -> properties.put("prefix", prefix));
-            properties.put("view-endpoints-supported", Boolean.toString(viewEndpointsEnabled));
-            properties.put("trino-version", trinoVersion);
-            properties.put(AUTH_SESSION_TIMEOUT_MS, String.valueOf(sessionTimeout.toMillis()));
-            connectionTimeout.ifPresent(duration -> properties.put("rest.client.connection-timeout-ms", String.valueOf(duration.toMillis())));
-            socketTimeout.ifPresent(duration -> properties.put("rest.client.socket-timeout-ms", String.valueOf(duration.toMillis())));
-            properties.putAll(securityProperties.get());
-
-            if (vendedCredentialsEnabled) {
-                properties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
-            }
-
             RESTSessionCatalog icebergCatalogInstance = new RESTSessionCatalog(
                     config -> HTTPClient.builder(config)
                             .uri(config.get(CatalogProperties.URI))
@@ -151,7 +120,7 @@ public class TrinoIcebergRestCatalogFactory
                                 : ConnectorIdentity.ofUser("fake");
                         return fileIoFactory.create(fileSystemFactory.create(currentIdentity, config), true, config);
                     });
-            icebergCatalogInstance.initialize(catalogName.toString(), properties.buildOrThrow());
+            icebergCatalogInstance.initialize(catalogName.toString(), catalogPropertiesProvider.catalogProperties());
 
             icebergCatalog = icebergCatalogInstance;
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentials.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+sealed interface VendedCredentials
+        permits S3VendedCredentials, GcsVendedCredentials, AzureVendedCredentials
+{
+    Map<String, String> toExtraCredentials();
+
+    Optional<Instant> expiresAt();
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+public interface VendedCredentialsProvider<T extends VendedCredentials>
+{
+    T getCredentials();
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.http.server.HttpServerConfig;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.ServerFeature;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.node.NodeInfo;
+import io.trino.hdfs.DynamicHdfsConfiguration;
+import io.trino.hdfs.HdfsConfig;
+import io.trino.hdfs.HdfsConfiguration;
+import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.hdfs.authentication.NoHdfsAuthentication;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorSession;
+import io.trino.testing.sql.TestTable;
+import io.trino.tpch.TpchTable;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.trino.tpch.TpchTable.REGION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+abstract class AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+        extends AbstractTestQueryFramework
+{
+    private static final List<TpchTable<?>> REQUIRED_TPCH_TABLES = ImmutableList.of(REGION);
+
+    protected String warehouseLocation;
+    private VendedCredentialsRestCatalogServlet servlet;
+    protected final AtomicReference<Instant> sessionTokenExpirationTime = new AtomicReference<>(Instant.now().plus(1, ChronoUnit.HOURS));
+
+    protected abstract String setupStorageAndGetWarehouseLocation()
+            throws Exception;
+
+    protected abstract Map<String, String> backendCatalogFileIoProperties();
+
+    protected abstract VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog);
+
+    protected abstract Map<String, String> catalogFileSystemProperties();
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        warehouseLocation = setupStorageAndGetWarehouseLocation();
+
+        JdbcCatalog backend = closeAfterClass(buildBackendCatalog(warehouseLocation));
+        servlet = createServlet(backend);
+
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerConfig config = new HttpServerConfig()
+                .setHttpPort(0)
+                .setHttpEnabled(true);
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        TestingHttpServer testServer = new TestingHttpServer("rest-catalog", httpServerInfo, nodeInfo, config, servlet, ServerFeature.builder()
+                .withLegacyUriCompliance(true)
+                .build());
+        testServer.start();
+        closeAfterClass(testServer::stop);
+
+        IcebergQueryRunner.Builder builder = IcebergQueryRunner.builder()
+                .addIcebergProperty("iceberg.catalog.type", "rest")
+                .addIcebergProperty("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
+                .addIcebergProperty("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                .addIcebergProperty("iceberg.writer-sort-buffer-size", "1MB");
+        catalogFileSystemProperties().forEach(builder::addIcebergProperty);
+        return builder
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    private JdbcCatalog buildBackendCatalog(String warehouseLocation)
+            throws IOException
+    {
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        properties.put(CatalogProperties.URI, "jdbc:h2:file:" + Files.createTempFile(null, null).toAbsolutePath());
+        properties.put(JdbcCatalog.PROPERTY_PREFIX + "username", "user");
+        properties.put(JdbcCatalog.PROPERTY_PREFIX + "password", "password");
+        properties.put(JdbcCatalog.PROPERTY_PREFIX + "schema-version", "V1");
+        properties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation);
+        properties.putAll(backendCatalogFileIoProperties());
+
+        ConnectorSession connectorSession = TestingConnectorSession.builder().build();
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+        HdfsContext context = new HdfsContext(connectorSession);
+
+        JdbcCatalog catalog = new JdbcCatalog();
+        catalog.setConf(hdfsEnvironment.getConfiguration(context, new Path(warehouseLocation)));
+        catalog.initialize("backend_jdbc", properties.buildOrThrow());
+        return catalog;
+    }
+
+    @BeforeEach
+    public void initSessionTokenExpirationTime()
+    {
+        // Simulate a real-world expiration time of the token ~ 1 hour
+        sessionTokenExpirationTime.set(Instant.now().plus(1, ChronoUnit.HOURS));
+    }
+
+    @Test
+    public void testCreateTableAsSelect()
+    {
+        try (TestTable testTable = newTrinoTable("test_ctas", "AS SELECT * FROM region")) {
+            // Intentionally set the expiration time to be in the near future to test credential refresh logic
+            sessionTokenExpirationTime.set(Instant.now().plusSeconds(60));
+            int refreshCount = servlet.getVendedCredentialsRefreshCount();
+            assertQuery("SELECT * FROM " + testTable.getName(), "SELECT * FROM region");
+            assertThat(servlet.getVendedCredentialsRefreshCount()).isGreaterThan(refreshCount);
+
+            // Providing a session token that expires only in one hour should not trigger token refresh
+            sessionTokenExpirationTime.set(Instant.now().plus(1, ChronoUnit.HOURS));
+            refreshCount = servlet.getVendedCredentialsRefreshCount();
+            assertQuery("SELECT * FROM " + testTable.getName(), "SELECT * FROM region");
+            assertThat(servlet.getVendedCredentialsRefreshCount()).isEqualTo(refreshCount);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.sas.AccountSasPermission;
+import com.azure.storage.common.sas.AccountSasResourceType;
+import com.azure.storage.common.sas.AccountSasService;
+import com.azure.storage.common.sas.AccountSasSignatureValues;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.azure.AzureAuthAccessKey;
+import io.trino.filesystem.azure.AzureFileSystemConfig;
+import io.trino.filesystem.azure.AzureFileSystemFactory;
+import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.azure.adlsv2.ADLSFileIO;
+import org.apache.iceberg.catalog.Catalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
+
+final class TestIcebergAzureRestCatalogVendedCredentialsRefreshTest
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+{
+    private static final Logger LOG = Logger.get(TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.class);
+
+    private final String container = requiredNonEmptySystemProperty("testing.azure-abfs-container");
+    private final String account = requiredNonEmptySystemProperty("testing.azure-abfs-account");
+    private final String accessKey = requiredNonEmptySystemProperty("testing.azure-abfs-access-key");
+
+    private String sasToken;
+    private long sasTokenExpiresAtMs;
+    private TrinoFileSystem fileSystem;
+
+    @BeforeAll
+    public void initFileSystem()
+    {
+        AzureAuthAccessKey azureAuth = new AzureAuthAccessKey(accessKey);
+        fileSystem = new AzureFileSystemFactory(
+                OpenTelemetry.noop(),
+                azureAuth,
+                new AzureFileSystemConfig())
+                .create(SESSION);
+    }
+
+    @AfterAll
+    public void removeTestData()
+    {
+        if (fileSystem == null) {
+            return;
+        }
+        try {
+            fileSystem.deleteDirectory(Location.of(stripTrailingSlash(warehouseLocation)));
+        }
+        catch (IOException e) {
+            LOG.warn(e, "Failed to clean up Azure test directory: %s", warehouseLocation);
+        }
+    }
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+    {
+        OffsetDateTime sasTokenExpiry = OffsetDateTime.now().plusHours(1);
+        sasToken = generateAccountSasToken(sasTokenExpiry);
+        sasTokenExpiresAtMs = sasTokenExpiry.toInstant().toEpochMilli();
+
+        return "abfss://%s@%s.dfs.core.windows.net/azure-vending-rest-refresh-test-%s/".formatted(container, account, randomNameSuffix());
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, ADLSFileIO.class.getName())
+                .put(AzureProperties.ADLS_SHARED_KEY_ACCOUNT_NAME, account)
+                .put(AzureProperties.ADLS_SHARED_KEY_ACCOUNT_KEY, accessKey)
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        VendedCredentialsRestCatalogAdapter adapter = new VendedCredentialsRestCatalogAdapter(backendCatalog)
+        {
+            @Override
+            public Map<String, String> getVendedCredentialsConfig(String restServerUri)
+            {
+                return ImmutableMap.<String, String>builder()
+                        .put(AzureProperties.ADLS_SAS_TOKEN_PREFIX + account, sasToken)
+                        .put(AzureProperties.ADLS_REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                        .put(AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + account, Long.toString(sessionTokenExpirationTime.get().toEpochMilli()))
+                        .buildOrThrow();
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "abfss://";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                return ImmutableMap.<String, String>builder()
+                        .put(AzureProperties.ADLS_SAS_TOKEN_PREFIX + account, sasToken)
+                        .put(AzureProperties.ADLS_REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + account, Long.toString(sasTokenExpiresAtMs))
+                        .buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.azure.enabled", "true")
+                .put("azure.auth-type", "DEFAULT")
+                .buildOrThrow();
+    }
+
+    private String generateAccountSasToken(OffsetDateTime expiryTime)
+    {
+        StorageSharedKeyCredential credential = new StorageSharedKeyCredential(account, accessKey);
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+                .endpoint("https://%s.blob.core.windows.net".formatted(account))
+                .credential(credential)
+                .buildClient();
+
+        AccountSasPermission permissions = new AccountSasPermission()
+                .setReadPermission(true)
+                .setWritePermission(true)
+                .setDeletePermission(true)
+                .setListPermission(true)
+                .setCreatePermission(true);
+
+        AccountSasResourceType resourceTypes = new AccountSasResourceType()
+                .setContainer(true)
+                .setObject(true)
+                .setService(true);
+
+        AccountSasService services = new AccountSasService()
+                .setBlobAccess(true);
+
+        AccountSasSignatureValues sasValues = new AccountSasSignatureValues(
+                expiryTime,
+                permissions,
+                services,
+                resourceTypes);
+
+        return blobServiceClient.generateAccountSas(sasValues);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.gcs.GcsFileSystemConfig;
+import io.trino.filesystem.gcs.GcsFileSystemFactory;
+import io.trino.filesystem.gcs.GcsServiceAccountAuth;
+import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
+import io.trino.filesystem.gcs.GcsStorageFactory;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.gcp.gcs.GCSFileIO;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Map;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+
+final class TestIcebergGcsRestCatalogVendedCredentialsRefreshTest
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+{
+    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.class);
+
+    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
+    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+
+    private String oauthToken;
+    private long tokenExpiresAtMs;
+    private String gcpProjectId;
+    private TrinoFileSystem fileSystem;
+
+    @BeforeAll
+    public void initFileSystem()
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        GcsFileSystemConfig config = new GcsFileSystemConfig();
+        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
+        GcsStorageFactory storageFactory;
+        try {
+            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+    }
+
+    @AfterAll
+    public void removeTestData()
+    {
+        if (fileSystem == null) {
+            return;
+        }
+        try {
+            fileSystem.deleteDirectory(Location.of(warehouseLocation));
+        }
+        catch (IOException e) {
+            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
+            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+        }
+    }
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+            throws Exception
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
+                .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        AccessToken accessToken = credentials.refreshAccessToken();
+        oauthToken = accessToken.getTokenValue();
+        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
+
+        JsonMapper mapper = new JsonMapper();
+        JsonNode jsonKey = mapper.readTree(gcpCredentials);
+        gcpProjectId = jsonKey.get("project_id").asText();
+
+        return "gs://%s/gcs-vending-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, GCSFileIO.class.getName())
+                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        VendedCredentialsRestCatalogAdapter adapter = new VendedCredentialsRestCatalogAdapter(backendCatalog)
+        {
+            @Override
+            public Map<String, String> getVendedCredentialsConfig(String restServerUri)
+            {
+                return ImmutableMap.<String, String>builder()
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                        .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                        // Intentionally set the expiration time to be in the near future to test credential refresh logic
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(sessionTokenExpirationTime.get().toEpochMilli()))
+                        .buildOrThrow();
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "gs://";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                return ImmutableMap.<String, String>builder()
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                        .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
+                        .buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.gcs.enabled", "true")
+                .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .buildOrThrow();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -14,14 +14,28 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.filesystem.UriLocation;
+import io.trino.filesystem.encryption.EncryptionKey;
+import io.trino.spi.NodeVersion;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.filesystem.azure.AzureFileSystemConstants.EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX;
@@ -41,20 +55,17 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 S3FileIOProperties.ACCESS_KEY_ID, "test-access-key",
                 S3FileIOProperties.SECRET_ACCESS_KEY, "test-secret-key",
                 S3FileIOProperties.SESSION_TOKEN, "test-session-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("s3://bucket/path"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -70,18 +81,15 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -97,13 +105,10 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.<String, String>builder()
                 .put(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token")
@@ -111,7 +116,7 @@ final class TestIcebergRestCatalogFileSystemFactory
                 .put(GCPProperties.GCS_PROJECT_ID, "my-gcp-project")
                 .buildOrThrow();
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -130,10 +135,7 @@ final class TestIcebergRestCatalogFileSystemFactory
             return null;
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(false);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, false);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token",
@@ -153,13 +155,10 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
         factory.create(originalIdentity, ImmutableMap.of());
@@ -174,18 +173,15 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -199,19 +195,16 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account1", "sas-token-1",
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account2", "sas-token-2");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@account1.dfs.core.windows.net/some/path/file"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -226,17 +219,14 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(true);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -250,13 +240,10 @@ final class TestIcebergRestCatalogFileSystemFactory
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
             capturedIdentity.set(identity);
-            return null;
+            return new MockTrinoFileSystem();
         };
 
-        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
-                .setBaseUri("http://localhost")
-                .setVendedCredentialsEnabled(false);
-        IcebergRestCatalogFileSystemFactory factory = new IcebergRestCatalogFileSystemFactory(delegate, config);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, false);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
@@ -267,5 +254,139 @@ final class TestIcebergRestCatalogFileSystemFactory
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
         assertThat(identity.getExtraCredentials()).isEmpty();
+    }
+
+    private static IcebergRestCatalogFileSystemFactory createFactory(TrinoFileSystemFactory delegate, boolean vendedCredentialsEnabled)
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setBaseUri("http://localhost")
+                .setVendedCredentialsEnabled(vendedCredentialsEnabled);
+        IcebergRestCatalogPropertiesProvider catalogPropertiesProvider = new IcebergRestCatalogPropertiesProvider(
+                config,
+                new NoneSecurityProperties(),
+                new NodeVersion("test"));
+        return new IcebergRestCatalogFileSystemFactory(
+                delegate,
+                config,
+                catalogPropertiesProvider);
+    }
+
+    private static class MockTrinoFileSystem
+            implements TrinoFileSystem
+    {
+        @Override
+        public TrinoInputFile newEncryptedInputFile(Location location, long length, EncryptionKey key)
+        {
+            return TrinoFileSystem.super.newEncryptedInputFile(location, length, key);
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location)
+        {
+            return null;
+        }
+
+        @Override
+        public TrinoInputFile newEncryptedInputFile(Location location, EncryptionKey key)
+        {
+            return TrinoFileSystem.super.newEncryptedInputFile(location, key);
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length)
+        {
+            return null;
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+        {
+            return null;
+        }
+
+        @Override
+        public TrinoInputFile newEncryptedInputFile(Location location, long length, Instant lastModified, EncryptionKey key)
+        {
+            return TrinoFileSystem.super.newEncryptedInputFile(location, length, lastModified, key);
+        }
+
+        @Override
+        public TrinoOutputFile newOutputFile(Location location)
+        {
+            return null;
+        }
+
+        @Override
+        public TrinoOutputFile newEncryptedOutputFile(Location location, EncryptionKey key)
+        {
+            return null;
+        }
+
+        @Override
+        public void deleteFile(Location location)
+        {
+        }
+
+        @Override
+        public void deleteFiles(Collection<Location> locations)
+        {
+        }
+
+        @Override
+        public void deleteDirectory(Location location)
+        {
+        }
+
+        @Override
+        public void renameFile(Location source, Location target)
+        {
+        }
+
+        @Override
+        public FileIterator listFiles(Location location)
+        {
+            return null;
+        }
+
+        @Override
+        public Optional<Boolean> directoryExists(Location location)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public void createDirectory(Location location)
+        {
+        }
+
+        @Override
+        public void renameDirectory(Location source, Location target)
+        {
+        }
+
+        @Override
+        public Set<Location> listDirectories(Location location)
+        {
+            return Set.of();
+        }
+
+        @Override
+        public Optional<Location> createTemporaryDirectory(Location targetPath, String temporaryPrefix, String relativePrefix)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UriLocation> preSignedUri(Location location, Duration ttl)
+                throws IOException
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<UriLocation> encryptedPreSignedUri(Location location, Duration ttl, EncryptionKey key)
+        {
+            return Optional.empty();
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogVendedCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogVendedCredentialsRefreshTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.containers.Minio;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.testcontainers.containers.Network;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import java.net.URI;
+import java.util.Map;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+
+final class TestIcebergS3RestCatalogVendedCredentialsRefreshTest
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+{
+    private final String bucketName = "test-iceberg-refresh-vending-credentials-rest-" + randomNameSuffix();
+    private Minio minio;
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+    {
+        Network network = closeAfterClass(Network.newNetwork());
+        minio = closeAfterClass(Minio.builder().withNetwork(network).build());
+        minio.start();
+        minio.createBucket(bucketName);
+        return "s3://%s/default/".formatted(bucketName);
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, S3FileIO.class.getName())
+                .put(S3FileIOProperties.PATH_STYLE_ACCESS, "true")
+                .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                .put(S3FileIOProperties.ACCESS_KEY_ID, MINIO_ROOT_USER)
+                .put(S3FileIOProperties.SECRET_ACCESS_KEY, MINIO_ROOT_PASSWORD)
+                .put(S3FileIOProperties.ENDPOINT, minio.getMinioAddress())
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        VendedCredentialsRestCatalogAdapter adapter = new VendedCredentialsRestCatalogAdapter(backendCatalog)
+        {
+            @Override
+            public Map<String, String> getVendedCredentialsConfig(String restServerUri)
+            {
+                Credentials sessionCredentials = getSessionCredentials();
+                ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
+                        .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                        .put(S3FileIOProperties.ACCESS_KEY_ID, sessionCredentials.accessKeyId())
+                        .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
+                        .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
+                        .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                        .put("s3.session-token-expires-at-ms", Long.toString(sessionTokenExpirationTime.get().toEpochMilli()));
+                return builder.buildOrThrow();
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "s3://";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                Credentials sessionCredentials = getSessionCredentials();
+                ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
+                        .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                        .put(S3FileIOProperties.ACCESS_KEY_ID, sessionCredentials.accessKeyId())
+                        .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
+                        .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
+                        .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put("s3.session-token-expires-at-ms", Long.toString(sessionCredentials.expiration().toEpochMilli()));
+                return builder.buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.s3.enabled", "true")
+                .put("s3.region", MINIO_REGION)
+                .put("s3.endpoint", minio.getMinioAddress())
+                .put("s3.path-style-access", "true")
+                .buildOrThrow();
+    }
+
+    public Credentials getSessionCredentials()
+    {
+        AwsCredentials rootCredentials = AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
+        try (StsClient stsClient = StsClient.builder()
+                .endpointOverride(URI.create(minio.getMinioAddress()))
+                .credentialsProvider(StaticCredentialsProvider.create(rootCredentials))
+                .region(Region.of(MINIO_REGION))
+                .build()) {
+            AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(AssumeRoleRequest.builder().build());
+            return assumeRoleResponse.credentials();
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsRestCatalogAdapter.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsRestCatalogAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+public abstract class VendedCredentialsRestCatalogAdapter
+        extends RESTCatalogAdapter
+{
+    public VendedCredentialsRestCatalogAdapter(Catalog delegate)
+    {
+        super(delegate);
+    }
+
+    @Override
+    protected <T extends RESTResponse> T execute(
+            HTTPRequest request,
+            Class<T> responseType,
+            Consumer<ErrorResponse> errorHandler,
+            Consumer<Map<String, String>> responseHeaders)
+    {
+        T response = super.execute(request, responseType, errorHandler, responseHeaders);
+        if (response instanceof LoadTableResponse loadTableResponse) {
+            TableMetadata metadata = loadTableResponse.tableMetadata();
+
+            String host = request.headers().entries("host").stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Host header not found in request"))
+                    .value();
+            String restServerUri = "http://" + host;
+
+            LoadTableResponse modified = LoadTableResponse.builder()
+                    .withTableMetadata(metadata)
+                    .addAllConfig(loadTableResponse.config())
+                    .addAllConfig(getVendedCredentialsConfig(restServerUri))
+                    .build();
+            return responseType.cast(modified);
+        }
+        return response;
+    }
+
+    protected abstract Map<String, String> getVendedCredentialsConfig(String restServerUri);
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsRestCatalogServlet.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsRestCatalogServlet.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RestCatalogServlet;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
+import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
+import org.apache.iceberg.rest.responses.LoadCredentialsResponseParser;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Extends {@link RestCatalogServlet} to handle the {@code GET .../credentials} custom endpoint.
+ */
+public abstract class VendedCredentialsRestCatalogServlet
+        extends RestCatalogServlet
+{
+    private final AtomicInteger vendedCredentialsRefreshCount = new AtomicInteger();
+
+    public VendedCredentialsRestCatalogServlet(RESTCatalogAdapter restCatalogAdapter)
+    {
+        super(restCatalogAdapter);
+    }
+
+    public int getVendedCredentialsRefreshCount()
+    {
+        return vendedCredentialsRefreshCount.get();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException
+    {
+        String path = request.getRequestURI().substring(1);
+        if (path.equals("credentials")) {
+            handleCredentialsRequest(response);
+            return;
+        }
+        super.doGet(request, response);
+    }
+
+    private void handleCredentialsRequest(HttpServletResponse response)
+            throws IOException
+    {
+        vendedCredentialsRefreshCount.incrementAndGet();
+        LoadCredentialsResponse credentialsResponse = ImmutableLoadCredentialsResponse.builder()
+                .addCredentials(ImmutableCredential.builder()
+                        .prefix(getPrefix())
+                        .putAllConfig(getCredentialsConfig())
+                        .build())
+                .build();
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader("Content-Type", ContentType.APPLICATION_JSON.getMimeType());
+        response.getWriter().write(LoadCredentialsResponseParser.toJson(credentialsResponse));
+    }
+
+    protected abstract String getPrefix();
+
+    protected abstract Map<String, String> getCredentialsConfig();
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This contribution adds refreshable vended credentials support for Iceberg REST catalog across S3, GCS, and Azure storage backends.
      
Introduce storage-specific credential providers that cache vended
credentials from the Iceberg REST catalog and refresh them via the
catalog's credentials endpoint 5 minutes before expiration. This
enables long-running file operations (large scans, writes) to survive
short-lived token lifetimes.

Add `IcebergRestCatalogFileSystem`, a delegating `TrinoFileSystem`
that lazily resolves the underlying file system per location, so that
each storage operation gets a file system configured with freshly
resolved credentials from the appropriate provider based on the
location scheme.

### Testing

**Manual tests**
Manual testing showcased positive results while testing with `io.trino.plugin.iceberg.IcebergQueryRunner.IcebergDatabricksUnityS3QueryRunnerMain`

**Integration tests**
Each test verifies that the REST catalog credential refresh endpoint
is called when vended credentials are near expiration.
The `VendedCredentialsRESTCatalogAdapter` implementations provide
for `LoadTableResponse` an access token with the expiration time
very close to expiration in order to trigger the vended credentials
refresh flow.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Supersedes https://github.com/trinodb/trino/pull/28792
Fixes https://github.com/trinodb/trino/issues/25827

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support for refreshable vended credentials for Iceberg REST catalog (S3, GCS, Azure). ({issue}`28998 `)
```
