### PR TITLE
Add parallel import support for the Exasol connector

### DIFF
--- a/docs/src/main/sphinx/connector/exasol.md
+++ b/docs/src/main/sphinx/connector/exasol.md
@@ -49,6 +49,49 @@ specify the certificate's fingerprint in the JDBC URL using parameter
 ``fingerprint``, e.g.: ``jdbc:exa:exasol.example.com:8563;fingerprint=ABC123``.
 :::
 
+### Parallel connections
+
+To speed up importing data from an Exasol cluster with multiple nodes,
+you can enable parallel connections by specifying property
+``exasol.parallel-connections.worker-count`` with value 2 or higher.
+This will enable a custom page source that uses Exasol's
+[parallel connections](https://exasol.my.site.com/s/article/Parallel-connections-with-JDBC)
+to read query results in parallel. The actual number of parallel connections
+depends on the number of nodes in the Exasol cluster.
+Parallel connections are deactivated by default.
+
+Property value 0 will deactivate parallel connection explicitly. A value
+of 1 will use the custom page source with a single connection. This is only
+useful for testing.
+
+You can override the setting for an Exasol catalog using session property
+``parallel_connections_worker_count`` by running the following SQL statement:
+
+```sql
+set session catalog.parallel_connections_worker_count = 4;
+```
+
+:::{important}
+There is a known issue with the Exasol JDBC driver when loading small
+result sets using parallel connections. This operation may block forever
+when the query result only contains few rows (around 25 rows per connection),
+i.e. when at least one subconnection returns an empty result set.
+
+When this happens you need to restart the Trino cluster.
+
+We recommend using parallel connections only with large result sets
+containing more than 25 rows per connection.
+:::
+
+:::{note}
+* Even with parallel connections, Trino will read the query result only
+  on a single Trino node, but in multiple threads.
+* The actual number of parallel connections depends on the Exasol cluster.
+  The database may decide to use fewer connections than specified.
+* Parallel connections cause overhead for each query. They only make sense
+  if the query reads a large amount of data.
+:::
+
 ```{include} jdbc-authentication.fragment
 ```
 

--- a/plugin/trino-exasol/pom.xml
+++ b/plugin/trino-exasol/pom.xml
@@ -36,8 +36,23 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
         </dependency>
 
         <dependency>
@@ -48,6 +63,16 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>
@@ -84,12 +109,6 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>log</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/BufferedSourcePageQueue.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/BufferedSourcePageQueue.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import io.trino.spi.connector.SourcePage;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+final class BufferedSourcePageQueue
+{
+    private final BlockingQueue<SourcePage> queue;
+    private final AtomicReference<CompletableFuture<Void>> dataAvailableFuture = new AtomicReference<>(new CompletableFuture<>());
+    private final Map<Integer, ProducerState> producerStates;
+
+    BufferedSourcePageQueue(int producerCount)
+    {
+        queue = new LinkedBlockingQueue<>(Math.max(8, producerCount * 4));
+        producerStates = IntStream.range(0, producerCount)
+                .boxed()
+                .collect(ConcurrentHashMap::new, (states, producerId) -> states.put(producerId, ProducerState.active()), ConcurrentHashMap::putAll);
+    }
+
+    void add(SourcePage page)
+            throws InterruptedException
+    {
+        queue.put(page);
+        signalDataAvailable();
+    }
+
+    void finish(int producerId)
+    {
+        producerStates.compute(producerId, (_, currentState) -> requireTrackedProducer(producerId, currentState).finish());
+        signalDataAvailable();
+    }
+
+    void fail(int producerId, Throwable throwable)
+    {
+        producerStates.compute(producerId, (_, currentState) -> requireTrackedProducer(producerId, currentState).fail(throwable));
+        signalDataAvailable();
+    }
+
+    Throwable getFailure()
+    {
+        return producerStates.values().stream()
+                .map(ProducerState::failure)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    SourcePage poll()
+    {
+        SourcePage page = queue.poll();
+        if (page != null) {
+            signalDataAvailable();
+        }
+        return page;
+    }
+
+    int size()
+    {
+        return queue.size();
+    }
+
+    boolean isEmpty()
+    {
+        return queue.isEmpty();
+    }
+
+    CompletableFuture<?> isBlocked()
+    {
+        if (!queue.isEmpty() || getFailure() != null || allProducersFinished()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        CompletableFuture<Void> blocked = dataAvailableFuture.get();
+        if (blocked.isDone()) {
+            CompletableFuture<Void> newBlocked = new CompletableFuture<>();
+            if (dataAvailableFuture.compareAndSet(blocked, newBlocked)) {
+                blocked = newBlocked;
+            }
+            else {
+                blocked = dataAvailableFuture.get();
+            }
+        }
+
+        if (!queue.isEmpty() || getFailure() != null || allProducersFinished()) {
+            blocked.complete(null);
+            return CompletableFuture.completedFuture(null);
+        }
+        return blocked;
+    }
+
+    private boolean allProducersFinished()
+    {
+        return producerStates.values().stream().allMatch(ProducerState::isTerminal);
+    }
+
+    boolean isFinished()
+    {
+        boolean producersFinished = allProducersFinished();
+        boolean queueEmpty = queue.isEmpty();
+        boolean noFailure = getFailure() == null;
+        boolean finished = queueEmpty && noFailure && producersFinished;
+        return finished;
+    }
+
+    private void signalDataAvailable()
+    {
+        dataAvailableFuture.get().complete(null);
+    }
+
+    private static ProducerState requireTrackedProducer(int producerId, ProducerState currentState)
+    {
+        if (currentState == null) {
+            throw new IllegalArgumentException("Unknown producer: " + producerId);
+        }
+        return currentState;
+    }
+
+    private record ProducerState(boolean finished, Throwable failure)
+    {
+        private static ProducerState active()
+        {
+            return new ProducerState(false, null);
+        }
+
+        private ProducerState finish()
+        {
+            return new ProducerState(true, failure);
+        }
+
+        private ProducerState fail(Throwable throwable)
+        {
+            return new ProducerState(true, throwable);
+        }
+
+        private boolean isTerminal()
+        {
+            return finished;
+        }
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClient.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClient.java
@@ -353,7 +353,7 @@ public class ExasolClient
     @Override
     public boolean isTopNGuaranteed(ConnectorSession session)
     {
-        return true;
+        return ExasolSessionProperties.getParallelImportWorkerCount(session) <= 1;
     }
 
     @Override

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClientModule.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolClientModule.java
@@ -28,12 +28,15 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.function.table.ConnectorTableFunction;
 
 import java.util.Properties;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 
 public class ExasolClientModule
         extends AbstractConfigurationAwareModule
@@ -42,8 +45,13 @@ public class ExasolClientModule
     protected void setup(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(ExasolClient.class).in(Scopes.SINGLETON);
+        bindSessionPropertiesProvider(binder, ExasolSessionProperties.class);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);
+        configBinder(binder).bindConfig(ExasolConfig.class);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorPageSourceProvider.class).setBinding().to(ExasolParallelPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ExasolTlsCertificateFingerprintProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ParallelConnectionFactory.class).in(Scopes.SINGLETON);
     }
 
     @Provides
@@ -55,6 +63,7 @@ public class ExasolClientModule
         // Deactivate SNAPSHOT_MODE (https://docs.exasol.com/db/latest/database_concepts/snapshot_mode.htm)
         // to ensure that {@link Connection#getMetaData()} always returns up-to-date data.
         connectionProperties.setProperty("snapshottransactions", "1");
+
         return DriverConnectionFactory.builder(
                         new EXADriver(),
                         config.getConnectionUrl(),

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolConfig.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class ExasolConfig
+{
+    private int parallelConnectionsWorkerCount;
+
+    public int getParallelConnectionsWorkerCount()
+    {
+        return parallelConnectionsWorkerCount;
+    }
+
+    @ConfigDescription("Maximum number of workers to use for parallel JDBC import. Set to 0 to deactivate parallel import")
+    @Config("exasol.parallel-connections.worker-count")
+    public void setParallelConnectionsWorkerCount(int parallelConnectionsWorkerCount)
+    {
+        this.parallelConnectionsWorkerCount = parallelConnectionsWorkerCount;
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolParallelPageSource.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolParallelPageSource.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.exasol.jdbc.EXAResultSet;
+import io.trino.plugin.jdbc.BaseJdbcConnectorTableHandle;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcPageSource;
+import io.trino.plugin.jdbc.JdbcProcedureHandle;
+import io.trino.plugin.jdbc.JdbcSplit;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SourcePage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+public class ExasolParallelPageSource
+        implements ConnectorPageSource
+{
+    private static final Logger log = LoggerFactory.getLogger(ExasolParallelPageSource.class);
+    private final List<ExasolResultHandlePageSource> subConnectionPageSources;
+    private final ExecutorService executor;
+    private final BufferedSourcePageQueue pageQueue;
+    private final Connection mainConnection;
+    private final PreparedStatement mainStatement;
+    private final ResultSet mainResultSet;
+    private volatile List<? extends Future<?>> readerTasks = List.of();
+    private volatile boolean closed;
+
+    private ExasolParallelPageSource(List<ExasolResultHandlePageSource> subConnectionPageSources, ExecutorService executor, Connection mainConnection, PreparedStatement mainStatement, ResultSet mainResultSet)
+    {
+        this.subConnectionPageSources = subConnectionPageSources;
+        this.executor = executor;
+        this.pageQueue = new BufferedSourcePageQueue(subConnectionPageSources.size());
+        this.mainConnection = mainConnection;
+        this.mainStatement = mainStatement;
+        this.mainResultSet = mainResultSet;
+    }
+
+    public static ConnectorPageSource create(JdbcClient jdbcClient, ExecutorService executor, ParallelConnectionFactory parallelConnectionFactory, ConnectorSession session, JdbcSplit jdbcSplit, BaseJdbcConnectorTableHandle table, List<JdbcColumnHandle> columnHandles)
+    {
+        int parallelImportWorkerCount = ExasolSessionProperties.getParallelImportWorkerCount(session);
+        if (parallelImportWorkerCount == 0) {
+            return new JdbcPageSource(jdbcClient, executor, session, jdbcSplit, table, columnHandles);
+        }
+        return createParallelConnectionPageSource(jdbcClient, executor, parallelConnectionFactory, session, jdbcSplit, table, columnHandles);
+    }
+
+    private static ExasolParallelPageSource createParallelConnectionPageSource(JdbcClient jdbcClient, ExecutorService executor, ParallelConnectionFactory parallelConnectionFactory, ConnectorSession session, JdbcSplit jdbcSplit, BaseJdbcConnectorTableHandle table, List<JdbcColumnHandle> columnHandles)
+    {
+        Connection mainConnection = null;
+        PreparedStatement mainStatement = null;
+        ResultSet mainResultSet = null;
+        List<Connection> subConnections = List.of();
+        try {
+            mainConnection = createExaConnection(jdbcClient, session, table);
+            subConnections = parallelConnectionFactory.createConnections(session, mainConnection);
+            mainStatement = prepareStatement(jdbcClient, session, mainConnection, table, jdbcSplit, columnHandles);
+            mainResultSet = mainStatement.executeQuery();
+            int resultSetHandle = mainResultSet.unwrap(EXAResultSet.class).GetHandle();
+            List<ExasolResultHandlePageSource> subConnectionPageSources = subConnections.stream()
+                    .map(subConnection -> new ExasolResultHandlePageSource(jdbcClient, executor, session, subConnection, resultSetHandle, columnHandles))
+                    .toList();
+            ExasolParallelPageSource pageSource = new ExasolParallelPageSource(subConnectionPageSources, executor, mainConnection, mainStatement, mainResultSet);
+            pageSource.startReading();
+            return pageSource;
+        }
+        catch (SQLException | RuntimeException e) {
+            closeResources(mainConnection, mainStatement, mainResultSet, subConnections);
+            log.error("Error creating parallel connection page source: {}", e.getMessage(), e);
+            throw new RuntimeException("Error creating parallel connection page source: " + e.getMessage(), e);
+        }
+    }
+
+    private static void closeResources(Connection mainConnection, PreparedStatement mainStatement, ResultSet mainResultSet, List<Connection> subConnections)
+    {
+        try (Connection _ = mainConnection;
+                Statement statement = mainStatement;
+                ResultSet _ = mainResultSet) {
+            if (statement != null) {
+                try {
+                    statement.cancel();
+                }
+                catch (SQLException e) {
+                    log.debug("Cancel failed during cleanup", e);
+                }
+            }
+        }
+        catch (SQLException | RuntimeException e) {
+            log.debug("Closing failed during cleanup", e);
+        }
+
+        for (Connection subConnection : subConnections) {
+            try {
+                subConnection.close();
+            }
+            catch (SQLException e) {
+                log.debug("Failed to close subconnection during cleanup", e);
+            }
+        }
+    }
+
+    private void startReading()
+    {
+        readerTasks = IntStream.range(0, subConnectionPageSources.size())
+                .mapToObj(producerId -> executor.submit(() -> consumePageSource(producerId, subConnectionPageSources.get(producerId))))
+                .toList();
+    }
+
+    private void consumePageSource(int producerId, ExasolResultHandlePageSource source)
+    {
+        try {
+            log.info("Reading all pages from {}...", source);
+            while (!source.isFinished()) {
+                SourcePage page = source.getNextSourcePage();
+                if (page != null) {
+                    pageQueue.add(page);
+                    log.debug("Found page {} with {} rows from source {}, queue size: {}", page, page.getPositionCount(), source, pageQueue.size());
+                }
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.debug("Reading interrupted for source {}", source, e);
+        }
+        catch (Throwable e) {
+            log.error("Error reading from source {}: {}", source, e.getMessage(), e);
+            pageQueue.fail(producerId, e);
+        }
+        finally {
+            pageQueue.finish(producerId);
+        }
+    }
+
+    private static PreparedStatement prepareStatement(JdbcClient jdbcClient, ConnectorSession session, Connection mainConnection, BaseJdbcConnectorTableHandle table, JdbcSplit jdbcSplit, List<JdbcColumnHandle> columnHandles)
+            throws SQLException
+    {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return jdbcClient.buildProcedure(session, mainConnection, jdbcSplit, procedureHandle);
+        }
+        else {
+            return jdbcClient.buildSql(session, mainConnection, jdbcSplit, (JdbcTableHandle) table, columnHandles);
+        }
+    }
+
+    private static Connection createExaConnection(JdbcClient jdbcClient, ConnectorSession session, BaseJdbcConnectorTableHandle table)
+            throws SQLException
+    {
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            return jdbcClient.getConnection(session, null, procedureHandle);
+        }
+        else {
+            return jdbcClient.getConnection(session, null, (JdbcTableHandle) table);
+        }
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        Throwable throwable = pageQueue.getFailure();
+        if (throwable != null) {
+            throw new RuntimeException("Sub connection failure: " + throwable.getMessage(), throwable);
+        }
+        SourcePage page = pageQueue.poll();
+        log.debug("Got next source page {}, remaining queue size: {}", page, pageQueue.size());
+        return page;
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return pageQueue.isBlocked();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return subConnectionPageSources.stream().mapToLong(ConnectorPageSource::getCompletedBytes).sum();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return subConnectionPageSources.stream()
+                .map(ConnectorPageSource::getCompletedPositions)
+                .filter(OptionalLong::isPresent)
+                .mapToLong(OptionalLong::getAsLong)
+                .reduce(Long::sum);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return subConnectionPageSources.stream().mapToLong(ConnectorPageSource::getReadTimeNanos).sum();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return pageQueue.isFinished();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return subConnectionPageSources.stream().mapToLong(ConnectorPageSource::getMemoryUsage).sum();
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            log.debug("Page sources already closed");
+            return;
+        }
+        readerTasks.forEach(task -> task.cancel(true));
+
+        log.debug("Closing main connection...");
+        // use try with resources to close everything properly
+        try (Connection _ = this.mainConnection;
+                Statement statement = this.mainStatement;
+                ResultSet _ = this.mainResultSet) {
+            if (statement != null) {
+                try {
+                    log.debug("Cancelling statement...");
+                    // Trying to cancel running statement as close() may not do it
+                    statement.cancel();
+                }
+                catch (SQLException e) {
+                    log.debug("Cancel failed", e);
+                    // statement already closed or cancel is not supported
+                }
+            }
+        }
+        catch (SQLException | RuntimeException e) {
+            // ignore exception from close
+            log.debug("Closing failed", e);
+        }
+
+        // Subconnections must be closed after the main connection.
+        // When main connection is still open, closing of subconnections will block.
+        log.debug("Closing {} subconnection page sources of {}...", subConnectionPageSources.size(), this);
+        subConnectionPageSources.forEach(ExasolResultHandlePageSource::close);
+
+        closed = true;
+        log.debug("Closed page source {} successfully", this);
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolParallelPageSourceProvider.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolParallelPageSourceProvider.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import dev.failsafe.RetryPolicy;
+import io.trino.plugin.base.MappedPageSource;
+import io.trino.plugin.jdbc.BaseJdbcConnectorTableHandle;
+import io.trino.plugin.jdbc.ForJdbcClient;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcProcedureHandle;
+import io.trino.plugin.jdbc.JdbcSplit;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.MergeJdbcPageSource;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.DynamicFilter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static io.trino.plugin.jdbc.DefaultJdbcMetadata.MERGE_ROW_ID;
+import static io.trino.plugin.jdbc.RetryingModule.retry;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.UnaryOperator.identity;
+
+public class ExasolParallelPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private final JdbcClient jdbcClient;
+    private final ExecutorService executor;
+    private final RetryPolicy<Object> policy;
+    private final ParallelConnectionFactory parallelConnectionFactory;
+
+    @Inject
+    public ExasolParallelPageSourceProvider(JdbcClient jdbcClient, @ForJdbcClient ExecutorService executor, RetryPolicy<Object> policy, ParallelConnectionFactory parallelConnectionFactory)
+    {
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.policy = requireNonNull(policy, "policy is null");
+        this.parallelConnectionFactory = requireNonNull(parallelConnectionFactory, "parallelConnectionFactory is null");
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableHandle table,
+            Optional<ConnectorTableCredentials> tableCredentials,
+            List<ColumnHandle> columns,
+            DynamicFilter dynamicFilter)
+    {
+        JdbcSplit jdbcSplit = (JdbcSplit) split;
+        List<JdbcColumnHandle> jdbcColumns = columns.stream()
+                .map(JdbcColumnHandle.class::cast)
+                .collect(toImmutableList());
+
+        if (table instanceof JdbcProcedureHandle procedureHandle) {
+            List<JdbcColumnHandle> sourceColumns = procedureHandle.getColumns().orElseThrow();
+            Map<JdbcColumnHandle, Integer> columnIndexMap = IntStream.range(0, sourceColumns.size())
+                    .boxed()
+                    .collect(toImmutableMap(sourceColumns::get, identity()));
+
+            return new MappedPageSource(
+                    createPageSource(session, jdbcSplit, procedureHandle, sourceColumns),
+                    jdbcColumns.stream()
+                            .map(columnIndexMap::get)
+                            .collect(toImmutableList()));
+        }
+
+        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        Optional<JdbcColumnHandle> mergeRowId = jdbcColumns.stream()
+                .filter(column -> column.getColumnName().equalsIgnoreCase(MERGE_ROW_ID))
+                .collect(toOptional());
+        if (mergeRowId.isEmpty()) {
+            return ExasolParallelPageSource.create(
+                    jdbcClient,
+                    executor,
+                    parallelConnectionFactory,
+                    session,
+                    jdbcSplit,
+                    tableHandle.intersectedWithConstraint(jdbcSplit.getDynamicFilter().transformKeys(ColumnHandle.class::cast)),
+                    jdbcColumns);
+        }
+
+        return createMergePageSource(session, jdbcSplit, jdbcColumns, tableHandle, mergeRowId);
+    }
+
+    private MergeJdbcPageSource createMergePageSource(
+            ConnectorSession session,
+            JdbcSplit jdbcSplit,
+            List<JdbcColumnHandle> columns,
+            JdbcTableHandle tableHandle,
+            Optional<JdbcColumnHandle> mergeRowId)
+    {
+        List<JdbcColumnHandle> primaryKeys = jdbcClient.getPrimaryKeys(session, tableHandle.getRequiredNamedRelation().getRemoteTableName());
+        List<JdbcColumnHandle> scanColumns = getScanColumns(session, jdbcClient, tableHandle, primaryKeys);
+
+        ImmutableList.Builder<MergeJdbcPageSource.ColumnAdaptation> columnAdaptationsBuilder = ImmutableList.builder();
+        for (JdbcColumnHandle columnHandle : columns) {
+            if (columnHandle.equals(mergeRowId.get())) {
+                columnAdaptationsBuilder.add(buildMergeIdColumnAdaptation(scanColumns, primaryKeys));
+            }
+            else {
+                columnAdaptationsBuilder.add(new MergeJdbcPageSource.SourceColumn(scanColumns.indexOf(columnHandle)));
+            }
+        }
+
+        JdbcTableHandle newTableHandle = new JdbcTableHandle(
+                tableHandle.getRelationHandle(),
+                tableHandle.getConstraint(),
+                tableHandle.getConstraintExpressions(),
+                tableHandle.getSortOrder(),
+                tableHandle.getLimit(),
+                Optional.of(scanColumns),
+                tableHandle.getOtherReferencedTables(),
+                tableHandle.getNextSyntheticColumnId(),
+                tableHandle.getAuthorization(),
+                tableHandle.getUpdateAssignments());
+        return new MergeJdbcPageSource(
+                createPageSource(session, jdbcSplit, newTableHandle, scanColumns),
+                columnAdaptationsBuilder.build());
+    }
+
+    private ConnectorPageSource createPageSource(
+            ConnectorSession session,
+            JdbcSplit jdbcSplit,
+            BaseJdbcConnectorTableHandle table,
+            List<JdbcColumnHandle> columnHandles)
+    {
+        return retry(policy, () -> ExasolParallelPageSource.create(jdbcClient, executor, parallelConnectionFactory, session, jdbcSplit, table, columnHandles));
+    }
+
+    private static List<JdbcColumnHandle> getScanColumns(
+            ConnectorSession session,
+            JdbcClient jdbcClient,
+            JdbcTableHandle tableHandle,
+            List<JdbcColumnHandle> primaryKeys)
+    {
+        List<JdbcColumnHandle> allTableColumns = jdbcClient.getColumns(session, tableHandle.getRequiredNamedRelation().getSchemaTableName(), tableHandle.getRequiredNamedRelation().getRemoteTableName());
+
+        ImmutableList.Builder<JdbcColumnHandle> scanColumnsBuilder = ImmutableList.builder();
+        scanColumnsBuilder.addAll(allTableColumns);
+        // Add merge row id fields
+        for (JdbcColumnHandle primaryKey : primaryKeys) {
+            if (!allTableColumns.contains(primaryKey)) {
+                scanColumnsBuilder.add(primaryKey);
+            }
+        }
+        return scanColumnsBuilder.build();
+    }
+
+    private static MergeJdbcPageSource.ColumnAdaptation buildMergeIdColumnAdaptation(List<JdbcColumnHandle> scanColumns, List<JdbcColumnHandle> primaryKeys)
+    {
+        List<Integer> mergeRowIdSourceChannels = primaryKeys.stream()
+                .map(scanColumns::indexOf)
+                .peek(channel -> checkArgument(channel >= 0, "There are primary keys not exist in scan columns"))
+                .collect(toImmutableList());
+        return new MergeJdbcPageSource.MergedRowAdaptation(mergeRowIdSourceChannels);
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolResultHandlePageSource.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolResultHandlePageSource.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.exasol;
+
+import com.exasol.jdbc.EXAConnection;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.trino.plugin.jdbc.BooleanReadFunction;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.DoubleReadFunction;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.LongReadFunction;
+import io.trino.plugin.jdbc.ObjectReadFunction;
+import io.trino.plugin.jdbc.ReadFunction;
+import io.trino.plugin.jdbc.SliceReadFunction;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.Type;
+import jakarta.annotation.Nullable;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static java.lang.System.nanoTime;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+public final class ExasolResultHandlePageSource
+        implements ConnectorPageSource
+{
+    private static final Logger log = Logger.get(ExasolResultHandlePageSource.class);
+    private static final CompletableFuture<ResultSet> UNINITIALIZED_RESULT_SET_FUTURE = CompletableFuture.completedFuture(null);
+
+    private final List<JdbcColumnHandle> columnHandles;
+    private final ReadFunction[] readFunctions;
+    private final BooleanReadFunction[] booleanReadFunctions;
+    private final DoubleReadFunction[] doubleReadFunctions;
+    private final LongReadFunction[] longReadFunctions;
+    private final SliceReadFunction[] sliceReadFunctions;
+    private final ObjectReadFunction[] objectReadFunctions;
+
+    private final JdbcClient jdbcClient;
+    private final ExecutorService executor;
+    private final Connection connection;
+    private final int resultSetHandle;
+    private final AtomicLong readTimeNanos = new AtomicLong(0);
+    private final PageBuilder pageBuilder;
+    private CompletableFuture<ResultSet> resultSetFuture;
+    @Nullable
+    private ResultSet resultSet;
+
+    private boolean finished;
+    private boolean closed;
+    private long completedPositions;
+
+    public ExasolResultHandlePageSource(
+            JdbcClient jdbcClient,
+            ExecutorService executor,
+            ConnectorSession session,
+            Connection connection,
+            int resultSetHandle,
+            List<JdbcColumnHandle> columnHandles)
+    {
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.connection = requireNonNull(connection, "connection is null");
+        this.resultSetHandle = resultSetHandle;
+        this.columnHandles = ImmutableList.copyOf(columnHandles);
+
+        readFunctions = new ReadFunction[columnHandles.size()];
+        booleanReadFunctions = new BooleanReadFunction[columnHandles.size()];
+        doubleReadFunctions = new DoubleReadFunction[columnHandles.size()];
+        longReadFunctions = new LongReadFunction[columnHandles.size()];
+        sliceReadFunctions = new SliceReadFunction[columnHandles.size()];
+        objectReadFunctions = new ObjectReadFunction[columnHandles.size()];
+
+        try {
+            for (int i = 0; i < this.columnHandles.size(); i++) {
+                JdbcColumnHandle columnHandle = columnHandles.get(i);
+                ColumnMapping columnMapping = jdbcClient.toColumnMapping(session, connection, columnHandle.getJdbcTypeHandle())
+                        .orElseThrow(() -> new VerifyException("Column %s has unsupported type %s".formatted(columnHandle.getColumnName(), columnHandle.getJdbcTypeHandle())));
+                verify(columnHandle.getColumnType().equals(columnMapping.getType()),
+                        "Type mismatch: column handle has type %s but %s is mapped to %s",
+                        columnHandle.getColumnType(),
+                        columnHandle.getJdbcTypeHandle(),
+                        columnMapping.getType());
+                Class<?> javaType = columnMapping.getType().getJavaType();
+                ReadFunction readFunction = columnMapping.getReadFunction();
+                readFunctions[i] = readFunction;
+
+                if (javaType == boolean.class) {
+                    booleanReadFunctions[i] = (BooleanReadFunction) readFunction;
+                }
+                else if (javaType == double.class) {
+                    doubleReadFunctions[i] = (DoubleReadFunction) readFunction;
+                }
+                else if (javaType == long.class) {
+                    longReadFunctions[i] = (LongReadFunction) readFunction;
+                }
+                else if (javaType == Slice.class) {
+                    sliceReadFunctions[i] = (SliceReadFunction) readFunction;
+                }
+                else {
+                    objectReadFunctions[i] = (ObjectReadFunction) readFunction;
+                }
+            }
+
+            pageBuilder = new PageBuilder(columnHandles.stream()
+                    .map(JdbcColumnHandle::getColumnType)
+                    .collect(toImmutableList()));
+            resultSetFuture = UNINITIALIZED_RESULT_SET_FUTURE;
+        }
+        catch (RuntimeException e) {
+            throw handleSqlException(e);
+        }
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos.get();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        verify(pageBuilder.isEmpty(), "Expected pageBuilder to be empty");
+        if (finished) {
+            return null;
+        }
+        try {
+            if (resultSetFuture == UNINITIALIZED_RESULT_SET_FUTURE && resultSet == null) {
+                checkState(!closed, "page source is closed");
+                resultSetFuture = supplyAsync(() -> {
+                    long start = nanoTime();
+                    try {
+                        log.debug("Getting result set for handle %d...", resultSetHandle);
+                        ResultSet rs = exaConnection().DescribeResult(resultSetHandle);
+                        log.debug("Got result set for handle: %s", rs);
+                        return rs;
+                    }
+                    catch (SQLException e) {
+                        log.error(e, "Error describing result set for handle %s: %s", resultSetHandle, e.getMessage());
+                        throw handleSqlException(e);
+                    }
+                    finally {
+                        readTimeNanos.addAndGet(nanoTime() - start);
+                    }
+                }, executor);
+            }
+            if (resultSet == null) {
+                if (!resultSetFuture.isDone()) {
+                    return null;
+                }
+                resultSet = requireNonNull(getFutureValue(resultSetFuture), "resultSet is null");
+            }
+
+            checkState(!closed, "page source is closed");
+            while (!pageBuilder.isFull() && resultSet.next()) {
+                pageBuilder.declarePosition();
+                completedPositions++;
+                for (int i = 0; i < columnHandles.size(); i++) {
+                    BlockBuilder output = pageBuilder.getBlockBuilder(i);
+                    Type type = columnHandles.get(i).getColumnType();
+                    if (readFunctions[i].isNull(resultSet, i + 1)) {
+                        output.appendNull();
+                    }
+                    else if (booleanReadFunctions[i] != null) {
+                        type.writeBoolean(output, booleanReadFunctions[i].readBoolean(resultSet, i + 1));
+                    }
+                    else if (doubleReadFunctions[i] != null) {
+                        type.writeDouble(output, doubleReadFunctions[i].readDouble(resultSet, i + 1));
+                    }
+                    else if (longReadFunctions[i] != null) {
+                        type.writeLong(output, longReadFunctions[i].readLong(resultSet, i + 1));
+                    }
+                    else if (sliceReadFunctions[i] != null) {
+                        type.writeSlice(output, sliceReadFunctions[i].readSlice(resultSet, i + 1));
+                    }
+                    else {
+                        type.writeObject(output, objectReadFunctions[i].readObject(resultSet, i + 1));
+                    }
+                }
+            }
+
+            if (!pageBuilder.isFull()) {
+                finished = true;
+            }
+        }
+        catch (SQLException | RuntimeException e) {
+            throw handleSqlException(e);
+        }
+
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return SourcePage.create(page);
+    }
+
+    private EXAConnection exaConnection()
+            throws SQLException
+    {
+        return connection.unwrap(EXAConnection.class);
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return resultSetFuture;
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        resultSetFuture.cancel(true);
+
+        // use try with resources to close everything properly
+        try (Connection connection = this.connection;
+                ResultSet resultSet = this.resultSet) {
+            if (resultSet != null) {
+                jdbcClient.abortReadConnection(connection, resultSet);
+            }
+            else {
+                connection.close();
+            }
+        }
+        catch (SQLException | RuntimeException e) {
+            // ignore exception from close
+        }
+        resultSet = null;
+    }
+
+    private RuntimeException handleSqlException(Exception e)
+    {
+        try {
+            close();
+        }
+        catch (Exception closeException) {
+            // Self-suppression not permitted
+            if (e != closeException) {
+                e.addSuppressed(closeException);
+            }
+        }
+        return new TrinoException(JDBC_ERROR, e);
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolSessionProperties.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolSessionProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
+
+public class ExasolSessionProperties
+        implements SessionPropertiesProvider
+{
+    public static final String PARALLEL_CONNECTIONS_WORKER_COUNT = "parallel_connections_worker_count";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public ExasolSessionProperties(ExasolConfig exasolConfig)
+    {
+        sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(integerProperty(
+                        PARALLEL_CONNECTIONS_WORKER_COUNT,
+                        "Maximum number of workers to use for parallel JDBC import. Set to 0 to deactivate parallel import.",
+                        exasolConfig.getParallelConnectionsWorkerCount(),
+                        false))
+                .build();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    public static int getParallelImportWorkerCount(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(PARALLEL_CONNECTIONS_WORKER_COUNT, Integer.class)).orElse(0);
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolTlsCertificateFingerprintProvider.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ExasolTlsCertificateFingerprintProvider.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HostAndPort;
+import com.google.inject.Inject;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Locale;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExasolTlsCertificateFingerprintProvider
+{
+    private static final int DEFAULT_TLS_PORT = 8563;
+    private static final int SOCKET_TIMEOUT_MILLIS = 10_000;
+
+    private final HostAndPort hostAndPort;
+    private final CertificateReader certificateReader;
+    private volatile String fingerprint;
+
+    @Inject
+    public ExasolTlsCertificateFingerprintProvider(BaseJdbcConfig config)
+    {
+        this(extractHostAndPort(config.getConnectionUrl()), new SslCertificateReader());
+    }
+
+    @VisibleForTesting
+    ExasolTlsCertificateFingerprintProvider(HostAndPort hostAndPort, CertificateReader certificateReader)
+    {
+        this.hostAndPort = requireNonNull(hostAndPort, "hostAndPort is null");
+        this.certificateReader = requireNonNull(certificateReader, "certificateReader is null");
+    }
+
+    public String getCertificateFingerprint()
+    {
+        String currentFingerprint = fingerprint;
+        if (currentFingerprint == null) {
+            synchronized (this) {
+                currentFingerprint = fingerprint;
+                if (currentFingerprint == null) {
+                    currentFingerprint = toSha256Fingerprint(certificateReader.read(hostAndPort.getHost(), hostAndPort.getPortOrDefault(DEFAULT_TLS_PORT)));
+                    fingerprint = currentFingerprint;
+                }
+            }
+        }
+        return currentFingerprint;
+    }
+
+    @VisibleForTesting
+    static HostAndPort extractHostAndPort(String jdbcUrl)
+    {
+        requireNonNull(jdbcUrl, "jdbcUrl is null");
+
+        String normalizedUrl = jdbcUrl;
+        if (normalizedUrl.startsWith("jdbc:exa-worker:")) {
+            normalizedUrl = normalizedUrl.substring("jdbc:exa-worker:".length());
+        }
+        else if (normalizedUrl.startsWith("jdbc:exa:")) {
+            normalizedUrl = normalizedUrl.substring("jdbc:exa:".length());
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported Exasol JDBC URL: " + jdbcUrl);
+        }
+
+        int parametersStart = normalizedUrl.indexOf(';');
+        if (parametersStart >= 0) {
+            normalizedUrl = normalizedUrl.substring(0, parametersStart);
+        }
+
+        int schemaSeparator = normalizedUrl.indexOf('/');
+        if (schemaSeparator >= 0) {
+            normalizedUrl = normalizedUrl.substring(0, schemaSeparator);
+        }
+
+        int clusterSeparator = normalizedUrl.indexOf(',');
+        if (clusterSeparator >= 0) {
+            normalizedUrl = normalizedUrl.substring(0, clusterSeparator);
+        }
+
+        int rangeSeparator = normalizedUrl.indexOf("..");
+        if (rangeSeparator >= 0) {
+            normalizedUrl = normalizedUrl.substring(0, rangeSeparator);
+        }
+
+        return HostAndPort.fromString(normalizedUrl).withDefaultPort(DEFAULT_TLS_PORT);
+    }
+
+    @VisibleForTesting
+    static String toSha256Fingerprint(X509Certificate certificate)
+    {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded());
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                hex.append(String.format(Locale.ENGLISH, "%02X", value));
+            }
+            return hex.toString();
+        }
+        catch (GeneralSecurityException e) {
+            throw new RuntimeException("Failed to calculate Exasol TLS certificate fingerprint", e);
+        }
+    }
+
+    interface CertificateReader
+    {
+        X509Certificate read(String host, int port);
+    }
+
+    private static class SslCertificateReader
+            implements CertificateReader
+    {
+        @Override
+        public X509Certificate read(String host, int port)
+        {
+            try {
+                SSLSocketFactory socketFactory = createTrustAllSslContext().getSocketFactory();
+                try (SSLSocket socket = (SSLSocket) socketFactory.createSocket()) {
+                    socket.connect(new InetSocketAddress(host, port), SOCKET_TIMEOUT_MILLIS);
+                    socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+                    socket.startHandshake();
+                    Certificate certificate = socket.getSession().getPeerCertificates()[0];
+                    return (X509Certificate) certificate;
+                }
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Failed to retrieve Exasol TLS certificate from %s:%s".formatted(host, port), e);
+            }
+        }
+
+        private SSLContext createTrustAllSslContext()
+                throws GeneralSecurityException
+        {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[] {new TrustAllX509TrustManager()}, null);
+            return sslContext;
+        }
+    }
+
+    private static class TrustAllX509TrustManager
+            implements X509TrustManager
+    {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers()
+        {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ParallelConnectionFactory.java
+++ b/plugin/trino-exasol/src/main/java/io/trino/plugin/exasol/ParallelConnectionFactory.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.exasol.jdbc.EXAConnection;
+import com.exasol.jdbc.EXADriver;
+import com.google.inject.Inject;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+import io.trino.spi.connector.ConnectorSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+import static java.util.Objects.requireNonNull;
+
+public class ParallelConnectionFactory
+{
+    private static final Logger log = LoggerFactory.getLogger(ParallelConnectionFactory.class);
+
+    private final CredentialProvider credentialProvider;
+    private final ExasolTlsCertificateFingerprintProvider tlsCertificateFingerprintProvider;
+    private final OpenTelemetry openTelemetry;
+
+    @Inject
+    public ParallelConnectionFactory(CredentialProvider credentialProvider, ExasolTlsCertificateFingerprintProvider tlsCertificateFingerprintProvider, OpenTelemetry openTelemetry)
+    {
+        this.credentialProvider = requireNonNull(credentialProvider);
+        this.tlsCertificateFingerprintProvider = requireNonNull(tlsCertificateFingerprintProvider);
+        this.openTelemetry = requireNonNull(openTelemetry);
+    }
+
+    public List<Connection> createConnections(ConnectorSession session, Connection connection)
+    {
+        try {
+            EXAConnection exaConnection = connection.unwrap(EXAConnection.class);
+            int maxWorkers = ExasolSessionProperties.getParallelImportWorkerCount(session);
+            exaConnection.RequestParallelConnections(maxWorkers);
+            String[] hosts = exaConnection.GetAvailableWorkerHosts();
+            long token = exaConnection.GetWorkerToken();
+            long sessionId = exaConnection.getSessionID();
+            return createConnections(session, hosts, token, sessionId);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException("Error creating subconnections: " + e.getMessage(), e);
+        }
+    }
+
+    private List<Connection> createConnections(ConnectorSession session, String[] hosts, long token, long sessionId)
+    {
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<CompletableFuture<Connection>> connectionFutures = IntStream.range(0, hosts.length)
+                    .mapToObj(workerId -> new WorkerConnectionInfo(session, workerId, hosts[workerId], token, sessionId))
+                    .map(connectionInfo -> CompletableFuture.supplyAsync(() -> createSubConnection(connectionInfo), executor))
+                    .toList();
+
+            List<Connection> connections = new ArrayList<>(hosts.length);
+            try {
+                for (CompletableFuture<Connection> connectionFuture : connectionFutures) {
+                    connections.add(connectionFuture.get());
+                }
+                return List.copyOf(connections);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                closeConnections(connectionFutures);
+                throw new RuntimeException("Interrupted while creating subconnections", e);
+            }
+            catch (ExecutionException e) {
+                closeConnections(connectionFutures);
+                throw new RuntimeException("Error creating subconnections", e.getCause());
+            }
+        }
+    }
+
+    private Connection createSubConnection(WorkerConnectionInfo connectionInfo)
+    {
+        log.info("Creating subconnection #{} to host {}...", connectionInfo.workerId(), connectionInfo.host());
+        try {
+            try (DriverConnectionFactory connectionFactory = buildConnectionFactory(connectionInfo)) {
+                return connectionFactory.openConnection(connectionInfo.session());
+            }
+        }
+        catch (SQLException e) {
+            log.error("Failed to create subconnection #{} to {}: {}", connectionInfo.workerId(), connectionInfo.host(), e.getMessage(), e);
+            throw new RuntimeException("Failed connecting to %s: %s".formatted(connectionInfo.host(), e.getMessage()), e);
+        }
+    }
+
+    private DriverConnectionFactory buildConnectionFactory(WorkerConnectionInfo connectionInfo)
+    {
+        return DriverConnectionFactory.builder(
+                        new EXADriver(),
+                        connectionInfo.getJdbcUrl(),
+                        credentialProvider)
+                .setConnectionProperties(buildConnectionProperties(connectionInfo))
+                .setOpenTelemetry(openTelemetry)
+                .build();
+    }
+
+    private Properties buildConnectionProperties(WorkerConnectionInfo connectionInfo)
+    {
+        Properties connectionProperties = new Properties();
+        connectionProperties.setProperty("workertoken", String.valueOf(connectionInfo.token()));
+        connectionProperties.setProperty("sessionid", String.valueOf(connectionInfo.sessionId()));
+        connectionProperties.setProperty("autocommit", "0");
+        connectionProperties.setProperty("fingerprint", tlsCertificateFingerprintProvider.getCertificateFingerprint());
+        connectionProperties.setProperty("validateservercertificate", "1");
+
+        return connectionProperties;
+    }
+
+    private void closeConnections(List<CompletableFuture<Connection>> connectionFutures)
+    {
+        for (CompletableFuture<Connection> connectionFuture : connectionFutures) {
+            connectionFuture.cancel(true);
+            if (!connectionFuture.isDone() || connectionFuture.isCompletedExceptionally() || connectionFuture.isCancelled()) {
+                continue;
+            }
+
+            try {
+                connectionFuture.get().close();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            catch (ExecutionException | SQLException e) {
+                log.debug("Failed closing subconnection during cleanup", e);
+            }
+        }
+    }
+
+    private record WorkerConnectionInfo(ConnectorSession session, int workerId, String host, long token, long sessionId)
+    {
+        private String getJdbcUrl()
+        {
+            return "jdbc:exa-worker:" + host;
+        }
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestBufferedSourcePageQueue.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestBufferedSourcePageQueue.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import io.trino.spi.Page;
+import io.trino.spi.connector.SourcePage;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestBufferedSourcePageQueue
+{
+    @Test
+    void testUnblocksWhenPageIsAdded()
+            throws InterruptedException
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+        CompletableFuture<?> blocked = queue.isBlocked();
+        SourcePage page = SourcePage.create(new Page(1));
+
+        assertThat(blocked.isDone()).isFalse();
+
+        queue.add(page);
+
+        assertThat(blocked.isDone()).isTrue();
+        assertThat(queue.poll()).isSameAs(page);
+        assertThat(queue.isFinished()).isFalse();
+    }
+
+    @Test
+    void testReportsImmediateAvailabilityWhenQueueHasData()
+            throws InterruptedException
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+        SourcePage page = SourcePage.create(new Page(1));
+
+        assertThat(queue.size()).isZero();
+        assertThat(queue.isEmpty()).isTrue();
+
+        queue.add(page);
+
+        assertThat(queue.size()).isEqualTo(1);
+        assertThat(queue.isEmpty()).isFalse();
+        assertThat(queue.isBlocked().isDone()).isTrue();
+    }
+
+    @Test
+    void testAddBlocksWhenQueueIsFull()
+            throws Exception
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+        int queueCapacity = 8;
+        for (int i = 0; i < queueCapacity; i++) {
+            queue.add(SourcePage.create(new Page(1)));
+        }
+        SourcePage nextPage = SourcePage.create(new Page(1));
+
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            Future<?> blockedAdd = executor.submit(() -> {
+                try {
+                    queue.add(nextPage);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            });
+
+            TimeUnit.MILLISECONDS.sleep(100);
+            assertThat(blockedAdd.isDone()).isFalse();
+
+            assertThat(queue.poll()).isNotNull();
+            blockedAdd.get();
+
+            while (queue.size() > 1) {
+                assertThat(queue.poll()).isNotNull();
+            }
+            assertThat(queue.poll()).isSameAs(nextPage);
+        }
+    }
+
+    @Test
+    void testFinishesAfterAllProducersCompleteAndQueueIsDrained()
+            throws InterruptedException
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(2);
+        SourcePage page = SourcePage.create(new Page(1));
+
+        queue.add(page);
+        queue.finish(0);
+        queue.finish(1);
+
+        assertThat(queue.isFinished()).isFalse();
+        assertThat(queue.poll()).isSameAs(page);
+        assertThat(queue.isFinished()).isTrue();
+        assertThat(queue.isBlocked().isDone()).isTrue();
+    }
+
+    @Test
+    void testBlockedFutureIsRefreshedAfterPreviousFutureCompletes()
+            throws InterruptedException
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+        CompletableFuture<?> initialBlocked = queue.isBlocked();
+
+        queue.add(SourcePage.create(new Page(1)));
+        queue.poll();
+
+        CompletableFuture<?> refreshedBlocked = queue.isBlocked();
+
+        assertThat(initialBlocked.isDone()).isTrue();
+        assertThat(refreshedBlocked).isNotSameAs(initialBlocked);
+        assertThat(refreshedBlocked.isDone()).isFalse();
+    }
+
+    @Test
+    void testIsBlockedReturnsCompletedFutureWhenAllProducersFinished()
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+
+        queue.finish(0);
+
+        assertThat(queue.isBlocked().isDone()).isTrue();
+        assertThat(queue.isFinished()).isTrue();
+    }
+
+    @Test
+    void testFinishesWhenNoResultPageIsProduced()
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+
+        queue.finish(0);
+
+        assertThat(queue.poll()).isNull();
+        assertThat(queue.isEmpty()).isTrue();
+        assertThat(queue.isFinished()).isTrue();
+    }
+
+    @Test
+    void testFailureIsReportedAndUnblocksConsumers()
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+        CompletableFuture<?> blocked = queue.isBlocked();
+        RuntimeException failure = new RuntimeException("boom");
+
+        queue.fail(0, failure);
+
+        assertThat(blocked.isDone()).isTrue();
+        assertThat(queue.getFailure()).isSameAs(failure);
+        assertThat(queue.isFinished()).isFalse();
+        assertThat(queue.poll()).isNull();
+    }
+
+    @Test
+    void testRejectsUnknownProducer()
+    {
+        BufferedSourcePageQueue queue = new BufferedSourcePageQueue(1);
+
+        assertThatThrownBy(() -> queue.finish(1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unknown producer: 1");
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolTlsCertificateFingerprintProvider.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestExasolTlsCertificateFingerprintProvider.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import com.google.common.net.HostAndPort;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestExasolTlsCertificateFingerprintProvider
+{
+    @Test
+    void testExtractHostAndPortFromJdbcUrl()
+    {
+        assertExtractedHostAndPort("jdbc:exa:exa.example.com:8563", HostAndPort.fromParts("exa.example.com", 8563));
+        assertExtractedHostAndPort("jdbc:exa:exa.example.com;schema=tpch", HostAndPort.fromParts("exa.example.com", 8563));
+        assertExtractedHostAndPort("jdbc:exa-worker:worker.example.com", HostAndPort.fromParts("worker.example.com", 8563));
+        assertExtractedHostAndPort("jdbc:exa:[2001:db8::1]:8564", HostAndPort.fromParts("2001:db8::1", 8564));
+        assertExtractedHostAndPort("jdbc:exa:192.0.2.10", HostAndPort.fromParts("192.0.2.10", 8563));
+        assertExtractedHostAndPort("jdbc:exa:192.0.2.10:8564", HostAndPort.fromParts("192.0.2.10", 8564));
+        assertExtractedHostAndPort("jdbc:exa:exa1.example.com,exa2.example.com", HostAndPort.fromParts("exa1.example.com", 8563));
+        assertExtractedHostAndPort("jdbc:exa:exa1.example.com:8564,exa2.example.com:8565", HostAndPort.fromParts("exa1.example.com", 8564));
+        assertExtractedHostAndPort("jdbc:exa:10.0.0.11..14", HostAndPort.fromParts("10.0.0.11", 8563));
+        assertExtractedHostAndPort("jdbc:exa:exa.example.com:8564/my_schema", HostAndPort.fromParts("exa.example.com", 8564));
+    }
+
+    @Test
+    void testComputesUppercaseSha256Fingerprint()
+    {
+        assertThat(ExasolTlsCertificateFingerprintProvider.toSha256Fingerprint(new TestingX509Certificate(new byte[] {1, 2, 3})))
+                .isEqualTo("039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81");
+    }
+
+    @Test
+    void testRejectsUnsupportedJdbcUrl()
+    {
+        assertThatThrownBy(() -> ExasolTlsCertificateFingerprintProvider.extractHostAndPort("jdbc:postgresql://exa.example.com:5432/db"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported Exasol JDBC URL: jdbc:postgresql://exa.example.com:5432/db");
+    }
+
+    private static void assertExtractedHostAndPort(String jdbcUrl, HostAndPort expected)
+    {
+        assertThat(ExasolTlsCertificateFingerprintProvider.extractHostAndPort(jdbcUrl))
+                .isEqualTo(expected);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final class TestingX509Certificate
+            extends X509Certificate
+    {
+        private final byte[] encoded;
+
+        private TestingX509Certificate(byte[] encoded)
+        {
+            this.encoded = encoded.clone();
+        }
+
+        @Override
+        public byte[] getEncoded()
+                throws CertificateEncodingException
+        {
+            return encoded.clone();
+        }
+
+        @Override
+        public void verify(PublicKey key) {}
+
+        @Override
+        public void verify(PublicKey key, String sigProvider) {}
+
+        @Override
+        public String toString()
+        {
+            return "TestingX509Certificate";
+        }
+
+        @Override
+        public PublicKey getPublicKey()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void checkValidity() {}
+
+        @Override
+        public void checkValidity(Date date) {}
+
+        @Override
+        public int getVersion()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BigInteger getSerialNumber()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Principal getIssuerDN()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Principal getSubjectDN()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Date getNotBefore()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Date getNotAfter()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public byte[] getTBSCertificate()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public byte[] getSignature()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getSigAlgName()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getSigAlgOID()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public byte[] getSigAlgParams()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean[] getIssuerUniqueID()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean[] getSubjectUniqueID()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean[] getKeyUsage()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getBasicConstraints()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public byte[] getExtensionValue(String oid)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> getNonCriticalExtensionOIDs()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> getCriticalExtensionOIDs()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasUnsupportedCriticalExtension()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestParallelConnections.java
+++ b/plugin/trino-exasol/src/test/java/io/trino/plugin/exasol/TestParallelConnections.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exasol;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.tpch.TpchTable.NATION;
+
+public class TestParallelConnections
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingExasolServer exasolServer = closeAfterClass(new TestingExasolServer());
+        return ExasolQueryRunner.builder(exasolServer)
+                .setInitialTables(List.of(NATION))
+                .addConnectorProperty("exasol.parallel-connections.worker-count", "2")
+                .build();
+    }
+
+    @Test
+    void testParallelConnections()
+    {
+        assertQuery("SELECT count(*) FROM nation", "SELECT 25");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This change adds an Exasol-specific parallel page source that uses Exasol JDBC parallel connections to read result sets through multiple worker connections. The feature is configurable at both catalog and session level, and remains disabled by default.

Closes https://github.com/trinodb/trino/issues/29014

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- Added Exasol connector config `exasol.parallel-connections.worker-count`
- Added session property `parallel_connections_worker_count`
- Wired a custom `ConnectorPageSourceProvider` for Exasol
- Added `ExasolParallelPageSource` to coordinate parallel reads from worker connections
- Added `ExasolResultHandlePageSource` to read from an Exasol result handle on each subconnection
- Added `ParallelConnectionFactory` to request and open Exasol worker connections
- Added `BufferedSourcePageQueue` for coordinating pages produced by parallel readers
- Added connector docs describing configuration, session override, and operational caveats

### Behavior

- `worker-count = 0` keeps the current single-connection behavior
- `worker-count >= 2` enables Exasol parallel connections for imports
- `worker-count = 1` uses the custom page source with a single worker, mainly for testing

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Exasol connector
* Improved import performance by using Exasol JDBC parallel connections. ({issue}`29014`)
```
