### PR TITLE
Replace deprecated Type.getTypeParameters usage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -606,10 +606,10 @@ public class SignatureBinder
         if (fromType instanceof UnknownType || toType instanceof UnknownType) {
             return true;
         }
-        if (fromType instanceof RowType) {
-            if (toType instanceof RowType) {
-                List<Type> fromTypeParameters = fromType.getTypeParameters();
-                List<Type> toTypeParameters = toType.getTypeParameters();
+        if (fromType instanceof RowType fromRowType) {
+            if (toType instanceof RowType toRowType) {
+                List<Type> fromTypeParameters = fromRowType.getFieldTypes();
+                List<Type> toTypeParameters = toRowType.getFieldTypes();
                 if (fromTypeParameters.size() != toTypeParameters.size()) {
                     return false;
                 }
@@ -626,9 +626,9 @@ public class SignatureBinder
             }
             return false;
         }
-        if (toType instanceof RowType) {
+        if (toType instanceof RowType toRowType) {
             if (isRecursiveCastToRow(fromType)) {
-                return toType.getTypeParameters().stream()
+                return toRowType.getFieldTypes().stream()
                         .allMatch(toTypeParameter -> canCast(fromType, toTypeParameter));
             }
         }

--- a/core/trino-main/src/main/java/io/trino/util/variant/RowVariantWriter.java
+++ b/core/trino-main/src/main/java/io/trino/util/variant/RowVariantWriter.java
@@ -64,7 +64,7 @@ final class RowVariantWriter
         ImmutableList.Builder<Optional<VariantWriter>> writersInWriteOrder = ImmutableList.builderWithExpectedSize(fieldCount);
 
         for (int fieldIndex : writeOrder) {
-            Type fieldType = type.getTypeParameters().get(fieldIndex);
+            Type fieldType = type.getFieldTypes().get(fieldIndex);
             fieldNamesInWriteOrder.add(fieldNames.get(fieldIndex));
             fieldTypesInWriteOrder.add(fieldType);
 

--- a/core/trino-main/src/main/java/io/trino/util/variant/VariantUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/variant/VariantUtil.java
@@ -162,7 +162,7 @@ public final class VariantUtil
                     canCastToVariant(mapType.getValueType());
         }
         if (type instanceof RowType rowType) {
-            return rowType.getTypeParameters().stream().allMatch(VariantUtil::canCastToVariant);
+            return rowType.getFieldTypes().stream().allMatch(VariantUtil::canCastToVariant);
         }
         return false;
     }
@@ -196,7 +196,7 @@ public final class VariantUtil
             return mapType.getKeyType() instanceof VarcharType && canCastFromVariant(mapType.getValueType());
         }
         if (type instanceof RowType rowType) {
-            return rowType.getTypeParameters().stream().allMatch(VariantUtil::canCastFromVariant);
+            return rowType.getFieldTypes().stream().allMatch(VariantUtil::canCastFromVariant);
         }
         return false;
     }


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.