### PR TITLE
Decorrelate lateral top-n queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -235,6 +235,7 @@ import io.trino.sql.planner.iterative.rule.TransformCorrelatedGroupedAggregation
 import io.trino.sql.planner.iterative.rule.TransformCorrelatedGroupedAggregationWithoutProjection;
 import io.trino.sql.planner.iterative.rule.TransformCorrelatedInPredicateToJoin;
 import io.trino.sql.planner.iterative.rule.TransformCorrelatedJoinToJoin;
+import io.trino.sql.planner.iterative.rule.TransformCorrelatedLateralTopNToJoin;
 import io.trino.sql.planner.iterative.rule.TransformCorrelatedScalarSubquery;
 import io.trino.sql.planner.iterative.rule.TransformCorrelatedSingleRowSubqueryToProject;
 import io.trino.sql.planner.iterative.rule.TransformExistsApplyToCorrelatedJoin;
@@ -550,6 +551,7 @@ public class PlanOptimizers
                                 new RemoveUnreferencedScalarSubqueries(),
                                 new TransformUncorrelatedSubqueryToJoin(),
                                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
+                                new TransformCorrelatedLateralTopNToJoin(plannerContext),
                                 new TransformCorrelatedJoinToJoin(plannerContext),
                                 new DecorrelateInnerUnnestWithGlobalAggregation(metadata),
                                 new DecorrelateLeftUnnestWithGlobalAggregation(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantSort.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantSort.java
@@ -41,7 +41,7 @@ public class RemoveRedundantSort
         if (cardinality.isEmpty()) {
             return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols()));
         }
-        if (cardinality.isScalar()) {
+        if (cardinality.isAtMostScalar()) {
             return Result.ofPlanNode(node.getSource());
         }
         return Result.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedLateralTopNToJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedLateralTopNToJoin.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.optimizations.PlanNodeDecorrelator;
+import io.trino.sql.planner.plan.AssignUniqueId;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.CorrelatedJoinNode;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.EnforceSingleRowNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.LimitNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.SortNode;
+import io.trino.sql.planner.plan.TopNNode;
+import io.trino.sql.planner.plan.WindowNode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.matching.Pattern.nonEmpty;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.Comparison.Operator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.ir.IrUtils.combineConjuncts;
+import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.trino.sql.planner.plan.JoinType.INNER;
+import static io.trino.sql.planner.plan.JoinType.LEFT;
+import static io.trino.sql.planner.plan.Patterns.CorrelatedJoin.correlation;
+import static io.trino.sql.planner.plan.Patterns.CorrelatedJoin.filter;
+import static io.trino.sql.planner.plan.Patterns.correlatedJoin;
+import static io.trino.sql.planner.plan.WindowNode.Frame.DEFAULT_FRAME;
+import static java.util.Objects.requireNonNull;
+
+public class TransformCorrelatedLateralTopNToJoin
+        implements Rule<CorrelatedJoinNode>
+{
+    private static final Pattern<CorrelatedJoinNode> PATTERN = correlatedJoin()
+            .with(nonEmpty(correlation()))
+            .with(filter().equalTo(TRUE));
+
+    private final PlannerContext plannerContext;
+
+    public TransformCorrelatedLateralTopNToJoin(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Pattern<CorrelatedJoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
+    {
+        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: %s", correlatedJoinNode.getType());
+
+        PlanNode subquery = context.getLookup().resolve(correlatedJoinNode.getSubquery());
+
+        // Let the scalar query decorrelator handle scalar queries (i.e., those containing EnforceSingleRow)
+        if (searchFrom(subquery, context.getLookup())
+                .where(EnforceSingleRowNode.class::isInstance)
+                .recurseOnlyWhen(ProjectNode.class::isInstance)
+                .matches()) {
+            return Result.empty();
+        }
+
+        Optional<CorrelatedTopNDescriptor> topN = extractCorrelatedTopN(subquery, context);
+        if (topN.isEmpty()) {
+            return Result.empty();
+        }
+        // The rule doesn't support correlations in the ORDER BY clause
+        if (topN.get().orderingScheme().orderBy().stream().anyMatch(correlatedJoinNode.getInput().getOutputSymbols()::contains)) {
+            return Result.empty();
+        }
+
+        PlanNodeDecorrelator decorrelator = new PlanNodeDecorrelator(plannerContext, context.getSymbolAllocator(), context.getLookup());
+        Optional<PlanNodeDecorrelator.DecorrelatedNode> decorrelatedSource = decorrelator.decorrelateFilters(topN.get().source(), correlatedJoinNode.getCorrelation());
+        if (decorrelatedSource.isEmpty()) {
+            return Result.empty();
+        }
+
+        Symbol uniqueSymbol = context.getSymbolAllocator().newSymbol("unique", BIGINT);
+        PlanNode inputWithUniqueId = new AssignUniqueId(
+                context.getIdAllocator().getNextId(),
+                correlatedJoinNode.getInput(),
+                uniqueSymbol);
+
+        Expression joinFilter = combineConjuncts(
+                decorrelatedSource.get().getCorrelatedPredicates().orElse(TRUE),
+                correlatedJoinNode.getFilter());
+        JoinNode joinNode = new JoinNode(
+                context.getIdAllocator().getNextId(),
+                correlatedJoinNode.getType(),
+                inputWithUniqueId,
+                decorrelatedSource.get().getNode(),
+                ImmutableList.of(),
+                inputWithUniqueId.getOutputSymbols(),
+                decorrelatedSource.get().getNode().getOutputSymbols(),
+                false,
+                joinFilter.equals(TRUE) ? Optional.empty() : Optional.of(joinFilter),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                Optional.empty());
+
+        Symbol rowNumberSymbol = context.getSymbolAllocator().newSymbol("row_number", BIGINT);
+        WindowNode.Function rowNumberFunction = new WindowNode.Function(
+                plannerContext.getMetadata().resolveBuiltinFunction("row_number", ImmutableList.of()),
+                ImmutableList.of(),
+                Optional.empty(),
+                DEFAULT_FRAME,
+                false,
+                false);
+        PlanNode rewritten = new FilterNode(
+                context.getIdAllocator().getNextId(),
+                new WindowNode(
+                        context.getIdAllocator().getNextId(),
+                        joinNode,
+                        new DataOrganizationSpecification(ImmutableList.of(uniqueSymbol), Optional.of(topN.get().orderingScheme())),
+                        ImmutableMap.of(rowNumberSymbol, rowNumberFunction),
+                        ImmutableSet.of(),
+                        0),
+                new Comparison(LESS_THAN_OR_EQUAL, rowNumberSymbol.toSymbolReference(), new Constant(BIGINT, topN.get().count())));
+
+        for (ProjectNode project : topN.get().projections()) {
+            Assignments.Builder assignments = Assignments.builder();
+            Set<Symbol> outputs = project.getAssignments().outputs();
+            rewritten.getOutputSymbols().stream()
+                    .filter(symbol -> !outputs.contains(symbol))
+                    .forEach(assignments::putIdentity);
+            assignments.putAll(project.getAssignments());
+            rewritten = new ProjectNode(project.getId(), rewritten, assignments.build());
+        }
+
+        return Result.ofPlanNode(new ProjectNode(
+                correlatedJoinNode.getId(),
+                rewritten,
+                Assignments.identity(correlatedJoinNode.getOutputSymbols())));
+    }
+
+    private Optional<CorrelatedTopNDescriptor> extractCorrelatedTopN(PlanNode query, Context context)
+    {
+        PlanNode resolved = context.getLookup().resolve(query);
+        List<ProjectNode> projections = new ArrayList<>();
+        while (resolved instanceof ProjectNode project) {
+            projections.add(project);
+            resolved = context.getLookup().resolve(project.getSource());
+        }
+        Collections.reverse(projections);
+
+        if (resolved instanceof TopNNode topN && topN.getCount() > 0 && topN.getStep() == TopNNode.Step.SINGLE) {
+            return Optional.of(new CorrelatedTopNDescriptor(topN.getSource(), topN.getCount(), topN.getOrderingScheme(), ImmutableList.copyOf(projections)));
+        }
+
+        if (resolved instanceof LimitNode limitNode &&
+                !limitNode.isWithTies() &&
+                !limitNode.requiresPreSortedInputs() &&
+                limitNode.getCount() > 0 &&
+                context.getLookup().resolve(limitNode.getSource()) instanceof SortNode sortNode &&
+                !sortNode.isPartial()) {
+            return Optional.of(new CorrelatedTopNDescriptor(sortNode.getSource(), limitNode.getCount(), sortNode.getOrderingScheme(), ImmutableList.copyOf(projections)));
+        }
+
+        return Optional.empty();
+    }
+
+    private record CorrelatedTopNDescriptor(PlanNode source, long count, OrderingScheme orderingScheme, List<ProjectNode> projections) {}
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantSort.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantSort.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import org.junit.jupiter.api.Test;
 
@@ -66,5 +67,20 @@ public class TestRemoveRedundantSort
                                         .singleGroupingSet(p.symbol("foo"))
                                         .source(p.values(20, p.symbol("foo"))))))
                 .doesNotFire();
+    }
+
+    @Test
+    public void testForAtMostScalar()
+    {
+        tester().assertThat(new RemoveRedundantSort())
+                .on(p ->
+                        p.sort(
+                                ImmutableList.of(p.symbol("c")),
+                                p.limit(
+                                        1,
+                                        p.values(20, p.symbol("c")))))
+                .matches(
+                        node(LimitNode.class,
+                                node(ValuesNode.class)));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedLateralTopNToJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedLateralTopNToJoin.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Comparison;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.Assignments;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.Comparison.Operator.EQUAL;
+import static io.trino.sql.ir.Comparison.Operator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.ir.Logical.Operator.AND;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.window;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.windowFunction;
+import static io.trino.sql.planner.plan.JoinType.INNER;
+import static io.trino.sql.planner.plan.JoinType.LEFT;
+import static io.trino.sql.planner.plan.WindowNode.Frame.DEFAULT_FRAME;
+
+public class TestTransformCorrelatedLateralTopNToJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void rewritesInnerCorrelatedTopN()
+    {
+        tester().assertThat(new TransformCorrelatedLateralTopNToJoin(tester().getPlannerContext()))
+                .on(p -> {
+                    var corr = p.symbol("corr", BIGINT);
+                    var limit = p.symbol("limit", BIGINT);
+                    var match = p.symbol("match", BIGINT);
+                    var ordering = p.symbol("ordering", BIGINT);
+                    var payload = p.symbol("payload", BIGINT);
+
+                    return p.correlatedJoin(
+                            ImmutableList.of(corr, limit),
+                            p.values(corr, limit),
+                            INNER,
+                            TRUE,
+                            p.topN(
+                                    1,
+                                    ImmutableList.of(ordering),
+                                    p.filter(
+                                            new Logical(
+                                                    AND,
+                                                    ImmutableList.of(
+                                                            new Comparison(EQUAL, match.toSymbolReference(), corr.toSymbolReference()),
+                                                            new Comparison(LESS_THAN_OR_EQUAL, ordering.toSymbolReference(), limit.toSymbolReference()))),
+                                            p.values(match, ordering, payload))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "row_number"), new Constant(BIGINT, 1L)),
+                                        window(builder -> builder
+                                                        .specification(specification(
+                                                                ImmutableList.of("unique"),
+                                                                ImmutableList.of("ordering"),
+                                                                ImmutableMap.of("ordering", ASC_NULLS_FIRST)))
+                                                        .addFunction("row_number", windowFunction("row_number", ImmutableList.of(), DEFAULT_FRAME)),
+                                                join(INNER, builder -> builder
+                                                        .filter(new Logical(
+                                                                AND,
+                                                                ImmutableList.of(
+                                                                        new Comparison(EQUAL, new Reference(BIGINT, "match"), new Reference(BIGINT, "corr")),
+                                                                        new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "ordering"), new Reference(BIGINT, "limit")))))
+                                                        .left(assignUniqueId("unique", values("corr", "limit")))
+                                                        .right(filter(TRUE, values("match", "ordering", "payload"))))))));
+    }
+
+    @Test
+    public void rewritesLeftCorrelatedTopNWithProjection()
+    {
+        tester().assertThat(new TransformCorrelatedLateralTopNToJoin(tester().getPlannerContext()))
+                .on(p -> {
+                    var corr = p.symbol("corr", BIGINT);
+                    var limit = p.symbol("limit", BIGINT);
+                    var match = p.symbol("match", BIGINT);
+                    var ordering = p.symbol("ordering", BIGINT);
+                    var payload = p.symbol("payload", BIGINT);
+                    var payloadAlias = p.symbol("payload_alias", BIGINT);
+
+                    return p.correlatedJoin(
+                            ImmutableList.of(corr, limit),
+                            p.values(corr, limit),
+                            LEFT,
+                            TRUE,
+                            p.project(
+                                    Assignments.of(payloadAlias, new Constant(BIGINT, 11L)),
+                                    p.topN(
+                                            1,
+                                            ImmutableList.of(ordering),
+                                            p.filter(
+                                                    new Logical(
+                                                            AND,
+                                                            ImmutableList.of(
+                                                                    new Comparison(EQUAL, match.toSymbolReference(), corr.toSymbolReference()),
+                                                                    new Comparison(LESS_THAN_OR_EQUAL, ordering.toSymbolReference(), limit.toSymbolReference()))),
+                                                    p.values(match, ordering, payload)))));
+                })
+                .matches(
+                        project(
+                                project(
+                                        ImmutableMap.of("payload_alias", expression(new Constant(BIGINT, 11L))),
+                                        filter(
+                                                new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "row_number"), new Constant(BIGINT, 1L)),
+                                                window(builder -> builder
+                                                                .specification(specification(
+                                                                        ImmutableList.of("unique"),
+                                                                        ImmutableList.of("ordering"),
+                                                                        ImmutableMap.of("ordering", ASC_NULLS_FIRST)))
+                                                                .addFunction("row_number", windowFunction("row_number", ImmutableList.of(), DEFAULT_FRAME)),
+                                                        join(LEFT, builder -> builder
+                                                                .filter(new Logical(
+                                                                        AND,
+                                                                        ImmutableList.of(
+                                                                                new Comparison(EQUAL, new Reference(BIGINT, "match"), new Reference(BIGINT, "corr")),
+                                                                                new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "ordering"), new Reference(BIGINT, "limit")))))
+                                                                .left(assignUniqueId("unique", values("corr", "limit")))
+                                                                .right(filter(TRUE, values("match", "ordering", "payload")))))))));
+    }
+
+    @Test
+    public void rewritesCorrelatedLimitWithSort()
+    {
+        tester().assertThat(new TransformCorrelatedLateralTopNToJoin(tester().getPlannerContext()))
+                .on(p -> {
+                    var corr = p.symbol("corr", BIGINT);
+                    var limit = p.symbol("limit", BIGINT);
+                    var match = p.symbol("match", BIGINT);
+                    var ordering = p.symbol("ordering", BIGINT);
+                    var payload = p.symbol("payload", BIGINT);
+
+                    return p.correlatedJoin(
+                            ImmutableList.of(corr, limit),
+                            p.values(corr, limit),
+                            INNER,
+                            TRUE,
+                            p.limit(
+                                    1,
+                                    p.sort(
+                                            ImmutableList.of(ordering),
+                                            p.filter(
+                                                    new Logical(
+                                                            AND,
+                                                            ImmutableList.of(
+                                                                    new Comparison(EQUAL, match.toSymbolReference(), corr.toSymbolReference()),
+                                                                    new Comparison(LESS_THAN_OR_EQUAL, ordering.toSymbolReference(), limit.toSymbolReference()))),
+                                                    p.values(match, ordering, payload)))));
+                })
+                .matches(
+                        project(
+                                filter(
+                                        new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "row_number"), new Constant(BIGINT, 1L)),
+                                        window(builder -> builder
+                                                        .specification(specification(
+                                                                ImmutableList.of("unique"),
+                                                                ImmutableList.of("ordering"),
+                                                                ImmutableMap.of("ordering", ASC_NULLS_FIRST)))
+                                                        .addFunction("row_number", windowFunction("row_number", ImmutableList.of(), DEFAULT_FRAME)),
+                                                join(INNER, builder -> builder
+                                                        .filter(new Logical(
+                                                                AND,
+                                                                ImmutableList.of(
+                                                                        new Comparison(EQUAL, new Reference(BIGINT, "match"), new Reference(BIGINT, "corr")),
+                                                                        new Comparison(LESS_THAN_OR_EQUAL, new Reference(BIGINT, "ordering"), new Reference(BIGINT, "limit")))))
+                                                        .left(assignUniqueId("unique", values("corr", "limit")))
+                                                        .right(filter(TRUE, values("match", "ordering", "payload"))))))));
+    }
+
+    @Test
+    public void doesNotFireOnScalarSubqueryShape()
+    {
+        tester().assertThat(new TransformCorrelatedLateralTopNToJoin(tester().getPlannerContext()))
+                .on(p -> {
+                    var corr = p.symbol("corr", BIGINT);
+                    var match = p.symbol("match", BIGINT);
+                    var ordering = p.symbol("ordering", BIGINT);
+
+                    return p.correlatedJoin(
+                            ImmutableList.of(corr),
+                            p.values(corr),
+                            p.project(
+                                    Assignments.identity(ordering),
+                                    p.enforceSingleRow(
+                                            p.topN(
+                                                    1,
+                                                    ImmutableList.of(ordering),
+                                                    p.filter(
+                                                            new Comparison(EQUAL, match.toSymbolReference(), corr.toSymbolReference()),
+                                                            p.values(match, ordering))))));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -382,6 +382,42 @@ public class TestSubqueries
                         "(2, 'w'), " +
                         "(3, null), " +
                         "(null, null)");
+        assertThat(assertions.query(
+                "SELECT * " +
+                        "FROM (VALUES ('A', 10), ('A', 12), ('B', 7)) trades(symbol, ts) " +
+                        "CROSS JOIN LATERAL (" +
+                        "    SELECT quote_ts, bid " +
+                        "    FROM (VALUES " +
+                        "        ('A', 5, 100), " +
+                        "        ('A', 9, 101), " +
+                        "        ('A', 11, 102), " +
+                        "        ('B', 8, 200)) quotes(symbol, quote_ts, bid) " +
+                        "    WHERE quotes.symbol = trades.symbol " +
+                        "      AND quotes.quote_ts <= trades.ts " +
+                        "    ORDER BY quotes.quote_ts DESC " +
+                        "    FETCH FIRST 1 ROW ONLY)"))
+                .matches("VALUES " +
+                        "('A', 10, 9, 101), " +
+                        "('A', 12, 11, 102)");
+        assertThat(assertions.query(
+                "SELECT * " +
+                        "FROM (VALUES ('A', 10), ('A', 12), ('B', 7)) trades(symbol, ts) " +
+                        "LEFT JOIN LATERAL (" +
+                        "    SELECT quote_ts, bid " +
+                        "    FROM (VALUES " +
+                        "        ('A', 5, 100), " +
+                        "        ('A', 9, 101), " +
+                        "        ('A', 11, 102), " +
+                        "        ('B', 8, 200)) quotes(symbol, quote_ts, bid) " +
+                        "    WHERE quotes.symbol = trades.symbol " +
+                        "      AND quotes.quote_ts <= trades.ts " +
+                        "    ORDER BY quotes.quote_ts DESC " +
+                        "    FETCH FIRST 1 ROW ONLY) " +
+                        "ON TRUE"))
+                .matches("VALUES " +
+                        "('A', 10, 9, 101), " +
+                        "('A', 12, 11, 102), " +
+                        "('B', 7, null, null)");
         // correlated symbol in predicate not bound to inner relation + Limit
         assertThat(assertions.query(
                 "SELECT * " +


### PR DESCRIPTION
Add support for executing queries of the form

```sql
SELECT ...
FROM ..., LATERAL (
    SELECT ...
    FROM ...
    WHERE <correlated filter>
    ORDER BY ...
    LIMIT ...
)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for correlated `LATERAL` subqueries involving `ORDER BY ... LIMIT`. ({issue}`issuenumber`)
```
