### PR TITLE
Run only CTAS in Redshift FTE smoke test

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftQueryFailureRecoverySmokeTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftQueryFailureRecoverySmokeTest.java
@@ -39,4 +39,48 @@ public class TestRedshiftQueryFailureRecoverySmokeTest
                 .finishesSuccessfully()
                 .cleansUpTemporaryTables();
     }
+
+    @Test
+    @Override
+    protected void testCreateTable() {}
+
+    @Test
+    @Override
+    protected void testInsert() {}
+
+    @Test
+    @Override
+    protected void testDelete() {}
+
+    @Test
+    @Override
+    protected void testDeleteWithSubquery() {}
+
+    @Test
+    @Override
+    protected void testUpdate() {}
+
+    @Test
+    @Override
+    protected void testUpdateWithSubquery() {}
+
+    @Test
+    @Override
+    protected void testAnalyzeTable() {}
+
+    @Test
+    @Override
+    protected void testMerge() {}
+
+    @Test
+    @Override
+    protected void testRefreshMaterializedView() {}
+
+    @Test
+    @Override
+    protected void testExplainAnalyze() {}
+
+    @Test
+    @Override
+    protected void testRequestTimeouts() {}
 }


### PR DESCRIPTION
## Description

The purpose of TestRedshiftQueryFailureRecoverySmokeTest is to run CTAS only. 
However, it currently runs all FTE tests. 

- Relates to https://github.com/trinodb/trino/pull/18480

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.