### PR TITLE
Avoid Iceberg fileScanTask.spec() calls, which contains expensive json parsing

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -344,6 +344,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnMetadatas;
 import static io.trino.plugin.iceberg.IcebergUtil.getCompressionPropertyName;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
+import static io.trino.plugin.iceberg.IcebergUtil.getFileScanPartitionSpec;
 import static io.trino.plugin.iceberg.IcebergUtil.getHiveCompressionCodec;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionColumns;
@@ -936,11 +937,13 @@ public class IcebergMetadata
                         .filter(toIcebergExpression(enforcedPredicate))
                         .planWith(icebergPlanningExecutor);
 
+                Map<Integer, PartitionSpec> specsById = icebergTable.specs();
                 try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
                     Map<StructLikeWrapperWithFieldIdToIndex, PartitionSpec> partitions = new HashMap<>();
                     for (FileScanTask fileScanTask : fileScanTasks) {
-                        StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(fileScanTask);
-                        partitions.putIfAbsent(structLikeWrapperWithFieldIdToIndex, fileScanTask.spec());
+                        PartitionSpec spec = getFileScanPartitionSpec(fileScanTask, specsById);
+                        StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(spec, fileScanTask.file().partition());
+                        partitions.putIfAbsent(structLikeWrapperWithFieldIdToIndex, spec);
                     }
                     return partitions;
                 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -108,6 +108,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getSplitSize;
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileModifiedTimeDomain;
+import static io.trino.plugin.iceberg.IcebergUtil.getFileScanPartitionSpec;
 import static io.trino.plugin.iceberg.IcebergUtil.getModificationTime;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionDomain;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
@@ -406,14 +407,15 @@ public class IcebergSplitSource
         // Assess if the partition that wholeFileTask belongs to should be included for OPTIMIZE
         // If file was partitioned under an old spec, OPTIMIZE may be able to merge it with another file under new partitioning spec
         // We don't know which partition of new spec this file belongs to, so we include all files in OPTIMIZE
-        if (currentSpecId != wholeFileTask.spec().specId()) {
+        PartitionSpec spec = getFileScanPartitionSpec(wholeFileTask, specsById);
+        if (currentSpecId != spec.specId()) {
             Stream<FileScanTaskWithDomain> allQueuedTasks = scannedFilesByPartition.values().stream()
                     .filter(Optional::isPresent)
                     .map(Optional::get);
             scannedFilesByPartition = null;
             return Stream.concat(allQueuedTasks, Stream.of(fileScanTaskWithDomain)).collect(toImmutableList());
         }
-        StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(wholeFileTask);
+        StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(spec, wholeFileTask.file().partition());
         Optional<FileScanTaskWithDomain> alreadyQueuedFileTask = scannedFilesByPartition.get(structLikeWrapperWithFieldIdToIndex);
         if (alreadyQueuedFileTask != null) {
             // Optional.empty() is a marker for partitions where we've seen enough files to avoid skipping them from OPTIMIZE
@@ -442,8 +444,9 @@ public class IcebergSplitSource
             return true;
         }
 
+        PartitionSpec partitionSpec = getFileScanPartitionSpec(fileScanTask, specsById);
         if (!partitionDomain.isAll()) {
-            String partition = fileScanTask.spec().partitionToPath(fileScanTask.partition());
+            String partition = partitionSpec.partitionToPath(fileScanTask.partition());
             if (!partitionDomain.includesNullableValue(utf8Slice(partition))) {
                 return true;
             }
@@ -461,7 +464,7 @@ public class IcebergSplitSource
         }
 
         Schema fileSchema = fileScanTask.schema();
-        Map<Integer, Optional<String>> partitionKeys = getPartitionKeys(fileScanTask);
+        Map<Integer, Optional<String>> partitionKeys = getPartitionKeys(fileScanTask.partition(), partitionSpec);
 
         Set<IcebergColumnHandle> identityPartitionColumns = partitionKeys.keySet().stream()
                 .map(fieldId -> getColumnHandle(fileSchema.findField(fieldId), typeManager))
@@ -486,7 +489,7 @@ public class IcebergSplitSource
 
     private boolean noDataColumnsProjected(FileScanTask fileScanTask)
     {
-        return fileScanTask.spec().fields().stream()
+        return getFileScanPartitionSpec(fileScanTask, specsById).fields().stream()
                 .filter(partitionField -> partitionField.transform().isIdentity())
                 .map(PartitionField::sourceId)
                 .collect(toImmutableSet())
@@ -727,6 +730,7 @@ public class IcebergSplitSource
     private IcebergSplit toIcebergSplit(FileScanTaskWithDomain taskWithDomain)
     {
         FileScanTask task = taskWithDomain.fileScanTask();
+        PartitionSpec partitionSpec = getFileScanPartitionSpec(task, specsById);
 
         Optional<String> affinityKey = splitAffinityProvider.getKey(task.file().location(), task.start(), task.length());
         return new IcebergSplit(
@@ -736,8 +740,8 @@ public class IcebergSplitSource
                 task.file().fileSizeInBytes(),
                 task.file().recordCount(),
                 IcebergFileFormat.fromIceberg(task.file().format()),
-                task.spec().specId(),
-                getPartitionBlockValues(task, typeManager),
+                partitionSpec.specId(),
+                getPartitionBlockValues(task, partitionSpec, typeManager),
                 task.deletes().stream()
                         .peek(file -> verifyDeletionVectorReferencesDataFile(task, file))
                         .map(DeleteFile::fromIceberg)
@@ -749,9 +753,8 @@ public class IcebergSplitSource
                 task.file().firstRowId() == null ? OptionalLong.empty() : OptionalLong.of(task.file().firstRowId()));
     }
 
-    private static List<Block> getPartitionBlockValues(FileScanTask task, TypeManager typeManager)
+    private static List<Block> getPartitionBlockValues(FileScanTask task, PartitionSpec spec, TypeManager typeManager)
     {
-        PartitionSpec spec = task.spec();
         StructLike partition = task.file().partition();
         List<PartitionField> fields = spec.fields();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -803,11 +803,6 @@ public final class IcebergUtil
      * Returns a map from fieldId to serialized partition value containing entries for all identity partitions.
      * {@code null} partition values are represented with {@link Optional#empty}.
      */
-    public static Map<Integer, Optional<String>> getPartitionKeys(FileScanTask scanTask)
-    {
-        return getPartitionKeys(scanTask.file().partition(), scanTask.spec());
-    }
-
     public static Map<Integer, Optional<String>> getPartitionKeys(StructLike partition, PartitionSpec spec)
     {
         ImmutableMap.Builder<Integer, Optional<String>> partitionKeys = ImmutableMap.builder();
@@ -1335,6 +1330,13 @@ public final class IcebergUtil
     public static ManifestReader<? extends ContentFile<?>> readerForManifest(ManifestFile manifest, Table table)
     {
         return readerForManifest(manifest, table.io(), table.specs());
+    }
+
+    public static PartitionSpec getFileScanPartitionSpec(FileScanTask fileScanTask, Map<Integer, PartitionSpec> specs)
+    {
+        int specId = fileScanTask.file().specId();
+        PartitionSpec spec = specs.get(specId);
+        return requireNonNull(spec, "Table specs doesn't contain specId: " + specId);
     }
 
     public static ManifestReader<? extends ContentFile<?>> readerForManifest(ManifestFile manifest, FileIO fileIO, Map<Integer, PartitionSpec> specsById)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/StructLikeWrapperWithFieldIdToIndex.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/StructLikeWrapperWithFieldIdToIndex.java
@@ -15,7 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
@@ -30,13 +30,9 @@ public class StructLikeWrapperWithFieldIdToIndex
     private final StructLikeWrapper structLikeWrapper;
     private final Map<Integer, Integer> fieldIdToIndex;
 
-    public static StructLikeWrapperWithFieldIdToIndex createStructLikeWrapper(FileScanTask fileScanTask)
+    public static StructLikeWrapperWithFieldIdToIndex createStructLikeWrapper(PartitionSpec partitionSpec, StructLike partition)
     {
-        return createStructLikeWrapper(fileScanTask.spec().partitionType(), fileScanTask.file().partition());
-    }
-
-    public static StructLikeWrapperWithFieldIdToIndex createStructLikeWrapper(Types.StructType structType, StructLike partition)
-    {
+        Types.StructType structType = partitionSpec.partitionType();
         StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(partition);
         return new StructLikeWrapperWithFieldIdToIndex(partitionWrapper, structType);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsTable.java
@@ -31,6 +31,7 @@ import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
@@ -53,6 +54,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
+import static io.trino.plugin.iceberg.IcebergUtil.getFileScanPartitionSpec;
 import static io.trino.plugin.iceberg.IcebergUtil.getIdentityPartitions;
 import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
 import static io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex.createStructLikeWrapper;
@@ -175,15 +177,17 @@ public class PartitionsTable
     private Map<StructLikeWrapperWithFieldIdToIndex, IcebergStatistics> getStatisticsByPartition(TableScan tableScan)
     {
         try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
+            Map<Integer, PartitionSpec> specsById = icebergTable.specs();
             Map<StructLikeWrapperWithFieldIdToIndex, IcebergStatistics.Builder> partitions = new HashMap<>();
             for (FileScanTask fileScanTask : fileScanTasks) {
                 DataFile dataFile = fileScanTask.file();
-                StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(fileScanTask);
+                PartitionSpec spec = getFileScanPartitionSpec(fileScanTask, specsById);
+                StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(spec, dataFile.partition());
 
                 partitions.computeIfAbsent(
                                 structLikeWrapperWithFieldIdToIndex,
                                 _ -> new IcebergStatistics.Builder(icebergTable.schema().columns(), typeManager))
-                        .acceptDataFile(dataFile, fileScanTask.spec());
+                        .acceptDataFile(dataFile, spec);
             }
 
             return partitions.entrySet().stream()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/files/FilesTablePageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/files/FilesTablePageSource.java
@@ -321,7 +321,7 @@ public final class FilesTablePageSource
     {
         if (partitionColumnType.isPresent() && columnNameToIndex.containsKey(FilesTable.PARTITION_COLUMN_NAME)) {
             PartitionSpec partitionSpec = idToPartitionSpecMapping.get(contentFile.specId());
-            StructLikeWrapperWithFieldIdToIndex partitionStruct = createStructLikeWrapper(partitionSpec.partitionType(), contentFile.partition());
+            StructLikeWrapperWithFieldIdToIndex partitionStruct = createStructLikeWrapper(partitionSpec, contentFile.partition());
             List<Type> partitionTypes = partitionTypes(partitionFields, idToTypeMapping);
             List<? extends Class<?>> partitionColumnClass = partitionTypes.stream()
                     .map(type -> type.typeId().javaClass())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Reduce call of Iceberg `task.spec()` if specs map is available.

FileScanTask.spec() call contains potentially expensive json parsing as seen in the code listing below:

https://github.com/apache/iceberg/blob/49839545d0027f17970868c5044f8005abce1267/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java#L68-L77


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
