### PR TITLE
Use a lambda function to simulate a long running query in testCancellation

### DIFF
--- a/plugin/trino-redshift/README.md
+++ b/plugin/trino-redshift/README.md
@@ -97,6 +97,94 @@ create ephemeral Amazon Redshift clusters:
 }
 ```
 
+### AWS Lambda setup
+
+The test `io.trino.plugin.redshift.TestRedshiftConnectorTest.testCancellation` relies on an AWS Lambda function to simulate a long running query 
+in Redshift and test the cancellation of it.
+Below are the steps to create and configure the AWS Lambda function:
+
+1. Create the function code
+
+```
+cat > lambda_function.py << 'EOF'                                                                                      
+import json
+import time
+
+def lambda_handler(event, context):
+    results = []
+    for row_args in event['arguments']:
+        time.sleep(row_args[0])
+        results.append(1)
+    return json.dumps({"results": results, "success": True})
+
+EOF
+```
+
+2. Package it
+
+```
+zip lambda_function.zip lambda_function.py
+```
+
+3. Prepare the execution role for the function
+
+```
+aws iam create-role \
+    --role-name trino-redshift-sleep-lambda-execution \
+    --assume-role-policy-document '{                                                                                     
+      "Version": "2012-10-17",                                                                                           
+      "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"Service": "lambda.amazonaws.com"},
+        "Action": "sts:AssumeRole"
+      }]
+    }'
+```
+
+```
+aws iam attach-role-policy \
+    --role-name trino-redshift-sleep-lambda-execution \
+    --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 
+```
+
+4. Create the AWS lambda function
+
+```
+aws lambda create-function \
+    --function-name trino-redshift-ci-sleep \
+    --runtime python3.12 \
+    --handler lambda_function.lambda_handler \
+    --role arn:aws:iam::894365193301:role/trino-redshift-sleep-lambda-execution \
+    --zip-file fileb://lambda_function.zip \
+    --timeout 120 \
+    --region us-east-2
+```
+
+5. Allow Redshift to invoke it:
+
+```
+aws lambda add-permission \
+    --function-name trino-redshift-ci-sleep \
+    --statement-id redshift-ci-invoke \
+    --action lambda:InvokeFunction \
+    --principal arn:aws:iam::894365193301:role/redshift-ci \
+    --region us-east-2
+```
+
+```
+aws iam put-role-policy \
+    --role-name redshift-ci \
+    --policy-name invoke-trino-ci-redshift-sleep \
+    --policy-document '{                                                                                                 
+      "Version": "2012-10-17",                                                                                         
+      "Statement": [{
+        "Effect": "Allow",
+        "Action": "lambda:InvokeFunction",                                                                               
+        "Resource": "arn:aws:lambda:us-east-2:894365193301:function:trino-redshift-ci-sleep"
+      }]                                                                                                                 
+    }'
+```
+
 ### AWS S3 setup
 
 The `trino-redshift` tests rely on a Redshift cluster 

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -52,6 +52,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SystemSessionProperties.DISTINCT_AGGREGATIONS_STRATEGY;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.redshift.RedshiftQueryRunner.IAM_ROLE;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_PASSWORD;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_URL;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_USER;
@@ -888,15 +889,14 @@ public class TestRedshiftConnectorTest
     {
         long secondsToSleep = round(minimalQueryDuration.convertTo(SECONDS).getValue() + 1);
         // pg_sleep unsupported: https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-functions.html,
-        // adding a python UDF replacement
+        // Using a predefined AWS lambda replacement
         onRemoteDatabaseWithSchema(TEST_SCHEMA).execute(
                 """
-                CREATE OR REPLACE FUNCTION janky_sleep (x float) RETURNS bool IMMUTABLE as $$
-                    from time import sleep
-                    sleep(x)
-                    return True
-                $$ LANGUAGE plpythonu;
-                """);
+                CREATE OR REPLACE EXTERNAL FUNCTION\s
+                        janky_sleep(x int) returns int
+                        lambda 'trino-redshift-ci-sleep' IAM_ROLE '%s'
+                STABLE
+                """.formatted(IAM_ROLE));
         return new io.trino.testing.sql.TestView(
                 onRemoteDatabaseWithSchema(TEST_SCHEMA),
                 "test_sleeping_view",

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -95,8 +95,8 @@ public class TestRedshiftConnectorTest
     {
         return switch (connectorBehavior) {
             case SUPPORTS_COMMENT_ON_COLUMN,
-                 SUPPORTS_JOIN_PUSHDOWN,
                  SUPPORTS_CANCELLATION,
+                 SUPPORTS_JOIN_PUSHDOWN,
                  SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY -> true;
             case SUPPORTS_ADD_COLUMN_NOT_NULL_CONSTRAINT,
                  SUPPORTS_ADD_COLUMN_WITH_COMMENT,
@@ -111,8 +111,11 @@ public class TestRedshiftConnectorTest
                  SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM,
                  SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN,
                  SUPPORTS_MAP_TYPE,
+                 SUPPORTS_PREDICATE_ARITHMETIC_EXPRESSION_PUSHDOWN,
                  SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS,
                  SUPPORTS_ROW_TYPE,
+                 SUPPORTS_ROW_LEVEL_UPDATE,
+                 SUPPORTS_MERGE,
                  SUPPORTS_SET_COLUMN_TYPE -> false;
             default -> super.hasBehavior(connectorBehavior);
         };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Amazon Redshift will no longer support the creation of new Python UDFs:
https://aws.amazon.com/blogs/big-data/amazon-redshift-python-user-defined-functions-will-reach-end-of-support-after-june-30-2026/

The test
`io.trino.plugin.redshift.TestRedshiftConnectorTest.testCancellation` relies on an AWS Lambda function to simulate a
long running query in Redshift and test the
cancellation of it.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

```
How to Calculate Your Cost
To find your compute cost, use this formula:
$$\text{Cost} = \text{Allocated Memory (GB)} \times \text{Execution Time (Seconds)} \times \text{Rate}$$

Example:If you run a function with 1 GB of memory for 1 second:x86: $0.0000166667 per execution.
ARM: $0.0000133334 per execution.
If your function only uses 128 MB (0.125 GB) and runs for 200ms (0.2s):
$0.125 \times 0.2 \times 0.0000166667 = \$0.000000416$ per run.
```



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
