### PR TITLE
Fix OPTIMIZE skipping single files with deletion vectors in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -283,6 +283,10 @@ public class DeltaLakeSplitManager
                         pendingAddFileEntriesMap.put(canonicalPartitionValues, Optional.empty());
                         return Stream.of(alreadyQueuedAddFileEntry.get(), addFileEntry);
                     }
+                    if (addFileEntry.getDeletionVector().isPresent()) {
+                        pendingAddFileEntriesMap.put(canonicalPartitionValues, Optional.empty());
+                        return Stream.of(addFileEntry);
+                    }
 
                     pendingAddFileEntriesMap.put(canonicalPartitionValues, Optional.of(addFileEntry));
                     return Stream.empty();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -1224,6 +1224,36 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    public void testOptimizeSingleFileWithDeletionVector()
+            throws Exception
+    {
+        try (TestTable table = newTrinoTable(
+                "test_optimize_single_file_dv_",
+                "(x int) WITH (deletion_vectors_enabled = true)")) {
+            String tableName = table.getName();
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1, 2, 3", 3);
+            assertUpdate("DELETE FROM " + tableName + " WHERE x = 1", 1);
+
+            Set<String> initialFiles = getActiveFiles(tableName);
+            assertThat(initialFiles).hasSize(1);
+
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            Session singleWriterSession = Session.builder(getSession())
+                    .setSystemProperty("task_min_writer_count", "1")
+                    .build();
+            assertQuerySucceeds(singleWriterSession, "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
+
+            Set<String> updatedFiles = getActiveFiles(tableName);
+            assertThat(updatedFiles)
+                    .hasSize(1)
+                    .doesNotContainAnyElementsOf(initialFiles);
+
+            assertQuery("SELECT * FROM " + tableName, "VALUES (2), (3)");
+        }
+    }
+
+    @Test
     public void testFileSizeHiddenColumn()
     {
         try (TestTable table = newTrinoTable("test_file_size_column", "(val VARCHAR)")) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -29,6 +29,7 @@ import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.statistics.ExtendedStatistics;
 import io.trino.plugin.deltalake.statistics.MetaDirStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
@@ -60,6 +61,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -99,6 +101,24 @@ public class TestDeltaLakeSplitManager
             false,
             Optional.empty(),
             Optional.empty(),
+            0,
+            false);
+    private static final DeltaLakeTableHandle optimizeTableHandle = new DeltaLakeTableHandle(
+            "schema",
+            "table",
+            true,
+            TABLE_PATH,
+            metadataEntry,
+            new ProtocolEntry(1, 2, Optional.empty(), Optional.empty()),
+            TupleDomain.all(),
+            TupleDomain.all(),
+            ImmutableSet.of(),
+            false,
+            Optional.empty(),
+            Optional.empty(),
+            false,
+            true, // isOptimize
+            Optional.of(DataSize.ofBytes(1_000_000)),
             0,
             false);
     private final HiveTransactionHandle transactionHandle = new HiveTransactionHandle(true);
@@ -181,6 +201,26 @@ public class TestDeltaLakeSplitManager
         assertThat(splits).isEqualTo(expected);
     }
 
+    @Test
+    public void testOptimizeSingleFileWithDeletionVector()
+            throws ExecutionException, InterruptedException
+    {
+        AddFileEntry fileWithDv = addFileEntryWithDeletionVector(FILE_PATH, 100L);
+        DeltaLakeConfig config = new DeltaLakeConfig();
+        DeltaLakeSplitManager splitManager = setupSplitManager(ImmutableList.of(fileWithDv), config);
+
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                transactionHandle,
+                testingConnectorSessionWithConfig(config),
+                optimizeTableHandle,
+                ImmutableSet.of(),
+                Constraint.alwaysTrue());
+
+        List<ConnectorSplit> splits = splitSource.getNextBatch(10, new DynamicFilterSnapshot(TupleDomain.all(), true)).get();
+
+        assertThat(splits).hasSize(1);
+    }
+
     private DeltaLakeSplitManager setupSplitManager(List<AddFileEntry> addFileEntries, DeltaLakeConfig deltaLakeConfig)
     {
         TestingConnectorContext context = new TestingConnectorContext();
@@ -260,6 +300,27 @@ public class TestDeltaLakeSplitManager
     private AddFileEntry addFileEntryOfSize(String path, long fileSize)
     {
         return new AddFileEntry(path, ImmutableMap.of(), fileSize, 0, false, Optional.empty(), Optional.empty(), ImmutableMap.of(), Optional.empty());
+    }
+
+    private AddFileEntry addFileEntryWithDeletionVector(String path, long fileSize)
+    {
+        DeletionVectorEntry dvEntry = new DeletionVectorEntry(
+                "u",
+                "random_id",
+                OptionalInt.empty(),
+                1,
+                1);
+
+        return new AddFileEntry(
+                path,
+                ImmutableMap.of(),
+                fileSize,
+                0L,
+                false,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                Optional.of(dvEntry));
     }
 
     private DeltaLakeSplit makeSplit(String path, long start, long splitSize, long fileSize, long maxSplitSize, double minimumAssignedSplitWeight)


### PR DESCRIPTION
## Description

This PR fixes a bug in the Delta Lake connector where running `ALTER TABLE ... EXECUTE OPTIMIZE` would skip rewriting a partition if it only contained a single data file, even if that file had deletion vector attached to it. This resulted in deletion vectors remaining un-purged and failed to optimize read performance.

## Additional context and related issues

In `filterValidDataFilesForOptimize`, the compact logic waits for a second file in a given partition before yielding the files to the optimization queue. If a partition only had one file, it was left pending in the map and eventually swallowed by returning `Stream.empty()`.

This PR adds a condition to check `addFileEntry.getDeletionVector().isPresent()`. If a deletion vector exists, the file is immediately emitted for optimization (still leaving the partition value in the pending map to ensure subsequent files are still processed correctly). 

Added a unit test in `TestDeltaLakeSplitManager`.

Fixes #29041

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake Connector
* Fix `OPTIMIZE` to properly rewrite single data files that contain deletion vectors. ({issue}`29041`)
```