### PR TITLE
DeltaLake support `optimize` output metrics in result

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -731,6 +731,14 @@ EXECUTE <alter-table-execute>`.
 ```{include} optimize.fragment
 ```
 
+```text
+        metric_name             | metric_value
+--------------------------------+--------------
+ rewritten_data_files_count     |            1
+ removed_deletion_vectors_count |            1
+ added_data_files_count         |            2
+```
+
 Use a `WHERE` clause with [metadata columns](delta-lake-special-columns) to filter
 which files are optimized.
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2943,13 +2943,12 @@ public class DeltaLakeMetadata
         DeltaLakeTableExecuteHandle executeHandle = (DeltaLakeTableExecuteHandle) tableExecuteHandle;
         switch (executeHandle.procedureId()) {
             case OPTIMIZE:
-                finishOptimize(session, executeHandle, fragments, splitSourceInfo);
-                return ImmutableMap.of();
+                return finishOptimize(session, executeHandle, fragments, splitSourceInfo).toMap();
         }
         throw new IllegalArgumentException("Unknown procedure '" + executeHandle.procedureId() + "'");
     }
 
-    private void finishOptimize(ConnectorSession session, DeltaLakeTableExecuteHandle executeHandle, Collection<Slice> fragments, List<Object> splitSourceInfo)
+    private OptimizeResult finishOptimize(ConnectorSession session, DeltaLakeTableExecuteHandle executeHandle, Collection<Slice> fragments, List<Object> splitSourceInfo)
     {
         DeltaTableOptimizeHandle optimizeHandle = (DeltaTableOptimizeHandle) executeHandle.procedureHandle();
         String tableLocation = executeHandle.tableLocation();
@@ -2958,6 +2957,12 @@ public class DeltaLakeMetadata
         Set<DeltaLakeScannedDataFile> scannedDataFiles = splitSourceInfo.stream()
                 .map(DeltaLakeScannedDataFile.class::cast)
                 .collect(toImmutableSet());
+
+        // delete vector
+        Set<String> filesToDelete = scannedDataFiles.stream()
+                .map(scannedDataFile -> scannedDataFile.deletionVector().map(DeletionVectorEntry::uniqueId))
+                .flatMap(Optional::stream)
+                .collect(Collectors.toSet());
 
         // files to be added
         List<DataFileInfo> dataFileInfos = fragments.stream()
@@ -3001,6 +3006,19 @@ public class DeltaLakeMetadata
                 cleanupFailedWrite(session, optimizeHandle.getCredentialsHandle(), dataFileInfos);
             }
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
+        }
+        return new OptimizeResult(scannedDataFiles.size(), filesToDelete.size(), dataFileInfos.size());
+    }
+
+    private record OptimizeResult(long rewrittenDataFiles, long removedDeleteFiles, long addedDataFiles)
+    {
+        Map<String, Long> toMap()
+        {
+            return ImmutableMap.<String, Long>builder()
+                    .put("rewritten_data_files_count", rewrittenDataFiles)
+                    .put("removed_delete_files_count", removedDeleteFiles)
+                    .put("added_data_files_count", addedDataFiles)
+                    .buildOrThrow();
         }
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -3153,15 +3153,12 @@ public class DeltaLakeMetadata
     {
         DeltaLakeTableExecuteHandle executeHandle = (DeltaLakeTableExecuteHandle) tableExecuteHandle;
         return switch (executeHandle.procedureId()) {
-            case OPTIMIZE -> {
-                finishOptimize(session, executeHandle, fragments, splitSourceInfo);
-                yield ImmutableMap.of();
-            }
+            case OPTIMIZE -> finishOptimize(session, executeHandle, fragments, splitSourceInfo);
             default -> throw new IllegalArgumentException("Unknown procedure '" + executeHandle.procedureId() + "'");
         };
     }
 
-    private void finishOptimize(ConnectorSession session, DeltaLakeTableExecuteHandle executeHandle, Collection<Slice> fragments, List<Object> splitSourceInfo)
+    private Map<String, Long> finishOptimize(ConnectorSession session, DeltaLakeTableExecuteHandle executeHandle, Collection<Slice> fragments, List<Object> splitSourceInfo)
     {
         DeltaTableOptimizeHandle optimizeHandle = (DeltaTableOptimizeHandle) executeHandle.procedureHandle();
         String tableLocation = executeHandle.tableLocation();
@@ -3215,6 +3212,16 @@ public class DeltaLakeMetadata
             }
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
         }
+        long removedDeleteFiles = scannedDataFiles.stream()
+                .map(file -> file.deletionVector().map(DeletionVectorEntry::uniqueId))
+                .flatMap(Optional::stream)
+                .collect(toImmutableSet())
+                .size();
+        return ImmutableMap.<String, Long>builder()
+                .put("rewritten_data_files_count", (long) scannedDataFiles.size())
+                .put("removed_deletion_vectors_count", removedDeleteFiles)
+                .put("added_data_files_count", (long) dataFileInfos.size())
+                .buildOrThrow();
     }
 
     private long commitOptimizeOperation(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeScannedDataFile.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeScannedDataFile.java
@@ -14,17 +14,19 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record DeltaLakeScannedDataFile(String path, Map<String, Optional<String>> partitionKeys)
+public record DeltaLakeScannedDataFile(String path, Map<String, Optional<String>> partitionKeys, Optional<DeletionVectorEntry> deletionVector)
 {
     public DeltaLakeScannedDataFile
     {
         requireNonNull(path, "path is null");
         partitionKeys = ImmutableMap.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
+        requireNonNull(deletionVector, "deletionVector is null");
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
@@ -146,7 +146,13 @@ public class DeltaLakeSplitSource
                                     split.getStatisticsPredicate().overlaps(dynamicFilterPredicate))
                             .collect(toImmutableList());
                     if (recordScannedFiles) {
-                        filteredSplits.forEach(split -> scannedFilePaths.add(new DeltaLakeScannedDataFile(((DeltaLakeSplit) split).getPath(), ((DeltaLakeSplit) split).getPartitionKeys())));
+                        filteredSplits.forEach(split -> {
+                            DeltaLakeSplit deltaLakeSplit = (DeltaLakeSplit) split;
+                            scannedFilePaths.add(new DeltaLakeScannedDataFile(
+                                    deltaLakeSplit.getPath(),
+                                    deltaLakeSplit.getPartitionKeys(),
+                                    deltaLakeSplit.getDeletionVector()));
+                        });
                     }
                     return new ConnectorSplitBatch(filteredSplits, noMoreSplits);
                 },

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
@@ -136,7 +136,13 @@ public class DeltaLakeSplitSource
                                     split.statisticsPredicate().overlaps(dynamicFilterPredicate))
                             .collect(toImmutableList());
                     if (recordScannedFiles) {
-                        filteredSplits.forEach(split -> scannedFilePaths.add(new DeltaLakeScannedDataFile(((DeltaLakeSplit) split).path(), ((DeltaLakeSplit) split).partitionKeys())));
+                        filteredSplits.forEach(split -> {
+                            DeltaLakeSplit deltaLakeSplit = (DeltaLakeSplit) split;
+                            scannedFilePaths.add(new DeltaLakeScannedDataFile(
+                                    deltaLakeSplit.path(),
+                                    deltaLakeSplit.partitionKeys(),
+                                    deltaLakeSplit.deletionVector()));
+                        });
                     }
                     return filteredSplits;
                 },

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -385,17 +385,14 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         String tableLocation = getLocationForTable(bucketName, tableName);
         assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (location = '" + tableLocation + "')");
         try {
-            // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
-            int workerCount = getQueryRunner().getNodeCount();
-
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one')", 1);
 
             for (int i = 0; i < 3; i++) {
                 Set<String> initialFiles = getActiveFiles(tableName);
-                computeActual("ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+                computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
                 Set<String> filesAfterOptimize = getActiveFiles(tableName);
                 assertThat(filesAfterOptimize)
-                        .hasSizeBetween(1, workerCount)
+                        .hasSize(1)
                         .containsExactlyElementsOf(initialFiles);
             }
 
@@ -444,18 +441,15 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         String tableLocation = getLocationForTable(bucketName, tableName);
         assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (location = '" + tableLocation + "', partitioned_by = ARRAY['key'])");
         try {
-            // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
-            int workerCount = getQueryRunner().getNodeCount();
-
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'one')", 1);
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 'two')", 1);
 
             for (int i = 0; i < 3; i++) {
                 Set<String> initialFiles = getActiveFiles(tableName);
-                computeActual("ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+                computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
                 Set<String> filesAfterOptimize = getActiveFiles(tableName);
                 assertThat(filesAfterOptimize)
-                        .hasSizeBetween(1, workerCount)
+                        .hasSize(2)
                         .containsExactlyInAnyOrderElementsOf(initialFiles);
             }
             assertQuery("SELECT * FROM " + tableName, "VALUES(1, 'one'), (2, 'two')");
@@ -1949,12 +1943,12 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                     // Verify we have sufficiently many test rows with respect to worker count.
                     .hasSizeGreaterThan(workerCount);
 
-            computeActual("ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+            computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
             assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + tableName))
                     .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
             Set<String> updatedFiles = getActiveFiles(tableName);
             assertThat(updatedFiles)
-                    .hasSizeBetween(1, workerCount)
+                    .hasSize(1)
                     .doesNotContainAnyElementsOf(initialFiles);
             // No files should be removed (this is VACUUM's job)
             assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
@@ -2005,14 +1999,14 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             Set<String> initialFiles = getActiveFiles(tableName);
             assertThat(initialFiles).hasSize(9);
 
-            computeActual("ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+            computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
 
             assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY value) FROM " + tableName))
                     .matches("VALUES (BIGINT '508', VARCHAR 'ONE Three four one one one tHrEe three two')");
 
             Set<String> updatedFiles = getActiveFiles(tableName);
             assertThat(updatedFiles)
-                    .hasSizeBetween(7, initialFiles.size());
+                    .hasSize(7);
             assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
         }
         finally {
@@ -2046,7 +2040,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             Set<String> initialFiles = getActiveFiles(tableName, currentSession);
             assertThat(initialFiles).hasSize(10);
 
-            computeActual(currentSession, "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+            computeActual(withSingleWriterPerTask(currentSession), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
 
             assertThat(query(currentSession, "SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY value) FROM " + tableName))
                     .matches("VALUES (BIGINT '55', VARCHAR 'one one one one one one one three two two')");
@@ -2058,6 +2052,13 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         finally {
             assertUpdate("DROP TABLE " + tableName);
         }
+    }
+
+    private Session withSingleWriterPerTask(Session session)
+    {
+        return Session.builder(session)
+                .setSystemProperty("task_min_writer_count", "1")
+                .build();
     }
 
     private void fillWithInserts(String tableName, String values, int toCreate)
@@ -2144,7 +2145,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         Set<String> initialFiles = getActiveFiles(tableName);
         assertThat(initialFiles).hasSize(10);
 
-        computeActual("ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+        computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
 
         assertThat(query("SELECT " +
                 "sum(value1), " +

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1999,7 +1999,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             Set<String> initialFiles = getActiveFiles(tableName);
             assertThat(initialFiles).hasSize(9);
 
-            computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+            assertUpdate(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 3), ('removed_delete_files_count', 0), ('added_data_files_count', 1)");
 
             assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY value) FROM " + tableName))
                     .matches("VALUES (BIGINT '508', VARCHAR 'ONE Three four one one one tHrEe three two')");
@@ -2008,6 +2009,58 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
             assertThat(updatedFiles)
                     .hasSize(7);
             assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    public void testOptimizeWithDeletionVectors()
+    {
+        String tableName = "test_optimize_partitioned_table_" + randomNameSuffix();
+        String tableLocation = getLocationForTable(bucketName, tableName);
+        assertQuerySucceeds(withSingleWriterPerTask(getSession()), "CREATE TABLE " + tableName + " WITH (deletion_vectors_enabled = true, location = '" + tableLocation + "') AS SELECT * FROM tpch.tiny.nation");
+        try {
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation");
+            Set<String> initFile = getActiveFiles(tableName);
+            assertThat(initFile).hasSize(6);
+            assertQuerySucceeds("DELETE FROM " + tableName + " WHERE nationkey < 5");
+            assertUpdate(withSingleWriterPerTask(getSession()),"ALTER TABLE " + tableName + " EXECUTE optimize",
+                    "VALUES ('rewritten_data_files_count', 6), ('removed_delete_files_count', 6), ('added_data_files_count', 1)");
+            assertThat(getActiveFiles(tableName)).hasSize(1);
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    public void testOptimizeWithPartitionedTableAndDeleteVector()
+    {
+        String tableName = "test_optimize_partitioned_table_" + randomNameSuffix();
+        String tableLocation = getLocationForTable(bucketName, tableName);
+        assertQuerySucceeds(withSingleWriterPerTask(getSession()), "CREATE TABLE " + tableName + " WITH (deletion_vectors_enabled = true, partitioned_by = ARRAY['regionkey'], location = '" + tableLocation + "') AS SELECT nationkey, regionkey FROM tpch.tiny.nation");
+        try {
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation");
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation");
+
+            Set<String> initialFiles = getActiveFiles(tableName);
+            assertThat(initialFiles).hasSize(30);
+            assertQuerySucceeds("DELETE FROM " + tableName + " WHERE nationkey < 5");
+
+            assertUpdate(withSingleWriterPerTask(getSession()), "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 30), ('removed_delete_files_count', 18), ('added_data_files_count', 5)");
+            Set<String> updatedFiles = getActiveFiles(tableName);
+            assertThat(updatedFiles)
+                    .hasSize(5);
         }
         finally {
             assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -935,6 +935,97 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    public void testOptimizeReturnsMetrics()
+    {
+        try (TestTable table = newTrinoTable("test_optimize_returns_metrics", "(key integer, value varchar)")) {
+            String tableName = table.getName();
+            assertUpdate("INSERT INTO " + tableName + " VALUES (11, 'eleven')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (12, 'twelve')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (13, 'thirteen')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (14, 'fourteen')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (15, 'fifteen')", 1);
+
+            Set<String> initialFiles = getActiveFiles(tableName);
+            assertThat(initialFiles).hasSize(5);
+
+            Session singleWriterSession = Session.builder(getSession())
+                    .setSystemProperty("task_min_writer_count", "1")
+                    .build();
+            assertUpdate(
+                    singleWriterSession,
+                    "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 5), ('removed_deletion_vectors_count', 0), ('added_data_files_count', 1)");
+
+            assertQuery(
+                    "SELECT * FROM " + tableName,
+                    "VALUES (11, 'eleven'), (12, 'twelve'), (13, 'thirteen'), (14, 'fourteen'), (15, 'fifteen')");
+            Set<String> updatedFiles = getActiveFiles(tableName);
+            assertThat(updatedFiles)
+                    .hasSize(1)
+                    .doesNotContainAnyElementsOf(initialFiles);
+        }
+    }
+
+    @Test
+    public void testOptimizeWithDeletionVectors()
+    {
+        try (TestTable table = newTrinoTable(
+                "test_optimize_deletion_vectors",
+                "WITH (deletion_vectors_enabled = true) AS SELECT * FROM tpch.tiny.nation")) {
+            String tableName = table.getName();
+            assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT * FROM tpch.tiny.nation", 25);
+
+            Set<String> initialFiles = getActiveFiles(tableName);
+            assertThat(initialFiles).hasSize(6);
+            assertUpdate("DELETE FROM " + tableName + " WHERE nationkey < 5", 30);
+
+            Session singleWriterSession = Session.builder(getSession())
+                    .setSystemProperty("task_min_writer_count", "1")
+                    .build();
+            assertUpdate(
+                    singleWriterSession,
+                    "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 6), ('removed_deletion_vectors_count', 6), ('added_data_files_count', 1)");
+            assertThat(getActiveFiles(tableName)).hasSize(1);
+        }
+    }
+
+    @Test
+    public void testOptimizeWithPartitionedTableAndDeleteVector()
+    {
+        try (TestTable table = newTrinoTable(
+                "test_optimize_partitioned_deletion_vectors",
+                "WITH (deletion_vectors_enabled = true, partitioned_by = ARRAY['regionkey']) AS SELECT nationkey, regionkey FROM tpch.tiny.nation")) {
+            String tableName = table.getName();
+            assertUpdate("INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation", 25);
+            assertUpdate("INSERT INTO " + tableName + " SELECT nationkey, regionkey FROM tpch.tiny.nation", 25);
+
+            Set<String> initialFiles = getActiveFiles(tableName);
+            assertThat(initialFiles).hasSize(30);
+            assertUpdate("DELETE FROM " + tableName + " WHERE regionkey = 1 AND nationkey < 5", 18);
+
+            Session singleWriterSession = Session.builder(getSession())
+                    .setSystemProperty("task_min_writer_count", "1")
+                    .build();
+            assertUpdate(
+                    singleWriterSession,
+                    "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 30), ('removed_deletion_vectors_count', 6), ('added_data_files_count', 5)");
+            assertThat(getActiveFiles(tableName)).hasSize(5);
+            assertQuery(
+                    "SELECT nationkey, regionkey, count(*) FROM " + tableName + " GROUP BY nationkey, regionkey",
+                    "SELECT nationkey, regionkey, 6 FROM nation WHERE regionkey <> 1 OR nationkey >= 5");
+        }
+    }
+
+    @Test
     public void testAddColumnAndVacuum()
             throws Exception
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Allow distributed table procedures to output metrics in result.
DeltaLake OPTIMIZE procedure returns the output below:

```
trino> ALTER TABLE deltalake.tpch.region EXECUTE optimize;
ALTER TABLE EXECUTE
        metric_name             | metric_value
--------------------------------+--------------
 rewritten_data_files_count     |            1
 removed_deletion_vectors_count |            1
 added_data_files_count         |            2
(3 rows)
```

- Fixes https://github.com/trinodb/trino/issues/28999

## Release notes

```markdown
## Delta Lake
* Add support for execution metrics while running the `optimize` procedure. ({issue}`28992`)
```
