### PR TITLE
Add VARIANT_JSON and VARIANT_BINARY client capabilities

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -13,6 +13,7 @@
  */
 package io.trino.cli;
 
+import io.trino.client.ClientCapabilities;
 import io.trino.client.ClientSession;
 import io.trino.client.StatementClient;
 import io.trino.client.uri.HttpClientFactory;
@@ -20,17 +21,25 @@ import io.trino.client.uri.TrinoUri;
 import okhttp3.OkHttpClient;
 
 import java.io.Closeable;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.client.ClientSession.stripTransactionId;
 import static io.trino.client.StatementClientFactory.newStatementClient;
 import static io.trino.client.UserAgentBuilder.createUserAgent;
+import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 public class QueryRunner
         implements Closeable
 {
     private static final String USER_AGENT = createUserAgent("trino-cli");
+    private static final Set<String> CLIENT_CAPABILITIES = stream(ClientCapabilities.values())
+            .filter(capability -> capability != ClientCapabilities.VARIANT_BINARY)
+            .map(Enum::name)
+            .collect(toUnmodifiableSet());
 
     private final AtomicReference<ClientSession> session;
     private final boolean debug;
@@ -78,7 +87,7 @@ public class QueryRunner
 
     private StatementClient startInternalQuery(ClientSession session, String query)
     {
-        return newStatementClient(httpClient, segmentHttpClient, session, query);
+        return newStatementClient(httpClient, segmentHttpClient, session, query, Optional.of(CLIENT_CAPABILITIES));
     }
 
     @Override

--- a/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
@@ -34,6 +34,12 @@ public enum ClientCapabilities
     NUMBER,
 
     /**
+     * Whether client supports the `VARIANT` type.
+     * When this capability is not set, the server returns `json` for `VARIANT` columns.
+     */
+    VARIANT,
+
+    /**
      * Whether clients support the session authorization set/reset feature
      */
     SESSION_AUTHORIZATION;

--- a/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
@@ -35,9 +35,14 @@ public enum ClientCapabilities
 
     /**
      * Whether client supports the `VARIANT` type.
-     * When this capability is not set, the server returns `json` for `VARIANT` columns.
+     * When neither this capability nor `VARIANT_BINARY` are set, the server returns `json` for `VARIANT` columns.
      */
     VARIANT,
+
+    /**
+     * Whether client supports the `VARIANT` type encoded as a binary payload on the wire.
+     */
+    VARIANT_BINARY,
 
     /**
      * Whether clients support the session authorization set/reset feature

--- a/client/trino-client/src/main/java/io/trino/client/EncodedVariant.java
+++ b/client/trino-client/src/main/java/io/trino/client/EncodedVariant.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class EncodedVariant
+{
+    private final byte[] metadataBytes;
+    private final byte[] valueBytes;
+
+    private EncodedVariant(byte[] metadataBytes, byte[] valueBytes)
+    {
+        this.metadataBytes = requireNonNull(metadataBytes, "metadataBytes is null");
+        this.valueBytes = requireNonNull(valueBytes, "valueBytes is null");
+        checkArgument(valueBytes.length > 0, "valueBytes is empty");
+    }
+
+    public static EncodedVariant fromBytes(byte[] metadataBytes, byte[] valueBytes)
+    {
+        requireNonNull(metadataBytes, "metadataBytes is null");
+        requireNonNull(valueBytes, "valueBytes is null");
+        return new EncodedVariant(metadataBytes, valueBytes);
+    }
+
+    public byte[] getMetadataBytes()
+    {
+        return metadataBytes;
+    }
+
+    public byte[] getValueBytes()
+    {
+        return valueBytes;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/JsonDecodingUtils.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonDecodingUtils.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
+import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
+import static com.fasterxml.jackson.core.JsonToken.FIELD_NAME;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -87,16 +89,17 @@ public final class JsonDecodingUtils
     private static final RealDecoder REAL_DECODER = new RealDecoder();
     private static final BooleanDecoder BOOLEAN_DECODER = new BooleanDecoder();
     private static final StringDecoder STRING_DECODER = new StringDecoder();
-    private static final VariantDecoder VARIANT_DECODER = new VariantDecoder();
+    private static final VariantJsonDecoder VARIANT_JSON_DECODER = new VariantJsonDecoder();
+    private static final VariantBinaryDecoder VARIANT_BINARY_DECODER = new VariantBinaryDecoder();
     private static final Base64Decoder BASE_64_DECODER = new Base64Decoder();
     private static final ObjectDecoder OBJECT_DECODER = new ObjectDecoder();
 
-    public static TypeDecoder[] createTypeDecoders(List<Column> columns)
+    public static TypeDecoder[] createTypeDecoders(List<Column> columns, boolean supportsVariantBinary)
     {
         verify(!columns.isEmpty(), "Columns must not be empty");
         TypeDecoder[] decoders = new TypeDecoder[columns.size()];
         for (int i = 0; i < columns.size(); i++) {
-            decoders[i] = createTypeDecoder(columns.get(i).getTypeSignature());
+            decoders[i] = createTypeDecoder(columns.get(i).getTypeSignature(), supportsVariantBinary);
         }
         return decoders;
     }
@@ -107,7 +110,7 @@ public final class JsonDecodingUtils
                 throws IOException;
     }
 
-    private static TypeDecoder createTypeDecoder(ClientTypeSignature signature)
+    private static TypeDecoder createTypeDecoder(ClientTypeSignature signature, boolean supportsVariantBinary)
     {
         switch (signature.getRawType()) {
             case BIGINT:
@@ -125,13 +128,13 @@ public final class JsonDecodingUtils
             case BOOLEAN:
                 return BOOLEAN_DECODER;
             case VARIANT:
-                return VARIANT_DECODER;
+                return supportsVariantBinary ? VARIANT_BINARY_DECODER : VARIANT_JSON_DECODER;
             case ARRAY:
-                return new ArrayDecoder(signature);
+                return new ArrayDecoder(signature, supportsVariantBinary);
             case MAP:
-                return new MapDecoder(signature);
+                return new MapDecoder(signature, supportsVariantBinary);
             case ROW:
-                return new RowDecoder(signature);
+                return new RowDecoder(signature, supportsVariantBinary);
             case VARCHAR:
             case JSON:
             case TIME:
@@ -296,7 +299,7 @@ public final class JsonDecodingUtils
         }
     }
 
-    private static class VariantDecoder
+    private static class VariantJsonDecoder
             implements TypeDecoder
     {
         @Override
@@ -308,6 +311,46 @@ public final class JsonDecodingUtils
                 generator.copyCurrentStructure(parser);
             }
             return writer.toString();
+        }
+    }
+
+    private static class VariantBinaryDecoder
+            implements TypeDecoder
+    {
+        @Override
+        public Object decode(JsonParser parser)
+                throws IOException
+        {
+            if (requireNonNull(parser.currentToken()) != START_OBJECT) {
+                throw illegalToken(parser);
+            }
+
+            byte[] metadataBytes = null;
+            byte[] valueBytes = null;
+            while (parser.nextToken() != END_OBJECT) {
+                if (requireNonNull(parser.currentToken()) != FIELD_NAME) {
+                    throw illegalToken(parser);
+                }
+
+                String fieldName = parser.currentName();
+                if (parser.nextToken() != JsonToken.VALUE_STRING) {
+                    throw illegalToken(parser);
+                }
+
+                switch (fieldName) {
+                    case "metadata":
+                        metadataBytes = Base64.getDecoder().decode(parser.getValueAsString());
+                        break;
+                    case "value":
+                        valueBytes = Base64.getDecoder().decode(parser.getValueAsString());
+                        break;
+                }
+            }
+
+            if (metadataBytes == null || valueBytes == null) {
+                throw illegalToken(parser);
+            }
+            return EncodedVariant.fromBytes(metadataBytes, valueBytes);
         }
     }
 
@@ -327,11 +370,11 @@ public final class JsonDecodingUtils
     {
         private final TypeDecoder typeDecoder;
 
-        public ArrayDecoder(ClientTypeSignature signature)
+        public ArrayDecoder(ClientTypeSignature signature, boolean supportsVariantBinary)
         {
             requireNonNull(signature, "signature is null");
             checkArgument(signature.getRawType().equals(ARRAY), "not an array type signature: %s", signature);
-            this.typeDecoder = createTypeDecoder(signature.getArgumentsAsTypeSignatures().get(0));
+            this.typeDecoder = createTypeDecoder(signature.getArgumentsAsTypeSignatures().get(0), supportsVariantBinary);
         }
 
         @Override
@@ -363,12 +406,12 @@ public final class JsonDecodingUtils
         private final String keyType;
         private final TypeDecoder valueDecoder;
 
-        public MapDecoder(ClientTypeSignature signature)
+        public MapDecoder(ClientTypeSignature signature, boolean supportsVariantBinary)
         {
             requireNonNull(signature, "signature is null");
             checkArgument(signature.getRawType().equals(MAP), "not a map type signature: %s", signature);
             this.keyType = signature.getArgumentsAsTypeSignatures().get(0).getRawType();
-            this.valueDecoder = createTypeDecoder(signature.getArgumentsAsTypeSignatures().get(1));
+            this.valueDecoder = createTypeDecoder(signature.getArgumentsAsTypeSignatures().get(1), supportsVariantBinary);
         }
 
         @Override
@@ -446,7 +489,7 @@ public final class JsonDecodingUtils
         private final TypeDecoder[] fieldDecoders;
         private final List<Optional<String>> fieldNames;
 
-        private RowDecoder(ClientTypeSignature signature)
+        private RowDecoder(ClientTypeSignature signature, boolean supportsVariantBinary)
         {
             requireNonNull(signature, "signature is null");
             checkArgument(signature.getRawType().equals(ROW), "not a row type signature: %s", signature);
@@ -455,7 +498,7 @@ public final class JsonDecodingUtils
 
             int index = 0;
             for (ClientTypeSignatureParameter parameter : signature.getArguments()) {
-                fieldDecoders[index] = createTypeDecoder(parameter.getTypeSignature());
+                fieldDecoders[index] = createTypeDecoder(parameter.getTypeSignature(), supportsVariantBinary);
                 fieldNames.add(parameter.getName());
                 index++;
             }

--- a/client/trino-client/src/main/java/io/trino/client/JsonIterators.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonIterators.java
@@ -138,10 +138,10 @@ public final class JsonIterators
         }
     }
 
-    public static CloseableIterator<List<Object>> forJsonParser(JsonParser parser, List<Column> columns)
+    public static CloseableIterator<List<Object>> forJsonParser(JsonParser parser, List<Column> columns, boolean supportsVariantBinary)
             throws IOException
     {
-        return new JsonIterator(parser, createTypeDecoders(columns));
+        return new JsonIterator(parser, createTypeDecoders(columns, supportsVariantBinary));
     }
 
     public static CloseableIterator<List<Object>> forInputStream(InputStream stream, TypeDecoder[] decoders)

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataDecoder.java
@@ -23,7 +23,7 @@ public interface QueryDataDecoder
 {
     interface Factory
     {
-        QueryDataDecoder create(List<Column> columns, DataAttributes attributes);
+        QueryDataDecoder create(List<Column> columns, DataAttributes attributes, boolean supportsVariantBinary);
 
         String encoding();
     }

--- a/client/trino-client/src/main/java/io/trino/client/ResultRowsDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/ResultRowsDecoder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.trino.client.spooling.DataAttributes;
 import io.trino.client.spooling.EncodedQueryData;
 import io.trino.client.spooling.SegmentLoader;
@@ -38,16 +39,19 @@ public class ResultRowsDecoder
         implements AutoCloseable
 {
     private final SegmentLoader loader;
+    private final boolean supportsVariantBinary;
     private QueryDataDecoder decoder;
 
+    @VisibleForTesting
     public ResultRowsDecoder()
     {
-        this(new OkHttpSegmentLoader());
+        this(new OkHttpSegmentLoader(), false);
     }
 
-    public ResultRowsDecoder(SegmentLoader loader)
+    ResultRowsDecoder(SegmentLoader loader, boolean supportsVariantBinary)
     {
         this.loader = requireNonNull(loader, "loader is null");
+        this.supportsVariantBinary = supportsVariantBinary;
     }
 
     private void setEncoding(List<Column> columns, String encoding)
@@ -59,7 +63,7 @@ public class ResultRowsDecoder
             checkState(!columns.isEmpty(), "Columns must be set when decoding data");
             this.decoder = QueryDataDecoders.get(encoding)
                     // we don't use query-level attributes for now
-                    .create(columns, DataAttributes.empty());
+                    .create(columns, DataAttributes.empty(), supportsVariantBinary);
         }
     }
 
@@ -88,7 +92,7 @@ public class ResultRowsDecoder
         if (data instanceof JsonQueryData) {
             JsonQueryData jsonData = (JsonQueryData) data;
             try {
-                return wrapIterator(JsonIterators.forJsonParser(jsonData.getJsonParser(), columns), jsonData.getRowsCount());
+                return wrapIterator(JsonIterators.forJsonParser(jsonData.getJsonParser(), columns, supportsVariantBinary), jsonData.getRowsCount());
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientFactory.java
@@ -28,6 +28,11 @@ public final class StatementClientFactory
         return new StatementClientV1(httpCallFactory, segmentHttpCallFactory, session, query, Optional.empty());
     }
 
+    public static StatementClient newStatementClient(Call.Factory httpCallFactory, Call.Factory segmentHttpCallFactory, ClientSession session, String query, Optional<Set<String>> clientCapabilities)
+    {
+        return new StatementClientV1(httpCallFactory, segmentHttpCallFactory, session, query, clientCapabilities);
+    }
+
     public static StatementClient newStatementClient(OkHttpClient httpClient, Call.Factory segmentHttpCallFactory, ClientSession session, String query, Optional<Set<String>> clientCapabilities)
     {
         return new StatementClientV1((Call.Factory) httpClient, segmentHttpCallFactory, session, query, clientCapabilities);

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -69,7 +69,6 @@ import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
-import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -132,13 +131,16 @@ class StatementClientV1
                 .map(Optional::get)
                 .findFirst();
         this.setOriginalRoles.addAll(session.getOriginalRoles());
-        this.clientCapabilities = Joiner.on(",").join(clientCapabilities.orElseGet(() -> stream(ClientCapabilities.values())
+        Set<String> effectiveClientCapabilities = clientCapabilities.orElseGet(() -> Stream.of(ClientCapabilities.values())
                 .map(Enum::name)
-                .collect(toImmutableSet())));
+                .collect(toImmutableSet()));
+        this.clientCapabilities = Joiner.on(",").join(effectiveClientCapabilities);
         this.compressionDisabled = session.isCompressionDisabled();
         this.heartbeatInterval = session.getHeartbeatInterval().toMillis() * 1_000_000;
 
-        this.resultRowsDecoder = new ResultRowsDecoder(new OkHttpSegmentLoader(requireNonNull(segmentHttpCallFactory, "segmentHttpCallFactory is null")));
+        this.resultRowsDecoder = new ResultRowsDecoder(
+                new OkHttpSegmentLoader(requireNonNull(segmentHttpCallFactory, "segmentHttpCallFactory is null")),
+                effectiveClientCapabilities.contains(ClientCapabilities.VARIANT_BINARY.toString()));
 
         Request request = buildQueryRequest(session, query, session.getEncoding());
         // Pass empty as materializedJsonSizeLimit to always materialize the first response

--- a/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/encoding/JsonQueryDataDecoder.java
@@ -54,9 +54,9 @@ public class JsonQueryDataDecoder
             implements QueryDataDecoder.Factory
     {
         @Override
-        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes)
+        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes, boolean supportsVariantBinary)
         {
-            return new JsonQueryDataDecoder(createTypeDecoders(columns));
+            return new JsonQueryDataDecoder(createTypeDecoders(columns, supportsVariantBinary));
         }
 
         @Override
@@ -70,9 +70,9 @@ public class JsonQueryDataDecoder
             extends Factory
     {
         @Override
-        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes)
+        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes, boolean supportsVariantBinary)
         {
-            return new ZstdQueryDataDecoder(super.create(columns, queryAttributes));
+            return new ZstdQueryDataDecoder(super.create(columns, queryAttributes, supportsVariantBinary));
         }
 
         @Override
@@ -86,9 +86,9 @@ public class JsonQueryDataDecoder
             extends Factory
     {
         @Override
-        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes)
+        public QueryDataDecoder create(List<Column> columns, DataAttributes queryAttributes, boolean supportsVariantBinary)
         {
-            return new Lz4QueryDataDecoder(super.create(columns, queryAttributes));
+            return new Lz4QueryDataDecoder(super.create(columns, queryAttributes, supportsVariantBinary));
         }
 
         @Override

--- a/client/trino-client/src/test/java/io/trino/client/TestResultRowsDecoder.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestResultRowsDecoder.java
@@ -117,7 +117,7 @@ class TestResultRowsDecoder
     {
         AtomicInteger loaded = new AtomicInteger();
         AtomicInteger acknowledged = new AtomicInteger();
-        try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged))) {
+        try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged), false)) {
             assertThat(eagerlyMaterialize(decoder.toRows(fromSegments(spooledSegment(2), spooledSegment(2)))))
                     .hasSize(4)
                     .containsExactly(ImmutableList.of(2137), ImmutableList.of(1337), ImmutableList.of(2137), ImmutableList.of(1337));
@@ -132,7 +132,7 @@ class TestResultRowsDecoder
     {
         AtomicInteger loaded = new AtomicInteger();
         AtomicInteger acknowledged = new AtomicInteger();
-        try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged))) {
+        try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged), false)) {
             assertThat(eagerlyMaterialize(decoder.toRows(fromSegments(spooledSegment(2), spooledSegment(2)))))
                     .hasSize(4)
                     .containsExactly(ImmutableList.of(2137), ImmutableList.of(1337), ImmutableList.of(2137), ImmutableList.of(1337));
@@ -148,7 +148,7 @@ class TestResultRowsDecoder
                 .mapToObj(Integer::toString)
                 .reduce("[", (a, b) -> a + "[" + b + "],", String::concat) + "[1337]]";
         CountingInputStream stream = new CountingInputStream(new ByteArrayInputStream(data.getBytes(UTF_8)));
-        try (ResultRowsDecoder decoder = new ResultRowsDecoder(loaderFromStream(stream))) {
+        try (ResultRowsDecoder decoder = new ResultRowsDecoder(loaderFromStream(stream), false)) {
             Iterator<List<Object>> iterator = decoder.toRows(fromSegments(spooledSegment(2501))).iterator();
             assertThat(stream.getCount()).isEqualTo(0);
             iterator.next();
@@ -174,7 +174,7 @@ class TestResultRowsDecoder
     {
         AtomicInteger loaded = new AtomicInteger();
         AtomicInteger acknowledged = new AtomicInteger();
-        try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged))) {
+        try (ResultRowsDecoder decoder = new ResultRowsDecoder(new StaticLoader(loaded, acknowledged), false)) {
             Iterator<List<Object>> iterator = decoder.toRows(fromSegments(spooledSegment(2), spooledSegment(2)))
                     .iterator();
 

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -19,6 +19,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
@@ -99,6 +105,12 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -184,6 +196,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>security</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -23,10 +23,11 @@ import io.trino.client.ClientTypeSignature;
 import io.trino.client.ClientTypeSignatureParameter;
 import io.trino.client.CloseableIterator;
 import io.trino.client.Column;
+import io.trino.client.EncodedVariant;
 import io.trino.client.IntervalDayTime;
 import io.trino.client.IntervalYearMonth;
-import io.trino.jdbc.ColumnInfo.Nullable;
 import io.trino.jdbc.TypeConversions.NoConversionRegisteredException;
+import jakarta.annotation.Nullable;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
@@ -150,6 +151,7 @@ abstract class AbstractTrinoResultSet
             .put("interval day to second", TrinoIntervalDayTime.class)
             .put("map", Map.class)
             .put("row", Row.class)
+            .put("variant", Object.class)
             .buildOrThrow();
 
     @VisibleForTesting
@@ -200,6 +202,11 @@ abstract class AbstractTrinoResultSet
                         }
                         return result;
                     })
+                    .add("variant", EncodedVariant.class, Object.class, value -> decodeVariant(value).toObject())
+                    .add("variant", EncodedVariant.class, String.class, value -> decodeVariant(value).toJson())
+                    .add("variant", EncodedVariant.class, Variant.class, AbstractTrinoResultSet::decodeVariant)
+                    .add("variant", EncodedVariant.class, Map.class, value -> variantToMap(decodeVariant(value)))
+                    .add("variant", EncodedVariant.class, List.class, value -> variantToList(decodeVariant(value)))
                     .build();
     protected final CloseableIterator<List<Object>> results;
     private final Map<String, Integer> fieldMap;
@@ -676,8 +683,8 @@ abstract class AbstractTrinoResultSet
         return column(columnIndex);
     }
 
-    @jakarta.annotation.Nullable
-    private static Object convertFromClientRepresentation(ClientTypeSignature columnType, @jakarta.annotation.Nullable Object value)
+    @Nullable
+    private static Object convertFromClientRepresentation(ClientTypeSignature columnType, @Nullable Object value)
             throws SQLException
     {
         requireNonNull(columnType, "columnType is null");
@@ -739,6 +746,29 @@ abstract class AbstractTrinoResultSet
     private static TrinoIntervalYearMonth parseIntervalYearMonth(String value)
     {
         return new TrinoIntervalYearMonth(IntervalYearMonth.parseMonths(value));
+    }
+
+    private static Variant decodeVariant(EncodedVariant value)
+    {
+        return Variant.fromBytes(value.getMetadataBytes(), value.getValueBytes());
+    }
+
+    private static Map<?, ?> variantToMap(Variant variant)
+            throws SQLException
+    {
+        if (variant.valueType() != Variant.ValueType.OBJECT) {
+            throw new SQLException("VARIANT is not an object");
+        }
+        return (Map<?, ?>) variant.toObject();
+    }
+
+    private static List<?> variantToList(Variant variant)
+            throws SQLException
+    {
+        if (variant.valueType() != Variant.ValueType.ARRAY) {
+            throw new SQLException("VARIANT is not an array");
+        }
+        return (List<?>) variant.toObject();
     }
 
     private static TrinoIntervalDayTime parseIntervalDayTime(String value)
@@ -1837,7 +1867,12 @@ abstract class AbstractTrinoResultSet
 
         try {
             T converted = TYPE_CONVERSIONS.convert(columnTypeSignature, object, type);
-            verify(converted != null, "Conversion cannot return null for non-null input, as this breaks wasNull()");
+            boolean variantObjectRepresentation = type == Object.class &&
+                    columnTypeSignature.getRawType().equals("variant");
+            // VARIANT null is a non-SQL-null value whose Java object representation is null.
+            verify(
+                    converted != null || variantObjectRepresentation,
+                    "Conversion cannot return null for non-null input, as this breaks wasNull()");
             return converted;
         }
         catch (NoConversionRegisteredException e) {
@@ -1999,7 +2034,7 @@ abstract class AbstractTrinoResultSet
                     .setColumnLabel(column.getName())
                     .setColumnName(column.getName()) // TODO
                     .setColumnTypeSignature(column.getTypeSignature())
-                    .setNullable(Nullable.UNKNOWN)
+                    .setNullable(ColumnInfo.Nullable.UNKNOWN)
                     .setCurrency(false);
             setTypeInfo(builder, column.getTypeSignature());
             list.add(builder.build());

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/Variant.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/Variant.java
@@ -1,0 +1,914 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.util.JsonRecyclerPools;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkElementIndex;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.multiplyExact;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * JDBC representation for a {@code VARIANT} value encoded according to the Iceberg specification.
+ * <p>
+ * The value can be inspected with {@link #valueType()} and then read with the
+ * corresponding typed accessor, or converted recursively to Java objects with
+ * {@link #toObject()}.
+ */
+public final class Variant
+{
+    private static final JsonFactory JSON_FACTORY = jsonFactory();
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
+    private static final VarHandle SHORT_HANDLE = MethodHandles.byteArrayViewVarHandle(short[].class, LITTLE_ENDIAN);
+    private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, LITTLE_ENDIAN);
+    private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, LITTLE_ENDIAN);
+    private static final long MICROS_PER_SECOND = 1_000_000L;
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+    private final Metadata metadata;
+    private final byte[] valueBytes;
+    private final int valueOffset;
+    private final BasicType basicType;
+    private final PrimitiveType primitiveType;
+    private final ValueType valueType;
+
+    private Variant(Metadata metadata, byte[] valueBytes, int valueOffset, int valueLength)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.valueBytes = requireNonNull(valueBytes, "valueBytes is null");
+        checkArgument(valueLength > 0, "valueBytes is empty");
+        checkArgument(valueOffset >= 0, "valueOffset is negative");
+        checkArgument(valueOffset + valueLength <= valueBytes.length, "Invalid value range: offset=%s length=%s", valueOffset, valueLength);
+
+        this.valueOffset = valueOffset;
+
+        byte header = valueBytes[valueOffset];
+        this.basicType = BasicType.fromHeader(header);
+        this.primitiveType = (basicType == BasicType.PRIMITIVE) ? PrimitiveType.fromHeader(header) : null;
+        this.valueType = ValueType.from(basicType, primitiveType);
+    }
+
+    public static Variant fromBytes(byte[] metadataBytes, byte[] valueBytes)
+    {
+        requireNonNull(metadataBytes, "metadataBytes is null");
+        requireNonNull(valueBytes, "valueBytes is null");
+
+        return new Variant(Metadata.fromBytes(metadataBytes), valueBytes, 0, valueBytes.length);
+    }
+
+    public byte[] getMetadataBytes()
+    {
+        return metadata.getBytes();
+    }
+
+    public byte[] getValueBytes()
+    {
+        int valueSize = valueSize(valueBytes, valueOffset);
+        if (valueOffset == 0 && valueSize == valueBytes.length) {
+            return valueBytes;
+        }
+        return copyBytes(valueBytes, valueOffset, valueSize);
+    }
+
+    /**
+     * Returns the logical VARIANT value type.
+     */
+    public ValueType valueType()
+    {
+        return valueType;
+    }
+
+    public boolean isNull()
+    {
+        return valueType == ValueType.NULL;
+    }
+
+    public boolean getBoolean()
+    {
+        verifyValueType(ValueType.BOOLEAN);
+        return primitiveType == PrimitiveType.BOOLEAN_TRUE;
+    }
+
+    public byte getByte()
+    {
+        verifyValueType(ValueType.INT8);
+        return valueBytes[valueOffset + 1];
+    }
+
+    public short getShort()
+    {
+        verifyValueType(ValueType.INT16);
+        return readShort(valueBytes, valueOffset + 1);
+    }
+
+    public int getInt()
+    {
+        verifyValueType(ValueType.INT32);
+        return readInt(valueBytes, valueOffset + 1);
+    }
+
+    public long getLong()
+    {
+        verifyValueType(ValueType.INT64);
+        return readLong(valueBytes, valueOffset + 1);
+    }
+
+    public BigDecimal getDecimal()
+    {
+        verifyValueType(ValueType.DECIMAL);
+
+        int scale = valueBytes[valueOffset + 1] & 0xFF;
+        switch (primitiveType) {
+            case DECIMAL4:
+                return BigDecimal.valueOf(readInt(valueBytes, valueOffset + 2), scale);
+            case DECIMAL8:
+                return BigDecimal.valueOf(readLong(valueBytes, valueOffset + 2), scale);
+            case DECIMAL16: {
+                byte[] bigEndian = new byte[16];
+                LONG_HANDLE.set(bigEndian, 0, Long.reverseBytes(readLong(valueBytes, valueOffset + 2 + Long.BYTES)));
+                LONG_HANDLE.set(bigEndian, Long.BYTES, Long.reverseBytes(readLong(valueBytes, valueOffset + 2)));
+                return new BigDecimal(new BigInteger(bigEndian), scale);
+            }
+            default:
+                throw new AssertionError("Unexpected decimal primitive type: " + primitiveType);
+        }
+    }
+
+    public float getFloat()
+    {
+        verifyValueType(ValueType.FLOAT);
+        return Float.intBitsToFloat(readInt(valueBytes, valueOffset + 1));
+    }
+
+    public double getDouble()
+    {
+        verifyValueType(ValueType.DOUBLE);
+        return Double.longBitsToDouble(readLong(valueBytes, valueOffset + 1));
+    }
+
+    public int getDate()
+    {
+        verifyValueType(ValueType.DATE);
+        return readInt(valueBytes, valueOffset + 1);
+    }
+
+    public LocalDate getLocalDate()
+    {
+        return LocalDate.ofEpochDay(getDate());
+    }
+
+    public long getTimeMicros()
+    {
+        verifyValueType(ValueType.TIME_NTZ_MICROS);
+        return readLong(valueBytes, valueOffset + 1);
+    }
+
+    public LocalTime getLocalTime()
+    {
+        long nanoOfDay = multiplyExact(getTimeMicros(), 1_000L);
+        return LocalTime.ofNanoOfDay(nanoOfDay);
+    }
+
+    public long getTimestampMicros()
+    {
+        checkState(
+                valueType == ValueType.TIMESTAMP_UTC_MICROS || valueType == ValueType.TIMESTAMP_NTZ_MICROS,
+                "Expected TIMESTAMP micros but got %s",
+                valueType);
+        return readLong(valueBytes, valueOffset + 1);
+    }
+
+    public long getTimestampNanos()
+    {
+        checkState(
+                valueType == ValueType.TIMESTAMP_UTC_NANOS || valueType == ValueType.TIMESTAMP_NTZ_NANOS,
+                "Expected TIMESTAMP nanos but got %s",
+                valueType);
+        return readLong(valueBytes, valueOffset + 1);
+    }
+
+    public Instant getInstant()
+    {
+        long seconds;
+        int nanoOfSecond;
+        if (valueType == ValueType.TIMESTAMP_UTC_MICROS) {
+            long micros = getTimestampMicros();
+            seconds = floorDiv(micros, 1_000_000);
+            nanoOfSecond = floorMod(micros, 1_000_000) * 1_000;
+        }
+        else if (valueType == ValueType.TIMESTAMP_UTC_NANOS) {
+            long nanos = getTimestampNanos();
+            seconds = floorDiv(nanos, 1_000_000_000L);
+            nanoOfSecond = floorMod(nanos, 1_000_000_000);
+        }
+        else {
+            throw new IllegalStateException("Expected TIMESTAMP UTC but got " + valueType);
+        }
+        return Instant.ofEpochSecond(seconds, nanoOfSecond);
+    }
+
+    public LocalDateTime getLocalDateTime()
+    {
+        long seconds;
+        int nanoOfSecond;
+        if (valueType == ValueType.TIMESTAMP_NTZ_MICROS) {
+            long micros = getTimestampMicros();
+            seconds = floorDiv(micros, 1_000_000);
+            nanoOfSecond = floorMod(micros, 1_000_000) * 1_000;
+        }
+        else if (valueType == ValueType.TIMESTAMP_NTZ_NANOS) {
+            long nanos = getTimestampNanos();
+            seconds = floorDiv(nanos, 1_000_000_000L);
+            nanoOfSecond = floorMod(nanos, 1_000_000_000);
+        }
+        else {
+            throw new IllegalStateException("Expected TIMESTAMP NTZ but got " + valueType);
+        }
+        return LocalDateTime.ofEpochSecond(seconds, nanoOfSecond, ZoneOffset.UTC);
+    }
+
+    public byte[] getBinary()
+    {
+        verifyValueType(ValueType.BINARY);
+        int length = readInt(valueBytes, valueOffset + 1);
+        return copyBytes(valueBytes, valueOffset + 5, length);
+    }
+
+    public String getString()
+    {
+        verifyValueType(ValueType.STRING);
+        if (basicType == BasicType.SHORT_STRING) {
+            return new String(valueBytes, valueOffset + 1, shortStringLength(valueBytes[valueOffset]), StandardCharsets.UTF_8);
+        }
+
+        int length = readInt(valueBytes, valueOffset + 1);
+        return new String(valueBytes, valueOffset + 5, length, StandardCharsets.UTF_8);
+    }
+
+    public UUID getUuid()
+    {
+        verifyValueType(ValueType.UUID);
+        long mostSigBits = Long.reverseBytes(readLong(valueBytes, valueOffset + 1));
+        long leastSigBits = Long.reverseBytes(readLong(valueBytes, valueOffset + 9));
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    public int getArrayLength()
+    {
+        verifyValueType(ValueType.ARRAY);
+        return arrayIsLarge(valueBytes[valueOffset]) ? readInt(valueBytes, valueOffset + 1) : valueBytes[valueOffset + 1] & 0xFF;
+    }
+
+    public Variant getArrayElement(int index)
+    {
+        verifyValueType(ValueType.ARRAY);
+        int count = getArrayLength();
+        checkElementIndex(index, count, "index");
+
+        int offsetSize = arrayFieldOffsetSize(valueBytes[valueOffset]);
+        int offsetsStart = valueOffset + 1 + (arrayIsLarge(valueBytes[valueOffset]) ? 4 : 1);
+        int valuesStart = offsetsStart + (count + 1) * offsetSize;
+        int start = valuesStart + readOffset(valueBytes, offsetsStart + index * offsetSize, offsetSize);
+        int end = valuesStart + readOffset(valueBytes, offsetsStart + (index + 1) * offsetSize, offsetSize);
+        return new Variant(metadata, valueBytes, start, end - start);
+    }
+
+    public List<Variant> getArrayElements()
+    {
+        int count = getArrayLength();
+        List<Variant> elements = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            elements.add(getArrayElement(i));
+        }
+        return unmodifiableList(elements);
+    }
+
+    public int getObjectFieldCount()
+    {
+        verifyValueType(ValueType.OBJECT);
+        return objectIsLarge(valueBytes[valueOffset]) ? readInt(valueBytes, valueOffset + 1) : valueBytes[valueOffset + 1] & 0xFF;
+    }
+
+    public Map<String, Variant> getObjectFields()
+    {
+        verifyValueType(ValueType.OBJECT);
+        int count = getObjectFieldCount();
+        int idSize = objectFieldIdSize(valueBytes[valueOffset]);
+        int offsetSize = objectFieldOffsetSize(valueBytes[valueOffset]);
+        int idsStart = valueOffset + 1 + (objectIsLarge(valueBytes[valueOffset]) ? 4 : 1);
+        int offsetsStart = idsStart + count * idSize;
+        int valuesStart = offsetsStart + (count + 1) * offsetSize;
+
+        Map<String, Variant> fields = new LinkedHashMap<>(count);
+        for (int index = 0; index < count; index++) {
+            int fieldId = readOffset(valueBytes, idsStart + index * idSize, idSize);
+            int fieldOffset = readOffset(valueBytes, offsetsStart + index * offsetSize, offsetSize);
+            int start = valuesStart + fieldOffset;
+            int size = valueSize(valueBytes, start);
+            fields.put(metadata.get(fieldId), new Variant(metadata, valueBytes, start, size));
+        }
+        return unmodifiableMap(fields);
+    }
+
+    /**
+     * Returns this value converted to the corresponding Java object representation.
+     * <ul>
+     * <li>{@link ValueType#NULL}: {@code null}</li>
+     * <li>{@link ValueType#BOOLEAN}: {@link Boolean}</li>
+     * <li>{@link ValueType#INT8}: {@link Byte}</li>
+     * <li>{@link ValueType#INT16}: {@link Short}</li>
+     * <li>{@link ValueType#INT32}: {@link Integer}</li>
+     * <li>{@link ValueType#INT64}: {@link Long}</li>
+     * <li>{@link ValueType#DOUBLE}: {@link Double}</li>
+     * <li>{@link ValueType#DECIMAL}: {@link BigDecimal}</li>
+     * <li>{@link ValueType#DATE}: {@link LocalDate}</li>
+     * <li>{@link ValueType#TIMESTAMP_UTC_MICROS} and {@link ValueType#TIMESTAMP_UTC_NANOS}: {@link Instant}</li>
+     * <li>{@link ValueType#TIMESTAMP_NTZ_MICROS} and {@link ValueType#TIMESTAMP_NTZ_NANOS}: {@link LocalDateTime}</li>
+     * <li>{@link ValueType#FLOAT}: {@link Float}</li>
+     * <li>{@link ValueType#BINARY}: {@code byte[]}</li>
+     * <li>{@link ValueType#STRING}: {@link String}</li>
+     * <li>{@link ValueType#TIME_NTZ_MICROS}: {@link LocalTime}</li>
+     * <li>{@link ValueType#UUID}: {@link UUID}</li>
+     * <li>{@link ValueType#ARRAY}: {@code List<Object>}</li>
+     * <li>{@link ValueType#OBJECT}: {@code Map<String, Object>}</li>
+     * </ul>
+     */
+    public Object toObject()
+    {
+        switch (valueType) {
+            case NULL:
+                return null;
+            case BOOLEAN:
+                return getBoolean();
+            case INT8:
+                return getByte();
+            case INT16:
+                return getShort();
+            case INT32:
+                return getInt();
+            case INT64:
+                return getLong();
+            case DOUBLE:
+                return getDouble();
+            case DECIMAL:
+                return getDecimal();
+            case DATE:
+                return getLocalDate();
+            case TIMESTAMP_UTC_MICROS:
+            case TIMESTAMP_UTC_NANOS:
+                return getInstant();
+            case TIMESTAMP_NTZ_MICROS:
+            case TIMESTAMP_NTZ_NANOS:
+                return getLocalDateTime();
+            case FLOAT:
+                return getFloat();
+            case BINARY:
+                return getBinary();
+            case STRING:
+                return getString();
+            case TIME_NTZ_MICROS:
+                return getLocalTime();
+            case UUID:
+                return getUuid();
+            case ARRAY:
+                List<Object> array = new ArrayList<>(getArrayLength());
+                for (Variant element : getArrayElements()) {
+                    array.add(element.toObject());
+                }
+                return unmodifiableList(array);
+            case OBJECT:
+                Map<String, Object> object = new LinkedHashMap<>(getObjectFieldCount());
+                for (Map.Entry<String, Variant> entry : getObjectFields().entrySet()) {
+                    object.put(entry.getKey(), entry.getValue().toObject());
+                }
+                return unmodifiableMap(object);
+        }
+        throw new AssertionError("Unhandled value type: " + valueType);
+    }
+
+    /**
+     * Returns this value serialized to the same JSON representation used by the Trino protocol VARIANT JSON fallback.
+     */
+    public String toJson()
+    {
+        StringWriter writer = new StringWriter();
+        try (JsonGenerator generator = JSON_FACTORY.createGenerator(writer)) {
+            writeJson(generator);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to serialize VARIANT to JSON", e);
+        }
+        return writer.toString();
+    }
+
+    private void writeJson(JsonGenerator generator)
+            throws IOException
+    {
+        switch (valueType) {
+            case NULL:
+                generator.writeNull();
+                return;
+            case BOOLEAN:
+                generator.writeBoolean(getBoolean());
+                return;
+            case INT8:
+                generator.writeNumber(getByte());
+                return;
+            case INT16:
+                generator.writeNumber(getShort());
+                return;
+            case INT32:
+                generator.writeNumber(getInt());
+                return;
+            case INT64:
+                generator.writeNumber(getLong());
+                return;
+            case DOUBLE:
+                generator.writeNumber(getDouble());
+                return;
+            case DECIMAL:
+                generator.writeNumber(getDecimal());
+                return;
+            case DATE:
+                generator.writeString(getLocalDate().toString());
+                return;
+            case TIMESTAMP_UTC_MICROS:
+                generator.writeString(formatTimestamp(getTimestampMicros(), MICROS_PER_SECOND, 6, true));
+                return;
+            case TIMESTAMP_NTZ_MICROS:
+                generator.writeString(formatTimestamp(getTimestampMicros(), MICROS_PER_SECOND, 6, false));
+                return;
+            case FLOAT:
+                generator.writeNumber(getFloat());
+                return;
+            case BINARY:
+                generator.writeBinary(getBinary());
+                return;
+            case STRING:
+                generator.writeString(getString());
+                return;
+            case TIME_NTZ_MICROS:
+                generator.writeString(formatTimeMicros(getTimeMicros()));
+                return;
+            case TIMESTAMP_UTC_NANOS:
+                generator.writeString(formatTimestamp(getTimestampNanos(), NANOS_PER_SECOND, 9, true));
+                return;
+            case TIMESTAMP_NTZ_NANOS:
+                generator.writeString(formatTimestamp(getTimestampNanos(), NANOS_PER_SECOND, 9, false));
+                return;
+            case UUID:
+                generator.writeString(getUuid().toString());
+                return;
+            case ARRAY:
+                generator.writeStartArray();
+                for (Variant element : getArrayElements()) {
+                    element.writeJson(generator);
+                }
+                generator.writeEndArray();
+                return;
+            case OBJECT:
+                generator.writeStartObject();
+                for (Map.Entry<String, Variant> entry : getObjectFields().entrySet()) {
+                    generator.writeFieldName(entry.getKey());
+                    entry.getValue().writeJson(generator);
+                }
+                generator.writeEndObject();
+                return;
+        }
+        throw new AssertionError("Unhandled value type: " + valueType);
+    }
+
+    private void verifyValueType(ValueType expected)
+    {
+        checkState(valueType == expected, "Expected %s but got %s", expected, valueType);
+    }
+
+    @SuppressModernizer
+    // JsonFactoryBuilder usage is intentional as JDBC should not depend on plugin-toolkit's JsonUtils.
+    private static JsonFactory jsonFactory()
+    {
+        return new JsonFactoryBuilder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxStringLength(Integer.MAX_VALUE)
+                        .maxNestingDepth(Integer.MAX_VALUE)
+                        .maxNumberLength(Integer.MAX_VALUE)
+                        .build())
+                .enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)
+                .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                .recyclerPool(JsonRecyclerPools.threadLocalPool())
+                .build();
+    }
+
+    private static String formatTimeMicros(long micros)
+    {
+        long secondsOfDay = micros / MICROS_PER_SECOND;
+        int microsOfSecond = (int) (micros % MICROS_PER_SECOND);
+        int hours = (int) (secondsOfDay / 3_600);
+        int minutes = (int) ((secondsOfDay / 60) % 60);
+        int seconds = (int) (secondsOfDay % 60);
+
+        StringBuilder builder = new StringBuilder("HH:mm:ss.SSSSSS".length());
+        appendFixedWidth(builder, hours, 2);
+        builder.append(':');
+        appendFixedWidth(builder, minutes, 2);
+        builder.append(':');
+        appendFixedWidth(builder, seconds, 2);
+        builder.append('.');
+        appendFixedWidth(builder, microsOfSecond, 6);
+        return builder.toString();
+    }
+
+    private static String formatTimestamp(long value, long unitsPerSecond, int fractionalSecondsLength, boolean withTimeZone)
+    {
+        long epochSecond = floorDiv(value, unitsPerSecond);
+        long fractionalSeconds = floorMod(value, unitsPerSecond);
+        LocalDateTime dateTime = LocalDateTime.ofEpochSecond(epochSecond, 0, ZoneOffset.UTC);
+
+        StringBuilder builder = new StringBuilder("yyyy-MM-dd HH:mm:ss.SSSSSSSSS UTC".length());
+        TIMESTAMP_FORMATTER.formatTo(dateTime, builder);
+        appendFraction(builder, fractionalSeconds, fractionalSecondsLength);
+        if (withTimeZone) {
+            builder.append(" UTC");
+        }
+        return builder.toString();
+    }
+
+    private static void appendFraction(StringBuilder builder, long fractionalSeconds, int fractionalSecondsLength)
+    {
+        if (fractionalSecondsLength == 0) {
+            return;
+        }
+
+        builder.append('.');
+        appendFixedWidth(builder, fractionalSeconds, fractionalSecondsLength);
+    }
+
+    private static void appendFixedWidth(StringBuilder builder, long value, int width)
+    {
+        checkArgument(value >= 0, "value is negative: %s", value);
+        String text = Long.toString(value);
+        checkArgument(text.length() <= width, "value does not fit in %s digits: %s", width, value);
+        builder.append("0".repeat(width - text.length()));
+        builder.append(text);
+    }
+
+    private static int valueSize(byte[] data, int offset)
+    {
+        byte header = data[offset];
+        BasicType basicType = BasicType.fromHeader(header);
+        if (basicType == BasicType.PRIMITIVE) {
+            PrimitiveType primitiveType = PrimitiveType.fromHeader(header);
+            switch (primitiveType) {
+                case NULL:
+                case BOOLEAN_TRUE:
+                case BOOLEAN_FALSE:
+                    return 1;
+                case INT8:
+                    return 2;
+                case INT16:
+                    return 3;
+                case INT32:
+                case FLOAT:
+                case DATE:
+                    return 5;
+                case INT64:
+                case DOUBLE:
+                case TIME_NTZ_MICROS:
+                case TIMESTAMP_UTC_MICROS:
+                case TIMESTAMP_NTZ_MICROS:
+                case TIMESTAMP_UTC_NANOS:
+                case TIMESTAMP_NTZ_NANOS:
+                    return 9;
+                case DECIMAL4:
+                    return 6;
+                case DECIMAL8:
+                    return 10;
+                case DECIMAL16:
+                    return 18;
+                case BINARY:
+                case STRING:
+                    return 5 + readInt(data, offset + 1);
+                case UUID:
+                    return 17;
+                default:
+                    throw new AssertionError("Unexpected primitive type: " + primitiveType);
+            }
+        }
+        if (basicType == BasicType.SHORT_STRING) {
+            return 1 + shortStringLength(header);
+        }
+        if (basicType == BasicType.ARRAY) {
+            boolean large = arrayIsLarge(header);
+            int offsetSize = arrayFieldOffsetSize(header);
+            int count = large ? readInt(data, offset + 1) : data[offset + 1] & 0xFF;
+            int offsetsStart = offset + 1 + (large ? 4 : 1);
+            int valuesStart = offsetsStart + (count + 1) * offsetSize;
+            return valuesStart - offset + readOffset(data, offsetsStart + count * offsetSize, offsetSize);
+        }
+
+        boolean large = objectIsLarge(header);
+        int idSize = objectFieldIdSize(header);
+        int offsetSize = objectFieldOffsetSize(header);
+        int count = large ? readInt(data, offset + 1) : data[offset + 1] & 0xFF;
+        int idsStart = offset + 1 + (large ? 4 : 1);
+        int offsetsStart = idsStart + count * idSize;
+        int valuesStart = offsetsStart + (count + 1) * offsetSize;
+        // Object field offsets do not need to be sorted; the final offset stores the total encoded object size.
+        int objectSize = readOffset(data, offsetsStart + count * offsetSize, offsetSize);
+        return valuesStart - offset + objectSize;
+    }
+
+    private static byte[] copyBytes(byte[] source, int offset, int length)
+    {
+        byte[] copy = new byte[length];
+        System.arraycopy(source, offset, copy, 0, length);
+        return copy;
+    }
+
+    private static int readOffset(byte[] data, int offset, int size)
+    {
+        switch (size) {
+            case 1:
+                return data[offset] & 0xFF;
+            case 2:
+                return readShort(data, offset) & 0xFFFF;
+            case 3:
+                return (data[offset] & 0xFF) |
+                        ((data[offset + 1] & 0xFF) << 8) |
+                        ((data[offset + 2] & 0xFF) << 16);
+            case 4:
+                return readInt(data, offset);
+            default:
+                throw new IllegalArgumentException("Unsupported offset size: " + size);
+        }
+    }
+
+    private static short readShort(byte[] data, int offset)
+    {
+        return (short) SHORT_HANDLE.get(data, offset);
+    }
+
+    private static int readInt(byte[] data, int offset)
+    {
+        return (int) INT_HANDLE.get(data, offset);
+    }
+
+    private static long readLong(byte[] data, int offset)
+    {
+        return (long) LONG_HANDLE.get(data, offset);
+    }
+
+    private static int shortStringLength(byte header)
+    {
+        return (header & 0b1111_1100) >>> 2;
+    }
+
+    private static int objectFieldOffsetSize(byte header)
+    {
+        return ((header & 0b0000_1100) >>> 2) + 1;
+    }
+
+    private static int objectFieldIdSize(byte header)
+    {
+        return ((header & 0b0011_0000) >>> 4) + 1;
+    }
+
+    private static boolean objectIsLarge(byte header)
+    {
+        return (header & 0b0100_0000) != 0;
+    }
+
+    private static int arrayFieldOffsetSize(byte header)
+    {
+        return ((header & 0b0000_1100) >>> 2) + 1;
+    }
+
+    private static boolean arrayIsLarge(byte header)
+    {
+        return (header & 0b0001_0000) != 0;
+    }
+
+    private static int metadataVersion(byte header)
+    {
+        return header & 0b0000_1111;
+    }
+
+    private static int metadataOffsetSize(byte header)
+    {
+        return ((header & 0b1100_0000) >>> 6) + 1;
+    }
+
+    private static final class Metadata
+    {
+        private final byte[] metadataBytes;
+        private final int dictionarySize;
+        private final int offsetSize;
+
+        private Metadata(byte[] metadataBytes, int dictionarySize, int offsetSize)
+        {
+            this.metadataBytes = metadataBytes;
+            this.dictionarySize = dictionarySize;
+            this.offsetSize = offsetSize;
+        }
+
+        public static Metadata fromBytes(byte[] metadataBytes)
+        {
+            requireNonNull(metadataBytes, "metadataBytes is null");
+            if (metadataBytes.length == 0) {
+                return new Metadata(metadataBytes, 0, 1);
+            }
+            checkArgument(metadataBytes.length >= 3, "metadataBytes is too short");
+
+            byte header = metadataBytes[0];
+            checkArgument(metadataVersion(header) == 1, "Unsupported metadata version: %s", metadataVersion(header));
+
+            int offsetSize = metadataOffsetSize(header);
+            int dictionarySize = readOffset(metadataBytes, 1, offsetSize);
+            return new Metadata(metadataBytes, dictionarySize, offsetSize);
+        }
+
+        public byte[] getBytes()
+        {
+            return metadataBytes;
+        }
+
+        public String get(int id)
+        {
+            checkArgument(id >= 0 && id < dictionarySize, "Invalid field id: %s", id);
+
+            int offsetsBase = 1 + offsetSize;
+            int start = readOffset(metadataBytes, offsetsBase + id * offsetSize, offsetSize);
+            int end = readOffset(metadataBytes, offsetsBase + (id + 1) * offsetSize, offsetSize);
+            int dictionaryStart = offsetsBase + (dictionarySize + 1) * offsetSize;
+            return new String(metadataBytes, dictionaryStart + start, end - start, StandardCharsets.UTF_8);
+        }
+    }
+
+    private enum BasicType
+    {
+        PRIMITIVE,
+        SHORT_STRING,
+        OBJECT,
+        ARRAY;
+
+        private static BasicType fromHeader(byte header)
+        {
+            return values()[header & 0b0000_0011];
+        }
+    }
+
+    private enum PrimitiveType
+    {
+        NULL,
+        BOOLEAN_TRUE,
+        BOOLEAN_FALSE,
+        INT8,
+        INT16,
+        INT32,
+        INT64,
+        DOUBLE,
+        DECIMAL4,
+        DECIMAL8,
+        DECIMAL16,
+        DATE,
+        TIMESTAMP_UTC_MICROS,
+        TIMESTAMP_NTZ_MICROS,
+        FLOAT,
+        BINARY,
+        STRING,
+        TIME_NTZ_MICROS,
+        TIMESTAMP_UTC_NANOS,
+        TIMESTAMP_NTZ_NANOS,
+        UUID;
+
+        private static PrimitiveType fromHeader(byte header)
+        {
+            return values()[(header & 0b1111_1100) >>> 2];
+        }
+    }
+
+    public enum ValueType
+    {
+        NULL,
+        BOOLEAN,
+        INT8,
+        INT16,
+        INT32,
+        INT64,
+        DOUBLE,
+        DECIMAL,
+        DATE,
+        TIMESTAMP_UTC_MICROS,
+        TIMESTAMP_NTZ_MICROS,
+        FLOAT,
+        BINARY,
+        STRING,
+        TIME_NTZ_MICROS,
+        TIMESTAMP_UTC_NANOS,
+        TIMESTAMP_NTZ_NANOS,
+        UUID,
+        OBJECT,
+        ARRAY;
+
+        private static ValueType from(BasicType basicType, PrimitiveType primitiveType)
+        {
+            switch (basicType) {
+                case SHORT_STRING:
+                    return STRING;
+                case OBJECT:
+                    return OBJECT;
+                case ARRAY:
+                    return ARRAY;
+                case PRIMITIVE:
+                    switch (primitiveType) {
+                        case NULL:
+                            return NULL;
+                        case BOOLEAN_TRUE:
+                        case BOOLEAN_FALSE:
+                            return BOOLEAN;
+                        case INT8:
+                            return INT8;
+                        case INT16:
+                            return INT16;
+                        case INT32:
+                            return INT32;
+                        case INT64:
+                            return INT64;
+                        case DOUBLE:
+                            return DOUBLE;
+                        case DECIMAL4:
+                        case DECIMAL8:
+                        case DECIMAL16:
+                            return DECIMAL;
+                        case DATE:
+                            return DATE;
+                        case TIMESTAMP_UTC_MICROS:
+                            return TIMESTAMP_UTC_MICROS;
+                        case TIMESTAMP_NTZ_MICROS:
+                            return TIMESTAMP_NTZ_MICROS;
+                        case FLOAT:
+                            return FLOAT;
+                        case BINARY:
+                            return BINARY;
+                        case STRING:
+                            return STRING;
+                        case TIME_NTZ_MICROS:
+                            return TIME_NTZ_MICROS;
+                        case TIMESTAMP_UTC_NANOS:
+                            return TIMESTAMP_UTC_NANOS;
+                        case TIMESTAMP_NTZ_NANOS:
+                            return TIMESTAMP_NTZ_NANOS;
+                        case UUID:
+                            return UUID;
+                    }
+                    throw new AssertionError("Unhandled primitive type: " + primitiveType);
+            }
+            throw new AssertionError("Unhandled basic type: " + basicType);
+        }
+    }
+}

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.type.DateTimes.NANOSECONDS_PER_MILLISECOND;
@@ -566,6 +567,222 @@ public abstract class BaseTestJdbcResultSet
                 assertThat(rs.getDouble(column)).isEqualTo(Double.NEGATIVE_INFINITY);
                 assertThat(rs.getString(column)).isEqualTo("-Infinity");
                 assertSqlExceptionThrownBy(() -> rs.getBytes(column)).hasMessage("Value is not a byte array: -Infinity");
+            });
+        }
+    }
+
+    @Test
+    public void testVariant()
+            throws Exception
+    {
+        try (ConnectedStatement connectedStatement = newStatement()) {
+            checkRepresentation(connectedStatement.getStatement(), "CAST(NULL AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getObject(column, Object.class)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getString(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+                assertThat(rs.getBytes(column)).isNull();
+                assertThat(rs.wasNull()).isTrue();
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(JSON 'null' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isNull();
+                assertThat(rs.wasNull()).isFalse();
+                assertThat(rs.getObject(column, Object.class)).isNull();
+                assertThat(rs.wasNull()).isFalse();
+                assertThat(rs.getString(column)).isEqualTo("null");
+                assertThat(rs.wasNull()).isFalse();
+                assertThat(rs.getObject(column, String.class)).isEqualTo("null");
+                assertThat(rs.wasNull()).isFalse();
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.isNull()).isTrue();
+                assertThat(variant.toObject()).isNull();
+                assertThat(rs.wasNull()).isFalse();
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(TRUE AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(true);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(true);
+                assertThat(rs.getString(column)).isEqualTo("true");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("true");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.BOOLEAN);
+                assertThat(variant.getBoolean()).isTrue();
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(TINYINT '123' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo((byte) 123);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo((byte) 123);
+                assertThat(rs.getString(column)).isEqualTo("123");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("123");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.INT8);
+                assertThat(variant.getByte()).isEqualTo((byte) 123);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(SMALLINT '12345' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo((short) 12345);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo((short) 12345);
+                assertThat(rs.getString(column)).isEqualTo("12345");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("12345");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.INT16);
+                assertThat(variant.getShort()).isEqualTo((short) 12345);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(INTEGER '123456' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(123456);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(123456);
+                assertThat(rs.getString(column)).isEqualTo("123456");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("123456");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.INT32);
+                assertThat(variant.getInt()).isEqualTo(123456);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(BIGINT '1234567890123' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(1234567890123L);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(1234567890123L);
+                assertThat(rs.getString(column)).isEqualTo("1234567890123");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("1234567890123");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.INT64);
+                assertThat(variant.getLong()).isEqualTo(1234567890123L);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(DECIMAL '123.45' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(new BigDecimal("123.45"));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(new BigDecimal("123.45"));
+                assertThat(rs.getString(column)).isEqualTo("123.45");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("123.45");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.DECIMAL);
+                assertThat(variant.getDecimal()).isEqualByComparingTo("123.45");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(CAST(123.25 AS real) AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(123.25f);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(123.25f);
+                assertThat(rs.getString(column)).isEqualTo("123.25");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("123.25");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.FLOAT);
+                assertThat(variant.getFloat()).isEqualTo(123.25f);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(DOUBLE '123.5' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(123.5);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(123.5);
+                assertThat(rs.getString(column)).isEqualTo("123.5");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("123.5");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.DOUBLE);
+                assertThat(variant.getDouble()).isEqualTo(123.5);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(DATE '2021-02-03' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(LocalDate.of(2021, 2, 3));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(LocalDate.of(2021, 2, 3));
+                assertThat(rs.getString(column)).isEqualTo("\"2021-02-03\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"2021-02-03\"");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.DATE);
+                assertThat(variant.getLocalDate()).isEqualTo(LocalDate.of(2021, 2, 3));
+                assertSqlExceptionThrownBy(() -> rs.getObject(column, Map.class)).hasMessage("VARIANT is not an object");
+                assertSqlExceptionThrownBy(() -> rs.getObject(column, List.class)).hasMessage("VARIANT is not an array");
+
+                ResultSetMetaData metaData = rs.getMetaData();
+                assertThat(metaData.getColumnTypeName(column)).isEqualTo("variant");
+                assertThat(metaData.getColumnClassName(column)).isEqualTo("java.lang.Object");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(TIME '12:34:56.123456' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(LocalTime.of(12, 34, 56, 123456000));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(LocalTime.of(12, 34, 56, 123456000));
+                assertThat(rs.getString(column)).isEqualTo("\"12:34:56.123456\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"12:34:56.123456\"");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.TIME_NTZ_MICROS);
+                assertThat(variant.getLocalTime()).isEqualTo(LocalTime.of(12, 34, 56, 123456000));
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(TIMESTAMP '2021-02-03 04:05:06.123456' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(LocalDateTime.of(2021, 2, 3, 4, 5, 6, 123456000));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(LocalDateTime.of(2021, 2, 3, 4, 5, 6, 123456000));
+                assertThat(rs.getString(column)).isEqualTo("\"2021-02-03 04:05:06.123456\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"2021-02-03 04:05:06.123456\"");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.TIMESTAMP_NTZ_MICROS);
+                assertThat(variant.getLocalDateTime()).isEqualTo(LocalDateTime.of(2021, 2, 3, 4, 5, 6, 123456000));
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(TIMESTAMP '2021-02-03 04:05:06.123456 UTC' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo(Instant.parse("2021-02-03T04:05:06.123456Z"));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(Instant.parse("2021-02-03T04:05:06.123456Z"));
+                assertThat(rs.getString(column)).isEqualTo("\"2021-02-03 04:05:06.123456 UTC\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"2021-02-03 04:05:06.123456 UTC\"");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.TIMESTAMP_UTC_MICROS);
+                assertThat(variant.getInstant()).isEqualTo(Instant.parse("2021-02-03T04:05:06.123456Z"));
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST('hello \"variant\"' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                assertThat(rs.getObject(column)).isEqualTo("hello \"variant\"");
+                assertThat(rs.getObject(column, Object.class)).isEqualTo("hello \"variant\"");
+                assertThat(rs.getString(column)).isEqualTo("\"hello \\\"variant\\\"\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"hello \\\"variant\\\"\"");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(X'010203' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.BINARY);
+                assertThat(variant.getBinary()).containsExactly((byte) 0x01, (byte) 0x02, (byte) 0x03);
+                assertThat((byte[]) rs.getObject(column)).containsExactly((byte) 0x01, (byte) 0x02, (byte) 0x03);
+                assertThat((byte[]) rs.getObject(column, Object.class)).containsExactly((byte) 0x01, (byte) 0x02, (byte) 0x03);
+                assertThat(rs.getString(column)).isEqualTo("\"AQID\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"AQID\"");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(UUID '0397e63b-2b78-4b7b-9c87-e085fa225dd8' AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                UUID uuid = UUID.fromString("0397e63b-2b78-4b7b-9c87-e085fa225dd8");
+                assertThat(rs.getObject(column)).isEqualTo(uuid);
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(uuid);
+                assertThat(rs.getString(column)).isEqualTo("\"0397e63b-2b78-4b7b-9c87-e085fa225dd8\"");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("\"0397e63b-2b78-4b7b-9c87-e085fa225dd8\"");
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.UUID);
+                assertThat(variant.getUuid()).isEqualTo(uuid);
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(ARRAY[1, 2, 3] AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.ARRAY);
+                assertThat(variant.getArrayElement(0).getInt()).isEqualTo(1);
+                assertThat(variant.getArrayElement(1).getInt()).isEqualTo(2);
+                assertThat(variant.getArrayElement(2).getInt()).isEqualTo(3);
+                assertThat(rs.getObject(column)).isEqualTo(ImmutableList.of(1, 2, 3));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(ImmutableList.of(1, 2, 3));
+                assertThat(rs.getString(column)).isEqualTo("[1,2,3]");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("[1,2,3]");
+                assertThat(rs.getObject(column, List.class)).isEqualTo(ImmutableList.of(1, 2, 3));
+                assertSqlExceptionThrownBy(() -> rs.getObject(column, Map.class)).hasMessage("VARIANT is not an object");
+            });
+
+            checkRepresentation(connectedStatement.getStatement(), "CAST(MAP(ARRAY['a', 'b'], ARRAY[1, 2]) AS variant)", Types.JAVA_OBJECT, (rs, column) -> {
+                Variant variant = rs.getObject(column, Variant.class);
+                assertThat(variant.valueType()).isEqualTo(Variant.ValueType.OBJECT);
+                assertThat(variant.getObjectFields()).containsKey("a");
+                assertThat(variant.getObjectFields()).containsKey("b");
+                assertThat(variant.getObjectFields().get("a").getInt()).isEqualTo(1);
+                assertThat(variant.getObjectFields().get("b").getInt()).isEqualTo(2);
+                assertThat(rs.getObject(column)).isEqualTo(ImmutableMap.of("a", 1, "b", 2));
+                assertThat(rs.getObject(column, Object.class)).isEqualTo(ImmutableMap.of("a", 1, "b", 2));
+                assertThat(rs.getString(column)).isEqualTo("{\"a\":1,\"b\":2}");
+                assertThat(rs.getObject(column, String.class)).isEqualTo("{\"a\":1,\"b\":2}");
+                assertThat(rs.getObject(column, Map.class)).isEqualTo(ImmutableMap.of("a", 1, "b", 2));
+                assertSqlExceptionThrownBy(() -> rs.getObject(column, List.class)).hasMessage("VARIANT is not an array");
             });
         }
     }
@@ -1396,8 +1613,10 @@ public abstract class BaseTestJdbcResultSet
                 // general contract for metadata.getColumnTypeName
                 assertThat(object).isInstanceOf(objectClass);
                 // for any non-NULL (not UNKNOWN) type, we should know better than Object.class
-                assertThat(objectClass).as("getColumnTypeName for value of type %s [%s] returning %s", metadata.getColumnType(1), expression, object.getClass())
-                        .isNotEqualTo(Object.class);
+                if (!metadata.getColumnTypeName(1).equals("variant")) {
+                    assertThat(objectClass).as("getColumnTypeName for value of type %s [%s] returning %s", metadata.getColumnType(1), expression, object.getClass())
+                            .isNotEqualTo(Object.class);
+                }
             }
             assertThat(rs.next()).isFalse();
         }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAbstractTrinoResultSet.java
@@ -25,6 +25,9 @@ public class TestAbstractTrinoResultSet
     public void testRepresentationImplemented()
     {
         DEFAULT_OBJECT_REPRESENTATION.forEach((sourceRawType, target) -> {
+            if (target == Object.class) {
+                return;
+            }
             if (!TYPE_CONVERSIONS.hasConversion(sourceRawType, target)) {
                 fail(String.format("No conversion registered from %s to %s", sourceRawType, target));
             }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestVariant.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestVariant.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import io.airlift.slice.Slice;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestVariant
+{
+    private static final Class<?> SPI_VARIANT_CLASS = loadClass("io.trino.spi.variant.Variant");
+    private static final Class<?> SPI_METADATA_CLASS = loadClass("io.trino.spi.variant.Metadata");
+    private static final Class<?> SPI_VARIANT_UTIL_CLASS = loadClass("io.trino.util.variant.VariantUtil");
+
+    @Test
+    public void testPrimitiveCompatibilityWithSpiVariant()
+    {
+        Variant nullVariant = spiCompatibleVariant("NULL_VALUE");
+        assertThat(nullVariant.valueType()).isEqualTo(Variant.ValueType.NULL);
+        assertThat(nullVariant.isNull()).isTrue();
+        assertThat(nullVariant.toObject()).isNull();
+
+        Variant trueVariant = spiCompatibleVariant("ofBoolean", true);
+        assertThat(trueVariant.valueType()).isEqualTo(Variant.ValueType.BOOLEAN);
+        assertThat(trueVariant.getBoolean()).isTrue();
+        assertThat(trueVariant.toObject()).isEqualTo(true);
+
+        Variant falseVariant = spiCompatibleVariant("ofBoolean", false);
+        assertThat(falseVariant.getBoolean()).isFalse();
+
+        Variant byteVariant = spiCompatibleVariant("ofByte", (byte) 0x7f);
+        assertThat(byteVariant.valueType()).isEqualTo(Variant.ValueType.INT8);
+        assertThat(byteVariant.getByte()).isEqualTo((byte) 0x7f);
+
+        Variant shortVariant = spiCompatibleVariant("ofShort", (short) 0x1234);
+        assertThat(shortVariant.valueType()).isEqualTo(Variant.ValueType.INT16);
+        assertThat(shortVariant.getShort()).isEqualTo((short) 0x1234);
+
+        Variant intVariant = spiCompatibleVariant("ofInt", 0x1234_5678);
+        assertThat(intVariant.valueType()).isEqualTo(Variant.ValueType.INT32);
+        assertThat(intVariant.getInt()).isEqualTo(0x1234_5678);
+
+        Variant longVariant = spiCompatibleVariant("ofLong", 0x0102_0304_0506_0708L);
+        assertThat(longVariant.valueType()).isEqualTo(Variant.ValueType.INT64);
+        assertThat(longVariant.getLong()).isEqualTo(0x0102_0304_0506_0708L);
+
+        Variant floatVariant = spiCompatibleVariant("ofFloat", 123.25f);
+        assertThat(floatVariant.valueType()).isEqualTo(Variant.ValueType.FLOAT);
+        assertThat(floatVariant.getFloat()).isEqualTo(123.25f);
+
+        Variant doubleVariant = spiCompatibleVariant("ofDouble", -123.5d);
+        assertThat(doubleVariant.valueType()).isEqualTo(Variant.ValueType.DOUBLE);
+        assertThat(doubleVariant.getDouble()).isEqualTo(-123.5d);
+
+        Variant decimal4Variant = spiCompatibleVariant("ofDecimal", new BigDecimal("123.45"));
+        assertThat(decimal4Variant.valueType()).isEqualTo(Variant.ValueType.DECIMAL);
+        assertThat(decimal4Variant.getDecimal()).isEqualByComparingTo("123.45");
+
+        Variant decimal8Variant = spiCompatibleVariant("ofDecimal", new BigDecimal("-1234567890123.45"));
+        assertThat(decimal8Variant.getDecimal()).isEqualByComparingTo("-1234567890123.45");
+
+        Variant decimal16Variant = spiCompatibleVariant("ofDecimal", new BigDecimal("-123456789012345678901234567890.1234"));
+        assertThat(decimal16Variant.getDecimal()).isEqualByComparingTo("-123456789012345678901234567890.1234");
+
+        Variant dateVariant = spiCompatibleVariant("ofDate", LocalDate.of(1969, 12, 31));
+        assertThat(dateVariant.valueType()).isEqualTo(Variant.ValueType.DATE);
+        assertThat(dateVariant.getDate()).isEqualTo(-1);
+        assertThat(dateVariant.getLocalDate()).isEqualTo(LocalDate.of(1969, 12, 31));
+
+        Variant timeVariant = spiCompatibleVariant("ofTimeMicrosNtz", 12_345_678L);
+        assertThat(timeVariant.valueType()).isEqualTo(Variant.ValueType.TIME_NTZ_MICROS);
+        assertThat(timeVariant.getTimeMicros()).isEqualTo(12_345_678L);
+        assertThat(timeVariant.getLocalTime()).isEqualTo(LocalTime.ofNanoOfDay(12_345_678_000L));
+
+        UUID uuid = UUID.fromString("01234567-89ab-cdef-0123-456789abcdef");
+        Variant uuidVariant = spiCompatibleVariant("ofUuid", uuid);
+        assertThat(uuidVariant.valueType()).isEqualTo(Variant.ValueType.UUID);
+        assertThat(uuidVariant.getUuid()).isEqualTo(uuid);
+    }
+
+    @Test
+    public void testTimestampCompatibilityWithSpiVariant()
+    {
+        Variant utcMicros = spiCompatibleVariant("ofTimestampMicrosUtc", -1L);
+        assertThat(utcMicros.valueType()).isEqualTo(Variant.ValueType.TIMESTAMP_UTC_MICROS);
+        assertThat(utcMicros.getTimestampMicros()).isEqualTo(-1);
+        assertThat(utcMicros.getInstant()).isEqualTo(Instant.ofEpochSecond(-1, 999_999_000));
+        assertThat(utcMicros.toObject()).isEqualTo(Instant.ofEpochSecond(-1, 999_999_000));
+
+        Variant utcNanos = spiCompatibleVariant("ofTimestampNanosUtc", -1L);
+        assertThat(utcNanos.valueType()).isEqualTo(Variant.ValueType.TIMESTAMP_UTC_NANOS);
+        assertThat(utcNanos.getTimestampNanos()).isEqualTo(-1);
+        assertThat(utcNanos.getInstant()).isEqualTo(Instant.ofEpochSecond(-1, 999_999_999));
+
+        Variant ntzMicros = spiCompatibleVariant("ofTimestampMicrosNtz", -1L);
+        assertThat(ntzMicros.valueType()).isEqualTo(Variant.ValueType.TIMESTAMP_NTZ_MICROS);
+        assertThat(ntzMicros.getTimestampMicros()).isEqualTo(-1);
+        assertThat(ntzMicros.getLocalDateTime()).isEqualTo(LocalDateTime.ofEpochSecond(-1, 999_999_000, ZoneOffset.UTC));
+        assertThat(ntzMicros.toObject()).isEqualTo(LocalDateTime.ofEpochSecond(-1, 999_999_000, ZoneOffset.UTC));
+
+        Variant ntzNanos = spiCompatibleVariant("ofTimestampNanosNtz", -1L);
+        assertThat(ntzNanos.valueType()).isEqualTo(Variant.ValueType.TIMESTAMP_NTZ_NANOS);
+        assertThat(ntzNanos.getTimestampNanos()).isEqualTo(-1);
+        assertThat(ntzNanos.getLocalDateTime()).isEqualTo(LocalDateTime.ofEpochSecond(-1, 999_999_999, ZoneOffset.UTC));
+    }
+
+    @Test
+    public void testStringBinaryAndUuidCompatibilityWithSpiVariant()
+    {
+        Variant shortStringFixture = spiCompatibleVariant("ofString", "hello");
+        Variant shortString = shortStringFixture;
+        assertThat(shortString.valueType()).isEqualTo(Variant.ValueType.STRING);
+        assertThat(shortString.getString()).isEqualTo("hello");
+        assertThat(shortString.getValueBytes()).isEqualTo(shortStringFixture.getValueBytes());
+
+        String longText = "x".repeat(80);
+        Variant longStringFixture = spiCompatibleVariant("ofString", longText);
+        Variant longString = longStringFixture;
+        assertThat(longString.valueType()).isEqualTo(Variant.ValueType.STRING);
+        assertThat(longString.getString()).isEqualTo(longText);
+        assertThat(longString.getValueBytes()).isEqualTo(longStringFixture.getValueBytes());
+
+        byte[] binaryPayload = new byte[] {0x01, 0x02, 0x03, (byte) 0xff};
+        Variant binaryVariant = spiCompatibleVariant("ofBinary", (Object) binaryPayload);
+        assertThat(binaryVariant.valueType()).isEqualTo(Variant.ValueType.BINARY);
+        assertThat(binaryVariant.getBinary()).containsExactly(binaryPayload);
+        assertThat((byte[]) binaryVariant.toObject()).containsExactly(binaryPayload);
+    }
+
+    @Test
+    public void testNestedContainerCompatibilityWithSpiVariant()
+    {
+        Variant alphaFixture = spiCompatibleVariant("ofInt", 111);
+        Variant betaFixture = spiCompatibleVariant("ofArray", List.of(
+                spiCompatibleVariant("ofBoolean", true),
+                spiCompatibleVariant("ofString", "two"),
+                spiCompatibleVariant("NULL_VALUE")));
+
+        Map<String, Variant> fields = new LinkedHashMap<>();
+        fields.put("beta", betaFixture);
+        fields.put("alpha", alphaFixture);
+
+        Variant variant = spiCompatibleVariant("ofObject", fields);
+
+        assertThat(variant.valueType()).isEqualTo(Variant.ValueType.OBJECT);
+        assertThat(variant.getObjectFieldCount()).isEqualTo(2);
+
+        Map<String, Variant> objectFields = variant.getObjectFields();
+        assertThat(objectFields.keySet()).containsExactly("alpha", "beta");
+        assertThat(objectFields.get("alpha").getInt()).isEqualTo(111);
+        assertThat(objectFields.get("alpha").getValueBytes()).isEqualTo(alphaFixture.getValueBytes());
+        assertThat(objectFields.get("beta").valueType()).isEqualTo(Variant.ValueType.ARRAY);
+        assertThat(objectFields.get("beta").getValueBytes()).isEqualTo(betaFixture.getValueBytes());
+        assertThat(objectFields.get("beta").getArrayElements()).hasSize(3);
+        assertThat(objectFields.get("beta").getArrayElement(0).getBoolean()).isTrue();
+        assertThat(objectFields.get("beta").getArrayElement(1).getString()).isEqualTo("two");
+        assertThat(objectFields.get("beta").getArrayElement(2).isNull()).isTrue();
+
+        assertThatThrownBy(() -> objectFields.put("gamma", variant))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> objectFields.get("beta").getArrayElements().add(variant))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        Map<String, Object> object = castToMap(variant.toObject());
+        assertThat(object).containsEntry("alpha", 111);
+        assertThat(castToList(object.get("beta"))).containsExactly(true, "two", null);
+        assertThatThrownBy(() -> object.put("gamma", 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void testJsonCompatibilityWithServerVariant()
+    {
+        assertJson("NULL_VALUE", "null");
+        assertJson("ofBoolean", "true", true);
+        assertJson("ofInt", "123", 123);
+        assertJson("ofDecimal", "123.45", new BigDecimal("123.45"));
+        assertJson("ofString", "\"hello \\\"variant\\\"\"", "hello \"variant\"");
+        assertJson("ofBinary", "\"AQID/w==\"", (Object) new byte[] {0x01, 0x02, 0x03, (byte) 0xff});
+        assertJson("ofDate", "\"2021-05-18\"", LocalDate.of(2021, 5, 18));
+        assertJson("ofTimeMicrosNtz", "\"22:23:24.123456\"", 80_604_123_456L);
+        assertJson("ofTimestampMicrosUtc", "\"1969-12-31 23:59:59.999999 UTC\"", -1L);
+        assertJson("ofTimestampMicrosNtz", "\"1969-12-31 23:59:59.999999\"", -1L);
+        assertJson("ofTimestampNanosUtc", "\"1969-12-31 23:59:59.999999999 UTC\"", -1L);
+        assertJson("ofTimestampNanosNtz", "\"1969-12-31 23:59:59.999999999\"", -1L);
+
+        Map<String, Variant> fields = new LinkedHashMap<>();
+        fields.put("beta", spiCompatibleVariant("ofArray", List.of(
+                spiCompatibleVariant("ofBoolean", true),
+                spiCompatibleVariant("ofString", "two"),
+                spiCompatibleVariant("NULL_VALUE"))));
+        fields.put("alpha", spiCompatibleVariant("ofInt", 111));
+        assertJson("ofObject", "{\"alpha\":111,\"beta\":[true,\"two\",null]}", fields);
+    }
+
+    @Test
+    public void testLargeContainerCompatibilityWithSpiVariant()
+    {
+        List<Variant> arrayElements = new ArrayList<>();
+        for (int index = 0; index < 300; index++) {
+            arrayElements.add(spiCompatibleVariant("ofString", String.format("element-%03d-abcdefghij", index)));
+        }
+
+        Variant arrayVariant = spiCompatibleVariant("ofArray", arrayElements);
+        assertThat(arrayVariant.valueType()).isEqualTo(Variant.ValueType.ARRAY);
+        assertThat(arrayVariant.getArrayLength()).isEqualTo(300);
+        assertThat(arrayVariant.getArrayElement(299).getString()).isEqualTo("element-299-abcdefghij");
+
+        Map<String, Variant> objectFields = new LinkedHashMap<>();
+        for (int index = 299; index >= 0; index--) {
+            objectFields.put(String.format("field-%03d", index), spiCompatibleVariant("ofInt", index));
+        }
+
+        Variant objectVariant = spiCompatibleVariant("ofObject", objectFields);
+        assertThat(objectVariant.valueType()).isEqualTo(Variant.ValueType.OBJECT);
+        assertThat(objectVariant.getObjectFieldCount()).isEqualTo(300);
+        assertThat(objectVariant.getObjectFields().get("field-299").getInt()).isEqualTo(299);
+    }
+
+    @Test
+    public void testVariantUsesProvidedByteArrays()
+    {
+        Variant fixture = spiCompatibleVariant("ofObject", Map.of(
+                "value", spiCompatibleVariant("ofInt", 123)));
+
+        byte[] metadataBytes = fixture.getMetadataBytes();
+        byte[] valueBytes = fixture.getValueBytes();
+
+        Variant variant = Variant.fromBytes(metadataBytes, valueBytes);
+
+        assertThat(variant.getObjectFields().get("value").getInt()).isEqualTo(123);
+        assertThat(variant.getMetadataBytes()).isSameAs(metadataBytes);
+        assertThat(variant.getValueBytes()).isSameAs(valueBytes);
+    }
+
+    @Test
+    public void testWrongAccessorAndBoundsChecks()
+    {
+        Variant stringVariant = spiCompatibleVariant("ofString", "abc");
+        assertThatThrownBy(stringVariant::getInt)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Expected INT32");
+
+        Variant arrayVariant = spiCompatibleVariant("ofArray", List.of(
+                spiCompatibleVariant("ofInt", 1)));
+        assertThatThrownBy(() -> arrayVariant.getArrayElement(1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+
+        assertThatThrownBy(() -> Variant.fromBytes(new byte[0], new byte[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valueBytes is empty");
+    }
+
+    /**
+     * Reflectively builds a JDBC variant using the SPI variant encoder. This must
+     * be performed reflectively, because the SPI is compiled against a newer version
+     * of Java.
+     */
+    private static Variant spiCompatibleVariant(String memberName, Object... arguments)
+    {
+        try {
+            Object spiVariant = newSpiVariant(memberName, arguments);
+
+            Object metadata = spiVariant.getClass().getMethod("metadata").invoke(spiVariant);
+            Slice metadataSlice = (Slice) metadata.getClass().getMethod("toSlice").invoke(metadata);
+            Slice dataSlice = (Slice) spiVariant.getClass().getMethod("data").invoke(spiVariant);
+
+            Variant variant = Variant.fromBytes(metadataSlice.getBytes(), dataSlice.getBytes());
+            assertThat(variant.getMetadataBytes()).isEqualTo(metadataSlice.getBytes());
+            assertThat(variant.getValueBytes()).isEqualTo(dataSlice.getBytes());
+            return variant;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to create JDBC Variant from SPI member " + memberName, e);
+        }
+    }
+
+    private static void assertJson(String memberName, String expectedJson, Object... arguments)
+    {
+        Variant variant = spiCompatibleVariant(memberName, arguments);
+        assertThat(variant.toJson()).isEqualTo(expectedJson);
+        assertThat(variant.toJson()).isEqualTo(spiVariantJson(memberName, arguments));
+    }
+
+    private static String spiVariantJson(String memberName, Object... arguments)
+    {
+        try {
+            Object spiVariant = newSpiVariant(memberName, arguments);
+            Slice json = (Slice) SPI_VARIANT_UTIL_CLASS.getMethod("asJson", SPI_VARIANT_CLASS).invoke(null, spiVariant);
+            return json.toStringUtf8();
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to serialize SPI Variant " + memberName + " as JSON", e);
+        }
+    }
+
+    private static Object newSpiVariant(String memberName, Object... arguments)
+            throws ReflectiveOperationException
+    {
+        if (arguments.length == 0) {
+            return SPI_VARIANT_CLASS.getField(memberName).get(null);
+        }
+        Method method = SPI_VARIANT_CLASS.getMethod(memberName, parameterTypes(arguments));
+        return method.invoke(null, spiArguments(arguments));
+    }
+
+    private static Class<?>[] parameterTypes(Object[] arguments)
+    {
+        Class<?>[] parameterTypes = new Class<?>[arguments.length];
+        for (int index = 0; index < arguments.length; index++) {
+            Object argument = arguments[index];
+            if (argument instanceof Boolean) {
+                parameterTypes[index] = boolean.class;
+            }
+            else if (argument instanceof Byte) {
+                parameterTypes[index] = byte.class;
+            }
+            else if (argument instanceof Short) {
+                parameterTypes[index] = short.class;
+            }
+            else if (argument instanceof Integer) {
+                parameterTypes[index] = int.class;
+            }
+            else if (argument instanceof Long) {
+                parameterTypes[index] = long.class;
+            }
+            else if (argument instanceof Float) {
+                parameterTypes[index] = float.class;
+            }
+            else if (argument instanceof Double) {
+                parameterTypes[index] = double.class;
+            }
+            else if (argument instanceof byte[]) {
+                parameterTypes[index] = Slice.class;
+            }
+            else if (argument instanceof List<?>) {
+                parameterTypes[index] = List.class;
+            }
+            else if (argument instanceof Map<?, ?>) {
+                parameterTypes[index] = Map.class;
+            }
+            else {
+                parameterTypes[index] = argument.getClass();
+            }
+        }
+        return parameterTypes;
+    }
+
+    private static Object[] spiArguments(Object[] arguments)
+    {
+        Object[] spiArguments = new Object[arguments.length];
+        for (int index = 0; index < arguments.length; index++) {
+            spiArguments[index] = toSpiArgument(arguments[index]);
+        }
+        return spiArguments;
+    }
+
+    private static Object toSpiArgument(Object argument)
+    {
+        if (argument instanceof byte[]) {
+            return wrappedBuffer((byte[]) argument);
+        }
+        if (argument instanceof Variant) {
+            Variant variant = (Variant) argument;
+            try {
+                Method metadataFrom = SPI_METADATA_CLASS.getMethod("from", Slice.class);
+                Object metadata = metadataFrom.invoke(null, wrappedBuffer(variant.getMetadataBytes()));
+                Method variantFrom = SPI_VARIANT_CLASS.getMethod("from", SPI_METADATA_CLASS, Slice.class);
+                return variantFrom.invoke(null, metadata, wrappedBuffer(variant.getValueBytes()));
+            }
+            catch (ReflectiveOperationException e) {
+                throw new RuntimeException("Failed to convert JDBC Variant back to SPI Variant", e);
+            }
+        }
+        if (argument instanceof List<?>) {
+            List<?> list = (List<?>) argument;
+            return list.stream()
+                    .map(TestVariant::toSpiArgument)
+                    .collect(Collectors.toList());
+        }
+        if (argument instanceof Map<?, ?>) {
+            Map<?, ?> map = (Map<?, ?>) argument;
+            Map<Object, Object> converted = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object key = entry.getKey() instanceof String ? utf8Slice((String) entry.getKey()) : entry.getKey();
+                converted.put(key, toSpiArgument(entry.getValue()));
+            }
+            return converted;
+        }
+        return argument;
+    }
+
+    private static Class<?> loadClass(String name)
+    {
+        try {
+            return Class.forName(name);
+        }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to load class " + name, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> castToMap(Object value)
+    {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> castToList(Object value)
+    {
+        return (List<Object>) value;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
@@ -52,6 +52,7 @@ import io.trino.util.variant.VariantUtil;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -92,13 +93,14 @@ public final class JsonEncodingUtils
         Set<String> clientCapabilities = session.getClientCapabilities();
         boolean supportsParametricDateTime = clientCapabilities.contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
         boolean supportsVariant = clientCapabilities.contains(ClientCapabilities.VARIANT.toString());
+        boolean supportsVariantBinary = clientCapabilities.contains(ClientCapabilities.VARIANT_BINARY.toString());
 
         return types.stream()
-                .map(type -> createTypeEncoder(type, supportsParametricDateTime, supportsVariant))
+                .map(type -> createTypeEncoder(type, supportsParametricDateTime, supportsVariant, supportsVariantBinary))
                 .toArray(TypeEncoder[]::new);
     }
 
-    public static TypeEncoder createTypeEncoder(Type type, boolean supportsParametricDateTime, boolean supportsVariant)
+    public static TypeEncoder createTypeEncoder(Type type, boolean supportsParametricDateTime, boolean supportsVariant, boolean supportsVariantBinary)
     {
         return switch (type) {
             case BigintType _ -> BIGINT_ENCODER;
@@ -111,13 +113,13 @@ public final class JsonEncodingUtils
             case VarcharType _ -> VARCHAR_ENCODER;
             case VarbinaryType _ -> VARBINARY_ENCODER;
             case CharType charType -> new CharEncoder(charType.getLength());
-            case VariantType _ -> new VariantEncoder(supportsVariant);
+            case VariantType _ -> new VariantEncoder(supportsVariant, supportsVariantBinary);
             // TODO: add specialized Short/Long decimal encoders
-            case ArrayType arrayType -> new ArrayEncoder(arrayType, createTypeEncoder(arrayType.getElementType(), supportsParametricDateTime, supportsVariant));
-            case MapType mapType -> new MapEncoder(mapType, createTypeEncoder(mapType.getValueType(), supportsParametricDateTime, supportsVariant));
+            case ArrayType arrayType -> new ArrayEncoder(arrayType, createTypeEncoder(arrayType.getElementType(), supportsParametricDateTime, supportsVariant, supportsVariantBinary));
+            case MapType mapType -> new MapEncoder(mapType, createTypeEncoder(mapType.getValueType(), supportsParametricDateTime, supportsVariant, supportsVariantBinary));
             case RowType rowType -> new RowEncoder(rowType, rowType.getFieldTypes()
                     .stream()
-                    .map(elementType -> createTypeEncoder(elementType, supportsParametricDateTime, supportsVariant))
+                    .map(elementType -> createTypeEncoder(elementType, supportsParametricDateTime, supportsVariant, supportsVariantBinary))
                     .toArray(TypeEncoder[]::new));
             case Type _ -> new TypeObjectValueEncoder(type, supportsParametricDateTime);
         };
@@ -322,10 +324,12 @@ public final class JsonEncodingUtils
             implements TypeEncoder
     {
         private final boolean supportsVariant;
+        private final boolean supportsVariantBinary;
 
-        public VariantEncoder(boolean supportsVariant)
+        public VariantEncoder(boolean supportsVariant, boolean supportsVariantBinary)
         {
             this.supportsVariant = supportsVariant;
+            this.supportsVariantBinary = supportsVariantBinary;
         }
 
         @Override
@@ -338,12 +342,21 @@ public final class JsonEncodingUtils
             }
 
             Variant variant = VARIANT.getObject(block, position);
-            String json = VariantUtil.asJson(variant).toStringUtf8();
-            if (supportsVariant) {
-                generator.writeRawValue(json);
-                return;
+            if (supportsVariantBinary) {
+                generator.writeStartObject();
+                generator.writeStringField("metadata", Base64.getEncoder().encodeToString(variant.metadata().toSlice().getBytes()));
+                generator.writeStringField("value", Base64.getEncoder().encodeToString(variant.data().getBytes()));
+                generator.writeEndObject();
             }
-            generator.writeString(json);
+            else {
+                String json = VariantUtil.asJson(variant).toStringUtf8();
+                if (supportsVariant) {
+                    generator.writeRawValue(json);
+                }
+                else {
+                    generator.writeString(json);
+                }
+            }
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/JsonEncodingUtils.java
@@ -53,6 +53,7 @@ import io.trino.util.variant.VariantUtil;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Verify.verify;
@@ -83,22 +84,21 @@ public final class JsonEncodingUtils
     private static final TinyintEncoder TINYINT_ENCODER = new TinyintEncoder();
     private static final VarcharEncoder VARCHAR_ENCODER = new VarcharEncoder();
     private static final VarbinaryEncoder VARBINARY_ENCODER = new VarbinaryEncoder();
-    private static final VariantEncoder VARIANT_ENCODER = new VariantEncoder();
 
     public static TypeEncoder[] createTypeEncoders(Session session, List<Type> types)
     {
         verify(!types.isEmpty(), "Columns must not be empty");
 
-        boolean supportsParametricDateTime = requireNonNull(session, "session is null")
-                .getClientCapabilities()
-                .contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
+        Set<String> clientCapabilities = session.getClientCapabilities();
+        boolean supportsParametricDateTime = clientCapabilities.contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
+        boolean supportsVariant = clientCapabilities.contains(ClientCapabilities.VARIANT.toString());
 
         return types.stream()
-                .map(type -> createTypeEncoder(type, supportsParametricDateTime))
+                .map(type -> createTypeEncoder(type, supportsParametricDateTime, supportsVariant))
                 .toArray(TypeEncoder[]::new);
     }
 
-    public static TypeEncoder createTypeEncoder(Type type, boolean supportsParametricDateTime)
+    public static TypeEncoder createTypeEncoder(Type type, boolean supportsParametricDateTime, boolean supportsVariant)
     {
         return switch (type) {
             case BigintType _ -> BIGINT_ENCODER;
@@ -111,13 +111,13 @@ public final class JsonEncodingUtils
             case VarcharType _ -> VARCHAR_ENCODER;
             case VarbinaryType _ -> VARBINARY_ENCODER;
             case CharType charType -> new CharEncoder(charType.getLength());
-            case VariantType _ -> VARIANT_ENCODER;
+            case VariantType _ -> new VariantEncoder(supportsVariant);
             // TODO: add specialized Short/Long decimal encoders
-            case ArrayType arrayType -> new ArrayEncoder(arrayType, createTypeEncoder(arrayType.getElementType(), supportsParametricDateTime));
-            case MapType mapType -> new MapEncoder(mapType, createTypeEncoder(mapType.getValueType(), supportsParametricDateTime));
+            case ArrayType arrayType -> new ArrayEncoder(arrayType, createTypeEncoder(arrayType.getElementType(), supportsParametricDateTime, supportsVariant));
+            case MapType mapType -> new MapEncoder(mapType, createTypeEncoder(mapType.getValueType(), supportsParametricDateTime, supportsVariant));
             case RowType rowType -> new RowEncoder(rowType, rowType.getFieldTypes()
                     .stream()
-                    .map(elementType -> createTypeEncoder(elementType, supportsParametricDateTime))
+                    .map(elementType -> createTypeEncoder(elementType, supportsParametricDateTime, supportsVariant))
                     .toArray(TypeEncoder[]::new));
             case Type _ -> new TypeObjectValueEncoder(type, supportsParametricDateTime);
         };
@@ -321,6 +321,13 @@ public final class JsonEncodingUtils
     private static final class VariantEncoder
             implements TypeEncoder
     {
+        private final boolean supportsVariant;
+
+        public VariantEncoder(boolean supportsVariant)
+        {
+            this.supportsVariant = supportsVariant;
+        }
+
         @Override
         public void encode(JsonGenerator generator, Block block, int position)
                 throws IOException
@@ -331,7 +338,12 @@ public final class JsonEncodingUtils
             }
 
             Variant variant = VARIANT.getObject(block, position);
-            generator.writeRawValue(VariantUtil.asJson(variant).toStringUtf8());
+            String json = VariantUtil.asJson(variant).toStringUtf8();
+            if (supportsVariant) {
+                generator.writeRawValue(json);
+                return;
+            }
+            generator.writeString(json);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ProtocolUtil.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ProtocolUtil.java
@@ -78,14 +78,14 @@ public final class ProtocolUtil
 
     private ProtocolUtil() {}
 
-    public static Column createColumn(String name, Type type, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
+    public static Column createColumn(String name, Type type, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant, boolean supportsVariantBinary)
     {
-        String formatted = formatType(TypeSignatureTranslator.toSqlType(type), supportsParametricDateTime, supportsNumberType, supportsVariant);
+        String formatted = formatType(TypeSignatureTranslator.toSqlType(type), supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary);
 
-        return new Column(name, formatted, toClientTypeSignature(type.getTypeSignature(), supportsParametricDateTime, supportsNumberType, supportsVariant));
+        return new Column(name, formatted, toClientTypeSignature(type.getTypeSignature(), supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary));
     }
 
-    private static String formatType(DataType type, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
+    private static String formatType(DataType type, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant, boolean supportsVariantBinary)
     {
         return switch (type) {
             case DateTimeDataType dataTimeType -> {
@@ -107,13 +107,14 @@ public final class ProtocolUtil
                 yield ExpressionFormatter.formatExpression(type);
             }
             case RowDataType rowDataType -> rowDataType.getFields().stream()
-                    .map(field -> field.getName().map(name -> name + " ").orElse("") + formatType(field.getType(), supportsParametricDateTime, supportsNumberType, supportsVariant))
+                    .map(field -> field.getName().map(name -> name + " ").orElse("") +
+                            formatType(field.getType(), supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary))
                     .collect(Collectors.joining(", ", ROW + "(", ")"));
             case GenericDataType dataType -> {
                 if (!supportsNumberType && dataType.getName().getValue().equalsIgnoreCase(NUMBER)) {
                     yield VARCHAR;
                 }
-                if (!supportsVariant && dataType.getName().getValue().equalsIgnoreCase(VARIANT)) {
+                if (!supportsVariant && !supportsVariantBinary && dataType.getName().getValue().equalsIgnoreCase(VARIANT)) {
                     yield JSON;
                 }
                 if (dataType.getArguments().isEmpty()) {
@@ -126,7 +127,7 @@ public final class ProtocolUtil
                                 return numericParameter.getValue();
                             }
                             if (parameter instanceof io.trino.sql.tree.TypeParameter typeParameter) {
-                                return formatType(typeParameter.getValue(), supportsParametricDateTime, supportsNumberType, supportsVariant);
+                                return formatType(typeParameter.getValue(), supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary);
                             }
                             throw new IllegalArgumentException("Unsupported parameter type: " + parameter.getClass().getName());
                         })
@@ -136,7 +137,7 @@ public final class ProtocolUtil
         };
     }
 
-    private static ClientTypeSignature toClientTypeSignature(TypeSignature signature, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
+    private static ClientTypeSignature toClientTypeSignature(TypeSignature signature, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant, boolean supportsVariantBinary)
     {
         if (!supportsParametricDateTime) {
             if (signature.getBase().equalsIgnoreCase(TIMESTAMP)) {
@@ -155,25 +156,25 @@ public final class ProtocolUtil
         if (!supportsNumberType && signature.getBase().equalsIgnoreCase(NUMBER)) {
             return new ClientTypeSignature(VARCHAR);
         }
-        if (!supportsVariant && signature.getBase().equalsIgnoreCase(VARIANT)) {
+        if (!supportsVariant && !supportsVariantBinary && signature.getBase().equalsIgnoreCase(VARIANT)) {
             return new ClientTypeSignature(JSON);
         }
 
         return new ClientTypeSignature(signature.getBase(), signature.getParameters().stream()
-                .map(parameter -> toClientTypeSignatureParameter(signature.getBase(), parameter, supportsParametricDateTime, supportsNumberType, supportsVariant))
+                .map(parameter -> toClientTypeSignatureParameter(signature.getBase(), parameter, supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary))
                 .collect(toImmutableList()));
     }
 
-    private static ClientTypeSignatureParameter toClientTypeSignatureParameter(String base, TypeParameter parameter, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
+    private static ClientTypeSignatureParameter toClientTypeSignatureParameter(String base, TypeParameter parameter, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant, boolean supportsVariantBinary)
     {
         return switch (parameter) {
             case TypeParameter.Type(Optional<String> name, TypeSignature type) -> {
                 if (base.equalsIgnoreCase(ROW)) { // for backward compatibility with old clients, which expect NAMED_TYPE for row fields
                     yield ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(
                             name.map(RowFieldName::new),
-                            toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType, supportsVariant)));
+                            toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary)));
                 }
-                yield ClientTypeSignatureParameter.ofType(toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType, supportsVariant));
+                yield ClientTypeSignatureParameter.ofType(toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary));
             }
             case TypeParameter.Numeric number -> ClientTypeSignatureParameter.ofLong(number.value());
             case TypeParameter.Variable _ -> throw new IllegalArgumentException("Unsupported parameter kind: " + parameter);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ProtocolUtil.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ProtocolUtil.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.execution.QueryState.FAILED;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.StandardTypes.NUMBER;
 import static io.trino.spi.type.StandardTypes.ROW;
 import static io.trino.spi.type.StandardTypes.TIME;
@@ -65,6 +66,7 @@ import static io.trino.spi.type.StandardTypes.TIMESTAMP;
 import static io.trino.spi.type.StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static io.trino.spi.type.StandardTypes.TIME_WITH_TIME_ZONE;
 import static io.trino.spi.type.StandardTypes.VARCHAR;
+import static io.trino.spi.type.StandardTypes.VARIANT;
 import static io.trino.util.Failures.toFailure;
 import static java.lang.String.format;
 import static java.util.HashSet.newHashSet;
@@ -76,14 +78,14 @@ public final class ProtocolUtil
 
     private ProtocolUtil() {}
 
-    public static Column createColumn(String name, Type type, boolean supportsParametricDateTime, boolean supportsNumberType)
+    public static Column createColumn(String name, Type type, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
     {
-        String formatted = formatType(TypeSignatureTranslator.toSqlType(type), supportsParametricDateTime, supportsNumberType);
+        String formatted = formatType(TypeSignatureTranslator.toSqlType(type), supportsParametricDateTime, supportsNumberType, supportsVariant);
 
-        return new Column(name, formatted, toClientTypeSignature(type.getTypeSignature(), supportsParametricDateTime, supportsNumberType));
+        return new Column(name, formatted, toClientTypeSignature(type.getTypeSignature(), supportsParametricDateTime, supportsNumberType, supportsVariant));
     }
 
-    private static String formatType(DataType type, boolean supportsParametricDateTime, boolean supportsNumberType)
+    private static String formatType(DataType type, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
     {
         return switch (type) {
             case DateTimeDataType dataTimeType -> {
@@ -105,11 +107,14 @@ public final class ProtocolUtil
                 yield ExpressionFormatter.formatExpression(type);
             }
             case RowDataType rowDataType -> rowDataType.getFields().stream()
-                    .map(field -> field.getName().map(name -> name + " ").orElse("") + formatType(field.getType(), supportsParametricDateTime, supportsNumberType))
+                    .map(field -> field.getName().map(name -> name + " ").orElse("") + formatType(field.getType(), supportsParametricDateTime, supportsNumberType, supportsVariant))
                     .collect(Collectors.joining(", ", ROW + "(", ")"));
             case GenericDataType dataType -> {
                 if (!supportsNumberType && dataType.getName().getValue().equalsIgnoreCase(NUMBER)) {
                     yield VARCHAR;
+                }
+                if (!supportsVariant && dataType.getName().getValue().equalsIgnoreCase(VARIANT)) {
+                    yield JSON;
                 }
                 if (dataType.getArguments().isEmpty()) {
                     yield dataType.getName().getValue();
@@ -121,7 +126,7 @@ public final class ProtocolUtil
                                 return numericParameter.getValue();
                             }
                             if (parameter instanceof io.trino.sql.tree.TypeParameter typeParameter) {
-                                return formatType(typeParameter.getValue(), supportsParametricDateTime, supportsNumberType);
+                                return formatType(typeParameter.getValue(), supportsParametricDateTime, supportsNumberType, supportsVariant);
                             }
                             throw new IllegalArgumentException("Unsupported parameter type: " + parameter.getClass().getName());
                         })
@@ -131,7 +136,7 @@ public final class ProtocolUtil
         };
     }
 
-    private static ClientTypeSignature toClientTypeSignature(TypeSignature signature, boolean supportsParametricDateTime, boolean supportsNumberType)
+    private static ClientTypeSignature toClientTypeSignature(TypeSignature signature, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
     {
         if (!supportsParametricDateTime) {
             if (signature.getBase().equalsIgnoreCase(TIMESTAMP)) {
@@ -150,22 +155,25 @@ public final class ProtocolUtil
         if (!supportsNumberType && signature.getBase().equalsIgnoreCase(NUMBER)) {
             return new ClientTypeSignature(VARCHAR);
         }
+        if (!supportsVariant && signature.getBase().equalsIgnoreCase(VARIANT)) {
+            return new ClientTypeSignature(JSON);
+        }
 
         return new ClientTypeSignature(signature.getBase(), signature.getParameters().stream()
-                .map(parameter -> toClientTypeSignatureParameter(signature.getBase(), parameter, supportsParametricDateTime, supportsNumberType))
+                .map(parameter -> toClientTypeSignatureParameter(signature.getBase(), parameter, supportsParametricDateTime, supportsNumberType, supportsVariant))
                 .collect(toImmutableList()));
     }
 
-    private static ClientTypeSignatureParameter toClientTypeSignatureParameter(String base, TypeParameter parameter, boolean supportsParametricDateTime, boolean supportsNumberType)
+    private static ClientTypeSignatureParameter toClientTypeSignatureParameter(String base, TypeParameter parameter, boolean supportsParametricDateTime, boolean supportsNumberType, boolean supportsVariant)
     {
         return switch (parameter) {
             case TypeParameter.Type(Optional<String> name, TypeSignature type) -> {
                 if (base.equalsIgnoreCase(ROW)) { // for backward compatibility with old clients, which expect NAMED_TYPE for row fields
                     yield ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(
                             name.map(RowFieldName::new),
-                            toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType)));
+                            toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType, supportsVariant)));
                 }
-                yield ClientTypeSignatureParameter.ofType(toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType));
+                yield ClientTypeSignatureParameter.ofType(toClientTypeSignature(type, supportsParametricDateTime, supportsNumberType, supportsVariant));
             }
             case TypeParameter.Numeric number -> ClientTypeSignatureParameter.ofLong(number.value());
             case TypeParameter.Variable _ -> throw new IllegalArgumentException("Unsupported parameter kind: " + parameter);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -138,6 +138,7 @@ class Query
     private final boolean supportsParametricDateTime;
     private final boolean supportsNumberType;
     private final boolean supportsVariant;
+    private final boolean supportsVariantBinary;
 
     @GuardedBy("this")
     private OptionalLong nextToken = OptionalLong.of(0);
@@ -267,6 +268,7 @@ class Query
         this.supportsParametricDateTime = session.getClientCapabilities().contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
         this.supportsNumberType = session.getClientCapabilities().contains(ClientCapabilities.NUMBER.toString());
         this.supportsVariant = session.getClientCapabilities().contains(ClientCapabilities.VARIANT.toString());
+        this.supportsVariantBinary = session.getClientCapabilities().contains(ClientCapabilities.VARIANT_BINARY.toString());
         this.serdeFactory = createExchangePagesSerdeFactory(blockEncodingSerde, session);
     }
 
@@ -708,7 +710,7 @@ class Query
 
             ImmutableList.Builder<Column> list = ImmutableList.builder();
             for (int i = 0; i < columnNames.size(); i++) {
-                list.add(createColumn(columnNames.get(i), columnTypes.get(i), supportsParametricDateTime, supportsNumberType, supportsVariant));
+                list.add(createColumn(columnNames.get(i), columnTypes.get(i), supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary));
             }
             columns = list.build();
             types = outputInfo.getColumnTypes();

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -137,6 +137,7 @@ class Query
     private boolean exchangeFinished;
     private final boolean supportsParametricDateTime;
     private final boolean supportsNumberType;
+    private final boolean supportsVariant;
 
     @GuardedBy("this")
     private OptionalLong nextToken = OptionalLong.of(0);
@@ -265,6 +266,7 @@ class Query
         this.timeoutExecutor = timeoutExecutor;
         this.supportsParametricDateTime = session.getClientCapabilities().contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
         this.supportsNumberType = session.getClientCapabilities().contains(ClientCapabilities.NUMBER.toString());
+        this.supportsVariant = session.getClientCapabilities().contains(ClientCapabilities.VARIANT.toString());
         this.serdeFactory = createExchangePagesSerdeFactory(blockEncodingSerde, session);
     }
 
@@ -706,7 +708,7 @@ class Query
 
             ImmutableList.Builder<Column> list = ImmutableList.builder();
             for (int i = 0; i < columnNames.size(); i++) {
-                list.add(createColumn(columnNames.get(i), columnTypes.get(i), supportsParametricDateTime, supportsNumberType));
+                list.add(createColumn(columnNames.get(i), columnTypes.get(i), supportsParametricDateTime, supportsNumberType, supportsVariant));
             }
             columns = list.build();
             types = outputInfo.getColumnTypes();

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.client.ClientCapabilities;
 import io.trino.client.CloseableIterator;
 import io.trino.client.Column;
+import io.trino.client.EncodedVariant;
 import io.trino.client.QueryDataDecoder;
 import io.trino.client.Row;
 import io.trino.client.spooling.DataAttributes;
@@ -44,6 +45,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +84,7 @@ public class TestJsonEncodingUtils
 {
     protected QueryDataDecoder createDecoder(List<Column> columns)
     {
-        return new JsonQueryDataDecoder.Factory().create(columns, DataAttributes.empty());
+        return new JsonQueryDataDecoder.Factory().create(columns, DataAttributes.empty(), false);
     }
 
     protected QueryDataEncoder createEncoder(List<OutputColumn> columns)
@@ -430,8 +432,46 @@ public class TestJsonEncodingUtils
         Block block = blockBuilder.build();
 
         Page page = page(block);
-        assertThat(roundTrip(columns, page, "[[null],[{\"a\":1,\"b\":[true,null]}],[null]]"))
+        assertThat(roundTrip(
+                sessionWithoutCapability(ClientCapabilities.VARIANT_BINARY),
+                columns,
+                true,
+                false,
+                page,
+                "[[null],[{\"a\":1,\"b\":[true,null]}],[null]]"))
                 .isEqualTo(column(null, "{\"a\":1,\"b\":[true,null]}", null));
+    }
+
+    @Test
+    public void testVariantBinarySerialization()
+            throws IOException
+    {
+        List<TypedColumn> columns = ImmutableList.of(typed("col0", VARIANT));
+        BlockBuilder blockBuilder = VARIANT.createBlockBuilder(null, 3);
+        blockBuilder.appendNull();
+        Variant variant = Variant.ofObject(Map.of(
+                utf8Slice("a"), Variant.ofInt(1),
+                utf8Slice("b"), Variant.ofArray(List.of(Variant.ofBoolean(true), Variant.NULL_VALUE))));
+        VARIANT.writeObject(blockBuilder, variant);
+        VARIANT.writeObject(blockBuilder, Variant.NULL_VALUE);
+        Block block = blockBuilder.build();
+
+        Page page = page(block);
+        List<List<Object>> rows = roundTrip(
+                sessionWithCapability(ClientCapabilities.VARIANT_BINARY),
+                columns,
+                false,
+                true,
+                page,
+                "[[null],[" + toBinaryEnvelopeJson(variant) + "],[" + toBinaryEnvelopeJson(Variant.NULL_VALUE) + "]]");
+        assertThat(rows).hasSize(3);
+        assertThat(rows.get(0)).containsExactly((Object) null);
+        assertThat(rows.get(1)).hasSize(1);
+        assertThat(rows.get(1).get(0)).isInstanceOf(EncodedVariant.class);
+        assertEncodedVariant((EncodedVariant) rows.get(1).get(0), variant);
+        assertThat(rows.get(2)).hasSize(1);
+        assertThat(rows.get(2).get(0)).isInstanceOf(EncodedVariant.class);
+        assertEncodedVariant((EncodedVariant) rows.get(2).get(0), Variant.NULL_VALUE);
     }
 
     @Test
@@ -448,8 +488,83 @@ public class TestJsonEncodingUtils
         Block block = blockBuilder.build();
 
         Page page = page(block);
-        assertThat(roundTrip(sessionWithoutCapability(ClientCapabilities.VARIANT), columns, false, page, "[[null],[\"{\\\"a\\\":1,\\\"b\\\":[true,null]}\"],[\"null\"]]"))
+        assertThat(roundTrip(sessionWithoutVariantCapabilities(), columns, false, page, "[[null],[\"{\\\"a\\\":1,\\\"b\\\":[true,null]}\"],[\"null\"]]"))
                 .isEqualTo(column(null, "{\"a\":1,\"b\":[true,null]}", "null"));
+    }
+
+    @Test
+    public void testVariantBinarySerializationInRows()
+            throws IOException
+    {
+        RowType rowType = RowType.from(ImmutableList.of(
+                RowType.field("id", BIGINT),
+                RowType.field("payload", VARIANT)));
+        List<TypedColumn> columns = ImmutableList.of(typed("col0", rowType));
+        RowBlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1);
+
+        Variant payload = Variant.ofObject(Map.of(
+                utf8Slice("a"), Variant.ofInt(1),
+                utf8Slice("nested"), Variant.ofArray(List.of(Variant.ofBoolean(true), Variant.NULL_VALUE))));
+        blockBuilder.buildEntry(builders -> {
+            BIGINT.writeLong(builders.get(0), 1);
+            VARIANT.writeObject(builders.get(1), payload);
+        });
+
+        Page page = page(blockBuilder.build());
+        List<List<Object>> rows = roundTrip(
+                sessionWithCapability(ClientCapabilities.VARIANT_BINARY),
+                columns,
+                false,
+                true,
+                page,
+                "[[[1," + toBinaryEnvelopeJson(payload) + "]]]");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0)).hasSize(1);
+        assertThat(rows.get(0).get(0)).isInstanceOf(Row.class);
+        Row row = (Row) rows.get(0).get(0);
+        assertThat(row.getFields()).hasSize(2);
+        assertThat(row.getFields().get(0).getName()).contains("id");
+        assertThat(row.getFields().get(0).getValue()).isEqualTo(1L);
+        assertThat(row.getFields().get(1).getName()).contains("payload");
+        assertThat(row.getFields().get(1).getValue()).isInstanceOf(EncodedVariant.class);
+        assertEncodedVariant((EncodedVariant) row.getFields().get(1).getValue(), payload);
+    }
+
+    @Test
+    public void testVariantBinarySerializationInArrays()
+            throws IOException
+    {
+        ArrayType arrayType = new ArrayType(VARIANT);
+        List<TypedColumn> columns = ImmutableList.of(typed("col0", arrayType));
+        ArrayBlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 1);
+
+        Variant payload = Variant.ofObject(Map.of(
+                utf8Slice("a"), Variant.ofInt(1),
+                utf8Slice("nested"), Variant.ofArray(List.of(Variant.ofBoolean(true), Variant.NULL_VALUE))));
+        blockBuilder.buildEntry(builder -> {
+            VARIANT.writeObject(builder, payload);
+            VARIANT.writeObject(builder, Variant.NULL_VALUE);
+            builder.appendNull();
+        });
+
+        Page page = page(blockBuilder.build());
+        List<List<Object>> rows = roundTrip(
+                sessionWithCapability(ClientCapabilities.VARIANT_BINARY),
+                columns,
+                false,
+                true,
+                page,
+                "[[[" + toBinaryEnvelopeJson(payload) + "," + toBinaryEnvelopeJson(Variant.NULL_VALUE) + ",null]]]");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0)).hasSize(1);
+        assertThat(rows.get(0).get(0)).isInstanceOf(List.class);
+        List<?> values = (List<?>) rows.get(0).get(0);
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0)).isInstanceOf(EncodedVariant.class);
+        assertEncodedVariant((EncodedVariant) values.get(0), payload);
+        assertThat(values.get(1)).isInstanceOf(EncodedVariant.class);
+        assertEncodedVariant((EncodedVariant) values.get(1), Variant.NULL_VALUE);
+        assertThat(values.get(2)).isNull();
     }
 
     @Test
@@ -470,7 +585,7 @@ public class TestJsonEncodingUtils
         });
 
         Page page = page(blockBuilder.build());
-        assertThat(roundTrip(sessionWithoutCapability(ClientCapabilities.VARIANT), columns, false, page, "[[[1,\"{\\\"a\\\":1,\\\"nested\\\":[true,null]}\"]]]"))
+        assertThat(roundTrip(sessionWithoutVariantCapabilities(), columns, false, page, "[[[1,\"{\\\"a\\\":1,\\\"nested\\\":[true,null]}\"]]]"))
                 .containsExactly(List.of(Row.builderWithExpectedSize(2)
                         .addField("id", 1L)
                         .addField("payload", "{\"a\":1,\"nested\":[true,null]}")
@@ -499,7 +614,7 @@ public class TestJsonEncodingUtils
 
         Page page = page(blockBuilder.build());
         assertThat(roundTrip(
-                sessionWithoutCapability(ClientCapabilities.VARIANT),
+                sessionWithoutVariantCapabilities(),
                 columns,
                 false,
                 page,
@@ -630,13 +745,19 @@ public class TestJsonEncodingUtils
     protected List<List<Object>> roundTrip(Session session, List<TypedColumn> columns, boolean supportsVariant, Page page, String expectedJson)
             throws IOException
     {
+        return roundTrip(session, columns, supportsVariant, false, page, expectedJson);
+    }
+
+    protected List<List<Object>> roundTrip(Session session, List<TypedColumn> columns, boolean supportsVariant, boolean supportsVariantBinary, Page page, String expectedJson)
+            throws IOException
+    {
         QueryDataEncoder encoder = newEncoder(session, columns);
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         encoder.encodeTo(output, List.of(page));
 
         assertThat(output.toString(UTF_8)).isEqualTo(expectedJson);
 
-        return ImmutableList.copyOf(parseJson(columns, supportsVariant, output.toByteArray()));
+        return ImmutableList.copyOf(parseJson(columns, supportsVariant, supportsVariantBinary, output.toByteArray()));
     }
 
     protected void assertInvalidJson(List<TypedColumn> columns, String json, String expectedError)
@@ -654,7 +775,7 @@ public class TestJsonEncodingUtils
     protected List<List<Object>> parseJson(List<TypedColumn> columns, byte[] json)
             throws IOException
     {
-        QueryDataDecoder decoder = newDecoder(columns, true);
+        QueryDataDecoder decoder = newDecoder(columns, true, false);
         try (CloseableIterator<List<Object>> iterator = decoder.decode(new ByteArrayInputStream(json), null)) {
             return ImmutableList.copyOf(iterator);
         }
@@ -663,7 +784,13 @@ public class TestJsonEncodingUtils
     protected List<List<Object>> parseJson(List<TypedColumn> columns, boolean supportsVariant, byte[] json)
             throws IOException
     {
-        QueryDataDecoder decoder = newDecoder(columns, supportsVariant);
+        return parseJson(columns, supportsVariant, false, json);
+    }
+
+    protected List<List<Object>> parseJson(List<TypedColumn> columns, boolean supportsVariant, boolean supportsVariantBinary, byte[] json)
+            throws IOException
+    {
+        QueryDataDecoder decoder = newDecoder(columns, supportsVariant, supportsVariantBinary);
         try (CloseableIterator<List<Object>> iterator = decoder.decode(new ByteArrayInputStream(json), null)) {
             return ImmutableList.copyOf(iterator);
         }
@@ -693,13 +820,13 @@ public class TestJsonEncodingUtils
         return createEncoder(session, columns.build());
     }
 
-    private QueryDataDecoder newDecoder(List<TypedColumn> types, boolean supportsVariant)
+    private QueryDataDecoder newDecoder(List<TypedColumn> types, boolean supportsVariant, boolean supportsVariantBinary)
     {
         ImmutableList.Builder<Column> columns = ImmutableList.builderWithExpectedSize(types.size());
         for (TypedColumn typedColumn : types) {
-            columns.add(createColumn(typedColumn.name(), typedColumn.type(), true, true, supportsVariant));
+            columns.add(createColumn(typedColumn.name(), typedColumn.type(), true, true, supportsVariant, supportsVariantBinary));
         }
-        return createDecoder(columns.build());
+        return new JsonQueryDataDecoder.Factory().create(columns.build(), DataAttributes.empty(), supportsVariantBinary);
     }
 
     private static Session sessionWithoutCapability(ClientCapabilities capability)
@@ -707,6 +834,16 @@ public class TestJsonEncodingUtils
         return Session.builder(TEST_SESSION)
                 .setClientCapabilities(TEST_SESSION.getClientCapabilities().stream()
                         .filter(value -> !value.equals(capability.toString()))
+                        .collect(toImmutableSet()))
+                .build();
+    }
+
+    private static Session sessionWithoutVariantCapabilities()
+    {
+        return Session.builder(TEST_SESSION)
+                .setClientCapabilities(TEST_SESSION.getClientCapabilities().stream()
+                        .filter(value -> !value.equals(ClientCapabilities.VARIANT.toString()))
+                        .filter(value -> !value.equals(ClientCapabilities.VARIANT_BINARY.toString()))
                         .collect(toImmutableSet()))
                 .build();
     }
@@ -721,6 +858,18 @@ public class TestJsonEncodingUtils
                         .stream()
                         .collect(toImmutableSet()))
                 .build();
+    }
+
+    private static String toBinaryEnvelopeJson(Variant variant)
+    {
+        return "{\"metadata\":\"" + Base64.getEncoder().encodeToString(variant.metadata().toSlice().getBytes()) +
+                "\",\"value\":\"" + Base64.getEncoder().encodeToString(variant.data().getBytes()) + "\"}";
+    }
+
+    private static void assertEncodedVariant(EncodedVariant actual, Variant expected)
+    {
+        assertThat(actual.getMetadataBytes()).isEqualTo(expected.metadata().toSlice().getBytes());
+        assertThat(actual.getValueBytes()).isEqualTo(expected.data().getBytes());
     }
 
     private static Page page(Block... blocks)

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
@@ -14,6 +14,8 @@
 package io.trino.server.protocol;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.client.ClientCapabilities;
 import io.trino.client.CloseableIterator;
 import io.trino.client.Column;
 import io.trino.client.QueryDataDecoder;
@@ -25,6 +27,7 @@ import io.trino.server.protocol.spooling.encoding.JsonQueryDataEncoder;
 import io.trino.spi.Page;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.type.ArrayType;
@@ -85,6 +88,11 @@ public class TestJsonEncodingUtils
     protected QueryDataEncoder createEncoder(List<OutputColumn> columns)
     {
         return new JsonQueryDataEncoder.Factory().create(TEST_SESSION, columns);
+    }
+
+    protected QueryDataEncoder createEncoder(Session session, List<OutputColumn> columns)
+    {
+        return new JsonQueryDataEncoder.Factory().create(session, columns);
     }
 
     @Test
@@ -413,7 +421,7 @@ public class TestJsonEncodingUtils
             throws IOException
     {
         List<TypedColumn> columns = ImmutableList.of(typed("col0", VARIANT));
-        var blockBuilder = VARIANT.createBlockBuilder(null, 3);
+        BlockBuilder blockBuilder = VARIANT.createBlockBuilder(null, 3);
         blockBuilder.appendNull();
         VARIANT.writeObject(blockBuilder, Variant.ofObject(Map.of(
                 utf8Slice("a"), Variant.ofInt(1),
@@ -424,6 +432,82 @@ public class TestJsonEncodingUtils
         Page page = page(block);
         assertThat(roundTrip(columns, page, "[[null],[{\"a\":1,\"b\":[true,null]}],[null]]"))
                 .isEqualTo(column(null, "{\"a\":1,\"b\":[true,null]}", null));
+    }
+
+    @Test
+    public void testVariantJsonFallbackSerialization()
+            throws IOException
+    {
+        List<TypedColumn> columns = ImmutableList.of(typed("col0", VARIANT));
+        BlockBuilder blockBuilder = VARIANT.createBlockBuilder(null, 3);
+        blockBuilder.appendNull();
+        VARIANT.writeObject(blockBuilder, Variant.ofObject(Map.of(
+                utf8Slice("a"), Variant.ofInt(1),
+                utf8Slice("b"), Variant.ofArray(List.of(Variant.ofBoolean(true), Variant.NULL_VALUE)))));
+        VARIANT.writeObject(blockBuilder, Variant.NULL_VALUE);
+        Block block = blockBuilder.build();
+
+        Page page = page(block);
+        assertThat(roundTrip(sessionWithoutCapability(ClientCapabilities.VARIANT), columns, false, page, "[[null],[\"{\\\"a\\\":1,\\\"b\\\":[true,null]}\"],[\"null\"]]"))
+                .isEqualTo(column(null, "{\"a\":1,\"b\":[true,null]}", "null"));
+    }
+
+    @Test
+    public void testVariantJsonFallbackSerializationInRows()
+            throws IOException
+    {
+        RowType rowType = RowType.from(ImmutableList.of(
+                RowType.field("id", BIGINT),
+                RowType.field("payload", VARIANT)));
+        List<TypedColumn> columns = ImmutableList.of(typed("col0", rowType));
+        RowBlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1);
+
+        blockBuilder.buildEntry(builders -> {
+            BIGINT.writeLong(builders.get(0), 1);
+            VARIANT.writeObject(builders.get(1), Variant.ofObject(Map.of(
+                    utf8Slice("a"), Variant.ofInt(1),
+                    utf8Slice("nested"), Variant.ofArray(List.of(Variant.ofBoolean(true), Variant.NULL_VALUE)))));
+        });
+
+        Page page = page(blockBuilder.build());
+        assertThat(roundTrip(sessionWithoutCapability(ClientCapabilities.VARIANT), columns, false, page, "[[[1,\"{\\\"a\\\":1,\\\"nested\\\":[true,null]}\"]]]"))
+                .containsExactly(List.of(Row.builderWithExpectedSize(2)
+                        .addField("id", 1L)
+                        .addField("payload", "{\"a\":1,\"nested\":[true,null]}")
+                        .build()));
+    }
+
+    @Test
+    public void testVariantJsonFallbackSerializationInMaps()
+            throws IOException
+    {
+        MapType mapType = new MapType(VARCHAR, VARIANT, new TypeOperators());
+        List<TypedColumn> columns = ImmutableList.of(typed("col0", mapType));
+        MapBlockBuilder blockBuilder = mapType.createBlockBuilder(null, 3);
+
+        blockBuilder.buildEntry((keyBuilder, valueBuilder) -> {
+            VARCHAR.writeSlice(keyBuilder, utf8Slice("first"));
+            VARIANT.writeObject(valueBuilder, Variant.ofObject(Map.of(
+                    utf8Slice("a"), Variant.ofInt(1))));
+
+            VARCHAR.writeSlice(keyBuilder, utf8Slice("second"));
+            VARIANT.writeObject(valueBuilder, Variant.NULL_VALUE);
+
+            VARCHAR.writeSlice(keyBuilder, utf8Slice("third"));
+            valueBuilder.appendNull();
+        });
+
+        Page page = page(blockBuilder.build());
+        assertThat(roundTrip(
+                sessionWithoutCapability(ClientCapabilities.VARIANT),
+                columns,
+                false,
+                page,
+                "[[{\"first\":\"{\\\"a\\\":1}\",\"second\":\"null\",\"third\":null}]]").getFirst())
+                .containsExactly(map(
+                        entry("first", "{\"a\":1}"),
+                        entry("second", "null"),
+                        entry("third", null)));
     }
 
     @Test
@@ -534,13 +618,25 @@ public class TestJsonEncodingUtils
     protected List<List<Object>> roundTrip(List<TypedColumn> columns, Page page, String expectedJson)
             throws IOException
     {
-        QueryDataEncoder encoder = newEncoder(columns);
+        QueryDataEncoder encoder = newEncoder(TEST_SESSION, columns);
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         encoder.encodeTo(output, List.of(page));
 
         assertThat(output.toString(UTF_8)).isEqualTo(expectedJson);
 
         return ImmutableList.copyOf(parseJson(columns, output.toByteArray()));
+    }
+
+    protected List<List<Object>> roundTrip(Session session, List<TypedColumn> columns, boolean supportsVariant, Page page, String expectedJson)
+            throws IOException
+    {
+        QueryDataEncoder encoder = newEncoder(session, columns);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        encoder.encodeTo(output, List.of(page));
+
+        assertThat(output.toString(UTF_8)).isEqualTo(expectedJson);
+
+        return ImmutableList.copyOf(parseJson(columns, supportsVariant, output.toByteArray()));
     }
 
     protected void assertInvalidJson(List<TypedColumn> columns, String json, String expectedError)
@@ -558,7 +654,16 @@ public class TestJsonEncodingUtils
     protected List<List<Object>> parseJson(List<TypedColumn> columns, byte[] json)
             throws IOException
     {
-        QueryDataDecoder decoder = newDecoder(columns);
+        QueryDataDecoder decoder = newDecoder(columns, true);
+        try (CloseableIterator<List<Object>> iterator = decoder.decode(new ByteArrayInputStream(json), null)) {
+            return ImmutableList.copyOf(iterator);
+        }
+    }
+
+    protected List<List<Object>> parseJson(List<TypedColumn> columns, boolean supportsVariant, byte[] json)
+            throws IOException
+    {
+        QueryDataDecoder decoder = newDecoder(columns, supportsVariant);
         try (CloseableIterator<List<Object>> iterator = decoder.decode(new ByteArrayInputStream(json), null)) {
             return ImmutableList.copyOf(iterator);
         }
@@ -578,23 +683,44 @@ public class TestJsonEncodingUtils
         }
     }
 
-    private QueryDataEncoder newEncoder(List<TypedColumn> types)
+    private QueryDataEncoder newEncoder(Session session, List<TypedColumn> types)
     {
         ImmutableList.Builder<OutputColumn> columns = ImmutableList.builderWithExpectedSize(types.size());
         for (int i = 0; i < types.size(); i++) {
             TypedColumn typedColumn = types.get(i);
             columns.add(new OutputColumn(i, typedColumn.name(), typedColumn.type()));
         }
-        return createEncoder(columns.build());
+        return createEncoder(session, columns.build());
     }
 
-    private QueryDataDecoder newDecoder(List<TypedColumn> types)
+    private QueryDataDecoder newDecoder(List<TypedColumn> types, boolean supportsVariant)
     {
         ImmutableList.Builder<Column> columns = ImmutableList.builderWithExpectedSize(types.size());
         for (TypedColumn typedColumn : types) {
-            columns.add(createColumn(typedColumn.name(), typedColumn.type(), true, true));
+            columns.add(createColumn(typedColumn.name(), typedColumn.type(), true, true, supportsVariant));
         }
         return createDecoder(columns.build());
+    }
+
+    private static Session sessionWithoutCapability(ClientCapabilities capability)
+    {
+        return Session.builder(TEST_SESSION)
+                .setClientCapabilities(TEST_SESSION.getClientCapabilities().stream()
+                        .filter(value -> !value.equals(capability.toString()))
+                        .collect(toImmutableSet()))
+                .build();
+    }
+
+    private static Session sessionWithCapability(ClientCapabilities capability)
+    {
+        return Session.builder(TEST_SESSION)
+                .setClientCapabilities(ImmutableList.<String>builder()
+                        .addAll(TEST_SESSION.getClientCapabilities())
+                        .add(capability.toString())
+                        .build()
+                        .stream()
+                        .collect(toImmutableSet()))
+                .build();
     }
 
     private static Page page(Block... blocks)

--- a/docs/src/main/sphinx/develop/client-protocol.md
+++ b/docs/src/main/sphinx/develop/client-protocol.md
@@ -187,6 +187,10 @@ requests, just like browser cookies.
 * - `X-Trino-Client-Tags`
   - A comma-separated list of "tag" strings, used to identify Trino resource
     groups.
+* - `X-Trino-Client-Capabilities`
+  - A comma-separated list of optional protocol features supported by the
+    client. Supported values include `PATH`, `PARAMETRIC_DATETIME`, `NUMBER`,
+    `VARIANT`, `VARIANT_BINARY`, and `SESSION_AUTHORIZATION`.
 * - `X-Trino-Resource-Estimate`
   - A comma-separated list of `resource=value` type assignments. The possible
     choices of `resource` are `EXECUTION_TIME`, `CPU_TIME`,  `PEAK_MEMORY` and

--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
@@ -148,6 +148,20 @@ public class TestJdbcResultSetCompatibilityOldServer
     }
 
     @Override
+    public void testVariant()
+            throws Exception
+    {
+        if (parseInt(getTestedTrinoVersion()) < 481) {
+            try (ConnectedStatement statementWrapper = newStatement()) {
+                assertThatThrownBy(() -> statementWrapper.getStatement().executeQuery("SELECT CAST(NULL AS variant)"))
+                        .hasMessageMatching(".*Unknown type: variant.*");
+            }
+            return;
+        }
+        super.testVariant();
+    }
+
+    @Override
     protected Connection createConnection()
             throws SQLException
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
@@ -16,6 +16,7 @@ package io.trino.testing;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
 import io.trino.Session;
+import io.trino.client.EncodedVariant;
 import io.trino.client.IntervalDayTime;
 import io.trino.client.IntervalYearMonth;
 import io.trino.client.QueryStatusInfo;
@@ -36,6 +37,8 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
+import io.trino.spi.variant.Metadata;
+import io.trino.spi.variant.Variant;
 import io.trino.type.SqlIntervalDayTime;
 import io.trino.type.SqlIntervalYearMonth;
 import io.trino.util.variant.VariantWriter;
@@ -335,6 +338,11 @@ public class TestingTrinoClient
             return (String) value;
         }
         if (type == VARIANT) {
+            if (value instanceof EncodedVariant encodedVariant) {
+                return Variant.from(
+                        Metadata.from(Slices.wrappedBuffer(encodedVariant.getMetadataBytes())),
+                        Slices.wrappedBuffer(encodedVariant.getValueBytes()));
+            }
             return JSON_VARIANT_WRITER.write(Slices.utf8Slice((String) value));
         }
         if (type instanceof ArrayType arrayType) {


### PR DESCRIPTION
## Description

Add support for `VARIANT` in clients.  There are three supported scenarios, based on the settings of client capabilities:
1. nothing set: return type `JSON` with data encoded as `JSON` (legacy clients)
2. `VARIANT`: return type `VARIANT` with data encoded as `JSON`
3. `VARIANT_BINARY`: return type `VARIANT` with data in standard binary variant format.

The cli uses `VARIANT`, and the JDBC driver uses `VARIANT_BINARY`.

The JDBC client uses binary `VARIANT` directly without lowering to JSON and losing all type information.  `VARIANT` columns can be fetched with:
- `rs.getObject(column)` or `rs.getObject(column, Object.class)` to get the corresponding Java object representation. This is the same as `variant.toObject`
- `rs.getObject(column, io.trino.jdbc.Variant.class)` to get an `io.trino.jdbc.Variant`
- `rs.getObject(column, Map.class)` Same as `getObject(Column)` but only works when the result would be a Map. Throws an exception if the variant is not an object.
- `rs.getObject(column, List.class)` Same as `getObject(Column)` but only works when the result would be a Array. Throws an exception if the variant is not an array.
- `rs.getString(column)` or `rs.getObject(column, String.class)` to get the corresponding JSON representation. This is the same as `variant.toJson`, which is the same as the `VARIANT_JSON` encoding.

When mapping to Java object representation, `VARIANT` values map to Java objects as follows:

| VARIANT value | Java object |
| --- | --- |
| null | `null` |
| boolean | `Boolean` |
| int8 | `Byte` |
| int16 | `Short` |
| int32 | `Integer` |
| int64 | `Long` |
| float | `Float` |
| double | `Double` |
| decimal | `BigDecimal` |
| string | `String` |
| binary | `byte[]` |
| date | `LocalDate` |
| time(ntz) | `LocalTime` |
| timestamp(utc) | `Instant` |
| timestamp(ntz) | `LocalDateTime` |
| uuid | `UUID` |
| array | `List<Object>` |
| object | `Map<String, Object>` |

The `io.trino.jdbc.Variant` class is a minimal implementation of VARIANT for decoding data.  This supports getting the raw underlying byte arrays for the value and metdata is the client wants to interact with the raw data (storing in a separate system directly without reencoding).  The SPI Variant class cannot be used because it is compiled with Java 25.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## CLI, JDBC
* Add support for VARIANT type. ({issue}`29046`)
```
