### PR TITLE
Mark more scalar functions as never failing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/AbstractGreatestLeast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/AbstractGreatestLeast.java
@@ -84,6 +84,7 @@ public abstract class AbstractGreatestLeast
                         .variableArity()
                         .build())
                 .nullable()
+                .neverFails()
                 .argumentNullability(true)
                 .description(description)
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CastFromUnknownOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CastFromUnknownOperator.java
@@ -44,6 +44,7 @@ public final class CastFromUnknownOperator
                         .returnType(new TypeSignature("E"))
                         .argumentType(UNKNOWN)
                         .build())
+                .neverFails()
                 .build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
@@ -42,6 +42,7 @@ public class GenericComparisonUnorderedFirstOperator
                         .argumentType(new TypeSignature("T"))
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
@@ -42,6 +42,7 @@ public class GenericComparisonUnorderedLastOperator
                         .argumentType(new TypeSignature("T"))
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericEqualOperator.java
@@ -43,6 +43,7 @@ public class GenericEqualOperator
                         .argumentType(new TypeSignature("T"))
                         .build())
                 .nullable()
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericHashCodeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericHashCodeOperator.java
@@ -41,6 +41,7 @@ public class GenericHashCodeOperator
                         .returnType(BIGINT)
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIdenticalOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIdenticalOperator.java
@@ -43,6 +43,7 @@ public class GenericIdenticalOperator
                         .argumentType(new TypeSignature("T"))
                         .build())
                 .argumentNullability(true, true)
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIndeterminateOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIndeterminateOperator.java
@@ -42,6 +42,7 @@ public class GenericIndeterminateOperator
                         .argumentType(new TypeSignature("T"))
                         .build())
                 .argumentNullability(true)
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
@@ -42,6 +42,7 @@ public class GenericLessThanOperator
                         .argumentType(new TypeSignature("T"))
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
@@ -42,6 +42,7 @@ public class GenericLessThanOrEqualOperator
                         .argumentType(new TypeSignature("T"))
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericReadValueOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericReadValueOperator.java
@@ -40,6 +40,7 @@ public class GenericReadValueOperator
                         .returnType(new TypeSignature("T"))
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericXxHash64Operator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericXxHash64Operator.java
@@ -41,6 +41,7 @@ public class GenericXxHash64Operator
                         .returnType(BIGINT)
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/IdentityCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/IdentityCast.java
@@ -41,6 +41,7 @@ public class IdentityCast
                         .returnType(new TypeSignature("T"))
                         .argumentType(new TypeSignature("T"))
                         .build())
+                .neverFails()
                 .build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VersionFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VersionFunction.java
@@ -41,6 +41,7 @@ public final class VersionFunction
                         .returnType(VARCHAR)
                         .build())
                 .hidden()
+                .neverFails()
                 .description("Return server version")
                 .build());
         this.nodeVersion = nodeVersion;


### PR DESCRIPTION
mayFail is too conservative for majority of the expressions due to a missing neverFails() on scalar operator functions
 
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
