### PR TITLE
Minor Iceberg refactors to simplify PartitionData usage

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
@@ -33,10 +33,8 @@ import org.apache.iceberg.FileContent;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.io.LocationProvider;
-import org.apache.iceberg.types.Type;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,7 +64,6 @@ public class IcebergMergeSink
     private final ConnectorSession session;
     private final IcebergFileFormat fileFormat;
     private final Map<String, String> storageProperties;
-    private final Schema schema;
     private final Map<Integer, PartitionSpec> partitionsSpecs;
     private final ConnectorPageSink insertPageSink;
     private final int columnCount;
@@ -82,7 +79,6 @@ public class IcebergMergeSink
             ConnectorSession session,
             IcebergFileFormat fileFormat,
             Map<String, String> storageProperties,
-            Schema schema,
             Map<Integer, PartitionSpec> partitionsSpecs,
             ConnectorPageSink insertPageSink,
             int columnCount)
@@ -95,7 +91,6 @@ public class IcebergMergeSink
         this.session = requireNonNull(session, "session is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.storageProperties = ImmutableMap.copyOf(requireNonNull(storageProperties, "storageProperties is null"));
-        this.schema = requireNonNull(schema, "schema is null");
         this.partitionsSpecs = ImmutableMap.copyOf(requireNonNull(partitionsSpecs, "partitionsSpecs is null"));
         this.insertPageSink = requireNonNull(insertPageSink, "insertPageSink is null");
         this.columnCount = columnCount;
@@ -169,7 +164,9 @@ public class IcebergMergeSink
         else if (formatVersion == 3) {
             fileDeletions.forEach((dataFilePath, deletion) -> deletion.rowsToDelete().build().ifPresent(deletionVector -> {
                 PartitionSpec partitionSpec = partitionsSpecs.get(deletion.partitionSpecId());
-                Optional<PartitionData> partitionData = createPartitionData(partitionSpec, deletion.partitionDataJson());
+                Optional<PartitionData> partitionData = partitionSpec.isPartitioned()
+                        ? Optional.of(PartitionData.fromJson(deletion.partitionDataJson(), partitionSpec))
+                        : Optional.empty();
                 CommitTaskData task = new CommitTaskData(
                         "", // path of the v2 delete file
                         fileFormat,
@@ -200,10 +197,13 @@ public class IcebergMergeSink
 
     private PositionDeleteWriter createPositionDeleteWriter(String dataFilePath, PartitionSpec partitionSpec, String partitionDataJson)
     {
+        Optional<PartitionData> partitionData = partitionSpec.isPartitioned()
+                ? Optional.of(PartitionData.fromJson(partitionDataJson, partitionSpec))
+                : Optional.empty();
         return new PositionDeleteWriter(
                 dataFilePath,
                 partitionSpec,
-                createPartitionData(partitionSpec, partitionDataJson),
+                partitionData,
                 locationProvider,
                 fileWriterFactory,
                 fileSystem,
@@ -223,18 +223,6 @@ public class IcebergMergeSink
             closeAllSuppress(t, writer::abort);
             throw t;
         }
-    }
-
-    private Optional<PartitionData> createPartitionData(PartitionSpec partitionSpec, String partitionDataAsJson)
-    {
-        if (!partitionSpec.isPartitioned()) {
-            return Optional.empty();
-        }
-
-        Type[] columnTypes = partitionSpec.fields().stream()
-                .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
-                .toArray(Type[]::new);
-        return Optional.of(PartitionData.fromJson(partitionDataAsJson, columnTypes));
     }
 
     private Page createInsertionsPageWithRowId(Page insertionsPage, Page inputPage)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -776,7 +776,7 @@ public class IcebergMetadata
             return Optional.empty();
         }
         PartitionSpec partitionSpec = icebergTable.spec();
-        if (partitionSpec.fields().isEmpty()) {
+        if (partitionSpec.isUnpartitioned()) {
             return Optional.empty();
         }
 
@@ -1659,7 +1659,7 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!partitionSpec.fields().isEmpty()) {
+            if (partitionSpec.isPartitioned()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
                 builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
@@ -2112,7 +2112,7 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!partitionSpec.fields().isEmpty()) {
+            if (partitionSpec.isPartitioned()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
                 builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
@@ -3315,7 +3315,7 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!icebergTable.spec().fields().isEmpty()) {
+            if (partitionSpec.isPartitioned()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
                 builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
@@ -3347,7 +3347,7 @@ public class IcebergMetadata
                         .withFileSizeInBytes(task.fileSizeInBytes())
                         .withMetrics(task.metrics().metrics());
                 task.fileSplitOffsets().ifPresent(deleteBuilder::withSplitOffsets);
-                if (!partitionSpec.fields().isEmpty()) {
+                if (partitionSpec.isPartitioned()) {
                     deleteBuilder.withPartition(PartitionData.fromJson(
                             task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
                             partitionSpec));
@@ -3363,7 +3363,7 @@ public class IcebergMetadata
         List<DeletionVectorInfo> deletionVectorInfos = deleteTasks.stream()
                 .map(task -> {
                     PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
-                    Optional<PartitionData> partitionData = !partitionSpec.fields().isEmpty()
+                    Optional<PartitionData> partitionData = partitionSpec.isPartitioned()
                             ? Optional.of(PartitionData.fromJson(
                             task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
                             partitionSpec))
@@ -3957,7 +3957,7 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!partitionSpec.fields().isEmpty()) {
+            if (partitionSpec.isPartitioned()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
                 builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1646,16 +1646,12 @@ public class IcebergMetadata
 
         IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
         Table icebergTable = transaction.table();
-        Schema schema = icebergTable.schema();
-        Type[] partitionColumnTypes = icebergTable.spec().fields().stream()
-                .map(field -> field.transform().getResultType(
-                        schema.findType(field.sourceId())))
-                .toArray(Type[]::new);
 
         AppendFiles appendFiles = isMergeManifestsOnWrite(session) ? transaction.newAppend() : transaction.newFastAppend();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
+        PartitionSpec partitionSpec = icebergTable.spec();
         for (CommitTaskData task : commitTasks) {
-            DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
+            DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFileSizeInBytes(task.fileSizeInBytes())
                     .withFormat(table.fileFormat().toIceberg())
@@ -1663,10 +1659,10 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!icebergTable.spec().fields().isEmpty()) {
+            if (!partitionSpec.fields().isEmpty()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
+                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
             }
 
             appendFiles.appendFile(builder.build());
@@ -2104,15 +2100,11 @@ public class IcebergMetadata
                 .map(commitTaskCodec::fromJson)
                 .collect(toImmutableList());
 
-        Type[] partitionColumnTypes = icebergTable.spec().fields().stream()
-                .map(field -> field.transform().getResultType(
-                        icebergTable.schema().findType(field.sourceId())))
-                .toArray(Type[]::new);
-
         Set<DataFile> newFiles = new HashSet<>();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
+        PartitionSpec partitionSpec = icebergTable.spec();
         for (CommitTaskData task : commitTasks) {
-            DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
+            DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFileSizeInBytes(task.fileSizeInBytes())
                     .withFormat(optimizeHandle.fileFormat().toIceberg())
@@ -2120,10 +2112,10 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!icebergTable.spec().fields().isEmpty()) {
+            if (!partitionSpec.fields().isEmpty()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
+                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
             }
 
             newFiles.add(builder.build());
@@ -3315,10 +3307,6 @@ public class IcebergMetadata
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
         for (CommitTaskData task : dataTasks) {
             PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
-            Type[] partitionColumnTypes = partitionSpec.fields().stream()
-                    .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
-                    .toArray(Type[]::new);
-
             DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFormat(task.fileFormat().toIceberg())
@@ -3330,7 +3318,7 @@ public class IcebergMetadata
             if (!icebergTable.spec().fields().isEmpty()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
+                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
             }
             rowDelta.addRows(builder.build());
         }
@@ -3359,7 +3347,12 @@ public class IcebergMetadata
                         .withFileSizeInBytes(task.fileSizeInBytes())
                         .withMetrics(task.metrics().metrics());
                 task.fileSplitOffsets().ifPresent(deleteBuilder::withSplitOffsets);
-                toPartitionData(partitionSpec, schema, task.partitionDataJson()).ifPresent(deleteBuilder::withPartition);
+                if (!partitionSpec.fields().isEmpty()) {
+                    deleteBuilder.withPartition(PartitionData.fromJson(
+                            task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
+                            partitionSpec));
+                }
+
                 rowDelta.addDeletes(deleteBuilder.build());
             }
             commitUpdateAndTransaction(rowDelta, session, transaction, "write");
@@ -3370,13 +3363,18 @@ public class IcebergMetadata
         List<DeletionVectorInfo> deletionVectorInfos = deleteTasks.stream()
                 .map(task -> {
                     PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
+                    Optional<PartitionData> partitionData = !partitionSpec.fields().isEmpty()
+                            ? Optional.of(PartitionData.fromJson(
+                            task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
+                            partitionSpec))
+                            : Optional.empty();
                     return new DeletionVectorInfo(
                             task.referencedDataFile().orElseThrow(() -> new VerifyException("v3 POSITION_DELETES task missing referencedDataFile")),
                             task.serializedDeletionVector()
                                     .map(Slices::wrappedBuffer)
                                     .orElseThrow(() -> new VerifyException("v3 POSITION_DELETES task missing serializedDeletionVector")),
                             partitionSpec,
-                            toPartitionData(partitionSpec, schema, task.partitionDataJson()));
+                            partitionData);
                 })
                 .toList();
 
@@ -3385,25 +3383,10 @@ public class IcebergMetadata
         commitUpdateAndTransaction(rowDelta, session, transaction, "write");
     }
 
-    private static Optional<PartitionData> toPartitionData(PartitionSpec partitionSpec, Schema schema, Optional<String> partitionDataJson)
-    {
-        if (partitionSpec.fields().isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(PartitionData.fromJson(
-                partitionDataJson.orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
-                partitionSpec.fields().stream()
-                        .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
-                        .toArray(Type[]::new)));
-    }
-
     static TupleDomain<IcebergColumnHandle> extractTupleDomainsFromCommitTasks(IcebergTableHandle table, Table icebergTable, List<CommitTaskData> commitTasks, TypeManager typeManager)
     {
         Set<IcebergColumnHandle> partitionColumns = new HashSet<>(getProjectedColumns(icebergTable.schema(), typeManager, identityPartitionColumnsInAllSpecs(icebergTable)));
         PartitionSpec partitionSpec = icebergTable.spec();
-        Type[] partitionColumnTypes = partitionSpec.fields().stream()
-                .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
-                .toArray(Type[]::new);
         Schema schema = SchemaParser.fromJson(table.getTableSchemaJson());
         Map<IcebergColumnHandle, List<Domain>> domainsFromTasks = new HashMap<>();
         for (CommitTaskData commitTask : commitTasks) {
@@ -3414,7 +3397,7 @@ public class IcebergMetadata
                 return TupleDomain.all();
             }
 
-            PartitionData partitionData = PartitionData.fromJson(commitTask.partitionDataJson().get(), partitionColumnTypes);
+            PartitionData partitionData = PartitionData.fromJson(commitTask.partitionDataJson().get(), partitionSpec);
             Map<Integer, Optional<String>> partitionKeys = getPartitionKeys(partitionData, partitionSpec);
             Map<ColumnHandle, NullableValue> partitionValues = getPartitionValues(partitionColumns, partitionKeys);
 
@@ -3962,15 +3945,11 @@ public class IcebergMetadata
                 .map(commitTaskCodec::fromJson)
                 .collect(toImmutableList());
 
-        Type[] partitionColumnTypes = icebergTable.spec().fields().stream()
-                .map(field -> field.transform().getResultType(
-                        icebergTable.schema().findType(field.sourceId())))
-                .toArray(Type[]::new);
-
         AppendFiles appendFiles = isMergeManifestsOnWrite(session) ? transaction.newAppend() : transaction.newFastAppend();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
+        PartitionSpec partitionSpec = icebergTable.spec();
         for (CommitTaskData task : commitTasks) {
-            DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
+            DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFileSizeInBytes(task.fileSizeInBytes())
                     .withFormat(table.fileFormat().toIceberg())
@@ -3978,10 +3957,10 @@ public class IcebergMetadata
                     .withSortOrder(sortOrders.get(task.sortOrderId()));
             task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
 
-            if (!icebergTable.spec().fields().isEmpty()) {
+            if (!partitionSpec.fields().isEmpty()) {
                 String partitionDataJson = task.partitionDataJson()
                         .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
+                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
             }
 
             appendFiles.appendFile(builder.build());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -208,7 +208,6 @@ public class IcebergPageSinkProvider
                 session,
                 tableHandle.fileFormat(),
                 tableHandle.storageProperties(),
-                schema,
                 partitionsSpecs,
                 pageSink,
                 schema.columns().size());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -342,7 +342,7 @@ public final class IcebergUtil
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
         IcebergFileFormat fileFormat = getFileFormat(icebergTable);
         properties.put(FILE_FORMAT_PROPERTY, fileFormat);
-        if (!icebergTable.spec().fields().isEmpty()) {
+        if (icebergTable.spec().isPartitioned()) {
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionData.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -123,6 +124,14 @@ public class PartitionData
             }
         }
         return new PartitionData(values);
+    }
+
+    public static PartitionData fromJson(String partitionDataAsJson, PartitionSpec partitionSpec)
+    {
+        Type[] types = partitionSpec.fields().stream()
+                .map(field -> field.transform().getResultType(partitionSpec.schema().findType(field.sourceId())))
+                .toArray(Type[]::new);
+        return fromJson(partitionDataAsJson, types);
     }
 
     public static PartitionData fromJson(String partitionDataAsJson, Type[] types)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -84,9 +84,6 @@ public class TableChangesFunctionProcessor
 
         Schema tableSchema = SchemaParser.fromJson(functionHandle.tableSchemaJson());
         PartitionSpec partitionSpec = PartitionSpecParser.fromJson(tableSchema, split.partitionSpecJson());
-        org.apache.iceberg.types.Type[] partitionColumnTypes = partitionSpec.fields().stream()
-                .map(field -> field.transform().getResultType(tableSchema.findType(field.sourceId())))
-                .toArray(org.apache.iceberg.types.Type[]::new);
 
         int delegateColumnIndex = 0;
         int[] delegateColumnMap = new int[functionHandle.columns().size()];
@@ -123,7 +120,7 @@ public class TableChangesFunctionProcessor
                 functionHandle.columns(),
                 tableSchema,
                 partitionSpec,
-                PartitionData.fromJson(split.partitionDataJson(), partitionColumnTypes),
+                PartitionData.fromJson(split.partitionDataJson(), partitionSpec),
                 ImmutableList.of(),
                 DynamicFilter.EMPTY,
                 TupleDomain.all(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

I noticed that there's a good amount of repeated code around creating `PartitionData`, and inconsistent ways of checking whether a spec is partitioned. I wanted to simplify this a bit.

This isn't tied to any open issues.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
