### PR TITLE
Fix NPE in PartitionData.toJson() for unpartitioned tables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionData.java
@@ -87,6 +87,9 @@ public class PartitionData
 
     public static String toJson(StructLike structLike)
     {
+        if (structLike == null) {
+            return "{}";
+        }
         try {
             StringWriter writer = new StringWriter();
             JsonGenerator generator = FACTORY.createGenerator(writer);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionData.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionData.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPartitionData
+{
+    @Test
+    public void testToJsonWithNullReturnsEmptyObject()
+    {
+        assertThat(PartitionData.toJson(null)).isEqualTo("{}");
+    }
+
+    @Test
+    public void testToJsonWithEmptyPartitionData()
+    {
+        PartitionData empty = new PartitionData(new Object[0]);
+        String json = PartitionData.toJson(empty);
+        assertThat(json).isEqualTo("{\"partitionValues\":[]}");
+    }
+
+    @Test
+    public void testToJsonRoundTrip()
+    {
+        PartitionData original = new PartitionData(new Object[] {42, "hello"});
+        String json = PartitionData.toJson(original);
+        assertThat(json).contains("\"partitionValues\"");
+
+        PartitionData restored = PartitionData.fromJson(json,
+                new org.apache.iceberg.types.Type[] {Types.IntegerType.get(), Types.StringType.get()});
+        assertThat(restored.size()).isEqualTo(2);
+        assertThat(restored.get(0, Integer.class)).isEqualTo(42);
+        assertThat(restored.get(1, String.class)).isEqualTo("hello");
+    }
+
+    @Test
+    public void testFromJsonWithNullReturnsNull()
+    {
+        assertThat(PartitionData.fromJson(null, new org.apache.iceberg.types.Type[0])).isNull();
+    }
+}


### PR DESCRIPTION
PartitionData.toJson(StructLike) throws NullPointerException when called with null, which happens for unpartitioned Iceberg tables where no partition data exists. This was exposed by the upstream change to use Block-based partition values (830084850a0), which routes through PartitionData.fromBlocks() and can produce null PartitionData for unpartitioned specs in certain code paths.

The fix adds a null guard in toJson() that returns "{}" for null input, consistent with the empty-partition semantic already used throughout the codebase.

Add TestPartitionData with 4 tests covering:
- toJson(null) returns "{}" (was NPE)
- toJson(empty PartitionData) produces valid JSON
- toJson/fromJson round-trip with values
- fromJson(null) returns null

Made-with: Cursor

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
