### PR TITLE
Fix NULL grouping-key rows dropped by MultipleDistinctAggregationsToSubqueries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/MultipleDistinctAggregationsToSubqueries.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/MultipleDistinctAggregationsToSubqueries.java
@@ -16,11 +16,31 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slices;
 import io.trino.cost.TaskCountEstimator;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.metadata.Metadata;
+import io.trino.spi.type.AbstractIntType;
+import io.trino.spi.type.AbstractLongType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IsNull;
 import io.trino.sql.planner.NodeAndMappings;
 import io.trino.sql.planner.PlanCopier;
 import io.trino.sql.planner.Symbol;
@@ -41,10 +61,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.planner.iterative.rule.DistinctAggregationStrategyChooser.createDistinctAggregationStrategyChooser;
 import static io.trino.sql.planner.plan.JoinType.INNER;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
@@ -114,6 +134,17 @@ public class MultipleDistinctAggregationsToSubqueries
         if (!distinctAggregationStrategyChooser.shouldSplitToSubqueries(aggregationNode, context.getSession(), context.getStatsProvider(), context.getLookup())) {
             return Result.empty();
         }
+
+        // Null-safe join on the grouping keys requires a non-null sentinel value per key type
+        // (see buildJoin for details). If any grouping key has a type without a sentinel, skip
+        // the rewrite: a cross join would be required to preserve NULL groups, and that is
+        // not obviously better than the other distinct aggregation strategies.
+        for (Symbol groupingKey : aggregationNode.getGroupingKeys()) {
+            if (nullSentinel(groupingKey.type()).isEmpty()) {
+                return Result.empty();
+            }
+        }
+
         // group aggregations by arguments
         Map<Set<Expression>, Map<Symbol, Aggregation>> aggregationsByArguments = new LinkedHashMap<>(aggregationNode.getAggregations().size());
         // sort the aggregation by output symbol to have consistent join layout
@@ -181,18 +212,80 @@ public class MultipleDistinctAggregationsToSubqueries
     private JoinNode buildJoin(PlanNode left, List<Symbol> leftJoinSymbols, PlanNode right, List<Symbol> rightJoinSymbols, Context context)
     {
         checkArgument(leftJoinSymbols.size() == rightJoinSymbols.size());
-        List<EquiJoinClause> criteria = IntStream.range(0, leftJoinSymbols.size())
-                .mapToObj(i -> new EquiJoinClause(leftJoinSymbols.get(i), rightJoinSymbols.get(i)))
-                .collect(toImmutableList());
 
+        if (leftJoinSymbols.isEmpty()) {
+            // Global aggregation: both sides produce exactly one row, so a plain cross join suffices.
+            // TODO: we dont need dynamic filters for this join at all. We could add skipDf field to the JoinNode and make use of it in PredicatePushDown
+            return new JoinNode(
+                    context.getIdAllocator().getNextId(),
+                    INNER,
+                    left,
+                    right,
+                    ImmutableList.of(),
+                    left.getOutputSymbols(),
+                    right.getOutputSymbols(),
+                    false,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableMap.of(),
+                    Optional.empty());
+        }
+
+        // The join must match NULL grouping-key rows correctly. GROUP BY collapses NULL
+        // values into a single group, but SQL `=` (EquiJoinClause) evaluates NULL = NULL
+        // as UNKNOWN, dropping the NULL group.
+        //
+        // To preserve NULL groups while keeping hash-join O(N) performance, each grouping
+        // key k is projected to two non-nullable columns:
+        //   k_is_null  = (k IS NULL)                            -- BOOLEAN, always non-null
+        //   k_coalesced = COALESCE(k, <type_zero>)              -- same type as k, always non-null
+        //
+        // The join criteria are then (k_is_null_left = k_is_null_right) AND
+        // (k_coalesced_left = k_coalesced_right) for each key.  No collision is possible:
+        // null rows give (TRUE, zero) while a row with k = zero gives (FALSE, zero).
+        //
+        // apply() already guarantees that nullSentinel() is present for every grouping key
+        // type; otherwise the rule bails out.
+        ImmutableList.Builder<EquiJoinClause> criteriaBuilder = ImmutableList.builder();
+        Assignments.Builder leftNullSafeKeyProjections = Assignments.builder();
+        Assignments.Builder rightNullSafeKeyProjections = Assignments.builder();
+        for (int i = 0; i < leftJoinSymbols.size(); i++) {
+            Symbol leftKey = leftJoinSymbols.get(i);
+            Symbol rightKey = rightJoinSymbols.get(i);
+            Object sentinel = nullSentinel(leftKey.type())
+                    .orElseThrow(() -> new IllegalStateException("Missing null sentinel for grouping key type: " + leftKey.type()));
+
+            Symbol leftIsNullKey = context.getSymbolAllocator().newSymbol("null_key", BOOLEAN);
+            Symbol rightIsNullKey = context.getSymbolAllocator().newSymbol("null_key", BOOLEAN);
+            Symbol leftCoalescedKey = context.getSymbolAllocator().newSymbol("coalesced_key", leftKey.type());
+            Symbol rightCoalescedKey = context.getSymbolAllocator().newSymbol("coalesced_key", rightKey.type());
+
+            leftNullSafeKeyProjections.put(leftIsNullKey, new IsNull(leftKey.toSymbolReference()));
+            leftNullSafeKeyProjections.put(leftCoalescedKey, new Coalesce(ImmutableList.of(leftKey.toSymbolReference(), new Constant(leftKey.type(), sentinel))));
+            rightNullSafeKeyProjections.put(rightIsNullKey, new IsNull(rightKey.toSymbolReference()));
+            rightNullSafeKeyProjections.put(rightCoalescedKey, new Coalesce(ImmutableList.of(rightKey.toSymbolReference(), new Constant(rightKey.type(), sentinel))));
+
+            criteriaBuilder.add(new EquiJoinClause(leftIsNullKey, rightIsNullKey));
+            criteriaBuilder.add(new EquiJoinClause(leftCoalescedKey, rightCoalescedKey));
+        }
+
+        PlanNode leftProjected = new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                left,
+                Assignments.builder().putIdentities(left.getOutputSymbols()).putAll(leftNullSafeKeyProjections.build()).build());
+        PlanNode rightProjected = new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                right,
+                Assignments.builder().putIdentities(right.getOutputSymbols()).putAll(rightNullSafeKeyProjections.build()).build());
         // TODO: we dont need dynamic filters for this join at all. We could add skipDf field to the JoinNode and make use of it in PredicatePushDown
         return new JoinNode(
                 context.getIdAllocator().getNextId(),
                 INNER,
-                left,
-                right,
-                criteria,
-                left.getOutputSymbols(),
+                leftProjected,
+                rightProjected,
+                criteriaBuilder.build(),
+                left.getOutputSymbols(),   // original symbols only in output
                 right.getOutputSymbols(),
                 false, // since we only work on global aggregation or grouped rows, there are no duplicates, so we don't have to skip it
                 Optional.empty(),
@@ -200,5 +293,44 @@ public class MultipleDistinctAggregationsToSubqueries
                 Optional.empty(),
                 ImmutableMap.of(),
                 Optional.empty());
+    }
+
+    /**
+     * Returns a non-null sentinel value for {@code type} suitable for use in
+     * {@code COALESCE(k, sentinel)} when building null-safe equi-join keys.
+     * Returns an empty {@link Optional} if no sentinel is available for this type.
+     */
+    static Optional<Object> nullSentinel(Type type)
+    {
+        // AbstractIntType covers DateType, IntegerType, RealType (REAL stores float as int bits packed in a long -> 0L == 0.0f)
+        // AbstractLongType covers BigintType and TimeType
+        if (type instanceof AbstractIntType || type instanceof AbstractLongType
+                || type instanceof SmallintType || type instanceof TinyintType) {
+            return Optional.of(0L);
+        }
+        if (type instanceof BooleanType) {
+            return Optional.of(false);
+        }
+        if (type instanceof DoubleType) {
+            return Optional.of(0.0d);
+        }
+        if (type instanceof VarcharType || type instanceof CharType) {
+            return Optional.of(Slices.EMPTY_SLICE);
+        }
+        if (type instanceof TimestampType timestampType) {
+            // Short precision (<=6) is stored as a long (epoch micros).
+            // Long precision (>6) is stored as LongTimestamp(epochMicros, picosOfMicro).
+            return Optional.of(timestampType.isShort() ? 0L : new LongTimestamp(0, 0));
+        }
+        if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
+            // Short precision (<=3) is stored as a packed long (millis + zone key).
+            // Long precision (>3) is stored as LongTimestampWithTimeZone.
+            return Optional.of(timestampWithTimeZoneType.isShort() ? 0L
+                    : LongTimestampWithTimeZone.fromEpochMillisAndFraction(0, 0, TimeZoneKey.UTC_KEY));
+        }
+        if (type instanceof DecimalType decimalType) {
+            return Optional.of(decimalType.isShort() ? 0L : Int128.ZERO);
+        }
+        return Optional.empty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMultipleDistinctAggregationsToSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestMultipleDistinctAggregationsToSubqueries.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.connector.MockConnectorColumnHandle;
 import io.trino.connector.MockConnectorFactory;
@@ -32,8 +33,16 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Type;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.IsNull;
@@ -59,13 +68,24 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static io.trino.SystemSessionProperties.DISTINCT_AGGREGATIONS_STRATEGY;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
@@ -77,6 +97,7 @@ import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static io.trino.sql.planner.plan.AggregationNode.groupingSets;
 import static io.trino.sql.planner.plan.JoinType.INNER;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMultipleDistinctAggregationsToSubqueries
         extends BaseRuleTest
@@ -118,6 +139,44 @@ public class TestMultipleDistinctAggregationsToSubqueries
     {
         closeAllRuntimeException(ruleTester);
         ruleTester = null;
+    }
+
+    @Test
+    public void testNullSentinelCoversSupportedTypes()
+    {
+        // Scalar types the rule must handle: verify each produces a non-null sentinel
+        // of the correct native representation for Constant(type, value).
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(BIGINT)).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(INTEGER)).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(SMALLINT)).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(TINYINT)).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(BOOLEAN)).hasValue(false);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(DOUBLE)).hasValue(0.0d);
+        // REAL stores float as raw-int bits packed in a long; 0L == floatToRawIntBits(0.0f)
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(REAL)).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(DATE)).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(VARCHAR)).hasValue(Slices.EMPTY_SLICE);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createCharType(10))).hasValue(Slices.EMPTY_SLICE);
+        // Short-precision timestamps are stored as long
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampType(3))).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampType(6))).hasValue(0L);
+        // Long-precision timestamps use LongTimestamp
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampType(9))).hasValue(new LongTimestamp(0, 0));
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampType(12))).hasValue(new LongTimestamp(0, 0));
+        // Short-precision TSWTZ is stored as packed long
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampWithTimeZoneType(3))).hasValue(0L);
+        // Long-precision TSWTZ uses LongTimestampWithTimeZone
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampWithTimeZoneType(6)))
+                .hasValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(0, 0, TimeZoneKey.UTC_KEY));
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createTimestampWithTimeZoneType(9)))
+                .hasValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(0, 0, TimeZoneKey.UTC_KEY));
+        // Short decimal stored as long, long decimal as Int128
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createDecimalType(10, 2))).hasValue(0L);
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(createDecimalType(38, 2))).hasValue(Int128.ZERO);
+
+        // Complex types don't have a readily available sentinel -> rule must bail out.
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(RowType.anonymous(ImmutableList.of(BIGINT)))).isEmpty();
+        assertThat(MultipleDistinctAggregationsToSubqueries.nullSentinel(new ArrayType(BIGINT))).isEmpty();
     }
 
     @Test
@@ -332,6 +391,24 @@ public class TestMultipleDistinctAggregationsToSubqueries
                                                     input2Symbol, COLUMN_2_HANDLE)))));
                 })
                 .doesNotFire();
+
+        // grouping key type without a null sentinel (ROW): rule must skip because NULL-safe
+        // equi-join cannot be built, and a cross-join fallback is not obviously better than
+        // other distinct aggregation strategies.
+        Type rowType = RowType.anonymous(ImmutableList.of(BIGINT));
+        ruleTester.assertThat(newMultipleDistinctAggregationsToSubqueries(ruleTester))
+                .setSystemProperty(DISTINCT_AGGREGATIONS_STRATEGY, "split_to_subqueries")
+                .on(p -> {
+                    Symbol input1Symbol = p.symbol("input1Symbol", BIGINT);
+                    Symbol input2Symbol = p.symbol("input2Symbol", BIGINT);
+                    Symbol groupingKey = p.symbol("groupingKey", rowType);
+                    return p.aggregation(builder -> builder
+                            .singleGroupingSet(groupingKey)
+                            .addAggregation(p.symbol("output1", BIGINT), PlanBuilder.aggregation("count", true, ImmutableList.of(new Reference(BIGINT, "input1Symbol"))), ImmutableList.of(BIGINT))
+                            .addAggregation(p.symbol("output2", BIGINT), PlanBuilder.aggregation("sum", true, ImmutableList.of(new Reference(BIGINT, "input2Symbol"))), ImmutableList.of(BIGINT))
+                            .source(p.values(input1Symbol, input2Symbol, groupingKey)));
+                })
+                .doesNotFire();
     }
 
     @Test
@@ -393,27 +470,37 @@ public class TestMultipleDistinctAggregationsToSubqueries
                         join(
                                 INNER,
                                 builder -> builder
-                                        .equiCriteria("left_groupingKey", "right_groupingKey")
-                                        .left(aggregation(
-                                                singleGroupingSet("left_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                tableScan(
-                                                        TABLE_SCHEMA.getTableName(),
-                                                        ImmutableMap.of(
-                                                                "input1Symbol", COLUMN_1,
-                                                                "left_groupingKey", GROUPING_KEY_COLUMN))))
-                                        .right(aggregation(
-                                                singleGroupingSet("right_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                tableScan(
-                                                        TABLE_SCHEMA.getTableName(),
-                                                        ImmutableMap.of(
-                                                                "input2Symbol", COLUMN_2,
-                                                                "right_groupingKey", GROUPING_KEY_COLUMN)))))));
+                                        .equiCriteria(ImmutableList.of(
+                                                equiJoinClause("left_null_key", "right_null_key"),
+                                                equiJoinClause("left_coalesced_key", "right_coalesced_key")))
+                                        .left(project(
+                                                ImmutableMap.of(
+                                                        "left_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "left_groupingKey"))),
+                                                        "left_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "left_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("left_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        tableScan(
+                                                                TABLE_SCHEMA.getTableName(),
+                                                                ImmutableMap.of(
+                                                                        "input1Symbol", COLUMN_1,
+                                                                        "left_groupingKey", GROUPING_KEY_COLUMN)))))
+                                        .right(project(
+                                                ImmutableMap.of(
+                                                        "right_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "right_groupingKey"))),
+                                                        "right_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "right_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("right_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        tableScan(
+                                                                TABLE_SCHEMA.getTableName(),
+                                                                ImmutableMap.of(
+                                                                        "input2Symbol", COLUMN_2,
+                                                                        "right_groupingKey", GROUPING_KEY_COLUMN))))))));
 
         // single_step is not preferred, the overhead of groupingKeys is bigger than 50%
         String aggregationId = "aggregationId";
@@ -617,33 +704,43 @@ public class TestMultipleDistinctAggregationsToSubqueries
                         join(
                                 INNER,
                                 builder -> builder
-                                        .equiCriteria("left_groupingKey", "right_groupingKey")
-                                        .left(aggregation(
-                                                singleGroupingSet("left_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                filter(
-                                                        not(ruleTester.getMetadata(), new IsNull(new Reference(BIGINT, "left_filterInput"))),
-                                                        tableScan(
-                                                                TABLE_SCHEMA.getTableName(),
-                                                                ImmutableMap.of(
-                                                                        "input1Symbol", COLUMN_1,
-                                                                        "left_groupingKey", GROUPING_KEY_COLUMN,
-                                                                        "left_filterInput", GROUPING_KEY2_COLUMN)))))
-                                        .right(aggregation(
-                                                singleGroupingSet("right_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                filter(
-                                                        not(ruleTester.getMetadata(), new IsNull(new Reference(BIGINT, "right_filterInput"))),
-                                                        tableScan(
-                                                                TABLE_SCHEMA.getTableName(),
-                                                                ImmutableMap.of(
-                                                                        "input2Symbol", COLUMN_2,
-                                                                        "right_groupingKey", GROUPING_KEY_COLUMN,
-                                                                        "right_filterInput", GROUPING_KEY2_COLUMN))))))));
+                                        .equiCriteria(ImmutableList.of(
+                                                equiJoinClause("left_null_key", "right_null_key"),
+                                                equiJoinClause("left_coalesced_key", "right_coalesced_key")))
+                                        .left(project(
+                                                ImmutableMap.of(
+                                                        "left_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "left_groupingKey"))),
+                                                        "left_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "left_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("left_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        filter(
+                                                                not(ruleTester.getMetadata(), new IsNull(new Reference(BIGINT, "left_filterInput"))),
+                                                                tableScan(
+                                                                        TABLE_SCHEMA.getTableName(),
+                                                                        ImmutableMap.of(
+                                                                                "input1Symbol", COLUMN_1,
+                                                                                "left_groupingKey", GROUPING_KEY_COLUMN,
+                                                                                "left_filterInput", GROUPING_KEY2_COLUMN))))))
+                                        .right(project(
+                                                ImmutableMap.of(
+                                                        "right_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "right_groupingKey"))),
+                                                        "right_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "right_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("right_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        filter(
+                                                                not(ruleTester.getMetadata(), new IsNull(new Reference(BIGINT, "right_filterInput"))),
+                                                                tableScan(
+                                                                        TABLE_SCHEMA.getTableName(),
+                                                                        ImmutableMap.of(
+                                                                                "input2Symbol", COLUMN_2,
+                                                                                "right_groupingKey", GROUPING_KEY_COLUMN,
+                                                                                "right_filterInput", GROUPING_KEY2_COLUMN)))))))));
     }
 
     @Test
@@ -918,27 +1015,37 @@ public class TestMultipleDistinctAggregationsToSubqueries
                         join(
                                 INNER,
                                 builder -> builder
-                                        .equiCriteria("left_groupingKey", "right_groupingKey")
-                                        .left(aggregation(
-                                                singleGroupingSet("left_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                tableScan(
-                                                        TABLE_SCHEMA.getTableName(),
-                                                        ImmutableMap.of(
-                                                                "input1Symbol", COLUMN_1,
-                                                                "left_groupingKey", GROUPING_KEY_COLUMN))))
-                                        .right(aggregation(
-                                                singleGroupingSet("right_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                tableScan(
-                                                        TABLE_SCHEMA.getTableName(),
-                                                        ImmutableMap.of(
-                                                                "input2Symbol", COLUMN_2,
-                                                                "right_groupingKey", GROUPING_KEY_COLUMN)))))));
+                                        .equiCriteria(ImmutableList.of(
+                                                equiJoinClause("left_null_key", "right_null_key"),
+                                                equiJoinClause("left_coalesced_key", "right_coalesced_key")))
+                                        .left(project(
+                                                ImmutableMap.of(
+                                                        "left_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "left_groupingKey"))),
+                                                        "left_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "left_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("left_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        tableScan(
+                                                                TABLE_SCHEMA.getTableName(),
+                                                                ImmutableMap.of(
+                                                                        "input1Symbol", COLUMN_1,
+                                                                        "left_groupingKey", GROUPING_KEY_COLUMN)))))
+                                        .right(project(
+                                                ImmutableMap.of(
+                                                        "right_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "right_groupingKey"))),
+                                                        "right_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "right_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("right_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        tableScan(
+                                                                TABLE_SCHEMA.getTableName(),
+                                                                ImmutableMap.of(
+                                                                        "input2Symbol", COLUMN_2,
+                                                                        "right_groupingKey", GROUPING_KEY_COLUMN))))))));
     }
 
     @Test
@@ -1002,57 +1109,67 @@ public class TestMultipleDistinctAggregationsToSubqueries
                         join(
                                 INNER,
                                 builder -> builder
-                                        .equiCriteria("left_groupingKey", "right_groupingKey")
-                                        .left(aggregation(
-                                                singleGroupingSet("left_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol1")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                union(
-                                                        filter(
-                                                                new Comparison(GREATER_THAN, new Reference(BIGINT, "input1_1_1Symbol"), new Constant(BIGINT, 0L)),
-                                                                tableScan(
-                                                                        TABLE_SCHEMA.getTableName(),
-                                                                        ImmutableMap.of(
-                                                                                "input1_1_1Symbol", COLUMN_1,
-                                                                                "input2_1_1Symbol", COLUMN_2,
-                                                                                "left_groupingKey1", GROUPING_KEY_COLUMN))),
-                                                        filter(
-                                                                new Comparison(GREATER_THAN, new Reference(BIGINT, "input2_2_1Symbol"), new Constant(BIGINT, 2L)),
-                                                                tableScan(
-                                                                        TABLE_SCHEMA.getTableName(),
-                                                                        ImmutableMap.of(
-                                                                                "input1_2_1Symbol", COLUMN_1,
-                                                                                "input2_2_1Symbol", COLUMN_2,
-                                                                                "left_groupingKey2", GROUPING_KEY_COLUMN))))
-                                                        .withAlias("input1Symbol1", new SetOperationOutputMatcher(0))
-                                                        .withAlias("input2Symbol1", new SetOperationOutputMatcher(1))
-                                                        .withAlias("left_groupingKey", new SetOperationOutputMatcher(2))))
-                                        .right(aggregation(
-                                                singleGroupingSet("right_groupingKey"),
-                                                ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol2")))),
-                                                Optional.empty(),
-                                                SINGLE,
-                                                union(
-                                                        filter(
-                                                                new Comparison(GREATER_THAN, new Reference(BIGINT, "input1_1_2Symbol"), new Constant(BIGINT, 0L)),
-                                                                tableScan(
-                                                                        TABLE_SCHEMA.getTableName(),
-                                                                        ImmutableMap.of(
-                                                                                "input1_1_2Symbol", COLUMN_1,
-                                                                                "input2_1_2Symbol", COLUMN_2,
-                                                                                "right_groupingKey1", GROUPING_KEY_COLUMN))),
-                                                        filter(
-                                                                new Comparison(GREATER_THAN, new Reference(BIGINT, "input2_2_2Symbol"), new Constant(BIGINT, 2L)),
-                                                                tableScan(
-                                                                        TABLE_SCHEMA.getTableName(),
-                                                                        ImmutableMap.of(
-                                                                                "input1_2_2Symbol", COLUMN_1,
-                                                                                "input2_2_2Symbol", COLUMN_2,
-                                                                                "right_groupingKey2", GROUPING_KEY_COLUMN))))
-                                                        .withAlias("input1Symbol2", new SetOperationOutputMatcher(0))
-                                                        .withAlias("input2Symbol2", new SetOperationOutputMatcher(1))
-                                                        .withAlias("right_groupingKey", new SetOperationOutputMatcher(2)))))));
+                                        .equiCriteria(ImmutableList.of(
+                                                equiJoinClause("left_null_key", "right_null_key"),
+                                                equiJoinClause("left_coalesced_key", "right_coalesced_key")))
+                                        .left(project(
+                                                ImmutableMap.of(
+                                                        "left_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "left_groupingKey"))),
+                                                        "left_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "left_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("left_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output1"), aggregationFunction("count", true, ImmutableList.of(symbol("input1Symbol1")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        union(
+                                                                filter(
+                                                                        new Comparison(GREATER_THAN, new Reference(BIGINT, "input1_1_1Symbol"), new Constant(BIGINT, 0L)),
+                                                                        tableScan(
+                                                                                TABLE_SCHEMA.getTableName(),
+                                                                                ImmutableMap.of(
+                                                                                        "input1_1_1Symbol", COLUMN_1,
+                                                                                        "input2_1_1Symbol", COLUMN_2,
+                                                                                        "left_groupingKey1", GROUPING_KEY_COLUMN))),
+                                                                filter(
+                                                                        new Comparison(GREATER_THAN, new Reference(BIGINT, "input2_2_1Symbol"), new Constant(BIGINT, 2L)),
+                                                                        tableScan(
+                                                                                TABLE_SCHEMA.getTableName(),
+                                                                                ImmutableMap.of(
+                                                                                        "input1_2_1Symbol", COLUMN_1,
+                                                                                        "input2_2_1Symbol", COLUMN_2,
+                                                                                        "left_groupingKey2", GROUPING_KEY_COLUMN))))
+                                                                .withAlias("input1Symbol1", new SetOperationOutputMatcher(0))
+                                                                .withAlias("input2Symbol1", new SetOperationOutputMatcher(1))
+                                                                .withAlias("left_groupingKey", new SetOperationOutputMatcher(2)))))
+                                        .right(project(
+                                                ImmutableMap.of(
+                                                        "right_null_key", PlanMatchPattern.expression(new IsNull(new Reference(BIGINT, "right_groupingKey"))),
+                                                        "right_coalesced_key", PlanMatchPattern.expression(new Coalesce(new Reference(BIGINT, "right_groupingKey"), new Constant(BIGINT, 0L)))),
+                                                aggregation(
+                                                        singleGroupingSet("right_groupingKey"),
+                                                        ImmutableMap.of(Optional.of("output2"), aggregationFunction("sum", true, ImmutableList.of(symbol("input2Symbol2")))),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        union(
+                                                                filter(
+                                                                        new Comparison(GREATER_THAN, new Reference(BIGINT, "input1_1_2Symbol"), new Constant(BIGINT, 0L)),
+                                                                        tableScan(
+                                                                                TABLE_SCHEMA.getTableName(),
+                                                                                ImmutableMap.of(
+                                                                                        "input1_1_2Symbol", COLUMN_1,
+                                                                                        "input2_1_2Symbol", COLUMN_2,
+                                                                                        "right_groupingKey1", GROUPING_KEY_COLUMN))),
+                                                                filter(
+                                                                        new Comparison(GREATER_THAN, new Reference(BIGINT, "input2_2_2Symbol"), new Constant(BIGINT, 2L)),
+                                                                        tableScan(
+                                                                                TABLE_SCHEMA.getTableName(),
+                                                                                ImmutableMap.of(
+                                                                                        "input1_2_2Symbol", COLUMN_1,
+                                                                                        "input2_2_2Symbol", COLUMN_2,
+                                                                                        "right_groupingKey2", GROUPING_KEY_COLUMN))))
+                                                                .withAlias("input1Symbol2", new SetOperationOutputMatcher(0))
+                                                                .withAlias("input2Symbol2", new SetOperationOutputMatcher(1))
+                                                                .withAlias("right_groupingKey", new SetOperationOutputMatcher(2))))))));
     }
 
     private static MultipleDistinctAggregationsToSubqueries newMultipleDistinctAggregationsToSubqueries(RuleTester ruleTester)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -391,6 +391,42 @@ public abstract class AbstractTestAggregations
         assertQuery("select a, array_agg(b), array_agg(distinct c) from (values (1,1,1)) t(a,b,c) group by a");
     }
 
+    // Regression: MultipleDistinctAggregationsToSubqueries rewrites a grouped multi-distinct
+    // aggregation into an INNER JOIN on the grouping keys. The join criteria must be null-safe
+    // so rows belonging to the NULL grouping-key group are preserved.  Prior to the fix,
+    // SQL `=` in EquiJoinClause dropped the NULL group silently.
+    @Test
+    public void testMultipleDistinctAggregationsPreserveNullGroupKey()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(DISTINCT_AGGREGATIONS_STRATEGY, "split_to_subqueries")
+                .build();
+
+        // nation has 25 rows with regionkey in {0..4}; the CASE nulls regionkey for values > 1,
+        // yielding three groups: 0 (5 rows), 1 (5 rows), NULL (15 rows).
+        assertQuery(
+                session,
+                "SELECT regionkey, count(DISTINCT name), count(DISTINCT nationkey) " +
+                        "FROM (SELECT nationkey, name, CASE WHEN regionkey > 1 THEN NULL ELSE regionkey END AS regionkey FROM nation) n " +
+                        "GROUP BY regionkey",
+                "VALUES (CAST(0 AS BIGINT), CAST(5 AS BIGINT), CAST(5 AS BIGINT)), " +
+                        "       (CAST(1 AS BIGINT), CAST(5 AS BIGINT), CAST(5 AS BIGINT)), " +
+                        "       (CAST(NULL AS BIGINT), CAST(15 AS BIGINT), CAST(15 AS BIGINT))");
+
+        assertQuery(
+                session,
+                "SELECT regionkey, count(DISTINCT name), count(DISTINCT nationkey) " +
+                        "FROM (" +
+                        "    SELECT nationkey, name, " +
+                        "           CASE WHEN regionkey > 1 THEN NULL ELSE to_utf8(CAST(regionkey AS VARCHAR)) END AS regionkey_bytes, " +
+                        "           CASE WHEN regionkey > 1 THEN NULL ELSE CAST(regionkey AS VARCHAR) END AS regionkey " +
+                        "    FROM nation) n " +
+                        "GROUP BY regionkey_bytes, regionkey",
+                "VALUES ('0', CAST(5 AS BIGINT), CAST(5 AS BIGINT)), " +
+                        "       ('1', CAST(5 AS BIGINT), CAST(5 AS BIGINT)), " +
+                        "       (CAST(NULL AS VARCHAR), CAST(15 AS BIGINT), CAST(15 AS BIGINT))");
+    }
+
     @Test
     public void testDistinctAndNonDistinctAggregationOnTheSameColumn()
     {


### PR DESCRIPTION
## Description

`MultipleDistinctAggregationsToSubqueries` rewrites a grouped multi-distinct aggregation such as

```sql
SELECT k, count(DISTINCT a), count(DISTINCT b)
FROM t
GROUP BY k
```

into an `INNER JOIN` of sub-aggregations joined on the grouping keys. The join used regular equi-criteria, so rows belonging to the `NULL` grouping-key group did not match across sub-aggregations. `GROUP BY` collapses `NULL` values into a single group, but `NULL = NULL` is UNKNOWN, so the join could silently drop the `NULL` group.

Reproducer:

```sql
CREATE TABLE iceberg.test.null_group_sales (region VARCHAR, customer_id BIGINT, product_id BIGINT);
INSERT INTO iceberg.test.null_group_sales VALUES
    ('US', 1, 100),
    ('EU', 2, 200),
    (NULL, 3, 300),
    (NULL, 4, 400),
    (NULL, 3, 500);

WITH SESSION distinct_aggregations_strategy = 'split_to_subqueries'
SELECT region, count(DISTINCT customer_id), count(DISTINCT product_id)
FROM iceberg.test.null_group_sales
GROUP BY region;
```

Expected:

```text
 region | _col1 | _col2
--------+-------+-------
 US     |   1   |   1
 EU     |   1   |   1
 NULL   |   2   |   3
```

Actual before this fix: the `NULL` group is missing.

## Fix

For each grouping key `k`, project two non-null join keys on both sides:

```text
k_is_null   = k IS NULL
k_coalesced = COALESCE(k, <type sentinel>)
```

Then join on both symbols. This keeps the plan as a hashable equi-join and distinguishes real sentinel values from `NULL` rows: `NULL` becomes `(TRUE, sentinel)`, while a real sentinel value becomes `(FALSE, sentinel)`.

If any grouping key type has no native sentinel, skip this rewrite. That avoids replacing the rewrite with a cross join that is not obviously better than the other distinct aggregation strategies. Global aggregations with no grouping keys still use a plain cross join of the single-row sub-aggregations.

## Additional context and related issues

- The bug is reachable on the default path. `DistinctAggregationsStrategy` defaults to `AUTOMATIC`, and `DistinctAggregationStrategyChooser#chooseMarkDistinctStrategy` can auto-select `SPLIT_TO_SUBQUERIES` for multi-distinct grouped aggregations over simple sources with low/unknown NDV.
- Existing connector tests in `TestDistinctToSubqueriesAggregations` run against TPC-H tables, where every column is `NOT NULL` by spec, so the `NULL` grouping-key path was not exercised before.
- Added regression coverage in `AbstractTestAggregations#testMultipleDistinctAggregationsPreserveNullGroupKey`, using TPC-H `nation` under `split_to_subqueries`.
- Added coverage for an unsupported/no-sentinel `VARBINARY` grouping key to verify the rule skips the rewrite correctly.
- Updated rule tests to assert sentinel support, unsupported types, and the null-safe equi-join shape.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix incorrect results for queries that combine multiple `DISTINCT` aggregations with a `GROUP BY` on a nullable column. Previously, rows with `NULL` in the grouping key could be silently dropped when the `split_to_subqueries` strategy (including automatic selection) was used.
```
