### PR TITLE
Test Ignite handling of decimal type with negative scale

### DIFF
--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -250,7 +250,8 @@ public class IgniteClient
                     int scale = min(decimalDigits, getDecimalDefaultScale(session));
                     return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
                 }
-                precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
+                // Ignite enforces the declared precision regardless of scale, so decimal(p, -s)
+                // stores at most p digits; map to decimal(p, 0) rather than decimal(p+s, 0).
                 if (precision > Decimals.MAX_PRECISION) {
                     break;
                 }

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -259,6 +259,20 @@ public class TestIgniteTypeMapping
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // IgniteClient.toColumnMapping maps decimal(p, -s) to decimal(p+s, 0), but this
+        // code path was never tested. Trino does not support negative scale decimal types,
+        // so these cases can only be exercised by creating the table directly in Ignite.
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(5, -1)", "123450", createDecimalType(6, 0), "DECIMAL '123450'")
+                .addRoundTrip("decimal(5, -3)", "12345000", createDecimalType(8, 0), "DECIMAL '12345000'")
+                .addRoundTrip("decimal(9, -7)", "1234567890000000", createDecimalType(16, 0), "DECIMAL '1234567890000000'")
+                .addRoundTrip("decimal(27, -11)", "12345678901234567890123456700000000000", createDecimalType(38, 0), "DECIMAL '12345678901234567890123456700000000000'")
+                .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
+    }
+
+    @Test
     public void testBinary()
     {
         binaryTest("binary")

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -261,14 +261,15 @@ public class TestIgniteTypeMapping
     @Test
     public void testDecimalNegativeScale()
     {
-        // IgniteClient.toColumnMapping maps decimal(p, -s) to decimal(p+s, 0), but this
-        // code path was never tested. Trino does not support negative scale decimal types,
-        // so these cases can only be exercised by creating the table directly in Ignite.
+        // Ignite accepts negative scale in DDL but enforces the declared precision without
+        // adjustment, so decimal(p, -s) stores at most p digits and maps to decimal(p, 0).
+        // Trino does not support negative scale decimal types, so these cases can only be
+        // exercised by creating the table directly in Ignite.
         SqlDataTypeTest.create()
-                .addRoundTrip("decimal(5, -1)", "123450", createDecimalType(6, 0), "DECIMAL '123450'")
-                .addRoundTrip("decimal(5, -3)", "12345000", createDecimalType(8, 0), "DECIMAL '12345000'")
-                .addRoundTrip("decimal(9, -7)", "1234567890000000", createDecimalType(16, 0), "DECIMAL '1234567890000000'")
-                .addRoundTrip("decimal(27, -11)", "12345678901234567890123456700000000000", createDecimalType(38, 0), "DECIMAL '12345678901234567890123456700000000000'")
+                .addRoundTrip("decimal(5, -1)", "12340", createDecimalType(5, 0), "DECIMAL '12340'")
+                .addRoundTrip("decimal(5, -3)", "12000", createDecimalType(5, 0), "DECIMAL '12000'")
+                .addRoundTrip("decimal(9, -7)", "120000000", createDecimalType(9, 0), "DECIMAL '120000000'")
+                .addRoundTrip("decimal(27, -11)", "123456789012345670000000000", createDecimalType(27, 0), "DECIMAL '123456789012345670000000000'")
                 .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
     }
 


### PR DESCRIPTION
\`IgniteClient.toColumnMapping\` maps \`decimal(p, -s)\` to \`decimal(p+s, 0)\` but
this code path was not tested. Negative scale decimal columns can only be
created directly in Ignite (Trino does not expose negative scale in its type
system), so the test uses \`igniteCreateAndInsert\` to verify that Trino reads
such columns correctly.

Fixes #28416