### PR TITLE
Update Minio container image

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
@@ -40,7 +40,7 @@ public class Minio
 
     private static final String MINIO_ROOT_USER = "minio-access-key";
     private static final String MINIO_ROOT_PASSWORD = "minio-secret-key";
-    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
+    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:f2aba4b9c84b61881933142f1cb7cc1a20f8e8456f1f1aa353ddd248f23037f7")
             .asCanonicalNameString();
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Minio.java
@@ -40,7 +40,7 @@ public class Minio
 
     private static final String MINIO_ROOT_USER = "minio-access-key";
     private static final String MINIO_ROOT_PASSWORD = "minio-secret-key";
-    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
+    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:f767919bd003062ac69713cdce920eb922c9fa3388efe96264e78b763342ca1a")
             .asCanonicalNameString();
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
@@ -48,7 +48,7 @@ public class SpoolingMinio
     private static final String MINIO_SPOOLING_CONTAINER_NAME = "spooling-minio";
     private static final String MINIO_ROOT_USER = "minio-access-key";
     private static final String MINIO_ROOT_PASSWORD = "minio-secret-key";
-    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
+    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:f2aba4b9c84b61881933142f1cb7cc1a20f8e8456f1f1aa353ddd248f23037f7")
             .asCanonicalNameString();
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SpoolingMinio.java
@@ -48,7 +48,7 @@ public class SpoolingMinio
     private static final String MINIO_SPOOLING_CONTAINER_NAME = "spooling-minio";
     private static final String MINIO_ROOT_USER = "minio-access-key";
     private static final String MINIO_ROOT_PASSWORD = "minio-secret-key";
-    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
+    private static final String MINIO_RELEASE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:f767919bd003062ac69713cdce920eb922c9fa3388efe96264e78b763342ca1a")
             .asCanonicalNameString();
 
     private static final int MINIO_PORT = 9080; // minio uses 9000 by default, which conflicts with hadoop

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -41,8 +41,7 @@ public class Minio
         extends BaseTestContainer
 {
     private static final Logger log = Logger.get(Minio.class);
-
-    public static final String DEFAULT_IMAGE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
+    public static final String DEFAULT_IMAGE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:f2aba4b9c84b61881933142f1cb7cc1a20f8e8456f1f1aa353ddd248f23037f7")
             .asCanonicalNameString();
     public static final String DEFAULT_HOST_NAME = "minio";
 

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -42,7 +42,7 @@ public class Minio
 {
     private static final Logger log = Logger.get(Minio.class);
 
-    public static final String DEFAULT_IMAGE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8")
+    public static final String DEFAULT_IMAGE = DockerImageName.parse("cgr.dev/chainguard/minio@sha256:f767919bd003062ac69713cdce920eb922c9fa3388efe96264e78b763342ca1a")
             .asCanonicalNameString();
     public static final String DEFAULT_HOST_NAME = "minio";
 


### PR DESCRIPTION
## Description

Addresses [CVE-2026-39414](https://github.com/advisories/GHSA-h749-fxx7-pwpg) ([GHSA-h749-fxx7-pwpg](https://github.com/advisories/GHSA-h749-fxx7-pwpg)) in the older image. 

## Additional context and related issues

This is now using the Chainguard EmeritOSS maintained version of MinIO, which now includes patches for security issues.

Uses https://github.com/chainguard-forks/minio/releases/tag/RELEASE.2026-04-10T21-52-59Z

Related PR for aws-proxy is at https://github.com/trinodb/aws-proxy/pull/210

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
