### PR TITLE
Implement .well-known/oauth-authorization-server for OAuth2

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2AuthorizationServerMetadataResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2AuthorizationServerMetadataResource.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.server.security.ResourceSecurity;
+import io.trino.server.security.oauth2.OAuth2ServerConfigProvider.OAuth2ServerConfig;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import java.util.Map;
+
+import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static java.util.Objects.requireNonNull;
+
+@Path("/.well-known/oauth-authorization-server")
+@ResourceSecurity(PUBLIC)
+public class OAuth2AuthorizationServerMetadataResource
+{
+    private final OAuth2Config config;
+    private final OAuth2ServerConfigProvider serverConfigProvider;
+
+    @Inject
+    public OAuth2AuthorizationServerMetadataResource(OAuth2Config config, OAuth2ServerConfigProvider serverConfigProvider)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.serverConfigProvider = requireNonNull(serverConfigProvider, "serverConfigProvider is null");
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Map<String, Object> getMetadata()
+    {
+        OAuth2ServerConfig serverConfig = serverConfigProvider.get();
+
+        ImmutableMap.Builder<String, Object> metadata = ImmutableMap.builder();
+        metadata.put("issuer", config.getIssuer());
+        metadata.put("authorization_endpoint", serverConfig.authUrl().toString());
+        metadata.put("token_endpoint", serverConfig.tokenUrl().toString());
+        metadata.put("jwks_uri", serverConfig.jwksUrl().toString());
+        metadata.put("scopes_supported", config.getScopes());
+        metadata.put("response_types_supported", "code");
+        serverConfig.userinfoUrl().ifPresent(uri -> metadata.put("userinfo_endpoint", uri.toString()));
+        serverConfig.endSessionUrl().ifPresent(uri -> metadata.put("end_session_endpoint", uri.toString()));
+        serverConfig.accessTokenIssuer().ifPresent(issuer -> metadata.put("access_token_issuer", issuer));
+
+        return metadata.buildOrThrow();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -39,6 +39,7 @@ public class OAuth2ServiceModule
     protected void setup(Binder binder)
     {
         jaxrsBinder(binder).bind(OAuth2CallbackResource.class);
+        jaxrsBinder(binder).bind(OAuth2AuthorizationServerMetadataResource.class);
         newOptionalBinder(binder, OAuth2WebUiInstalled.class);
 
         configBinder(binder).bindConfig(OAuth2Config.class);

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2AuthorizationServerMetadataResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2AuthorizationServerMetadataResource.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import io.trino.server.security.oauth2.OAuth2ServerConfigProvider.OAuth2ServerConfig;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestOAuth2AuthorizationServerMetadataResource
+{
+    @Test
+    void testMetadataWithAllEndpoints()
+    {
+        OAuth2Config config = new OAuth2Config()
+                .setIssuer("https://issuer.example.com")
+                .setClientId("client-id")
+                .setClientSecret("client-secret");
+
+        OAuth2ServerConfig serverConfig = new OAuth2ServerConfig(
+                Optional.of("https://issuer.example.com/access"),
+                URI.create("https://issuer.example.com/authorize"),
+                URI.create("https://issuer.example.com/token"),
+                URI.create("https://issuer.example.com/jwks"),
+                Optional.of(URI.create("https://issuer.example.com/userinfo")),
+                Optional.of(URI.create("https://issuer.example.com/logout")));
+
+        OAuth2AuthorizationServerMetadataResource resource = new OAuth2AuthorizationServerMetadataResource(config, () -> serverConfig);
+
+        Map<String, Object> metadata = resource.getMetadata();
+
+        assertThat(metadata)
+                .containsEntry("issuer", "https://issuer.example.com")
+                .containsEntry("authorization_endpoint", "https://issuer.example.com/authorize")
+                .containsEntry("token_endpoint", "https://issuer.example.com/token")
+                .containsEntry("jwks_uri", "https://issuer.example.com/jwks")
+                .containsEntry("scopes_supported", config.getScopes())
+                .containsEntry("response_types_supported", "code")
+                .containsEntry("userinfo_endpoint", "https://issuer.example.com/userinfo")
+                .containsEntry("end_session_endpoint", "https://issuer.example.com/logout")
+                .containsEntry("access_token_issuer", "https://issuer.example.com/access");
+    }
+
+    @Test
+    void testMetadataWithMinimalEndpoints()
+    {
+        OAuth2Config config = new OAuth2Config()
+                .setIssuer("https://issuer.example.com")
+                .setClientId("client-id")
+                .setClientSecret("client-secret");
+
+        OAuth2ServerConfig serverConfig = new OAuth2ServerConfig(
+                Optional.empty(),
+                URI.create("https://issuer.example.com/authorize"),
+                URI.create("https://issuer.example.com/token"),
+                URI.create("https://issuer.example.com/jwks"),
+                Optional.empty(),
+                Optional.empty());
+
+        OAuth2AuthorizationServerMetadataResource resource = new OAuth2AuthorizationServerMetadataResource(config, () -> serverConfig);
+
+        Map<String, Object> metadata = resource.getMetadata();
+
+        assertThat(metadata)
+                .containsEntry("issuer", "https://issuer.example.com")
+                .containsEntry("authorization_endpoint", "https://issuer.example.com/authorize")
+                .containsEntry("token_endpoint", "https://issuer.example.com/token")
+                .containsEntry("jwks_uri", "https://issuer.example.com/jwks")
+                .containsEntry("scopes_supported", config.getScopes())
+                .containsEntry("response_types_supported", "code")
+                .doesNotContainKey("userinfo_endpoint")
+                .doesNotContainKey("end_session_endpoint")
+                .doesNotContainKey("access_token_issuer");
+    }
+}


### PR DESCRIPTION
Tested with our `singlenode-oauth2` endpoint which returns for this new endpoint:

```
{
  "issuer": "https://hydra:4444/",
  "authorization_endpoint": "https://hydra:4444/oauth2/auth",
  "token_endpoint": "https://hydra:4444/oauth2/token",
  "jwks_uri": "https://hydra:4444/.well-known/jwks.json",
  "scopes_supported": [
    "openid"
  ],
  "response_types_supported": "code"
}
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add `.well-known/oauth-authorization-server` endpoint to OAuth2 support ({issue}`issuenumber`)
```
