### PR TITLE
Add support for running Trino in OpenShift

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN \
       curl-minimal grep `# required by health-check` \
       zlib `#required by java` \
       shadow-utils `# required by useradd` \
+      nss_wrapper `# required by run-trino to fake passwd entry on OpenShift` \
       tar `# required to support kubectl cp` && \
       rm -rf /tmp/overlay/var/cache/*
 

--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -62,13 +62,15 @@ RUN \
     groupadd trino --gid 1000 && \
     useradd trino --uid 1000 --gid 1000 --create-home && \
     mkdir -p /usr/lib/trino /data/trino && \
-    chown -R "trino:trino" /usr/lib/trino /data/trino
+    chown -R "trino:0" /usr/lib/trino /data/trino
 
-COPY --chown=trino:trino trino-cli.jar /usr/bin/trino
-COPY --chown=trino:trino --exclude=bin/darwin-* --exclude=bin/linux-* trino-server /usr/lib/trino
-COPY --chown=trino:trino trino-server/bin/linux-${ARCH} /usr/lib/trino/bin/linux-${ARCH}
-COPY --chown=trino:trino default/etc /etc/trino
-COPY --chown=trino:trino --from=jvmkill /libjvmkill.so /usr/lib/trino/bin
+COPY --chown=trino:0 trino-cli.jar /usr/bin/trino
+COPY --chown=trino:0 --exclude=bin/darwin-* --exclude=bin/linux-* trino-server /usr/lib/trino
+COPY --chown=trino:0 trino-server/bin/linux-${ARCH} /usr/lib/trino/bin/linux-${ARCH}
+COPY --chown=trino:0 default/etc /etc/trino
+COPY --chown=trino:0 --from=jvmkill /libjvmkill.so /usr/lib/trino/bin
+
+RUN chmod -R g=u /usr/lib/trino /data/trino /usr/bin/trino /etc/trino
 
 EXPOSE 8080
 USER trino:trino

--- a/core/docker/bin/run-trino
+++ b/core/docker/bin/run-trino
@@ -2,6 +2,33 @@
 
 set -xeuo pipefail
 
+myuid="$(id -u)"
+mygid="$(id -g)"
+username="${TRINO_USER_NAME:-trino}"
+
+# Force NSS to report $username as the name for our UID, regardless of
+# whether CRI-O has auto-injected a numeric-named entry in /etc/passwd
+# (as happens on OpenShift with random UIDs).
+if [ "$(id -un 2>/dev/null || true)" != "$username" ]; then
+    for wrapper in {/usr,}/lib{64,,/*}/libnss_wrapper.so; do
+        if [ -s "$wrapper" ]; then
+            NSS_WRAPPER_PASSWD="$(mktemp)"
+            NSS_WRAPPER_GROUP="$(mktemp)"
+            # Seed from the container's passwd/group (may include CRI-O's
+            # numeric-named entry), drop any line matching our UID/GID, then
+            # add the $username entry so NSS lookups resolve to it.
+            grep -v "^[^:]*:x:${myuid}:" /etc/passwd > "$NSS_WRAPPER_PASSWD" || true
+            printf '%s:x:%s:%s:Trino:/home/trino:/bin/false\n' \
+                "$username" "$myuid" "$mygid" >> "$NSS_WRAPPER_PASSWD"
+            grep -v "^[^:]*:x:${mygid}:" /etc/group > "$NSS_WRAPPER_GROUP" || true
+            printf '%s:x:%s:\n' "$username" "$mygid" >> "$NSS_WRAPPER_GROUP"
+            export NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+            export LD_PRELOAD="${wrapper}${LD_PRELOAD:+:$LD_PRELOAD}"
+            break
+        fi
+    done
+fi
+
 launcher_opts=(--etc-dir /etc/trino)
 if ! grep -s -q 'node.id' /etc/trino/node.properties; then
     launcher_opts+=("-Dnode.id=${HOSTNAME}")


### PR DESCRIPTION
## Description

Trino images do not currently work in Openshift. The core issue is that Openshift run
Pods/Containers as a random UID while Trino image assumes user 'trino' has specific
permissions on certain directories, for instance `/data/trino`

This PR uses Openshift best practices to make files and directories owned by
`trino:0` and make the owner and group permissions the same.

Additionally, this patch installs `nss_wrapper` to fake the Unix login username so
it will always appear as 'trino' from applications instead of the random UID.

- Fixes https://github.com/trinodb/trino/issues/22281

## Release notes

```markdown
## General
* Add support for running Trino in OpenShift. ({issue}`22281`)
```
