### PR TITLE
Retry testRowLevelDelete in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -170,6 +170,16 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    @Override
+    public void testRowLevelDelete()
+    {
+        // there is a brief delay before newly written data becomes visible in the BigQuery connector
+        // https://github.com/trinodb/trino/issues/20894
+        Failsafe.with(RetryPolicy.builder().withMaxAttempts(3).build())
+                .run(super::testRowLevelDelete);
+    }
+
+    @Test
     public void testPredicatePushdown()
     {
         testPredicatePushdown("true", "true", true);


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/actions/runs/24552138043/job/71780216473?pr=29152

```
Error:  io.trino.plugin.bigquery.TestBigQueryAvroConnectorTest.testRowLevelDelete -- Time elapsed: 34.75 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
[update count for query 20260417_070410_00511_yejya] 
expected: 1L
 but was: 0L
	at io.trino.testing.QueryAssertions.assertDistributedUpdate(QueryAssertions.java:147)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:65)
	at io.trino.testing.QueryAssertions.assertUpdate(QueryAssertions.java:59)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:426)
	at io.trino.testing.AbstractTestQueryFramework.assertUpdate(AbstractTestQueryFramework.java:421)
	at io.trino.testing.BaseConnectorTest.testRowLevelDelete(BaseConnectorTest.java:5495)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.