### PR TITLE
Add Maven Enforcer Plugin for version enforcement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2932,6 +2932,29 @@
                             <failOnError>true</failOnError>
                         </configuration>
                     </plugin>
+                            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+                <execution>
+                    <id>enforce</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <requireJavaVersion>
+                                <version>[25,)</version>
+                            </requireJavaVersion>
+                            <requireMavenVersion>
+                                <version>[3.9,)</version>
+                            </requireMavenVersion>
+                        </rules>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Checks added:
- Java 25+
- Maven 3.9+

Benefits:
- Prevents unsupported build environments
- Improves consistency across contributors
- Fails fast with clear validation errors
- 
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
