### PR TITLE
Fix IS NOT NULL on Glue partition column causing planning timeout

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueExpressionUtil.java
@@ -149,8 +149,11 @@ public final class GlueExpressionUtil
         }
 
         // Glue throws an exception (e.g. input string: "__HIVE_D" is not an integer)
-        // for column <> '__HIVE_DEFAULT_PARTITION__' or column = '__HIVE_DEFAULT_PARTITION__' expression on numeric types
+        // for column <> '__HIVE_DEFAULT_PARTITION__' or column = '__HIVE_DEFAULT_PARTITION__' expression on numeric types.
         // "IS NULL" operator in the official documentation always returns empty result regardless of the type.
+        // For quoted types (e.g. varchar), the <> expression can be parsed by Glue, but prevents Glue from using
+        // partition indexes efficiently, causing severe performance degradation (planning timeouts).
+        // IS NOT NULL filtering is handled client-side by HivePartitionManager instead.
         // https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-partitions.html#aws-glue-api-catalog-partitions-GetPartitions
         if ((domain.getValues().isAll() || domain.isNullAllowed()) && !isQuotedType(domain.getType())) {
             return Optional.empty();
@@ -158,7 +161,7 @@ public final class GlueExpressionUtil
 
         if (domain.getValues().isAll()) {
             verify(!domain.isNullAllowed(), "Unexpected domain: %s", domain);
-            return Optional.of(format("(%s <> '%s')", columnName, NULL_STRING));
+            return Optional.empty();
         }
 
         if (domain.getValues().isNone()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueExpressionUtil.java
@@ -134,7 +134,7 @@ public class TestGlueExpressionUtil
                 .addDomain("col1", Domain.notNull(VarcharType.VARCHAR))
                 .build();
         String expression = buildGlueExpression(ImmutableList.of("col1"), filter, true);
-        assertThat(expression).isEqualTo(format("(col1 <> '%s')", GlueExpressionUtil.NULL_STRING));
+        assertThat(expression).isEqualTo("");
     }
 
     @Test
@@ -156,7 +156,7 @@ public class TestGlueExpressionUtil
                 .addDomain("col2", Domain.notNull(VarcharType.VARCHAR))
                 .build();
         String expression = buildGlueExpression(ImmutableList.of("col1", "col2"), filter, true);
-        assertThat(expression).isEqualTo(format("((col1 = '2020-01-01')) AND (col2 <> '%s')", GlueExpressionUtil.NULL_STRING));
+        assertThat(expression).isEqualTo("((col1 = '2020-01-01'))");
     }
 
     @Test


### PR DESCRIPTION
- From https://github.com/trinodb/trino/pull/29068

## Description

Stop pushing `(col <> '__HIVE_DEFAULT_PARTITION__')` expression to Glue's `GetPartitions` API for varchar partition columns. The not-equals expression prevents Glue from using partition indexes, causing a full partition scan and planning timeouts on large tables.

**Reproducer:**

```sql
CREATE TABLE hive.wheres_etl.airbridge_inapps_v2 (
      ....,
      app_bundle varchar,
      utc_basic_time varchar
  )
  WITH (
      format = 'PARQUET',
      partitioned_by = ARRAY['app_bundle', 'utc_basic_time']
  )
```
The number of partitions would be more than 200,000.

```sql
-- Planning Times out:
SELECT DISTINCT app_bundle FROM wheres_etl.airbridge_inapps_v2
WHERE utc_basic_time = '2026-03-19-02' AND app_bundle IS NOT NULL;

  ⎿  Error: Exit code 1
   Query 20260410_160910_00000_i5rcy failed: The optimizer exhausted the time limit of 180000 ms: Top rules: {
     io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan: 181613 ms, 1 invocations, 1 applications}

-- Works fine (same query without IS NOT NULL):
SELECT DISTINCT app_bundle FROM wheres_etl.airbridge_inapps_v2
WHERE utc_basic_time = '2026-03-19-02';
```

## Additional context and related issues

IS NOT NULL filtering is already handled client-side by `HivePartitionManager`, which correctly filters out null partitions via `parseValuesAndFilterPartition` → `HiveUtil.parsePartitionValue` → `partitionMatches`. This is the same mechanism that already protects non-quoted types (INTEGER, BIGINT).

Non-quoted types already returned `Optional.empty()` at the earlier guard, so this bug only affected quoted types (VARCHAR, CHAR).

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* Fix planning timeout when using `IS NOT NULL` on varchar partition columns with Glue metastore. ({issue}`issuenumber`)
```