### PR TITLE
Remove trino-main compile dependency from trino-faker

### DIFF
--- a/plugin/trino-faker/pom.xml
+++ b/plugin/trino-faker/pom.xml
@@ -49,22 +49,6 @@
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-main</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-parser</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
@@ -148,6 +132,12 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/DateTimeParsing.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/DateTimeParsing.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.faker;
+
+import io.trino.spi.type.DateTimeEncoding;
+import io.trino.spi.type.LongTimeWithTimeZone;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.trino.spi.type.DateTimeEncoding.packTimeWithTimeZone;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
+import static java.lang.Math.multiplyExact;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
+
+final class DateTimeParsing
+{
+    static final Pattern DATETIME_PATTERN = Pattern.compile("" +
+            "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
+            "( (?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
+            "\\s*(?<timezone>.+)?)?");
+
+    static final Pattern TIME_PATTERN = Pattern.compile("" +
+            "(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?" +
+            "\\s*((?<sign>[+-])(?<offsetHour>\\d\\d):(?<offsetMinute>\\d\\d))?");
+
+    private static final long[] POWERS_OF_TEN = {
+            1L,
+            10L,
+            100L,
+            1000L,
+            10_000L,
+            100_000L,
+            1_000_000L,
+            10_000_000L,
+            100_000_000L,
+            1_000_000_000L,
+            10_000_000_000L,
+            100_000_000_000L,
+            1000_000_000_000L,
+    };
+
+    private static final int MICROSECONDS_PER_SECOND = 1_000_000;
+    private static final long NANOSECONDS_PER_SECOND = 1_000_000_000;
+    private static final long PICOSECONDS_PER_SECOND = 1_000_000_000_000L;
+    private static final int PICOSECONDS_PER_MICROSECOND = 1_000_000;
+
+    private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR, 4, 10, SignStyle.NORMAL)
+            .appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+            .appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    private DateTimeParsing() {}
+
+    static int parseDate(String value)
+    {
+        return toIntExact(LocalDate.parse(value, DATE_FORMATTER).toEpochDay());
+    }
+
+    static long parseDayTimeInterval(String value)
+    {
+        boolean negative = value.startsWith("-");
+        if (negative) {
+            value = value.substring(1);
+        }
+
+        int dotIndex = value.indexOf('.');
+        long seconds;
+        long millis;
+        if (dotIndex >= 0) {
+            seconds = Long.parseLong(value.substring(0, dotIndex));
+            String fraction = value.substring(dotIndex + 1);
+            if (fraction.length() > 3) {
+                fraction = fraction.substring(0, 3);
+            }
+            while (fraction.length() < 3) {
+                fraction = fraction + "0";
+            }
+            millis = Long.parseLong(fraction);
+        }
+        else {
+            seconds = Long.parseLong(value);
+            millis = 0;
+        }
+
+        long result = seconds * 1000 + millis;
+        return negative ? -result : result;
+    }
+
+    static long parseYearMonthInterval(String value)
+    {
+        return Long.parseLong(value);
+    }
+
+    static Object parseTimestamp(int precision, String value)
+    {
+        if (precision <= MAX_SHORT_PRECISION) {
+            return parseShortTimestamp(value);
+        }
+        return parseLongTimestamp(value);
+    }
+
+    static Object parseTimestampWithTimeZone(int precision, String value)
+    {
+        if (precision <= TimestampWithTimeZoneType.MAX_SHORT_PRECISION) {
+            return parseShortTimestampWithTimeZone(value);
+        }
+        return parseLongTimestampWithTimeZone(value);
+    }
+
+    static long parseTime(String value)
+    {
+        Matcher matcher = TIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("offsetHour") != null || matcher.group("offsetMinute") != null) {
+            throw new IllegalArgumentException("Invalid TIME: " + value);
+        }
+
+        int hour = Integer.parseInt(matcher.group("hour"));
+        int minute = Integer.parseInt(matcher.group("minute"));
+        int second = matcher.group("second") == null ? 0 : Integer.parseInt(matcher.group("second"));
+
+        if (hour > 23 || minute > 59 || second > 59) {
+            throw new IllegalArgumentException("Invalid TIME: " + value);
+        }
+
+        int precision = 0;
+        String fraction = matcher.group("fraction");
+        long fractionValue = 0;
+        if (fraction != null) {
+            precision = fraction.length();
+            fractionValue = Long.parseLong(fraction);
+        }
+
+        if (precision > TimeType.MAX_PRECISION) {
+            throw new IllegalArgumentException("Invalid TIME: " + value);
+        }
+
+        return (((hour * 60L) + minute) * 60 + second) * PICOSECONDS_PER_SECOND + rescale(fractionValue, precision, 12);
+    }
+
+    static Object parseTimeWithTimeZone(int precision, String value)
+    {
+        if (precision <= TimeWithTimeZoneType.MAX_SHORT_PRECISION) {
+            return parseShortTimeWithTimeZone(value);
+        }
+        return parseLongTimeWithTimeZone(value);
+    }
+
+    private static long parseShortTimestamp(String value)
+    {
+        Matcher matcher = DATETIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("timezone") != null) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP: " + value);
+        }
+
+        String year = matcher.group("year");
+        String month = matcher.group("month");
+        String day = matcher.group("day");
+        String hour = matcher.group("hour");
+        String minute = matcher.group("minute");
+        String second = matcher.group("second");
+        String fraction = matcher.group("fraction");
+
+        long epochSecond = toEpochSecond(year, month, day, hour, minute, second, UTC);
+
+        int precision = 0;
+        long fractionValue = 0;
+        if (fraction != null) {
+            precision = fraction.length();
+            fractionValue = Long.parseLong(fraction);
+        }
+
+        if (precision > MAX_SHORT_PRECISION) {
+            throw new IllegalArgumentException(format("Cannot parse '%s' as short timestamp. Max allowed precision = %s", value, MAX_SHORT_PRECISION));
+        }
+
+        return multiplyExact(epochSecond, MICROSECONDS_PER_SECOND) + rescale(fractionValue, precision, 6);
+    }
+
+    private static LongTimestamp parseLongTimestamp(String value)
+    {
+        Matcher matcher = DATETIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("timezone") != null) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP: " + value);
+        }
+
+        String year = matcher.group("year");
+        String month = matcher.group("month");
+        String day = matcher.group("day");
+        String hour = matcher.group("hour");
+        String minute = matcher.group("minute");
+        String second = matcher.group("second");
+        String fraction = matcher.group("fraction");
+
+        if (fraction == null || fraction.length() <= MAX_SHORT_PRECISION) {
+            throw new IllegalArgumentException(format("Cannot parse '%s' as long timestamp. Precision must be in the range [%s, %s]", value, MAX_SHORT_PRECISION + 1, TimestampType.MAX_PRECISION));
+        }
+
+        int precision = fraction.length();
+        long epochSecond = toEpochSecond(year, month, day, hour, minute, second, UTC);
+        long picoFraction = rescale(Long.parseLong(fraction), precision, 12);
+
+        return longTimestamp(epochSecond, picoFraction);
+    }
+
+    private static long parseShortTimestampWithTimeZone(String value)
+    {
+        Matcher matcher = DATETIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("timezone") == null) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP WITH TIME ZONE: " + value);
+        }
+
+        String year = matcher.group("year");
+        String month = matcher.group("month");
+        String day = matcher.group("day");
+        String hour = matcher.group("hour");
+        String minute = matcher.group("minute");
+        String second = matcher.group("second");
+        String fraction = matcher.group("fraction");
+        String timezone = matcher.group("timezone");
+
+        ZoneId zoneId = ZoneId.of(timezone);
+        long epochSecond = toEpochSecond(year, month, day, hour, minute, second, zoneId);
+
+        int precision = 0;
+        long fractionValue = 0;
+        if (fraction != null) {
+            precision = fraction.length();
+            fractionValue = Long.parseLong(fraction);
+        }
+
+        if (precision > MAX_SHORT_PRECISION) {
+            throw new IllegalArgumentException(format("Cannot parse '%s' as short timestamp. Max allowed precision = %s", value, MAX_SHORT_PRECISION));
+        }
+
+        long epochMillis = epochSecond * 1000 + rescale(fractionValue, precision, 3);
+        return DateTimeEncoding.packDateTimeWithZone(epochMillis, timezone);
+    }
+
+    private static LongTimestampWithTimeZone parseLongTimestampWithTimeZone(String value)
+    {
+        Matcher matcher = DATETIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("timezone") == null) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP: " + value);
+        }
+
+        String year = matcher.group("year");
+        String month = matcher.group("month");
+        String day = matcher.group("day");
+        String hour = matcher.group("hour");
+        String minute = matcher.group("minute");
+        String second = matcher.group("second");
+        String fraction = matcher.group("fraction");
+        String timezone = matcher.group("timezone");
+
+        if (fraction == null || fraction.length() <= TimestampWithTimeZoneType.MAX_SHORT_PRECISION) {
+            throw new IllegalArgumentException(format("Cannot parse '%s' as long timestamp. Precision must be in the range [%s, %s]", value, TimestampWithTimeZoneType.MAX_SHORT_PRECISION + 1, TimestampWithTimeZoneType.MAX_PRECISION));
+        }
+
+        ZoneId zoneId = ZoneId.of(timezone);
+        long epochSecond = toEpochSecond(year, month, day, hour, minute, second, zoneId);
+
+        return LongTimestampWithTimeZone.fromEpochSecondsAndFraction(epochSecond, rescale(Long.parseLong(fraction), fraction.length(), 12), getTimeZoneKey(timezone));
+    }
+
+    private static long parseShortTimeWithTimeZone(String value)
+    {
+        Matcher matcher = TIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("offsetHour") == null || matcher.group("offsetMinute") == null) {
+            throw new IllegalArgumentException("Invalid TIME WITH TIME ZONE: " + value);
+        }
+
+        int hour = Integer.parseInt(matcher.group("hour"));
+        int minute = Integer.parseInt(matcher.group("minute"));
+        int second = matcher.group("second") == null ? 0 : Integer.parseInt(matcher.group("second"));
+        int offsetSign = matcher.group("sign").equals("+") ? 1 : -1;
+        int offsetHour = Integer.parseInt(matcher.group("offsetHour"));
+        int offsetMinute = Integer.parseInt(matcher.group("offsetMinute"));
+
+        if (hour > 23 || minute > 59 || second > 59 || !isValidOffset(offsetHour, offsetMinute)) {
+            throw new IllegalArgumentException("Invalid TIME WITH TIME ZONE: " + value);
+        }
+
+        int precision = 0;
+        String fraction = matcher.group("fraction");
+        long fractionValue = 0;
+        if (fraction != null) {
+            precision = fraction.length();
+            fractionValue = Long.parseLong(fraction);
+        }
+
+        long nanos = (((hour * 60L) + minute) * 60 + second) * NANOSECONDS_PER_SECOND + rescale(fractionValue, precision, 9);
+        return packTimeWithTimeZone(nanos, (offsetSign * (offsetHour * 60 + offsetMinute)));
+    }
+
+    private static LongTimeWithTimeZone parseLongTimeWithTimeZone(String value)
+    {
+        Matcher matcher = TIME_PATTERN.matcher(value);
+        if (!matcher.matches() || matcher.group("offsetHour") == null || matcher.group("offsetMinute") == null) {
+            throw new IllegalArgumentException("Invalid TIME WITH TIME ZONE: " + value);
+        }
+
+        int hour = Integer.parseInt(matcher.group("hour"));
+        int minute = Integer.parseInt(matcher.group("minute"));
+        int second = matcher.group("second") == null ? 0 : Integer.parseInt(matcher.group("second"));
+        int offsetSign = matcher.group("sign").equals("+") ? 1 : -1;
+        int offsetHour = Integer.parseInt(matcher.group("offsetHour"));
+        int offsetMinute = Integer.parseInt(matcher.group("offsetMinute"));
+
+        if (hour > 23 || minute > 59 || second > 59 || !isValidOffset(offsetHour, offsetMinute)) {
+            throw new IllegalArgumentException("Invalid TIME WITH TIME ZONE: " + value);
+        }
+
+        int precision = 0;
+        String fraction = matcher.group("fraction");
+        long fractionValue = 0;
+        if (fraction != null) {
+            precision = fraction.length();
+            fractionValue = Long.parseLong(fraction);
+        }
+
+        long picos = (((hour * 60) + minute) * 60 + second) * PICOSECONDS_PER_SECOND + rescale(fractionValue, precision, 12);
+        return new LongTimeWithTimeZone(picos, (offsetSign * (offsetHour * 60 + offsetMinute)));
+    }
+
+    private static long toEpochSecond(String year, String month, String day, String hour, String minute, String second, ZoneId zoneId)
+    {
+        LocalDateTime timestamp = LocalDateTime.of(
+                Integer.parseInt(year),
+                Integer.parseInt(month),
+                Integer.parseInt(day),
+                hour == null ? 0 : Integer.parseInt(hour),
+                minute == null ? 0 : Integer.parseInt(minute),
+                second == null ? 0 : Integer.parseInt(second),
+                0);
+
+        List<ZoneOffset> offsets = zoneId.getRules().getValidOffsets(timestamp);
+        if (offsets.isEmpty()) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP due to daylight savings transition");
+        }
+
+        return timestamp.toEpochSecond(offsets.get(0));
+    }
+
+    private static LongTimestamp longTimestamp(long epochSecond, long fractionInPicos)
+    {
+        return new LongTimestamp(
+                multiplyExact(epochSecond, MICROSECONDS_PER_SECOND) + fractionInPicos / PICOSECONDS_PER_MICROSECOND,
+                (int) (fractionInPicos % PICOSECONDS_PER_MICROSECOND));
+    }
+
+    private static long rescale(long value, int fromPrecision, int toPrecision)
+    {
+        if (fromPrecision <= toPrecision) {
+            value *= scaleFactor(fromPrecision, toPrecision);
+        }
+        else {
+            value /= scaleFactor(toPrecision, fromPrecision);
+        }
+        return value;
+    }
+
+    private static long scaleFactor(int fromPrecision, int toPrecision)
+    {
+        if (fromPrecision > toPrecision) {
+            throw new IllegalArgumentException("fromPrecision must be <= toPrecision");
+        }
+        return POWERS_OF_TEN[toPrecision - fromPrecision];
+    }
+
+    private static boolean isValidOffset(int hour, int minute)
+    {
+        return (hour == 14 && minute == 0) ||
+                (hour >= 0 && hour < 14 && minute >= 0 && minute <= 59);
+    }
+}

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerMetadata.java
@@ -64,13 +64,11 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.P4HyperLogLogType;
 import io.trino.spi.type.QuantileDigestType;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import io.trino.type.IpAddressType;
-import io.trino.type.JsonType;
-import io.trino.type.TDigestType;
 import net.datafaker.Faker;
 
 import java.util.ArrayList;
@@ -416,14 +414,14 @@ public class FakerMetadata
         return !(type instanceof BooleanType ||
                 type instanceof HyperLogLogType ||
                 type instanceof QuantileDigestType ||
-                type instanceof TDigestType ||
+                type.getBaseName().equals(StandardTypes.TDIGEST) ||
                 type instanceof P4HyperLogLogType ||
                 isCharacterType(type) ||
                 type instanceof RowType ||
                 type instanceof ArrayType ||
                 type instanceof MapType ||
-                type instanceof JsonType ||
-                type instanceof IpAddressType ||
+                type.getBaseName().equals(StandardTypes.JSON) ||
+                type.getBaseName().equals(StandardTypes.IPADDRESS) ||
                 type instanceof UuidType);
     }
 

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
@@ -41,6 +41,7 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeWithTimeZoneType;
 import io.trino.spi.type.TimeZoneKey;
@@ -50,8 +51,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import io.trino.type.IpAddressType;
-import io.trino.type.JsonType;
 import net.datafaker.Faker;
 
 import java.math.BigDecimal;
@@ -90,9 +89,6 @@ import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
-import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
-import static io.trino.type.IpAddressType.IPADDRESS;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -310,7 +306,7 @@ class FakerPageSource
             DoubleRange range = DoubleRange.of(genericRange, (double) handle.step().getSingleValue());
             return (blockBuilder, rowId) -> DOUBLE.writeDouble(blockBuilder, range.at(rowId));
         }
-        if (INTERVAL_DAY_TIME.equals(type) || INTERVAL_YEAR_MONTH.equals(type)) {
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_DAY_TO_SECOND) || type.getBaseName().equals(StandardTypes.INTERVAL_YEAR_TO_MONTH)) {
             // step is seconds or months
             IntRange range = IntRange.of(genericRange, (long) handle.step().getSingleValue());
             return (blockBuilder, rowId) -> type.writeLong(blockBuilder, range.at(rowId));
@@ -385,8 +381,8 @@ class FakerPageSource
             MapBlock emptyBlock = (MapBlock) mapBlockBuilder.build();
             return (blockBuilder) -> blockBuilder.append(emptyBlock, 0);
         }
-        if (type instanceof JsonType jsonType) {
-            return (blockBuilder) -> jsonType.writeSlice(blockBuilder, EMPTY_SLICE);
+        if (type.getBaseName().equals(StandardTypes.JSON)) {
+            return (blockBuilder) -> type.writeSlice(blockBuilder, EMPTY_SLICE);
         }
 
         Range genericRange = handle.domain().getValues().getRanges().getSpan();
@@ -435,13 +431,13 @@ class FakerPageSource
             return (blockBuilder) -> DOUBLE.writeDouble(blockBuilder, range.low == range.high ? range.low : random.nextDouble(range.low, range.high));
         }
         // not supported: HYPER_LOG_LOG, QDIGEST, TDIGEST, P4_HYPER_LOG_LOG
-        if (INTERVAL_DAY_TIME.equals(type)) {
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_DAY_TO_SECOND)) {
             LongRange range = LongRange.of(genericRange);
-            return (blockBuilder) -> INTERVAL_DAY_TIME.writeLong(blockBuilder, numberBetween(range.low, range.high));
+            return (blockBuilder) -> type.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
-        if (INTERVAL_YEAR_MONTH.equals(type)) {
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_YEAR_TO_MONTH)) {
             IntRange range = IntRange.of(genericRange);
-            return (blockBuilder) -> INTERVAL_YEAR_MONTH.writeLong(blockBuilder, numberBetween(range.low, range.high));
+            return (blockBuilder) -> type.writeLong(blockBuilder, numberBetween(range.low, range.high));
         }
         if (type instanceof TimestampType timestampType) {
             return timestampGenerator(genericRange, timestampType);
@@ -479,8 +475,8 @@ class FakerPageSource
             }
             return (blockBuilder) -> charType.writeSlice(blockBuilder, boundedSentenceGenerator.get(charType.getLength()));
         }
-        if (type instanceof IpAddressType) {
-            return generateIpV4(genericRange);
+        if (type.getBaseName().equals(StandardTypes.IPADDRESS)) {
+            return generateIpV4(type, genericRange);
         }
         // not supported: GEOMETRY
         if (type instanceof UuidType) {
@@ -526,11 +522,11 @@ class FakerPageSource
             return (blockBuilder, value) -> DOUBLE.writeDouble(blockBuilder, (Double) value);
         }
         // not supported: HYPER_LOG_LOG, QDIGEST, TDIGEST, P4_HYPER_LOG_LOG
-        if (INTERVAL_DAY_TIME.equals(type)) {
-            return (blockBuilder, value) -> INTERVAL_DAY_TIME.writeLong(blockBuilder, (Long) value);
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_DAY_TO_SECOND)) {
+            return (blockBuilder, value) -> type.writeLong(blockBuilder, (Long) value);
         }
-        if (INTERVAL_YEAR_MONTH.equals(type)) {
-            return (blockBuilder, value) -> INTERVAL_YEAR_MONTH.writeLong(blockBuilder, (Long) value);
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_YEAR_TO_MONTH)) {
+            return (blockBuilder, value) -> type.writeLong(blockBuilder, (Long) value);
         }
         if (type instanceof TimestampType tzType) {
             if (tzType.isShort()) {
@@ -569,8 +565,8 @@ class FakerPageSource
             return (blockBuilder, value) -> charType.writeSlice(blockBuilder, (Slice) value);
         }
         // not supported: ROW, ARRAY, MAP, JSON
-        if (type instanceof IpAddressType) {
-            return (blockBuilder, value) -> IPADDRESS.writeSlice(blockBuilder, (Slice) value);
+        if (type.getBaseName().equals(StandardTypes.IPADDRESS)) {
+            return (blockBuilder, value) -> type.writeSlice(blockBuilder, (Slice) value);
         }
         // not supported: GEOMETRY
         if (type instanceof UuidType) {
@@ -1062,7 +1058,7 @@ class FakerPageSource
         return bigMin.add(bigMax.subtract(bigMin).multiply(randomValue)).longValue();
     }
 
-    private Generator generateIpV4(Range range)
+    private Generator generateIpV4(Type type, Range range)
     {
         if (!range.isAll()) {
             throw new TrinoException(INVALID_ROW_FILTER, "Predicates for ipaddress columns are not supported");
@@ -1087,7 +1083,7 @@ class FakerPageSource
             bytes[11] = (byte) 0xff;
             arraycopy(address, 0, bytes, 12, 4);
 
-            IPADDRESS.writeSlice(blockBuilder, Slices.wrappedBuffer(bytes, 0, 16));
+            type.writeSlice(blockBuilder, Slices.wrappedBuffer(bytes, 0, 16));
         };
     }
 

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/Literal.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/Literal.java
@@ -31,6 +31,7 @@ import io.trino.spi.type.SqlTimeWithTimeZone;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.SqlVarbinary;
+import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimeWithTimeZoneType;
 import io.trino.spi.type.TimestampType;
@@ -39,10 +40,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.UuidType;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
-import io.trino.sql.tree.IntervalField;
-import io.trino.type.IntervalDayTimeType;
-import io.trino.type.IntervalYearMonthType;
-import io.trino.type.IpAddressType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,8 +47,6 @@ import java.math.MathContext;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.LocalDate;
-import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -61,6 +56,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.plugin.faker.DateTimeParsing.parseDate;
+import static io.trino.plugin.faker.DateTimeParsing.parseDayTimeInterval;
+import static io.trino.plugin.faker.DateTimeParsing.parseTime;
+import static io.trino.plugin.faker.DateTimeParsing.parseTimeWithTimeZone;
+import static io.trino.plugin.faker.DateTimeParsing.parseTimestamp;
+import static io.trino.plugin.faker.DateTimeParsing.parseTimestampWithTimeZone;
+import static io.trino.plugin.faker.DateTimeParsing.parseYearMonthInterval;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
@@ -79,15 +81,6 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.UuidType.javaUuidToTrinoUuid;
 import static io.trino.spi.type.UuidType.trinoUuidToJavaUuid;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static io.trino.type.DateTimes.parseTime;
-import static io.trino.type.DateTimes.parseTimeWithTimeZone;
-import static io.trino.type.DateTimes.parseTimestamp;
-import static io.trino.type.DateTimes.parseTimestampWithTimeZone;
-import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
-import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
-import static io.trino.util.DateTimeUtils.parseDate;
-import static io.trino.util.DateTimeUtils.parseDayTimeInterval;
-import static io.trino.util.DateTimeUtils.parseYearMonthInterval;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
@@ -130,11 +123,11 @@ public class Literal
             return Double.parseDouble(value);
         }
         // not supported: HYPER_LOG_LOG, QDIGEST, TDIGEST, P4_HYPER_LOG_LOG
-        if (INTERVAL_DAY_TIME.equals(type)) {
-            return parseDayTimeInterval(value, new IntervalField.Second(OptionalInt.empty()), Optional.empty());
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_DAY_TO_SECOND)) {
+            return parseDayTimeInterval(value);
         }
-        if (INTERVAL_YEAR_MONTH.equals(type)) {
-            return parseYearMonthInterval(value, new IntervalField.Month(), Optional.empty());
+        if (type.getBaseName().equals(StandardTypes.INTERVAL_YEAR_TO_MONTH)) {
+            return parseYearMonthInterval(value);
         }
         if (type instanceof TimestampType timestampType) {
             return parseTimestamp(timestampType.getPrecision(), value);
@@ -155,7 +148,7 @@ public class Literal
             return utf8Slice(value);
         }
         // not supported: ROW, ARRAY, MAP, JSON
-        if (type instanceof IpAddressType) {
+        if (type.getBaseName().equals(StandardTypes.IPADDRESS)) {
             return parseIpAddress(value);
         }
         // not supported: GEOMETRY
@@ -353,33 +346,33 @@ public class Literal
                         unpackZoneKey(typedValue)).toString();
             }
 
-            if (type instanceof IntervalDayTimeType) {
+            if (type.getBaseName().equals(StandardTypes.INTERVAL_DAY_TO_SECOND)) {
                 long epochSeconds = floorDiv(typedValue, (long) MILLISECONDS_PER_SECOND);
                 long fractionalSecond = floorMod(typedValue, (long) MILLISECONDS_PER_SECOND);
                 return "%d.%03d".formatted(epochSeconds, fractionalSecond);
             }
 
-            if (type instanceof IntervalYearMonthType) {
+            if (type.getBaseName().equals(StandardTypes.INTERVAL_YEAR_TO_MONTH)) {
                 return Long.toString(typedValue);
             }
         }
 
         if (javaType == Slice.class) {
             Slice typedValue = (Slice) value;
+            if (type.getBaseName().equals(StandardTypes.IPADDRESS)) {
+                try {
+                    return InetAddresses.toAddrString(InetAddress.getByAddress(typedValue.getBytes()));
+                }
+                catch (UnknownHostException e) {
+                    throw new RuntimeException(e);
+                }
+            }
             switch (type) {
                 case VarcharType _, CharType _ -> {
                     return typedValue.toStringUtf8();
                 }
                 case VarbinaryType _ -> {
                     return new SqlVarbinary(typedValue.getBytes()).toString();
-                }
-                case IpAddressType _ -> {
-                    try {
-                        return InetAddresses.toAddrString(InetAddress.getByAddress(typedValue.getBytes()));
-                    }
-                    catch (UnknownHostException e) {
-                        throw new RuntimeException(e);
-                    }
                 }
                 case UuidType _ -> {
                     return trinoUuidToJavaUuid(typedValue).toString();

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestDateTimeParsing.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestDateTimeParsing.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.faker;
+
+import io.trino.spi.type.LongTimeWithTimeZone;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import org.junit.jupiter.api.Test;
+
+import java.time.DateTimeException;
+import java.time.format.DateTimeParseException;
+
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateTimeEncoding.unpackOffsetMinutes;
+import static io.trino.spi.type.DateTimeEncoding.unpackTimeNanos;
+import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestDateTimeParsing
+{
+    @Test
+    void testParseDate()
+    {
+        // valid dates
+        assertThat(DateTimeParsing.parseDate("1970-01-01")).isEqualTo(0);
+        assertThat(DateTimeParsing.parseDate("1970-02-01")).isEqualTo(31);
+        assertThat(DateTimeParsing.parseDate("1969-12-01")).isEqualTo(-31);
+        assertThat(DateTimeParsing.parseDate("2022-02-28")).isEqualTo(19051);
+        assertThat(DateTimeParsing.parseDate("0000-01-01")).isEqualTo(-719528);
+        assertThat(DateTimeParsing.parseDate("9999-12-31")).isEqualTo(2932896);
+        // extended year format
+        assertThat(DateTimeParsing.parseDate("5881580-07-11")).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    void testParseDateInvalidFormat()
+    {
+        // invalid length
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1970-2-01"))
+                .isInstanceOf(DateTimeParseException.class);
+        // invalid characters
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("a970-02-10"))
+                .isInstanceOf(DateTimeParseException.class);
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1p70-02-10"))
+                .isInstanceOf(DateTimeParseException.class);
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("19%0-02-10"))
+                .isInstanceOf(DateTimeParseException.class);
+        // wrong separators
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1970_02-01"))
+                .isInstanceOf(DateTimeParseException.class);
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1970/02/01"))
+                .isInstanceOf(DateTimeParseException.class);
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1970-02/01"))
+                .isInstanceOf(DateTimeParseException.class);
+        // completely wrong format
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("Dec 24 2022"))
+                .isInstanceOf(DateTimeParseException.class);
+    }
+
+    @Test
+    void testParseDateInvalidValue()
+    {
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("2022-02-29"))
+                .isInstanceOf(DateTimeException.class);
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1970-32-01"))
+                .isInstanceOf(DateTimeException.class);
+        assertThatThrownBy(() -> DateTimeParsing.parseDate("1970-02-41"))
+                .isInstanceOf(DateTimeException.class);
+    }
+
+    @Test
+    void testParseDayTimeInterval()
+    {
+        // whole seconds
+        assertThat(DateTimeParsing.parseDayTimeInterval("0")).isEqualTo(0);
+        assertThat(DateTimeParsing.parseDayTimeInterval("1")).isEqualTo(1000);
+        assertThat(DateTimeParsing.parseDayTimeInterval("60")).isEqualTo(60_000);
+
+        // fractional seconds
+        assertThat(DateTimeParsing.parseDayTimeInterval("1.5")).isEqualTo(1500);
+        assertThat(DateTimeParsing.parseDayTimeInterval("123.456")).isEqualTo(123456);
+        assertThat(DateTimeParsing.parseDayTimeInterval("0.001")).isEqualTo(1);
+        assertThat(DateTimeParsing.parseDayTimeInterval("0.1")).isEqualTo(100);
+        assertThat(DateTimeParsing.parseDayTimeInterval("0.12")).isEqualTo(120);
+
+        // fraction truncated to 3 digits (millis)
+        assertThat(DateTimeParsing.parseDayTimeInterval("1.1234")).isEqualTo(1123);
+        assertThat(DateTimeParsing.parseDayTimeInterval("1.9999")).isEqualTo(1999);
+
+        // negative values
+        assertThat(DateTimeParsing.parseDayTimeInterval("-1")).isEqualTo(-1000);
+        assertThat(DateTimeParsing.parseDayTimeInterval("-1.5")).isEqualTo(-1500);
+        assertThat(DateTimeParsing.parseDayTimeInterval("-0")).isEqualTo(0);
+    }
+
+    @Test
+    void testParseYearMonthInterval()
+    {
+        assertThat(DateTimeParsing.parseYearMonthInterval("0")).isEqualTo(0);
+        assertThat(DateTimeParsing.parseYearMonthInterval("1")).isEqualTo(1);
+        assertThat(DateTimeParsing.parseYearMonthInterval("12")).isEqualTo(12);
+        assertThat(DateTimeParsing.parseYearMonthInterval("-3")).isEqualTo(-3);
+        assertThat(DateTimeParsing.parseYearMonthInterval("-12")).isEqualTo(-12);
+
+        assertThatThrownBy(() -> DateTimeParsing.parseYearMonthInterval("abc"))
+                .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    void testParseTime()
+    {
+        // midnight
+        assertThat(DateTimeParsing.parseTime("00:00:00")).isEqualTo(0);
+        // hour and minute only
+        assertThat(DateTimeParsing.parseTime("12:34")).isEqualTo(12 * 3600 * 1_000_000_000_000L + 34 * 60 * 1_000_000_000_000L);
+        // full time
+        assertThat(DateTimeParsing.parseTime("12:34:56")).isEqualTo(
+                (12 * 3600L + 34 * 60 + 56) * 1_000_000_000_000L);
+        // end of day
+        assertThat(DateTimeParsing.parseTime("23:59:59")).isEqualTo(
+                (23 * 3600L + 59 * 60 + 59) * 1_000_000_000_000L);
+        // with fractional seconds
+        assertThat(DateTimeParsing.parseTime("12:34:56.1")).isEqualTo(
+                (12 * 3600L + 34 * 60 + 56) * 1_000_000_000_000L + 100_000_000_000L);
+        assertThat(DateTimeParsing.parseTime("12:34:56.123")).isEqualTo(
+                (12 * 3600L + 34 * 60 + 56) * 1_000_000_000_000L + 123_000_000_000L);
+        assertThat(DateTimeParsing.parseTime("12:34:56.123456789012")).isEqualTo(
+                (12 * 3600L + 34 * 60 + 56) * 1_000_000_000_000L + 123456789012L);
+    }
+
+    @Test
+    void testParseTimeInvalid()
+    {
+        // hour out of range
+        assertThatThrownBy(() -> DateTimeParsing.parseTime("25:00:00"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME");
+        // minute out of range
+        assertThatThrownBy(() -> DateTimeParsing.parseTime("12:60:00"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME");
+        // second out of range
+        assertThatThrownBy(() -> DateTimeParsing.parseTime("12:00:60"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME");
+        // precision too high (max is 12)
+        assertThatThrownBy(() -> DateTimeParsing.parseTime("12:00:00.1234567890123"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME");
+        // time with timezone offset should be rejected
+        assertThatThrownBy(() -> DateTimeParsing.parseTime("12:34:56+05:30"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME");
+        // not a time
+        assertThatThrownBy(() -> DateTimeParsing.parseTime("not-a-time"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME");
+    }
+
+    @Test
+    void testParseTimeWithTimeZoneShort()
+    {
+        // short precision (0-3) returns packed long
+        Object result = DateTimeParsing.parseTimeWithTimeZone(3, "12:34:56+05:30");
+        assertThat(result).isInstanceOf(Long.class);
+        long packed = (long) result;
+        assertThat(unpackTimeNanos(packed)).isEqualTo((12 * 3600L + 34 * 60 + 56) * 1_000_000_000L);
+        assertThat(unpackOffsetMinutes(packed)).isEqualTo(5 * 60 + 30);
+
+        // negative offset
+        Object negativeOffset = DateTimeParsing.parseTimeWithTimeZone(0, "08:00:00-03:00");
+        assertThat(negativeOffset).isInstanceOf(Long.class);
+        assertThat(unpackOffsetMinutes((long) negativeOffset)).isEqualTo(-180);
+
+        // UTC offset
+        Object utcOffset = DateTimeParsing.parseTimeWithTimeZone(0, "00:00:00+00:00");
+        assertThat(utcOffset).isInstanceOf(Long.class);
+        assertThat(unpackTimeNanos((long) utcOffset)).isEqualTo(0);
+        assertThat(unpackOffsetMinutes((long) utcOffset)).isEqualTo(0);
+    }
+
+    @Test
+    void testParseTimeWithTimeZoneLong()
+    {
+        // long precision (>9) returns LongTimeWithTimeZone
+        Object result = DateTimeParsing.parseTimeWithTimeZone(10, "12:34:56.1234567890+05:30");
+        assertThat(result).isInstanceOf(LongTimeWithTimeZone.class);
+        LongTimeWithTimeZone longTime = (LongTimeWithTimeZone) result;
+        assertThat(longTime.getOffsetMinutes()).isEqualTo(5 * 60 + 30);
+    }
+
+    @Test
+    void testParseTimeWithTimeZoneInvalid()
+    {
+        // missing timezone offset
+        assertThatThrownBy(() -> DateTimeParsing.parseTimeWithTimeZone(3, "12:34:56"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME WITH TIME ZONE");
+        // invalid offset (>14:00)
+        assertThatThrownBy(() -> DateTimeParsing.parseTimeWithTimeZone(3, "12:34:56+15:00"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIME WITH TIME ZONE");
+        // max valid offset is +14:00
+        assertThat(DateTimeParsing.parseTimeWithTimeZone(3, "12:34:56+14:00"))
+                .isInstanceOf(Long.class);
+    }
+
+    @Test
+    void testParseTimestampShort()
+    {
+        // precision 0 - no fractional seconds
+        Object result = DateTimeParsing.parseTimestamp(0, "2020-01-01 12:34:56");
+        assertThat(result).isInstanceOf(Long.class);
+        // epoch micros for 2020-01-01 12:34:56 UTC
+        assertThat((long) result).isEqualTo(1577882096000000L);
+
+        // precision 3
+        result = DateTimeParsing.parseTimestamp(3, "2020-01-01 12:34:56.789");
+        assertThat(result).isInstanceOf(Long.class);
+        assertThat((long) result).isEqualTo(1577882096789000L);
+
+        // precision 6
+        result = DateTimeParsing.parseTimestamp(6, "2020-01-01 12:34:56.123456");
+        assertThat(result).isInstanceOf(Long.class);
+        assertThat((long) result).isEqualTo(1577882096123456L);
+
+        // date only (no time component)
+        result = DateTimeParsing.parseTimestamp(0, "2020-01-01");
+        assertThat(result).isInstanceOf(Long.class);
+        assertThat((long) result).isEqualTo(1577836800000000L);
+    }
+
+    @Test
+    void testParseTimestampLong()
+    {
+        // precision 7+
+        Object result = DateTimeParsing.parseTimestamp(9, "2020-01-01 12:34:56.123456789");
+        assertThat(result).isInstanceOf(LongTimestamp.class);
+        LongTimestamp longTs = (LongTimestamp) result;
+        assertThat(longTs.getEpochMicros()).isEqualTo(1577882096123456L);
+        assertThat(longTs.getPicosOfMicro()).isEqualTo(789000);
+
+        // precision 12
+        result = DateTimeParsing.parseTimestamp(12, "2020-01-01 12:34:56.123456789012");
+        assertThat(result).isInstanceOf(LongTimestamp.class);
+        longTs = (LongTimestamp) result;
+        assertThat(longTs.getEpochMicros()).isEqualTo(1577882096123456L);
+        assertThat(longTs.getPicosOfMicro()).isEqualTo(789012);
+    }
+
+    @Test
+    void testParseTimestampInvalid()
+    {
+        // timestamp with timezone should be rejected
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestamp(3, "2020-01-01 12:34:56.789 UTC"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIMESTAMP");
+        // short precision with too many fractional digits
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestamp(3, "2020-01-01 12:34:56.1234567"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("short timestamp");
+        // long precision with too few fractional digits
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestamp(9, "2020-01-01 12:34:56.123"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("long timestamp");
+        // completely invalid
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestamp(3, "not-a-timestamp"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIMESTAMP");
+    }
+
+    @Test
+    void testParseTimestampDstTransition()
+    {
+        // DST gap - this timestamp doesn't exist in Europe/Warsaw but parseTimestamp uses UTC
+        // so it should succeed
+        assertThat(DateTimeParsing.parseTimestamp(0, "2020-03-29 02:30:00"))
+                .isInstanceOf(Long.class);
+    }
+
+    @Test
+    void testParseTimestampWithTimeZoneShort()
+    {
+        Object result = DateTimeParsing.parseTimestampWithTimeZone(3, "2020-01-01 12:34:56.789 UTC");
+        assertThat(result).isInstanceOf(Long.class);
+        long packed = (long) result;
+        assertThat(unpackMillisUtc(packed)).isEqualTo(1577882096789L);
+        assertThat(unpackZoneKey(packed).getId()).isEqualTo("UTC");
+
+        // named timezone
+        result = DateTimeParsing.parseTimestampWithTimeZone(3, "2020-01-01 12:34:56.789 America/New_York");
+        assertThat(result).isInstanceOf(Long.class);
+        packed = (long) result;
+        assertThat(unpackZoneKey(packed).getId()).isEqualTo("America/New_York");
+        // New York is UTC-5 in January, so epoch millis should be 5 hours later than UTC
+        assertThat(unpackMillisUtc(packed)).isEqualTo(1577900096789L);
+    }
+
+    @Test
+    void testParseTimestampWithTimeZoneLong()
+    {
+        Object result = DateTimeParsing.parseTimestampWithTimeZone(9, "2020-01-01 12:34:56.123456789 America/New_York");
+        assertThat(result).isInstanceOf(LongTimestampWithTimeZone.class);
+        LongTimestampWithTimeZone longTstz = (LongTimestampWithTimeZone) result;
+        assertThat(longTstz.getTimeZoneKey()).isEqualTo(getTimeZoneKey("America/New_York").getKey());
+    }
+
+    @Test
+    void testParseTimestampWithTimeZoneInvalid()
+    {
+        // missing timezone
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestampWithTimeZone(3, "2020-01-01 12:34:56.789"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIMESTAMP WITH TIME ZONE");
+        // long precision with too few fractional digits
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestampWithTimeZone(9, "2020-01-01 12:34:56.789 UTC"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("long timestamp");
+        // completely invalid
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestampWithTimeZone(3, "not-a-timestamp"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TIMESTAMP WITH TIME ZONE");
+    }
+
+    @Test
+    void testParseTimestampWithTimeZoneDstTransition()
+    {
+        // DST gap in Europe/Warsaw: 2020-03-29 02:00 doesn't exist (clocks jump from 02:00 to 03:00)
+        assertThatThrownBy(() -> DateTimeParsing.parseTimestampWithTimeZone(3, "2020-03-29 02:30:00.000 Europe/Warsaw"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("daylight savings");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2780,7 +2780,7 @@
             <plugin>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-maven-plugin</artifactId>
-                <version>17</version>
+                <version>19</version>
                 <extensions>true</extensions>
             </plugin>
 


### PR DESCRIPTION
## Summary
- Remove compile-scoped `trino-main` and `trino-parser` dependencies from the faker plugin
- Copy datetime parsing methods from `DateTimes` and `DateTimeUtils` into a local `DateTimeParsing` class, simplifying where possible:
  - `parseDate`: java.time `DateTimeFormatter` instead of Joda
  - `parseDayTimeInterval`: manual seconds.millis parsing instead of Joda `PeriodFormatter`
  - `parseYearMonthInterval`: simple `Long.parseLong` instead of Joda `PeriodFormatter`
  - time/timestamp parsing: copied as-is (only depends on trino-spi)
- Replace `instanceof` type checks (`IpAddressType`, `JsonType`, `TDigestType`, `IntervalDayTimeType`, `IntervalYearMonthType`) with `type.getBaseName().equals(StandardTypes.X)` comparisons
- Rewrite `FakerFunctionProvider` to use `FunctionMetadata.scalarBuilder()` and `MethodHandle` instead of `ScalarFromAnnotationsParser`/`SqlScalarFunction` from trino-main

## Test plan
- [x] `mvnd test -pl plugin/trino-faker` — all 48 tests pass
- [x] Tests pass with non-UTC JVM timezone (`-Duser.timezone=Asia/Kathmandu`)
- [x] CI

Fixes #29065