### PR TITLE
Fix flaky TestCassandraTypeMapping tests by waiting for table metadata propagation

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraCreateAndInsertDataSetup.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraCreateAndInsertDataSetup.java
@@ -31,9 +31,11 @@ import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.cassandra.CassandraMetadata.PRESTO_COMMENT_METADATA;
 import static io.trino.plugin.cassandra.util.CassandraCqlUtils.ID_COLUMN_NAME;
 import static io.trino.plugin.cassandra.util.CassandraCqlUtils.quoteStringLiteral;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // The reasons for not using CreateAndInsertDataSetup are:
 // (1) Cassandra tables must define a single PRIMARY KEY
@@ -71,6 +73,7 @@ public class CassandraCreateAndInsertDataSetup
         try {
             insertRows(keyspaceName, tableName, inputs);
             refreshSizeEstimates(keyspaceName, tableName);
+            waitForTableVisibility(keyspaceName, tableName);
         }
         catch (Exception e) {
             closeAllSuppress(e, testTable);
@@ -98,6 +101,13 @@ public class CassandraCreateAndInsertDataSetup
         catch (Exception e) {
             throw new RuntimeException(format("Error refreshing size estimates for %s.%s", keyspaceName, tableName), e);
         }
+    }
+
+    private void waitForTableVisibility(String keyspaceName, String tableName)
+    {
+        assertEventually(() -> assertThat(cassandraServer.getSession()
+                .execute(format("SELECT table_name FROM system_schema.tables WHERE keyspace_name = '%s' AND table_name = '%s'", keyspaceName, tableName)).all())
+                .isNotEmpty());
     }
 
     private TestTable createTestTable(List<ColumnSetup> inputs)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

We've seen `TestCassandraTypeMapping` tests intermittently fail with 'Table does not exist' errors due to Cassandra driver metadata propagation delays. This change adds an `assertEventually` to ensure the table is queryable before finishing table setup.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
