### PR TITLE
Add configuration to pass additional non-sensitive HTTP headers to iceberg REST catalog 

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -536,6 +536,9 @@ following properties:
 * - `iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl`
   - [Duration](prop-type-duration) for which case-insensitive namespace, table, 
     and view names are cached. Defaults to `1m`.
+* - `iceberg.rest-catalog.http-headers`
+  - Additional *non-sensitive* HTTP headers to include with requests to the REST catalog.
+    Example: `Header-1: value 1, Header-2: value 2`.
   :::
 
 The following example shows a minimal catalog configuration using an Iceberg

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
@@ -22,8 +23,12 @@ import jakarta.validation.constraints.NotNull;
 import org.apache.iceberg.CatalogProperties;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -59,6 +64,7 @@ public class IcebergRestCatalogConfig
     private boolean vendedCredentialsEnabled;
     private boolean viewEndpointsEnabled = true;
     private boolean caseInsensitiveNameMatching;
+    private Map<String, String> httpHeaders = ImmutableMap.of();
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
 
     @NotNull
@@ -221,6 +227,27 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setCaseInsensitiveNameMatching(boolean caseInsensitiveNameMatching)
     {
         this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
+        return this;
+    }
+
+    public Map<String, String> getHttpHeaders()
+    {
+        return httpHeaders;
+    }
+
+    @Config("iceberg.rest-catalog.http-headers")
+    @ConfigDescription("Additional HTTP headers to attach to REST catalog requests")
+    public IcebergRestCatalogConfig setHttpHeaders(List<String> httpHeaders)
+    {
+        try {
+            this.httpHeaders = httpHeaders.stream()
+                    .collect(toImmutableMap(kvs -> kvs.split(":", 2)[0], kvs -> kvs.split(":", 2)[1]));
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(format(
+                    "Cannot parse http headers from property iceberg.rest-catalog.http-headers; value provided was %s, expected format is \"Header-Name-1: header value 1, Header-Value-2: header value 2, ...\"",
+                    String.join(", ", httpHeaders)), e);
+        }
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogPropertiesProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogPropertiesProvider.java
@@ -19,6 +19,7 @@ import io.trino.spi.NodeVersion;
 import org.apache.iceberg.CatalogProperties;
 
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.AUTH_SESSION_TIMEOUT_MS;
@@ -50,6 +51,11 @@ public class IcebergRestCatalogPropertiesProvider
         if (restConfig.isVendedCredentialsEnabled()) {
             properties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
         }
+
+        for (Entry<String, String> entry : restConfig.getHttpHeaders().entrySet()) {
+            properties.put("header.".concat(entry.getKey()), entry.getValue());
+        }
+
         catalogProperties = properties.buildOrThrow();
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -278,6 +278,22 @@ public class TestIcebergPlugin
     }
 
     @Test
+    public void testRestCatalogHttpHeaders()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+        factory.create(
+                        "test",
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", "https://foo:1234")
+                                .put("iceberg.rest-catalog.http-headers", "Polaris-Realm: default-realm")
+                                .put("bootstrap.quiet", "true")
+                                .buildOrThrow(),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+
+    @Test
     public void testJdbcCatalog()
     {
         ConnectorFactory factory = getConnectorFactory();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
@@ -89,6 +89,7 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
                 .addIcebergProperty("iceberg.rest-catalog.security", "OAUTH2")
                 .addIcebergProperty("iceberg.rest-catalog.oauth2.credential", TestingPolarisCatalog.CREDENTIAL)
                 .addIcebergProperty("iceberg.rest-catalog.oauth2.scope", "PRINCIPAL_ROLE:ALL")
+                .addIcebergProperty("iceberg.rest-catalog.http-headers", TestingPolarisCatalog.POLARIS_REALM_HEADER + ": " + TestingPolarisCatalog.POLARIS_REALM_NAME)
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -18,6 +18,7 @@ import io.airlift.units.Duration;
 import org.apache.iceberg.CatalogProperties;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -45,7 +46,8 @@ public class TestIcebergRestCatalogConfig
                 .setVendedCredentialsEnabled(false)
                 .setViewEndpointsEnabled(true)
                 .setCaseInsensitiveNameMatching(false)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setHttpHeaders(List.of()));
     }
 
     @Test
@@ -65,6 +67,7 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.view-endpoints-enabled", "false")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl", "3m")
+                .put("iceberg.rest-catalog.http-headers", "Polaris-Realm: default-realm")
                 .buildOrThrow();
 
         IcebergRestCatalogConfig expected = new IcebergRestCatalogConfig()
@@ -80,7 +83,8 @@ public class TestIcebergRestCatalogConfig
                 .setVendedCredentialsEnabled(true)
                 .setViewEndpointsEnabled(false)
                 .setCaseInsensitiveNameMatching(true)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES))
+                .setHttpHeaders(List.of("Polaris-Realm: default-realm"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestingPolarisCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestingPolarisCatalog.java
@@ -49,7 +49,8 @@ public final class TestingPolarisCatalog
 
     private static final JsonMapper JSON_MAPPER = new JsonMapperProvider().get();
     private static final HttpClient HTTP_CLIENT = new JettyHttpClient();
-    private static final HeaderName POLARIS_REALM_HEADER = HeaderName.of("Polaris-Realm");
+    public static final HeaderName POLARIS_REALM_HEADER = HeaderName.of("Polaris-Realm");
+    public static final String POLARIS_REALM_NAME = "default-realm";
 
     private final GenericContainer<?> polarisCatalog;
     private final String token;
@@ -64,8 +65,10 @@ public final class TestingPolarisCatalog
         polarisCatalog.addExposedPort(POLARIS_PORT);
         polarisCatalog.withFileSystemBind(warehouseLocation, warehouseLocation, BindMode.READ_WRITE);
         polarisCatalog.waitingFor(new LogMessageWaitStrategy().withRegEx(".*Apache Polaris Server.* started.*"));
-        polarisCatalog.withEnv("POLARIS_BOOTSTRAP_CREDENTIALS", "default-realm,root,s3cr3t");
-        polarisCatalog.withEnv("polaris.realm-context.realms", "default-realm");
+        polarisCatalog.withEnv("POLARIS_BOOTSTRAP_CREDENTIALS", POLARIS_REALM_NAME.concat(",root,s3cr3t"));
+        polarisCatalog.withEnv("polaris.realm-context.realms", POLARIS_REALM_NAME);
+        polarisCatalog.withEnv("polaris.realm-context.header-name", POLARIS_REALM_HEADER.toString());
+        polarisCatalog.withEnv("polaris.realm-context.require-header", "true");
         polarisCatalog.withEnv("polaris.readiness.ignore-severe-issues", "true");
         polarisCatalog.withEnv("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
         polarisCatalog.withEnv("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true");
@@ -83,7 +86,7 @@ public final class TestingPolarisCatalog
         String body = "grant_type=client_credentials&client_id=root&client_secret=s3cr3t&scope=PRINCIPAL_ROLE:ALL";
         Request request = Request.Builder.preparePost()
                 .setUri(URI.create(restUri() + "/api/catalog/v1/oauth/tokens"))
-                .setHeader(POLARIS_REALM_HEADER, "default-realm")
+                .setHeader(POLARIS_REALM_HEADER, POLARIS_REALM_NAME)
                 .setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
                 .build();
@@ -111,6 +114,7 @@ public final class TestingPolarisCatalog
                 .setUri(URI.create(restUri() + "/api/management/v1/catalogs"))
                 .setHeader(AUTHORIZATION, "Bearer " + token)
                 .setHeader(CONTENT_TYPE, "application/json")
+                .setHeader(POLARIS_REALM_HEADER, POLARIS_REALM_NAME)
                 .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
                 .build();
         StatusResponseHandler.StatusResponse response = HTTP_CLIENT.execute(request, createStatusResponseHandler());
@@ -125,6 +129,7 @@ public final class TestingPolarisCatalog
                 .setUri(URI.create(restUri() + "/api/management/v1/catalogs/polaris/catalog-roles/catalog_admin/grants"))
                 .setHeader(AUTHORIZATION, "Bearer " + token)
                 .setHeader(CONTENT_TYPE, "application/json")
+                .setHeader(POLARIS_REALM_HEADER, POLARIS_REALM_NAME)
                 .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
                 .build();
         HTTP_CLIENT.execute(request, createStatusResponseHandler());
@@ -136,6 +141,7 @@ public final class TestingPolarisCatalog
                 .setUri(URI.create(restUri() + "/api/catalog/v1/polaris/namespaces/" + schema + "/tables/" + table))
                 .setHeader(AUTHORIZATION, "Bearer " + token)
                 .setHeader(CONTENT_TYPE, "application/json")
+                .setHeader(POLARIS_REALM_HEADER, POLARIS_REALM_NAME)
                 .build();
         HTTP_CLIENT.execute(request, createStatusResponseHandler());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Fixes https://github.com/trinodb/trino/issues/24236

This PR adds additional configuration to allow passing additional non-sensitive HTTP headers via the iceberg REST catalog configuration. The new configuration option is `iceberg.rest-catalog.http-headers` which accepts a string of comma-delimited key-value pairs as headers. 

This enables Trino to interact with iceberg REST catalog implementations (such as Apache Polaris) which optionally require additional authorization and/or validation via prescribed HTTP headers. To ensure the header functionality, the configuration requiring realm context headers has been added to the Polaris test fixture which enforces these headers in the smoke tests.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Certain iceberg REST catalog implementations require additional HTTP headers for things like authorization and/or validation of requests. One such example is Apache Polaris.

Apache Polaris provides documentation for [recommended configuration for production](https://polaris.apache.org/releases/1.3.0/configuring-polaris-for-production/). In this documentation it recommends enforcing realm header validation. This enforcement requires all requests to contain headers that indicate a specific [realm](https://polaris.apache.org/releases/1.3.0/realm/), which acts as a logical partitioning mechanism within its catalog system.

The realm context headers are configured via the [application properties](https://polaris.apache.org/releases/1.3.0/configuring-polaris-for-production/#realm-context-resolver), with the default value for the header being `Polaris-Realm`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support for specifying HTTP headers in REST catalog. ({issue}`24236`)
```
