### PR TITLE
Inline analyzer Field factories

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -2633,7 +2633,7 @@ public class ExpressionAnalyzer
             for (int i = 0; i < lambdaArguments.size(); i++) {
                 LambdaArgumentDeclaration lambdaArgument = lambdaArguments.get(i);
                 Type type = types.get(i);
-                fields.add(Field.newUnqualified(lambdaArgument.getName().getValue(), type));
+                fields.add(Field.builder().name(lambdaArgument.getName().getValue()).type(type).build());
                 setExpressionType(lambdaArgument, type);
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -36,24 +36,6 @@ public class Field
         return new Builder();
     }
 
-    public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
-    {
-        requireNonNull(relationAlias, "relationAlias is null");
-        requireNonNull(name, "name is null");
-        requireNonNull(type, "type is null");
-        requireNonNull(originTable, "originTable is null");
-
-        return builder()
-                .relationAlias(Optional.of(relationAlias))
-                .name(name)
-                .type(type)
-                .hidden(hidden)
-                .originTable(originTable)
-                .originColumnName(originColumn)
-                .aliased(aliased)
-                .build();
-    }
-
     private Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumnName, boolean aliased)
     {
         requireNonNull(relationAlias, "relationAlias is null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -47,17 +47,6 @@ public class Field
                 .build();
     }
 
-    public static Field newUnqualified(Optional<String> name, Type type)
-    {
-        requireNonNull(name, "name is null");
-        requireNonNull(type, "type is null");
-
-        return builder()
-                .name(name)
-                .type(type)
-                .build();
-    }
-
     public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
     {
         requireNonNull(name, "name is null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -36,17 +36,6 @@ public class Field
         return new Builder();
     }
 
-    public static Field newUnqualified(String name, Type type)
-    {
-        requireNonNull(name, "name is null");
-        requireNonNull(type, "type is null");
-
-        return builder()
-                .name(Optional.of(name))
-                .type(type)
-                .build();
-    }
-
     public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
     {
         requireNonNull(name, "name is null");
@@ -216,6 +205,11 @@ public class Field
         {
             this.relationAlias = requireNonNull(relationAlias, "relationAlias is null");
             return this;
+        }
+
+        public Builder name(String name)
+        {
+            return name(Optional.of(name));
         }
 
         public Builder name(Optional<String> name)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -36,21 +36,6 @@ public class Field
         return new Builder();
     }
 
-    public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
-    {
-        requireNonNull(name, "name is null");
-        requireNonNull(type, "type is null");
-        requireNonNull(originTable, "originTable is null");
-
-        return builder()
-                .name(name)
-                .type(type)
-                .originTable(originTable)
-                .originColumnName(originColumn)
-                .aliased(aliased)
-                .build();
-    }
-
     public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
     {
         requireNonNull(relationAlias, "relationAlias is null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
@@ -171,27 +171,20 @@ public class RelationType
         for (Field field : allFields) {
             Optional<String> columnAlias = field.getName();
             if (columnAliases == null) {
-                fieldsBuilder.add(Field.newQualified(
-                        QualifiedName.of(relationAlias),
-                        columnAlias,
-                        field.getType(),
-                        field.isHidden(),
-                        field.getOriginTable(),
-                        field.getOriginColumnName(),
-                        field.isAliased()));
+                fieldsBuilder.add(field.rebuild()
+                        .relationAlias(Optional.of(QualifiedName.of(relationAlias)))
+                        .name(columnAlias)
+                        .build());
             }
             else if (!field.isHidden()) {
                 // hidden fields are not exposed when there are column aliases
                 columnAlias = Optional.of(columnAliases.get(aliasIndex));
                 aliasIndex++;
-                fieldsBuilder.add(Field.newQualified(
-                        QualifiedName.of(relationAlias),
-                        columnAlias,
-                        field.getType(),
-                        false,
-                        field.getOriginTable(),
-                        field.getOriginColumnName(),
-                        field.isAliased()));
+                fieldsBuilder.add(field.rebuild()
+                        .relationAlias(Optional.of(QualifiedName.of(relationAlias)))
+                        .name(columnAlias)
+                        .hidden(false)
+                        .build());
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1663,16 +1663,16 @@ class StatementAnalyzer
                     Type elementType = arrayType.getElementType();
                     if (elementType instanceof RowType rowType) {
                         rowType.getFields().stream()
-                                .map(field -> Field.newUnqualified(field.getName(), field.getType()))
+                                .map(field -> Field.builder().name(field.getName()).type(field.getType()).build())
                                 .forEach(expressionOutputs::add);
                     }
                     else {
-                        expressionOutputs.add(Field.newUnqualified(Optional.empty(), elementType));
+                        expressionOutputs.add(Field.builder().type(elementType).build());
                     }
                 }
                 else if (expressionType instanceof MapType mapType) {
-                    expressionOutputs.add(Field.newUnqualified(Optional.empty(), mapType.getKeyType()));
-                    expressionOutputs.add(Field.newUnqualified(Optional.empty(), mapType.getValueType()));
+                    expressionOutputs.add(Field.builder().type(mapType.getKeyType()).build());
+                    expressionOutputs.add(Field.builder().type(mapType.getValueType()).build());
                 }
                 else {
                     throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Cannot unnest type: " + expressionType);
@@ -1685,7 +1685,7 @@ class StatementAnalyzer
 
             Optional<Field> ordinalityField = Optional.empty();
             if (node.isWithOrdinality()) {
-                ordinalityField = Optional.of(Field.newUnqualified(Optional.empty(), BIGINT));
+                ordinalityField = Optional.of(Field.builder().type(BIGINT).build());
             }
 
             ordinalityField.ifPresent(outputFields::add);
@@ -1877,7 +1877,10 @@ class StatementAnalyzer
             if (properColumnsDescriptor != null) {
                 properColumnsDescriptor.getFields().stream()
                         // per spec, field names are mandatory. We support anonymous fields.
-                        .map(field -> Field.newUnqualified(field.getName(), field.getType().orElseThrow(() -> new IllegalStateException("missing returned type for proper field"))))
+                        .map(field -> Field.builder()
+                                .name(field.getName())
+                                .type(field.getType().orElseThrow(() -> new IllegalStateException("missing returned type for proper field")))
+                                .build())
                         .forEach(fields::add);
             }
 
@@ -2411,7 +2414,7 @@ class StatementAnalyzer
                 // Add the row id field
                 ColumnHandle rowIdColumnHandle = metadata.getMergeRowIdColumnHandle(session, tableHandle.get());
                 Type type = metadata.getColumnMetadata(session, tableHandle.get(), rowIdColumnHandle).getType();
-                Field field = Field.newUnqualified(Optional.empty(), type);
+                Field field = Field.builder().type(type).build();
                 fields.add(field);
                 analysis.setColumn(field, rowIdColumnHandle);
             }
@@ -4236,7 +4239,7 @@ class StatementAnalyzer
             }
 
             List<Field> fields = commonSuperType.getFields().stream()
-                    .map(field -> Field.newUnqualified(field.getName(), field.getType()))
+                    .map(field -> Field.builder().name(field.getName()).type(field.getType()).build())
                     .collect(toImmutableList());
 
             return createAndAssignScope(node, scope, fields);
@@ -5167,7 +5170,7 @@ class StatementAnalyzer
                 if (!allColumns.getAliases().isEmpty()) {
                     name = Optional.of(allColumns.getAliases().get(i).getValue());
                 }
-                itemOutputFieldBuilder.add(Field.newUnqualified(name, outputExpressionType));
+                itemOutputFieldBuilder.add(Field.builder().name(name).type(outputExpressionType).build());
             }
             selectExpressionBuilder.add(new SelectExpression(expression, Optional.of(unfoldedExpressionsBuilder.build())));
             analysis.setSelectAllResultFields(allColumns, itemOutputFieldBuilder.build());

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4893,7 +4893,12 @@ class StatementAnalyzer
                             name = field.getName();
                         }
 
-                        Field newField = Field.newUnqualified(name, field.getType(), field.getOriginTable(), field.getOriginColumnName(), false);
+                        Field newField = field.rebuild()
+                                .name(name)
+                                .aliased(false)
+                                .hidden(false)
+                                .relationAlias(Optional.empty())
+                                .build();
                         analysis.addSourceColumns(newField, analysis.getSourceColumns(field));
                         outputFields.add(newField);
                     }
@@ -4927,7 +4932,13 @@ class StatementAnalyzer
                         }
                     }
 
-                    Field newField = Field.newUnqualified(field.map(Identifier::getValue), analysis.getType(expression), originTable, originColumn, column.getAlias().isPresent()); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
+                    Field newField = Field.builder()
+                            .name(field.map(Identifier::getValue))
+                            .type(analysis.getType(expression))
+                            .originTable(originTable)
+                            .originColumnName(originColumn)
+                            .aliased(column.getAlias().isPresent())
+                            .build(); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
                     if (originTable.isPresent()) {
                         analysis.addSourceColumns(newField, ImmutableSet.of(new SourceColumn(originTable.get(), originColumn.orElseThrow())));
                     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2592,14 +2592,11 @@ class StatementAnalyzer
                 for (int i = 0; i < queryDescriptor.getAllFieldCount(); i++) {
                     Field inputField = queryDescriptor.getFieldByIndex(i);
                     if (!inputField.isHidden()) {
-                        Field field = Field.newQualified(
-                                QualifiedName.of(table.getName().getSuffix()),
-                                Optional.of(aliases.next().getValue()),
-                                inputField.getType(),
-                                false,
-                                inputField.getOriginTable(),
-                                inputField.getOriginColumnName(),
-                                inputField.isAliased());
+                        Field field = inputField.rebuild()
+                                .relationAlias(Optional.of(QualifiedName.of(table.getName().getSuffix())))
+                                .name(aliases.next().getValue())
+                                .hidden(false)
+                                .build();
                         fieldBuilder.add(field);
                         analysis.addSourceColumns(field, analysis.getSourceColumns(inputField));
                     }
@@ -2611,14 +2608,10 @@ class StatementAnalyzer
                 for (int i = 0; i < queryDescriptor.getAllFieldCount(); i++) {
                     Field inputField = queryDescriptor.getFieldByIndex(i);
                     if (!inputField.isHidden()) {
-                        Field field = Field.newQualified(
-                                QualifiedName.of(table.getName().getSuffix()),
-                                inputField.getName(),
-                                inputField.getType(),
-                                false,
-                                inputField.getOriginTable(),
-                                inputField.getOriginColumnName(),
-                                inputField.isAliased());
+                        Field field = inputField.rebuild()
+                                .relationAlias(Optional.of(QualifiedName.of(table.getName().getSuffix())))
+                                .hidden(false)
+                                .build();
                         fieldBuilder.add(field);
                         analysis.addSourceColumns(field, analysis.getSourceColumns(inputField));
                     }
@@ -2694,14 +2687,15 @@ class StatementAnalyzer
             // This is needed in case the underlying table(s) changed and the query in the view now produces types that
             // are implicitly coercible to the declared view types.
             List<Field> viewFields = columns.stream()
-                    .map(column -> Field.newQualified(
-                            table.getName(),
-                            Optional.of(column.name()),
-                            getViewColumnType(column, name, table),
-                            false,
-                            Optional.of(name),
-                            Optional.of(column.name()),
-                            false))
+                    .map(column -> Field.builder()
+                            .relationAlias(Optional.of(table.getName()))
+                            .name(column.name())
+                            .type(getViewColumnType(column, name, table))
+                            .hidden(false)
+                            .originTable(Optional.of(name))
+                            .originColumnName(Optional.of(column.name()))
+                            .aliased(false)
+                            .build())
                     .collect(toImmutableList());
 
             if (freshStorageTable.isPresent()) {
@@ -2808,14 +2802,15 @@ class StatementAnalyzer
             // TODO: discover columns lazily based on where they are needed (to support connectors that can't enumerate all tables)
             ImmutableList.Builder<Field> fields = ImmutableList.builder();
             for (ColumnSchema column : tableSchema.columns()) {
-                Field field = Field.newQualified(
-                        table.getName(),
-                        Optional.of(column.getName()),
-                        column.getType(),
-                        column.isHidden(),
-                        Optional.of(tableName),
-                        Optional.of(column.getName()),
-                        false);
+                Field field = Field.builder()
+                        .relationAlias(Optional.of(table.getName()))
+                        .name(column.getName())
+                        .type(column.getType())
+                        .hidden(column.isHidden())
+                        .originTable(Optional.of(tableName))
+                        .originColumnName(Optional.of(column.getName()))
+                        .aliased(false)
+                        .build();
                 fields.add(field);
                 ColumnHandle columnHandle = columnHandles.get(column.getName());
                 checkArgument(columnHandle != null, "Unknown field %s", field);
@@ -3099,27 +3094,19 @@ class StatementAnalyzer
                 for (int i = 0; i < properColumnsCount; i++) {
                     // proper columns are not hidden, so we don't need to skip hidden fields
                     Field field = relationType.getFieldByIndex(i);
-                    fieldsBuilder.add(Field.newQualified(
-                            QualifiedName.of(ImmutableList.of(relation.getAlias())),
-                            Optional.of(relation.getColumnNames().get(i).getCanonicalValue()), // although the canonical name is recorded, fields are resolved case-insensitive
-                            field.getType(),
-                            field.isHidden(),
-                            field.getOriginTable(),
-                            field.getOriginColumnName(),
-                            field.isAliased()));
+                    // although the canonical name is recorded, fields are resolved case-insensitive
+                    fieldsBuilder.add(field.rebuild()
+                            .relationAlias(Optional.of(QualifiedName.of(ImmutableList.of(relation.getAlias()))))
+                            .name(relation.getColumnNames().get(i).getCanonicalValue())
+                            .build());
                 }
             }
             else {
                 for (int i = 0; i < properColumnsCount; i++) {
                     Field field = relationType.getFieldByIndex(i);
-                    fieldsBuilder.add(Field.newQualified(
-                            QualifiedName.of(ImmutableList.of(relation.getAlias())),
-                            field.getName(),
-                            field.getType(),
-                            field.isHidden(),
-                            field.getOriginTable(),
-                            field.getOriginColumnName(),
-                            field.isAliased()));
+                    fieldsBuilder.add(field.rebuild()
+                            .relationAlias(Optional.of(QualifiedName.of(ImmutableList.of(relation.getAlias()))))
+                            .build());
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -704,7 +704,7 @@ class StatementAnalyzer
                                     (column, field) -> new OutputColumn(column, analysis.getSourceColumns(field)))
                             .collect(toImmutableList())));
 
-            return createAndAssignScope(insert, scope, Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(insert, scope, Field.builder().name("rows").type(BIGINT).build());
         }
 
         @Override
@@ -783,7 +783,7 @@ class StatementAnalyzer
                                     (column, field) -> new OutputColumn(column, analysis.getSourceColumns(field)))
                             .collect(toImmutableList())));
 
-            return createAndAssignScope(refreshMaterializedView, scope, Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(refreshMaterializedView, scope, Field.builder().name("rows").type(BIGINT).build());
         }
 
         private boolean typesMatchForInsert(List<Type> tableTypes, List<Type> queryTypes)
@@ -892,7 +892,7 @@ class StatementAnalyzer
 
             createMergeAnalysis(table, handle, tableSchema, tableScope, tableScope, ImmutableList.of(), ImmutableMultimap.of());
 
-            return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(node, scope, Field.builder().name("rows").type(BIGINT).build());
         }
 
         @Override
@@ -939,7 +939,7 @@ class StatementAnalyzer
                 throw new AccessDeniedException(format("Cannot ANALYZE (missing insert privilege) table %s", tableName), exception);
             }
 
-            return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(node, scope, Field.builder().name("rows").type(BIGINT).build());
         }
 
         @Override
@@ -960,7 +960,7 @@ class StatementAnalyzer
                             false));
                     analysis.setUpdateType("CREATE TABLE");
                     analysis.setUpdateTarget(targetTableHandle.get().catalogHandle().getVersion(), targetTable, Optional.empty(), Optional.of(ImmutableList.of()));
-                    return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
+                    return createAndAssignScope(node, scope, Field.builder().name("rows").type(BIGINT).build());
                 }
                 throw semanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
             }
@@ -1056,7 +1056,7 @@ class StatementAnalyzer
                     Optional.empty(),
                     Optional.of(outputColumns.build()));
 
-            return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(node, scope, Field.builder().name("rows").type(BIGINT).build());
         }
 
         @Override
@@ -1342,7 +1342,9 @@ class StatementAnalyzer
             analysis.setUpdateType("ALTER TABLE EXECUTE");
             analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), tableName, Optional.of(table), Optional.empty());
 
-            return createAndAssignScope(node, scope, Field.newUnqualified("metric_name", VARCHAR), Field.newUnqualified("metric_value", BIGINT));
+            return createAndAssignScope(node, scope,
+                    Field.builder().name("metric_name").type(VARCHAR).build(),
+                    Field.builder().name("metric_value").type(BIGINT).build());
         }
 
         private List<Property> processTableExecuteArguments(TableExecute node, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
@@ -1578,14 +1580,14 @@ class StatementAnalyzer
         protected Scope visitExplain(Explain node, Optional<Scope> scope)
         {
             process(node.getStatement(), scope);
-            return createAndAssignScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
+            return createAndAssignScope(node, scope, Field.builder().name("Query Plan").type(VARCHAR).build());
         }
 
         @Override
         protected Scope visitExplainAnalyze(ExplainAnalyze node, Optional<Scope> scope)
         {
             process(node.getStatement(), scope);
-            return createAndAssignScope(node, scope, Field.newUnqualified("Query Plan", VARCHAR));
+            return createAndAssignScope(node, scope, Field.builder().name("Query Plan").type(VARCHAR).build());
         }
 
         @Override
@@ -2946,9 +2948,10 @@ class StatementAnalyzer
                 }
             }
             for (MeasureDefinition measureDefinition : relation.getMeasures()) {
-                outputFieldsBuilder.add(Field.newUnqualified(
-                        measureDefinition.getName().getValue(),
-                        measureTypes.get(NodeRef.of(measureDefinition.getExpression()))));
+                outputFieldsBuilder.add(Field.builder()
+                        .name(measureDefinition.getName().getValue())
+                        .type(measureTypes.get(NodeRef.of(measureDefinition.getExpression())))
+                        .build());
             }
             if (!oneRowPerMatch) {
                 Set<Field> inputFieldsOnOutput = inputFieldsOnOutputBuilder.build();
@@ -3700,7 +3703,7 @@ class StatementAnalyzer
             updatedColumnHandles.forEach(columnHandle -> updateCaseColumnsBuilder.put(0, columnHandle));
             createMergeAnalysis(table, handle, tableSchema, tableScope, tableScope, ImmutableList.of(updatedColumnHandles), updateCaseColumnsBuilder.build());
 
-            return createAndAssignScope(update, scope, Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(update, scope, Field.builder().name("rows").type(BIGINT).build());
         }
 
         @Override
@@ -3886,7 +3889,7 @@ class StatementAnalyzer
 
             createMergeAnalysis(table, targetTableHandle, tableSchema, targetTableScope, joinScope, mergeCaseColumnHandles, updateCaseColumnHandles.build());
 
-            return createAndAssignScope(merge, Optional.empty(), Field.newUnqualified("rows", BIGINT));
+            return createAndAssignScope(merge, Optional.empty(), Field.builder().name("rows").type(BIGINT).build());
         }
 
         private void createMergeAnalysis(
@@ -4056,7 +4059,7 @@ class StatementAnalyzer
                 Optional<Type> type = typeCoercion.getCommonSuperType(leftField.getType(), rightField.getType());
                 analysis.addTypes(ImmutableMap.of(NodeRef.of(column), type.orElseThrow()));
 
-                joinFields.add(Field.newUnqualified(column.getValue(), type.get()));
+                joinFields.add(Field.builder().name(column.getValue()).type(type.get()).build());
 
                 leftJoinFields.add(leftField.getRelationFieldIndex());
                 rightJoinFields.add(rightField.getRelationFieldIndex());
@@ -4318,7 +4321,7 @@ class StatementAnalyzer
                         if (!uniqueNames.add(name)) {
                             throw semanticException(DUPLICATE_COLUMN_OR_PATH_NAME, ordinalityColumn.getName(), "All column and path names in JSON_TABLE invocation must be unique");
                         }
-                        outputFields.add(Field.newUnqualified(name, BIGINT));
+                        outputFields.add(Field.builder().name(name).type(BIGINT).build());
                         orderedOutputColumns.add(NodeRef.of(ordinalityColumn));
                     }
                     case ValueColumn valueColumn -> {
@@ -4345,7 +4348,7 @@ class StatementAnalyzer
                                 correlationSupport);
                         // default values can contain subqueries - the subqueries are recorded under the enclosing JsonTable node
                         analysis.recordSubqueries(jsonTable, typeAndAnalysis.analysis());
-                        outputFields.add(Field.newUnqualified(name, typeAndAnalysis.type()));
+                        outputFields.add(Field.builder().name(name).type(typeAndAnalysis.type()).build());
                         orderedOutputColumns.add(NodeRef.of(valueColumn));
                     }
                     case QueryColumn queryColumn -> {
@@ -4358,7 +4361,7 @@ class StatementAnalyzer
                                 .orElseGet(() -> analyzeImplicitJsonPath(getImplicitJsonPath(name), queryColumn.getLocation()));
                         analysis.setJsonPathAnalysis(queryColumn, pathAnalysis);
                         Type type = analyzeJsonQueryExpression(queryColumn, session, plannerContext, statementAnalyzerFactory, accessControl, enclosingScope, analysis, warningCollector);
-                        outputFields.add(Field.newUnqualified(name, type));
+                        outputFields.add(Field.builder().name(name).type(type).build());
                         orderedOutputColumns.add(NodeRef.of(queryColumn));
                     }
                     case NestedColumns nestedColumns -> {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -479,7 +479,7 @@ public class LogicalPlanner
 
         checkState(assignments.size() == finalColumns.size(), "Assignment and column count must match");
         List<Field> fields = finalColumns.stream()
-                .map(column -> Field.newUnqualified(column.getName(), column.getType()))
+                .map(column -> Field.builder().name(column.getName()).type(column.getType()).build())
                 .collect(toImmutableList());
 
         ProjectNode projectNode = new ProjectNode(idAllocator.getNextId(), plan.getRoot(), assignments);
@@ -566,7 +566,7 @@ public class LogicalPlanner
 
         List<ColumnMetadata> insertedColumns = insertedColumnsBuilder.build();
         List<Field> fields = insertedColumns.stream()
-                .map(column -> Field.newUnqualified(column.getName(), column.getType()))
+                .map(column -> Field.builder().name(column.getName()).type(column.getType()).build())
                 .collect(toImmutableList());
         Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields)).build();
 

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -564,7 +564,7 @@ public class SqlRoutineAnalyzer
         private Type analyzeExpression(Context context, Expression expression)
         {
             List<Field> fields = context.variables().entrySet().stream()
-                    .map(entry -> Field.newUnqualified(entry.getKey(), entry.getValue()))
+                    .map(entry -> Field.builder().name(entry.getKey()).type(entry.getValue()).build())
                     .collect(toImmutableList());
 
             Scope scope = Scope.builder()

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
@@ -302,7 +302,7 @@ public final class SqlRoutinePlanner
         {
             // build symbol and field indexes for translation
             List<Field> fields = context.variables().entrySet().stream()
-                    .map(entry -> Field.newUnqualified(entry.getKey(), entry.getValue().type()))
+                    .map(entry -> Field.builder().name(entry.getKey()).type(entry.getValue().type()).build())
                     .collect(toImmutableList());
 
             Scope scope = Scope.builder()

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestScope.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestScope.java
@@ -30,12 +30,44 @@ public class TestScope
     {
         Scope root = Scope.create();
 
-        Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), Optional.empty(), false);
-        Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field outerColumn1 = Field.builder()
+                .relationAlias(Optional.of(QualifiedName.of("outer", "column1")))
+                .name("c1")
+                .type(BIGINT)
+                .hidden(false)
+                .originTable(Optional.empty())
+                .originColumnName(Optional.empty())
+                .aliased(false)
+                .build();
+        Field outerColumn2 = Field.builder()
+                .relationAlias(Optional.of(QualifiedName.of("outer", "column2")))
+                .name("c2")
+                .type(BIGINT)
+                .hidden(false)
+                .originTable(Optional.empty())
+                .originColumnName(Optional.empty())
+                .aliased(false)
+                .build();
         Scope outer = Scope.builder().withParent(root).withRelationType(RelationId.anonymous(), new RelationType(outerColumn1, outerColumn2)).build();
 
-        Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), false);
-        Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field innerColumn2 = Field.builder()
+                .relationAlias(Optional.of(QualifiedName.of("inner", "column2")))
+                .name("c2")
+                .type(BIGINT)
+                .hidden(false)
+                .originTable(Optional.empty())
+                .originColumnName(Optional.empty())
+                .aliased(false)
+                .build();
+        Field innerColumn3 = Field.builder()
+                .relationAlias(Optional.of(QualifiedName.of("inner", "column3")))
+                .name("c3")
+                .type(BIGINT)
+                .hidden(false)
+                .originTable(Optional.empty())
+                .originColumnName(Optional.empty())
+                .aliased(false)
+                .build();
         Scope inner = Scope.builder().withOuterQueryParent(outer).withRelationType(RelationId.anonymous(), new RelationType(innerColumn2, innerColumn3)).build();
 
         Expression c1 = name("c1");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

With the builder added in #29183 it is more readable now to use it instead of the more-or-less-opaque factory methods. This is especially relevant when:

* There are many parameters, in which case it's easier to see which is which instead of a positional parameter soup
* The `Field` constructed is actually a modified copy of some original field, in which case we can only set the fields that change

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow-up to #29183.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
