### PR TITLE
Remove deprecated methods in DateTimeTestingUtils

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/DateTimeTestingUtils.java
+++ b/core/trino-main/src/main/java/io/trino/testing/DateTimeTestingUtils.java
@@ -92,24 +92,6 @@ public final class DateTimeTestingUtils
         return sqlTimestampOf(precision, dateTime.getMillis());
     }
 
-    /**
-     * @deprecated Use {@link #sqlTimestampOf(int precision, DateTime dateTime)}
-     */
-    @Deprecated
-    public static SqlTimestamp sqlTimestampOf(DateTime dateTime)
-    {
-        return sqlTimestampOf(dateTime.getMillis());
-    }
-
-    /**
-     * @deprecated Use {@link #sqlTimestampOf(int precision, long millis)}
-     */
-    @Deprecated
-    public static SqlTimestamp sqlTimestampOf(long millis)
-    {
-        return sqlTimestampOf(3, millis);
-    }
-
     public static SqlTimestamp sqlTimestampOf(int precision, long millis)
     {
         return SqlTimestamp.fromMillis(precision, millis);
@@ -123,29 +105,6 @@ public final class DateTimeTestingUtils
             int nanoOfSecond)
     {
         return sqlTimeOf(precision, LocalTime.of(hour, minuteOfHour, secondOfMinute, nanoOfSecond));
-    }
-
-    /**
-     * @deprecated Use {@link #sqlTimeOf(int precision, int hour, int minuteOfHour, int secondOfMinute, int nanoOfSecond)}
-     */
-    @Deprecated
-    public static SqlTime sqlTimeOf(
-            int hourOfDay,
-            int minuteOfHour,
-            int secondOfMinute,
-            int millisOfSecond)
-    {
-        LocalTime time = LocalTime.of(hourOfDay, minuteOfHour, secondOfMinute, millisToNanos(millisOfSecond));
-        return sqlTimeOf(time);
-    }
-
-    /**
-     * @deprecated Use {@link #sqlTimeOf(int precision, LocalTime time)}
-     */
-    @Deprecated
-    public static SqlTime sqlTimeOf(LocalTime time)
-    {
-        return sqlTimeOf(3, time);
     }
 
     public static SqlTime sqlTimeOf(int precision, LocalTime time)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -731,7 +731,7 @@ public class TestDefaultJdbcQueryBuilder
 
     private static long toTimeRepresentation(int hour, int minute, int second)
     {
-        SqlTime time = sqlTimeOf(hour, minute, second, 0);
+        SqlTime time = sqlTimeOf(3, hour, minute, second, 0);
         return time.getPicos();
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -2267,7 +2267,7 @@ public abstract class AbstractTestParquetReader
         if (input == null) {
             return null;
         }
-        return sqlTimestampOf((long) input);
+        return sqlTimestampOf(3, (long) input);
     }
 
     private static Date intToDate(Integer input)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
These methods have been deprecated for 6 years and there are few remaining usages.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
