### PR TITLE
Ensure ephemeral Redshift cluster accepts TCP connections

### DIFF
--- a/.github/bin/redshift/setup-aws-redshift.sh
+++ b/.github/bin/redshift/setup-aws-redshift.sh
@@ -43,7 +43,7 @@ echo "Waiting for the Amazon Redshift cluster ${REDSHIFT_CLUSTER_IDENTIFIER} on 
 aws redshift wait cluster-available \
   --cluster-identifier ${REDSHIFT_CLUSTER_IDENTIFIER}
 
-echo "The Amazon Redshift cluster ${REDSHIFT_CLUSTER_IDENTIFIER} on the region ${AWS_REGION} is available for queries."
+echo "The Amazon Redshift cluster ${REDSHIFT_CLUSTER_IDENTIFIER} on the region ${AWS_REGION} reports available status."
 
 REDSHIFT_CLUSTER_DESCRIPTION=$(aws redshift describe-clusters --cluster-identifier ${REDSHIFT_CLUSTER_IDENTIFIER})
 
@@ -52,3 +52,21 @@ export REDSHIFT_PORT=$(echo ${REDSHIFT_CLUSTER_DESCRIPTION} | jq -r '.Clusters[0
 export REDSHIFT_CLUSTER_DATABASE_NAME=$(echo ${REDSHIFT_CLUSTER_DESCRIPTION} | jq -r '.Clusters[0].DBName' )
 export REDSHIFT_USER=$(echo ${REDSHIFT_CLUSTER_DESCRIPTION} | jq -r '.Clusters[0].MasterUsername' )
 export REDSHIFT_PASSWORD
+
+# The AWS API status "available" doesn't guarantee the endpoint is accepting connections yet.
+# Poll the actual TCP port until Redshift is truly ready.
+echo "Waiting for the Redshift endpoint ${REDSHIFT_ENDPOINT}:${REDSHIFT_PORT} to accept connections..."
+MAX_RETRIES=30
+RETRY_INTERVAL_SECONDS=10
+for ((i=1; i<=MAX_RETRIES; i++)); do
+    if nc -z -w 5 "${REDSHIFT_ENDPOINT}" "${REDSHIFT_PORT}" 2>/dev/null; then
+        echo "The Amazon Redshift cluster ${REDSHIFT_CLUSTER_IDENTIFIER} on the region ${AWS_REGION} is accepting connections."
+        break
+    fi
+    if [ "$i" -eq "$MAX_RETRIES" ]; then
+        echo "ERROR: Redshift endpoint ${REDSHIFT_ENDPOINT}:${REDSHIFT_PORT} did not become reachable after $((MAX_RETRIES * RETRY_INTERVAL_SECONDS)) seconds."
+        exit 1
+    fi
+    echo "  Attempt ${i}/${MAX_RETRIES}: endpoint not ready yet, retrying in ${RETRY_INTERVAL_SECONDS}s..."
+    sleep ${RETRY_INTERVAL_SECONDS}
+done


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The AWS API status "available" returned by the command

```
 aws redshift wait cluster-available
```

does not guarantee the endpoint is accepting connections yet. Poll the actual TCP port until Redshift is truly ready.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
