### PR TITLE
Add arrayType, rowType, mapType and varbinary support to format()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -13,12 +13,14 @@
  */
 package io.trino.operator.scalar;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.SqlMap;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
@@ -28,21 +30,26 @@ import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionDependencyDeclaration.FunctionDependencyDeclarationBuilder;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
+import io.trino.spi.type.UuidType;
+import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 
 import java.lang.invoke.MethodHandle;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Base64;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -124,7 +131,21 @@ public final class FormatFunction
                 type instanceof TimeType ||
                 type instanceof DecimalType ||
                 type instanceof VarcharType ||
-                type instanceof CharType) {
+                type instanceof CharType ||
+                type instanceof VarbinaryType) {
+            return;
+        }
+        if (type instanceof ArrayType arrayType) {
+            addDependencies(builder, arrayType.getElementType());
+            return;
+        }
+        if (type instanceof MapType mapType) {
+            addDependencies(builder, mapType.getKeyType());
+            addDependencies(builder, mapType.getValueType());
+            return;
+        }
+        if (type instanceof RowType rowType) {
+            rowType.getTypeParameters().forEach(t -> addDependencies(builder, t));
             return;
         }
 
@@ -236,6 +257,18 @@ public final class FormatFunction
         if (type instanceof CharType charType) {
             return (block, position) -> padSpaces(charType.getSlice(block, position), charType).toStringUtf8();
         }
+        if (type instanceof RowType rowType) {
+            return (block, position) -> rowToString(functionDependencies, rowType, (SqlRow) rowType.getObject(block, position));
+        }
+        if (type instanceof MapType mapType) {
+            return (block, position) -> mapToString(functionDependencies, mapType, (SqlMap) mapType.getObject(block, position));
+        }
+        if (type instanceof ArrayType arrayType) {
+            return (block, position) -> arrayToString(functionDependencies, arrayType, (Block) arrayType.getObject(block, position));
+        }
+        if (type instanceof VarbinaryType varbinaryType) {
+            return (block, position) -> Base64.getEncoder().encodeToString(varbinaryType.getSlice(block, position).getBytes());
+        }
 
         BiFunction<Block, Integer, Object> function;
         if (type.getJavaType() == long.class) {
@@ -256,6 +289,63 @@ public final class FormatFunction
 
         MethodHandle handle = functionDependencies.getCastImplementation(type, VARCHAR, simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
         return (block, position) -> convertToString(handle, function.apply(block, position));
+    }
+
+    private static Object quotedValue(FunctionDependencies functionDependencies, Type type, Block block, int position)
+    {
+        Object value = FormatFunction.converter(functionDependencies, type).apply(block, position);
+        if (value != null && (
+                type instanceof VarcharType ||
+                type instanceof CharType ||
+                type instanceof VarbinaryType ||
+                type instanceof UuidType)) {
+            return String.format("\"%s\"", new String(JsonStringEncoder.getInstance().quoteAsString((String) value)));
+        }
+        return value;
+    }
+
+    private static String rowToString(FunctionDependencies functionDependencies, RowType rowType, SqlRow row)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        boolean hasAllFieldNames = fields.stream().allMatch(field -> field.getName().isPresent());
+        StringBuilder builder = new StringBuilder(hasAllFieldNames ? "{" : "[");
+        int rawIndex = row.getRawIndex();
+        for (int i = 0; i < fields.size(); i++) {
+            builder.append(i == 0 ? "" : ", ");
+            if (hasAllFieldNames) {
+                String fieldName = fields.get(i).getName().get();
+                builder.append('"').append(new String(JsonStringEncoder.getInstance().quoteAsString(fieldName))).append("\": ");
+            }
+            builder.append(quotedValue(functionDependencies, fields.get(i).getType(), row.getRawFieldBlock(i), rawIndex));
+        }
+        return builder.append(hasAllFieldNames ? '}' : ']').toString();
+    }
+
+    private static String mapToString(FunctionDependencies functionDependencies, MapType mapType, SqlMap sqlMap)
+    {
+        StringBuilder builder = new StringBuilder("{");
+        Block keys = sqlMap.getRawKeyBlock();
+        Block values = sqlMap.getRawValueBlock();
+        int rawOffset = sqlMap.getRawOffset();
+        for (int i = 0; i < sqlMap.getSize(); i++) {
+            builder
+                    .append(i == 0 ? "" : ", ")
+                    .append(quotedValue(functionDependencies, mapType.getKeyType(), keys, rawOffset + i))
+                    .append(": ")
+                    .append(quotedValue(functionDependencies, mapType.getValueType(), values, rawOffset + i));
+        }
+        return builder.append('}').toString();
+    }
+
+    private static String arrayToString(FunctionDependencies functionDependencies, ArrayType arrayType, Block elementBlock)
+    {
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < elementBlock.getPositionCount(); i++) {
+            builder
+                    .append(i == 0 ? "" : ", ")
+                    .append(quotedValue(functionDependencies, arrayType.getElementType(), elementBlock, i));
+        }
+        return builder.append(']').toString();
     }
 
     private static LocalTime toLocalTime(long value)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -13,12 +13,14 @@
  */
 package io.trino.operator.scalar;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.SqlMap;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
@@ -28,20 +30,25 @@ import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionDependencyDeclaration.FunctionDependencyDeclarationBuilder;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.UuidType;
+import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 
 import java.lang.invoke.MethodHandle;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Base64;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -124,7 +131,21 @@ public final class FormatFunction
                 type instanceof TimeType ||
                 type instanceof DecimalType ||
                 type instanceof VarcharType ||
-                type instanceof CharType) {
+                type instanceof CharType ||
+                type instanceof VarbinaryType) {
+            return;
+        }
+        if (type instanceof ArrayType arrayType) {
+            addDependencies(builder, arrayType.getElementType());
+            return;
+        }
+        if (type instanceof MapType mapType) {
+            addDependencies(builder, mapType.getKeyType());
+            addDependencies(builder, mapType.getValueType());
+            return;
+        }
+        if (type instanceof RowType rowType) {
+            rowType.getTypeParameters().forEach(t -> addDependencies(builder, t));
             return;
         }
 
@@ -236,6 +257,18 @@ public final class FormatFunction
         if (type instanceof CharType charType) {
             return (block, position) -> padSpaces(charType.getSlice(block, position), charType).toStringUtf8();
         }
+        if (type instanceof RowType rowType) {
+            return (block, position) -> rowToString(functionDependencies, rowType, rowType.getObject(block, position));
+        }
+        if (type instanceof MapType mapType) {
+            return (block, position) -> mapToString(functionDependencies, mapType, mapType.getObject(block, position));
+        }
+        if (type instanceof ArrayType arrayType) {
+            return (block, position) -> arrayToString(functionDependencies, arrayType, arrayType.getObject(block, position));
+        }
+        if (type instanceof VarbinaryType varbinaryType) {
+            return (block, position) -> Base64.getEncoder().encodeToString(varbinaryType.getSlice(block, position).getBytes());
+        }
 
         BiFunction<Block, Integer, Object> function;
         if (type.getJavaType() == long.class) {
@@ -256,6 +289,62 @@ public final class FormatFunction
 
         MethodHandle handle = functionDependencies.getCastImplementation(type, VARCHAR, simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
         return (block, position) -> convertToString(handle, function.apply(block, position));
+    }
+
+    private static Object quotedValue(FunctionDependencies functionDependencies, Type type, Block block, int position)
+    {
+        Object value = FormatFunction.converter(functionDependencies, type).apply(block, position);
+        if (value != null && (type instanceof VarcharType ||
+                type instanceof CharType ||
+                type instanceof VarbinaryType ||
+                type instanceof UuidType)) {
+            return String.format("\"%s\"", new String(JsonStringEncoder.getInstance().quoteAsString((String) value)));
+        }
+        return value;
+    }
+
+    private static String rowToString(FunctionDependencies functionDependencies, RowType rowType, SqlRow row)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        boolean hasAllFieldNames = fields.stream().allMatch(field -> field.getName().isPresent());
+        StringBuilder builder = new StringBuilder(hasAllFieldNames ? "{" : "[");
+        int rawIndex = row.getRawIndex();
+        for (int i = 0; i < fields.size(); i++) {
+            builder.append(i == 0 ? "" : ", ");
+            if (hasAllFieldNames) {
+                String fieldName = fields.get(i).getName().get();
+                builder.append('"').append(new String(JsonStringEncoder.getInstance().quoteAsString(fieldName))).append("\": ");
+            }
+            builder.append(quotedValue(functionDependencies, fields.get(i).getType(), row.getRawFieldBlock(i), rawIndex));
+        }
+        return builder.append(hasAllFieldNames ? '}' : ']').toString();
+    }
+
+    private static String mapToString(FunctionDependencies functionDependencies, MapType mapType, SqlMap sqlMap)
+    {
+        StringBuilder builder = new StringBuilder("{");
+        Block keys = sqlMap.getRawKeyBlock();
+        Block values = sqlMap.getRawValueBlock();
+        int rawOffset = sqlMap.getRawOffset();
+        for (int i = 0; i < sqlMap.getSize(); i++) {
+            builder
+                    .append(i == 0 ? "" : ", ")
+                    .append(quotedValue(functionDependencies, mapType.getKeyType(), keys, rawOffset + i))
+                    .append(": ")
+                    .append(quotedValue(functionDependencies, mapType.getValueType(), values, rawOffset + i));
+        }
+        return builder.append('}').toString();
+    }
+
+    private static String arrayToString(FunctionDependencies functionDependencies, ArrayType arrayType, Block elementBlock)
+    {
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < elementBlock.getPositionCount(); i++) {
+            builder
+                    .append(i == 0 ? "" : ", ")
+                    .append(quotedValue(functionDependencies, arrayType.getElementType(), elementBlock, i));
+        }
+        return builder.append(']').toString();
     }
 
     private static LocalTime toLocalTime(long value)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestFormatFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestFormatFunction.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Arrays;
 
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,6 +148,78 @@ public class TestFormatFunction
         assertThat(format("%s", "cast('test' AS char(5))"))
                 .isEqualTo("test ");
 
+        assertThat(format("%s", "cast(row('hello', 'world') AS row(greeting varchar, planet varchar))"))
+                .isEqualTo("{\"greeting\": \"hello\", \"planet\": \"world\"}");
+
+        assertThat(format("%s", "row('hello', 'world')"))
+                .isEqualTo("[\"hello\", \"world\"]");
+
+        assertThat(format("%s", "cast(row('hello', array['world']) AS row(greeting varchar, planet array(varchar)))"))
+                .isEqualTo("{\"greeting\": \"hello\", \"planet\": [\"world\"]}");
+
+        assertThat(format("%s", "cast(row('hello', 1337) AS row(greeting varchar, planet integer))"))
+                .isEqualTo("{\"greeting\": \"hello\", \"planet\": 1337}");
+
+        assertThat(format("%s", "cast(row('hello', from_base64('d29ybGQ=')) AS row(greeting varchar, planet varbinary))"))
+                .isEqualTo("{\"greeting\": \"hello\", \"planet\": \"d29ybGQ=\"}");
+
+        assertThat(format("%s", "ARRAY['hello', 'world']"))
+                .isEqualTo("[\"hello\", \"world\"]");
+
+        assertThat(format("%s", "ARRAY['hel\"l\\o\nworld']"))
+                .isEqualTo("[\"hel\\\"l\\\\o\\nworld\"]");
+
+        assertThat(format("%s", "ARRAY[1, 2, 3]"))
+                .isEqualTo("[1, 2, 3]");
+
+        assertThat(format("%s", "ARRAY[TRUE, FALSE]"))
+                .isEqualTo("[true, false]");
+
+        assertThat(format("%s", "from_base64('d29ybGQ=')"))
+                .isEqualTo("d29ybGQ=");
+
+        assertThat(format("%s", "map(ARRAY['greeting', 'planet'], ARRAY['hello', 'world'])"))
+                .isEqualTo("{\"greeting\": \"hello\", \"planet\": \"world\"}");
+
+        assertThat(format("%s", "map(ARRAY['greeting', 'planet'], ARRAY[1, 2])"))
+                .isEqualTo("{\"greeting\": 1, \"planet\": 2}");
+
+        assertThat(format("%s", "ARRAY[null, 'world']"))
+                .isEqualTo("[null, \"world\"]");
+
+        assertThat(format("%s", "cast(row(null, 'world') AS row(greeting varchar, planet varchar))"))
+                .isEqualTo("{\"greeting\": null, \"planet\": \"world\"}");
+
+        assertThat(format("%s", "map(ARRAY['greeting'], ARRAY[null])"))
+                .isEqualTo("{\"greeting\": null}");
+
+        assertThat(format("%s", "ARRAY[cast('hello' AS char(5))]"))
+                .isEqualTo("[\"hello\"]");
+
+        assertThat(format("%s", "cast(row(cast('hi' AS char(3))) AS row(greeting char(3)))"))
+                .isEqualTo("{\"greeting\": \"hi \"}");
+
+        assertThat(format("%s", "ARRAY[ARRAY['a', 'b'], ARRAY['c']]"))
+                .isEqualTo("[[\"a\", \"b\"], [\"c\"]]");
+
+        assertThat(format("%s", "map(ARRAY['nums'], ARRAY[ARRAY[1, 2]])"))
+                .isEqualTo("{\"nums\": [1, 2]}");
+
+        assertThat(format("%s", "map(ARRAY[1, 2], ARRAY['hello', 'world'])"))
+                .isEqualTo("{1: \"hello\", 2: \"world\"}");
+
+        assertThat(format("%s", "ARRAY[uuid '03780fd9-76cf-4366-b720-0cfc6b957e8f']"))
+                .isEqualTo("[\"03780fd9-76cf-4366-b720-0cfc6b957e8f\"]");
+
+        assertThat(format("%s", "row(uuid '03780fd9-76cf-4366-b720-0cfc6b957e8f')"))
+                .isEqualTo("[\"03780fd9-76cf-4366-b720-0cfc6b957e8f\"]");
+
+        assertThat(format("%s", "cast(row(uuid '03780fd9-76cf-4366-b720-0cfc6b957e8f') AS row(id uuid))"))
+                .isEqualTo("{\"id\": \"03780fd9-76cf-4366-b720-0cfc6b957e8f\"}");
+
+        assertThat(format("%s", "map(ARRAY['id'], ARRAY[uuid '03780fd9-76cf-4366-b720-0cfc6b957e8f'])"))
+                .isEqualTo("{\"id\": \"03780fd9-76cf-4366-b720-0cfc6b957e8f\"}");
+
         assertTrinoExceptionThrownBy(format("%.4d", "8")::evaluate)
                 .hasMessage("Invalid format string: %.4d (IllegalFormatPrecision: 4)");
 
@@ -175,10 +246,6 @@ public class TestFormatFunction
 
         assertTrinoExceptionThrownBy(format("%tT", "current_time")::evaluate)
                 .hasMessage("Invalid format string: %tT (IllegalFormatConversion: T != java.lang.String)");
-
-        assertTrinoExceptionThrownBy(format("%s", "array[8]")::evaluate)
-                .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("line 1:20: Type not supported for formatting: array(integer)");
 
         assertTrinoExceptionThrownBy(assertions.function("format", "5", "8")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)

--- a/docs/src/main/sphinx/functions/conversion.md
+++ b/docs/src/main/sphinx/functions/conversion.md
@@ -46,6 +46,21 @@ SELECT format('%2$s %3$s %1$s', 'a', 'b', 'c');
 
 SELECT format('%1$tA, %1$tB %1$te, %1$tY', date '2006-07-04');
 -- 'Tuesday, July 4, 2006'
+
+SELECT format('%s', cast(row('hello', 'world') AS row(greeting varchar, planet varchar)));
+-- '{"greeting": "hello", "planet": "world"}'
+
+SELECT format('%s', row('hello', 'world'));
+-- '["hello", "world"]'
+
+SELECT format('%s', ARRAY['hello', 'world']);
+-- '["hello", "world"]'
+
+SELECT format('%s', map(ARRAY['greeting', 'planet'], ARRAY['hello', 'world']));
+-- '{"greeting": "hello", "planet": "world"}'
+
+SELECT format('%s', from_base64('d29ybGQ='));
+-- 'd29ybGQ='
 ```
 :::
 


### PR DESCRIPTION
## Description
Second attempt after https://github.com/trinodb/trino/pull/28234 was rejected. The goal is to create a readable string representation of row, array, map and varbinary, as suggested by @martint .

```sql
SELECT format('%s', cast(row('hello', 'world') AS row(greeting varchar, planet varchar)));
-- '{"greeting": "hello", "planet": "world"}'

SELECT format('%s', row('hello', 'world'));
-- '["hello", "world"]'

SELECT format('%s', ARRAY['hello', 'world']);
-- '["hello", "world"]'

SELECT format('%s', map(ARRAY['greeting', 'planet'], ARRAY['hello', 'world']));
-- '{"greeting": "hello", "planet": "world"}'

SELECT format('%s', from_base64('d29ybGQ='));
-- 'd29ybGQ='
```

Consideration: the strings in rows and arrays are using double quotes, to make them json compatible. However, we could consider to use single quotes as they would better fit the sql standard.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## Section
* Add arrayType, rowType, mapType and varbinary support to format()
```
