### PR TITLE
Close Reader in JsonInputFunctions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonInputFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonInputFunctions.java
@@ -64,8 +64,9 @@ public final class JsonInputFunctions
     @SqlType(StandardTypes.JSON_2016)
     public static JsonNode varcharToJson(@SqlType(StandardTypes.VARCHAR) Slice inputExpression, @SqlType(StandardTypes.BOOLEAN) boolean failOnError)
     {
-        Reader reader = new InputStreamReader(inputExpression.getInput(), UTF_8);
-        return toJson(reader, failOnError);
+        try (Reader reader = new InputStreamReader(inputExpression.getInput(), UTF_8)) {
+            return toJson(reader, failOnError);
+        }
     }
 
     @ScalarFunction(value = VARBINARY_TO_JSON, hidden = true)


### PR DESCRIPTION
This in JsonInputFunctions only surfaces in the edge case, so may not be a priority. The resource opened there can leak if JsonInputFunctions exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.