### PR TITLE
Make gcs.json-key-file-path optional for Iceberg REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -578,6 +578,11 @@ fs.gcs.enabled=true
 gcs.json-key-file-path=/path/to/gcs_keyfile.json
 ```
 
+`gcs.json-key-file-path` is optional. When omitted, [Application Default
+Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+(ADC) are used, which supports GKE Workload Identity and other
+environment-based credential sources.
+
 The REST catalog supports [view management](sql-view-management) 
 using the [Iceberg View specification](https://iceberg.apache.org/view-spec/).
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
@@ -30,11 +30,13 @@ public class GoogleAuthProperties
     @Inject
     public GoogleAuthProperties(GoogleSecurityConfig config)
     {
-        properties = ImmutableMap.<String, String>builder()
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
                 .put(AUTH_TYPE, AUTH_TYPE_GOOGLE)
-                .put(GCP_CREDENTIALS_PATH_PROPERTY, config.getJsonKeyFilePath())
-                .put("header.x-goog-user-project", config.getProjectId())
-                .buildOrThrow();
+                .put("header.x-goog-user-project", config.getProjectId());
+        if (config.getJsonKeyFilePath() != null) {
+            builder.put(GCP_CREDENTIALS_PATH_PROPERTY, config.getJsonKeyFilePath());
+        }
+        properties = builder.buildOrThrow();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
@@ -30,11 +30,11 @@ public class GoogleAuthProperties
     @Inject
     public GoogleAuthProperties(GoogleSecurityConfig config)
     {
-        properties = ImmutableMap.<String, String>builder()
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
                 .put(AUTH_TYPE, AUTH_TYPE_GOOGLE)
-                .put(GCP_CREDENTIALS_PATH_PROPERTY, config.getJsonKeyFilePath())
-                .put("header.x-goog-user-project", config.getProjectId())
-                .buildOrThrow();
+                .put("header.x-goog-user-project", config.getProjectId());
+        config.getJsonKeyFilePath().ifPresent(path -> builder.put(GCP_CREDENTIALS_PATH_PROPERTY, path));
+        properties = builder.buildOrThrow();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.rest;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 
 public class GoogleSecurityConfig
@@ -37,14 +38,15 @@ public class GoogleSecurityConfig
         return this;
     }
 
-    @NotNull
+    @Nullable
     @FileExists
     public String getJsonKeyFilePath()
     {
         return jsonKeyFilePath;
     }
 
-    // Duplicated from GcsFileSystemConfig to enforce the property in BigLake metastore
+    // Duplicated from GcsFileSystemConfig. When null, Application Default Credentials (ADC) are used,
+    // which enables GKE Workload Identity and environment-based credential sources.
     @Config("gcs.json-key-file-path")
     @ConfigDescription("JSON key file used to access Google Cloud Storage")
     public GoogleSecurityConfig setJsonKeyFilePath(String jsonKeyFilePath)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
@@ -18,6 +18,8 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.Optional;
+
 public class GoogleSecurityConfig
 {
     private String projectId;
@@ -37,14 +39,13 @@ public class GoogleSecurityConfig
         return this;
     }
 
-    @NotNull
-    @FileExists
-    public String getJsonKeyFilePath()
+    // Duplicated from GcsFileSystemConfig. When absent, Application Default Credentials (ADC) are used,
+    // which enables GKE Workload Identity and environment-based credential sources.
+    public Optional<@FileExists String> getJsonKeyFilePath()
     {
-        return jsonKeyFilePath;
+        return Optional.ofNullable(jsonKeyFilePath);
     }
 
-    // Duplicated from GcsFileSystemConfig to enforce the property in BigLake metastore
     @Config("gcs.json-key-file-path")
     @ConfigDescription("JSON key file used to access Google Cloud Storage")
     public GoogleSecurityConfig setJsonKeyFilePath(String jsonKeyFilePath)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -259,6 +259,23 @@ public class TestIcebergPlugin
     }
 
     @Test
+    void testRestCatalogWithBigLakeMetastoreUsingApplicationDefaultCredentials()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+        factory.create(
+                        "test",
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", "https://foo:1234")
+                                .put("iceberg.rest-catalog.security", "GOOGLE")
+                                .put("iceberg.rest-catalog.google-project-id", "dev")
+                                .put("bootstrap.quiet", "true")
+                                .buildOrThrow(),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+
+    @Test
     public void testRestCatalogValidations()
     {
         ConnectorFactory factory = getConnectorFactory();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestGoogleAuthProperties.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestGoogleAuthProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.apache.iceberg.gcp.auth.GoogleAuthManager.GCP_CREDENTIALS_PATH_PROPERTY;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE;
+import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE_GOOGLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestGoogleAuthProperties
+{
+    @Test
+    void testApplicationDefaultCredentials()
+    {
+        GoogleSecurityConfig config = new GoogleSecurityConfig()
+                .setProjectId("my-project");
+        // jsonKeyFilePath intentionally omitted to use Workload Identity / ADC
+
+        Map<String, String> properties = new GoogleAuthProperties(config).get();
+
+        assertThat(properties).containsEntry(AUTH_TYPE, AUTH_TYPE_GOOGLE);
+        assertThat(properties).containsEntry("header.x-goog-user-project", "my-project");
+        assertThat(properties).doesNotContainKey(GCP_CREDENTIALS_PATH_PROPERTY);
+    }
+
+    @Test
+    void testServiceAccountJsonKeyFile(@TempDir Path tempDir)
+            throws IOException
+    {
+        Path keyFile = Files.createFile(tempDir.resolve("key.json"));
+        GoogleSecurityConfig config = new GoogleSecurityConfig()
+                .setProjectId("my-project")
+                .setJsonKeyFilePath(keyFile.toString());
+
+        Map<String, String> properties = new GoogleAuthProperties(config).get();
+
+        assertThat(properties).containsEntry(AUTH_TYPE, AUTH_TYPE_GOOGLE);
+        assertThat(properties).containsEntry("header.x-goog-user-project", "my-project");
+        assertThat(properties).containsEntry(GCP_CREDENTIALS_PATH_PROPERTY, keyFile.toString());
+    }
+}


### PR DESCRIPTION
## Description

When using `iceberg.rest-catalog.security=GOOGLE`, the `gcs.json-key-file-path` property was validated as mandatory by `GoogleSecurityConfig`, causing the server to fail at startup when the property was omitted. This prevented use of GKE Workload Identity or environment-based Application Default Credentials (ADC), forcing users to provision and mount physical Service Account JSON key files — contrary to GCP security best practices.

The underlying Iceberg library (`GoogleAuthManager`) already handles a null/absent credentials path by falling through to `GoogleCredentials.getApplicationDefault()`. The fix:

- Replaces `@NotNull` with `@Nullable` on `getJsonKeyFilePath()` in `GoogleSecurityConfig` (retaining `@FileExists` so the path is still validated when provided — consistent with the `@Nullable @FileExists` pattern used in `GcsServiceAccountAuthConfig`)
- Conditionally adds `GCP_CREDENTIALS_PATH_PROPERTY` to the REST catalog auth properties map only when a key file path is provided
- Adds `TestGoogleAuthProperties` covering both the ADC path and the explicit key file path

## Additional context and related issues

- Fixes #29084

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support for Workload Identity or Application Default Credentials in BigLake metastore. ({issue}`29084`)
```
