### PR TITLE
Add TestExamplePlugin

### DIFF
--- a/plugin/trino-example-http/src/test/java/io/trino/plugin/example/TestExamplePlugin.java
+++ b/plugin/trino-example-http/src/test/java/io/trino/plugin/example/TestExamplePlugin.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.example;
+
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+final class TestExamplePlugin
+{
+    @Test
+    void testCreateConnector()
+    {
+        ExamplePlugin plugin = new ExamplePlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create(
+                "test",
+                        Map.of("metadata-uri", "/tmp"),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+}

--- a/plugin/trino-example-http/src/test/resources/example-data/example-metadata.json
+++ b/plugin/trino-example-http/src/test/resources/example-data/example-metadata.json
@@ -75,7 +75,7 @@
                 },
                 {
                     "name": "linenumber",
-                    "type": "INTEGER"
+                    "type": "BIGINT"
                 },
                 {
                     "name": "quantity",


### PR DESCRIPTION
## Description
The current implementation throws an exception, however I'm not sure why it happens. This is also the only occurrence of a `.bindJsonMap(String.class, listJsonCodec(...)` in the whole codebase...

The code seems to be there for quite a while, but in the current build it fails to load. I've added a test to prove it.


```
io.airlift.bootstrap.ApplicationConfigurationException: Configuration errors:

1) Error: An exception was caught and reported. Message: class CollectionType cannot be cast to class MoreTypes$CompositeType (CollectionType and MoreTypes$CompositeType are in unnamed module of loader 'app')
  at ConfigurationFactory.registerConfigurationClasses(ConfigurationFactory.java:190)

1 error

======================
Full classname legend:
======================
CollectionType:          "com.fasterxml.jackson.databind.type.CollectionType"
ConfigurationFactory:    "io.airlift.configuration.ConfigurationFactory"
MoreTypes$CompositeType: "com.google.inject.internal.MoreTypes$CompositeType"
========================
End of classname legend:
========================


	at io.airlift.bootstrap.Bootstrap.configure(Bootstrap.java:322)
	at io.airlift.bootstrap.Bootstrap.initialize(Bootstrap.java:351)
	at io.trino.plugin.example.ExampleConnectorFactory.create(ExampleConnectorFactory.java:56)
	at io.trino.plugin.example.TestExampleConnectorFactory.testInit(TestExampleConnectorFactory.java:16)
Caused by: java.lang.ClassCastException: class com.fasterxml.jackson.databind.type.CollectionType cannot be cast to class com.google.inject.internal.MoreTypes$CompositeType (com.fasterxml.jackson.databind.type.CollectionType and com.google.inject.internal.MoreTypes$CompositeType are in unnamed module of loader 'app')
	at com.google.inject.internal.MoreTypes.isFullySpecified(MoreTypes.java:138)
	at com.google.inject.internal.MoreTypes.access$100(MoreTypes.java:44)
	at com.google.inject.internal.MoreTypes$ParameterizedTypeImpl.isFullySpecified(MoreTypes.java:425)
	at com.google.inject.internal.MoreTypes.isFullySpecified(MoreTypes.java:132)
	at com.google.inject.internal.MoreTypes.access$100(MoreTypes.java:44)
	at com.google.inject.internal.MoreTypes$ParameterizedTypeImpl.isFullySpecified(MoreTypes.java:425)
	at com.google.inject.internal.MoreTypes.isFullySpecified(MoreTypes.java:132)
	at com.google.inject.internal.MoreTypes.canonicalizeForKey(MoreTypes.java:90)
	at com.google.inject.Key.<init>(Key.java:125)
	at com.google.inject.Key.get(Key.java:239)
	at io.airlift.json.JsonCodecBinder.getJsonCodecKey(JsonCodecBinder.java:95)
	at io.airlift.json.JsonCodecBinder.bindMapJsonCodec(JsonCodecBinder.java:89)
	at io.trino.plugin.example.ExampleModule.configure(ExampleModule.java:37)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:426)
	at com.google.inject.spi.Elements.getElements(Elements.java:113)
	at com.google.inject.spi.Elements.getElements(Elements.java:106)
	at io.airlift.configuration.ConfigurationFactory.registerConfigurationClasses(ConfigurationFactory.java:190)
	at io.airlift.bootstrap.Bootstrap.configure(Bootstrap.java:304)
```

## Additional context and related issues
I also fixed the type of the `linenumber` in the `example-metadata.json`, as the current file throws a `Expected field 3 to be type integer but is bigint` (or the other way around)


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.