### PR TITLE
Convert analyzer's Field class to use the builder pattern

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -31,12 +31,20 @@ public class Field
     private final boolean hidden;
     private final boolean aliased;
 
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
     public static Field newUnqualified(String name, Type type)
     {
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
 
-        return new Field(Optional.empty(), Optional.of(name), type, false, Optional.empty(), Optional.empty(), false);
+        return builder()
+                .name(Optional.of(name))
+                .type(type)
+                .build();
     }
 
     public static Field newUnqualified(Optional<String> name, Type type)
@@ -44,7 +52,10 @@ public class Field
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
 
-        return new Field(Optional.empty(), name, type, false, Optional.empty(), Optional.empty(), false);
+        return builder()
+                .name(name)
+                .type(type)
+                .build();
     }
 
     public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
@@ -53,7 +64,13 @@ public class Field
         requireNonNull(type, "type is null");
         requireNonNull(originTable, "originTable is null");
 
-        return new Field(Optional.empty(), name, type, false, originTable, originColumn, aliased);
+        return builder()
+                .name(name)
+                .type(type)
+                .originTable(originTable)
+                .originColumnName(originColumn)
+                .aliased(aliased)
+                .build();
     }
 
     public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
@@ -63,10 +80,18 @@ public class Field
         requireNonNull(type, "type is null");
         requireNonNull(originTable, "originTable is null");
 
-        return new Field(Optional.of(relationAlias), name, type, hidden, originTable, originColumn, aliased);
+        return builder()
+                .relationAlias(Optional.of(relationAlias))
+                .name(name)
+                .type(type)
+                .hidden(hidden)
+                .originTable(originTable)
+                .originColumnName(originColumn)
+                .aliased(aliased)
+                .build();
     }
 
-    public Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumnName, boolean aliased)
+    private Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumnName, boolean aliased)
     {
         requireNonNull(relationAlias, "relationAlias is null");
         requireNonNull(name, "name is null");
@@ -81,6 +106,11 @@ public class Field
         this.originTable = originTable;
         this.originColumnName = originColumnName;
         this.aliased = aliased;
+    }
+
+    public Builder rebuild()
+    {
+        return new Builder(this);
     }
 
     public Optional<QualifiedObjectName> getOriginTable()
@@ -168,5 +198,77 @@ public class Field
                 .append(type);
 
         return result.toString();
+    }
+
+    public static class Builder
+    {
+        private Optional<QualifiedName> relationAlias = Optional.empty();
+        private Optional<String> name = Optional.empty();
+        private Type type;
+        private boolean hidden;
+        private Optional<QualifiedObjectName> originTable = Optional.empty();
+        private Optional<String> originColumnName = Optional.empty();
+        private boolean aliased;
+
+        private Builder() {}
+
+        private Builder(Field field)
+        {
+            this.relationAlias = field.relationAlias;
+            this.name = field.name;
+            this.type = field.type;
+            this.hidden = field.hidden;
+            this.originTable = field.originTable;
+            this.originColumnName = field.originColumnName;
+            this.aliased = field.aliased;
+        }
+
+        public Builder relationAlias(Optional<QualifiedName> relationAlias)
+        {
+            this.relationAlias = requireNonNull(relationAlias, "relationAlias is null");
+            return this;
+        }
+
+        public Builder name(Optional<String> name)
+        {
+            this.name = requireNonNull(name, "name is null");
+            return this;
+        }
+
+        public Builder type(Type type)
+        {
+            this.type = requireNonNull(type, "type is null");
+            return this;
+        }
+
+        public Builder hidden(boolean hidden)
+        {
+            this.hidden = hidden;
+            return this;
+        }
+
+        public Builder originTable(Optional<QualifiedObjectName> originTable)
+        {
+            this.originTable = requireNonNull(originTable, "originTable is null");
+            return this;
+        }
+
+        public Builder originColumnName(Optional<String> originColumnName)
+        {
+            this.originColumnName = requireNonNull(originColumnName, "originColumnName is null");
+            return this;
+        }
+
+        public Builder aliased(boolean aliased)
+        {
+            this.aliased = aliased;
+            return this;
+        }
+
+        public Field build()
+        {
+            requireNonNull(type, "type is null");
+            return new Field(relationAlias, name, type, hidden, originTable, originColumnName, aliased);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2986,26 +2986,17 @@ class StatementAnalyzer
 
         private Field unqualifiedVisible(Field field)
         {
-            return new Field(
-                    Optional.empty(),
-                    field.getName(),
-                    field.getType(),
-                    false,
-                    field.getOriginTable(),
-                    field.getOriginColumnName(),
-                    field.isAliased());
+            return field.rebuild()
+                    .relationAlias(Optional.empty())
+                    .hidden(false)
+                    .build();
         }
 
         private Field unqualified(Field field)
         {
-            return new Field(
-                    Optional.empty(),
-                    field.getName(),
-                    field.getType(),
-                    field.isHidden(),
-                    field.getOriginTable(),
-                    field.getOriginColumnName(),
-                    field.isAliased());
+            return field.rebuild()
+                    .relationAlias(Optional.empty())
+                    .build();
         }
 
         private ExpressionAnalysis analyzePatternRecognitionExpression(Expression expression, Scope scope, Set<String> labels)
@@ -3432,14 +3423,9 @@ class StatementAnalyzer
             RelationType firstDescriptor = childrenTypes.getFirst();
             for (int i = 0; i < outputFieldTypes.length; i++) {
                 Field oldField = firstDescriptor.getFieldByIndex(i);
-                outputDescriptorFields[i] = new Field(
-                        oldField.getRelationAlias(),
-                        oldField.getName(),
-                        outputFieldTypes[i],
-                        oldField.isHidden(),
-                        oldField.getOriginTable(),
-                        oldField.getOriginColumnName(),
-                        oldField.isAliased());
+                outputDescriptorFields[i] = oldField.rebuild()
+                        .type(outputFieldTypes[i])
+                        .build();
 
                 int index = i; // Variable used in Lambda should be final
                 analysis.addSourceColumns(
@@ -5128,14 +5114,11 @@ class StatementAnalyzer
                     alias = Optional.of(allColumns.getAliases().get(i).getValue());
                 }
 
-                Field newField = new Field(
-                        field.getRelationAlias(),
-                        alias,
-                        field.getType(),
-                        false,
-                        field.getOriginTable(),
-                        field.getOriginColumnName(),
-                        !allColumns.getAliases().isEmpty() || field.isAliased());
+                Field newField = field.rebuild()
+                        .name(alias)
+                        .hidden(false)
+                        .aliased(!allColumns.getAliases().isEmpty() || field.isAliased())
+                        .build();
                 itemOutputFieldBuilder.add(newField);
                 analysis.addSourceColumns(newField, analysis.getSourceColumns(field));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

It's the most beneficial in places where we construct a copy of the `Field` and only change one of a couple of properties - instead of a soup of positional parameter we have the changed properties clearly marked by name.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
