### PR TITLE
Remove dead code from LocalExecutionPlanner.visitTableScan

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -60,7 +60,6 @@ public class TableScanOperator
         private final Optional<ConnectorTableCredentials> tableCredentials;
         private final List<ColumnHandle> columns;
         private final List<Type> columnTypes;
-        private final DynamicFilter dynamicFilter;
         private boolean closed;
 
         public TableScanOperatorFactory(
@@ -71,8 +70,7 @@ public class TableScanOperator
                 TableHandle table,
                 Optional<ConnectorTableCredentials> tableCredentials,
                 List<ColumnHandle> columns,
-                List<Type> columnTypes,
-                DynamicFilter dynamicFilter)
+                List<Type> columnTypes)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -81,7 +79,6 @@ public class TableScanOperator
             this.tableCredentials = requireNonNull(tableCredentials, "tableCredentials is null");
             this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
             this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
-            this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
             this.pageSourceProvider = pageSourceProvider.createPageSourceProvider(table.catalogHandle());
         }
 
@@ -103,8 +100,7 @@ public class TableScanOperator
                     pageSourceProvider,
                     table,
                     tableCredentials,
-                    columns,
-                    dynamicFilter);
+                    columns);
 
             if (isSourcePagesValidationEnabled(operatorContext.getSession())) {
                 return new OutputValidatingSourceOperator(
@@ -128,7 +124,6 @@ public class TableScanOperator
     private final TableHandle table;
     private final Optional<ConnectorTableCredentials> tableCredentials;
     private final List<ColumnHandle> columns;
-    private final DynamicFilter dynamicFilter;
     private final LocalMemoryContext memoryContext;
     private final SettableFuture<Void> blocked = SettableFuture.create();
 
@@ -149,8 +144,7 @@ public class TableScanOperator
             PageSourceProvider pageSourceProvider,
             TableHandle table,
             Optional<ConnectorTableCredentials> tableCredentials,
-            List<ColumnHandle> columns,
-            DynamicFilter dynamicFilter)
+            List<ColumnHandle> columns)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.sourceId = requireNonNull(sourceId, "planNodeId is null");
@@ -158,7 +152,6 @@ public class TableScanOperator
         this.table = requireNonNull(table, "table is null");
         this.tableCredentials = requireNonNull(tableCredentials, "tableCredentials is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
-        this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
         this.memoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName());
     }
 
@@ -275,10 +268,7 @@ public class TableScanOperator
             return null;
         }
         if (source == null) {
-            if (!dynamicFilter.getCurrentPredicate().isAll()) {
-                operatorContext.recordDynamicFilterSplitProcessed(1L);
-            }
-            source = pageSourceProvider.createPageSource(operatorContext.getSession(), split, table, tableCredentials, columns, dynamicFilter);
+            source = pageSourceProvider.createPageSource(operatorContext.getSession(), split, table, tableCredentials, columns, DynamicFilter.EMPTY);
         }
 
         SourcePage sourcePage = source.getNextSourcePage();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2184,7 +2184,7 @@ public class LocalExecutionPlanner
             }
 
             Optional<ConnectorTableCredentials> tableCredentials = context.getTaskContext().getTableCredentials(node.getId());
-            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), planNodeId, node.getId(), pageSourceManager, node.getTable(), tableCredentials, columns.build(), columnTypes.build(), DynamicFilter.EMPTY);
+            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), planNodeId, node.getId(), pageSourceManager, node.getTable(), tableCredentials, columns.build(), columnTypes.build());
             return new PhysicalOperation(operatorFactory, makeLayout(node));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2013,20 +2013,8 @@ public class LocalExecutionPlanner
         @Override
         public PhysicalOperation visitFilter(FilterNode node, LocalExecutionPlanContext context)
         {
-            PlanNode sourceNode = node.getSource();
-            Expression filterExpression = node.getPredicate();
-
-            if (node.getSource() instanceof TableScanNode tableScanNode) {
-                DynamicFilters.ExtractResult extractDynamicFilterResult = extractDynamicFilters(filterExpression);
-                Expression staticFilter = combineConjuncts(extractDynamicFilterResult.getStaticConjuncts());
-                if (staticFilter.equals(TRUE) && extractDynamicFilterResult.getDynamicConjuncts().isEmpty()) {
-                    // filter node contains only empty dynamic filter, fallback to normal table scan
-                    return visitTableScan(node.getId(), tableScanNode, filterExpression, context);
-                }
-            }
-
             List<Symbol> outputSymbols = node.getOutputSymbols();
-            return visitScanFilterAndProject(context, node.getId(), sourceNode, Optional.of(filterExpression), Assignments.identity(outputSymbols), outputSymbols);
+            return visitScanFilterAndProject(context, node.getId(), node.getSource(), Optional.of(node.getPredicate()), Assignments.identity(outputSymbols), outputSymbols);
         }
 
         @Override
@@ -2187,11 +2175,7 @@ public class LocalExecutionPlanner
         @Override
         public PhysicalOperation visitTableScan(TableScanNode node, LocalExecutionPlanContext context)
         {
-            return visitTableScan(node.getId(), node, TRUE, context);
-        }
-
-        private PhysicalOperation visitTableScan(PlanNodeId planNodeId, TableScanNode node, Expression filterExpression, LocalExecutionPlanContext context)
-        {
+            PlanNodeId planNodeId = node.getId();
             ImmutableList.Builder<ColumnHandle> columns = ImmutableList.builder();
             ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
             for (Symbol symbol : node.getOutputSymbols()) {
@@ -2199,9 +2183,8 @@ public class LocalExecutionPlanner
                 columnTypes.add(symbol.type());
             }
 
-            DynamicFilter dynamicFilter = getDynamicFilter(node, filterExpression, context);
             Optional<ConnectorTableCredentials> tableCredentials = context.getTaskContext().getTableCredentials(node.getId());
-            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), planNodeId, node.getId(), pageSourceManager, node.getTable(), tableCredentials, columns.build(), columnTypes.build(), dynamicFilter);
+            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), planNodeId, node.getId(), pageSourceManager, node.getTable(), tableCredentials, columns.build(), columnTypes.build(), DynamicFilter.EMPTY);
             return new PhysicalOperation(operatorFactory, makeLayout(node));
         }
 

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryBlocking.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryBlocking.java
@@ -29,7 +29,6 @@ import io.trino.operator.TableScanOperator;
 import io.trino.operator.TaskContext;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.ConnectorSplit;
-import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
@@ -109,8 +108,7 @@ public class TestMemoryBlocking
                         .build()),
                 TEST_TABLE_HANDLE,
                 Optional.empty(),
-                ImmutableList.of(),
-                DynamicFilter.EMPTY);
+                ImmutableList.of());
         PageConsumerOperator sink = createSinkOperator(types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
         assertThat(driver.getDriverContext()).isSameAs(driverContext);

--- a/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
@@ -28,7 +28,6 @@ import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplit;
-import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.type.Type;
 import io.trino.split.PageSourceProvider;
@@ -176,8 +175,7 @@ public class TestDriver
                         .build()),
                 TEST_TABLE_HANDLE,
                 Optional.empty(),
-                ImmutableList.of(),
-                DynamicFilter.EMPTY);
+                ImmutableList.of());
 
         PageConsumerOperator sink = createSinkOperator(types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
@@ -583,7 +581,7 @@ public class TestDriver
                 TableHandle table,
                 List<ColumnHandle> columns)
         {
-            super(operatorContext, planNodeId, pageSourceProvider, table, Optional.empty(), columns, DynamicFilter.EMPTY);
+            super(operatorContext, planNodeId, pageSourceProvider, table, Optional.empty(), columns);
         }
 
         @Override
@@ -603,7 +601,7 @@ public class TestDriver
                 TableHandle table,
                 List<ColumnHandle> columns)
         {
-            super(operatorContext, planNodeId, pageSourceProvider, table, Optional.empty(), columns, DynamicFilter.EMPTY);
+            super(operatorContext, planNodeId, pageSourceProvider, table, Optional.empty(), columns);
         }
 
         @Override
@@ -628,7 +626,7 @@ public class TestDriver
                 TableHandle table,
                 List<ColumnHandle> columns)
         {
-            super(operatorContext, planNodeId, pageSourceProvider, table, Optional.empty(), columns, DynamicFilter.EMPTY);
+            super(operatorContext, planNodeId, pageSourceProvider, table, Optional.empty(), columns);
         }
 
         @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -600,8 +600,7 @@ public class TestOrcPageSourceMemoryTracking
                     TEST_TABLE_HANDLE,
                     Optional.empty(),
                     columns.stream().map(ColumnHandle.class::cast).collect(toImmutableList()),
-                    types,
-                    DynamicFilter.EMPTY);
+                    types);
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
             return operator;


### PR DESCRIPTION
Before the changes, the `visitTableScan` helper takes `filterExpression` which is effectively always TRUE. Additionally, the call from `visitFilter` is generally unreachable. There should be no FilterNode with trivial static condition and no dynamic filters. The commit removes the unreachable call and inlines now redundant helper.
