### PR TITLE
Explicitly ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ product-test-reports
 **/dependency-reduced-pom.xml
 core/trino-web-ui/src/main/resources/webapp/dist/
 .node
+.claude


### PR DESCRIPTION
Claude automatically adds .claude/settings.local.json to ~/.config/git/ignore on mac but it is better to have it explicitly ignored within repo. Also the rule should be wider than just settings.local.json
