### PR TITLE
Add option to enable debug log for Exasol JDBC driver

### DIFF
--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -49,6 +49,17 @@ specify the certificate's fingerprint in the JDBC URL using parameter
 ``fingerprint``, e.g.: ``jdbc:exa:exasol.example.com:8563;fingerprint=ABC123``.
 :::
 
+### JDBC driver debugging
+
+To diagnose issues with the Exasol JDBC driver, you can enable log output by specifying
+the target log directory with property ``exasol.jdbc-driver.log-dir``.
+The JDBC driver will create one log file for each session in this directory.
+Logging is disabled by default.
+
+:::{note}
+Logging creates a lot of overhead especially when loading large amounts of data.
+:::
+
 ```{include} jdbc-authentication.fragment
 ```
 

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClientModule.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClientModule.java
@@ -28,8 +28,11 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
+import io.trino.spi.NodeVersion;
 import io.trino.spi.function.table.ConnectorTableFunction;
 
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
@@ -43,18 +46,26 @@ public class ExasolClientModule
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(ExasolClient.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
+        configBinder(binder).bindConfig(ExasolConfig.class);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
     }
 
     @Provides
     @Singleton
     @ForBaseJdbc
-    public static ConnectionFactory connectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
+    public static ConnectionFactory connectionFactory(BaseJdbcConfig config, ExasolConfig exasolConfig, CredentialProvider credentialProvider, OpenTelemetry openTelemetry, NodeVersion trinoVersion)
     {
         Properties connectionProperties = new Properties();
         // Deactivate SNAPSHOT_MODE (https://docs.exasol.com/db/latest/database_concepts/snapshot_mode.htm)
         // to ensure that {@link Connection#getMetaData()} always returns up-to-date data.
         connectionProperties.setProperty("snapshottransactions", "1");
+        connectionProperties.setProperty("clientname", "Trino");
+        connectionProperties.setProperty("clientversion", trinoVersion.toString());
+        Optional<Path> logDir = exasolConfig.getJdbcDriverLogDir();
+        if (logDir.isPresent()) {
+            connectionProperties.setProperty("debug", "1");
+            connectionProperties.setProperty("logdir", logDir.get().toString());
+        }
         return DriverConnectionFactory.builder(
                         new EXADriver(),
                         config.getConnectionUrl(),

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolConfig.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class ExasolConfig
+{
+    private Path jdbcDriverLogDir;
+
+    public Optional<Path> getJdbcDriverLogDir()
+    {
+        return Optional.ofNullable(jdbcDriverLogDir);
+    }
+
+    @ConfigDescription("Set a log directory to enable logging for the Exasol JDBC driver")
+    @Config("exasol.jdbc-driver.log-dir")
+    public void setJdbcDriverLogDir(Path jdbcDriverLogDir)
+    {
+        this.jdbcDriverLogDir = jdbcDriverLogDir;
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolConfig.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestExasolConfig
+{
+    ExasolConfig exasolConfig;
+
+    @BeforeEach
+    void setup()
+    {
+        exasolConfig = new ExasolConfig();
+    }
+
+    @Test
+    void testDefaultLogDirEmpty()
+    {
+        assertThat(exasolConfig.getJdbcDriverLogDir()).isEmpty();
+    }
+
+    @Test
+    void testCustomLogDir()
+    {
+        Path jdbcDriverLogDir = Path.of("log-dir");
+        exasolConfig.setJdbcDriverLogDir(jdbcDriverLogDir);
+        assertThat(exasolConfig.getJdbcDriverLogDir()).contains(jdbcDriverLogDir);
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestJdbcDriverDebugLog.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestJdbcDriverDebugLog.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJdbcDriverDebugLog
+        extends AbstractTestQueryFramework
+{
+    @TempDir
+    static Path logDir;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingExasolServer exasolServer = closeAfterClass(new TestingExasolServer());
+        return ExasolQueryRunner.builder(exasolServer)
+                .setInitialTables(List.of(NATION))
+                .addConnectorProperty("exasol.jdbc-driver.log-dir", logDir.toString())
+                .build();
+    }
+
+    @Test
+    void testJdbcDriverCreatesDebugLogFiles()
+            throws IOException
+    {
+        assertQuery("SELECT count(*) FROM nation", "SELECT 25");
+        try (Stream<Path> logFiles = Files.list(logDir)) {
+            assertThat(logFiles).hasSizeGreaterThan(0);
+        }
+    }
+}


### PR DESCRIPTION
Config option `exasol.jdbc_driver.log_dir` will configure the JDBC driver to create one log file per session in this directory.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The Exasol JDBC driver allows enabling debug logging. This can help identify connection issues etc.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

In this PR we add a new configuration option `exasol.jdbc_driver.log_dir` for the Exasol plugin. We also configure the connection factory to add the necessary configuration properties. We test this by checking if the log dir contains log files after executing a query.

Additionally the connection factory also passes client name and client version to the Exasol DB. This helps identifying sessions in Exasol.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Add option that allows enabling debug logging for the Exasol JDBC driver
```
