### PR TITLE
Avoid static target name in renaming table tests

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -433,7 +433,7 @@ public abstract class BaseConnectorSmokeTest
             throws Exception
     {
         if (!hasBehavior(SUPPORTS_RENAME_TABLE)) {
-            assertQueryFails("ALTER TABLE nation RENAME TO yyyy", "This connector does not support renaming tables");
+            assertQueryFails("ALTER TABLE nation RENAME TO test_rename_table_" + randomNameSuffix(), "This connector does not support renaming tables");
             return;
         }
 
@@ -478,7 +478,7 @@ public abstract class BaseConnectorSmokeTest
             if (!hasBehavior(SUPPORTS_RENAME_TABLE)) {
                 abort("Skipping since rename table is not supported at all");
             }
-            assertQueryFails("ALTER TABLE nation RENAME TO other_schema.yyyy", "This connector does not support renaming tables across schemas");
+            assertQueryFails("ALTER TABLE nation RENAME TO other_schema.test_rename_table_" + randomNameSuffix(), "This connector does not support renaming tables across schemas");
             return;
         }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4662,7 +4662,7 @@ public abstract class BaseConnectorTest
             if (!hasBehavior(SUPPORTS_RENAME_TABLE)) {
                 abort("Skipping since rename table is not supported at all");
             }
-            assertQueryFails("ALTER TABLE nation RENAME TO other_schema.yyyy", "This connector does not support renaming tables across schemas");
+            assertQueryFails("ALTER TABLE nation RENAME TO other_schema.test_rename_table_" + randomNameSuffix(), "This connector does not support renaming tables across schemas");
             return;
         }
 


### PR DESCRIPTION
## Description

The engine verifies whether the target table already exists before the connector attempts to rename any tables.

SaaS connectors such as BigQuery may contain the same table name in the test environment, 
so this PR randomizes the table name.

https://github.com/trinodb/trino/blob/da5f973f44a9e1a8b71a47134dea8798b6f8a0e5/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java#L107-L115

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
