### PR TITLE
Cleanup deprecated APIs

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -330,6 +330,10 @@ public class TestJdbcConnection
                 statement.execute("SET SESSION join_distribution_type = 'BROADCAST'");
             }
 
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("EXECUTE IMMEDIATE 'SET SESSION join_distribution_type = ?' USING 'BROADCAST'");
+            }
+
             assertThat(listSession(connection))
                     .contains("join_distribution_type|BROADCAST|AUTOMATIC")
                     .contains("exchange_compression_codec|NONE|NONE");

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -34,8 +34,8 @@ import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.EquatableValueSet;
 import io.trino.spi.predicate.NullableValue;
@@ -43,13 +43,14 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.SortedRangeSet;
 import io.trino.spi.predicate.TupleDomain;
 
-import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -66,6 +67,8 @@ import static io.trino.connector.informationschema.InformationSchemaTable.VIEWS;
 import static io.trino.metadata.MetadataUtil.findColumnMetadata;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -120,7 +123,7 @@ public class InformationSchemaMetadata
         if (schemaName.isPresent() && !schemaName.get().equals(INFORMATION_SCHEMA)) {
             return ImmutableList.of();
         }
-        return Arrays.stream(InformationSchemaTable.values())
+        return stream(InformationSchemaTable.values())
                 .map(InformationSchemaTable::getSchemaTableName)
                 .collect(toImmutableList());
     }
@@ -151,12 +154,21 @@ public class InformationSchemaMetadata
     }
 
     @Override
-    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(ConnectorSession session, Optional<String> schemaName, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
-        requireNonNull(prefix, "prefix is null");
-        return Arrays.stream(InformationSchemaTable.values())
-                .filter(table -> prefix.matches(table.getSchemaTableName()))
-                .collect(toImmutableMap(InformationSchemaTable::getSchemaTableName, table -> table.getTableMetadata().getColumns()));
+        if (schemaName.isPresent() && !schemaName.get().equals(INFORMATION_SCHEMA)) {
+            return emptyIterator();
+        }
+
+        Set<SchemaTableName> tables = stream(InformationSchemaTable.values())
+                .map(InformationSchemaTable::getSchemaTableName)
+                .collect(toImmutableSet());
+
+        return relationFilter.apply(tables)
+                .stream()
+                .flatMap(name -> InformationSchemaTable.of(name).stream())
+                .map(table -> RelationColumnsMetadata.forTable(table.getSchemaTableName(), table.getTableMetadata().getColumns()))
+                .iterator();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemTablesMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemTablesMetadata.java
@@ -13,7 +13,6 @@
  */
 package io.trino.connector.system;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import io.trino.connector.system.jdbc.JdbcTable;
 import io.trino.spi.TrinoException;
@@ -28,25 +27,28 @@ import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.ConnectorWritableTableHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SystemColumnHandle;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.metadata.MetadataUtil.findColumnMetadata;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
-import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 
 public class SystemTablesMetadata
@@ -129,26 +131,16 @@ public class SystemTablesMetadata
     }
 
     @Override
-    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(ConnectorSession session, Optional<String> schemaName, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
-        requireNonNull(prefix, "prefix is null");
-
-        if (prefix.getTable().isPresent()) {
-            // if table is concrete we just use tables.getSystemTable to support tables which are not listable
-            SchemaTableName tableName = prefix.toSchemaTableName();
-            return tables.getSystemTable(session, tableName)
-                    .map(systemTable -> singletonMap(tableName, systemTable.getTableMetadata().getColumns()))
-                    .orElseGet(ImmutableMap::of);
-        }
-
-        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> builder = ImmutableMap.builder();
-        for (SystemTable table : tables.listSystemTables(session)) {
-            ConnectorTableMetadata tableMetadata = table.getTableMetadata();
-            if (prefix.matches(tableMetadata.getTable())) {
-                builder.put(tableMetadata.getTable(), tableMetadata.getColumns());
-            }
-        }
-        return builder.buildOrThrow();
+        Set<SchemaTableName> tableNames = tables.listSystemTables(session).stream()
+                .map(table -> table.getTableMetadata().getTable())
+                .filter(name -> schemaName.isEmpty() || name.getSchemaName().equals(schemaName.get()))
+                .collect(toImmutableSet());
+        return relationFilter.apply(tableNames).stream()
+                .flatMap(name -> tables.getSystemTable(session, name).stream())
+                .map(table -> RelationColumnsMetadata.forTable(table.getTableMetadata().getTable(), table.getTableMetadata().getColumns()))
+                .iterator();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -164,7 +164,7 @@ public class CallTask
             Expression expression = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(parameterLookup), callArgument.getValue());
 
             Type type = argument.getType();
-            Object value = evaluateConstant(expression, type, plannerContext, session, accessControl);
+            Object value = evaluateConstant(expression, type, parameterLookup, plannerContext, session, accessControl);
 
             values[index] = toTypeObjectValue(type, value);
         }

--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -151,6 +151,7 @@ public class CreateMaterializedViewTask
                     Long milliseconds = (Long) evaluateConstant(
                             expression,
                             type,
+                            parameterLookup,
                             plannerContext,
                             session,
                             accessControl);

--- a/core/trino-main/src/main/java/io/trino/execution/SetTimeZoneTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetTimeZoneTask.java
@@ -108,6 +108,7 @@ public class SetTimeZoneTask
         Object timeZoneValue = evaluateConstant(
                 expression,
                 type,
+                parameterLookup,
                 plannerContext,
                 stateMachine.getSession(),
                 accessControl);

--- a/core/trino-main/src/main/java/io/trino/metadata/PropertyUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PropertyUtil.java
@@ -156,7 +156,7 @@ public final class PropertyUtil
         Object sqlObjectValue;
         try {
             Expression rewritten = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(parameters), expression);
-            Object value = evaluateConstant(rewritten, propertyType, plannerContext, session, accessControl);
+            Object value = evaluateConstant(rewritten, propertyType, parameters, plannerContext, session, accessControl);
 
             // convert to object value type of SQL type
             Block block = writeNativeValue(propertyType, value);

--- a/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
@@ -228,7 +228,7 @@ public final class SessionPropertyManager
     public static Object evaluatePropertyValue(Expression expression, Type expectedType, Session session, PlannerContext plannerContext, AccessControl accessControl, Map<NodeRef<Parameter>, Expression> parameters)
     {
         Expression rewritten = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(parameters), expression);
-        Object value = evaluateConstant(rewritten, expectedType, plannerContext, session, accessControl);
+        Object value = evaluateConstant(rewritten, expectedType, parameters, plannerContext, session, accessControl);
 
         // convert to object value type of SQL type
         Block block = writeNativeValue(expectedType, value);

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -29,7 +29,6 @@ import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -572,17 +571,6 @@ public class InjectedConnectorAccessControl
             return ImmutableList.of();
         }
         throw new TrinoException(NOT_SUPPORTED, "Row filtering not supported");
-    }
-
-    @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        checkArgument(context == null, "context must be null");
-        ColumnSchema column = ColumnSchema.builder().setName(columnName).setType(type).build();
-        if (accessControl.getColumnMasks(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), ImmutableList.of(column)).containsKey(column)) {
-            return Optional.empty();
-        }
-        throw new TrinoException(NOT_SUPPORTED, "Column masking not supported");
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ConstantEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ConstantEvaluator.java
@@ -38,26 +38,6 @@ public final class ConstantEvaluator
 {
     private ConstantEvaluator() {}
 
-    /**
-     * @deprecated Use {@link #evaluateConstant(Expression, Type, Map, PlannerContext, Session, AccessControl)} instead to pass parameters explicitly.
-     */
-    @Deprecated // TODO https://github.com/trinodb/trino/issues/28708 Remove after all calls are updated to pass parameters explicitly
-    public static Object evaluateConstant(
-            Expression expression,
-            Type expectedType,
-            PlannerContext plannerContext,
-            Session session,
-            AccessControl accessControl)
-    {
-        return evaluateConstant(
-                expression,
-                expectedType,
-                ImmutableMap.of(),
-                plannerContext,
-                session,
-                accessControl);
-    }
-
     public static Object evaluateConstant(
             Expression expression,
             Type expectedType,

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -3967,7 +3967,7 @@ public class ExpressionAnalyzer
         try {
             ExpressionAnalyzer constantAnalyzer = createConstantAnalyzer(plannerContext, accessControl, session, parameters, warningCollector);
             Type literalType = constantAnalyzer.analyze(literal, Scope.create());
-            Object value = evaluateConstant(literal, literalType, plannerContext, session, accessControl);
+            Object value = evaluateConstant(literal, literalType, parameters, plannerContext, session, accessControl);
 
             if (!literalType.equals(columnType)) {
                 checkDefaultColumnValue(session, plannerContext, value, columnType, literalType);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2113,7 +2113,7 @@ class StatementAnalyzer
                 }
             }, expression);
             // currently, only constant arguments are supported
-            Object constantValue = evaluateConstant(inlined, type, plannerContext, session, accessControl);
+            Object constantValue = evaluateConstant(inlined, type, analysis.getParameters(), plannerContext, session, accessControl);
             return new ArgumentAnalysis(
                     ScalarArgument.builder()
                             .type(type)
@@ -3118,7 +3118,7 @@ class StatementAnalyzer
                 throw semanticException(INVALID_ARGUMENTS, samplePercentage, "Sample percentage cannot be NULL");
             }
 
-            Object samplePercentageObject = evaluateConstant(samplePercentage, samplePercentageType, plannerContext, session, accessControl);
+            Object samplePercentageObject = evaluateConstant(samplePercentage, samplePercentageType, analysis.getParameters(), plannerContext, session, accessControl);
             if (samplePercentageObject == null) {
                 throw semanticException(INVALID_ARGUMENTS, samplePercentage, "Sample percentage cannot be NULL");
             }
@@ -5977,6 +5977,7 @@ class StatementAnalyzer
                 value = evaluateConstant(
                         providedValue,
                         BIGINT,
+                        analysis.getParameters(),
                         plannerContext,
                         session,
                         accessControl);

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestInlineSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestInlineSession.java
@@ -81,6 +81,9 @@ public class TestInlineSession
         assertThat(assertions.query("WITH SESSION time_zone_id = 'Europe/Warsaw' SELECT current_timezone()"))
                 .matches("VALUES CAST('Europe/Warsaw' AS varchar)");
 
+        assertThat(assertions.query("EXECUTE IMMEDIATE 'WITH SESSION time_zone_id = ? SELECT current_timezone()' USING 'Europe/Warsaw'"))
+                .matches("VALUES CAST('Europe/Warsaw' AS varchar)");
+
         Session session = assertions.sessionBuilder()
                 .setSystemProperty("time_zone_id", "America/Los_Angeles")
                 .build();

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -119,7 +119,9 @@ public abstract class DefaultTraversalVisitor<C>
     protected Void visitQuery(Query node, C context)
     {
         if (!node.getSessionProperties().isEmpty()) {
-            node.getSessionProperties().forEach(sessionProperty -> process(sessionProperty.getValue(), context));
+            for (SessionProperty sessionProperty : node.getSessionProperties()) {
+                process(sessionProperty.getValue(), context);
+            }
         }
         if (node.getWith().isPresent()) {
             process(node.getWith().get(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -118,6 +118,9 @@ public abstract class DefaultTraversalVisitor<C>
     @Override
     protected Void visitQuery(Query node, C context)
     {
+        if (!node.getSessionProperties().isEmpty()) {
+            node.getSessionProperties().forEach(sessionProperty -> process(sessionProperty.getValue(), context));
+        }
         if (node.getWith().isPresent()) {
             process(node.getWith().get(), context);
         }
@@ -823,6 +826,15 @@ public abstract class DefaultTraversalVisitor<C>
     protected Void visitExplainAnalyze(ExplainAnalyze node, C context)
     {
         process(node.getStatement(), context);
+        return null;
+    }
+
+    @Override
+    protected Void visitCall(Call node, C context)
+    {
+        for (CallArgument argument : node.getArguments()) {
+            process(argument.getValue(), context);
+        }
         return null;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -18,13 +18,11 @@ import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static io.trino.spi.security.AccessDeniedException.denyAddColumn;
 import static io.trino.spi.security.AccessDeniedException.denyAlterColumn;
@@ -795,21 +793,6 @@ public interface ConnectorAccessControl
     }
 
     /**
-     * Get column mask associated with the given table, column and identity.
-     * <p>
-     * The mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
-     * must be written in terms of columns in the table.
-     *
-     * @return the mask if present, or empty if not applicable
-     * @deprecated use {@link #getColumnMasks(ConnectorSecurityContext, SchemaTableName, List)}
-     */
-    @Deprecated
-    default Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        return Optional.empty();
-    }
-
-    /**
      * Bulk method for getting column masks for a subset of columns in a table.
      * <p>
      * Each mask must be a scalar SQL expression of a type coercible to the type of the column being masked. The expression
@@ -819,9 +802,6 @@ public interface ConnectorAccessControl
      */
     default Map<ColumnSchema, ViewExpression> getColumnMasks(ConnectorSecurityContext context, SchemaTableName tableName, List<ColumnSchema> columns)
     {
-        return columns.stream()
-                .map(column -> Map.entry(column, getColumnMask(context, tableName, column.getName(), column.getType())))
-                .filter(entry -> entry.getValue().isPresent())
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().get()));
+        return emptyMap();
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -24,7 +24,6 @@ import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -635,14 +634,6 @@ public class ClassLoaderSafeConnectorAccessControl
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
             return delegate.getRowFilters(context, tableName);
-        }
-    }
-
-    @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getColumnMask(context, tableName, columnName, type);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -24,7 +24,6 @@ import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -272,12 +271,6 @@ public class AllowAllAccessControl
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         return ImmutableList.of();
-    }
-
-    @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        return Optional.empty();
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -30,7 +30,6 @@ import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -111,7 +110,6 @@ import static io.trino.spi.security.AccessDeniedException.denyShowFunctions;
 import static io.trino.spi.security.AccessDeniedException.denyShowTables;
 import static io.trino.spi.security.AccessDeniedException.denyTruncateTable;
 import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
-import static java.lang.String.format;
 
 public class FileBasedAccessControl
         implements ConnectorAccessControl
@@ -805,30 +803,6 @@ public class FileBasedAccessControl
                 .stream()
                 .flatMap(Optional::stream)
                 .collect(toImmutableList());
-    }
-
-    @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
-            return Optional.empty();
-        }
-
-        ConnectorIdentity identity = context.getIdentity();
-        List<ViewExpression> masks = tableRules.stream()
-                .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledSystemRoles(), identity.getGroups(), tableName))
-                .map(rule -> rule.getColumnMask(catalogName, tableName.getSchemaName(), columnName))
-                // we return the first one we find
-                .findFirst()
-                .stream()
-                .flatMap(Optional::stream)
-                .toList();
-
-        if (masks.size() > 1) {
-            throw new TrinoException(INVALID_COLUMN_MASK, format("Multiple masks defined for %s.%s", tableName, columnName));
-        }
-
-        return masks.stream().findFirst();
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -22,7 +22,6 @@ import io.trino.spi.function.SchemaFunctionName;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -494,12 +493,6 @@ public abstract class ForwardingConnectorAccessControl
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         return delegate().getRowFilters(context, tableName);
-    }
-
-    @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        return delegate().getColumnMask(context, tableName, columnName, type);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
@@ -20,6 +20,7 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.trino.spi.QueryId;
 import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -395,7 +396,7 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         accessControl.checkCanDeleteFromTable(userGroup1Group2, myTable);
         accessControl.checkCanDropTable(userGroup1Group2, myTable);
         accessControl.checkCanSelectFromColumns(userGroup1Group2, myTable, ImmutableSet.of());
-        assertThat(accessControl.getColumnMask(userGroup1Group2, myTable, "col_a", VARCHAR)).isEqualTo(Optional.empty());
+        assertThat(accessControl.getColumnMasks(userGroup1Group2, myTable, List.of(ColumnSchema.builder().setName("col_a").setType(VARCHAR).build()))).isEmpty();
         assertThat(accessControl.getRowFilters(userGroup1Group2, myTable)).isEqualTo(ImmutableList.of());
 
         assertDenied(() -> accessControl.checkCanCreateTable(userGroup2, myTable, Map.of()));
@@ -403,8 +404,9 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         assertDenied(() -> accessControl.checkCanDeleteFromTable(userGroup2, myTable));
         assertDenied(() -> accessControl.checkCanDropTable(userGroup2, myTable));
         accessControl.checkCanSelectFromColumns(userGroup2, myTable, ImmutableSet.of());
+        ColumnSchema colA = ColumnSchema.builder().setName("col_a").setType(VARCHAR).build();
         assertViewExpressionEquals(
-                accessControl.getColumnMask(userGroup2, myTable, "col_a", VARCHAR).orElseThrow(),
+                accessControl.getColumnMasks(userGroup2, myTable, List.of(colA)).get(colA),
                 ViewExpression.builder()
                         .catalog("test_catalog")
                         .schema("my_schema")
@@ -420,15 +422,14 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         accessControl.checkCanDeleteFromTable(userGroup1Group3, myTable);
         accessControl.checkCanDropTable(userGroup1Group3, myTable);
         accessControl.checkCanSelectFromColumns(userGroup1Group3, myTable, ImmutableSet.of());
-        assertThat(accessControl.getColumnMask(userGroup1Group3, myTable, "col_a", VARCHAR)).isEqualTo(Optional.empty());
-
+        assertThat(accessControl.getColumnMasks(userGroup1Group3, myTable, List.of(ColumnSchema.builder().setName("col_a").setType(VARCHAR).build()))).isEmpty();
         assertDenied(() -> accessControl.checkCanCreateTable(userGroup3, myTable, Map.of()));
         assertDenied(() -> accessControl.checkCanInsertIntoTable(userGroup3, myTable));
         assertDenied(() -> accessControl.checkCanDeleteFromTable(userGroup3, myTable));
         assertDenied(() -> accessControl.checkCanDropTable(userGroup3, myTable));
         accessControl.checkCanSelectFromColumns(userGroup3, myTable, ImmutableSet.of());
         assertViewExpressionEquals(
-                accessControl.getColumnMask(userGroup3, myTable, "col_a", VARCHAR).orElseThrow(),
+                accessControl.getColumnMasks(userGroup3, myTable, List.of(colA)).get(colA),
                 ViewExpression.builder()
                         .catalog("test_catalog")
                         .schema("my_schema")

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -2332,7 +2332,7 @@ public abstract class BaseJdbcConnectorTest
             assertUpdate("CALL system.execute('DELETE FROM " + schemaTableName + "')");
             assertQueryReturnsEmptyResult("SELECT * FROM " + schemaTableName);
 
-            assertUpdate("CALL system.execute('DROP TABLE " + schemaTableName + "')");
+            assertUpdate("EXECUTE IMMEDIATE 'CALL system.execute(?)' USING 'DROP TABLE " + schemaTableName + "'");
             assertThat(getQueryRunner().tableExists(getSession(), tableName)).isFalse();
         }
         finally {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -36,7 +36,6 @@ import io.trino.spi.security.Privilege;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
-import io.trino.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -707,12 +706,6 @@ public class SqlStandardAccessControl
     public List<ViewExpression> getRowFilters(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         return ImmutableList.of();
-    }
-
-    @Override
-    public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
-    {
-        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Support binding parameters in WITH SESSION, SET SESSION, CALL statements ({issue}`issuenumber`)
```

Following statements are now supported:

```
EXECUTE IMMEDIATE 'SET SESSION join_distribution_type = ?' USING 'BROADCAST'
EXECUTE IMMEDIATE 'WITH SESSION time_zone_id = ? SELECT current_timezone()' USING 'Europe/Warsaw'
EXECUTE IMMEDIATE 'CALL system.execute(?)' USING 'DROP TABLE test'
```
