### PR TITLE
Allow multiple input files for CLI execution

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -226,8 +226,8 @@ public class ClientOptions
     @Option(names = "--path", paramLabel = "<catalog.schema>", description = "Default SQL path", arity = "0..*")
     public List<String> path = ImmutableList.of();
 
-    @Option(names = {"-f", "--file"}, paramLabel = "<file>", description = "Execute statements from file and exit")
-    public String file;
+    @Option(names = {"-f", "--file"}, paramLabel = "<file>", description = "Execute statements from file and exit (can be repeated)")
+    public List<String> files = new ArrayList<>();
 
     @Option(names = DEBUG_OPTION_NAME, paramLabel = "<debug>", description = "Enable debug information")
     public boolean debug;

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -43,10 +43,8 @@ import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -131,21 +129,8 @@ public class Console
             query += ";";
         }
 
-        List<String> fileQueries = new ArrayList<>();
-
-        if (isFromFiles) {
-            if (hasQuery) {
-                throw new RuntimeException("both --execute and --file specified");
-            }
-
-            for (String file : clientOptions.files) {
-                try {
-                    fileQueries.add(asCharSource(new File(file), UTF_8).read());
-                }
-                catch (IOException e) {
-                    throw new RuntimeException(format("Error reading from file '%s': %s", file, e.getMessage()));
-                }
-            }
+        if (isFromFiles && hasQuery) {
+            throw new RuntimeException("both --execute and --file specified");
         }
 
         // Read queries from stdin
@@ -187,13 +172,17 @@ public class Console
                 clientOptions.maxQueuedRows,
                 clientOptions.maxBufferedRows)) {
             // Run query from each file sequentially
-            if (!fileQueries.isEmpty()) {
+            if (isFromFiles) {
                 boolean overallSuccess = true;
-                for (int i = 0; i < fileQueries.size(); i++) {
-                    String fileName = clientOptions.files.get(i);
-                    String fileQuery = fileQueries.get(i);
+                for (String file : clientOptions.files) {
+                    String fileQuery;
+                    try {
+                        fileQuery = asCharSource(new File(file), UTF_8).read();
+                    }
+                    catch (IOException e) {
+                        throw new RuntimeException(format("Error reading from file '%s': %s", file, e.getMessage()));
+                    }
 
-                    System.err.println("Processing file: '" + fileName + "'");
                     boolean success = executeCommand(
                             queryRunner,
                             exiting,

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -43,8 +43,10 @@ import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -122,23 +124,27 @@ public class Console
         TrinoUri uri = clientOptions.getTrinoUri(restrictedOptions);
         ClientSession session = clientOptions.toClientSession(uri);
         boolean hasQuery = clientOptions.execute != null;
-        boolean isFromFile = !isNullOrEmpty(clientOptions.file);
+        boolean isFromFiles = !clientOptions.files.isEmpty();
 
         String query = clientOptions.execute;
         if (hasQuery) {
             query += ";";
         }
 
-        if (isFromFile) {
+        List<String> fileQueries = new ArrayList<>();
+
+        if (isFromFiles) {
             if (hasQuery) {
                 throw new RuntimeException("both --execute and --file specified");
             }
-            try {
-                query = asCharSource(new File(clientOptions.file), UTF_8).read();
-                hasQuery = true;
-            }
-            catch (IOException e) {
-                throw new RuntimeException(format("Error reading from file %s: %s", clientOptions.file, e.getMessage()));
+
+            for (String file : clientOptions.files) {
+                try {
+                    fileQueries.add(asCharSource(new File(file), UTF_8).read());
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(format("Error reading from file '%s': %s", file, e.getMessage()));
+                }
             }
         }
 
@@ -180,6 +186,35 @@ public class Console
                 clientOptions.debug,
                 clientOptions.maxQueuedRows,
                 clientOptions.maxBufferedRows)) {
+            // Run query from each file sequentially
+            if (!fileQueries.isEmpty()) {
+                boolean overallSuccess = true;
+                for (int i = 0; i < fileQueries.size(); i++) {
+                    String fileName = clientOptions.files.get(i);
+                    String fileQuery = fileQueries.get(i);
+
+                    System.err.println("Processing file: '" + fileName + "'");
+                    boolean success = executeCommand(
+                            queryRunner,
+                            exiting,
+                            fileQuery,
+                            clientOptions.outputFormat,
+                            clientOptions.ignoreErrors,
+                            clientOptions.progress.orElse(false),
+                            clientOptions.decimalDataSize);
+
+                    if (!success) {
+                        if (clientOptions.ignoreErrors) {
+                            overallSuccess = false;
+                        }
+                        else {
+                            return false;
+                        }
+                    }
+                }
+                return overallSuccess;
+            }
+
             if (hasQuery) {
                 return executeCommand(
                         queryRunner,

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -368,6 +368,30 @@ public class TestClientOptions
     }
 
     @Test
+    public void testMultipleFiles()
+    {
+        Console console = createConsole("--file", "file1.sql", "--file", "file2.sql", "--file", "file3.sql");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.files).isEqualTo(ImmutableList.of("file1.sql", "file2.sql", "file3.sql"));
+    }
+
+    @Test
+    public void testMultipleFilesOrder()
+    {
+        Console console = createConsole("--file", "file1.sql", "--file", "file3.sql", "--file", "file2.sql");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.files).isEqualTo(ImmutableList.of("file1.sql", "file3.sql", "file2.sql"));
+    }
+
+    @Test
+    public void testRepeatedFiles()
+    {
+        Console console = createConsole("--file", "file1.sql", "--file", "file1.sql");
+        ClientOptions options = console.clientOptions;
+        assertThat(options.files).isEqualTo(ImmutableList.of("file1.sql", "file1.sql"));
+    }
+
+    @Test
     public void testAllClientOptionsHaveMappingToAConnectionProperty()
     {
         Set<String> fieldsWithoutMapping = Arrays.stream(ClientOptions.class.getDeclaredFields())
@@ -385,7 +409,7 @@ public class TestClientOptions
         switch (name) {
             case "url":
             case "server":
-            case "file":
+            case "files":
             case "debug":
             case "historyFile":
             case "progress":

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -545,7 +545,8 @@ mode:
 * - `--execute=<execute>`
   - Execute specified statements and exit.
 * - `-f`, `--file=<file>`
-  - Execute statements from file and exit.
+  - Execute statements from file and exit. Can be specified multiple times to
+    execute multiple files sequentially in the specified order.
 * - `--ignore-errors`
   - Continue processing in batch mode when an error occurs. Default is to exit
     immediately.
@@ -619,6 +620,20 @@ and displays an error message (which is unaffected by the output format):
 Query 20200707_170726_00030_2iup9 failed: line 1:25: Column 'region' cannot be resolved
 SELECT nationkey, name, region FROM tpch.sf1.nation LIMIT 3
 ```
+
+You can use the `--file` option multiple times to execute multiple SQL files
+sequentially. Files are executed in the order they are specified:
+
+```text
+trino --catalog iceberg --schema default --file ddls.sql --file inserts.sql
+```
+
+This executes all statements in `ddls.sql` first, followed by all statements in
+`inserts.sql`. By default, execution stops immediately if a query fails. Use the
+`--ignore-errors` flag to bypass this and continue running the remaining files.
+
+To help with debugging, the CLI always prints the current filename to standard 
+error (stderr) before executing it.
 
 (cli-spooling-protocol)=
 ## Spooling protocol


### PR DESCRIPTION
## Description

This PR updates the CLI to accept multiple `--file` (or `-f`) arguments, allowing users to pass several SQL scripts at once and run them sequentially. 

Example usage:
```bash
trino --catalog iceberg --schema default --file ddls.sql --file inserts.sql
```

## Additional context and related issues

Resolves #27532
Picks up the work from the stalled PR #27544

Based on the maintainer feedback in the previous PR, we shouldn't just concatenate the queries together into one massive string (to avoid memory issues and preserve accurate error line numbers). 

**Implementation details:**
* Changed the CLI to buffer file contents and execute them sequentially within the same `QueryRunner` session instead of concatenating queries.
* Added `Executing file: <filename>` logging to `stderr` before processing each file to provide context.
* Modified the error handling to respect the `--ignore-errors` flag, allowing execution to continue across remaining files while properly returning an overall failure exit status at the end.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI
* Allow passing multiple `--file` arguments to execute multiple SQL files sequentially. ({issue}`27532`)
```