### PR TITLE
Set null to Session.transactionId explicitly when create from other Session

### DIFF
--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -722,7 +722,7 @@ public final class Session
             checkArgument(session.getTransactionId().isEmpty(), "Session builder cannot be created from a session in a transaction");
             this.sessionPropertyManager = session.sessionPropertyManager;
             this.queryId = session.queryId;
-            this.transactionId = session.transactionId.orElse(null);
+            this.transactionId = null; // Set null explicitly as it's not allowed to create from a session in a transaction
             this.clientTransactionSupport = session.clientTransactionSupport;
             this.identity = session.identity;
             this.originalIdentity = session.originalIdentity;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
No need of copying `Session.transactionId` when it's created from other `Session` because it's always null as it's checked in advance here:
https://github.com/trinodb/trino/blob/de9553bb1920da9c03574079be64d57e26c5fbf5/core/trino-main/src/main/java/io/trino/Session.java#L722


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
