### PR TITLE
Fix DESCRIBE OUTPUT with versioned tables

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -6071,9 +6071,6 @@ class StatementAnalyzer
             if (version.isEmpty()) {
                 return tableVersion;
             }
-            if (analysis.isDescribe()) {
-                throw semanticException(NOT_SUPPORTED, table, "DESCRIBE is not supported if a versioned table uses parameters");
-            }
             ExpressionAnalysis expressionAnalysis = analyzeExpression(version.get(), scope.get());
             analysis.recordSubqueries(table, expressionAnalysis);
 
@@ -6081,6 +6078,9 @@ class StatementAnalyzer
             Type versionType = expressionAnalysis.getType(version.get());
             PointerType pointerType = toPointerType(table.getQueryPeriod().get().getRangeType());
             if (versionType == UNKNOWN) {
+                if (analysis.isDescribe()) {
+                    throw semanticException(NOT_SUPPORTED, table, "DESCRIBE is not supported if a versioned table uses parameters");
+                }
                 throw semanticException(INVALID_ARGUMENTS, table.getQueryPeriod().get(), "Pointer value cannot be NULL");
             }
             Object evaluatedVersion = evaluateConstant(version.get(), versionType, analysis.getParameters(), plannerContext, session, accessControl);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7949,6 +7949,32 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testDescribeOutputWithVersionedTable()
+    {
+        try (TestTable table = newTrinoTable("test", "(x int)", List.of("1"))) {
+            Session firstSession = Session.builder(getSession())
+                    .addPreparedStatement("my_query", "SELECT * FROM %s FOR VERSION AS OF %s".formatted(table.getName(), getCurrentSnapshotId(table.getName())))
+                    .build();
+            assertThat(query(firstSession, "DESCRIBE OUTPUT my_query"))
+                    .matches("VALUES ('x', 'iceberg', 'tpch', '" + table.getName() + "', 'integer', 4, false)");
+
+            // Add a new snapshot with a new column for a different output
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y int");
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 2)", 1);
+
+            Session secondSession = Session.builder(getSession())
+                    .addPreparedStatement("my_query", "SELECT * FROM %s FOR VERSION AS OF %s".formatted(table.getName(), getCurrentSnapshotId(table.getName())))
+                    .build();
+            assertThat(query(firstSession, "DESCRIBE OUTPUT my_query"))
+                    .matches("VALUES ('x', 'iceberg', 'tpch', '" + table.getName() + "', 'integer', 4, false)");
+            assertThat(query(secondSession, "DESCRIBE OUTPUT my_query"))
+                    .matches("VALUES" +
+                            "('x', 'iceberg', 'tpch', '" + table.getName() + "', 'integer', 4, false)," +
+                            "('y', 'iceberg', 'tpch', '" + table.getName() + "', 'integer', 4, false)");
+        }
+    }
+
+    @Test
     public void testDeleteRetainsTableHistory()
     {
         String tableName = "test_delete_retains_table_history_" + randomNameSuffix();


### PR DESCRIPTION
## Description

- Fixes #29077

## Release notes

```markdown
## General
* Fix failure when executing `DESCRIBE OUTPUT` with versioned tables. ({issue}`29077`)
```
