### PR TITLE
dropTable retry skips data directory cleanup after hms socket timeout

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -100,6 +100,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -904,6 +905,7 @@ public final class ThriftHiveMetastore
     public void dropTable(String databaseName, String tableName, boolean deleteData)
     {
         AtomicInteger attemptCount = new AtomicInteger();
+        AtomicReference<Table> previousTable = new AtomicReference<>();
         try {
             retry()
                     .stopOn(NoSuchObjectException.class)
@@ -922,8 +924,18 @@ public final class ThriftHiveMetastore
                                 }
                                 // If the table is not found on consecutive attempts, it was probably dropped on the first attempt and timeout occurred.
                                 // Exception in such a case can be safely ignored and dropping table is finished.
+                                // But in some cases when hms close socket the table can be removed but data still in the fs
+                                Table droppedTable = previousTable.get();
+                                if (droppedTable != null) {
+                                    String tableLocation = droppedTable.getSd().getLocation();
+                                    if (deleteFilesOnDrop && deleteData && isManagedTable(droppedTable) && !isNullOrEmpty(tableLocation)) {
+                                        log.info("Deleting data for table %s.%s at %s after successful retry (previous attempt timed out)", databaseName, tableName, tableLocation);
+                                        deleteDirRecursive(Location.of(tableLocation));
+                                    }
+                                }
                                 return null;
                             }
+                            previousTable.set(table);
                             client.dropTable(databaseName, tableName, deleteData);
                             String tableLocation = table.getSd().getLocation();
                             if (deleteFilesOnDrop && deleteData && isManagedTable(table) && !isNullOrEmpty(tableLocation)) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
@@ -13,15 +13,33 @@
  */
 package io.trino.plugin.hive.metastore.thrift;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import io.trino.hive.thrift.metastore.FieldSchema;
+import io.trino.hive.thrift.metastore.NoSuchObjectException;
+import io.trino.hive.thrift.metastore.SerDeInfo;
+import io.trino.hive.thrift.metastore.StorageDescriptor;
+import io.trino.hive.thrift.metastore.Table;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient.AlternativeCall;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestThriftHiveMetastoreClient
@@ -120,5 +138,86 @@ public class TestThriftHiveMetastoreClient
         {
             throw new UnsupportedOperationException();
         }
+    }
+
+    @Test
+    void testDropTableWhenThrowExceptionDuringRemoveDataFromS3()
+    {
+        AtomicInteger getTableCalls = new AtomicInteger();
+        AtomicBoolean directoryDeleted = new AtomicBoolean();
+
+        ThriftMetastoreClient client = createClient(getTableCalls);
+
+        ThriftHiveMetastore metastore = new ThriftHiveMetastore(
+                Optional.empty(),
+                _ -> new MemoryFileSystem() {
+                    @Override
+                    public void deleteDirectory(Location location)
+                    {
+                        directoryDeleted.set(true);
+                    }
+                },
+                _ -> client,
+                2.0,
+                new Duration(1, MILLISECONDS),
+                new Duration(10, MILLISECONDS),
+                new Duration(30, SECONDS),
+                new Duration(10, SECONDS),
+                3,
+                true,
+                false,
+                false,
+                new ThriftMetastoreStats(),
+                newSingleThreadExecutor());
+
+        metastore.dropTable("test_schema", "test_table", true);
+
+        assertThat(directoryDeleted.get())
+                .describedAs("Directory must be deleted on retry when HMS already dropped the table "
+                        + "but Trino got TTransportException (socket timeout)")
+                .isTrue();
+    }
+
+    private static ThriftMetastoreClient createClient(AtomicInteger getTableCalls)
+    {
+        // We want to reproduce case
+        // 1. call getTable -> return successfully that table exists
+        // 2. call dropTable -> the table successfully deleted from database, but throw exception 'Socket is closed by peer' during removing data from s3
+        // 3. call getTable -> return that table not found because was deleted on the previous step
+        InvocationHandler handler = (_, method, _) -> switch (method.getName()) {
+            case "getTable" -> {
+                if (getTableCalls.incrementAndGet() == 1) {
+                    yield managedTable();
+                }
+                throw new NoSuchObjectException("table not found");
+            }
+            case "dropTable" -> {
+                throw new TTransportException("Socket is closed by peer.");
+            }
+            case "close" -> null;
+            default -> throw new UnsupportedOperationException(method.getName());
+        };
+
+        return (ThriftMetastoreClient) Proxy.newProxyInstance(
+                ThriftMetastoreClient.class.getClassLoader(),
+                new Class<?>[] {ThriftMetastoreClient.class},
+                handler);
+    }
+
+    private static Table managedTable()
+    {
+        Table table = new Table();
+        table.setDbName("test_db");
+        table.setTableName("test_table");
+        table.setTableType(MANAGED_TABLE.name());
+        table.setSd(new StorageDescriptor(
+                ImmutableList.of(new FieldSchema("id", "bigint", "")),
+                "s3a://trino-sandbox/test_schema/test_table",
+                null, null, false, 0,
+                new SerDeInfo("test_table", null, ImmutableMap.of()),
+                null, null, ImmutableMap.of()));
+        table.setOwner("test");
+        table.setParameters(ImmutableMap.of());
+        return table;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When `ThriftHiveMetastore.dropTable()` succeeds in HMS (metadata deleted) but the Thrift response is lost due to a socket timeout (`TTransportException`) or other exception during remove from file system, the retry logic finds the table already gone (`NoSuchObjectException`) and returns without calling `deleteDirRecursive()`. This leaves data directories on storage, and as a result `CREATE TABLE` is failed with: `Target directory for table 'schema.table' already exists`

Root Cause

The retry branch in `dropTable()` handles `NoSuchObjectException` on attempt >= 2 by returning null, correctly assuming the previous attempt dropped the table. However, `deleteDirRecursive()` is only reachable after `client.dropTable()` on the normal path — the retry branch exits before it.
                                                                                                                                                                                                                                           
```java
  catch (NoSuchObjectException e) {                         
      if (attemptCount.get() == 1) { throw e; }
      // table was dropped on previous attempt, but data files are not cleaned up
      return null;  // deleteDirRecursive() never reached                                                                                                                                                                                
  }
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
