### PR TITLE
Fix IndexOutOfBoundsException in CompressingDecryptingPageDeserializer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/CompressingDecryptingPageDeserializer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/CompressingDecryptingPageDeserializer.java
@@ -344,6 +344,10 @@ public class CompressingDecryptingPageDeserializer
             }
 
             ReadBuffer source = buffers[buffers.length - 1];
+            if (source.available() == 0) {
+                return;
+            }
+
             ReadBuffer sink = buffers[buffers.length - 2];
             int bytesPreserved = sink.rollOver();
 
@@ -398,6 +402,10 @@ public class CompressingDecryptingPageDeserializer
             Decompressor decompressor = this.decompressor.get();
 
             ReadBuffer source = buffers[1];
+            if (source.available() == 0) {
+                return;
+            }
+
             ReadBuffer sink = buffers[0];
             int bytesPreserved = sink.rollOver();
 

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPagesSerde.java
@@ -180,6 +180,30 @@ public class TestPagesSerde
     }
 
     @Test
+    public void testSmallPageWithEncryption()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/23531
+        // Small pages that fit within a single encrypted block caused IndexOutOfBoundsException
+        // because decrypt() unconditionally read the next block header after all blocks were consumed.
+        SecretKey encryptionKey = createRandomAesEncryptionKey();
+        for (CompressionCodec compressionCodec : CompressionCodec.values()) {
+            // Use a large block size so the page fits in a single encrypted block
+            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(blockEncodingSerde, compressionCodec, 64 * 1024);
+            PageSerializer serializer = serdeFactory.createSerializer(Optional.of(encryptionKey));
+            PageDeserializer deserializer = serdeFactory.createDeserializer(Optional.of(encryptionKey));
+
+            // Single-row page is small enough to fit in one encrypted block
+            BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(1);
+            BIGINT.writeLong(builder, 42);
+            Page page = new Page(builder.build());
+
+            Slice serialized = serializer.serialize(page);
+            Page deserialized = deserializer.deserialize(serialized);
+            assertPageEquals(ImmutableList.of(BIGINT), deserialized, page);
+        }
+    }
+
+    @Test
     public void testBigintSerializedSize()
     {
         BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(5);


### PR DESCRIPTION
When fault-tolerant execution is enabled `(retry-policy=TASK)`, small pages that fit within a single encrypted block cause an `IndexOutOfBoundsException` during deserialization. This happens because `decrypt()` unconditionally reads the next encrypted block header from the source buffer without checking if the source has been fully consumed. When `ensureReadable()` triggers a second `decrypt()` call after all encrypted blocks have already been processed, `source.readInt()` reads past the end of the buffer.

Add an early return in both `decrypt()` and `decompress()` when their respective source buffers have no remaining data, which is the correct behavior when all blocks have been consumed.

Fixes https://github.com/trinodb/trino/issues/23531

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix `IndexOutOfBoundsException` during deserialization for fault-tolerant execution (https://github.com/trinodb/trino/issues/23531)
```
