### PR TITLE
Return unknown equality estimate when NDV and range are unknown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
@@ -67,6 +67,15 @@ public final class ComparisonStatsCalculator
             filterRange = new StatisticRange(literalValue.getAsDouble(), literalValue.getAsDouble(), 1);
         }
         else {
+            // When the literal cannot be represented as a double and the column has no NDV
+            // and no range, StatisticRange.overlapPercentWith falls back to the
+            // infinite-to-infinite 0.5 heuristic, which is meant for range overlap, not point
+            // equality. Treat the selectivity as unknown instead.
+            if (isNaN(expressionStatistics.getDistinctValuesCount())
+                    && !isFinite(expressionStatistics.getLowValue())
+                    && !isFinite(expressionStatistics.getHighValue())) {
+                return PlanNodeStatsEstimate.unknown();
+            }
             filterRange = new StatisticRange(NEGATIVE_INFINITY, POSITIVE_INFINITY, 1);
         }
         return estimateFilterRange(inputStatistics, expressionStatistics, expressionSymbol, filterRange);

--- a/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
@@ -864,6 +864,37 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0.0));
     }
 
+    @Test
+    public void testNotInOnColumnWithUnknownNdvAndRange()
+    {
+        // Regression: on a varchar column with unknown NDV and unbounded range,
+        // `c NOT IN ('a', 'b')` used to collapse to 0 rows. Each per-value equality
+        // returned a 0.5 heuristic selectivity, the IN sum saturated at the full
+        // non-null row count, and $not(IN) subtracted to 0.
+
+        VarcharType type = createVarcharType(16);
+        Symbol column = new Symbol(type, "c");
+        Reference ref = new Reference(type, "c");
+
+        SymbolStatsEstimate columnStats = SymbolStatsEstimate.builder()
+                .setAverageRowSize(NaN)
+                .setDistinctValuesCount(NaN)
+                .setLowValue(NEGATIVE_INFINITY)
+                .setHighValue(POSITIVE_INFINITY)
+                .setNullsFraction(0)
+                .build();
+        PlanNodeStatsEstimate input = PlanNodeStatsEstimate.builder()
+                .addSymbolStatistics(column, columnStats)
+                .setOutputRowCount(1000)
+                .build();
+
+        Constant a = new Constant(type, Slices.utf8Slice("a"));
+        Constant b = new Constant(type, Slices.utf8Slice("b"));
+
+        // NOT IN on an unknown column yields an unknown estimate rather than a fabricated row count.
+        assertExpression(not(new In(ref, ImmutableList.of(a, b))), input).outputRowsCountUnknown();
+    }
+
     private PlanNodeStatsAssertion assertExpression(Expression expression)
     {
         return assertExpression(expression, session);


### PR DESCRIPTION
## Description
On a column with unknown NDV and an unbounded range, StatisticRange.overlapPercentWith falls back to the infinite-to-infinite 0.5 heuristic, which is meant for range overlap, not point equality. It yielded 0.5 * non-null rows per equality, causing an IN list to saturate at the full non-null row count and $not(IN) to subtract to 0.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix suboptimal join ordering that could cause excessive memory usage for queries on columns with unknown statistics. ({issue}`29157`)
```
