### PR TITLE
Add branch information to DML access control SPI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -257,6 +257,7 @@ public class CreateTableTask
                     accessControl.checkCanSelectFromColumns(
                             session.toSecurityContext(),
                             likeTableName,
+                            Optional.empty(),
                             likeTableMetadata.columns().stream()
                                     .map(ColumnMetadata::getName)
                                     .collect(toImmutableSet()));

--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -285,14 +285,14 @@ public interface AccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName);
+    void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch);
 
     /**
      * Check if identity is allowed to delete from the specified table.
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName);
+    void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch);
 
     /**
      * Check if identity is allowed to truncate the specified table.
@@ -306,7 +306,7 @@ public interface AccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames);
+    void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames);
 
     /**
      * Check if identity is allowed to create the specified view.
@@ -341,7 +341,7 @@ public interface AccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames);
+    void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames);
 
     /**
      * Check if identity is allowed to create the specified materialized view.
@@ -481,7 +481,7 @@ public interface AccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames);
+    void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames);
 
     /**
      * Check if identity is allowed to create the specified role.

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -719,29 +719,29 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanInsertIntoTable(SecurityContext securityContext, QualifiedObjectName tableName)
+    public void checkCanInsertIntoTable(SecurityContext securityContext, QualifiedObjectName tableName, Optional<String> branch)
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(tableName, "tableName is null");
 
         checkCanAccessCatalog(securityContext, tableName.catalogName());
 
-        systemAuthorizationCheck(control -> control.checkCanInsertIntoTable(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName()));
+        systemAuthorizationCheck(control -> control.checkCanInsertIntoTable(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), branch));
 
-        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanInsertIntoTable(context, tableName.asSchemaTableName()));
+        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanInsertIntoTable(context, tableName.asSchemaTableName(), branch));
     }
 
     @Override
-    public void checkCanDeleteFromTable(SecurityContext securityContext, QualifiedObjectName tableName)
+    public void checkCanDeleteFromTable(SecurityContext securityContext, QualifiedObjectName tableName, Optional<String> branch)
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(tableName, "tableName is null");
 
         checkCanAccessCatalog(securityContext, tableName.catalogName());
 
-        systemAuthorizationCheck(control -> control.checkCanDeleteFromTable(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName()));
+        systemAuthorizationCheck(control -> control.checkCanDeleteFromTable(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), branch));
 
-        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanDeleteFromTable(context, tableName.asSchemaTableName()));
+        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanDeleteFromTable(context, tableName.asSchemaTableName(), branch));
     }
 
     @Override
@@ -758,16 +758,16 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanUpdateTableColumns(SecurityContext securityContext, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    public void checkCanUpdateTableColumns(SecurityContext securityContext, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(tableName, "tableName is null");
 
         checkCanAccessCatalog(securityContext, tableName.catalogName());
 
-        systemAuthorizationCheck(control -> control.checkCanUpdateTableColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), updatedColumnNames));
+        systemAuthorizationCheck(control -> control.checkCanUpdateTableColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), branch, updatedColumnNames));
 
-        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanUpdateTableColumns(context, tableName.asSchemaTableName(), updatedColumnNames));
+        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanUpdateTableColumns(context, tableName.asSchemaTableName(), branch, updatedColumnNames));
     }
 
     @Override
@@ -824,16 +824,16 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext securityContext, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext securityContext, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(tableName, "tableName is null");
 
         checkCanAccessCatalog(securityContext, tableName.catalogName());
 
-        systemAuthorizationCheck(control -> control.checkCanCreateViewWithSelectFromColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columnNames));
+        systemAuthorizationCheck(control -> control.checkCanCreateViewWithSelectFromColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), branch, columnNames));
 
-        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanCreateViewWithSelectFromColumns(context, tableName.asSchemaTableName(), columnNames));
+        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanCreateViewWithSelectFromColumns(context, tableName.asSchemaTableName(), branch, columnNames));
     }
 
     @Override
@@ -1105,7 +1105,7 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext securityContext, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(SecurityContext securityContext, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(tableName, "tableName is null");
@@ -1113,9 +1113,9 @@ public class AccessControlManager
 
         checkCanAccessCatalog(securityContext, tableName.catalogName());
 
-        systemAuthorizationCheck(control -> control.checkCanSelectFromColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), columnNames));
+        systemAuthorizationCheck(control -> control.checkCanSelectFromColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), branch, columnNames));
 
-        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanSelectFromColumns(context, tableName.asSchemaTableName(), columnNames));
+        catalogAuthorizationCheck(tableName.catalogName(), securityContext, (control, context) -> control.checkCanSelectFromColumns(context, tableName.asSchemaTableName(), branch, columnNames));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
@@ -149,16 +149,16 @@ public class AllowAllAccessControl
     public void checkCanRenameColumn(SecurityContext context, QualifiedObjectName tableName) {}
 
     @Override
-    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName) {}
+    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch) {}
 
     @Override
-    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName) {}
+    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch) {}
 
     @Override
     public void checkCanTruncateTable(SecurityContext context, QualifiedObjectName tableName) {}
 
     @Override
-    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames) {}
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames) {}
 
     @Override
     public void checkCanCreateView(SecurityContext context, QualifiedObjectName viewName) {}
@@ -173,7 +173,7 @@ public class AllowAllAccessControl
     public void checkCanDropView(SecurityContext context, QualifiedObjectName viewName) {}
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames) {}
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames) {}
 
     @Override
     public void checkCanCreateMaterializedView(SecurityContext context, QualifiedObjectName materializedViewName, Map<String, Object> properties) {}
@@ -245,7 +245,7 @@ public class AllowAllAccessControl
     public void checkCanSetCatalogSessionProperty(SecurityContext context, String catalogName, String propertyName) {}
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames) {}
+    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames) {}
 
     @Override
     public void checkCanCreateRole(SecurityContext context, String role, Optional<TrinoPrincipal> grantor, Optional<String> catalogName) {}

--- a/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
@@ -315,13 +315,13 @@ public class DenyAllAccessControl
     @Override
     public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
-        denyInsertTable(tableName.toString());
+        denyInsertTable(tableName.toString(), branch);
     }
 
     @Override
     public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
-        denyDeleteTable(tableName.toString());
+        denyDeleteTable(tableName.toString(), branch);
     }
 
     @Override
@@ -333,7 +333,7 @@ public class DenyAllAccessControl
     @Override
     public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
-        denyUpdateTableColumns(tableName.toString(), updatedColumnNames);
+        denyUpdateTableColumns(tableName.toString(), branch, updatedColumnNames);
     }
 
     @Override
@@ -363,7 +363,7 @@ public class DenyAllAccessControl
     @Override
     public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
-        denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
+        denyCreateViewWithSelect(tableName.toString(), branch, context.getIdentity());
     }
 
     @Override
@@ -483,7 +483,7 @@ public class DenyAllAccessControl
     @Override
     public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
-        denySelectColumns(tableName.toString(), columnNames);
+        denySelectColumns(tableName.toString(), branch, columnNames);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
@@ -313,13 +313,13 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         denyInsertTable(tableName.toString());
     }
 
     @Override
-    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         denyDeleteTable(tableName.toString());
     }
@@ -331,7 +331,7 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
         denyUpdateTableColumns(tableName.toString(), updatedColumnNames);
     }
@@ -361,7 +361,7 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
     }
@@ -481,7 +481,7 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         denySelectColumns(tableName.toString(), columnNames);
     }

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -261,21 +261,21 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
-        delegate().checkCanInsertIntoTable(context, tableName);
+        delegate().checkCanInsertIntoTable(context, tableName, branch);
     }
 
     @Override
-    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
-        delegate().checkCanDeleteFromTable(context, tableName);
+        delegate().checkCanDeleteFromTable(context, tableName, branch);
     }
 
     @Override
-    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
-        delegate().checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+        delegate().checkCanUpdateTableColumns(context, tableName, branch, updatedColumnNames);
     }
 
     @Override
@@ -303,9 +303,9 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
-        delegate().checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+        delegate().checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames);
     }
 
     @Override
@@ -423,9 +423,9 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
-        delegate().checkCanSelectFromColumns(context, tableName, columnNames);
+        delegate().checkCanSelectFromColumns(context, tableName, branch, columnNames);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -230,31 +230,63 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        checkArgument(context == null, "context must be null");
+        accessControl.checkCanSelectFromColumns(securityContext, getQualifiedObjectName(tableName), branch, columnNames);
+    }
+
+    @Deprecated
+    @Override
     public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
         checkArgument(context == null, "context must be null");
-        accessControl.checkCanSelectFromColumns(securityContext, getQualifiedObjectName(tableName), columnNames);
+        accessControl.checkCanSelectFromColumns(securityContext, getQualifiedObjectName(tableName), Optional.empty(), columnNames);
     }
 
+    @Override
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        checkArgument(context == null, "context must be null");
+        accessControl.checkCanInsertIntoTable(securityContext, getQualifiedObjectName(tableName), branch);
+    }
+
+    @Deprecated
     @Override
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         checkArgument(context == null, "context must be null");
-        accessControl.checkCanInsertIntoTable(securityContext, getQualifiedObjectName(tableName));
+        accessControl.checkCanInsertIntoTable(securityContext, getQualifiedObjectName(tableName), Optional.empty());
     }
 
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        checkArgument(context == null, "context must be null");
+        accessControl.checkCanDeleteFromTable(securityContext, getQualifiedObjectName(tableName), branch);
+    }
+
+    @Deprecated
     @Override
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         checkArgument(context == null, "context must be null");
-        accessControl.checkCanDeleteFromTable(securityContext, getQualifiedObjectName(tableName));
+        accessControl.checkCanDeleteFromTable(securityContext, getQualifiedObjectName(tableName), Optional.empty());
     }
 
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
+    {
+        checkArgument(context == null, "context must be null");
+        accessControl.checkCanUpdateTableColumns(securityContext, getQualifiedObjectName(tableName), branch, updatedColumns);
+    }
+
+    @Deprecated
     @Override
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
     {
         checkArgument(context == null, "context must be null");
-        accessControl.checkCanUpdateTableColumns(securityContext, getQualifiedObjectName(tableName), updatedColumns);
+        accessControl.checkCanUpdateTableColumns(securityContext, getQualifiedObjectName(tableName), Optional.empty(), updatedColumns);
     }
 
     @Override
@@ -293,10 +325,18 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        checkArgument(context == null, "context must be null");
+        accessControl.checkCanCreateViewWithSelectFromColumns(securityContext, getQualifiedObjectName(tableName), branch, columnNames);
+    }
+
+    @Deprecated
+    @Override
     public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
         checkArgument(context == null, "context must be null");
-        accessControl.checkCanCreateViewWithSelectFromColumns(securityContext, getQualifiedObjectName(tableName), columnNames);
+        accessControl.checkCanCreateViewWithSelectFromColumns(securityContext, getQualifiedObjectName(tableName), Optional.empty(), columnNames);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -21,6 +21,7 @@ import io.trino.spi.security.ViewExpression;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
@@ -43,13 +44,13 @@ public class ViewAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         // This is intentional and matches the SQL standard for view security.
         // In SQL, views are special in that they execute with permissions of the owner.
         // This means that the owner of the view is effectively granting permissions to the user running the query,
         // and thus must have the equivalent of the SQL standard "GRANT ... WITH GRANT OPTION".
-        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
+        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames));
     }
 
     @Override
@@ -59,9 +60,9 @@ public class ViewAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
-        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
+        wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -159,8 +159,8 @@ public class Analysis
     private final Map<NodeRef<Node>, Scope> scopes = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, ResolvedField> columnReferences = new LinkedHashMap<>();
 
-    // a map of users to the columns per table that they access
-    private final Map<AccessControlInfo, Map<QualifiedObjectName, Set<String>>> tableColumnReferences = new LinkedHashMap<>();
+    // a map of users to the columns per table (and branch) that they access
+    private final Map<AccessControlInfo, Map<TableAndBranch, Set<String>>> tableColumnReferences = new LinkedHashMap<>();
 
     // Record fields prefixed with labels in row pattern recognition context
     private final Map<NodeRef<Expression>, Optional<String>> labels = new LinkedHashMap<>();
@@ -682,6 +682,7 @@ public class Analysis
             Table table,
             Optional<TableHandle> handle,
             QualifiedObjectName name,
+            Optional<String> branch,
             String authorization,
             Scope accessControlScope,
             Optional<String> viewText)
@@ -691,6 +692,7 @@ public class Analysis
                 new TableEntry(
                         handle,
                         name,
+                        branch,
                         authorization,
                         accessControlScope,
                         tablesForView.isEmpty() &&
@@ -1014,18 +1016,18 @@ public class Analysis
         return nearestAnalysis.get(NodeRef.of(node));
     }
 
-    public void addTableColumnReferences(AccessControl accessControl, Identity identity, Multimap<QualifiedObjectName, String> tableColumnMap)
+    public void addTableColumnReferences(AccessControl accessControl, Identity identity, Multimap<TableAndBranch, String> tableColumnMap)
     {
         AccessControlInfo accessControlInfo = new AccessControlInfo(accessControl, identity);
-        Map<QualifiedObjectName, Set<String>> references = tableColumnReferences.computeIfAbsent(accessControlInfo, k -> new LinkedHashMap<>());
+        Map<TableAndBranch, Set<String>> references = tableColumnReferences.computeIfAbsent(accessControlInfo, k -> new LinkedHashMap<>());
         tableColumnMap.asMap()
-                .forEach((key, value) -> references.computeIfAbsent(key, k -> new HashSet<>()).addAll(value));
+                .forEach((tableAndBranch, columns) -> references.computeIfAbsent(tableAndBranch, k -> new HashSet<>()).addAll(columns));
     }
 
-    public void addEmptyColumnReferencesForTable(AccessControl accessControl, Identity identity, QualifiedObjectName table)
+    public void addEmptyColumnReferencesForTable(AccessControl accessControl, Identity identity, QualifiedObjectName table, Optional<String> branch)
     {
         AccessControlInfo accessControlInfo = new AccessControlInfo(accessControl, identity);
-        tableColumnReferences.computeIfAbsent(accessControlInfo, k -> new LinkedHashMap<>()).computeIfAbsent(table, k -> new HashSet<>());
+        tableColumnReferences.computeIfAbsent(accessControlInfo, k -> new LinkedHashMap<>()).computeIfAbsent(new TableAndBranch(table, branch), k -> new HashSet<>());
     }
 
     public void addLabels(Map<NodeRef<Expression>, Optional<String>> labels)
@@ -1145,7 +1147,7 @@ public class Analysis
         return jsonTableAnalyses.get(NodeRef.of(jsonTable));
     }
 
-    public Map<AccessControlInfo, Map<QualifiedObjectName, Set<String>>> getTableColumnReferences()
+    public Map<AccessControlInfo, Map<TableAndBranch, Set<String>>> getTableColumnReferences()
     {
         return tableColumnReferences;
     }
@@ -1249,9 +1251,9 @@ public class Analysis
                 .map(entry -> {
                     NodeRef<Table> table = entry.getKey();
 
-                    QualifiedObjectName tableName = entry.getValue().getName();
+                    TableAndBranch tableAndBranch = new TableAndBranch(entry.getValue().getName(), entry.getValue().getBranch());
                     List<ColumnInfo> columns = tableColumnReferences.values().stream()
-                            .map(tablesToColumns -> tablesToColumns.get(tableName))
+                            .map(tablesToColumns -> tablesToColumns.get(tableAndBranch))
                             .filter(Objects::nonNull)
                             .flatMap(Collection::stream)
                             .distinct()
@@ -2098,6 +2100,8 @@ public class Analysis
         }
     }
 
+    public record TableAndBranch(QualifiedObjectName tableName, Optional<String> branch) {}
+
     private static class RowFilterScopeEntry
     {
         private final QualifiedObjectName table;
@@ -2169,6 +2173,7 @@ public class Analysis
     {
         private final Optional<TableHandle> handle;
         private final QualifiedObjectName name;
+        private final Optional<String> branch;
         private final String authorization;
         private final Scope accessControlScope; // synthetic scope for analysis of row filters and masks
         private final boolean directlyReferenced;
@@ -2178,6 +2183,7 @@ public class Analysis
         public TableEntry(
                 Optional<TableHandle> handle,
                 QualifiedObjectName name,
+                Optional<String> branch,
                 String authorization,
                 Scope accessControlScope,
                 boolean directlyReferenced,
@@ -2186,6 +2192,7 @@ public class Analysis
         {
             this.handle = requireNonNull(handle, "handle is null");
             this.name = requireNonNull(name, "name is null");
+            this.branch = requireNonNull(branch, "branch is null");
             this.authorization = requireNonNull(authorization, "authorization is null");
             this.accessControlScope = requireNonNull(accessControlScope, "accessControlScope is null");
             this.directlyReferenced = directlyReferenced;
@@ -2201,6 +2208,11 @@ public class Analysis
         public QualifiedObjectName getName()
         {
             return name;
+        }
+
+        public Optional<String> getBranch()
+        {
+            return branch;
         }
 
         public String getAuthorization()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -101,10 +101,11 @@ public class Analyzer
         try (var _ = scopedSpan(tracer, "access-control")) {
             // check column access permissions for each table
             analysis.getTableColumnReferences().forEach((accessControlInfo, tableColumnReferences) ->
-                    tableColumnReferences.forEach((tableName, columns) ->
+                    tableColumnReferences.forEach((tableAndBranch, columns) ->
                             accessControlInfo.getAccessControl().checkCanSelectFromColumns(
                                     accessControlInfo.getSecurityContext(session.getRequiredTransactionId(), session.getQueryId(), session.getStart()),
-                                    tableName,
+                                    tableAndBranch.tableName(),
+                                    tableAndBranch.branch(),
                                     columns)));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -28,7 +28,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionResolver;
 import io.trino.metadata.LanguageFunctionAnalysisException;
 import io.trino.metadata.OperatorNotFoundException;
-import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.operator.scalar.FormatFunction;
 import io.trino.security.AccessControl;
@@ -350,7 +349,7 @@ public class ExpressionAnalyzer
     // For lambda argument references, maps each QualifiedNameReference to the referenced LambdaArgumentDeclaration
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
     private final Set<NodeRef<FunctionCall>> windowFunctions = new LinkedHashSet<>();
-    private final Multimap<QualifiedObjectName, String> tableColumnReferences = HashMultimap.create();
+    private final Multimap<Analysis.TableAndBranch, String> tableColumnReferences = HashMultimap.create();
 
     // Track referenced fields from source relation node
     private final Multimap<NodeRef<Node>, Field> referencedFields = HashMultimap.create();
@@ -601,7 +600,7 @@ public class ExpressionAnalyzer
         return unmodifiableSet(windowFunctions);
     }
 
-    public Multimap<QualifiedObjectName, String> getTableColumnReferences()
+    public Multimap<Analysis.TableAndBranch, String> getTableColumnReferences()
     {
         return tableColumnReferences;
     }
@@ -791,7 +790,7 @@ public class ExpressionAnalyzer
             }
 
             if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
-                tableColumnReferences.put(field.getOriginTable().get(), field.getOriginColumnName().get());
+                tableColumnReferences.put(new Analysis.TableAndBranch(field.getOriginTable().get(), field.getOriginBranch()), field.getOriginColumnName().get());
             }
 
             sourceFields.add(field);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -24,6 +24,7 @@ import static java.util.Objects.requireNonNull;
 public class Field
 {
     private final Optional<QualifiedObjectName> originTable;
+    private final Optional<String> originBranch;
     private final Optional<String> originColumnName;
     private final Optional<QualifiedName> relationAlias;
     private final Optional<String> name;
@@ -58,27 +59,30 @@ public class Field
                 .build();
     }
 
-    public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
+    public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originBranch, Optional<String> originColumn, boolean aliased)
     {
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
         requireNonNull(originTable, "originTable is null");
+        requireNonNull(originBranch, "originBranch is null");
 
         return builder()
                 .name(name)
                 .type(type)
                 .originTable(originTable)
+                .originBranch(originBranch)
                 .originColumnName(originColumn)
                 .aliased(aliased)
                 .build();
     }
 
-    public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
+    public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originBranch, Optional<String> originColumn, boolean aliased)
     {
         requireNonNull(relationAlias, "relationAlias is null");
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
         requireNonNull(originTable, "originTable is null");
+        requireNonNull(originBranch, "originBranch is null");
 
         return builder()
                 .relationAlias(Optional.of(relationAlias))
@@ -86,17 +90,19 @@ public class Field
                 .type(type)
                 .hidden(hidden)
                 .originTable(originTable)
+                .originBranch(originBranch)
                 .originColumnName(originColumn)
                 .aliased(aliased)
                 .build();
     }
 
-    private Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumnName, boolean aliased)
+    private Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originBranch, Optional<String> originColumnName, boolean aliased)
     {
         requireNonNull(relationAlias, "relationAlias is null");
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
         requireNonNull(originTable, "originTable is null");
+        requireNonNull(originBranch, "originBranch is null");
         requireNonNull(originColumnName, "originColumnName is null");
 
         this.relationAlias = relationAlias;
@@ -104,6 +110,7 @@ public class Field
         this.type = type;
         this.hidden = hidden;
         this.originTable = originTable;
+        this.originBranch = originBranch;
         this.originColumnName = originColumnName;
         this.aliased = aliased;
     }
@@ -116,6 +123,11 @@ public class Field
     public Optional<QualifiedObjectName> getOriginTable()
     {
         return originTable;
+    }
+
+    public Optional<String> getOriginBranch()
+    {
+        return originBranch;
     }
 
     public Optional<String> getOriginColumnName()
@@ -207,6 +219,7 @@ public class Field
         private Type type;
         private boolean hidden;
         private Optional<QualifiedObjectName> originTable = Optional.empty();
+        private Optional<String> originBranch = Optional.empty();
         private Optional<String> originColumnName = Optional.empty();
         private boolean aliased;
 
@@ -253,6 +266,12 @@ public class Field
             return this;
         }
 
+        public Builder originBranch(Optional<String> originBranch)
+        {
+            this.originBranch = requireNonNull(originBranch, "originBranch is null");
+            return this;
+        }
+
         public Builder originColumnName(Optional<String> originColumnName)
         {
             this.originColumnName = requireNonNull(originColumnName, "originColumnName is null");
@@ -268,7 +287,7 @@ public class Field
         public Field build()
         {
             requireNonNull(type, "type is null");
-            return new Field(relationAlias, name, type, hidden, originTable, originColumnName, aliased);
+            return new Field(relationAlias, name, type, hidden, originTable, originBranch, originColumnName, aliased);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
@@ -177,6 +177,7 @@ public class RelationType
                         field.getType(),
                         field.isHidden(),
                         field.getOriginTable(),
+                        field.getOriginBranch(),
                         field.getOriginColumnName(),
                         field.isAliased()));
             }
@@ -190,6 +191,7 @@ public class RelationType
                         field.getType(),
                         false,
                         field.getOriginTable(),
+                        field.getOriginBranch(),
                         field.getOriginColumnName(),
                         field.isAliased()));
             }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2593,6 +2593,7 @@ class StatementAnalyzer
                                 inputField.getType(),
                                 false,
                                 inputField.getOriginTable(),
+                                inputField.getOriginBranch(),
                                 inputField.getOriginColumnName(),
                                 inputField.isAliased());
                         fieldBuilder.add(field);
@@ -2612,6 +2613,7 @@ class StatementAnalyzer
                                 inputField.getType(),
                                 false,
                                 inputField.getOriginTable(),
+                                inputField.getOriginBranch(),
                                 inputField.getOriginColumnName(),
                                 inputField.isAliased());
                         fieldBuilder.add(field);
@@ -2695,6 +2697,7 @@ class StatementAnalyzer
                             getViewColumnType(column, name, table),
                             false,
                             Optional.of(name),
+                            getBranchName(table),
                             Optional.of(column.name()),
                             false))
                     .collect(toImmutableList());
@@ -2809,6 +2812,7 @@ class StatementAnalyzer
                         column.getType(),
                         column.isHidden(),
                         Optional.of(tableName),
+                        getBranchName(table),
                         Optional.of(column.getName()),
                         false);
                 fields.add(field);
@@ -3099,6 +3103,7 @@ class StatementAnalyzer
                             field.getType(),
                             field.isHidden(),
                             field.getOriginTable(),
+                            field.getOriginBranch(),
                             field.getOriginColumnName(),
                             field.isAliased()));
                 }
@@ -3112,6 +3117,7 @@ class StatementAnalyzer
                             field.getType(),
                             field.isHidden(),
                             field.getOriginTable(),
+                            field.getOriginBranch(),
                             field.getOriginColumnName(),
                             field.isAliased()));
                 }
@@ -4886,7 +4892,7 @@ class StatementAnalyzer
                             name = field.getName();
                         }
 
-                        Field newField = Field.newUnqualified(name, field.getType(), field.getOriginTable(), field.getOriginColumnName(), false);
+                        Field newField = Field.newUnqualified(name, field.getType(), field.getOriginTable(), field.getOriginBranch(), field.getOriginColumnName(), false);
                         analysis.addSourceColumns(newField, analysis.getSourceColumns(field));
                         outputFields.add(newField);
                     }
@@ -4896,6 +4902,7 @@ class StatementAnalyzer
                     Optional<Identifier> field = column.getAlias();
 
                     Optional<QualifiedObjectName> originTable = Optional.empty();
+                    Optional<String> originBranch = Optional.empty();
                     Optional<String> originColumn = Optional.empty();
                     QualifiedName name = null;
 
@@ -4910,6 +4917,7 @@ class StatementAnalyzer
                         List<Field> matchingFields = sourceScope.getRelationType().resolveFields(name);
                         if (!matchingFields.isEmpty()) {
                             originTable = matchingFields.get(0).getOriginTable();
+                            originBranch = matchingFields.get(0).getOriginBranch();
                             originColumn = matchingFields.get(0).getOriginColumnName();
                         }
                     }
@@ -4920,7 +4928,7 @@ class StatementAnalyzer
                         }
                     }
 
-                    Field newField = Field.newUnqualified(field.map(Identifier::getValue), analysis.getType(expression), originTable, originColumn, column.getAlias().isPresent()); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
+                    Field newField = Field.newUnqualified(field.map(Identifier::getValue), analysis.getType(expression), originTable, originBranch, originColumn, column.getAlias().isPresent()); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
                     if (originTable.isPresent()) {
                         analysis.addSourceColumns(newField, ImmutableSet.of(new SourceColumn(originTable.get(), originColumn.orElseThrow())));
                     }
@@ -6156,6 +6164,20 @@ class StatementAnalyzer
         private OutputColumn createOutputColumn(Field field)
         {
             return new OutputColumn(new Column(field.getName().orElseThrow(), field.getType().toString()), analysis.getSourceColumns(field));
+        }
+
+        private Optional<String> getBranchName(Table table)
+        {
+            return table
+                    // branch is explicitly provided for INSERT @ branch, UPDATE @ branch, DELETE @ branch and MERGE @ branch:
+                    .getBranch().map(Identifier::getValue)
+                    // the version pointer is used for SELECT FROM table FOR VERSION AS OF 'branch':
+                    .or(() -> table.getQueryPeriod()
+                            .filter(queryPeriod -> queryPeriod.getRangeType() == QueryPeriod.RangeType.VERSION)
+                            .flatMap(QueryPeriod::getEnd)
+                            .filter(StringLiteral.class::isInstance)
+                            .map(StringLiteral.class::cast)
+                            .map(StringLiteral::getValue));
         }
 
         /**

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -606,11 +606,16 @@ class StatementAnalyzer
             // verify the insert destination columns match the query
             RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, targetTable, Optional.empty(), endVersion);
             Optional<TableHandle> targetTableHandle = redirection.tableHandle();
-            targetTable = redirection.redirectedTableName().orElse(targetTable);
             if (targetTableHandle.isEmpty()) {
                 throw semanticException(TABLE_NOT_FOUND, insert, "Table '%s' does not exist", targetTable);
             }
-            accessControl.checkCanInsertIntoTable(session.toSecurityContext(), targetTable);
+            if (redirection.redirectedTableName().isPresent()) {
+                if (insert.getTable().getBranch().isPresent()) {
+                    throw semanticException(NOT_SUPPORTED, insert, "Inserting into a branch of a redirected table is not supported");
+                }
+                targetTable = redirection.redirectedTableName().get();
+            }
+            accessControl.checkCanInsertIntoTable(session.toSecurityContext(), targetTable, insert.getTable().getBranch().map(Identifier::getValue));
 
             TableSchema tableSchema = metadata.getTableSchema(session, targetTableHandle.get());
 
@@ -631,7 +636,7 @@ class StatementAnalyzer
             analyzeFiltersAndMasks(insert.getTable(), targetTable, new RelationType(tableFields), accessControlScope);
             analyzeCheckConstraints(insert.getTable(), targetTable, accessControlScope, checkConstraints);
             analyzeDefaultColumnValues(insert.getTable(), targetTableHandle.get(), columnHandles.values(), queryScope);
-            analysis.registerTable(insert.getTable(), targetTableHandle, targetTable, session.getIdentity().getUser(), accessControlScope, Optional.empty());
+            analysis.registerTable(insert.getTable(), targetTableHandle, targetTable, insert.getTable().getBranch().map(Identifier::getValue), session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             List<String> tableColumns = columns.stream()
                     .map(ColumnSchema::getName)
@@ -861,11 +866,20 @@ class StatementAnalyzer
                 endVersion = Optional.of(toTableVersion(branch));
             }
             RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, originalName, Optional.empty(), endVersion);
-            QualifiedObjectName tableName = redirection.redirectedTableName().orElse(originalName);
+            QualifiedObjectName tableName;
+            if (redirection.redirectedTableName().isPresent()) {
+                if (table.getBranch().isPresent()) {
+                    throw semanticException(NOT_SUPPORTED, node, "Deleting from a branch of a redirected table is not supported");
+                }
+                tableName = redirection.redirectedTableName().get();
+            }
+            else {
+                tableName = originalName;
+            }
             TableHandle handle = redirection.tableHandle()
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", tableName));
 
-            accessControl.checkCanDeleteFromTable(session.toSecurityContext(), tableName);
+            accessControl.checkCanDeleteFromTable(session.toSecurityContext(), tableName, table.getBranch().map(Identifier::getValue));
 
             TableSchema tableSchema = metadata.getTableSchema(session, handle);
             if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableSchema.tableSchema().getColumns()).isEmpty()) {
@@ -888,7 +902,7 @@ class StatementAnalyzer
                     .build();
             analyzeFiltersAndMasks(table, tableName, analysis.getScope(table).getRelationType(), accessControlScope);
             analyzeCheckConstraints(table, tableName, accessControlScope, tableSchema.tableSchema().getCheckConstraints());
-            analysis.registerTable(table, Optional.of(handle), tableName, session.getIdentity().getUser(), accessControlScope, Optional.empty());
+            analysis.registerTable(table, Optional.of(handle), tableName, node.getTable().getBranch().map(Identifier::getValue), session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             createMergeAnalysis(table, handle, tableSchema, tableScope, tableScope, ImmutableList.of(), ImmutableMultimap.of());
 
@@ -929,11 +943,11 @@ class StatementAnalyzer
             analysis.addTableColumnReferences(
                     accessControl,
                     session.getIdentity(),
-                    ImmutableMultimap.<QualifiedObjectName, String>builder()
-                            .putAll(tableName, metadata.getColumnHandles(session, tableHandle).keySet())
+                    ImmutableMultimap.<Analysis.TableAndBranch, String>builder()
+                            .putAll(new Analysis.TableAndBranch(tableName, Optional.empty()), metadata.getColumnHandles(session, tableHandle).keySet())
                             .build());
             try {
-                accessControl.checkCanInsertIntoTable(session.toSecurityContext(), tableName);
+                accessControl.checkCanInsertIntoTable(session.toSecurityContext(), tableName, Optional.empty());
             }
             catch (AccessDeniedException exception) {
                 throw new AccessDeniedException(format("Cannot ANALYZE (missing insert privilege) table %s", tableName), exception);
@@ -2361,7 +2375,7 @@ class StatementAnalyzer
             Optional<MaterializedViewDefinition> optionalMaterializedView = metadata.getMaterializedView(session, name);
             if (optionalMaterializedView.isPresent()) {
                 MaterializedViewDefinition materializedViewDefinition = optionalMaterializedView.get();
-                analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name);
+                analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name, getBranchName(table));
                 if (isMaterializedViewSufficientlyFresh(session, name, materializedViewDefinition)) {
                     // If materialized view is sufficiently fresh with respect to its grace period, answer the query using the storage table
                     QualifiedName storageName = getMaterializedViewStorageTableName(materializedViewDefinition)
@@ -2382,15 +2396,24 @@ class StatementAnalyzer
             // This could be a reference to a logical view or a table
             Optional<ViewDefinition> optionalView = metadata.getView(session, name);
             if (optionalView.isPresent()) {
-                analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name);
+                analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name, getBranchName(table));
                 return createScopeForView(table, name, scope, optionalView.get());
             }
 
             // This can only be a table
             RedirectionAwareTableHandle redirection = getTableHandle(table, name, scope);
             Optional<TableHandle> tableHandle = redirection.tableHandle();
-            QualifiedObjectName targetTableName = redirection.redirectedTableName().orElse(name);
-            analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), targetTableName);
+            QualifiedObjectName targetTableName;
+            if (redirection.redirectedTableName().isPresent()) {
+                if (getBranchName(table).isPresent()) {
+                    throw semanticException(NOT_SUPPORTED, table, "Table redirection is not supported for branch tables");
+                }
+                targetTableName = redirection.redirectedTableName().get();
+            }
+            else {
+                targetTableName = name;
+            }
+            analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), targetTableName, getBranchName(table));
 
             if (tableHandle.isEmpty()) {
                 getRequiredCatalogHandle(metadata, session, table, targetTableName.catalogName());
@@ -2422,7 +2445,7 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
                     .build();
             analyzeFiltersAndMasks(table, targetTableName, new RelationType(outputFields), accessControlScope);
-            analysis.registerTable(table, tableHandle, targetTableName, session.getIdentity().getUser(), accessControlScope, Optional.empty());
+            analysis.registerTable(table, tableHandle, targetTableName, table.getBranch().map(Identifier::getValue), session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             Scope tableScope = createAndAssignScope(table, scope, outputFields);
 
@@ -2514,7 +2537,7 @@ class StatementAnalyzer
                         .setHidden(field.isHidden())
                         .build();
                 Optional.ofNullable(masks.get(columnSchema)).ifPresent(mask -> {
-                    if (checkCanSelectFromColumn(name, columnSchema.getName())) {
+                    if (checkCanSelectFromColumn(name, getBranchName(table), columnSchema.getName())) {
                         analyzeColumnMask(session.getIdentity().getUser(), table, name, field, accessControlScope, mask);
                     }
                 });
@@ -2558,10 +2581,10 @@ class StatementAnalyzer
             }
         }
 
-        private boolean checkCanSelectFromColumn(QualifiedObjectName name, String column)
+        private boolean checkCanSelectFromColumn(QualifiedObjectName name, Optional<String> branch, String column)
         {
             try {
-                accessControl.checkCanSelectFromColumns(session.toSecurityContext(), name, ImmutableSet.of(column));
+                accessControl.checkCanSelectFromColumns(session.toSecurityContext(), name, branch, ImmutableSet.of(column));
                 return true;
             }
             catch (AccessDeniedException e) {
@@ -2727,7 +2750,7 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(viewFields))
                     .build();
             analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
-            analysis.registerTable(table, freshStorageTable, name, session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
+            analysis.registerTable(table, freshStorageTable, name, table.getBranch().map(Identifier::getValue), session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
             viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow()))));
             return createAndAssignScope(table, scope, viewFields);
         }
@@ -3592,7 +3615,16 @@ class StatementAnalyzer
                 endVersion = Optional.of(toTableVersion(branch));
             }
             RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, originalName, Optional.empty(), endVersion);
-            QualifiedObjectName tableName = redirection.redirectedTableName().orElse(originalName);
+            QualifiedObjectName tableName;
+            if (redirection.redirectedTableName().isPresent()) {
+                if (update.getTable().getBranch().isPresent()) {
+                    throw semanticException(NOT_SUPPORTED, update, "Updating a branch of a redirected table is not supported");
+                }
+                tableName = redirection.redirectedTableName().get();
+            }
+            else {
+                tableName = originalName;
+            }
             TableHandle handle = redirection.tableHandle()
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", tableName));
 
@@ -3612,7 +3644,7 @@ class StatementAnalyzer
             Set<String> assignmentTargets = update.getAssignments().stream()
                     .map(assignment -> assignment.getName().getValue().toLowerCase(ENGLISH))
                     .collect(toImmutableSet());
-            accessControl.checkCanUpdateTableColumns(session.toSecurityContext(), tableName, assignmentTargets);
+            accessControl.checkCanUpdateTableColumns(session.toSecurityContext(), tableName, update.getTable().getBranch().map(Identifier::getValue), assignmentTargets);
 
             if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
                 throw semanticException(NOT_SUPPORTED, update, "Updating a table with a row filter is not supported");
@@ -3642,7 +3674,7 @@ class StatementAnalyzer
             Scope tableScope = analyzer.analyzeForUpdate(table, scope, UpdateKind.UPDATE);
             update.getWhere().ifPresent(where -> analyzeWhere(update, tableScope, where));
             analyzeCheckConstraints(table, tableName, tableScope, tableSchema.tableSchema().getCheckConstraints());
-            analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), tableScope, Optional.empty());
+            analysis.registerTable(table, redirection.tableHandle(), tableName, update.getTable().getBranch().map(Identifier::getValue), session.getIdentity().getUser(), tableScope, Optional.empty());
 
             ImmutableList.Builder<ExpressionAnalysis> analysesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> expressionTypesBuilder = ImmutableList.builder();
@@ -3731,7 +3763,16 @@ class StatementAnalyzer
             analysis.setUpdateType("MERGE");
 
             RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, originalTableName, Optional.empty(), endVersion);
-            QualifiedObjectName tableName = redirection.redirectedTableName().orElse(originalTableName);
+            QualifiedObjectName tableName;
+            if (redirection.redirectedTableName().isPresent()) {
+                if (table.getBranch().isPresent()) {
+                    throw semanticException(NOT_SUPPORTED, merge, "Merging into a branch of a redirected table is not supported");
+                }
+                tableName = redirection.redirectedTableName().get();
+            }
+            else {
+                tableName = originalTableName;
+            }
             TableHandle targetTableHandle = redirection.tableHandle()
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", tableName));
 
@@ -3745,15 +3786,16 @@ class StatementAnalyzer
                     .filter(column -> !column.isHidden())
                     .collect(toImmutableList());
 
+            Optional<String> mergeBranch = table.getBranch().map(Identifier::getValue);
             merge.getMergeCases().stream()
                     .filter(mergeCase -> mergeCase instanceof MergeInsert)
                     .findFirst()
-                    .ifPresent(mergeCase -> accessControl.checkCanInsertIntoTable(session.toSecurityContext(), tableName));
+                    .ifPresent(mergeCase -> accessControl.checkCanInsertIntoTable(session.toSecurityContext(), tableName, mergeBranch));
 
             merge.getMergeCases().stream()
                     .filter(mergeCase -> mergeCase instanceof MergeDelete)
                     .findFirst()
-                    .ifPresent(mergeCase -> accessControl.checkCanDeleteFromTable(session.toSecurityContext(), tableName));
+                    .ifPresent(mergeCase -> accessControl.checkCanDeleteFromTable(session.toSecurityContext(), tableName, mergeBranch));
 
             Set<String> allUpdateColumnNames = new HashSet<>();
             for (int caseCounter = 0; caseCounter < merge.getMergeCases().size(); caseCounter++) {
@@ -3764,7 +3806,7 @@ class StatementAnalyzer
                 }
             }
             if (!allUpdateColumnNames.isEmpty()) {
-                accessControl.checkCanUpdateTableColumns(session.toSecurityContext(), tableName, allUpdateColumnNames);
+                accessControl.checkCanUpdateTableColumns(session.toSecurityContext(), tableName, mergeBranch, allUpdateColumnNames);
             }
 
             if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
@@ -3775,7 +3817,7 @@ class StatementAnalyzer
             Scope sourceTableScope = process(merge.getSource(), mergeScope);
             Scope joinScope = createAndAssignScope(merge, Optional.of(mergeScope), targetTableScope.getRelationType().joinWith(sourceTableScope.getRelationType()));
             analyzeCheckConstraints(table, tableName, targetTableScope, tableSchema.tableSchema().getCheckConstraints());
-            analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), targetTableScope, Optional.empty());
+            analysis.registerTable(table, redirection.tableHandle(), tableName, table.getBranch().map(Identifier::getValue), session.getIdentity().getUser(), targetTableScope, Optional.empty());
 
             if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableSchema.columns()).isEmpty()) {
                 throw semanticException(NOT_SUPPORTED, merge, "Cannot merge into a table with column masks");
@@ -4098,7 +4140,7 @@ class StatementAnalyzer
                 analysis.addTableColumnReferences(
                         accessControl,
                         session.getIdentity(),
-                        ImmutableMultimap.of(field.getOriginTable().get(), field.getOriginColumnName().get()));
+                        ImmutableMultimap.of(new Analysis.TableAndBranch(field.getOriginTable().get(), field.getOriginBranch()), field.getOriginColumnName().get()));
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -494,24 +494,24 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), INSERT_TABLE)) {
             denyInsertTable(tableName.toString());
         }
         if (denyPrivileges.isEmpty()) {
-            super.checkCanInsertIntoTable(context, tableName);
+            super.checkCanInsertIntoTable(context, tableName, branch);
         }
     }
 
     @Override
-    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), DELETE_TABLE)) {
             denyDeleteTable(tableName.toString());
         }
         if (denyPrivileges.isEmpty()) {
-            super.checkCanDeleteFromTable(context, tableName);
+            super.checkCanDeleteFromTable(context, tableName, branch);
         }
     }
 
@@ -527,13 +527,13 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), UPDATE_TABLE)) {
             denyUpdateTableColumns(tableName.toString(), updatedColumnNames);
         }
         if (denyPrivileges.isEmpty()) {
-            super.checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+            super.checkCanUpdateTableColumns(context, tableName, branch, updatedColumnNames);
         }
     }
 
@@ -582,7 +582,7 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         if (!denyIdentityTable.test(context.getIdentity(), tableName.objectName())) {
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
@@ -591,7 +591,7 @@ public class TestingAccessControlManager
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
         }
         if (denyPrivileges.isEmpty() && denyIdentityTable.equals(IDENTITY_TABLE_TRUE)) {
-            super.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+            super.checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames);
         }
     }
 
@@ -694,7 +694,7 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columns)
+    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columns)
     {
         if (!denyIdentityTable.test(context.getIdentity(), tableName.objectName())) {
             denySelectColumns(tableName.toString(), columns);
@@ -708,7 +708,7 @@ public class TestingAccessControlManager
             }
         }
         if (denyPrivileges.isEmpty() && denyIdentityTable.equals(IDENTITY_TABLE_TRUE)) {
-            super.checkCanSelectFromColumns(context, tableName, columns);
+            super.checkCanSelectFromColumns(context, tableName, branch, columns);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -497,7 +497,7 @@ public class TestingAccessControlManager
     public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), INSERT_TABLE)) {
-            denyInsertTable(tableName.toString());
+            denyInsertTable(tableName.toString(), branch);
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanInsertIntoTable(context, tableName, branch);
@@ -508,7 +508,7 @@ public class TestingAccessControlManager
     public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), DELETE_TABLE)) {
-            denyDeleteTable(tableName.toString());
+            denyDeleteTable(tableName.toString(), branch);
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanDeleteFromTable(context, tableName, branch);
@@ -530,7 +530,7 @@ public class TestingAccessControlManager
     public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), UPDATE_TABLE)) {
-            denyUpdateTableColumns(tableName.toString(), updatedColumnNames);
+            denyUpdateTableColumns(tableName.toString(), branch, updatedColumnNames);
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanUpdateTableColumns(context, tableName, branch, updatedColumnNames);
@@ -588,7 +588,7 @@ public class TestingAccessControlManager
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
         }
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), CREATE_VIEW_WITH_SELECT_COLUMNS)) {
-            denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
+            denyCreateViewWithSelect(tableName.toString(), branch, context.getIdentity());
         }
         if (denyPrivileges.isEmpty() && denyIdentityTable.equals(IDENTITY_TABLE_TRUE)) {
             super.checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames);
@@ -697,14 +697,14 @@ public class TestingAccessControlManager
     public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columns)
     {
         if (!denyIdentityTable.test(context.getIdentity(), tableName.objectName())) {
-            denySelectColumns(tableName.toString(), columns);
+            denySelectColumns(tableName.toString(), branch, columns);
         }
         if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), SELECT_COLUMN)) {
-            denySelectColumns(tableName.toString(), columns);
+            denySelectColumns(tableName.toString(), branch, columns);
         }
         for (String column : columns) {
             if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName() + "." + column, SELECT_COLUMN)) {
-                denySelectColumns(tableName.toString(), columns);
+                denySelectColumns(tableName.toString(), branch, columns);
             }
         }
         if (denyPrivileges.isEmpty() && denyIdentityTable.equals(IDENTITY_TABLE_TRUE)) {

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -172,6 +172,16 @@ public class TestingAccessControlManager
         return new TestingPrivilege(Optional.of(actorName), entityName, type);
     }
 
+    public static TestingPrivilege branchPrivilege(String entityName, String branchName, TestingPrivilegeType type)
+    {
+        return new TestingPrivilege(Optional.empty(), entityName, Optional.of(branchName), type);
+    }
+
+    public static TestingPrivilege branchPrivilege(String actorName, String entityName, String branchName, TestingPrivilegeType type)
+    {
+        return new TestingPrivilege(Optional.of(actorName), entityName, Optional.of(branchName), type);
+    }
+
     public void deny(TestingPrivilege... deniedPrivileges)
     {
         Collections.addAll(this.denyPrivileges, deniedPrivileges);
@@ -496,7 +506,7 @@ public class TestingAccessControlManager
     @Override
     public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
-        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), INSERT_TABLE)) {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), branch, INSERT_TABLE)) {
             denyInsertTable(tableName.toString(), branch);
         }
         if (denyPrivileges.isEmpty()) {
@@ -507,7 +517,7 @@ public class TestingAccessControlManager
     @Override
     public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
-        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), DELETE_TABLE)) {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), branch, DELETE_TABLE)) {
             denyDeleteTable(tableName.toString(), branch);
         }
         if (denyPrivileges.isEmpty()) {
@@ -529,7 +539,7 @@ public class TestingAccessControlManager
     @Override
     public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
-        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), UPDATE_TABLE)) {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), branch, UPDATE_TABLE)) {
             denyUpdateTableColumns(tableName.toString(), branch, updatedColumnNames);
         }
         if (denyPrivileges.isEmpty()) {
@@ -587,7 +597,7 @@ public class TestingAccessControlManager
         if (!denyIdentityTable.test(context.getIdentity(), tableName.objectName())) {
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
         }
-        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), CREATE_VIEW_WITH_SELECT_COLUMNS)) {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), branch, CREATE_VIEW_WITH_SELECT_COLUMNS)) {
             denyCreateViewWithSelect(tableName.toString(), branch, context.getIdentity());
         }
         if (denyPrivileges.isEmpty() && denyIdentityTable.equals(IDENTITY_TABLE_TRUE)) {
@@ -699,11 +709,11 @@ public class TestingAccessControlManager
         if (!denyIdentityTable.test(context.getIdentity(), tableName.objectName())) {
             denySelectColumns(tableName.toString(), branch, columns);
         }
-        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), SELECT_COLUMN)) {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName(), branch, SELECT_COLUMN)) {
             denySelectColumns(tableName.toString(), branch, columns);
         }
         for (String column : columns) {
-            if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName() + "." + column, SELECT_COLUMN)) {
+            if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.objectName() + "." + column, branch, SELECT_COLUMN)) {
                 denySelectColumns(tableName.toString(), branch, columns);
             }
         }
@@ -778,13 +788,23 @@ public class TestingAccessControlManager
 
     private boolean shouldDenyPrivilege(String actorName, String entityName, TestingPrivilegeType verb)
     {
-        return shouldDenyPrivilege(Optional.of(actorName), entityName, verb);
+        return shouldDenyPrivilege(Optional.of(actorName), entityName, Optional.empty(), verb);
+    }
+
+    private boolean shouldDenyPrivilege(String actorName, String entityName, Optional<String> branch, TestingPrivilegeType verb)
+    {
+        return shouldDenyPrivilege(Optional.of(actorName), entityName, branch, verb);
     }
 
     private boolean shouldDenyPrivilege(Optional<String> actorName, String entityName, TestingPrivilegeType verb)
     {
+        return shouldDenyPrivilege(actorName, entityName, Optional.empty(), verb);
+    }
+
+    private boolean shouldDenyPrivilege(Optional<String> actorName, String entityName, Optional<String> branch, TestingPrivilegeType verb)
+    {
         for (TestingPrivilege denyPrivilege : denyPrivileges) {
-            if (denyPrivilege.matches(actorName, entityName, verb)) {
+            if (denyPrivilege.matches(actorName, entityName, branch, verb)) {
                 return true;
             }
         }
@@ -808,15 +828,25 @@ public class TestingAccessControlManager
     public static class TestingPrivilege
     {
         private final Optional<String> actorName;
-        private final Predicate<String> entityPredicate;
+        private final BiPredicate<String, Optional<String>> entityPredicate;
         private final TestingPrivilegeType type;
 
         public TestingPrivilege(Optional<String> actorName, String entityName, TestingPrivilegeType type)
         {
-            this(actorName, entityName::equals, type);
+            this(actorName, entityName, Optional.empty(), type);
+        }
+
+        public TestingPrivilege(Optional<String> actorName, String entityName, Optional<String> branchName, TestingPrivilegeType type)
+        {
+            this(actorName, (entity, branch) -> entityName.equals(entity) && (branchName.isEmpty() || branchName.equals(branch)), type);
         }
 
         public TestingPrivilege(Optional<String> actorName, Predicate<String> entityPredicate, TestingPrivilegeType type)
+        {
+            this(actorName, (entity, branch) -> entityPredicate.test(entity), type);
+        }
+
+        private TestingPrivilege(Optional<String> actorName, BiPredicate<String, Optional<String>> entityPredicate, TestingPrivilegeType type)
         {
             this.actorName = requireNonNull(actorName, "actorName is null");
             this.entityPredicate = requireNonNull(entityPredicate, "entityPredicate is null");
@@ -825,9 +855,14 @@ public class TestingAccessControlManager
 
         public boolean matches(Optional<String> actorName, String entityName, TestingPrivilegeType type)
         {
+            return matches(actorName, entityName, Optional.empty(), type);
+        }
+
+        public boolean matches(Optional<String> actorName, String entityName, Optional<String> branch, TestingPrivilegeType type)
+        {
             return (this.actorName.isEmpty() || this.actorName.equals(actorName)) &&
                     this.type == type &&
-                    this.entityPredicate.test(entityName);
+                    this.entityPredicate.test(entityName, branch);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingAccessControl.java
@@ -360,20 +360,20 @@ public class TracingAccessControl
     }
 
     @Override
-    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanInsertIntoTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         Span span = startSpan("checkCanInsertIntoTable");
         try (var _ = scopedSpan(span)) {
-            delegate.checkCanInsertIntoTable(context, tableName);
+            delegate.checkCanInsertIntoTable(context, tableName, branch);
         }
     }
 
     @Override
-    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName)
+    public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch)
     {
         Span span = startSpan("checkCanDeleteFromTable");
         try (var _ = scopedSpan(span)) {
-            delegate.checkCanDeleteFromTable(context, tableName);
+            delegate.checkCanDeleteFromTable(context, tableName, branch);
         }
     }
 
@@ -387,11 +387,11 @@ public class TracingAccessControl
     }
 
     @Override
-    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
         Span span = startSpan("checkCanUpdateTableColumns");
         try (var _ = scopedSpan(span)) {
-            delegate.checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+            delegate.checkCanUpdateTableColumns(context, tableName, branch, updatedColumnNames);
         }
     }
 
@@ -432,11 +432,11 @@ public class TracingAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         Span span = startSpan("checkCanCreateViewWithSelectFromColumns");
         try (var _ = scopedSpan(span)) {
-            delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+            delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames);
         }
     }
 
@@ -612,11 +612,11 @@ public class TracingAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
     {
         Span span = startSpan("checkCanSelectFromColumns");
         try (var _ = scopedSpan(span)) {
-            delegate.checkCanSelectFromColumns(context, tableName, columnNames);
+            delegate.checkCanSelectFromColumns(context, tableName, branch, columnNames);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -181,7 +181,7 @@ public class TestingTableFunctions
         {
             TableFunctionAnalysis analyzeResult = super.analyze(session, transaction, arguments, accessControl);
             SimpleTableFunction.SimpleTableFunctionHandle handle = (SimpleTableFunction.SimpleTableFunctionHandle) analyzeResult.getHandle();
-            accessControl.checkCanSelectFromColumns(null, handle.getTableHandle().getTableName(), ImmutableSet.of(handle.getColumnName()));
+            accessControl.checkCanSelectFromColumns(null, handle.getTableHandle().getTableName(), Optional.empty(), ImmutableSet.of(handle.getColumnName()));
 
             return analyzeResult;
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -190,7 +190,7 @@ public class TestCallTask
         public static void testingMethod(Target target, ConnectorAccessControl connectorAccessControl)
         {
             target.invoked = true;
-            connectorAccessControl.checkCanInsertIntoTable(null, new SchemaTableName("test", "testing_table"));
+            connectorAccessControl.checkCanInsertIntoTable(null, new SchemaTableName("test", "testing_table"), Optional.empty());
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestRefreshViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRefreshViewTask.java
@@ -327,7 +327,7 @@ final class TestRefreshViewTask
         }
 
         @Override
-        public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+        public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
         {
             if (deniedTables.contains(tableName.objectName())) {
                 denySelectColumns(tableName.toString(), columnNames);
@@ -335,7 +335,7 @@ final class TestRefreshViewTask
         }
 
         @Override
-        public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> columnNames)
+        public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
         {
             if (deniedTables.contains(tableName.objectName())) {
                 denySelectColumns(tableName.toString(), columnNames);

--- a/core/trino-main/src/test/java/io/trino/execution/TestRefreshViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRefreshViewTask.java
@@ -330,7 +330,7 @@ final class TestRefreshViewTask
         public void checkCanSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
         {
             if (deniedTables.contains(tableName.objectName())) {
-                denySelectColumns(tableName.toString(), columnNames);
+                denySelectColumns(tableName.toString(), branch, columnNames);
             }
         }
 
@@ -338,7 +338,7 @@ final class TestRefreshViewTask
         public void checkCanCreateViewWithSelectFromColumns(SecurityContext context, QualifiedObjectName tableName, Optional<String> branch, Set<String> columnNames)
         {
             if (deniedTables.contains(tableName.objectName())) {
-                denySelectColumns(tableName.toString(), columnNames);
+                denySelectColumns(tableName.toString(), branch, columnNames);
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -115,8 +115,8 @@ public class TestAccessControlManager
             accessControlManager.checkCanSetCatalogSessionProperty(securityContext, TEST_CATALOG_NAME, "property");
             accessControlManager.checkCanShowSchemas(securityContext, TEST_CATALOG_NAME);
             accessControlManager.checkCanShowTables(securityContext, new CatalogSchemaName(TEST_CATALOG_NAME, "schema"));
-            accessControlManager.checkCanSelectFromColumns(securityContext, tableName, ImmutableSet.of("column"));
-            accessControlManager.checkCanCreateViewWithSelectFromColumns(securityContext, tableName, ImmutableSet.of("column"));
+            accessControlManager.checkCanSelectFromColumns(securityContext, tableName, Optional.empty(), ImmutableSet.of("column"));
+            accessControlManager.checkCanCreateViewWithSelectFromColumns(securityContext, tableName, Optional.empty(), ImmutableSet.of("column"));
             Set<String> catalogs = ImmutableSet.of(TEST_CATALOG_NAME);
             assertThat(accessControlManager.filterCatalogs(securityContext, catalogs)).isEqualTo(catalogs);
             Set<String> schemas = ImmutableSet.of("schema");
@@ -124,7 +124,7 @@ public class TestAccessControlManager
             Set<SchemaTableName> tableNames = ImmutableSet.of(new SchemaTableName("schema", "table"));
             assertThat(accessControlManager.filterTables(securityContext, TEST_CATALOG_NAME, tableNames)).isEqualTo(tableNames);
 
-            assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(securityContext, tableName))
+            assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(securityContext, tableName, Optional.empty()))
                     .isInstanceOf(AccessDeniedException.class)
                     .hasMessage("Access Denied: Cannot insert into table test_catalog.schema.table");
         });
@@ -141,7 +141,7 @@ public class TestAccessControlManager
 
         transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
-                    accessControlManager.checkCanSelectFromColumns(context(transactionId), new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"), ImmutableSet.of("column"));
+                    accessControlManager.checkCanSelectFromColumns(context(transactionId), new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"), Optional.empty(), ImmutableSet.of("column"));
                 });
     }
 
@@ -150,7 +150,7 @@ public class TestAccessControlManager
     {
         assertAccessControl(new AllowAllSystemAccessControl(), new DenyConnectorAccessControl(), (accessControlManager, securityContext) ->
                 assertThatThrownBy(
-                        () -> accessControlManager.checkCanSelectFromColumns(securityContext, new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"), ImmutableSet.of("column")))
+                        () -> accessControlManager.checkCanSelectFromColumns(securityContext, new QualifiedObjectName(TEST_CATALOG_NAME, "schema", "table"), Optional.empty(), ImmutableSet.of("column")))
                         .isInstanceOf(AccessDeniedException.class)
                         .hasMessage("Access Denied: Cannot select from columns [column] in table or view schema.table"));
     }
@@ -160,7 +160,7 @@ public class TestAccessControlManager
     {
         assertAccessControl(new TestSystemAccessControl(), new AllowAllAccessControl(), (accessControlManager, securityContext) ->
                 assertThatThrownBy(
-                        () -> accessControlManager.checkCanSelectFromColumns(securityContext, new QualifiedObjectName("secured_catalog", "schema", "table"), ImmutableSet.of("column")))
+                        () -> accessControlManager.checkCanSelectFromColumns(securityContext, new QualifiedObjectName("secured_catalog", "schema", "table"), Optional.empty(), ImmutableSet.of("column")))
                         .isInstanceOf(AccessDeniedException.class)
                         .hasMessage("Access Denied: Cannot select from table secured_catalog.schema.table"));
     }
@@ -449,7 +449,7 @@ public class TestAccessControlManager
         }
 
         @Override
-        public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
+        public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
         {
             if (table.getCatalogName().equals("secured_catalog")) {
                 denySelectTable(table.toString());

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -352,10 +352,10 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanCreateTable(aliceContext, aliceTable, Map.of());
                     accessControlManager.checkCanDropTable(aliceContext, aliceTable);
                     accessControlManager.checkCanTruncateTable(aliceContext, aliceTable);
-                    accessControlManager.checkCanSelectFromColumns(aliceContext, aliceTable, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, aliceTable, ImmutableSet.of());
-                    accessControlManager.checkCanInsertIntoTable(aliceContext, aliceTable);
-                    accessControlManager.checkCanDeleteFromTable(aliceContext, aliceTable);
+                    accessControlManager.checkCanSelectFromColumns(aliceContext, aliceTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, aliceTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanInsertIntoTable(aliceContext, aliceTable, Optional.empty());
+                    accessControlManager.checkCanDeleteFromTable(aliceContext, aliceTable, Optional.empty());
                     accessControlManager.checkCanSetTableProperties(aliceContext, aliceTable, ImmutableMap.of());
                     accessControlManager.checkCanAddColumns(aliceContext, aliceTable);
                     accessControlManager.checkCanRenameColumn(aliceContext, aliceTable);
@@ -363,10 +363,10 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanCreateTable(aliceContext, staffTable, Map.of());
                     accessControlManager.checkCanDropTable(aliceContext, staffTable);
                     accessControlManager.checkCanTruncateTable(aliceContext, staffTable);
-                    accessControlManager.checkCanSelectFromColumns(aliceContext, staffTable, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, staffTable, ImmutableSet.of());
-                    accessControlManager.checkCanInsertIntoTable(aliceContext, staffTable);
-                    accessControlManager.checkCanDeleteFromTable(aliceContext, staffTable);
+                    accessControlManager.checkCanSelectFromColumns(aliceContext, staffTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, staffTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanInsertIntoTable(aliceContext, staffTable, Optional.empty());
+                    accessControlManager.checkCanDeleteFromTable(aliceContext, staffTable, Optional.empty());
                     accessControlManager.checkCanSetTableProperties(aliceContext, staffTable, ImmutableMap.of());
                     accessControlManager.checkCanAddColumns(aliceContext, staffTable);
                     accessControlManager.checkCanRenameColumn(aliceContext, staffTable);
@@ -380,16 +380,16 @@ public class TestFileBasedSystemAccessControl
                     assertThatThrownBy(() -> accessControlManager.checkCanTruncateTable(bobContext, aliceTable))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(bobContext, aliceTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(bobContext, aliceTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, aliceTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, aliceTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(bobContext, aliceTable))
+                    assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(bobContext, aliceTable, Optional.empty()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(bobContext, aliceTable))
+                    assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(bobContext, aliceTable, Optional.empty()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
                     assertThatThrownBy(() -> accessControlManager.checkCanSetTableProperties(bobContext, aliceTable, ImmutableMap.of()))
@@ -405,10 +405,10 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanCreateTable(bobContext, staffTable, Map.of());
                     accessControlManager.checkCanDropTable(bobContext, staffTable);
                     accessControlManager.checkCanTruncateTable(bobContext, staffTable);
-                    accessControlManager.checkCanSelectFromColumns(bobContext, staffTable, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, staffTable, ImmutableSet.of());
-                    accessControlManager.checkCanInsertIntoTable(bobContext, staffTable);
-                    accessControlManager.checkCanDeleteFromTable(bobContext, staffTable);
+                    accessControlManager.checkCanSelectFromColumns(bobContext, staffTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, staffTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanInsertIntoTable(bobContext, staffTable, Optional.empty());
+                    accessControlManager.checkCanDeleteFromTable(bobContext, staffTable, Optional.empty());
                     accessControlManager.checkCanSetTableProperties(bobContext, staffTable, ImmutableMap.of());
                     accessControlManager.checkCanAddColumns(bobContext, staffTable);
                     accessControlManager.checkCanRenameColumn(bobContext, staffTable);
@@ -422,16 +422,16 @@ public class TestFileBasedSystemAccessControl
                     assertThatThrownBy(() -> accessControlManager.checkCanTruncateTable(nonAsciiContext, aliceTable))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, aliceTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, aliceTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, aliceTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, aliceTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(nonAsciiContext, aliceTable))
+                    assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(nonAsciiContext, aliceTable, Optional.empty()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(nonAsciiContext, aliceTable))
+                    assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(nonAsciiContext, aliceTable, Optional.empty()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
                     assertThatThrownBy(() -> accessControlManager.checkCanSetTableProperties(nonAsciiContext, aliceTable, ImmutableMap.of()))
@@ -453,16 +453,16 @@ public class TestFileBasedSystemAccessControl
                     assertThatThrownBy(() -> accessControlManager.checkCanTruncateTable(nonAsciiContext, staffTable))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, staffTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, staffTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, staffTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, staffTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(nonAsciiContext, staffTable))
+                    assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(nonAsciiContext, staffTable, Optional.empty()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(nonAsciiContext, staffTable))
+                    assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(nonAsciiContext, staffTable, Optional.empty()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
                     assertThatThrownBy(() -> accessControlManager.checkCanSetTableProperties(nonAsciiContext, staffTable, ImmutableMap.of()))
@@ -491,7 +491,7 @@ public class TestFileBasedSystemAccessControl
                     assertThat(accessControlManager.filterTables(new SecurityContext(transactionId, alice, queryId, queryStart), "alice-catalog", aliceTables)).isEqualTo(aliceTables);
                     assertThat(accessControlManager.filterTables(new SecurityContext(transactionId, bob, queryId, queryStart), "alice-catalog", aliceTables)).isEqualTo(ImmutableSet.of());
 
-                    accessControlManager.checkCanSelectFromColumns(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, ImmutableSet.of());
+                    accessControlManager.checkCanSelectFromColumns(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, Optional.empty(), ImmutableSet.of());
                 });
 
         assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
@@ -510,12 +510,12 @@ public class TestFileBasedSystemAccessControl
                 .hasMessage("Access Denied: Cannot truncate table alice-catalog.schema.table");
 
         assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
-            accessControlManager.checkCanInsertIntoTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
+            accessControlManager.checkCanInsertIntoTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, Optional.empty());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot insert into table alice-catalog.schema.table");
 
         assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
-            accessControlManager.checkCanDeleteFromTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
+            accessControlManager.checkCanDeleteFromTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, Optional.empty());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot delete from table alice-catalog.schema.table");
 
@@ -556,18 +556,18 @@ public class TestFileBasedSystemAccessControl
 
                     accessControlManager.checkCanCreateView(aliceContext, aliceView);
                     accessControlManager.checkCanDropView(aliceContext, aliceView);
-                    accessControlManager.checkCanSelectFromColumns(aliceContext, aliceView, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, aliceTable, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, aliceView, ImmutableSet.of());
+                    accessControlManager.checkCanSelectFromColumns(aliceContext, aliceView, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, aliceTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, aliceView, Optional.empty(), ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(aliceContext, "alice-catalog", "property");
                     accessControlManager.checkCanGrantTablePrivilege(aliceContext, SELECT, aliceTable, new TrinoPrincipal(USER, "grantee"), true);
                     accessControlManager.checkCanRevokeTablePrivilege(aliceContext, SELECT, aliceTable, new TrinoPrincipal(USER, "revokee"), true);
 
                     accessControlManager.checkCanCreateView(aliceContext, staffView);
                     accessControlManager.checkCanDropView(aliceContext, staffView);
-                    accessControlManager.checkCanSelectFromColumns(aliceContext, staffView, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, staffTable, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, staffView, ImmutableSet.of());
+                    accessControlManager.checkCanSelectFromColumns(aliceContext, staffView, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, staffTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(aliceContext, staffView, Optional.empty(), ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(aliceContext, "alice-catalog", "property");
                     accessControlManager.checkCanGrantTablePrivilege(aliceContext, SELECT, staffTable, new TrinoPrincipal(USER, "grantee"), true);
                     accessControlManager.checkCanRevokeTablePrivilege(aliceContext, SELECT, staffTable, new TrinoPrincipal(USER, "revokee"), true);
@@ -578,13 +578,13 @@ public class TestFileBasedSystemAccessControl
                     assertThatThrownBy(() -> accessControlManager.checkCanDropView(bobContext, aliceView))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(bobContext, aliceView, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(bobContext, aliceView, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, aliceTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, aliceTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, aliceView, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, aliceView, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
                     assertThatThrownBy(() -> accessControlManager.checkCanSetCatalogSessionProperty(bobContext, "alice-catalog", "property"))
@@ -599,9 +599,9 @@ public class TestFileBasedSystemAccessControl
 
                     accessControlManager.checkCanCreateView(bobContext, staffView);
                     accessControlManager.checkCanDropView(bobContext, staffView);
-                    accessControlManager.checkCanSelectFromColumns(bobContext, staffView, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, staffTable, ImmutableSet.of());
-                    accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, staffView, ImmutableSet.of());
+                    accessControlManager.checkCanSelectFromColumns(bobContext, staffView, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, staffTable, Optional.empty(), ImmutableSet.of());
+                    accessControlManager.checkCanCreateViewWithSelectFromColumns(bobContext, staffView, Optional.empty(), ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(bobContext, "staff-catalog", "property");
                     accessControlManager.checkCanGrantTablePrivilege(bobContext, SELECT, staffTable, new TrinoPrincipal(USER, "grantee"), true);
                     accessControlManager.checkCanRevokeTablePrivilege(bobContext, SELECT, staffTable, new TrinoPrincipal(USER, "revokee"), true);
@@ -612,13 +612,13 @@ public class TestFileBasedSystemAccessControl
                     assertThatThrownBy(() -> accessControlManager.checkCanDropView(nonAsciiContext, aliceView))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, aliceView, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, aliceView, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, aliceTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, aliceTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, aliceView, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, aliceView, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog alice-catalog");
                     assertThatThrownBy(() -> accessControlManager.checkCanSetCatalogSessionProperty(nonAsciiContext, "alice-catalog", "property"))
@@ -637,13 +637,13 @@ public class TestFileBasedSystemAccessControl
                     assertThatThrownBy(() -> accessControlManager.checkCanDropView(nonAsciiContext, staffView))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, staffView, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(nonAsciiContext, staffView, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, staffTable, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, staffTable, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
-                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, staffView, ImmutableSet.of()))
+                    assertThatThrownBy(() -> accessControlManager.checkCanCreateViewWithSelectFromColumns(nonAsciiContext, staffView, Optional.empty(), ImmutableSet.of()))
                             .isInstanceOf(AccessDeniedException.class)
                             .hasMessage("Access Denied: Cannot access catalog staff-catalog");
                     assertThatThrownBy(() -> accessControlManager.checkCanSetCatalogSessionProperty(nonAsciiContext, "staff-catalog", "property"))
@@ -669,7 +669,7 @@ public class TestFileBasedSystemAccessControl
         transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     SecurityContext context = new SecurityContext(transactionId, alice, queryId, queryStart);
-                    accessControlManager.checkCanSelectFromColumns(context, aliceView, ImmutableSet.of());
+                    accessControlManager.checkCanSelectFromColumns(context, aliceView, Optional.empty(), ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(context, "alice-catalog", "property");
                 });
 
@@ -770,7 +770,7 @@ public class TestFileBasedSystemAccessControl
         transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     SecurityContext context = new SecurityContext(transactionId, alice, queryId, queryStart);
-                    accessControlManager.checkCanSelectFromColumns(context, aliceMaterializedView, ImmutableSet.of());
+                    accessControlManager.checkCanSelectFromColumns(context, aliceMaterializedView, Optional.empty(), ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(context, "alice-catalog", "property");
                 });
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestScope.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestScope.java
@@ -30,12 +30,12 @@ public class TestScope
     {
         Scope root = Scope.create();
 
-        Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), Optional.empty(), false);
-        Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), Optional.empty(), Optional.empty(), false);
+        Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), Optional.empty(), false);
         Scope outer = Scope.builder().withParent(root).withRelationType(RelationId.anonymous(), new RelationType(outerColumn1, outerColumn2)).build();
 
-        Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), false);
-        Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), Optional.empty(), false);
+        Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), Optional.empty(), Optional.empty(), false);
         Scope inner = Scope.builder().withOuterQueryParent(outer).withRelationType(RelationId.anonymous(), new RelationType(innerColumn2, innerColumn3)).build();
 
         Expression c1 = name("c1");

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -49,6 +49,7 @@ import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.FRESH;
 import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.STALE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
+import static io.trino.testing.TestingAccessControlManager.branchPrivilege;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -179,6 +180,7 @@ public class TestColumnMask
                     }
                     throw new UnsupportedOperationException();
                 })
+                .withBranches(ImmutableList.of("dev"))
                 .withData(schemaTableName -> {
                     if (schemaTableName.equals(new SchemaTableName("tiny", "nation_with_hidden_column"))) {
                         return TPCH_WITH_HIDDEN_COLUMN_DATA;
@@ -242,6 +244,32 @@ public class TestColumnMask
                         .expression("NULL")
                         .build());
         assertThat(assertions.query("SELECT custkey FROM orders WHERE orderkey = 1")).matches("VALUES CAST(NULL AS BIGINT)");
+    }
+
+    @Test
+    public void testSimpleMaskOnBranch()
+    {
+        accessControl.reset();
+        accessControl.columnMask(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_hidden_column"),
+                "nationkey",
+                USER,
+                ViewExpression.builder()
+                        .identity(USER)
+                        .expression("-nationkey")
+                        .build());
+        assertThat(assertions.query("SELECT nationkey FROM mock.tiny.nation_with_hidden_column FOR VERSION AS OF 'dev' WHERE name = 'ARGENTINA'")).matches("VALUES BIGINT '-1'");
+
+        accessControl.reset();
+        accessControl.columnMask(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_hidden_column"),
+                "nationkey",
+                USER,
+                ViewExpression.builder()
+                        .identity(USER)
+                        .expression("NULL")
+                        .build());
+        assertThat(assertions.query("SELECT nationkey FROM mock.tiny.nation_with_hidden_column FOR VERSION AS OF 'dev' WHERE name = 'ARGENTINA'")).matches("VALUES CAST(NULL AS BIGINT)");
     }
 
     @Test
@@ -931,6 +959,49 @@ public class TestColumnMask
                         .expression("(SELECT orderstatus FROM local.tiny.orders)")
                         .build());
         assertThat(assertions.query("SELECT orderkey FROM orders WHERE orderkey = 1")).matches("VALUES BIGINT '1'");
+    }
+
+    @Test
+    public void testNotReferencedAndDeniedColumnMaskingOnBranch()
+    {
+        // querying table, privilege on branch
+        accessControl.reset();
+        accessControl.deny(branchPrivilege("nation_with_hidden_column.name", "dev", SELECT_COLUMN));
+        accessControl.columnMask(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_hidden_column"),
+                "name",
+                USER,
+                ViewExpression.builder()
+                        .identity(USER)
+                        .expression("name")
+                        .build());
+        assertThat(assertions.query("SELECT nationkey FROM mock.tiny.nation_with_hidden_column WHERE nationkey = 1")).matches("VALUES BIGINT '1'");
+
+        // querying table branch, privilege on table
+        accessControl.reset();
+        accessControl.deny(privilege("nation_with_hidden_column.name", SELECT_COLUMN));
+        accessControl.columnMask(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_hidden_column"),
+                "name",
+                USER,
+                ViewExpression.builder()
+                        .identity(USER)
+                        .expression("name")
+                        .build());
+        assertThat(assertions.query("SELECT nationkey FROM mock.tiny.nation_with_hidden_column FOR VERSION AS OF 'dev' WHERE nationkey = 1")).matches("VALUES BIGINT '1'");
+
+        // querying table branch, privilege on branch
+        accessControl.reset();
+        accessControl.deny(branchPrivilege("nation_with_hidden_column.name", "dev", SELECT_COLUMN));
+        accessControl.columnMask(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_hidden_column"),
+                "name",
+                USER,
+                ViewExpression.builder()
+                        .identity(USER)
+                        .expression("name")
+                        .build());
+        assertThat(assertions.query("SELECT nationkey FROM mock.tiny.nation_with_hidden_column FOR VERSION AS OF 'dev' WHERE nationkey = 1")).matches("VALUES BIGINT '1'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -105,6 +105,7 @@ public class TestRowFilter
                     }
                     throw new UnsupportedOperationException();
                 })
+                .withBranches(ImmutableList.of("dev"))
                 .withData(schemaTableName -> {
                     if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
                         return TPCH_NATION_DATA;
@@ -167,6 +168,24 @@ public class TestRowFilter
                 USER,
                 ViewExpression.builder().expression("NULL").build());
         assertThat(assertions.query("SELECT count(*) FROM orders")).matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSimpleFilterOnBranch()
+    {
+        accessControl.reset();
+        accessControl.rowFilter(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_optional_column"),
+                USER,
+                ViewExpression.builder().expression("nationkey < 5").build());
+        assertThat(assertions.query("SELECT count(*) FROM mock.tiny.nation_with_optional_column FOR VERSION AS OF 'dev'")).matches("VALUES BIGINT '5'");
+
+        accessControl.reset();
+        accessControl.rowFilter(
+                new QualifiedObjectName(MOCK_CATALOG, "tiny", "nation_with_optional_column"),
+                USER,
+                ViewExpression.builder().expression("NULL").build());
+        assertThat(assertions.query("SELECT count(*) FROM mock.tiny.nation_with_optional_column FOR VERSION AS OF 'dev'")).matches("VALUES BIGINT '0'");
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -347,6 +347,15 @@ public interface ConnectorAccessControl
      *
      * @throws io.trino.spi.security.AccessDeniedException if not allowed
      */
+    default void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        checkCanSelectFromColumns(context, tableName, columnNames);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanSelectFromColumns(ConnectorSecurityContext, SchemaTableName, Optional, Set)}
+     */
+    @Deprecated
     default void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
         denySelectColumns(tableName.toString(), columnNames);
@@ -357,6 +366,15 @@ public interface ConnectorAccessControl
      *
      * @throws io.trino.spi.security.AccessDeniedException if not allowed
      */
+    default void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        checkCanInsertIntoTable(context, tableName);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanInsertIntoTable(ConnectorSecurityContext, SchemaTableName, Optional)}
+     */
+    @Deprecated
     default void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         denyInsertTable(tableName.toString());
@@ -367,6 +385,15 @@ public interface ConnectorAccessControl
      *
      * @throws io.trino.spi.security.AccessDeniedException if not allowed
      */
+    default void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        checkCanDeleteFromTable(context, tableName);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanDeleteFromTable(ConnectorSecurityContext, SchemaTableName, Optional)}
+     */
+    @Deprecated
     default void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         denyDeleteTable(tableName.toString());
@@ -387,6 +414,15 @@ public interface ConnectorAccessControl
      *
      * @throws io.trino.spi.security.AccessDeniedException if not allowed
      */
+    default void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
+    {
+        checkCanUpdateTableColumns(context, tableName, updatedColumns);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanUpdateTableColumns(ConnectorSecurityContext, SchemaTableName, Optional, Set)}
+     */
+    @Deprecated
     default void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
     {
         denyUpdateTableColumns(tableName.toString(), updatedColumns);
@@ -447,6 +483,15 @@ public interface ConnectorAccessControl
      *
      * @throws io.trino.spi.security.AccessDeniedException if not allowed
      */
+    default void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext, SchemaTableName, Optional, Set)}
+     */
+    @Deprecated
     default void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
         denyCreateViewWithSelect(tableName.toString(), context.getIdentity());

--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -372,32 +372,68 @@ public class AccessDeniedException
 
     public static void denySelectTable(String tableName)
     {
-        denySelectTable(tableName, null);
+        denySelectTable(tableName, (String) null);
     }
 
     public static void denySelectTable(String tableName, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot select from table %s%s", tableName, formatExtraInfo(extraInfo)));
+        denySelectTable(tableName, Optional.empty(), extraInfo);
+    }
+
+    public static void denySelectTable(String tableName, Optional<String> branchName)
+    {
+        denySelectTable(tableName, branchName, null);
+    }
+
+    public static void denySelectTable(String tableName, Optional<String> branchName, String extraInfo)
+    {
+        throw new AccessDeniedException(branchName
+                .map(branch -> format("Cannot select from branch %s in table %s%s", branch, tableName, formatExtraInfo(extraInfo)))
+                .orElseGet(() -> format("Cannot select from table %s%s", tableName, formatExtraInfo(extraInfo))));
     }
 
     public static void denyInsertTable(String tableName)
     {
-        denyInsertTable(tableName, null);
+        denyInsertTable(tableName, (String) null);
     }
 
     public static void denyInsertTable(String tableName, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot insert into table %s%s", tableName, formatExtraInfo(extraInfo)));
+        denyInsertTable(tableName, Optional.empty(), extraInfo);
+    }
+
+    public static void denyInsertTable(String tableName, Optional<String> branchName)
+    {
+        denyInsertTable(tableName, branchName, null);
+    }
+
+    public static void denyInsertTable(String tableName, Optional<String> branchName, String extraInfo)
+    {
+        throw new AccessDeniedException(branchName
+                .map(branch -> format("Cannot insert into branch %s in table %s%s", branch, tableName, formatExtraInfo(extraInfo)))
+                .orElseGet(() -> format("Cannot insert into table %s%s", tableName, formatExtraInfo(extraInfo))));
     }
 
     public static void denyDeleteTable(String tableName)
     {
-        denyDeleteTable(tableName, null);
+        denyDeleteTable(tableName, (String) null);
     }
 
     public static void denyDeleteTable(String tableName, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot delete from table %s%s", tableName, formatExtraInfo(extraInfo)));
+        denyDeleteTable(tableName, Optional.empty(), extraInfo);
+    }
+
+    public static void denyDeleteTable(String tableName, Optional<String> branchName)
+    {
+        denyDeleteTable(tableName, branchName, null);
+    }
+
+    public static void denyDeleteTable(String tableName, Optional<String> branchName, String extraInfo)
+    {
+        throw new AccessDeniedException(branchName
+                .map(branch -> format("Cannot delete from branch %s in table %s%s", branch, tableName, formatExtraInfo(extraInfo)))
+                .orElseGet(() -> format("Cannot delete from table %s%s", tableName, formatExtraInfo(extraInfo))));
     }
 
     public static void denyTruncateTable(String tableName)
@@ -417,7 +453,19 @@ public class AccessDeniedException
 
     public static void denyUpdateTableColumns(String tableName, Set<String> updatedColumnNames, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot update columns %s in table %s%s", updatedColumnNames, tableName, formatExtraInfo(extraInfo)));
+        denyUpdateTableColumns(tableName, Optional.empty(), updatedColumnNames, extraInfo);
+    }
+
+    public static void denyUpdateTableColumns(String tableName, Optional<String> branchName, Set<String> updatedColumnNames)
+    {
+        denyUpdateTableColumns(tableName, branchName, updatedColumnNames, null);
+    }
+
+    public static void denyUpdateTableColumns(String tableName, Optional<String> branchName, Set<String> updatedColumnNames, String extraInfo)
+    {
+        throw new AccessDeniedException(branchName
+                .map(branch -> format("Cannot update columns %s in branch %s in table %s%s", updatedColumnNames, branch, tableName, formatExtraInfo(extraInfo)))
+                .orElseGet(() -> format("Cannot update columns %s in table %s%s", updatedColumnNames, tableName, formatExtraInfo(extraInfo))));
     }
 
     public static void denyCreateView(String viewName)
@@ -442,7 +490,24 @@ public class AccessDeniedException
 
     public static void denyCreateViewWithSelect(String sourceName, ConnectorIdentity identity, String extraInfo)
     {
-        throw new AccessDeniedException(format("View owner '%s' cannot create view that selects from %s%s", identity.getUser(), sourceName, formatExtraInfo(extraInfo)));
+        denyCreateViewWithSelect(sourceName, Optional.empty(), identity, extraInfo);
+    }
+
+    public static void denyCreateViewWithSelect(String sourceName, Optional<String> branchName, Identity identity)
+    {
+        denyCreateViewWithSelect(sourceName, branchName, identity.toConnectorIdentity());
+    }
+
+    public static void denyCreateViewWithSelect(String sourceName, Optional<String> branchName, ConnectorIdentity identity)
+    {
+        denyCreateViewWithSelect(sourceName, branchName, identity, null);
+    }
+
+    public static void denyCreateViewWithSelect(String sourceName, Optional<String> branchName, ConnectorIdentity identity, String extraInfo)
+    {
+        throw new AccessDeniedException(branchName
+                .map(branch -> format("View owner '%s' cannot create view that selects from branch %s in %s%s", identity.getUser(), branch, sourceName, formatExtraInfo(extraInfo)))
+                .orElseGet(() -> format("View owner '%s' cannot create view that selects from %s%s", identity.getUser(), sourceName, formatExtraInfo(extraInfo))));
     }
 
     public static void denyRenameView(String viewName, String newViewName)
@@ -720,7 +785,19 @@ public class AccessDeniedException
 
     public static void denySelectColumns(String tableName, Collection<String> columnNames, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot select from columns %s in table or view %s%s", columnNames, tableName, formatExtraInfo(extraInfo)));
+        denySelectColumns(tableName, Optional.empty(), columnNames, extraInfo);
+    }
+
+    public static void denySelectColumns(String tableName, Optional<String> branchName, Collection<String> columnNames)
+    {
+        denySelectColumns(tableName, branchName, columnNames, null);
+    }
+
+    public static void denySelectColumns(String tableName, Optional<String> branchName, Collection<String> columnNames, String extraInfo)
+    {
+        throw new AccessDeniedException(branchName
+                .map(branch -> format("Cannot select from columns %s in branch %s in table %s%s", columnNames, branch, tableName, formatExtraInfo(extraInfo)))
+                .orElseGet(() -> format("Cannot select from columns %s in table or view %s%s", columnNames, tableName, formatExtraInfo(extraInfo))));
     }
 
     public static void denyCreateRole(String roleName)

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -517,6 +517,15 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
+    default void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
+    {
+        checkCanSelectFromColumns(context, table, columns);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanSelectFromColumns(SystemSecurityContext, CatalogSchemaTableName, Optional, Set)}
+     */
+    @Deprecated
     default void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
         denySelectColumns(table.toString(), columns);
@@ -527,6 +536,15 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
+    default void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
+    {
+        checkCanInsertIntoTable(context, table);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanInsertIntoTable(SystemSecurityContext, CatalogSchemaTableName, Optional)}
+     */
+    @Deprecated
     default void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         denyInsertTable(table.toString());
@@ -537,6 +555,15 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
+    default void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
+    {
+        checkCanDeleteFromTable(context, table);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanDeleteFromTable(SystemSecurityContext, CatalogSchemaTableName, Optional)}
+     */
+    @Deprecated
     default void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         denyDeleteTable(table.toString());
@@ -557,6 +584,15 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
+    default void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Optional<String> branch, Set<String> updatedColumnNames)
+    {
+        checkCanUpdateTableColumns(securityContext, table, updatedColumnNames);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanUpdateTableColumns(SystemSecurityContext, CatalogSchemaTableName, Optional, Set)}
+     */
+    @Deprecated
     default void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames)
     {
         denyUpdateTableColumns(table.toString(), updatedColumnNames);
@@ -633,6 +669,15 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
+    default void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
+    {
+        checkCanCreateViewWithSelectFromColumns(context, table, columns);
+    }
+
+    /**
+     * @deprecated use {@link #checkCanCreateViewWithSelectFromColumns(SystemSecurityContext, CatalogSchemaTableName, Optional, Set)}
+     */
+    @Deprecated
     default void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
         denyCreateViewWithSelect(table.toString(), context.getIdentity());

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -238,6 +238,15 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanSelectFromColumns(context, tableName, branch, columnNames);
+        }
+    }
+
+    @Deprecated
+    @Override
     public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
@@ -246,6 +255,15 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanInsertIntoTable(context, tableName, branch);
+        }
+    }
+
+    @Deprecated
+    @Override
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
@@ -253,6 +271,15 @@ public class ClassLoaderSafeConnectorAccessControl
         }
     }
 
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanDeleteFromTable(context, tableName, branch);
+        }
+    }
+
+    @Deprecated
     @Override
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
@@ -270,10 +297,19 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
-    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumnNames)
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumnNames)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+            delegate.checkCanUpdateTableColumns(context, tableName, branch, updatedColumnNames);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanUpdateTableColumns(context, tableName, updatedColumns);
         }
     }
 
@@ -317,6 +353,15 @@ public class ClassLoaderSafeConnectorAccessControl
         }
     }
 
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames);
+        }
+    }
+
+    @Deprecated
     @Override
     public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -115,17 +115,33 @@ public class AllowAllAccessControl
     public void checkCanSetTableAuthorization(ConnectorSecurityContext context, SchemaTableName tableName, TrinoPrincipal principal) {}
 
     @Override
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames) {}
+
+    @Deprecated
+    @Override
     public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames) {}
 
     @Override
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch) {}
+
+    @Deprecated
+    @Override
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName) {}
 
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch) {}
+
+    @Deprecated
     @Override
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName) {}
 
     @Override
     public void checkCanTruncateTable(ConnectorSecurityContext context, SchemaTableName tableName) {}
 
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumnNames) {}
+
+    @Deprecated
     @Override
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumnNames) {}
 
@@ -144,6 +160,10 @@ public class AllowAllAccessControl
     @Override
     public void checkCanDropView(ConnectorSecurityContext context, SchemaTableName viewName) {}
 
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames) {}
+
+    @Deprecated
     @Override
     public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames) {}
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -204,17 +204,33 @@ public class AllowAllSystemAccessControl
     public void checkCanAlterColumn(SystemSecurityContext context, CatalogSchemaTableName table) {}
 
     @Override
+    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns) {}
+
+    @Deprecated
+    @Override
     public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns) {}
 
     @Override
+    public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch) {}
+
+    @Deprecated
+    @Override
     public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table) {}
 
+    @Override
+    public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch) {}
+
+    @Deprecated
     @Override
     public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table) {}
 
     @Override
     public void checkCanTruncateTable(SystemSecurityContext context, CatalogSchemaTableName table) {}
 
+    @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Optional<String> branch, Set<String> updatedColumnNames) {}
+
+    @Deprecated
     @Override
     public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames) {}
 
@@ -233,6 +249,10 @@ public class AllowAllSystemAccessControl
     @Override
     public void checkCanRefreshView(SystemSecurityContext context, CatalogSchemaTableName view) {}
 
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns) {}
+
+    @Deprecated
     @Override
     public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns) {}
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -397,7 +397,7 @@ public class FileBasedAccessControl
                 .findFirst()
                 .orElse(false);
         if (!allowed) {
-            denySelectTable(tableName.toString());
+            denySelectTable(tableName.toString(), branch);
         }
     }
 
@@ -412,7 +412,7 @@ public class FileBasedAccessControl
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, INSERT)) {
-            denyInsertTable(tableName.toString());
+            denyInsertTable(tableName.toString(), branch);
         }
     }
 
@@ -427,7 +427,7 @@ public class FileBasedAccessControl
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, DELETE)) {
-            denyDeleteTable(tableName.toString());
+            denyDeleteTable(tableName.toString(), branch);
         }
     }
 
@@ -450,7 +450,7 @@ public class FileBasedAccessControl
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
     {
         if (!checkTablePermission(context, tableName, UPDATE)) {
-            denyUpdateTableColumns(tableName.toString(), updatedColumns);
+            denyUpdateTableColumns(tableName.toString(), branch, updatedColumns);
         }
     }
 
@@ -520,10 +520,10 @@ public class FileBasedAccessControl
                 .findFirst()
                 .orElse(null);
         if (rule == null || !rule.canSelectColumns(columnNames)) {
-            denySelectTable(tableName.toString());
+            denySelectTable(tableName.toString(), branch);
         }
         if (!rule.getPrivileges().contains(GRANT_SELECT)) {
-            denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
+            denyCreateViewWithSelect(tableName.toString(), branch, context.getIdentity());
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -384,7 +384,7 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
         if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
             return;
@@ -401,20 +401,41 @@ public class FileBasedAccessControl
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    {
+        checkCanSelectFromColumns(context, tableName, Optional.empty(), columnNames);
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, INSERT)) {
             denyInsertTable(tableName.toString());
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    {
+        checkCanInsertIntoTable(context, tableName, Optional.empty());
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, DELETE)) {
             denyDeleteTable(tableName.toString());
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    {
+        checkCanDeleteFromTable(context, tableName, Optional.empty());
     }
 
     @Override
@@ -426,11 +447,18 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
     {
         if (!checkTablePermission(context, tableName, UPDATE)) {
             denyUpdateTableColumns(tableName.toString(), updatedColumns);
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        checkCanUpdateTableColumns(context, tableName, Optional.empty(), updatedColumns);
     }
 
     @Override
@@ -480,7 +508,7 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
         if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
             return;
@@ -497,6 +525,13 @@ public class FileBasedAccessControl
         if (!rule.getPrivileges().contains(GRANT_SELECT)) {
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    {
+        checkCanCreateViewWithSelectFromColumns(context, tableName, Optional.empty(), columnNames);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -658,7 +658,7 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
+    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
     {
         if (!canAccessCatalog(context, table.getCatalogName(), READ_ONLY)) {
             denySelectTable(table.toString());
@@ -679,28 +679,56 @@ public class FileBasedSystemAccessControl
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table)
+    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
+    {
+        checkCanSelectFromColumns(context, table, Optional.empty(), columns);
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
     {
         if (!checkTablePermission(context, table, INSERT)) {
             denyInsertTable(table.toString());
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table)
+    public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table)
+    {
+        checkCanInsertIntoTable(context, table, Optional.empty());
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
     {
         if (!checkTablePermission(context, table, DELETE)) {
             denyDeleteTable(table.toString());
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table)
+    {
+        checkCanDeleteFromTable(context, table, Optional.empty());
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> updatedColumnNames)
     {
         if (!checkTablePermission(context, table, UPDATE)) {
             denyUpdateTableColumns(table.toString(), updatedColumnNames);
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    {
+        checkCanUpdateTableColumns(securityContext, table, Optional.empty(), updatedColumnNames);
     }
 
     @Override
@@ -745,7 +773,7 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
+    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
     {
         if (!canAccessCatalog(context, table.getCatalogName(), ALL)) {
             denySelectTable(table.toString());
@@ -766,6 +794,13 @@ public class FileBasedSystemAccessControl
         if (!rule.getPrivileges().contains(GRANT_SELECT)) {
             denyCreateViewWithSelect(table.toString(), context.getIdentity());
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
+    {
+        checkCanCreateViewWithSelectFromColumns(context, table, Optional.empty(), columns);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -661,7 +661,7 @@ public class FileBasedSystemAccessControl
     public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
     {
         if (!canAccessCatalog(context, table.getCatalogName(), READ_ONLY)) {
-            denySelectTable(table.toString());
+            denySelectTable(table.toString(), branch);
         }
 
         if (INFORMATION_SCHEMA_NAME.equals(table.getSchemaTableName().getSchemaName())) {
@@ -675,7 +675,7 @@ public class FileBasedSystemAccessControl
                 .findFirst()
                 .orElse(false);
         if (!allowed) {
-            denySelectTable(table.toString());
+            denySelectTable(table.toString(), branch);
         }
     }
 
@@ -690,7 +690,7 @@ public class FileBasedSystemAccessControl
     public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
     {
         if (!checkTablePermission(context, table, INSERT)) {
-            denyInsertTable(table.toString());
+            denyInsertTable(table.toString(), branch);
         }
     }
 
@@ -705,7 +705,7 @@ public class FileBasedSystemAccessControl
     public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
     {
         if (!checkTablePermission(context, table, DELETE)) {
-            denyDeleteTable(table.toString());
+            denyDeleteTable(table.toString(), branch);
         }
     }
 
@@ -720,7 +720,7 @@ public class FileBasedSystemAccessControl
     public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> updatedColumnNames)
     {
         if (!checkTablePermission(context, table, UPDATE)) {
-            denyUpdateTableColumns(table.toString(), updatedColumnNames);
+            denyUpdateTableColumns(table.toString(), branch, updatedColumnNames);
         }
     }
 
@@ -776,7 +776,7 @@ public class FileBasedSystemAccessControl
     public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
     {
         if (!canAccessCatalog(context, table.getCatalogName(), ALL)) {
-            denySelectTable(table.toString());
+            denySelectTable(table.toString(), branch);
         }
 
         if (INFORMATION_SCHEMA_NAME.equals(table.getSchemaTableName().getSchemaName())) {
@@ -789,10 +789,10 @@ public class FileBasedSystemAccessControl
                 .findFirst()
                 .orElse(null);
         if (rule == null || !rule.canSelectColumns(columns)) {
-            denySelectTable(table.toString());
+            denySelectTable(table.toString(), branch);
         }
         if (!rule.getPrivileges().contains(GRANT_SELECT)) {
-            denyCreateViewWithSelect(table.toString(), context.getIdentity());
+            denyCreateViewWithSelect(table.toString(), branch, context.getIdentity());
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -194,17 +194,38 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        delegate().checkCanSelectFromColumns(context, tableName, branch, columnNames);
+    }
+
+    @Deprecated
+    @Override
     public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
         delegate().checkCanSelectFromColumns(context, tableName, columnNames);
     }
 
     @Override
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        delegate().checkCanInsertIntoTable(context, tableName, branch);
+    }
+
+    @Deprecated
+    @Override
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         delegate().checkCanInsertIntoTable(context, tableName);
     }
 
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
+    {
+        delegate().checkCanDeleteFromTable(context, tableName, branch);
+    }
+
+    @Deprecated
     @Override
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
@@ -217,6 +238,13 @@ public abstract class ForwardingConnectorAccessControl
         delegate().checkCanTruncateTable(context, tableName);
     }
 
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
+    {
+        delegate().checkCanUpdateTableColumns(context, tableName, branch, updatedColumns);
+    }
+
+    @Deprecated
     @Override
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
     {
@@ -253,6 +281,13 @@ public abstract class ForwardingConnectorAccessControl
         delegate().checkCanDropView(context, viewName);
     }
 
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
+    {
+        delegate().checkCanCreateViewWithSelectFromColumns(context, tableName, branch, columnNames);
+    }
+
+    @Deprecated
     @Override
     public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -288,17 +288,38 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
+    {
+        delegate().checkCanSelectFromColumns(context, table, branch, columns);
+    }
+
+    @Deprecated
+    @Override
     public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
         delegate().checkCanSelectFromColumns(context, table, columns);
     }
 
     @Override
+    public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
+    {
+        delegate().checkCanInsertIntoTable(context, table, branch);
+    }
+
+    @Deprecated
+    @Override
     public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         delegate().checkCanInsertIntoTable(context, table);
     }
 
+    @Override
+    public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch)
+    {
+        delegate().checkCanDeleteFromTable(context, table, branch);
+    }
+
+    @Deprecated
     @Override
     public void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table)
     {
@@ -311,6 +332,13 @@ public abstract class ForwardingSystemAccessControl
         delegate().checkCanTruncateTable(context, table);
     }
 
+    @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> updatedColumnNames)
+    {
+        delegate().checkCanUpdateTableColumns(context, table, branch, updatedColumnNames);
+    }
+
+    @Deprecated
     @Override
     public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> updatedColumnNames)
     {
@@ -347,6 +375,13 @@ public abstract class ForwardingSystemAccessControl
         delegate().checkCanDropView(context, view);
     }
 
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns)
+    {
+        delegate().checkCanCreateViewWithSelectFromColumns(context, table, branch, columns);
+    }
+
+    @Deprecated
     @Override
     public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
@@ -148,25 +148,25 @@ public class ReadOnlyAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
         // allow
     }
 
     @Override
-    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         denyInsertTable(tableName.toString());
     }
 
     @Override
-    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         denyDeleteTable(tableName.toString());
     }
 
     @Override
-    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
     {
         denyUpdateTableColumns(tableName.toString(), updatedColumns);
     }
@@ -190,7 +190,7 @@ public class ReadOnlyAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
         // allow
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlySystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlySystemAccessControl.java
@@ -75,7 +75,7 @@ public class ReadOnlySystemAccessControl
     public void checkCanSetSystemSessionProperty(Identity identity, QueryId queryId, String propertyName) {}
 
     @Override
-    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns) {}
+    public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns) {}
 
     @Override
     public boolean canAccessCatalog(SystemSecurityContext context, String catalogName)
@@ -87,7 +87,7 @@ public class ReadOnlySystemAccessControl
     public void checkCanSetCatalogSessionProperty(SystemSecurityContext context, String catalogName, String propertyName) {}
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns) {}
+    public void checkCanCreateViewWithSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Optional<String> branch, Set<String> columns) {}
 
     @Override
     public Set<String> filterCatalogs(SystemSecurityContext context, Set<String> catalogs)

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
@@ -77,10 +77,10 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         assertDenied(() -> accessControl.checkCanSetSchemaAuthorization(UNKNOWN, "unknown", new TrinoPrincipal(ROLE, "some_role")));
         accessControl.checkCanShowCreateSchema(UNKNOWN, "unknown");
 
-        accessControl.checkCanSelectFromColumns(UNKNOWN, new SchemaTableName("unknown", "unknown"), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(UNKNOWN, new SchemaTableName("unknown", "unknown"), Optional.empty(), ImmutableSet.of());
         accessControl.checkCanShowColumns(UNKNOWN, new SchemaTableName("unknown", "unknown"));
-        accessControl.checkCanInsertIntoTable(UNKNOWN, new SchemaTableName("unknown", "unknown"));
-        accessControl.checkCanDeleteFromTable(UNKNOWN, new SchemaTableName("unknown", "unknown"));
+        accessControl.checkCanInsertIntoTable(UNKNOWN, new SchemaTableName("unknown", "unknown"), Optional.empty());
+        accessControl.checkCanDeleteFromTable(UNKNOWN, new SchemaTableName("unknown", "unknown"), Optional.empty());
 
         accessControl.checkCanCreateTable(UNKNOWN, new SchemaTableName("unknown", "unknown"), Map.of());
         accessControl.checkCanDropTable(UNKNOWN, new SchemaTableName("unknown", "unknown"));
@@ -297,25 +297,25 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         SchemaTableName bobTable = new SchemaTableName("bobschema", "bobtable");
 
         ConnectorAccessControl accessControl = createAccessControl("table.json");
-        accessControl.checkCanSelectFromColumns(ALICE, testTable, ImmutableSet.of());
-        accessControl.checkCanSelectFromColumns(ALICE, bobTable, ImmutableSet.of());
-        accessControl.checkCanSelectFromColumns(ALICE, bobTable, ImmutableSet.of("bobcolumn"));
+        accessControl.checkCanSelectFromColumns(ALICE, testTable, Optional.empty(), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(ALICE, bobTable, Optional.empty(), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(ALICE, bobTable, Optional.empty(), ImmutableSet.of("bobcolumn"));
 
         accessControl.checkCanShowColumns(ALICE, bobTable);
         assertThat(accessControl.filterColumns(ALICE, Map.of(bobTable, ImmutableSet.of("a"))))
                 .isEqualTo(Map.of(bobTable, ImmutableSet.of("a")));
-        accessControl.checkCanSelectFromColumns(BOB, bobTable, ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(BOB, bobTable, Optional.empty(), ImmutableSet.of());
         accessControl.checkCanShowColumns(BOB, bobTable);
         assertThat(accessControl.filterColumns(BOB, Map.of(bobTable, ImmutableSet.of("a"))))
                 .isEqualTo(Map.of(bobTable, ImmutableSet.of("a")));
 
-        accessControl.checkCanInsertIntoTable(BOB, bobTable);
-        accessControl.checkCanDeleteFromTable(BOB, bobTable);
+        accessControl.checkCanInsertIntoTable(BOB, bobTable, Optional.empty());
+        accessControl.checkCanDeleteFromTable(BOB, bobTable, Optional.empty());
         accessControl.checkCanTruncateTable(BOB, bobTable);
-        accessControl.checkCanSelectFromColumns(CHARLIE, bobTable, ImmutableSet.of());
-        accessControl.checkCanSelectFromColumns(CHARLIE, bobTable, ImmutableSet.of("bobcolumn"));
-        accessControl.checkCanInsertIntoTable(CHARLIE, bobTable);
-        accessControl.checkCanSelectFromColumns(JOE, bobTable, ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(CHARLIE, bobTable, Optional.empty(), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(CHARLIE, bobTable, Optional.empty(), ImmutableSet.of("bobcolumn"));
+        accessControl.checkCanInsertIntoTable(CHARLIE, bobTable, Optional.empty());
+        accessControl.checkCanSelectFromColumns(JOE, bobTable, Optional.empty(), ImmutableSet.of());
 
         accessControl.checkCanCreateTable(ADMIN, new SchemaTableName("bob", "test"), Map.of());
         accessControl.checkCanCreateTable(ADMIN, testTable, Map.of());
@@ -347,16 +347,16 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         accessControl.checkCanSetTableProperties(ADMIN, bobTable, ImmutableMap.of());
         accessControl.checkCanSetTableProperties(ALICE, aliceTable, ImmutableMap.of());
 
-        assertDenied(() -> accessControl.checkCanInsertIntoTable(ALICE, bobTable));
+        assertDenied(() -> accessControl.checkCanInsertIntoTable(ALICE, bobTable, Optional.empty()));
         assertDenied(() -> accessControl.checkCanDropTable(BOB, bobTable));
         assertDenied(() -> accessControl.checkCanRenameTable(BOB, bobTable, new SchemaTableName("bobschema", "newbobtable")));
         assertDenied(() -> accessControl.checkCanRenameTable(ALICE, aliceTable, new SchemaTableName("bobschema", "newalicetable")));
         assertDenied(() -> accessControl.checkCanSetViewComment(ALICE, new SchemaTableName("bobschema", "newalicetable")));
         assertDenied(() -> accessControl.checkCanAlterColumn(BOB, bobTable));
         assertDenied(() -> accessControl.checkCanSetTableProperties(BOB, bobTable, ImmutableMap.of()));
-        assertDenied(() -> accessControl.checkCanInsertIntoTable(BOB, testTable));
-        assertDenied(() -> accessControl.checkCanSelectFromColumns(ADMIN, new SchemaTableName("secret", "secret"), ImmutableSet.of()));
-        assertDenied(() -> accessControl.checkCanSelectFromColumns(JOE, new SchemaTableName("secret", "secret"), ImmutableSet.of()));
+        assertDenied(() -> accessControl.checkCanInsertIntoTable(BOB, testTable, Optional.empty()));
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(ADMIN, new SchemaTableName("secret", "secret"), Optional.empty(), ImmutableSet.of()));
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(JOE, new SchemaTableName("secret", "secret"), Optional.empty(), ImmutableSet.of()));
         assertDenied(() -> accessControl.checkCanCreateViewWithSelectFromColumns(JOE, bobTable, ImmutableSet.of()));
         assertDenied(() -> accessControl.checkCanRenameView(BOB, new SchemaTableName("bobschema", "bobview"), new SchemaTableName("bobschema", "newbobview")));
         assertDenied(() -> accessControl.checkCanRenameView(ALICE, aliceTable, new SchemaTableName("bobschema", "newalicetable")));
@@ -392,18 +392,18 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         ConnectorSecurityContext userGroup2 = user("user_2", ImmutableSet.of("group2"));
 
         accessControl.checkCanCreateTable(userGroup1Group2, myTable, Map.of());
-        accessControl.checkCanInsertIntoTable(userGroup1Group2, myTable);
-        accessControl.checkCanDeleteFromTable(userGroup1Group2, myTable);
+        accessControl.checkCanInsertIntoTable(userGroup1Group2, myTable, Optional.empty());
+        accessControl.checkCanDeleteFromTable(userGroup1Group2, myTable, Optional.empty());
         accessControl.checkCanDropTable(userGroup1Group2, myTable);
-        accessControl.checkCanSelectFromColumns(userGroup1Group2, myTable, ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(userGroup1Group2, myTable, Optional.empty(), ImmutableSet.of());
         assertThat(accessControl.getColumnMasks(userGroup1Group2, myTable, List.of(ColumnSchema.builder().setName("col_a").setType(VARCHAR).build()))).isEmpty();
         assertThat(accessControl.getRowFilters(userGroup1Group2, myTable)).isEqualTo(ImmutableList.of());
 
         assertDenied(() -> accessControl.checkCanCreateTable(userGroup2, myTable, Map.of()));
-        assertDenied(() -> accessControl.checkCanInsertIntoTable(userGroup2, myTable));
-        assertDenied(() -> accessControl.checkCanDeleteFromTable(userGroup2, myTable));
+        assertDenied(() -> accessControl.checkCanInsertIntoTable(userGroup2, myTable, Optional.empty()));
+        assertDenied(() -> accessControl.checkCanDeleteFromTable(userGroup2, myTable, Optional.empty()));
         assertDenied(() -> accessControl.checkCanDropTable(userGroup2, myTable));
-        accessControl.checkCanSelectFromColumns(userGroup2, myTable, ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(userGroup2, myTable, Optional.empty(), ImmutableSet.of());
         ColumnSchema colA = ColumnSchema.builder().setName("col_a").setType(VARCHAR).build();
         assertViewExpressionEquals(
                 accessControl.getColumnMasks(userGroup2, myTable, List.of(colA)).get(colA),
@@ -418,16 +418,16 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         ConnectorSecurityContext userGroup3 = user("user_3", ImmutableSet.of("group3"));
 
         accessControl.checkCanCreateTable(userGroup1Group3, myTable, Map.of());
-        accessControl.checkCanInsertIntoTable(userGroup1Group3, myTable);
-        accessControl.checkCanDeleteFromTable(userGroup1Group3, myTable);
+        accessControl.checkCanInsertIntoTable(userGroup1Group3, myTable, Optional.empty());
+        accessControl.checkCanDeleteFromTable(userGroup1Group3, myTable, Optional.empty());
         accessControl.checkCanDropTable(userGroup1Group3, myTable);
-        accessControl.checkCanSelectFromColumns(userGroup1Group3, myTable, ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(userGroup1Group3, myTable, Optional.empty(), ImmutableSet.of());
         assertThat(accessControl.getColumnMasks(userGroup1Group3, myTable, List.of(ColumnSchema.builder().setName("col_a").setType(VARCHAR).build()))).isEmpty();
         assertDenied(() -> accessControl.checkCanCreateTable(userGroup3, myTable, Map.of()));
-        assertDenied(() -> accessControl.checkCanInsertIntoTable(userGroup3, myTable));
-        assertDenied(() -> accessControl.checkCanDeleteFromTable(userGroup3, myTable));
+        assertDenied(() -> accessControl.checkCanInsertIntoTable(userGroup3, myTable, Optional.empty()));
+        assertDenied(() -> accessControl.checkCanDeleteFromTable(userGroup3, myTable, Optional.empty()));
         assertDenied(() -> accessControl.checkCanDropTable(userGroup3, myTable));
-        accessControl.checkCanSelectFromColumns(userGroup3, myTable, ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(userGroup3, myTable, Optional.empty(), ImmutableSet.of());
         assertViewExpressionEquals(
                 accessControl.getColumnMasks(userGroup3, myTable, List.of(colA)).get(colA),
                 ViewExpression.builder()

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -185,10 +185,10 @@ public abstract class BaseFileBasedSystemAccessControlTest
                 "Cannot set authorization for schema some-catalog.unknown to ROLE some_role");
         accessControl.checkCanShowCreateSchema(UNKNOWN, new CatalogSchemaName("some-catalog", "unknown"));
 
-        accessControl.checkCanSelectFromColumns(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"), Optional.empty(), ImmutableSet.of());
         accessControl.checkCanShowColumns(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"));
-        accessControl.checkCanInsertIntoTable(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"));
-        accessControl.checkCanDeleteFromTable(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"));
+        accessControl.checkCanInsertIntoTable(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"), Optional.empty());
+        accessControl.checkCanDeleteFromTable(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"), Optional.empty());
         accessControl.checkCanTruncateTable(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"));
 
         accessControl.checkCanCreateTable(UNKNOWN, new CatalogSchemaTableName("some-catalog", "unknown", "unknown"), Map.of());
@@ -444,33 +444,37 @@ public abstract class BaseFileBasedSystemAccessControlTest
     {
         SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-access-table.json");
 
-        accessControl.checkCanSelectFromColumns(ALICE, new CatalogSchemaTableName("some-catalog", "test", "test"), ImmutableSet.of());
-        accessControl.checkCanSelectFromColumns(ALICE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(ALICE, new CatalogSchemaTableName("some-catalog", "test", "test"), Optional.empty(), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(ALICE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), Optional.empty(), ImmutableSet.of());
         accessControl.checkCanSelectFromColumns(
                 ALICE,
                 new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
+                Optional.empty(),
                 ImmutableSet.of("bobcolumn", "private", "restricted"));
 
-        accessControl.checkCanSelectFromColumns(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableSet.of());
-        accessControl.checkCanSelectFromColumns(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableSet.of("bobcolumn"));
+        accessControl.checkCanSelectFromColumns(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), Optional.empty(), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), Optional.empty(), ImmutableSet.of("bobcolumn"));
         assertAccessDenied(
                 () -> accessControl.checkCanSelectFromColumns(
                         CHARLIE,
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
+                        Optional.empty(),
                         ImmutableSet.of("bobcolumn", "private")),
                 SELECT_TABLE_ACCESS_DENIED_MESSAGE);
-        accessControl.checkCanSelectFromColumns(JOE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(JOE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), Optional.empty(), ImmutableSet.of());
 
         assertAccessDenied(
                 () -> accessControl.checkCanSelectFromColumns(
                         ADMIN,
                         new CatalogSchemaTableName("secret", "secret", "secret"),
+                        Optional.empty(),
                         ImmutableSet.of()),
                 SELECT_TABLE_ACCESS_DENIED_MESSAGE);
         assertAccessDenied(
                 () -> accessControl.checkCanSelectFromColumns(
                         JOE,
                         new CatalogSchemaTableName("secret", "secret", "secret"),
+                        Optional.empty(),
                         ImmutableSet.of()),
                 SELECT_TABLE_ACCESS_DENIED_MESSAGE);
     }
@@ -618,10 +622,10 @@ public abstract class BaseFileBasedSystemAccessControlTest
 
     private static void assertTableRulesForCheckCanInsertIntoTable(SystemAccessControl accessControl)
     {
-        accessControl.checkCanInsertIntoTable(BOB, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"));
-        accessControl.checkCanInsertIntoTable(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"));
-        assertAccessDenied(() -> accessControl.checkCanInsertIntoTable(ALICE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable")), INSERT_TABLE_ACCESS_DENIED_MESSAGE);
-        assertAccessDenied(() -> accessControl.checkCanInsertIntoTable(BOB, new CatalogSchemaTableName("some-catalog", "test", "test")), INSERT_TABLE_ACCESS_DENIED_MESSAGE);
+        accessControl.checkCanInsertIntoTable(BOB, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), Optional.empty());
+        accessControl.checkCanInsertIntoTable(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), Optional.empty());
+        assertAccessDenied(() -> accessControl.checkCanInsertIntoTable(ALICE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), Optional.empty()), INSERT_TABLE_ACCESS_DENIED_MESSAGE);
+        assertAccessDenied(() -> accessControl.checkCanInsertIntoTable(BOB, new CatalogSchemaTableName("some-catalog", "test", "test"), Optional.empty()), INSERT_TABLE_ACCESS_DENIED_MESSAGE);
     }
 
     @Test
@@ -698,8 +702,8 @@ public abstract class BaseFileBasedSystemAccessControlTest
     {
         SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-access-table.json");
 
-        accessControl.checkCanDeleteFromTable(ADMIN, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"));
-        assertAccessDenied(() -> accessControl.checkCanDeleteFromTable(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable")), DELETE_TABLE_ACCESS_DENIED_MESSAGE);
+        accessControl.checkCanDeleteFromTable(ADMIN, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), Optional.empty());
+        assertAccessDenied(() -> accessControl.checkCanDeleteFromTable(CHARLIE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobtable"), Optional.empty()), DELETE_TABLE_ACCESS_DENIED_MESSAGE);
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunction.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunction.java
@@ -125,7 +125,7 @@ public class TableChangesFunction
                     .map(DeltaLakeColumnHandle.class::cast)
                     .filter(column -> column.columnType() != SYNTHESIZED)
                     .collect(toImmutableList());
-            accessControl.checkCanSelectFromColumns(null, schemaTableName, columnHandles.stream()
+            accessControl.checkCanSelectFromColumns(null, schemaTableName, Optional.empty(), columnHandles.stream()
                     // Lowercase column names because users don't know the original names
                     .map(column -> column.columnName().toLowerCase(ENGLISH))
                     .collect(toImmutableSet()));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
@@ -87,7 +87,7 @@ public class DropExtendedStatsProcedure
             if (tableHandle == null) {
                 throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", name));
             }
-            accessControl.checkCanInsertIntoTable(null, name);
+            accessControl.checkCanInsertIntoTable(null, name, Optional.empty());
             statsAccess.deleteExtendedStatistics(session, name, tableHandle.location(), tableHandle.toCredentialsHandle());
         }
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
@@ -186,8 +186,8 @@ public class VacuumProcedure
             checkProcedureArgument(connectorTableHandle != null, "Table '%s' does not exist", tableName);
             DeltaLakeTableHandle handle = checkValidTableHandle(connectorTableHandle);
 
-            accessControl.checkCanInsertIntoTable(null, tableName);
-            accessControl.checkCanDeleteFromTable(null, tableName);
+            accessControl.checkCanInsertIntoTable(null, tableName, Optional.empty());
+            accessControl.checkCanDeleteFromTable(null, tableName, Optional.empty());
 
             checkUnsupportedUniversalFormat(handle.getMetadataEntry());
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
@@ -117,7 +117,7 @@ public class CreateEmptyPartitionProcedure
                 throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", new SchemaTableName(schemaName, tableName)));
             }
 
-            accessControl.checkCanInsertIntoTable(null, new SchemaTableName(schemaName, tableName));
+            accessControl.checkCanInsertIntoTable(null, new SchemaTableName(schemaName, tableName), Optional.empty());
 
             List<String> actualPartitionColumnNames = hiveMetadata.getColumnHandles(session, tableHandle).values().stream()
                     .map(HiveColumnHandle.class::cast)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
@@ -113,7 +113,7 @@ public class DropStatsProcedure
                 throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", schemaTableName));
             }
 
-            accessControl.checkCanInsertIntoTable(null, schemaTableName);
+            accessControl.checkCanInsertIntoTable(null, schemaTableName, Optional.empty());
 
             Map<String, ColumnHandle> columns = hiveMetadata.getColumnHandles(session, handle);
             List<String> partitionColumns = columns.values().stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
@@ -125,7 +125,7 @@ public class RegisterPartitionProcedure
             Table table = metastore.getTable(schemaName, tableName)
                     .orElseThrow(() -> new TableNotFoundException(schemaTableName));
 
-            accessControl.checkCanInsertIntoTable(null, schemaTableName);
+            accessControl.checkCanInsertIntoTable(null, schemaTableName, Optional.empty());
 
             checkIsPartitionedTable(table);
             checkPartitionColumns(table, partitionColumns);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -137,10 +137,10 @@ public class SyncPartitionMetadataProcedure
             }
 
             if (syncMode == SyncMode.ADD || syncMode == SyncMode.FULL) {
-                accessControl.checkCanInsertIntoTable(null, new SchemaTableName(schemaName, tableName));
+                accessControl.checkCanInsertIntoTable(null, new SchemaTableName(schemaName, tableName), Optional.empty());
             }
             if (syncMode == SyncMode.DROP || syncMode == SyncMode.FULL) {
-                accessControl.checkCanDeleteFromTable(null, new SchemaTableName(schemaName, tableName));
+                accessControl.checkCanDeleteFromTable(null, new SchemaTableName(schemaName, tableName), Optional.empty());
             }
 
             Set<String> partitionNamesInMetastore = metastore.getPartitionNames(schemaName, tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterPartitionProcedure.java
@@ -33,6 +33,7 @@ import io.trino.spi.type.ArrayType;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static io.trino.metastore.Partitions.makePartName;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
@@ -104,7 +105,7 @@ public class UnregisterPartitionProcedure
             Table table = metastore.getTable(schemaName, tableName)
                     .orElseThrow(() -> new TableNotFoundException(schemaTableName));
 
-            accessControl.checkCanDeleteFromTable(null, schemaTableName);
+            accessControl.checkCanDeleteFromTable(null, schemaTableName, Optional.empty());
 
             checkIsPartitionedTable(table);
             checkPartitionColumns(table, partitionColumns);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -331,7 +331,7 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
         // TODO: Implement column level access control
         if (!checkTablePermission(context, tableName, SELECT, false)) {
@@ -339,20 +339,41 @@ public class SqlStandardAccessControl
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    {
+        checkCanSelectFromColumns(context, tableName, Optional.empty(), columnNames);
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, INSERT, false)) {
             denyInsertTable(tableName.toString());
         }
     }
 
+    @Deprecated
     @Override
-    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    {
+        checkCanInsertIntoTable(context, tableName, Optional.empty());
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, DELETE, false)) {
             denyDeleteTable(tableName.toString());
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
+    {
+        checkCanDeleteFromTable(context, tableName, Optional.empty());
     }
 
     @Override
@@ -364,11 +385,18 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
     {
         if (!checkTablePermission(context, tableName, UPDATE, false)) {
             denyUpdateTableColumns(tableName.toString(), updatedColumns);
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        checkCanUpdateTableColumns(context, tableName, Optional.empty(), updatedColumns);
     }
 
     @Override
@@ -404,14 +432,21 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
-        checkCanSelectFromColumns(context, tableName, columnNames);
+        checkCanSelectFromColumns(context, tableName, branch, columnNames);
 
         // TODO implement column level access control
         if (!checkTablePermission(context, tableName, SELECT, true)) {
             denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
         }
+    }
+
+    @Deprecated
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    {
+        checkCanCreateViewWithSelectFromColumns(context, tableName, Optional.empty(), columnNames);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -335,7 +335,7 @@ public class SqlStandardAccessControl
     {
         // TODO: Implement column level access control
         if (!checkTablePermission(context, tableName, SELECT, false)) {
-            denySelectTable(tableName.toString());
+            denySelectTable(tableName.toString(), branch);
         }
     }
 
@@ -350,7 +350,7 @@ public class SqlStandardAccessControl
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, INSERT, false)) {
-            denyInsertTable(tableName.toString());
+            denyInsertTable(tableName.toString(), branch);
         }
     }
 
@@ -365,7 +365,7 @@ public class SqlStandardAccessControl
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
         if (!checkTablePermission(context, tableName, DELETE, false)) {
-            denyDeleteTable(tableName.toString());
+            denyDeleteTable(tableName.toString(), branch);
         }
     }
 
@@ -388,7 +388,7 @@ public class SqlStandardAccessControl
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
     {
         if (!checkTablePermission(context, tableName, UPDATE, false)) {
-            denyUpdateTableColumns(tableName.toString(), updatedColumns);
+            denyUpdateTableColumns(tableName.toString(), branch, updatedColumns);
         }
     }
 
@@ -438,7 +438,7 @@ public class SqlStandardAccessControl
 
         // TODO implement column level access control
         if (!checkTablePermission(context, tableName, SELECT, true)) {
-            denyCreateViewWithSelect(tableName.toString(), context.getIdentity());
+            denyCreateViewWithSelect(tableName.toString(), branch, context.getIdentity());
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SystemTableAwareAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SystemTableAwareAccessControl.java
@@ -92,12 +92,12 @@ public class SystemTableAwareAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> columnNames)
     {
         Optional<SchemaTableName> sourceTableName = getSourceTableNameFromSystemTable(systemTableProviders, tableName);
         if (sourceTableName.isPresent()) {
             try {
-                checkCanSelectFromColumns(context, sourceTableName.get(), columnNames);
+                checkCanSelectFromColumns(context, sourceTableName.get(), branch, columnNames);
                 return;
             }
             catch (AccessDeniedException e) {
@@ -105,6 +105,6 @@ public class SystemTableAwareAccessControl
             }
         }
 
-        delegate.checkCanSelectFromColumns(context, tableName, columnNames);
+        delegate.checkCanSelectFromColumns(context, tableName, branch, columnNames);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1880,7 +1880,7 @@ public class IcebergMetadata
             throw new TrinoException(PERMISSION_DENIED, "add_files procedure is disabled");
         }
 
-        accessControl.checkCanInsertIntoTable(null, tableHandle.getSchemaTableName());
+        accessControl.checkCanInsertIntoTable(null, tableHandle.getSchemaTableName(), Optional.empty());
 
         String location = (String) requireProcedureArgument(executeProperties, "location");
         HiveStorageFormat format = (HiveStorageFormat) requireProcedureArgument(executeProperties, "format");
@@ -1916,7 +1916,7 @@ public class IcebergMetadata
 
     private Optional<ConnectorTableExecuteHandle> getTableHandleForAddFilesFromTable(ConnectorSession session, ConnectorAccessControl accessControl, IcebergTableHandle tableHandle, Map<String, Object> executeProperties)
     {
-        accessControl.checkCanInsertIntoTable(null, tableHandle.getSchemaTableName());
+        accessControl.checkCanInsertIntoTable(null, tableHandle.getSchemaTableName(), Optional.empty());
 
         String schemaName = (String) requireProcedureArgument(executeProperties, "schema_name");
         String tableName = (String) requireProcedureArgument(executeProperties, "table_name");
@@ -1931,7 +1931,7 @@ public class IcebergMetadata
                 .createMetastore(Optional.of(session.getIdentity()));
         SchemaTableName sourceName = new SchemaTableName(schemaName, tableName);
         io.trino.metastore.Table sourceTable = metastore.getTable(schemaName, tableName).orElseThrow(() -> new TableNotFoundException(sourceName));
-        accessControl.checkCanSelectFromColumns(null, sourceName, Stream.concat(sourceTable.getDataColumns().stream(), sourceTable.getPartitionColumns().stream())
+        accessControl.checkCanSelectFromColumns(null, sourceName, Optional.empty(), Stream.concat(sourceTable.getDataColumns().stream(), sourceTable.getPartitionColumns().stream())
                 .map(Column::getName)
                 .collect(toImmutableSet()));
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunction.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunction.java
@@ -148,7 +148,7 @@ public class TableChangesFunction
                 .build());
         List<IcebergColumnHandle> columnHandles = columnHandlesBuilder.build();
 
-        accessControl.checkCanSelectFromColumns(null, schemaTableName, columnHandles.stream()
+        accessControl.checkCanSelectFromColumns(null, schemaTableName, Optional.empty(), columnHandles.stream()
                 .map(IcebergColumnHandle::getName)
                 .collect(toImmutableSet()));
 

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -134,8 +134,8 @@ final class TestOpaAccessControl
         testTableResourceActions("DropColumn", OpaAccessControl::checkCanDropColumn);
         testTableResourceActions("AlterColumn", OpaAccessControl::checkCanAlterColumn);
         testTableResourceActions("RenameColumn", OpaAccessControl::checkCanRenameColumn);
-        testTableResourceActions("InsertIntoTable", OpaAccessControl::checkCanInsertIntoTable);
-        testTableResourceActions("DeleteFromTable", OpaAccessControl::checkCanDeleteFromTable);
+        testTableResourceActions("InsertIntoTable", (ac, ctx, tbl) -> ac.checkCanInsertIntoTable(ctx, tbl, Optional.empty()));
+        testTableResourceActions("DeleteFromTable", (ac, ctx, tbl) -> ac.checkCanDeleteFromTable(ctx, tbl, Optional.empty()));
         testTableResourceActions("TruncateTable", OpaAccessControl::checkCanTruncateTable);
         testTableResourceActions("CreateView", OpaAccessControl::checkCanCreateView);
         testTableResourceActions("DropView", OpaAccessControl::checkCanDropView);
@@ -529,8 +529,8 @@ final class TestOpaAccessControl
     @Test
     void testColumnOperationsOnTableLikeObjects()
     {
-        testColumnOperationOnTableLikeObject("SelectFromColumns", OpaAccessControl::checkCanSelectFromColumns);
-        testColumnOperationOnTableLikeObject("UpdateTableColumns", OpaAccessControl::checkCanUpdateTableColumns);
+        testColumnOperationOnTableLikeObject("SelectFromColumns", (ac, ctx, tbl, cols) -> ac.checkCanSelectFromColumns(ctx, tbl, Optional.empty(), cols));
+        testColumnOperationOnTableLikeObject("UpdateTableColumns", (ac, ctx, tbl, cols) -> ac.checkCanUpdateTableColumns(ctx, tbl, Optional.empty(), cols));
         testColumnOperationOnTableLikeObject("CreateViewWithSelectFromColumns", OpaAccessControl::checkCanCreateViewWithSelectFromColumns);
     }
 

--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
@@ -170,8 +170,8 @@ final class TestRangerSystemAccessControl
         accessControlManager.checkCanSetTableAuthorization(context(ALICE), TABLE_ALICE_SCH1_TBL1, new TrinoPrincipal(USER, "principal"));
         accessControlManager.checkCanShowTables(context(ALICE), SCHEMA_ALICE_SCH1);
         accessControlManager.checkCanShowCreateTable(context(ALICE), TABLE_ALICE_SCH1_TBL1);
-        accessControlManager.checkCanInsertIntoTable(context(ALICE), TABLE_ALICE_SCH1_TBL1);
-        accessControlManager.checkCanDeleteFromTable(context(ALICE), TABLE_ALICE_SCH1_TBL1);
+        accessControlManager.checkCanInsertIntoTable(context(ALICE), TABLE_ALICE_SCH1_TBL1, Optional.empty());
+        accessControlManager.checkCanDeleteFromTable(context(ALICE), TABLE_ALICE_SCH1_TBL1, Optional.empty());
         accessControlManager.checkCanTruncateTable(context(ALICE), TABLE_ALICE_SCH1_TBL1);
         accessControlManager.checkCanCreateTable(context(BOB), TABLE_USER_BOB_TBL1, ImmutableMap.of());
         accessControlManager.checkCanDropTable(context(BOB), TABLE_USER_BOB_TBL1);
@@ -188,8 +188,8 @@ final class TestRangerSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanSetTableAuthorization(context(BOB), TABLE_ALICE_SCH1_TBL1, new TrinoPrincipal(USER, "principal"))).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanShowTables(context(BOB), SCHEMA_ALICE_SCH1)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanShowCreateTable(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
-        assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
-        assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanInsertIntoTable(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty())).isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanDeleteFromTable(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty())).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanTruncateTable(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
     }
 
@@ -202,10 +202,10 @@ final class TestRangerSystemAccessControl
         accessControlManager.checkCanRenameColumn(context(ALICE), TABLE_ALICE_SCH1_TBL1);
         accessControlManager.checkCanSetColumnComment(context(ALICE), TABLE_ALICE_SCH1_TBL1);
         accessControlManager.checkCanShowColumns(context(ALICE), TABLE_ALICE_SCH1_TBL1);
-        accessControlManager.checkCanSelectFromColumns(context(ALICE), TABLE_ALICE_SCH1_TBL1, ImmutableSet.of());
-        accessControlManager.checkCanUpdateTableColumns(context(ALICE), TABLE_ALICE_SCH1_TBL1, ImmutableSet.of());
+        accessControlManager.checkCanSelectFromColumns(context(ALICE), TABLE_ALICE_SCH1_TBL1, Optional.empty(), ImmutableSet.of());
+        accessControlManager.checkCanUpdateTableColumns(context(ALICE), TABLE_ALICE_SCH1_TBL1, Optional.empty(), ImmutableSet.of());
         accessControlManager.checkCanAddColumn(context(BOB), TABLE_USER_BOB_TBL1);
-        accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_USER_BOB_TBL1, ImmutableSet.of());
+        accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_USER_BOB_TBL1, Optional.empty(), ImmutableSet.of());
         accessControlManager.checkCanDropColumn(context(BOB), TABLE_USER_BOB_TBL1);
 
         Set<String> columns = ImmutableSet.of("column-1");
@@ -222,8 +222,8 @@ final class TestRangerSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanRenameColumn(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanSetColumnComment(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanShowColumns(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
-        assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, ImmutableSet.of())).isInstanceOf(AccessDeniedException.class);
-        assertThatThrownBy(() -> accessControlManager.checkCanUpdateTableColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Collections.emptySet())).isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty(), ImmutableSet.of())).isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanUpdateTableColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty(), Collections.emptySet())).isInstanceOf(AccessDeniedException.class);
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.MockConnectorTableHandle;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.BigintType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_DATA;
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_SCHEMA;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_VIEW_WITH_SELECT_COLUMNS;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DELETE_TABLE;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
+import static io.trino.testing.TestingAccessControlManager.branchPrivilege;
+import static io.trino.testing.TestingAccessControlManager.privilege;
+
+final class TestBranchingAccessControl
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        QueryRunner queryRunner = new StandaloneQueryRunner(TEST_SESSION);
+
+        ConnectorViewDefinition view = new ConnectorViewDefinition(
+                "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'dev'",
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(
+                        new ConnectorViewDefinition.ViewColumn("nationkey", BigintType.BIGINT.getTypeId(), Optional.empty())),
+                Optional.empty(),
+                Optional.of("owner"),
+                false,
+                ImmutableList.of());
+
+        queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withGetTableHandle((_, schemaTableName) -> new MockConnectorTableHandle(schemaTableName))
+                .withGetColumns(schemaTableName -> {
+                    if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
+                        return TPCH_NATION_SCHEMA;
+                    }
+                    throw new UnsupportedOperationException();
+                })
+                .withBranches(ImmutableList.of("main", "dev"))
+                .withData(schemaTableName -> {
+                    if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
+                        return TPCH_NATION_DATA;
+                    }
+                    throw new UnsupportedOperationException();
+                })
+                .withGetViews((_, _) -> ImmutableMap.of(new SchemaTableName("tiny", "nation_view"), view))
+                .build()));
+        queryRunner.createCatalog("mock", "mock", ImmutableMap.of());
+
+        return queryRunner;
+    }
+
+    @Test
+    void testSelectFromBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'dev'",
+                "Cannot select from columns \\[nationkey] in branch dev in table mock.tiny.nation",
+                branchPrivilege("nation", "dev", SELECT_COLUMN));
+
+        // SELECT without branch is still allowed
+        assertAccessAllowed(
+                "SELECT nationkey FROM mock.tiny.nation",
+                branchPrivilege("nation", "dev", SELECT_COLUMN));
+
+        // SELECT from a different branch is still allowed
+        assertAccessAllowed(
+                "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'main'",
+                branchPrivilege("nation", "dev", SELECT_COLUMN));
+    }
+
+    @Test
+    void testSelectFromBranchDeniedByTablePrivilege()
+    {
+        // Denying without branch blocks all access, including branch access
+        // (This actually depends on specific semantics of the access control, but at least we'll test the error messages)
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'dev'",
+                "Cannot select from columns \\[nationkey] in branch dev in table mock.tiny.nation",
+                privilege("nation", SELECT_COLUMN));
+    }
+
+    @Test
+    void testInsertIntoBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "INSERT INTO mock.tiny.nation @ dev VALUES (101, 'POLAND', 0, 'No comment')",
+                "Cannot insert into branch dev in table mock.tiny.nation",
+                branchPrivilege("nation", "dev", INSERT_TABLE));
+
+        // INSERT without branch is still allowed
+        assertAccessAllowed(
+                "INSERT INTO mock.tiny.nation VALUES (101, 'POLAND', 0, 'No comment')",
+                branchPrivilege("nation", "dev", INSERT_TABLE));
+
+        // INSERT into a different branch is still allowed
+        assertAccessAllowed(
+                "INSERT INTO mock.tiny.nation @ main VALUES (101, 'POLAND', 0, 'No comment')",
+                branchPrivilege("nation", "dev", INSERT_TABLE));
+    }
+
+    @Test
+    void testInsertIntoBranchDeniedByTablePrivilege()
+    {
+        // Denying without branch blocks all access, including branch access
+        // (This actually depends on specific semantics of the access control, but at least we'll test the error messages)
+        assertAccessDenied(
+                "INSERT INTO mock.tiny.nation @ dev VALUES (101, 'POLAND', 0, 'No comment')",
+                "Cannot insert into branch dev in table mock.tiny.nation",
+                privilege("nation", INSERT_TABLE));
+    }
+
+    @Test
+    void testDeleteFromBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "DELETE FROM mock.tiny.nation @ dev WHERE nationkey < 0",
+                "Cannot delete from branch dev in table mock.tiny.nation",
+                branchPrivilege("nation", "dev", DELETE_TABLE));
+
+        // DELETE without branch is still allowed
+        assertAccessAllowed(
+                "DELETE FROM mock.tiny.nation WHERE nationkey < 0",
+                branchPrivilege("nation", "dev", DELETE_TABLE));
+
+        // DELETE from a different branch is still allowed
+        assertAccessAllowed(
+                "DELETE FROM mock.tiny.nation @ main WHERE nationkey < 0",
+                branchPrivilege("nation", "dev", DELETE_TABLE));
+    }
+
+    @Test
+    void testDeleteFromBranchDeniedByTablePrivilege()
+    {
+        // Denying without branch blocks all access, including branch access
+        // (This actually depends on specific semantics of the access control, but at least we'll test the error messages)
+        assertAccessDenied(
+                "DELETE FROM mock.tiny.nation @ dev WHERE nationkey < 0",
+                "Cannot delete from branch dev in table mock.tiny.nation",
+                privilege("nation", DELETE_TABLE));
+    }
+
+    @Test
+    void testUpdateBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "UPDATE mock.tiny.nation @ dev SET regionkey = 0 WHERE nationkey < 0",
+                "Cannot update columns \\[regionkey] in branch dev in table mock.tiny.nation",
+                branchPrivilege("nation", "dev", UPDATE_TABLE));
+
+        // UPDATE without branch is still allowed
+        assertAccessAllowed(
+                "UPDATE mock.tiny.nation SET regionkey = 0 WHERE nationkey < 0",
+                branchPrivilege("nation", "dev", UPDATE_TABLE));
+
+        // UPDATE on a different branch is still allowed
+        assertAccessAllowed(
+                "UPDATE mock.tiny.nation @ main SET regionkey = 0 WHERE nationkey < 0",
+                branchPrivilege("nation", "dev", UPDATE_TABLE));
+    }
+
+    @Test
+    void testUpdateBranchDeniedByTablePrivilege()
+    {
+        // Denying without branch blocks all access, including branch access
+        // (This actually depends on specific semantics of the access control, but at least we'll test the error messages)
+        assertAccessDenied(
+                "UPDATE mock.tiny.nation @ dev SET regionkey = 0 WHERE nationkey < 0",
+                "Cannot update columns \\[regionkey] in branch dev in table mock.tiny.nation",
+                privilege("nation", UPDATE_TABLE));
+    }
+
+    @Test
+    void testSelectFromViewReferencingBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation_view",
+                "View owner does not have sufficient privileges: View owner 'owner' cannot create view that selects from branch dev in mock.tiny.nation",
+                branchPrivilege("owner", "nation", "dev", CREATE_VIEW_WITH_SELECT_COLUMNS));
+    }
+
+    @Test
+    void testSelectFromViewReferencingBranchDeniedByTablePrivilege()
+    {
+        // Denying without branch blocks all access, including branch access
+        // (This actually depends on specific semantics of the access control, but at least we'll test the error messages)
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation_view",
+                "View owner does not have sufficient privileges: View owner 'owner' cannot create view that selects from branch dev in mock.tiny.nation",
+                privilege("owner", "nation", CREATE_VIEW_WITH_SELECT_COLUMNS));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

There are two sides of access control for table branches:

1. Access control for branch management
  a. `CREATE BRANCH ...`, `DROP BRANCH ...` etc.
  b. and associated `GRANT privilege ON BRANCH branch IN TABLE table ...`
2. Access control for accessing data on branches
  a. `SELECT * FROM table FOR VERSION AS OF 'branch'
  b. `INSERT INTO table @ branch ...` etc.
  c. and associated `GRANT SELECT ON BRANCH branch IN TABLE table ...`

Parts 1. and 2.c are already implemented - with some limitations, like inability to manage branch grants on SCHEMA level - but parts 2.a and 2.b were almost entirely missing. This commit implements most of it, which is:

* Adding a `branch` parameter to all relevant access control interface methods
  - covers `SELECT`, `INSERT`, `UPDATE`, `DELETE` and selecting from view with `SECURITY DEFINER` which references a branch in table
  - new methods are added while keeping the old interface for backwards compatibility: the engine (and tests, even in plugins not converted to the new methods) exclusively calls the new methods, which delegate to old methods, so that if the access control plugin implements only the old methods, it will behave the way it used to
  - the minor downside is that the branch information is lost in error messages of default implementations of those methods
* Tracking the branch information in the analyzer - it is already present in the parser, we just need to propagate it

In places where we register a table or columns/fields reference for later, we do that by associating the relevant information with a pair of the fully-qualified table name and branch (represented by `TableAndBranch` record) in place of just the name. This information is then used to call the access control methods.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Added table branch name parameter to access control SPI functions. ({issue}`29179`)
```
