### PR TITLE
Add StarRocks connector

### DIFF
--- a/docs/src/main/sphinx/connector.md
+++ b/docs/src/main/sphinx/connector.md
@@ -41,6 +41,7 @@ Redshift        <connector/redshift>
 SingleStore     <connector/singlestore>
 Snowflake       <connector/snowflake>
 SQL Server      <connector/sqlserver>
+StarRocks       <connector/starrocks>
 System          <connector/system>
 Thrift          <connector/thrift>
 TPC-DS           <connector/tpcds>

--- a/docs/src/main/sphinx/connector/starrocks.md
+++ b/docs/src/main/sphinx/connector/starrocks.md
@@ -1,0 +1,274 @@
+# StarRocks connector
+
+The StarRocks connector allows querying tables and views in an external
+[StarRocks](https://www.starrocks.io/) cluster.
+
+This connector is purpose-built for StarRocks. It does not rely on the generic
+MySQL connector path, because StarRocks metadata and type reporting do not
+always match MySQL connector assumptions.
+
+In v1, the connector is read-only:
+
+- metadata is discovered through the native StarRocks JDBC driver
+- table reads are executed through Arrow Flight SQL
+- writes and schema changes are intentionally out of scope
+
+## Requirements
+
+To connect to StarRocks, you need:
+
+- StarRocks 3.5.1 or higher
+- network access from the Trino coordinator and workers to the StarRocks FE
+  JDBC endpoint and Arrow Flight SQL endpoint
+- a StarRocks user with permission to inspect metadata and run read queries
+
+Arrow Flight SQL must be enabled on both FE and BE nodes, and the FE should be
+reachable by Trino on the configured Flight SQL port.
+
+If Trino cannot reach BE nodes directly, configure StarRocks FE proxy mode for
+new Arrow Flight SQL sessions using a routable FE endpoint, for example:
+
+```sql
+SET GLOBAL arrow_flight_proxy_enabled = true;
+SET GLOBAL arrow_flight_proxy = 'fe1.example.net:9408';
+```
+
+Some Arrow Flight SQL deployments also require JVM `--add-opens` flags on Java
+9 or later. If StarRocks or the Flight SQL client reports Arrow access errors,
+apply the `java.nio` opens recommended by the StarRocks Arrow Flight SQL
+documentation.
+
+## Connector architecture
+
+The connector uses two StarRocks-native interfaces:
+
+- StarRocks JDBC from `starrocks.jdbc-url` for schema, table, view, and column
+  discovery
+- StarRocks Arrow Flight SQL from `starrocks.flight-sql-host` and
+  `starrocks.flight-sql-port` for data reads
+
+This split is intentional:
+
+- JDBC is used as the source of truth for metadata because it is more reliable
+  than MySQL-emulation metadata paths for StarRocks
+- Arrow Flight SQL is used for reads because it is the best fit for
+  high-throughput, columnar result transport
+
+## Configuration
+
+To configure the StarRocks connector, create a catalog properties file in
+`etc/catalog`, for example `example.properties`, with the following contents:
+
+```text
+connector.name=starrocks
+starrocks.jdbc-url=jdbc:starrocks://fe1.example.net:9030
+starrocks.username=trino
+starrocks.password=secret
+starrocks.flight-sql-host=fe1.example.net
+starrocks.flight-sql-port=9408
+```
+
+Enable `starrocks.flight-sql.tls.enabled=true` for production deployments that
+send credentials to Flight SQL. With TLS disabled, Flight SQL authentication
+data is sent over a plaintext gRPC connection.
+
+The configuration properties are:
+
+:::{list-table} StarRocks configuration properties
+:widths: 30, 20, 50
+:header-rows: 1
+
+* - Property name
+  - Required
+  - Description
+* - `starrocks.jdbc-url`
+  - Yes
+  - StarRocks JDBC URL used for metadata discovery.
+* - `starrocks.catalog-name`
+  - No
+  - StarRocks catalog to expose through this Trino catalog. When set, Trino
+    schemas map to databases inside the configured StarRocks catalog.
+* - `starrocks.username`
+  - No
+  - StarRocks username used for JDBC metadata access and Flight SQL sessions.
+* - `starrocks.password`
+  - No
+  - StarRocks password used with `starrocks.username`.
+* - `starrocks.flight-sql-host`
+  - No
+  - Explicit FE host for Arrow Flight SQL. If omitted, the connector derives
+    the host from `starrocks.jdbc-url`.
+* - `starrocks.flight-sql-port`
+  - No
+  - FE Arrow Flight SQL port used for reads. The default is `9408`.
+* - `starrocks.flight-sql.max-allocation`
+  - No
+  - Maximum Arrow memory allocation per Flight SQL stream. The default is
+    `256MB`.
+* - `starrocks.flight-sql.tls.enabled`
+  - No
+  - Use TLS for Arrow Flight SQL connections. The default is `false`.
+* - `starrocks.flight-sql.tls.root-certificate`
+  - No
+  - Path to a PEM root certificate file for Arrow Flight SQL TLS.
+* - `starrocks.flight-sql.tls.skip-verify`
+  - No
+  - Skip Arrow Flight SQL server certificate verification. Use only for
+    development or controlled validation environments.
+* - `starrocks.flight-sql.tls.override-hostname`
+  - No
+  - Hostname used for Arrow Flight SQL TLS verification when it differs from
+    `starrocks.flight-sql-host`.
+:::
+
+If you create multiple catalog properties files, Trino creates one StarRocks
+catalog for each file. The catalog name is the filename without the
+`.properties` suffix.
+
+## Metadata behavior
+
+The StarRocks connector exposes StarRocks metadata through Trino's lowercase
+identifier model.
+
+- Each StarRocks database appears as a Trino schema.
+- If `starrocks.catalog-name` is configured, each database in that StarRocks
+  catalog appears as a Trino schema.
+- `SHOW SCHEMAS` excludes internal schemas such as `information_schema`,
+  `_statistics_`, and `sys`.
+- `SHOW TABLES` lists readable base tables and views.
+- Mixed-case StarRocks schema, table, and column names are resolved back to
+  the remote names during reads, as long as the lowercase name is unique.
+
+The connector uses StarRocks-native metadata paths and prefers
+`INFORMATION_SCHEMA` for column details when it exposes more accurate type
+information than JDBC metadata alone. This avoids breaking metadata access for
+tables that fail under the generic MySQL path or that expose StarRocks-specific
+types through lossy JDBC metadata.
+
+## Type mapping
+
+The connector maps StarRocks types to Trino types conservatively.
+
+### StarRocks to Trino type mapping
+
+:::{list-table} StarRocks to Trino type mapping
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - StarRocks type
+  - Trino type
+  - Notes
+* - `BOOLEAN`, `BOOL`
+  - `BOOLEAN`
+  -
+* - `TINYINT`
+  - `TINYINT`
+  - The connector does not infer MySQL-style `TINYINT(1)` booleans.
+* - `SMALLINT`
+  - `SMALLINT`
+  -
+* - `INT`, `INTEGER`
+  - `INTEGER`
+  -
+* - `BIGINT`
+  - `BIGINT`
+  -
+* - `DECIMAL`, `DECIMALV2`, `DECIMALV3`, `DECIMAL32`, `DECIMAL64`,
+    `DECIMAL128`, `DECIMAL128I`, `DECIMAL256`
+  - `DECIMAL(p, s)` or `VARCHAR`
+  - Maps to `VARCHAR` when StarRocks precision is missing or does not fit in
+    Trino `DECIMAL`.
+* - `FLOAT`
+  - `REAL`
+  -
+* - `DOUBLE`
+  - `DOUBLE`
+  -
+* - `CHAR(n)`
+  - `CHAR(n)`
+  -
+* - `VARCHAR(n)`
+  - `VARCHAR(n)`
+  -
+* - `DATE`
+  - `DATE`
+  -
+* - `DATETIME`, `DATETIMEV2`, `TIMESTAMP`
+  - `TIMESTAMP(p)`
+  - Precision is derived from StarRocks type metadata when available.
+* - `BINARY`, `VARBINARY`
+  - `VARBINARY`
+  -
+* - `JSON`, `VARIANT`
+  - `JSON`
+  - Values are read through the Arrow Flight SQL path as JSON text.
+* - `ARRAY<T>`
+  - `VARCHAR`
+  - Mapped conservatively in v1 because StarRocks textual complex values are
+    not guaranteed to use JSON syntax.
+* - `MAP<K,V>`
+  - `VARCHAR`
+  - Mapped conservatively in v1.
+* - `STRUCT<...>`
+  - `VARCHAR`
+  - Mapped conservatively in v1.
+* - `STRING`, `TEXT`
+  - `VARCHAR`
+  - These values are read textually in v1.
+* - `LARGEINT`, `BITMAP`, `PERCENTILE`
+  - `VARCHAR`
+  - These types are preserved for metadata visibility and mapped
+    conservatively because Trino does not have equivalent native semantics for
+    the full StarRocks value domain.
+* - `HLL`
+  - Not exposed
+  - StarRocks does not support direct reads of HLL state columns. Use
+    StarRocks HLL aggregate functions in StarRocks instead.
+:::
+
+## Querying StarRocks
+
+You can inspect StarRocks metadata with standard Trino commands:
+
+```sql
+SHOW SCHEMAS FROM example;
+SHOW TABLES FROM example.analytics;
+DESCRIBE example.analytics.events;
+SHOW CREATE TABLE example.analytics.events;
+```
+
+You can query StarRocks tables and views with standard `SELECT` statements:
+
+```sql
+SELECT count(*) FROM example.analytics.events;
+SELECT id, created_at, name FROM example.analytics.events ORDER BY id;
+SELECT * FROM example.analytics.events_view;
+```
+
+The connector pushes down basic predicates, `LIMIT`, numeric and temporal
+`ORDER BY ... LIMIT`, and basic aggregations into the SQL submitted through
+Arrow Flight SQL.
+
+Aggregation pushdown supports `count`, numeric `sum` and `avg`, and numeric or
+temporal `min` and `max` when the aggregation has no `DISTINCT`, `FILTER`, or
+aggregate-local `ORDER BY` clause. Unsupported aggregation forms, including
+string `min` and `max`, are evaluated end-to-end by Trino.
+
+## Limitations
+
+The initial version of the connector intentionally does not support:
+
+- `INSERT`, `UPDATE`, `DELETE`, or `MERGE`
+- table creation, schema creation, or other write-path DDL
+- DDL or write-path support for StarRocks complex types
+- native `ARRAY`, `MAP`, or `STRUCT` decoding
+- direct reads of `HLL` state columns
+- empty database discovery inside a configured StarRocks catalog when the
+  database has no tables
+- `DISTINCT`, filtered, sorted, statistical, regression, or approximate
+  aggregation pushdown
+- connector-specific split planning outside the partitions returned by Arrow
+  Flight SQL
+
+The connector prioritizes correct metadata discovery and stable read behavior
+for StarRocks-native deployments.

--- a/docs/src/main/sphinx/connector/starrocks.md
+++ b/docs/src/main/sphinx/connector/starrocks.md
@@ -97,6 +97,20 @@ The configuration properties are:
 * - `starrocks.flight-sql-port`
   - No
   - FE Arrow Flight SQL port used for reads. The default is `9408`.
+* - `starrocks.flight-sql.tls.enabled`
+  - No
+  - Use TLS for Arrow Flight SQL connections. The default is `false`.
+* - `starrocks.flight-sql.tls.root-certificate`
+  - No
+  - Path to a PEM root certificate file for Arrow Flight SQL TLS.
+* - `starrocks.flight-sql.tls.skip-verify`
+  - No
+  - Skip Arrow Flight SQL server certificate verification. Use only for
+    development or controlled validation environments.
+* - `starrocks.flight-sql.tls.override-hostname`
+  - No
+  - Hostname used for Arrow Flight SQL TLS verification when it differs from
+    `starrocks.flight-sql-host`.
 :::
 
 If you create multiple catalog properties files, Trino creates one StarRocks
@@ -180,13 +194,24 @@ The connector maps StarRocks types to Trino types conservatively.
 * - `JSON`, `VARIANT`
   - `JSON`
   - Values are read through the Arrow Flight SQL path as JSON text.
+* - `ARRAY<T>`
+  - `ARRAY<T>`
+  - Supported when StarRocks exposes a parseable nested type declaration and
+    Flight SQL returns either Arrow-native nested values or JSON text.
+* - `MAP<K,V>`
+  - `MAP<K,V>`
+  - Supported when the key type maps to a comparable Trino type.
+* - `STRUCT<...>`
+  - `ROW(...)`
+  - Supported when StarRocks exposes field names and parseable field types.
 * - `STRING`, `TEXT`
   - `VARCHAR`
   - These values are read textually in v1.
-* - `LARGEINT`, `BITMAP`, `HLL`, `PERCENTILE`, `ARRAY`, `MAP`, `STRUCT`
+* - `LARGEINT`, `BITMAP`, `HLL`, `PERCENTILE`
   - `VARCHAR`
   - These types are preserved for metadata visibility and mapped
-    conservatively in v1.
+    conservatively because Trino does not have equivalent native semantics for
+    the full StarRocks value domain.
 :::
 
 ## Querying StarRocks
@@ -209,7 +234,11 @@ SELECT * FROM example.analytics.events_view;
 ```
 
 The connector pushes down basic predicates, `LIMIT`, `ORDER BY ... LIMIT`, and
-`count` aggregations into the SQL submitted through Arrow Flight SQL.
+basic aggregations into the SQL submitted through Arrow Flight SQL.
+
+Aggregation pushdown supports `count`, `sum`, `avg`, `min`, and `max` when the
+aggregation has no `DISTINCT`, `FILTER`, or aggregate-local `ORDER BY` clause.
+Unsupported aggregation forms are evaluated end-to-end by Trino.
 
 ## Limitations
 
@@ -217,9 +246,13 @@ The initial version of the connector intentionally does not support:
 
 - `INSERT`, `UPDATE`, `DELETE`, or `MERGE`
 - table creation, schema creation, or other write-path DDL
-- native Trino `ARRAY`, `MAP`, or `ROW` decoding for StarRocks complex types
-- aggregations other than `count`
-- advanced split planning beyond the FE Arrow Flight SQL path
+- DDL or write-path support for StarRocks complex types
+- native complex-type decoding when StarRocks does not expose a parseable
+  nested type declaration or Flight SQL returns non-JSON textual values
+- `DISTINCT`, filtered, sorted, statistical, regression, or approximate
+  aggregation pushdown
+- connector-specific split planning outside the partitions returned by Arrow
+  Flight SQL
 
 The connector prioritizes correct metadata discovery and stable read behavior
 for StarRocks-native deployments.

--- a/docs/src/main/sphinx/connector/starrocks.md
+++ b/docs/src/main/sphinx/connector/starrocks.md
@@ -80,6 +80,10 @@ The configuration properties are:
 * - `starrocks.jdbc-url`
   - Yes
   - StarRocks JDBC URL used for metadata discovery.
+* - `starrocks.catalog-name`
+  - No
+  - StarRocks catalog to expose through this Trino catalog. When set, Trino
+    schemas map to databases inside the configured StarRocks catalog.
 * - `starrocks.username`
   - No
   - StarRocks username used for JDBC metadata access and Flight SQL sessions.
@@ -105,6 +109,8 @@ The StarRocks connector exposes StarRocks metadata through Trino's lowercase
 identifier model.
 
 - Each StarRocks database appears as a Trino schema.
+- If `starrocks.catalog-name` is configured, each database in that StarRocks
+  catalog appears as a Trino schema.
 - `SHOW SCHEMAS` excludes internal schemas such as `information_schema`,
   `_statistics_`, and `sys`.
 - `SHOW TABLES` lists readable base tables and views.
@@ -171,11 +177,13 @@ The connector maps StarRocks types to Trino types conservatively.
 * - `BINARY`, `VARBINARY`
   - `VARBINARY`
   -
-* - `STRING`, `TEXT`, `JSON`
+* - `JSON`, `VARIANT`
+  - `JSON`
+  - Values are read through the Arrow Flight SQL path as JSON text.
+* - `STRING`, `TEXT`
   - `VARCHAR`
   - These values are read textually in v1.
-* - `LARGEINT`, `BITMAP`, `HLL`, `PERCENTILE`, `ARRAY`, `MAP`, `STRUCT`,
-    `VARIANT`
+* - `LARGEINT`, `BITMAP`, `HLL`, `PERCENTILE`, `ARRAY`, `MAP`, `STRUCT`
   - `VARCHAR`
   - These types are preserved for metadata visibility and mapped
     conservatively in v1.
@@ -200,13 +208,17 @@ SELECT id, created_at, name FROM example.analytics.events ORDER BY id;
 SELECT * FROM example.analytics.events_view;
 ```
 
+The connector pushes down basic predicates, `LIMIT`, `ORDER BY ... LIMIT`, and
+`count` aggregations into the SQL submitted through Arrow Flight SQL.
+
 ## Limitations
 
 The initial version of the connector intentionally does not support:
 
 - `INSERT`, `UPDATE`, `DELETE`, or `MERGE`
 - table creation, schema creation, or other write-path DDL
-- StarRocks-specific type fidelity for every complex type
+- native Trino `ARRAY`, `MAP`, or `ROW` decoding for StarRocks complex types
+- aggregations other than `count`
 - advanced split planning beyond the FE Arrow Flight SQL path
 
 The connector prioritizes correct metadata discovery and stable read behavior

--- a/docs/src/main/sphinx/connector/starrocks.md
+++ b/docs/src/main/sphinx/connector/starrocks.md
@@ -1,0 +1,213 @@
+# StarRocks connector
+
+The StarRocks connector allows querying tables and views in an external
+[StarRocks](https://www.starrocks.io/) cluster.
+
+This connector is purpose-built for StarRocks. It does not rely on the generic
+MySQL connector path, because StarRocks metadata and type reporting do not
+always match MySQL connector assumptions.
+
+In v1, the connector is read-only:
+
+- metadata is discovered through the native StarRocks JDBC driver
+- table reads are executed through Arrow Flight SQL
+- writes and schema changes are intentionally out of scope
+
+## Requirements
+
+To connect to StarRocks, you need:
+
+- StarRocks 3.5.1 or higher
+- network access from the Trino coordinator and workers to the StarRocks FE
+  JDBC endpoint and Arrow Flight SQL endpoint
+- a StarRocks user with permission to inspect metadata and run read queries
+
+Arrow Flight SQL must be enabled on both FE and BE nodes, and the FE should be
+reachable by Trino on the configured Flight SQL port.
+
+If Trino cannot reach BE nodes directly, configure StarRocks FE proxy mode for
+new Arrow Flight SQL sessions using a routable FE endpoint, for example:
+
+```sql
+SET GLOBAL arrow_flight_proxy_enabled = true;
+SET GLOBAL arrow_flight_proxy = 'fe1.example.net:9408';
+```
+
+Some Arrow Flight SQL deployments also require JVM `--add-opens` flags on Java
+9 or later. If StarRocks or the Flight SQL client reports Arrow access errors,
+apply the `java.nio` opens recommended by the StarRocks Arrow Flight SQL
+documentation.
+
+## Connector architecture
+
+The connector uses two StarRocks-native interfaces:
+
+- StarRocks JDBC from `starrocks.jdbc-url` for schema, table, view, and column
+  discovery
+- StarRocks Arrow Flight SQL from `starrocks.flight-sql-host` and
+  `starrocks.flight-sql-port` for data reads
+
+This split is intentional:
+
+- JDBC is used as the source of truth for metadata because it is more reliable
+  than MySQL-emulation metadata paths for StarRocks
+- Arrow Flight SQL is used for reads because it is the best fit for
+  high-throughput, columnar result transport
+
+## Configuration
+
+To configure the StarRocks connector, create a catalog properties file in
+`etc/catalog`, for example `example.properties`, with the following contents:
+
+```text
+connector.name=starrocks
+starrocks.jdbc-url=jdbc:starrocks://fe1.example.net:9030
+starrocks.username=trino
+starrocks.password=secret
+starrocks.flight-sql-host=fe1.example.net
+starrocks.flight-sql-port=9408
+```
+
+The configuration properties are:
+
+:::{list-table} StarRocks configuration properties
+:widths: 30, 20, 50
+:header-rows: 1
+
+* - Property name
+  - Required
+  - Description
+* - `starrocks.jdbc-url`
+  - Yes
+  - StarRocks JDBC URL used for metadata discovery.
+* - `starrocks.username`
+  - No
+  - StarRocks username used for JDBC metadata access and Flight SQL sessions.
+* - `starrocks.password`
+  - No
+  - StarRocks password used with `starrocks.username`.
+* - `starrocks.flight-sql-host`
+  - No
+  - Explicit FE host for Arrow Flight SQL. If omitted, the connector derives
+    the host from `starrocks.jdbc-url`.
+* - `starrocks.flight-sql-port`
+  - No
+  - FE Arrow Flight SQL port used for reads. The default is `9408`.
+:::
+
+If you create multiple catalog properties files, Trino creates one StarRocks
+catalog for each file. The catalog name is the filename without the
+`.properties` suffix.
+
+## Metadata behavior
+
+The StarRocks connector exposes StarRocks metadata through Trino's lowercase
+identifier model.
+
+- Each StarRocks database appears as a Trino schema.
+- `SHOW SCHEMAS` excludes internal schemas such as `information_schema`,
+  `_statistics_`, and `sys`.
+- `SHOW TABLES` lists readable base tables and views.
+- Mixed-case StarRocks schema, table, and column names are resolved back to
+  the remote names during reads, as long as the lowercase name is unique.
+
+The connector uses StarRocks-native metadata paths and prefers
+`INFORMATION_SCHEMA` for column details when it exposes more accurate type
+information than JDBC metadata alone. This avoids breaking metadata access for
+tables that fail under the generic MySQL path or that expose StarRocks-specific
+types through lossy JDBC metadata.
+
+## Type mapping
+
+The connector maps StarRocks types to Trino types conservatively.
+
+### StarRocks to Trino type mapping
+
+:::{list-table} StarRocks to Trino type mapping
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - StarRocks type
+  - Trino type
+  - Notes
+* - `BOOLEAN`, `BOOL`
+  - `BOOLEAN`
+  -
+* - `TINYINT`
+  - `BOOLEAN` or `TINYINT`
+  - `TINYINT(1)` and boolean aliases map to `BOOLEAN`.
+* - `SMALLINT`
+  - `SMALLINT`
+  -
+* - `INT`, `INTEGER`
+  - `INTEGER`
+  -
+* - `BIGINT`
+  - `BIGINT`
+  -
+* - `DECIMAL`, `DECIMALV2`, `DECIMALV3`, `DECIMAL32`, `DECIMAL64`,
+    `DECIMAL128`, `DECIMAL128I`, `DECIMAL256`
+  - `DECIMAL(p, s)` or `VARCHAR`
+  - Maps to `VARCHAR` when StarRocks precision is missing or does not fit in
+    Trino `DECIMAL`.
+* - `FLOAT`
+  - `REAL`
+  -
+* - `DOUBLE`
+  - `DOUBLE`
+  -
+* - `CHAR(n)`
+  - `CHAR(n)`
+  -
+* - `VARCHAR(n)`
+  - `VARCHAR(n)`
+  -
+* - `DATE`
+  - `DATE`
+  -
+* - `DATETIME`, `DATETIMEV2`, `TIMESTAMP`
+  - `TIMESTAMP(p)`
+  - Precision is derived from StarRocks type metadata when available.
+* - `BINARY`, `VARBINARY`
+  - `VARBINARY`
+  -
+* - `STRING`, `TEXT`, `JSON`
+  - `VARCHAR`
+  - These values are read textually in v1.
+* - `LARGEINT`, `BITMAP`, `HLL`, `PERCENTILE`, `ARRAY`, `MAP`, `STRUCT`,
+    `VARIANT`
+  - `VARCHAR`
+  - These types are preserved for metadata visibility and mapped
+    conservatively in v1.
+:::
+
+## Querying StarRocks
+
+You can inspect StarRocks metadata with standard Trino commands:
+
+```sql
+SHOW SCHEMAS FROM example;
+SHOW TABLES FROM example.analytics;
+DESCRIBE example.analytics.events;
+SHOW CREATE TABLE example.analytics.events;
+```
+
+You can query StarRocks tables and views with standard `SELECT` statements:
+
+```sql
+SELECT count(*) FROM example.analytics.events;
+SELECT id, created_at, name FROM example.analytics.events ORDER BY id;
+SELECT * FROM example.analytics.events_view;
+```
+
+## Limitations
+
+The initial version of the connector intentionally does not support:
+
+- `INSERT`, `UPDATE`, `DELETE`, or `MERGE`
+- table creation, schema creation, or other write-path DDL
+- StarRocks-specific type fidelity for every complex type
+- advanced split planning beyond the FE Arrow Flight SQL path
+
+The connector prioritizes correct metadata discovery and stable read behavior
+for StarRocks-native deployments.

--- a/plugin/trino-starrocks/pom.xml
+++ b/plugin/trino-starrocks/pom.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>482-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-starrocks</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - StarRocks Connector</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+        <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default} --add-opens=java.base/java.nio=ALL-UNNAMED</air.test.jvm.additional-arguments>
+        <dep.arrow.adbc.version>0.22.0</dep.arrow.adbc.version>
+        <dep.starrocks.jdbc.version>1.1.1</dep.starrocks.jdbc.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>starrocks-connector-j</artifactId>
+            <version>${dep.starrocks.jdbc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>flight-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-protobuf</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-stub</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow.adbc</groupId>
+            <artifactId>adbc-core</artifactId>
+            <version>${dep.arrow.adbc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow.adbc</groupId>
+            <artifactId>adbc-driver-flight-sql</artifactId>
+            <version>${dep.arrow.adbc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-sql-jdbc-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api-incubator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>flight-sql-jdbc-core</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <!-- flight-sql-jdbc-core requires avatica, which overlaps with Trino's dependency set -->
+                            <groupId>org.apache.calcite.avatica</groupId>
+                            <artifactId>avatica</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-starrocks/pom.xml
+++ b/plugin/trino-starrocks/pom.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>481-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-starrocks</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - StarRocks Connector</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+        <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default} --add-opens=java.base/java.nio=ALL-UNNAMED</air.test.jvm.additional-arguments>
+        <dep.arrow.adbc.version>0.22.0</dep.arrow.adbc.version>
+        <dep.starrocks.jdbc.version>1.1.1</dep.starrocks.jdbc.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>starrocks-connector-j</artifactId>
+            <version>${dep.starrocks.jdbc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>flight-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-protobuf</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-stub</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow.adbc</groupId>
+            <artifactId>adbc-core</artifactId>
+            <version>${dep.arrow.adbc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow.adbc</groupId>
+            <artifactId>adbc-driver-flight-sql</artifactId>
+            <version>${dep.arrow.adbc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-sql-jdbc-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api-incubator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>flight-sql-jdbc-core</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <!-- flight-sql-jdbc-core requires avatica, which overlaps with Trino's dependency set -->
+                            <groupId>org.apache.calcite.avatica</groupId>
+                            <artifactId>avatica</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/AdbcStarRocksFlightSqlClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/AdbcStarRocksFlightSqlClient.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.arrow.adbc.core.AdbcConnection;
+import org.apache.arrow.adbc.core.AdbcDatabase;
+import org.apache.arrow.adbc.core.AdbcDriver;
+import org.apache.arrow.adbc.core.AdbcException;
+import org.apache.arrow.adbc.core.AdbcStatement;
+import org.apache.arrow.adbc.core.AdbcStatusCode;
+import org.apache.arrow.adbc.core.PartitionDescriptor;
+import org.apache.arrow.adbc.driver.flightsql.FlightSqlConnectionProperties;
+import org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class AdbcStarRocksFlightSqlClient
+        implements StarRocksFlightSqlClient
+{
+    private static final String APPLICATION_NAME_PREFIX = "/* ApplicationName=Trino StarRocks Flight SQL Query */ ";
+
+    private final String flightSqlHost;
+    private final int flightSqlPort;
+    private final boolean flightSqlTlsEnabled;
+    private final Optional<File> flightSqlTlsRootCertificate;
+    private final boolean flightSqlTlsSkipVerify;
+    private final Optional<String> flightSqlTlsOverrideHostname;
+    private final Optional<String> username;
+    private final Optional<String> password;
+    private final long flightSqlMaxAllocationBytes;
+    private final StarRocksQueryBuilder queryBuilder;
+
+    @Inject
+    public AdbcStarRocksFlightSqlClient(StarRocksConfig config, StarRocksQueryBuilder queryBuilder)
+    {
+        requireNonNull(config, "config is null");
+        this.flightSqlHost = config.getFlightSqlHost()
+                .orElseGet(() -> inferFlightSqlHost(config.getJdbcUrl()
+                        .orElseThrow(() -> new IllegalArgumentException("starrocks.jdbc-url must be set"))));
+        this.flightSqlPort = config.getFlightSqlPort();
+        this.flightSqlTlsEnabled = config.isFlightSqlTlsEnabled();
+        this.flightSqlTlsRootCertificate = config.getFlightSqlTlsRootCertificate();
+        this.flightSqlTlsSkipVerify = config.isFlightSqlTlsSkipVerify();
+        this.flightSqlTlsOverrideHostname = config.getFlightSqlTlsOverrideHostname();
+        this.username = config.getUsername();
+        this.password = config.getPassword();
+        this.flightSqlMaxAllocationBytes = config.getFlightSqlMaxAllocation().toBytes();
+        this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder is null");
+    }
+
+    @Override
+    public List<StarRocksSplit> getSplits(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            List<StarRocksColumnHandle> columns)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(columns, "columns is null");
+
+        if (requiresSingleSplit(tableHandle)) {
+            return List.of(new StarRocksSplit());
+        }
+
+        String sql = APPLICATION_NAME_PREFIX + queryBuilder.buildSelectSql(tableHandle, columns);
+        try (AdbcResources resources = openResources();
+                AdbcStatement statement = resources.connection().createStatement()) {
+            statement.setSqlQuery(sql);
+            List<StarRocksSplit> splits = new ArrayList<>();
+            Iterable<PartitionDescriptor> partitionDescriptors;
+            try {
+                partitionDescriptors = statement.executePartitioned().getPartitionDescriptors();
+            }
+            catch (AdbcException e) {
+                if (!shouldFallbackToSingleSplit(e)) {
+                    throw e;
+                }
+                return List.of(new StarRocksSplit());
+            }
+            catch (UnsupportedOperationException e) {
+                return List.of(new StarRocksSplit());
+            }
+            for (PartitionDescriptor partitionDescriptor : partitionDescriptors) {
+                ByteBuffer descriptor = partitionDescriptor.getDescriptor();
+                byte[] bytes = new byte[descriptor.remaining()];
+                descriptor.get(bytes);
+                splits.add(new StarRocksSplit(Optional.of(bytes)));
+            }
+            if (splits.isEmpty()) {
+                return List.of(new StarRocksSplit());
+            }
+            return List.copyOf(splits);
+        }
+        catch (AdbcException | RuntimeException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to plan StarRocks Flight SQL splits", e);
+        }
+        catch (Exception e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to close StarRocks Flight SQL split planning resources", e);
+        }
+    }
+
+    @Override
+    public StarRocksFlightSqlResult openStream(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            StarRocksSplit split,
+            List<StarRocksColumnHandle> columns)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(split, "split is null");
+        requireNonNull(columns, "columns is null");
+
+        if (split.partitionDescriptor().isPresent()) {
+            return openPartition(split.partitionDescriptor().orElseThrow());
+        }
+        return openQuery(APPLICATION_NAME_PREFIX + queryBuilder.buildSelectSql(tableHandle, columns));
+    }
+
+    private StarRocksFlightSqlResult openQuery(String sql)
+    {
+        AdbcResources resources = null;
+        AdbcStatement statement = null;
+        AdbcStatement.QueryResult queryResult = null;
+        ArrowReader reader = null;
+
+        try {
+            resources = openResources();
+            statement = resources.connection().createStatement();
+            statement.setSqlQuery(sql);
+            queryResult = statement.executeQuery();
+            reader = queryResult.getReader();
+            return new AdbcResult(resources, statement, queryResult, reader);
+        }
+        catch (AdbcException | RuntimeException e) {
+            closeQuietly(reader);
+            closeQuietly(queryResult);
+            closeQuietly(statement);
+            closeQuietly(resources);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to execute StarRocks Flight SQL query", e);
+        }
+    }
+
+    private StarRocksFlightSqlResult openPartition(byte[] partitionDescriptor)
+    {
+        AdbcResources resources = null;
+        ArrowReader reader = null;
+
+        try {
+            resources = openResources();
+            reader = resources.connection().readPartition(ByteBuffer.wrap(partitionDescriptor));
+            return new AdbcResult(resources, null, null, reader);
+        }
+        catch (AdbcException | RuntimeException e) {
+            closeQuietly(reader);
+            closeQuietly(resources);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to read StarRocks Flight SQL partition", e);
+        }
+    }
+
+    private AdbcResources openResources()
+            throws AdbcException
+    {
+        BufferAllocator allocator = new RootAllocator(flightSqlMaxAllocationBytes);
+        AdbcDatabase database = null;
+        AdbcConnection connection = null;
+        InputStream rootCertificate = null;
+        try {
+            FlightSqlDriver driver = new FlightSqlDriver(allocator);
+            Map<String, Object> parameters = new HashMap<>();
+            AdbcDriver.PARAM_URI.set(parameters, location().getUri().toString());
+            username.ifPresent(value -> AdbcDriver.PARAM_USERNAME.set(parameters, value));
+            password.ifPresent(value -> AdbcDriver.PARAM_PASSWORD.set(parameters, value));
+            FlightSqlConnectionProperties.TLS_SKIP_VERIFY.set(parameters, flightSqlTlsSkipVerify);
+            flightSqlTlsOverrideHostname.ifPresent(value -> FlightSqlConnectionProperties.TLS_OVERRIDE_HOSTNAME.set(parameters, value));
+            if (flightSqlTlsRootCertificate.isPresent()) {
+                rootCertificate = new FileInputStream(flightSqlTlsRootCertificate.orElseThrow());
+                FlightSqlConnectionProperties.TLS_ROOT_CERTS.set(parameters, rootCertificate);
+            }
+
+            database = driver.open(parameters);
+            connection = database.connect();
+            return new AdbcResources(allocator, database, connection);
+        }
+        catch (AdbcException | RuntimeException e) {
+            closeQuietly(connection);
+            closeQuietly(database);
+            closeQuietly(allocator);
+            throw e;
+        }
+        catch (Exception e) {
+            closeQuietly(connection);
+            closeQuietly(database);
+            closeQuietly(allocator);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to open StarRocks Flight SQL connection", e);
+        }
+        finally {
+            closeQuietly(rootCertificate);
+        }
+    }
+
+    private Location location()
+    {
+        if (flightSqlTlsEnabled) {
+            return Location.forGrpcTls(flightSqlHost, flightSqlPort);
+        }
+        return Location.forGrpcInsecure(flightSqlHost, flightSqlPort);
+    }
+
+    private static String inferFlightSqlHost(String jdbcUrl)
+    {
+        try {
+            URI uri = URI.create(jdbcUrl.substring("jdbc:".length()));
+            if (uri.getHost() == null || uri.getHost().isBlank()) {
+                throw new IllegalArgumentException("Unable to infer host from configured StarRocks JDBC URL");
+            }
+            return uri.getHost();
+        }
+        catch (RuntimeException e) {
+            throw new IllegalArgumentException("Unable to infer StarRocks Flight SQL host from configured JDBC URL", e);
+        }
+    }
+
+    static boolean shouldFallbackToSingleSplit(AdbcException exception)
+    {
+        return exception.getStatus() == AdbcStatusCode.NOT_IMPLEMENTED;
+    }
+
+    private static boolean requiresSingleSplit(StarRocksTableHandle tableHandle)
+    {
+        return tableHandle.aggregation().isPresent() ||
+                tableHandle.limit().isPresent() ||
+                !tableHandle.sortOrder().isEmpty();
+    }
+
+    private static void closeQuietly(AutoCloseable closeable)
+    {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        }
+        catch (Exception _) {
+            // Cleanup failures are ignored so the original query failure is preserved.
+        }
+    }
+
+    private static final class AdbcResult
+            implements StarRocksFlightSqlResult
+    {
+        private final AdbcResources resources;
+        private final AdbcStatement statement;
+        private final AdbcStatement.QueryResult queryResult;
+        private final ArrowReader reader;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private AdbcResult(
+                AdbcResources resources,
+                AdbcStatement statement,
+                AdbcStatement.QueryResult queryResult,
+                ArrowReader reader)
+        {
+            this.resources = requireNonNull(resources, "resources is null");
+            this.statement = statement;
+            this.queryResult = queryResult;
+            this.reader = requireNonNull(reader, "reader is null");
+        }
+
+        @Override
+        public boolean loadNextBatch()
+        {
+            if (closed.get()) {
+                return false;
+            }
+
+            try {
+                return reader.loadNextBatch();
+            }
+            catch (Exception e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to load StarRocks Flight SQL batch", e);
+            }
+        }
+
+        @Override
+        public VectorSchemaRoot getVectorSchemaRoot()
+        {
+            try {
+                return reader.getVectorSchemaRoot();
+            }
+            catch (Exception e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to access StarRocks Flight SQL batch schema root", e);
+            }
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            if (closed.get()) {
+                return 0;
+            }
+            try {
+                return resources.allocator().getAllocatedMemory();
+            }
+            catch (RuntimeException ignored) {
+                return 0;
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            if (!closed.compareAndSet(false, true)) {
+                return;
+            }
+
+            Exception failure = null;
+            failure = closeResource(failure, reader);
+            failure = closeResource(failure, queryResult);
+            failure = closeResource(failure, statement);
+            failure = closeResource(failure, resources);
+
+            if (failure != null) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to close StarRocks Flight SQL result", failure);
+            }
+        }
+
+        private static Exception closeResource(Exception failure, AutoCloseable closeable)
+        {
+            if (closeable == null) {
+                return failure;
+            }
+            try {
+                closeable.close();
+            }
+            catch (Exception e) {
+                if (failure == null) {
+                    return e;
+                }
+                failure.addSuppressed(e);
+            }
+            return failure;
+        }
+    }
+
+    private record AdbcResources(BufferAllocator allocator, AdbcDatabase database, AdbcConnection connection)
+            implements AutoCloseable
+    {
+        private AdbcResources
+        {
+            requireNonNull(allocator, "allocator is null");
+            requireNonNull(database, "database is null");
+            requireNonNull(connection, "connection is null");
+        }
+
+        @Override
+        public void close()
+        {
+            try {
+                closeQuietly(connection);
+                closeQuietly(database);
+            }
+            finally {
+                closeQuietly(allocator);
+            }
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/AdbcStarRocksFlightSqlClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/AdbcStarRocksFlightSqlClient.java
@@ -21,6 +21,8 @@ import org.apache.arrow.adbc.core.AdbcDatabase;
 import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.core.AdbcStatement;
+import org.apache.arrow.adbc.core.PartitionDescriptor;
+import org.apache.arrow.adbc.driver.flightsql.FlightSqlConnectionProperties;
 import org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.memory.BufferAllocator;
@@ -28,7 +30,12 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +52,10 @@ public class AdbcStarRocksFlightSqlClient
 
     private final String flightSqlHost;
     private final int flightSqlPort;
+    private final boolean flightSqlTlsEnabled;
+    private final Optional<File> flightSqlTlsRootCertificate;
+    private final boolean flightSqlTlsSkipVerify;
+    private final Optional<String> flightSqlTlsOverrideHostname;
     private final Optional<String> username;
     private final Optional<String> password;
     private final StarRocksQueryBuilder queryBuilder;
@@ -57,9 +68,49 @@ public class AdbcStarRocksFlightSqlClient
                 .orElseGet(() -> inferFlightSqlHost(config.getJdbcUrl()
                         .orElseThrow(() -> new IllegalArgumentException("starrocks.jdbc-url must be set"))));
         this.flightSqlPort = config.getFlightSqlPort();
+        this.flightSqlTlsEnabled = config.isFlightSqlTlsEnabled();
+        this.flightSqlTlsRootCertificate = config.getFlightSqlTlsRootCertificate();
+        this.flightSqlTlsSkipVerify = config.isFlightSqlTlsSkipVerify();
+        this.flightSqlTlsOverrideHostname = config.getFlightSqlTlsOverrideHostname();
         this.username = config.getUsername();
         this.password = config.getPassword();
         this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder is null");
+    }
+
+    @Override
+    public List<StarRocksSplit> getSplits(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            List<StarRocksColumnHandle> columns)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(columns, "columns is null");
+
+        String sql = APPLICATION_NAME_PREFIX + queryBuilder.buildSelectSql(tableHandle, columns);
+        try (AdbcResources resources = openResources();
+                AdbcStatement statement = resources.connection().createStatement()) {
+            statement.setSqlQuery(sql);
+            List<StarRocksSplit> splits = new ArrayList<>();
+            for (PartitionDescriptor partitionDescriptor : statement.executePartitioned().getPartitionDescriptors()) {
+                ByteBuffer descriptor = partitionDescriptor.getDescriptor();
+                byte[] bytes = new byte[descriptor.remaining()];
+                descriptor.get(bytes);
+                splits.add(new StarRocksSplit(Optional.of(bytes)));
+            }
+            if (splits.isEmpty()) {
+                return List.of(new StarRocksSplit());
+            }
+            return List.copyOf(splits);
+        }
+        catch (AdbcException | RuntimeException e) {
+            if (e instanceof AdbcException) {
+                return List.of(new StarRocksSplit());
+            }
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to plan StarRocks Flight SQL splits", e);
+        }
+        catch (Exception e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to close StarRocks Flight SQL split planning resources", e);
+        }
     }
 
     @Override
@@ -73,44 +124,100 @@ public class AdbcStarRocksFlightSqlClient
         requireNonNull(split, "split is null");
         requireNonNull(columns, "columns is null");
 
-        String sql = APPLICATION_NAME_PREFIX + queryBuilder.buildSelectSql(tableHandle, columns);
-        return openStream(sql);
+        if (split.partitionDescriptor().isPresent()) {
+            return openPartition(split.partitionDescriptor().orElseThrow());
+        }
+        return openQuery(APPLICATION_NAME_PREFIX + queryBuilder.buildSelectSql(tableHandle, columns));
     }
 
-    private StarRocksFlightSqlResult openStream(String sql)
+    private StarRocksFlightSqlResult openQuery(String sql)
     {
-        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        AdbcDatabase database = null;
-        AdbcConnection connection = null;
+        AdbcResources resources = null;
         AdbcStatement statement = null;
         AdbcStatement.QueryResult queryResult = null;
         ArrowReader reader = null;
 
         try {
-            FlightSqlDriver driver = new FlightSqlDriver(allocator);
-            Map<String, Object> parameters = new HashMap<>();
-            AdbcDriver.PARAM_URI.set(parameters, Location.forGrpcInsecure(flightSqlHost, flightSqlPort).getUri().toString());
-            username.ifPresent(value -> AdbcDriver.PARAM_USERNAME.set(parameters, value));
-            password.ifPresent(value -> AdbcDriver.PARAM_PASSWORD.set(parameters, value));
-
-            database = driver.open(parameters);
-            connection = database.connect();
-            statement = connection.createStatement();
+            resources = openResources();
+            statement = resources.connection().createStatement();
             statement.setSqlQuery(sql);
             queryResult = statement.executeQuery();
             reader = queryResult.getReader();
-
-            return new AdbcResult(allocator, database, connection, statement, queryResult, reader);
+            return new AdbcResult(resources, statement, queryResult, reader);
         }
         catch (AdbcException | RuntimeException e) {
             closeQuietly(reader);
             closeQuietly(queryResult);
             closeQuietly(statement);
+            closeQuietly(resources);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to execute StarRocks Flight SQL query", e);
+        }
+    }
+
+    private StarRocksFlightSqlResult openPartition(byte[] partitionDescriptor)
+    {
+        AdbcResources resources = null;
+        ArrowReader reader = null;
+
+        try {
+            resources = openResources();
+            reader = resources.connection().readPartition(ByteBuffer.wrap(partitionDescriptor));
+            return new AdbcResult(resources, null, null, reader);
+        }
+        catch (AdbcException | RuntimeException e) {
+            closeQuietly(reader);
+            closeQuietly(resources);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to read StarRocks Flight SQL partition", e);
+        }
+    }
+
+    private AdbcResources openResources()
+            throws AdbcException
+    {
+        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        AdbcDatabase database = null;
+        AdbcConnection connection = null;
+        InputStream rootCertificate = null;
+        try {
+            FlightSqlDriver driver = new FlightSqlDriver(allocator);
+            Map<String, Object> parameters = new HashMap<>();
+            AdbcDriver.PARAM_URI.set(parameters, location().getUri().toString());
+            username.ifPresent(value -> AdbcDriver.PARAM_USERNAME.set(parameters, value));
+            password.ifPresent(value -> AdbcDriver.PARAM_PASSWORD.set(parameters, value));
+            FlightSqlConnectionProperties.TLS_SKIP_VERIFY.set(parameters, flightSqlTlsSkipVerify);
+            flightSqlTlsOverrideHostname.ifPresent(value -> FlightSqlConnectionProperties.TLS_OVERRIDE_HOSTNAME.set(parameters, value));
+            if (flightSqlTlsRootCertificate.isPresent()) {
+                rootCertificate = new FileInputStream(flightSqlTlsRootCertificate.orElseThrow());
+                FlightSqlConnectionProperties.TLS_ROOT_CERTS.set(parameters, rootCertificate);
+            }
+
+            database = driver.open(parameters);
+            connection = database.connect();
+            return new AdbcResources(allocator, database, connection);
+        }
+        catch (AdbcException | RuntimeException e) {
             closeQuietly(connection);
             closeQuietly(database);
             closeQuietly(allocator);
-            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to execute StarRocks Flight SQL query", e);
+            throw e;
         }
+        catch (Exception e) {
+            closeQuietly(connection);
+            closeQuietly(database);
+            closeQuietly(allocator);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to open StarRocks Flight SQL connection", e);
+        }
+        finally {
+            closeQuietly(rootCertificate);
+        }
+    }
+
+    private Location location()
+    {
+        if (flightSqlTlsEnabled) {
+            return Location.forGrpcTls(flightSqlHost, flightSqlPort);
+        }
+        return Location.forGrpcInsecure(flightSqlHost, flightSqlPort);
     }
 
     private static String inferFlightSqlHost(String jdbcUrl)
@@ -143,27 +250,21 @@ public class AdbcStarRocksFlightSqlClient
     private static final class AdbcResult
             implements StarRocksFlightSqlResult
     {
-        private final BufferAllocator allocator;
-        private final AdbcDatabase database;
-        private final AdbcConnection connection;
+        private final AdbcResources resources;
         private final AdbcStatement statement;
         private final AdbcStatement.QueryResult queryResult;
         private final ArrowReader reader;
         private final AtomicBoolean closed = new AtomicBoolean();
 
         private AdbcResult(
-                BufferAllocator allocator,
-                AdbcDatabase database,
-                AdbcConnection connection,
+                AdbcResources resources,
                 AdbcStatement statement,
                 AdbcStatement.QueryResult queryResult,
                 ArrowReader reader)
         {
-            this.allocator = requireNonNull(allocator, "allocator is null");
-            this.database = requireNonNull(database, "database is null");
-            this.connection = requireNonNull(connection, "connection is null");
-            this.statement = requireNonNull(statement, "statement is null");
-            this.queryResult = requireNonNull(queryResult, "queryResult is null");
+            this.resources = requireNonNull(resources, "resources is null");
+            this.statement = statement;
+            this.queryResult = queryResult;
             this.reader = requireNonNull(reader, "reader is null");
         }
 
@@ -200,7 +301,7 @@ public class AdbcStarRocksFlightSqlClient
                 return 0;
             }
             try {
-                return allocator.getAllocatedMemory();
+                return resources.allocator().getAllocatedMemory();
             }
             catch (RuntimeException ignored) {
                 return 0;
@@ -218,9 +319,7 @@ public class AdbcStarRocksFlightSqlClient
             failure = closeResource(failure, reader);
             failure = closeResource(failure, queryResult);
             failure = closeResource(failure, statement);
-            failure = closeResource(failure, connection);
-            failure = closeResource(failure, database);
-            failure = closeResource(failure, allocator);
+            failure = closeResource(failure, resources);
 
             if (failure != null) {
                 throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to close StarRocks Flight SQL result", failure);
@@ -229,6 +328,9 @@ public class AdbcStarRocksFlightSqlClient
 
         private static Exception closeResource(Exception failure, AutoCloseable closeable)
         {
+            if (closeable == null) {
+                return failure;
+            }
             try {
                 closeable.close();
             }
@@ -239,6 +341,29 @@ public class AdbcStarRocksFlightSqlClient
                 failure.addSuppressed(e);
             }
             return failure;
+        }
+    }
+
+    private record AdbcResources(BufferAllocator allocator, AdbcDatabase database, AdbcConnection connection)
+            implements AutoCloseable
+    {
+        private AdbcResources
+        {
+            requireNonNull(allocator, "allocator is null");
+            requireNonNull(database, "database is null");
+            requireNonNull(connection, "connection is null");
+        }
+
+        @Override
+        public void close()
+        {
+            try {
+                closeQuietly(connection);
+                closeQuietly(database);
+            }
+            finally {
+                closeQuietly(allocator);
+            }
         }
     }
 }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/AdbcStarRocksFlightSqlClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/AdbcStarRocksFlightSqlClient.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.arrow.adbc.core.AdbcConnection;
+import org.apache.arrow.adbc.core.AdbcDatabase;
+import org.apache.arrow.adbc.core.AdbcDriver;
+import org.apache.arrow.adbc.core.AdbcException;
+import org.apache.arrow.adbc.core.AdbcStatement;
+import org.apache.arrow.adbc.driver.flightsql.FlightSqlDriver;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class AdbcStarRocksFlightSqlClient
+        implements StarRocksFlightSqlClient
+{
+    private static final String APPLICATION_NAME_PREFIX = "/* ApplicationName=Trino StarRocks Flight SQL Query */ ";
+
+    private final String flightSqlHost;
+    private final int flightSqlPort;
+    private final Optional<String> username;
+    private final Optional<String> password;
+    private final StarRocksQueryBuilder queryBuilder;
+
+    @Inject
+    public AdbcStarRocksFlightSqlClient(StarRocksConfig config, StarRocksQueryBuilder queryBuilder)
+    {
+        requireNonNull(config, "config is null");
+        this.flightSqlHost = config.getFlightSqlHost()
+                .orElseGet(() -> inferFlightSqlHost(config.getJdbcUrl()
+                        .orElseThrow(() -> new IllegalArgumentException("starrocks.jdbc-url must be set"))));
+        this.flightSqlPort = config.getFlightSqlPort();
+        this.username = config.getUsername();
+        this.password = config.getPassword();
+        this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder is null");
+    }
+
+    @Override
+    public StarRocksFlightSqlResult openStream(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            StarRocksSplit split,
+            List<StarRocksColumnHandle> columns)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(split, "split is null");
+        requireNonNull(columns, "columns is null");
+
+        String sql = APPLICATION_NAME_PREFIX + queryBuilder.buildSelectSql(tableHandle, columns);
+        return openStream(sql);
+    }
+
+    private StarRocksFlightSqlResult openStream(String sql)
+    {
+        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        AdbcDatabase database = null;
+        AdbcConnection connection = null;
+        AdbcStatement statement = null;
+        AdbcStatement.QueryResult queryResult = null;
+        ArrowReader reader = null;
+
+        try {
+            FlightSqlDriver driver = new FlightSqlDriver(allocator);
+            Map<String, Object> parameters = new HashMap<>();
+            AdbcDriver.PARAM_URI.set(parameters, Location.forGrpcInsecure(flightSqlHost, flightSqlPort).getUri().toString());
+            username.ifPresent(value -> AdbcDriver.PARAM_USERNAME.set(parameters, value));
+            password.ifPresent(value -> AdbcDriver.PARAM_PASSWORD.set(parameters, value));
+
+            database = driver.open(parameters);
+            connection = database.connect();
+            statement = connection.createStatement();
+            statement.setSqlQuery(sql);
+            queryResult = statement.executeQuery();
+            reader = queryResult.getReader();
+
+            return new AdbcResult(allocator, database, connection, statement, queryResult, reader);
+        }
+        catch (AdbcException | RuntimeException e) {
+            closeQuietly(reader);
+            closeQuietly(queryResult);
+            closeQuietly(statement);
+            closeQuietly(connection);
+            closeQuietly(database);
+            closeQuietly(allocator);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to execute StarRocks Flight SQL query", e);
+        }
+    }
+
+    private static String inferFlightSqlHost(String jdbcUrl)
+    {
+        try {
+            URI uri = URI.create(jdbcUrl.substring("jdbc:".length()));
+            if (uri.getHost() == null || uri.getHost().isBlank()) {
+                throw new IllegalArgumentException("Unable to infer host from JDBC URL: " + jdbcUrl);
+            }
+            return uri.getHost();
+        }
+        catch (RuntimeException e) {
+            throw new IllegalArgumentException("Unable to infer StarRocks Flight SQL host from JDBC URL: " + jdbcUrl, e);
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable closeable)
+    {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        }
+        catch (Exception _) {
+            // Cleanup failures are ignored so the original query failure is preserved.
+        }
+    }
+
+    private static final class AdbcResult
+            implements StarRocksFlightSqlResult
+    {
+        private final BufferAllocator allocator;
+        private final AdbcDatabase database;
+        private final AdbcConnection connection;
+        private final AdbcStatement statement;
+        private final AdbcStatement.QueryResult queryResult;
+        private final ArrowReader reader;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private AdbcResult(
+                BufferAllocator allocator,
+                AdbcDatabase database,
+                AdbcConnection connection,
+                AdbcStatement statement,
+                AdbcStatement.QueryResult queryResult,
+                ArrowReader reader)
+        {
+            this.allocator = requireNonNull(allocator, "allocator is null");
+            this.database = requireNonNull(database, "database is null");
+            this.connection = requireNonNull(connection, "connection is null");
+            this.statement = requireNonNull(statement, "statement is null");
+            this.queryResult = requireNonNull(queryResult, "queryResult is null");
+            this.reader = requireNonNull(reader, "reader is null");
+        }
+
+        @Override
+        public boolean loadNextBatch()
+        {
+            if (closed.get()) {
+                return false;
+            }
+
+            try {
+                return reader.loadNextBatch();
+            }
+            catch (Exception e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to load StarRocks Flight SQL batch", e);
+            }
+        }
+
+        @Override
+        public VectorSchemaRoot getVectorSchemaRoot()
+        {
+            try {
+                return reader.getVectorSchemaRoot();
+            }
+            catch (Exception e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to access StarRocks Flight SQL batch schema root", e);
+            }
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            if (closed.get()) {
+                return 0;
+            }
+            try {
+                return allocator.getAllocatedMemory();
+            }
+            catch (RuntimeException ignored) {
+                return 0;
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            if (!closed.compareAndSet(false, true)) {
+                return;
+            }
+
+            Exception failure = null;
+            failure = closeResource(failure, reader);
+            failure = closeResource(failure, queryResult);
+            failure = closeResource(failure, statement);
+            failure = closeResource(failure, connection);
+            failure = closeResource(failure, database);
+            failure = closeResource(failure, allocator);
+
+            if (failure != null) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to close StarRocks Flight SQL result", failure);
+            }
+        }
+
+        private static Exception closeResource(Exception failure, AutoCloseable closeable)
+        {
+            try {
+                closeable.close();
+            }
+            catch (Exception e) {
+                if (failure == null) {
+                    return e;
+                }
+                failure.addSuppressed(e);
+            }
+            return failure;
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
@@ -1,0 +1,641 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcStarRocksMetadataClient
+        implements StarRocksMetadataClient
+{
+    private static final String LIST_SCHEMAS_SQL =
+            """
+            SELECT SCHEMA_NAME
+            FROM INFORMATION_SCHEMA.SCHEMATA
+            WHERE LOWER(SCHEMA_NAME) NOT IN ('information_schema', '_statistics_', 'sys')
+            ORDER BY SCHEMA_NAME
+            """;
+    private static final String LIST_SCHEMAS_IN_CATALOG_SQL =
+            """
+            SELECT SCHEMA_NAME
+            FROM INFORMATION_SCHEMA.SCHEMATA
+            WHERE CATALOG_NAME = ?
+              AND LOWER(SCHEMA_NAME) NOT IN ('information_schema', '_statistics_', 'sys')
+            ORDER BY SCHEMA_NAME
+            """;
+    private static final String LIST_SCHEMAS_IN_CATALOG_FROM_TABLES_SQL =
+            """
+            SELECT DISTINCT TABLE_SCHEMA AS SCHEMA_NAME
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
+            ORDER BY TABLE_SCHEMA
+            """;
+    private static final String LIST_ALL_TABLES_SQL =
+            """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_ALL_TABLES_IN_CATALOG_SQL =
+            """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_TABLES_IN_SCHEMA_SQL =
+            """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_TABLES_IN_CATALOG_SCHEMA_SQL =
+            """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String RESOLVE_TABLE_SQL =
+            """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String RESOLVE_TABLE_IN_CATALOG_SQL =
+            """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_COLUMNS_SQL =
+            """
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                COLUMN_TYPE,
+                COALESCE(CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION) AS COLUMN_SIZE,
+                COALESCE(NUMERIC_SCALE, DATETIME_PRECISION) AS DECIMAL_DIGITS,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            ORDER BY ORDINAL_POSITION
+            """;
+    private static final String LIST_COLUMNS_IN_CATALOG_SQL =
+            """
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                COLUMN_TYPE,
+                COALESCE(CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION) AS COLUMN_SIZE,
+                COALESCE(NUMERIC_SCALE, DATETIME_PRECISION) AS DECIMAL_DIGITS,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            ORDER BY ORDINAL_POSITION
+            """;
+    private static final String TABLE_ROW_COUNT_SQL =
+            """
+            SELECT TABLE_ROWS
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            """;
+    private static final String TABLE_ROW_COUNT_IN_CATALOG_SQL =
+            """
+            SELECT TABLE_ROWS
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            """;
+
+    private final StarRocksJdbcConnectionFactory connectionFactory;
+    private final Optional<String> catalogName;
+
+    @Inject
+    public JdbcStarRocksMetadataClient(StarRocksJdbcConnectionFactory connectionFactory, StarRocksConfig config)
+    {
+        this.connectionFactory = requireNonNull(connectionFactory, "connectionFactory is null");
+        this.catalogName = requireNonNull(config, "config is null").getCatalogName();
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        if (catalogName.isPresent()) {
+            return loadSchemaNamesFromInformationSchema(session);
+        }
+
+        List<String> schemas = loadSchemaNamesFromMetadata(session);
+        if (!schemas.isEmpty()) {
+            return schemas;
+        }
+        return loadSchemaNamesFromInformationSchema(session);
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        return listResolvedTables(session, schemaName).stream()
+                .map(ResolvedTable::schemaTableName)
+                .distinct()
+                .toList();
+    }
+
+    @Override
+    public Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        Optional<ResolvedTable> resolvedTable = resolveTable(session, tableName);
+        if (resolvedTable.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ResolvedTable table = resolvedTable.orElseThrow();
+        List<StarRocksRemoteColumn> columns = loadColumns(session, table);
+        if (columns.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new StarRocksRemoteTable(
+                table.schemaTableName(),
+                table.remoteCatalogName(),
+                table.remoteSchemaName(),
+                table.remoteTableName(),
+                table.relationType(),
+                columns));
+    }
+
+    @Override
+    public OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName)
+    {
+        Optional<ResolvedTable> resolvedTable = resolveTable(session, tableName);
+        if (resolvedTable.isEmpty()) {
+            return OptionalLong.empty();
+        }
+
+        String sql = catalogName.isPresent() ? TABLE_ROW_COUNT_IN_CATALOG_SQL : TABLE_ROW_COUNT_SQL;
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            statement.setString(index++, resolvedTable.orElseThrow().remoteSchemaName());
+            statement.setString(index, resolvedTable.orElseThrow().remoteTableName());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return OptionalLong.empty();
+                }
+
+                long rowCount = resultSet.getLong("TABLE_ROWS");
+                if (resultSet.wasNull()) {
+                    return OptionalLong.empty();
+                }
+                return OptionalLong.of(Math.max(0L, rowCount));
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to load StarRocks table row count for table '%s'".formatted(tableName), e);
+        }
+    }
+
+    private List<String> loadSchemaNamesFromMetadata(ConnectorSession session)
+    {
+        try (Connection connection = openConnection(session);
+                ResultSet resultSet = connection.getMetaData().getSchemas()) {
+            List<String> schemas = new ArrayList<>();
+            while (resultSet.next()) {
+                String schema = resultSet.getString("TABLE_SCHEM");
+                if (shouldExposeSchema(schema)) {
+                    schemas.add(lowercaseName(schema));
+                }
+            }
+            return schemas.stream().distinct().toList();
+        }
+        catch (SQLException ignored) {
+            return List.of();
+        }
+    }
+
+    private List<String> loadSchemaNamesFromInformationSchema(ConnectorSession session)
+    {
+        String sql = catalogName.isPresent() ? LIST_SCHEMAS_IN_CATALOG_SQL : LIST_SCHEMAS_SQL;
+        List<String> schemas = loadSchemaNames(session, sql);
+        if (catalogName.isPresent() && schemas.isEmpty()) {
+            return loadSchemaNames(session, LIST_SCHEMAS_IN_CATALOG_FROM_TABLES_SQL);
+        }
+        return schemas;
+    }
+
+    private List<String> loadSchemaNames(ConnectorSession session, String sql)
+    {
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            if (catalogName.isPresent()) {
+                statement.setString(1, catalogName.orElseThrow());
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<String> schemas = new ArrayList<>();
+                while (resultSet.next()) {
+                    schemas.add(lowercaseName(resultSet.getString("SCHEMA_NAME")));
+                }
+                return schemas.stream().distinct().toList();
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to list StarRocks schemas", e);
+        }
+    }
+
+    private List<ResolvedTable> listResolvedTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        List<ResolvedTable> tables = loadTablesFromMetadata(session, schemaName);
+        if (!tables.isEmpty()) {
+            return tables;
+        }
+        return loadTablesFromInformationSchema(session, schemaName);
+    }
+
+    private List<ResolvedTable> loadTablesFromMetadata(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (Connection connection = openConnection(session);
+                ResultSet resultSet = connection.getMetaData().getTables(
+                        catalogName.orElse(connection.getCatalog()),
+                        schemaName.orElse(null),
+                        null,
+                        new String[] {"TABLE", "VIEW"})) {
+            List<ResolvedTable> tables = new ArrayList<>();
+            while (resultSet.next()) {
+                String remoteSchema = resultSet.getString("TABLE_SCHEM");
+                String remoteTable = resultSet.getString("TABLE_NAME");
+                String tableType = resultSet.getString("TABLE_TYPE");
+                if (!shouldExposeTable(remoteSchema, tableType)) {
+                    continue;
+                }
+                tables.add(new ResolvedTable(catalogName, remoteSchema, remoteTable, toRelationType(tableType)));
+            }
+            return tables.stream().distinct().toList();
+        }
+        catch (SQLException ignored) {
+            return List.of();
+        }
+    }
+
+    private List<ResolvedTable> loadTablesFromInformationSchema(ConnectorSession session, Optional<String> schemaName)
+    {
+        String sql;
+        if (catalogName.isPresent()) {
+            sql = schemaName.isPresent() ? LIST_TABLES_IN_CATALOG_SCHEMA_SQL : LIST_ALL_TABLES_IN_CATALOG_SQL;
+        }
+        else {
+            sql = schemaName.isPresent() ? LIST_TABLES_IN_SCHEMA_SQL : LIST_ALL_TABLES_SQL;
+        }
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            if (schemaName.isPresent()) {
+                statement.setString(index, schemaName.get());
+            }
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<ResolvedTable> tables = new ArrayList<>();
+                while (resultSet.next()) {
+                    tables.add(new ResolvedTable(
+                            catalogName,
+                            resultSet.getString("TABLE_SCHEMA"),
+                            resultSet.getString("TABLE_NAME"),
+                            toRelationType(resultSet.getString("TABLE_TYPE"))));
+                }
+                return tables.stream().distinct().toList();
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to list StarRocks tables", e);
+        }
+    }
+
+    private Optional<ResolvedTable> resolveTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        List<ResolvedTable> matches = loadResolvedTableMatches(session, tableName);
+        if (matches.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ResolvedTable match = matches.getFirst();
+        if (matches.stream().skip(1).anyMatch(candidate -> !candidate.equals(match))) {
+            throw new TrinoException(
+                    NOT_SUPPORTED,
+                    "StarRocks objects that differ only by case are not addressable in Trino: " + tableName);
+        }
+        return Optional.of(match);
+    }
+
+    private List<ResolvedTable> loadResolvedTableMatches(ConnectorSession session, SchemaTableName tableName)
+    {
+        List<ResolvedTable> fromMetadata = listResolvedTables(session, Optional.of(tableName.getSchemaName())).stream()
+                .filter(candidate -> candidate.schemaTableName().getTableName().equals(tableName.getTableName().toLowerCase(ENGLISH)))
+                .toList();
+        if (!fromMetadata.isEmpty()) {
+            return fromMetadata;
+        }
+
+        String sql = catalogName.isPresent() ? RESOLVE_TABLE_IN_CATALOG_SQL : RESOLVE_TABLE_SQL;
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            statement.setString(index++, tableName.getSchemaName());
+            statement.setString(index, tableName.getTableName());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<ResolvedTable> matches = new ArrayList<>();
+                while (resultSet.next()) {
+                    matches.add(new ResolvedTable(
+                            catalogName,
+                            resultSet.getString("TABLE_SCHEMA"),
+                            resultSet.getString("TABLE_NAME"),
+                            toRelationType(resultSet.getString("TABLE_TYPE"))));
+                }
+                return matches;
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to resolve StarRocks table '%s'".formatted(tableName), e);
+        }
+    }
+
+    private List<StarRocksRemoteColumn> loadColumns(ConnectorSession session, ResolvedTable resolvedTable)
+    {
+        SQLException informationSchemaFailure = null;
+        try {
+            List<StarRocksRemoteColumn> columns = loadColumnsFromInformationSchema(session, resolvedTable);
+            if (!columns.isEmpty()) {
+                return columns;
+            }
+        }
+        catch (SQLException e) {
+            informationSchemaFailure = e;
+        }
+        if (catalogName.isPresent()) {
+            try {
+                List<StarRocksRemoteColumn> columns = loadColumnsFromShowFullColumns(session, resolvedTable);
+                if (!columns.isEmpty()) {
+                    return columns;
+                }
+            }
+            catch (SQLException e) {
+                if (informationSchemaFailure == null) {
+                    informationSchemaFailure = e;
+                }
+                else {
+                    informationSchemaFailure.addSuppressed(e);
+                }
+            }
+        }
+
+        List<StarRocksRemoteColumn> columns = loadColumnsFromMetadata(session, resolvedTable);
+        if (!columns.isEmpty()) {
+            return columns;
+        }
+        if (informationSchemaFailure != null) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed(
+                    "Failed to load StarRocks columns for table '%s'".formatted(resolvedTable.schemaTableName()),
+                    informationSchemaFailure);
+        }
+        return List.of();
+    }
+
+    private List<StarRocksRemoteColumn> loadColumnsFromMetadata(ConnectorSession session, ResolvedTable resolvedTable)
+    {
+        try (Connection connection = openConnection(session);
+                ResultSet resultSet = connection.getMetaData().getColumns(
+                        resolvedTable.remoteCatalogName().orElse(connection.getCatalog()),
+                        resolvedTable.remoteSchemaName(),
+                        resolvedTable.remoteTableName(),
+                        null)) {
+            List<StarRocksRemoteColumn> columns = new ArrayList<>();
+            while (resultSet.next()) {
+                String remoteColumnName = resultSet.getString("COLUMN_NAME");
+                columns.add(new StarRocksRemoteColumn(
+                        lowercaseName(remoteColumnName),
+                        remoteColumnName,
+                        requireNonNullElseEmpty(resultSet.getString("TYPE_NAME")),
+                        getOptionalInt(resultSet, "COLUMN_SIZE"),
+                        getOptionalInt(resultSet, "DECIMAL_DIGITS"),
+                        resultSet.getInt("ORDINAL_POSITION"),
+                        Optional.ofNullable(resultSet.getString("TYPE_NAME"))));
+            }
+            return deduplicateColumns(columns);
+        }
+        catch (SQLException ignored) {
+            return List.of();
+        }
+    }
+
+    private List<StarRocksRemoteColumn> loadColumnsFromInformationSchema(ConnectorSession session, ResolvedTable resolvedTable)
+            throws SQLException
+    {
+        String sql = catalogName.isPresent() ? LIST_COLUMNS_IN_CATALOG_SQL : LIST_COLUMNS_SQL;
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            statement.setString(index++, resolvedTable.remoteSchemaName());
+            statement.setString(index, resolvedTable.remoteTableName());
+
+            return readColumns(statement);
+        }
+    }
+
+    private List<StarRocksRemoteColumn> loadColumnsFromShowFullColumns(ConnectorSession session, ResolvedTable resolvedTable)
+            throws SQLException
+    {
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement("SHOW FULL COLUMNS FROM " + qualifiedRemoteTableName(resolvedTable))) {
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<StarRocksRemoteColumn> columns = new ArrayList<>();
+                int ordinalPosition = 1;
+                while (resultSet.next()) {
+                    String remoteColumnName = resultSet.getString("Field");
+                    String typeDefinition = requireNonNullElseEmpty(resultSet.getString("Type"));
+                    columns.add(new StarRocksRemoteColumn(
+                            lowercaseName(remoteColumnName),
+                            remoteColumnName,
+                            typeDefinition,
+                            Optional.empty(),
+                            Optional.empty(),
+                            ordinalPosition,
+                            Optional.of(typeDefinition)));
+                    ordinalPosition++;
+                }
+                return deduplicateColumns(columns);
+            }
+        }
+    }
+
+    private static List<StarRocksRemoteColumn> readColumns(PreparedStatement statement)
+            throws SQLException
+    {
+        try (ResultSet resultSet = statement.executeQuery()) {
+            List<StarRocksRemoteColumn> columns = new ArrayList<>();
+            while (resultSet.next()) {
+                String remoteColumnName = resultSet.getString("COLUMN_NAME");
+                columns.add(new StarRocksRemoteColumn(
+                        lowercaseName(remoteColumnName),
+                        remoteColumnName,
+                        resultSet.getString("DATA_TYPE"),
+                        getOptionalInt(resultSet, "COLUMN_SIZE"),
+                        getOptionalInt(resultSet, "DECIMAL_DIGITS"),
+                        resultSet.getInt("ORDINAL_POSITION"),
+                        Optional.ofNullable(resultSet.getString("COLUMN_TYPE"))));
+            }
+            return deduplicateColumns(columns);
+        }
+    }
+
+    private Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        if (session == null) {
+            return connectionFactory.openConnection();
+        }
+        return connectionFactory.openConnection(session);
+    }
+
+    private static List<StarRocksRemoteColumn> deduplicateColumns(List<StarRocksRemoteColumn> columns)
+    {
+        Map<String, StarRocksRemoteColumn> deduplicated = new LinkedHashMap<>();
+        for (StarRocksRemoteColumn column : columns) {
+            StarRocksRemoteColumn previous = deduplicated.putIfAbsent(column.columnName(), column);
+            if (previous != null && !previous.remoteColumnName().equals(column.remoteColumnName())) {
+                throw new TrinoException(
+                        NOT_SUPPORTED,
+                        "StarRocks columns that differ only by case are not addressable in Trino: " + column.remoteColumnName());
+            }
+        }
+        return List.copyOf(deduplicated.values());
+    }
+
+    private static boolean shouldExposeSchema(String schemaName)
+    {
+        if (schemaName == null) {
+            return false;
+        }
+        String normalized = lowercaseName(schemaName);
+        return !normalized.equals("information_schema") &&
+                !normalized.equals("_statistics_") &&
+                !normalized.equals("sys");
+    }
+
+    private static boolean shouldExposeTable(String schemaName, String tableType)
+    {
+        return shouldExposeSchema(schemaName) &&
+                tableType != null &&
+                (tableType.equalsIgnoreCase("TABLE") ||
+                        tableType.equalsIgnoreCase("BASE TABLE") ||
+                        tableType.equalsIgnoreCase("VIEW"));
+    }
+
+    private static StarRocksRelationType toRelationType(String tableType)
+    {
+        if (tableType != null && tableType.equalsIgnoreCase("VIEW")) {
+            return StarRocksRelationType.VIEW;
+        }
+        return StarRocksRelationType.TABLE;
+    }
+
+    private static Optional<Integer> getOptionalInt(ResultSet resultSet, String columnLabel)
+            throws SQLException
+    {
+        int value = resultSet.getInt(columnLabel);
+        if (resultSet.wasNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+
+    private static String requireNonNullElseEmpty(String value)
+    {
+        return value == null ? "" : value;
+    }
+
+    private static String qualifiedRemoteTableName(ResolvedTable table)
+    {
+        return table.remoteCatalogName()
+                .map(catalog -> StarRocksQueryBuilder.quoteIdentifier(catalog) + ".")
+                .orElse("") +
+                StarRocksQueryBuilder.quoteIdentifier(table.remoteSchemaName()) +
+                "." +
+                StarRocksQueryBuilder.quoteIdentifier(table.remoteTableName());
+    }
+
+    private static String lowercaseName(String value)
+    {
+        return value.toLowerCase(Locale.ENGLISH);
+    }
+
+    private record ResolvedTable(Optional<String> remoteCatalogName, String remoteSchemaName, String remoteTableName, StarRocksRelationType relationType)
+    {
+        private SchemaTableName schemaTableName()
+        {
+            return new SchemaTableName(lowercaseName(remoteSchemaName), lowercaseName(remoteTableName));
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcStarRocksMetadataClient
+        implements StarRocksMetadataClient
+{
+    private static final String LIST_SCHEMAS_SQL = """
+            SELECT SCHEMA_NAME
+            FROM INFORMATION_SCHEMA.SCHEMATA
+            WHERE LOWER(SCHEMA_NAME) NOT IN ('information_schema', '_statistics_', 'sys')
+            ORDER BY SCHEMA_NAME
+            """;
+    private static final String LIST_ALL_TABLES_SQL = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
+              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_TABLES_IN_SCHEMA_SQL = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String RESOLVE_TABLE_SQL = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_COLUMNS_SQL = """
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                COLUMN_TYPE,
+                COALESCE(CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION) AS COLUMN_SIZE,
+                COALESCE(NUMERIC_SCALE, DATETIME_PRECISION) AS DECIMAL_DIGITS,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            ORDER BY ORDINAL_POSITION
+            """;
+    private static final String TABLE_ROW_COUNT_SQL = """
+            SELECT TABLE_ROWS
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            """;
+
+    private final StarRocksJdbcConnectionFactory connectionFactory;
+
+    @Inject
+    public JdbcStarRocksMetadataClient(StarRocksJdbcConnectionFactory connectionFactory)
+    {
+        this.connectionFactory = requireNonNull(connectionFactory, "connectionFactory is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        List<String> schemas = loadSchemaNamesFromMetadata(session);
+        if (!schemas.isEmpty()) {
+            return schemas;
+        }
+        return loadSchemaNamesFromInformationSchema(session);
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        return listResolvedTables(session, schemaName).stream()
+                .map(ResolvedTable::schemaTableName)
+                .distinct()
+                .toList();
+    }
+
+    @Override
+    public Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        Optional<ResolvedTable> resolvedTable = resolveTable(session, tableName);
+        if (resolvedTable.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ResolvedTable table = resolvedTable.orElseThrow();
+        List<StarRocksRemoteColumn> columns = loadColumns(session, table);
+        if (columns.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new StarRocksRemoteTable(
+                table.schemaTableName(),
+                table.remoteSchemaName(),
+                table.remoteTableName(),
+                table.relationType(),
+                columns));
+    }
+
+    @Override
+    public OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName)
+    {
+        Optional<ResolvedTable> resolvedTable = resolveTable(session, tableName);
+        if (resolvedTable.isEmpty()) {
+            return OptionalLong.empty();
+        }
+
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(TABLE_ROW_COUNT_SQL)) {
+            statement.setString(1, resolvedTable.orElseThrow().remoteSchemaName());
+            statement.setString(2, resolvedTable.orElseThrow().remoteTableName());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return OptionalLong.empty();
+                }
+
+                long rowCount = resultSet.getLong("TABLE_ROWS");
+                if (resultSet.wasNull()) {
+                    return OptionalLong.empty();
+                }
+                return OptionalLong.of(Math.max(0L, rowCount));
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to load StarRocks table row count for table '%s'".formatted(tableName), e);
+        }
+    }
+
+    private List<String> loadSchemaNamesFromMetadata(ConnectorSession session)
+    {
+        try (Connection connection = openConnection(session);
+                ResultSet resultSet = connection.getMetaData().getSchemas()) {
+            List<String> schemas = new ArrayList<>();
+            while (resultSet.next()) {
+                String schema = resultSet.getString("TABLE_SCHEM");
+                if (shouldExposeSchema(schema)) {
+                    schemas.add(lowercaseName(schema));
+                }
+            }
+            return schemas.stream().distinct().toList();
+        }
+        catch (SQLException ignored) {
+            return List.of();
+        }
+    }
+
+    private List<String> loadSchemaNamesFromInformationSchema(ConnectorSession session)
+    {
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(LIST_SCHEMAS_SQL);
+                ResultSet resultSet = statement.executeQuery()) {
+            List<String> schemas = new ArrayList<>();
+            while (resultSet.next()) {
+                schemas.add(lowercaseName(resultSet.getString("SCHEMA_NAME")));
+            }
+            return schemas.stream().distinct().toList();
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to list StarRocks schemas", e);
+        }
+    }
+
+    private List<ResolvedTable> listResolvedTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        List<ResolvedTable> tables = loadTablesFromMetadata(session, schemaName);
+        if (!tables.isEmpty()) {
+            return tables;
+        }
+        return loadTablesFromInformationSchema(session, schemaName);
+    }
+
+    private List<ResolvedTable> loadTablesFromMetadata(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (Connection connection = openConnection(session);
+                ResultSet resultSet = connection.getMetaData().getTables(
+                        connection.getCatalog(),
+                        schemaName.orElse(null),
+                        null,
+                        new String[] {"TABLE", "VIEW"})) {
+            List<ResolvedTable> tables = new ArrayList<>();
+            while (resultSet.next()) {
+                String remoteSchema = resultSet.getString("TABLE_SCHEM");
+                String remoteTable = resultSet.getString("TABLE_NAME");
+                String tableType = resultSet.getString("TABLE_TYPE");
+                if (!shouldExposeTable(remoteSchema, tableType)) {
+                    continue;
+                }
+                tables.add(new ResolvedTable(remoteSchema, remoteTable, toRelationType(tableType)));
+            }
+            return tables.stream().distinct().toList();
+        }
+        catch (SQLException ignored) {
+            return List.of();
+        }
+    }
+
+    private List<ResolvedTable> loadTablesFromInformationSchema(ConnectorSession session, Optional<String> schemaName)
+    {
+        String sql = schemaName.isPresent() ? LIST_TABLES_IN_SCHEMA_SQL : LIST_ALL_TABLES_SQL;
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            if (schemaName.isPresent()) {
+                statement.setString(1, schemaName.get());
+            }
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<ResolvedTable> tables = new ArrayList<>();
+                while (resultSet.next()) {
+                    tables.add(new ResolvedTable(
+                            resultSet.getString("TABLE_SCHEMA"),
+                            resultSet.getString("TABLE_NAME"),
+                            toRelationType(resultSet.getString("TABLE_TYPE"))));
+                }
+                return tables.stream().distinct().toList();
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to list StarRocks tables", e);
+        }
+    }
+
+    private Optional<ResolvedTable> resolveTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        List<ResolvedTable> matches = loadResolvedTableMatches(session, tableName);
+        if (matches.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ResolvedTable match = matches.getFirst();
+        if (matches.stream().skip(1).anyMatch(candidate -> !candidate.equals(match))) {
+            throw new TrinoException(
+                    NOT_SUPPORTED,
+                    "StarRocks objects that differ only by case are not addressable in Trino: " + tableName);
+        }
+        return Optional.of(match);
+    }
+
+    private List<ResolvedTable> loadResolvedTableMatches(ConnectorSession session, SchemaTableName tableName)
+    {
+        List<ResolvedTable> fromMetadata = listResolvedTables(session, Optional.of(tableName.getSchemaName())).stream()
+                .filter(candidate -> candidate.schemaTableName().getTableName().equals(tableName.getTableName().toLowerCase(ENGLISH)))
+                .toList();
+        if (!fromMetadata.isEmpty()) {
+            return fromMetadata;
+        }
+
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(RESOLVE_TABLE_SQL)) {
+            statement.setString(1, tableName.getSchemaName());
+            statement.setString(2, tableName.getTableName());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<ResolvedTable> matches = new ArrayList<>();
+                while (resultSet.next()) {
+                    matches.add(new ResolvedTable(
+                            resultSet.getString("TABLE_SCHEMA"),
+                            resultSet.getString("TABLE_NAME"),
+                            toRelationType(resultSet.getString("TABLE_TYPE"))));
+                }
+                return matches;
+            }
+        }
+        catch (SQLException e) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to resolve StarRocks table '%s'".formatted(tableName), e);
+        }
+    }
+
+    private List<StarRocksRemoteColumn> loadColumns(ConnectorSession session, ResolvedTable resolvedTable)
+    {
+        SQLException informationSchemaFailure = null;
+        try {
+            List<StarRocksRemoteColumn> columns = loadColumnsFromInformationSchema(session, resolvedTable);
+            if (!columns.isEmpty()) {
+                return columns;
+            }
+        }
+        catch (SQLException e) {
+            informationSchemaFailure = e;
+        }
+
+        List<StarRocksRemoteColumn> columns = loadColumnsFromMetadata(session, resolvedTable);
+        if (!columns.isEmpty()) {
+            return columns;
+        }
+        if (informationSchemaFailure != null) {
+            throw StarRocksJdbcConnectionFactory.jdbcOperationFailed(
+                    "Failed to load StarRocks columns for table '%s'".formatted(resolvedTable.schemaTableName()),
+                    informationSchemaFailure);
+        }
+        return List.of();
+    }
+
+    private List<StarRocksRemoteColumn> loadColumnsFromMetadata(ConnectorSession session, ResolvedTable resolvedTable)
+    {
+        try (Connection connection = openConnection(session);
+                ResultSet resultSet = connection.getMetaData().getColumns(
+                        connection.getCatalog(),
+                        resolvedTable.remoteSchemaName(),
+                        resolvedTable.remoteTableName(),
+                        null)) {
+            List<StarRocksRemoteColumn> columns = new ArrayList<>();
+            while (resultSet.next()) {
+                String remoteColumnName = resultSet.getString("COLUMN_NAME");
+                columns.add(new StarRocksRemoteColumn(
+                        lowercaseName(remoteColumnName),
+                        remoteColumnName,
+                        requireNonNullElseEmpty(resultSet.getString("TYPE_NAME")),
+                        getOptionalInt(resultSet, "COLUMN_SIZE"),
+                        getOptionalInt(resultSet, "DECIMAL_DIGITS"),
+                        resultSet.getInt("ORDINAL_POSITION"),
+                        Optional.ofNullable(resultSet.getString("TYPE_NAME"))));
+            }
+            return deduplicateColumns(columns);
+        }
+        catch (SQLException ignored) {
+            return List.of();
+        }
+    }
+
+    private List<StarRocksRemoteColumn> loadColumnsFromInformationSchema(ConnectorSession session, ResolvedTable resolvedTable)
+            throws SQLException
+    {
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(LIST_COLUMNS_SQL)) {
+            statement.setString(1, resolvedTable.remoteSchemaName());
+            statement.setString(2, resolvedTable.remoteTableName());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<StarRocksRemoteColumn> columns = new ArrayList<>();
+                while (resultSet.next()) {
+                    String remoteColumnName = resultSet.getString("COLUMN_NAME");
+                    columns.add(new StarRocksRemoteColumn(
+                            lowercaseName(remoteColumnName),
+                            remoteColumnName,
+                            resultSet.getString("DATA_TYPE"),
+                            getOptionalInt(resultSet, "COLUMN_SIZE"),
+                            getOptionalInt(resultSet, "DECIMAL_DIGITS"),
+                            resultSet.getInt("ORDINAL_POSITION"),
+                            Optional.ofNullable(resultSet.getString("COLUMN_TYPE"))));
+                }
+                return deduplicateColumns(columns);
+            }
+        }
+    }
+
+    private Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        if (session == null) {
+            return connectionFactory.openConnection();
+        }
+        return connectionFactory.openConnection(session);
+    }
+
+    private static List<StarRocksRemoteColumn> deduplicateColumns(List<StarRocksRemoteColumn> columns)
+    {
+        Map<String, StarRocksRemoteColumn> deduplicated = new LinkedHashMap<>();
+        for (StarRocksRemoteColumn column : columns) {
+            StarRocksRemoteColumn previous = deduplicated.putIfAbsent(column.columnName(), column);
+            if (previous != null && !previous.remoteColumnName().equals(column.remoteColumnName())) {
+                throw new TrinoException(
+                        NOT_SUPPORTED,
+                        "StarRocks columns that differ only by case are not addressable in Trino: " + column.remoteColumnName());
+            }
+        }
+        return List.copyOf(deduplicated.values());
+    }
+
+    private static boolean shouldExposeSchema(String schemaName)
+    {
+        if (schemaName == null) {
+            return false;
+        }
+        String normalized = lowercaseName(schemaName);
+        return !normalized.equals("information_schema") &&
+                !normalized.equals("_statistics_") &&
+                !normalized.equals("sys");
+    }
+
+    private static boolean shouldExposeTable(String schemaName, String tableType)
+    {
+        return shouldExposeSchema(schemaName) &&
+                tableType != null &&
+                (tableType.equalsIgnoreCase("TABLE") ||
+                        tableType.equalsIgnoreCase("BASE TABLE") ||
+                        tableType.equalsIgnoreCase("VIEW"));
+    }
+
+    private static StarRocksRelationType toRelationType(String tableType)
+    {
+        if (tableType != null && tableType.equalsIgnoreCase("VIEW")) {
+            return StarRocksRelationType.VIEW;
+        }
+        return StarRocksRelationType.TABLE;
+    }
+
+    private static Optional<Integer> getOptionalInt(ResultSet resultSet, String columnLabel)
+            throws SQLException
+    {
+        int value = resultSet.getInt(columnLabel);
+        if (resultSet.wasNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+
+    private static String requireNonNullElseEmpty(String value)
+    {
+        return value == null ? "" : value;
+    }
+
+    private static String lowercaseName(String value)
+    {
+        return value.toLowerCase(Locale.ENGLISH);
+    }
+
+    private record ResolvedTable(String remoteSchemaName, String remoteTableName, StarRocksRelationType relationType)
+    {
+        private SchemaTableName schemaTableName()
+        {
+            return new SchemaTableName(lowercaseName(remoteSchemaName), lowercaseName(remoteTableName));
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
@@ -54,7 +54,7 @@ public class JdbcStarRocksMetadataClient
             SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
             FROM INFORMATION_SCHEMA.TABLES
             WHERE LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
-              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
     private static final String LIST_ALL_TABLES_IN_CATALOG_SQL = """
@@ -62,14 +62,14 @@ public class JdbcStarRocksMetadataClient
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_CATALOG = ?
               AND LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
-              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
     private static final String LIST_TABLES_IN_SCHEMA_SQL = """
             SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
             FROM INFORMATION_SCHEMA.TABLES
             WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
-              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
     private static final String LIST_TABLES_IN_CATALOG_SCHEMA_SQL = """
@@ -77,7 +77,7 @@ public class JdbcStarRocksMetadataClient
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_CATALOG = ?
               AND LOWER(TABLE_SCHEMA) = LOWER(?)
-              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
     private static final String RESOLVE_TABLE_SQL = """
@@ -85,7 +85,7 @@ public class JdbcStarRocksMetadataClient
             FROM INFORMATION_SCHEMA.TABLES
             WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
               AND LOWER(TABLE_NAME) = LOWER(?)
-              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
     private static final String RESOLVE_TABLE_IN_CATALOG_SQL = """
@@ -94,7 +94,7 @@ public class JdbcStarRocksMetadataClient
             WHERE TABLE_CATALOG = ?
               AND LOWER(TABLE_SCHEMA) = LOWER(?)
               AND LOWER(TABLE_NAME) = LOWER(?)
-              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+              AND UPPER(TABLE_TYPE) IN ('TABLE', 'BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
     private static final String LIST_COLUMNS_SQL = """
@@ -121,6 +121,19 @@ public class JdbcStarRocksMetadataClient
             FROM INFORMATION_SCHEMA.COLUMNS
             WHERE TABLE_CATALOG = ?
               AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            ORDER BY ORDINAL_POSITION
+            """;
+    private static final String LIST_COLUMNS_WITHOUT_CATALOG_SQL = """
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                COLUMN_TYPE,
+                COALESCE(CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION) AS COLUMN_SIZE,
+                COALESCE(NUMERIC_SCALE, DATETIME_PRECISION) AS DECIMAL_DIGITS,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
               AND LOWER(TABLE_NAME) = LOWER(?)
             ORDER BY ORDINAL_POSITION
             """;
@@ -398,6 +411,12 @@ public class JdbcStarRocksMetadataClient
             if (!columns.isEmpty()) {
                 return columns;
             }
+            if (catalogName.isPresent()) {
+                columns = loadColumnsFromInformationSchemaWithoutCatalog(session, resolvedTable);
+                if (!columns.isEmpty()) {
+                    return columns;
+                }
+            }
         }
         catch (SQLException e) {
             informationSchemaFailure = e;
@@ -442,6 +461,17 @@ public class JdbcStarRocksMetadataClient
         }
     }
 
+    private List<StarRocksRemoteColumn> loadColumnsFromInformationSchemaWithoutCatalog(ConnectorSession session, ResolvedTable resolvedTable)
+            throws SQLException
+    {
+        try (Connection connection = openConnection(session);
+                PreparedStatement statement = connection.prepareStatement(LIST_COLUMNS_WITHOUT_CATALOG_SQL)) {
+            statement.setString(1, resolvedTable.remoteSchemaName());
+            statement.setString(2, resolvedTable.remoteTableName());
+            return readColumns(statement);
+        }
+    }
+
     private List<StarRocksRemoteColumn> loadColumnsFromInformationSchema(ConnectorSession session, ResolvedTable resolvedTable)
             throws SQLException
     {
@@ -455,21 +485,27 @@ public class JdbcStarRocksMetadataClient
             statement.setString(index++, resolvedTable.remoteSchemaName());
             statement.setString(index, resolvedTable.remoteTableName());
 
-            try (ResultSet resultSet = statement.executeQuery()) {
-                List<StarRocksRemoteColumn> columns = new ArrayList<>();
-                while (resultSet.next()) {
-                    String remoteColumnName = resultSet.getString("COLUMN_NAME");
-                    columns.add(new StarRocksRemoteColumn(
-                            lowercaseName(remoteColumnName),
-                            remoteColumnName,
-                            resultSet.getString("DATA_TYPE"),
-                            getOptionalInt(resultSet, "COLUMN_SIZE"),
-                            getOptionalInt(resultSet, "DECIMAL_DIGITS"),
-                            resultSet.getInt("ORDINAL_POSITION"),
-                            Optional.ofNullable(resultSet.getString("COLUMN_TYPE"))));
-                }
-                return deduplicateColumns(columns);
+            return readColumns(statement);
+        }
+    }
+
+    private static List<StarRocksRemoteColumn> readColumns(PreparedStatement statement)
+            throws SQLException
+    {
+        try (ResultSet resultSet = statement.executeQuery()) {
+            List<StarRocksRemoteColumn> columns = new ArrayList<>();
+            while (resultSet.next()) {
+                String remoteColumnName = resultSet.getString("COLUMN_NAME");
+                columns.add(new StarRocksRemoteColumn(
+                        lowercaseName(remoteColumnName),
+                        remoteColumnName,
+                        resultSet.getString("DATA_TYPE"),
+                        getOptionalInt(resultSet, "COLUMN_SIZE"),
+                        getOptionalInt(resultSet, "DECIMAL_DIGITS"),
+                        resultSet.getInt("ORDINAL_POSITION"),
+                        Optional.ofNullable(resultSet.getString("COLUMN_TYPE"))));
             }
+            return deduplicateColumns(columns);
         }
     }
 

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/JdbcStarRocksMetadataClient.java
@@ -43,10 +43,25 @@ public class JdbcStarRocksMetadataClient
             WHERE LOWER(SCHEMA_NAME) NOT IN ('information_schema', '_statistics_', 'sys')
             ORDER BY SCHEMA_NAME
             """;
+    private static final String LIST_SCHEMAS_IN_CATALOG_SQL = """
+            SELECT DISTINCT TABLE_SCHEMA AS SCHEMA_NAME
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
+            ORDER BY TABLE_SCHEMA
+            """;
     private static final String LIST_ALL_TABLES_SQL = """
             SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
             FROM INFORMATION_SCHEMA.TABLES
             WHERE LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
+              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String LIST_ALL_TABLES_IN_CATALOG_SQL = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) NOT IN ('information_schema', '_statistics_', 'sys')
               AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
@@ -57,10 +72,27 @@ public class JdbcStarRocksMetadataClient
               AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
             """;
+    private static final String LIST_TABLES_IN_CATALOG_SCHEMA_SQL = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
     private static final String RESOLVE_TABLE_SQL = """
             SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
             FROM INFORMATION_SCHEMA.TABLES
             WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+              AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+    private static final String RESOLVE_TABLE_IN_CATALOG_SQL = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
               AND LOWER(TABLE_NAME) = LOWER(?)
               AND UPPER(TABLE_TYPE) IN ('BASE TABLE', 'VIEW')
             ORDER BY TABLE_SCHEMA, TABLE_NAME
@@ -78,24 +110,51 @@ public class JdbcStarRocksMetadataClient
               AND LOWER(TABLE_NAME) = LOWER(?)
             ORDER BY ORDINAL_POSITION
             """;
+    private static final String LIST_COLUMNS_IN_CATALOG_SQL = """
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                COLUMN_TYPE,
+                COALESCE(CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION) AS COLUMN_SIZE,
+                COALESCE(NUMERIC_SCALE, DATETIME_PRECISION) AS DECIMAL_DIGITS,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            ORDER BY ORDINAL_POSITION
+            """;
     private static final String TABLE_ROW_COUNT_SQL = """
             SELECT TABLE_ROWS
             FROM INFORMATION_SCHEMA.TABLES
             WHERE LOWER(TABLE_SCHEMA) = LOWER(?)
               AND LOWER(TABLE_NAME) = LOWER(?)
             """;
+    private static final String TABLE_ROW_COUNT_IN_CATALOG_SQL = """
+            SELECT TABLE_ROWS
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_CATALOG = ?
+              AND LOWER(TABLE_SCHEMA) = LOWER(?)
+              AND LOWER(TABLE_NAME) = LOWER(?)
+            """;
 
     private final StarRocksJdbcConnectionFactory connectionFactory;
+    private final Optional<String> catalogName;
 
     @Inject
-    public JdbcStarRocksMetadataClient(StarRocksJdbcConnectionFactory connectionFactory)
+    public JdbcStarRocksMetadataClient(StarRocksJdbcConnectionFactory connectionFactory, StarRocksConfig config)
     {
         this.connectionFactory = requireNonNull(connectionFactory, "connectionFactory is null");
+        this.catalogName = requireNonNull(config, "config is null").getCatalogName();
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
+        if (catalogName.isPresent()) {
+            return loadSchemaNamesFromInformationSchema(session);
+        }
+
         List<String> schemas = loadSchemaNamesFromMetadata(session);
         if (!schemas.isEmpty()) {
             return schemas;
@@ -128,6 +187,7 @@ public class JdbcStarRocksMetadataClient
 
         return Optional.of(new StarRocksRemoteTable(
                 table.schemaTableName(),
+                table.remoteCatalogName(),
                 table.remoteSchemaName(),
                 table.remoteTableName(),
                 table.relationType(),
@@ -142,10 +202,15 @@ public class JdbcStarRocksMetadataClient
             return OptionalLong.empty();
         }
 
+        String sql = catalogName.isPresent() ? TABLE_ROW_COUNT_IN_CATALOG_SQL : TABLE_ROW_COUNT_SQL;
         try (Connection connection = openConnection(session);
-                PreparedStatement statement = connection.prepareStatement(TABLE_ROW_COUNT_SQL)) {
-            statement.setString(1, resolvedTable.orElseThrow().remoteSchemaName());
-            statement.setString(2, resolvedTable.orElseThrow().remoteTableName());
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            statement.setString(index++, resolvedTable.orElseThrow().remoteSchemaName());
+            statement.setString(index, resolvedTable.orElseThrow().remoteTableName());
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (!resultSet.next()) {
@@ -184,14 +249,19 @@ public class JdbcStarRocksMetadataClient
 
     private List<String> loadSchemaNamesFromInformationSchema(ConnectorSession session)
     {
+        String sql = catalogName.isPresent() ? LIST_SCHEMAS_IN_CATALOG_SQL : LIST_SCHEMAS_SQL;
         try (Connection connection = openConnection(session);
-                PreparedStatement statement = connection.prepareStatement(LIST_SCHEMAS_SQL);
-                ResultSet resultSet = statement.executeQuery()) {
-            List<String> schemas = new ArrayList<>();
-            while (resultSet.next()) {
-                schemas.add(lowercaseName(resultSet.getString("SCHEMA_NAME")));
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            if (catalogName.isPresent()) {
+                statement.setString(1, catalogName.orElseThrow());
             }
-            return schemas.stream().distinct().toList();
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<String> schemas = new ArrayList<>();
+                while (resultSet.next()) {
+                    schemas.add(lowercaseName(resultSet.getString("SCHEMA_NAME")));
+                }
+                return schemas.stream().distinct().toList();
+            }
         }
         catch (SQLException e) {
             throw StarRocksJdbcConnectionFactory.jdbcOperationFailed("Failed to list StarRocks schemas", e);
@@ -211,7 +281,7 @@ public class JdbcStarRocksMetadataClient
     {
         try (Connection connection = openConnection(session);
                 ResultSet resultSet = connection.getMetaData().getTables(
-                        connection.getCatalog(),
+                        catalogName.orElse(connection.getCatalog()),
                         schemaName.orElse(null),
                         null,
                         new String[] {"TABLE", "VIEW"})) {
@@ -223,7 +293,7 @@ public class JdbcStarRocksMetadataClient
                 if (!shouldExposeTable(remoteSchema, tableType)) {
                     continue;
                 }
-                tables.add(new ResolvedTable(remoteSchema, remoteTable, toRelationType(tableType)));
+                tables.add(new ResolvedTable(catalogName, remoteSchema, remoteTable, toRelationType(tableType)));
             }
             return tables.stream().distinct().toList();
         }
@@ -234,17 +304,28 @@ public class JdbcStarRocksMetadataClient
 
     private List<ResolvedTable> loadTablesFromInformationSchema(ConnectorSession session, Optional<String> schemaName)
     {
-        String sql = schemaName.isPresent() ? LIST_TABLES_IN_SCHEMA_SQL : LIST_ALL_TABLES_SQL;
+        String sql;
+        if (catalogName.isPresent()) {
+            sql = schemaName.isPresent() ? LIST_TABLES_IN_CATALOG_SCHEMA_SQL : LIST_ALL_TABLES_IN_CATALOG_SQL;
+        }
+        else {
+            sql = schemaName.isPresent() ? LIST_TABLES_IN_SCHEMA_SQL : LIST_ALL_TABLES_SQL;
+        }
         try (Connection connection = openConnection(session);
                 PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
             if (schemaName.isPresent()) {
-                statement.setString(1, schemaName.get());
+                statement.setString(index, schemaName.get());
             }
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 List<ResolvedTable> tables = new ArrayList<>();
                 while (resultSet.next()) {
                     tables.add(new ResolvedTable(
+                            catalogName,
                             resultSet.getString("TABLE_SCHEMA"),
                             resultSet.getString("TABLE_NAME"),
                             toRelationType(resultSet.getString("TABLE_TYPE"))));
@@ -282,15 +363,21 @@ public class JdbcStarRocksMetadataClient
             return fromMetadata;
         }
 
+        String sql = catalogName.isPresent() ? RESOLVE_TABLE_IN_CATALOG_SQL : RESOLVE_TABLE_SQL;
         try (Connection connection = openConnection(session);
-                PreparedStatement statement = connection.prepareStatement(RESOLVE_TABLE_SQL)) {
-            statement.setString(1, tableName.getSchemaName());
-            statement.setString(2, tableName.getTableName());
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            statement.setString(index++, tableName.getSchemaName());
+            statement.setString(index, tableName.getTableName());
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 List<ResolvedTable> matches = new ArrayList<>();
                 while (resultSet.next()) {
                     matches.add(new ResolvedTable(
+                            catalogName,
                             resultSet.getString("TABLE_SCHEMA"),
                             resultSet.getString("TABLE_NAME"),
                             toRelationType(resultSet.getString("TABLE_TYPE"))));
@@ -332,7 +419,7 @@ public class JdbcStarRocksMetadataClient
     {
         try (Connection connection = openConnection(session);
                 ResultSet resultSet = connection.getMetaData().getColumns(
-                        connection.getCatalog(),
+                        resolvedTable.remoteCatalogName().orElse(connection.getCatalog()),
                         resolvedTable.remoteSchemaName(),
                         resolvedTable.remoteTableName(),
                         null)) {
@@ -358,10 +445,15 @@ public class JdbcStarRocksMetadataClient
     private List<StarRocksRemoteColumn> loadColumnsFromInformationSchema(ConnectorSession session, ResolvedTable resolvedTable)
             throws SQLException
     {
+        String sql = catalogName.isPresent() ? LIST_COLUMNS_IN_CATALOG_SQL : LIST_COLUMNS_SQL;
         try (Connection connection = openConnection(session);
-                PreparedStatement statement = connection.prepareStatement(LIST_COLUMNS_SQL)) {
-            statement.setString(1, resolvedTable.remoteSchemaName());
-            statement.setString(2, resolvedTable.remoteTableName());
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            if (catalogName.isPresent()) {
+                statement.setString(index++, catalogName.orElseThrow());
+            }
+            statement.setString(index++, resolvedTable.remoteSchemaName());
+            statement.setString(index, resolvedTable.remoteTableName());
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 List<StarRocksRemoteColumn> columns = new ArrayList<>();
@@ -452,7 +544,7 @@ public class JdbcStarRocksMetadataClient
         return value.toLowerCase(Locale.ENGLISH);
     }
 
-    private record ResolvedTable(String remoteSchemaName, String remoteTableName, StarRocksRelationType relationType)
+    private record ResolvedTable(Optional<String> remoteCatalogName, String remoteSchemaName, String remoteTableName, StarRocksRelationType relationType)
     {
         private SchemaTableName schemaTableName()
         {

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregateColumn.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregateColumn.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.type.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksAggregateColumn(String columnName, String expression, Type type)
+{
+    public StarRocksAggregateColumn
+    {
+        requireNonNull(columnName, "columnName is null");
+        requireNonNull(expression, "expression is null");
+        requireNonNull(type, "type is null");
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregateColumn.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregateColumn.java
@@ -13,15 +13,16 @@
  */
 package io.trino.plugin.starrocks;
 
-import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.Type;
 
-import java.util.List;
-import java.util.Optional;
+import static java.util.Objects.requireNonNull;
 
-record StarRocksRemoteTable(
-        SchemaTableName schemaTableName,
-        Optional<String> remoteCatalogName,
-        String remoteSchemaName,
-        String remoteTableName,
-        StarRocksRelationType relationType,
-        List<StarRocksRemoteColumn> columns) {}
+public record StarRocksAggregateColumn(String columnName, String expression, Type type)
+{
+    public StarRocksAggregateColumn
+    {
+        requireNonNull(columnName, "columnName is null");
+        requireNonNull(expression, "expression is null");
+        requireNonNull(type, "type is null");
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregation.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksAggregation(List<StarRocksColumnHandle> groupingColumns, List<StarRocksAggregateColumn> aggregateColumns)
+{
+    public StarRocksAggregation
+    {
+        groupingColumns = List.copyOf(requireNonNull(groupingColumns, "groupingColumns is null"));
+        aggregateColumns = List.copyOf(requireNonNull(aggregateColumns, "aggregateColumns is null"));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregation.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksAggregation.java
@@ -13,15 +13,15 @@
  */
 package io.trino.plugin.starrocks;
 
-import io.trino.spi.connector.SchemaTableName;
-
 import java.util.List;
-import java.util.Optional;
 
-record StarRocksRemoteTable(
-        SchemaTableName schemaTableName,
-        Optional<String> remoteCatalogName,
-        String remoteSchemaName,
-        String remoteTableName,
-        StarRocksRelationType relationType,
-        List<StarRocksRemoteColumn> columns) {}
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksAggregation(List<StarRocksColumnHandle> groupingColumns, List<StarRocksAggregateColumn> aggregateColumns)
+{
+    public StarRocksAggregation
+    {
+        groupingColumns = List.copyOf(requireNonNull(groupingColumns, "groupingColumns is null"));
+        aggregateColumns = List.copyOf(requireNonNull(aggregateColumns, "aggregateColumns is null"));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
@@ -1,0 +1,791 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.Decimal256Vector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.Chars.truncateToLengthAndTrimSpaces;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.encodeShortScaledValue;
+import static io.trino.spi.type.Decimals.overflows;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.round;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Math.multiplyExact;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
+
+public class StarRocksArrowToPageConverter
+{
+    private static final JsonCodec<Object> JSON_CODEC = jsonCodec(Object.class);
+    private static final long MAX_SECONDS_MAGNITUDE = 10_000_000_000L;
+    private static final long MAX_MILLIS_MAGNITUDE = 10_000_000_000_000L;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("uuuu-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+            .optionalEnd()
+            .toFormatter();
+
+    public Page convert(PageBuilder pageBuilder, List<StarRocksColumnHandle> columns, VectorSchemaRoot root)
+    {
+        requireNonNull(pageBuilder, "pageBuilder is null");
+        requireNonNull(columns, "columns is null");
+        requireNonNull(root, "root is null");
+
+        int positionCount = root.getRowCount();
+        pageBuilder.declarePositions(positionCount);
+
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            StarRocksColumnHandle column = columns.get(columnIndex);
+            FieldVector vector = root.getVector(column.columnName());
+            if (vector == null) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Missing StarRocks Arrow field for column '%s'".formatted(column.columnName()));
+            }
+            writeColumn(pageBuilder.getBlockBuilder(columnIndex), column.columnType(), vector, positionCount);
+        }
+
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return page;
+    }
+
+    private void writeColumn(BlockBuilder output, Type type, FieldVector vector, int positionCount)
+    {
+        try {
+            for (int index = 0; index < positionCount; index++) {
+                if (vector.isNull(index)) {
+                    output.appendNull();
+                    continue;
+                }
+
+                Class<?> javaType = type.getJavaType();
+                if (javaType == boolean.class) {
+                    type.writeBoolean(output, readBoolean(vector, index));
+                }
+                else if (javaType == long.class) {
+                    writeLongValue(output, type, vector, index);
+                }
+                else if (javaType == double.class) {
+                    type.writeDouble(output, readDouble(vector, index));
+                }
+                else if (javaType == Slice.class) {
+                    writeSliceValue(output, type, vector, index);
+                }
+                else if (javaType == Int128.class) {
+                    writeLongDecimal(output, (DecimalType) type, vector, index);
+                }
+                else if (type instanceof ArrayType || type instanceof MapType || type instanceof RowType) {
+                    writeObjectValue(output, type, readComplexValue(vector, index));
+                }
+                else {
+                    throw unsupportedType(type, vector);
+                }
+            }
+        }
+        catch (TrinoException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Failed to convert StarRocks Arrow field '%s' into Trino type '%s'".formatted(vector.getName(), type),
+                    e);
+        }
+    }
+
+    private void writeLongValue(BlockBuilder output, Type type, FieldVector vector, int index)
+    {
+        if (type == TINYINT) {
+            type.writeLong(output, readTinyint(vector, index));
+            return;
+        }
+        if (type == SMALLINT) {
+            type.writeLong(output, readSmallint(vector, index));
+            return;
+        }
+        if (type == INTEGER) {
+            type.writeLong(output, readInteger(vector, index));
+            return;
+        }
+        if (type == BIGINT) {
+            type.writeLong(output, readBigint(vector, index));
+            return;
+        }
+        if (type == REAL) {
+            type.writeLong(output, floatToRawIntBits(readFloat(vector, index)));
+            return;
+        }
+        if (type == DATE) {
+            type.writeLong(output, readDateValue(vector, index));
+            return;
+        }
+        if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+            type.writeLong(output, readTimestampMicros(vector, index, timestampType.getPrecision()));
+            return;
+        }
+        if (type instanceof DecimalType decimalType && decimalType.isShort()) {
+            decimalType.writeLong(output, encodeShortScaledValue(coerceDecimalValue(vector.getName(), readDecimalValue(vector, index), decimalType), decimalType.getScale()));
+            return;
+        }
+
+        throw unsupportedType(type, vector);
+    }
+
+    private void writeLongDecimal(BlockBuilder output, DecimalType decimalType, FieldVector vector, int index)
+    {
+        decimalType.writeObject(output, Decimals.encodeScaledValue(coerceDecimalValue(vector.getName(), readDecimalValue(vector, index), decimalType), decimalType.getScale()));
+    }
+
+    private void writeObjectValue(BlockBuilder output, Type type, Object value)
+    {
+        if (value == null) {
+            output.appendNull();
+            return;
+        }
+        if (type instanceof ArrayType arrayType) {
+            writeArrayValue(output, arrayType, value);
+            return;
+        }
+        if (type instanceof MapType mapType) {
+            writeMapValue(output, mapType, value);
+            return;
+        }
+        if (type instanceof RowType rowType) {
+            writeRowValue(output, rowType, value);
+            return;
+        }
+
+        Class<?> javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            type.writeBoolean(output, toBooleanValue(value));
+        }
+        else if (javaType == long.class) {
+            writeLongObject(output, type, value);
+        }
+        else if (javaType == double.class) {
+            type.writeDouble(output, ((Number) value).doubleValue());
+        }
+        else if (javaType == Slice.class) {
+            writeSliceObject(output, type, value);
+        }
+        else if (javaType == Int128.class) {
+            DecimalType decimalType = (DecimalType) type;
+            decimalType.writeObject(output, Decimals.encodeScaledValue(coerceDecimalValue(type.getDisplayName(), toBigDecimalValue(value), decimalType), decimalType.getScale()));
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported nested StarRocks value type: " + type);
+        }
+    }
+
+    private void writeArrayValue(BlockBuilder output, ArrayType arrayType, Object value)
+    {
+        if (!(value instanceof Iterable<?> iterable)) {
+            throw new IllegalArgumentException("Expected array value for " + arrayType + ": " + value);
+        }
+        ((ArrayBlockBuilder) output).buildEntry(elementBuilder -> {
+            for (Object element : iterable) {
+                writeObjectValue(elementBuilder, arrayType.getElementType(), element);
+            }
+        });
+    }
+
+    private void writeMapValue(BlockBuilder output, MapType mapType, Object value)
+    {
+        if (value instanceof Map<?, ?> map) {
+            ((MapBlockBuilder) output).buildEntry((keyBuilder, valueBuilder) -> {
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    writeObjectValue(keyBuilder, mapType.getKeyType(), entry.getKey());
+                    writeObjectValue(valueBuilder, mapType.getValueType(), entry.getValue());
+                }
+            });
+            return;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            ((MapBlockBuilder) output).buildEntry((keyBuilder, valueBuilder) -> {
+                for (Object element : iterable) {
+                    if (element instanceof Map<?, ?> entry && entry.containsKey("key") && entry.containsKey("value")) {
+                        writeObjectValue(keyBuilder, mapType.getKeyType(), entry.get("key"));
+                        writeObjectValue(valueBuilder, mapType.getValueType(), entry.get("value"));
+                    }
+                }
+            });
+            return;
+        }
+        throw new IllegalArgumentException("Expected map value for " + mapType + ": " + value);
+    }
+
+    private void writeRowValue(BlockBuilder output, RowType rowType, Object value)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        if (value instanceof Map<?, ?> map) {
+            ((RowBlockBuilder) output).buildEntry(fieldBuilders -> {
+                for (int index = 0; index < fields.size(); index++) {
+                    RowType.Field field = fields.get(index);
+                    writeObjectValue(fieldBuilders.get(index), field.getType(), map.get(field.getName().orElse("field" + index)));
+                }
+            });
+            return;
+        }
+        if (value instanceof List<?> list) {
+            ((RowBlockBuilder) output).buildEntry(fieldBuilders -> {
+                for (int index = 0; index < fields.size(); index++) {
+                    Object fieldValue = index < list.size() ? list.get(index) : null;
+                    writeObjectValue(fieldBuilders.get(index), fields.get(index).getType(), fieldValue);
+                }
+            });
+            return;
+        }
+        throw new IllegalArgumentException("Expected row value for " + rowType + ": " + value);
+    }
+
+    private void writeSliceValue(BlockBuilder output, Type type, FieldVector vector, int index)
+    {
+        if (type == VARBINARY) {
+            type.writeSlice(output, wrappedBuffer(readBinaryValue(vector, index)));
+            return;
+        }
+        if (type.getBaseName().equals(JSON)) {
+            type.writeSlice(output, utf8Slice(readJsonTextValue(vector, index)));
+            return;
+        }
+
+        Slice value = utf8Slice(readTextValue(vector, index));
+        if (type instanceof CharType charType) {
+            type.writeSlice(output, truncateToLengthAndTrimSpaces(value, charType));
+            return;
+        }
+        type.writeSlice(output, value);
+    }
+
+    private static void writeLongObject(BlockBuilder output, Type type, Object value)
+    {
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            type.writeLong(output, ((Number) value).longValue());
+            return;
+        }
+        if (type == REAL) {
+            type.writeLong(output, floatToRawIntBits(((Number) value).floatValue()));
+            return;
+        }
+        if (type == DATE) {
+            type.writeLong(output, toDateObject(value));
+            return;
+        }
+        if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+            long epochMicros = value instanceof Number number
+                    ? number.longValue()
+                    : toTrinoTimestampMicros(parseTimestampText(value.toString()));
+            if (timestampType.getPrecision() == TIMESTAMP_MICROS.getPrecision()) {
+                type.writeLong(output, epochMicros);
+                return;
+            }
+            type.writeLong(output, round(epochMicros, TIMESTAMP_MICROS.getPrecision() - timestampType.getPrecision()));
+            return;
+        }
+        if (type instanceof DecimalType decimalType && decimalType.isShort()) {
+            decimalType.writeLong(output, encodeShortScaledValue(coerceDecimalValue(type.getDisplayName(), toBigDecimalValue(value), decimalType), decimalType.getScale()));
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported nested StarRocks long value type: " + type);
+    }
+
+    private static void writeSliceObject(BlockBuilder output, Type type, Object value)
+    {
+        if (type == VARBINARY) {
+            type.writeSlice(output, wrappedBuffer(value instanceof byte[] bytes ? bytes : value.toString().getBytes(StandardCharsets.UTF_8)));
+            return;
+        }
+        if (type.getBaseName().equals(JSON)) {
+            String json = value instanceof CharSequence ? value.toString() : JSON_CODEC.toJson(toJsonCompatibleValue(value));
+            type.writeSlice(output, utf8Slice(json));
+            return;
+        }
+
+        Slice slice = utf8Slice(value instanceof Slice valueSlice ? valueSlice.toStringUtf8() : value.toString());
+        if (type instanceof CharType charType) {
+            type.writeSlice(output, truncateToLengthAndTrimSpaces(slice, charType));
+            return;
+        }
+        type.writeSlice(output, slice);
+    }
+
+    private static Object readComplexValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarCharVector || vector instanceof LargeVarCharVector) {
+            return JSON_CODEC.fromJson(readTextValue(vector, index));
+        }
+        Object value = vector.getObject(index);
+        if (value instanceof CharSequence) {
+            return JSON_CODEC.fromJson(value.toString());
+        }
+        if (value instanceof Slice slice) {
+            return JSON_CODEC.fromJson(slice.toStringUtf8());
+        }
+        return toJsonCompatibleValue(value);
+    }
+
+    private static boolean toBooleanValue(Object value)
+    {
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof Number number) {
+            return number.longValue() != 0;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    private static long toDateObject(Object value)
+    {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof LocalDate localDate) {
+            return localDate.toEpochDay();
+        }
+        return parseDateText(value.toString()).toEpochDay();
+    }
+
+    private static BigDecimal toBigDecimalValue(Object value)
+    {
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (value instanceof BigInteger integer) {
+            return new BigDecimal(integer);
+        }
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
+            return BigDecimal.valueOf(((Number) value).longValue());
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+
+    private static boolean readBoolean(FieldVector vector, int index)
+    {
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index) == 1;
+        }
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index) != 0;
+        }
+        return Boolean.parseBoolean(readTextValue(vector, index));
+    }
+
+    private static long readTinyint(FieldVector vector, int index)
+    {
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index);
+        }
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static long readSmallint(FieldVector vector, int index)
+    {
+        if (vector instanceof SmallIntVector smallIntVector) {
+            return smallIntVector.get(index);
+        }
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index);
+        }
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static long readInteger(FieldVector vector, int index)
+    {
+        if (vector instanceof IntVector intVector) {
+            return intVector.get(index);
+        }
+        if (vector instanceof SmallIntVector smallIntVector) {
+            return smallIntVector.get(index);
+        }
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index);
+        }
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static long readBigint(FieldVector vector, int index)
+    {
+        if (vector instanceof BigIntVector bigIntVector) {
+            return bigIntVector.get(index);
+        }
+        if (vector instanceof IntVector intVector) {
+            return intVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static float readFloat(FieldVector vector, int index)
+    {
+        if (vector instanceof Float4Vector float4Vector) {
+            return float4Vector.get(index);
+        }
+        return Float.parseFloat(readTextValue(vector, index));
+    }
+
+    private static double readDouble(FieldVector vector, int index)
+    {
+        if (vector instanceof Float8Vector float8Vector) {
+            return float8Vector.get(index);
+        }
+        if (vector instanceof Float4Vector float4Vector) {
+            return float4Vector.get(index);
+        }
+        return Double.parseDouble(readTextValue(vector, index));
+    }
+
+    private static long readDateValue(FieldVector vector, int index)
+    {
+        if (vector instanceof DateDayVector dateDayVector) {
+            return dateDayVector.get(index);
+        }
+        return parseDateText(readTextValue(vector, index)).toEpochDay();
+    }
+
+    private static long readTimestampMicros(FieldVector vector, int index, int precision)
+    {
+        long epochMicros;
+        if (vector instanceof TimeStampVector timestampVector) {
+            epochMicros = readArrowTimestampMicros(timestampVector, index);
+        }
+        else {
+            epochMicros = toTrinoTimestampMicros(parseTimestampText(readTextValue(vector, index)));
+        }
+
+        if (precision == TIMESTAMP_MICROS.getPrecision()) {
+            return epochMicros;
+        }
+        return round(epochMicros, TIMESTAMP_MICROS.getPrecision() - precision);
+    }
+
+    private static long readArrowTimestampMicros(TimeStampVector timestampVector, int index)
+    {
+        long rawValue = timestampVector.get(index);
+        long normalizedValue = normalizeTimestamp(timestampVector, rawValue);
+        String timeZone = arrowTimestampTimeZone(timestampVector);
+        if (normalizedValue != rawValue) {
+            if (timeZone != null && !timeZone.isBlank()) {
+                return toTrinoTimestampMicros(timestampMicrosToLocalDateTime(normalizedValue, timeZone));
+            }
+            return normalizedValue;
+        }
+
+        Object timestampValue = timestampVector.getObject(index);
+        if (timestampValue instanceof LocalDateTime localDateTime) {
+            return toTrinoTimestampMicros(localDateTime);
+        }
+        if (timestampValue instanceof OffsetDateTime offsetDateTime) {
+            return toTrinoTimestampMicros(offsetDateTime.toLocalDateTime());
+        }
+        if (timeZone != null && !timeZone.isBlank()) {
+            return toTrinoTimestampMicros(timestampMicrosToLocalDateTime(normalizedValue, timeZone));
+        }
+        return normalizedValue;
+    }
+
+    private static BigDecimal readDecimalValue(FieldVector vector, int index)
+    {
+        if (vector instanceof Decimal256Vector decimal256Vector) {
+            return decimal256Vector.getObject(index);
+        }
+        if (vector instanceof DecimalVector decimalVector) {
+            return decimalVector.getObject(index);
+        }
+        if (vector instanceof FixedSizeBinaryVector fixedSizeBinaryVector) {
+            return new BigDecimal(decodeLittleEndianSignedInteger(fixedSizeBinaryVector.get(index)));
+        }
+        if (vector instanceof BigIntVector bigIntVector) {
+            return BigDecimal.valueOf(bigIntVector.get(index));
+        }
+        if (vector instanceof IntVector intVector) {
+            return BigDecimal.valueOf(intVector.get(index));
+        }
+        return new BigDecimal(readTextValue(vector, index));
+    }
+
+    private static byte[] readBinaryValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarBinaryVector varBinaryVector) {
+            return varBinaryVector.get(index);
+        }
+        if (vector instanceof LargeVarBinaryVector largeVarBinaryVector) {
+            return largeVarBinaryVector.get(index);
+        }
+        if (vector instanceof FixedSizeBinaryVector fixedSizeBinaryVector) {
+            return fixedSizeBinaryVector.get(index);
+        }
+        return readTextValue(vector, index).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String readJsonTextValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarCharVector || vector instanceof LargeVarCharVector) {
+            return readTextValue(vector, index);
+        }
+
+        Object value = vector.getObject(index);
+        if (value instanceof Slice slice) {
+            return slice.toStringUtf8();
+        }
+        if (value instanceof CharSequence) {
+            return value.toString();
+        }
+        return JSON_CODEC.toJson(toJsonCompatibleValue(value));
+    }
+
+    private static Object toJsonCompatibleValue(Object value)
+    {
+        if (value == null ||
+                value instanceof Boolean ||
+                value instanceof Number ||
+                value instanceof CharSequence) {
+            return value;
+        }
+        if (value instanceof Slice slice) {
+            return slice.toStringUtf8();
+        }
+        if (value instanceof Map<?, ?> map) {
+            return map.entrySet().stream()
+                    .collect(toMap(
+                            entry -> entry.getKey().toString(),
+                            entry -> toJsonCompatibleValue(entry.getValue())));
+        }
+        if (value instanceof Iterable<?> iterable) {
+            ArrayList<Object> values = new ArrayList<>();
+            for (Object element : iterable) {
+                values.add(toJsonCompatibleValue(element));
+            }
+            return values;
+        }
+        return value.toString();
+    }
+
+    private static String readTextValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarCharVector varCharVector) {
+            return new String(varCharVector.get(index), StandardCharsets.UTF_8);
+        }
+        if (vector instanceof LargeVarCharVector largeVarCharVector) {
+            return new String(largeVarCharVector.get(index), StandardCharsets.UTF_8);
+        }
+        if (vector instanceof FixedSizeBinaryVector fixedSizeBinaryVector) {
+            return decodeLittleEndianSignedInteger(fixedSizeBinaryVector.get(index)).toString();
+        }
+        if (vector instanceof Decimal256Vector decimal256Vector) {
+            return decimal256Vector.getObject(index).toPlainString();
+        }
+        if (vector instanceof DecimalVector decimalVector) {
+            return decimalVector.getObject(index).toPlainString();
+        }
+        if (vector instanceof DateDayVector dateDayVector) {
+            return LocalDate.ofEpochDay(dateDayVector.get(index)).format(DATE_FORMATTER);
+        }
+        if (vector instanceof TimeStampVector) {
+            return SqlTimestamp.newInstance(6, readTimestampMicros(vector, index, 6), 0).toString();
+        }
+
+        Object value = vector.getObject(index);
+        if (value != null) {
+            return value.toString();
+        }
+        throw unsupportedVector(vector);
+    }
+
+    private static long normalizeTimestamp(TimeStampVector timestampVector, long value)
+    {
+        if (timestampVector.getField().getType() instanceof ArrowType.Timestamp timestampType) {
+            return switch (timestampType.getUnit()) {
+                case SECOND -> multiplyExact(value, MICROSECONDS_PER_SECOND);
+                case MILLISECOND -> multiplyExact(value, MICROSECONDS_PER_MILLISECOND);
+                case MICROSECOND -> value;
+                case NANOSECOND -> Math.floorDiv(value, 1_000L);
+            };
+        }
+        return normalizeTimestampHeuristically(value);
+    }
+
+    private static long normalizeTimestampHeuristically(long value)
+    {
+        if (value > -MAX_SECONDS_MAGNITUDE && value < MAX_SECONDS_MAGNITUDE) {
+            return multiplyExact(value, MICROSECONDS_PER_SECOND);
+        }
+        if (value > -MAX_MILLIS_MAGNITUDE && value < MAX_MILLIS_MAGNITUDE) {
+            return multiplyExact(value, MICROSECONDS_PER_MILLISECOND);
+        }
+        return value;
+    }
+
+    private static long toTrinoTimestampMicros(LocalDateTime timestamp)
+    {
+        return multiplyExact(timestamp.toEpochSecond(UTC), MICROSECONDS_PER_SECOND) + (timestamp.getLong(ChronoField.NANO_OF_SECOND) / 1_000);
+    }
+
+    private static LocalDateTime timestampMicrosToLocalDateTime(long epochMicros, String timeZone)
+    {
+        long epochSeconds = Math.floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+        long microsOfSecond = Math.floorMod(epochMicros, MICROSECONDS_PER_SECOND);
+        return Instant.ofEpochSecond(epochSeconds, microsOfSecond * 1_000L)
+                .atZone(ZoneId.of(timeZone))
+                .toLocalDateTime();
+    }
+
+    private static String arrowTimestampTimeZone(TimeStampVector timestampVector)
+    {
+        if (timestampVector.getField().getType() instanceof ArrowType.Timestamp timestampType) {
+            return timestampType.getTimezone();
+        }
+        return null;
+    }
+
+    private static LocalDate parseDateText(String value)
+    {
+        String normalized = value.trim();
+        if (normalized.contains(" ") || normalized.contains("T")) {
+            return parseTimestampText(normalized).toLocalDate();
+        }
+        return LocalDate.parse(normalized, DATE_FORMATTER);
+    }
+
+    private static LocalDateTime parseTimestampText(String value)
+    {
+        String normalized = value.trim().replace('T', ' ');
+        if (normalized.length() == 10) {
+            normalized = normalized + " 00:00:00";
+        }
+        return LocalDateTime.parse(normalized, TIMESTAMP_FORMATTER);
+    }
+
+    private static BigDecimal coerceDecimalValue(String columnName, BigDecimal value, DecimalType decimalType)
+    {
+        BigDecimal scaledValue;
+        try {
+            scaledValue = value.setScale(decimalType.getScale(), UNNECESSARY);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "StarRocks value '%s' for column '%s' cannot be represented as %s without rounding".formatted(value.toPlainString(), columnName, decimalType),
+                    e);
+        }
+
+        if (overflows(scaledValue, decimalType.getPrecision())) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "StarRocks value '%s' for column '%s' exceeds Trino type %s".formatted(value.toPlainString(), columnName, decimalType));
+        }
+        return scaledValue;
+    }
+
+    private static BigInteger decodeLittleEndianSignedInteger(byte[] littleEndianBytes)
+    {
+        byte[] bigEndianBytes = littleEndianBytes.clone();
+        for (int left = 0, right = bigEndianBytes.length - 1; left < right; left++, right--) {
+            byte temp = bigEndianBytes[left];
+            bigEndianBytes[left] = bigEndianBytes[right];
+            bigEndianBytes[right] = temp;
+        }
+        return new BigInteger(bigEndianBytes);
+    }
+
+    private static IllegalArgumentException unsupportedVector(FieldVector vector)
+    {
+        return new IllegalArgumentException("Unsupported StarRocks Arrow vector: " + vector.getClass().getSimpleName());
+    }
+
+    private static IllegalArgumentException unsupportedType(Type type, FieldVector vector)
+    {
+        return new IllegalArgumentException("Unsupported Trino type %s for StarRocks Arrow vector %s".formatted(type, vector.getClass().getSimpleName()));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
@@ -1,0 +1,520 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.Decimal256Vector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.List;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.Chars.truncateToLengthAndTrimSpaces;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.encodeShortScaledValue;
+import static io.trino.spi.type.Decimals.overflows;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.round;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Math.multiplyExact;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksArrowToPageConverter
+{
+    private static final long MAX_SECONDS_MAGNITUDE = 10_000_000_000L;
+    private static final long MAX_MILLIS_MAGNITUDE = 10_000_000_000_000L;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("uuuu-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+            .optionalEnd()
+            .toFormatter();
+
+    public Page convert(PageBuilder pageBuilder, List<StarRocksColumnHandle> columns, VectorSchemaRoot root)
+    {
+        requireNonNull(pageBuilder, "pageBuilder is null");
+        requireNonNull(columns, "columns is null");
+        requireNonNull(root, "root is null");
+
+        int positionCount = root.getRowCount();
+        pageBuilder.declarePositions(positionCount);
+
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            StarRocksColumnHandle column = columns.get(columnIndex);
+            FieldVector vector = root.getVector(column.columnName());
+            if (vector == null) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Missing StarRocks Arrow field for column '%s'".formatted(column.columnName()));
+            }
+            writeColumn(pageBuilder.getBlockBuilder(columnIndex), column.columnType(), vector, positionCount);
+        }
+
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return page;
+    }
+
+    private void writeColumn(BlockBuilder output, Type type, FieldVector vector, int positionCount)
+    {
+        try {
+            for (int index = 0; index < positionCount; index++) {
+                if (vector.isNull(index)) {
+                    output.appendNull();
+                    continue;
+                }
+
+                Class<?> javaType = type.getJavaType();
+                if (javaType == boolean.class) {
+                    type.writeBoolean(output, readBoolean(vector, index));
+                }
+                else if (javaType == long.class) {
+                    writeLongValue(output, type, vector, index);
+                }
+                else if (javaType == double.class) {
+                    type.writeDouble(output, readDouble(vector, index));
+                }
+                else if (javaType == Slice.class) {
+                    writeSliceValue(output, type, vector, index);
+                }
+                else if (javaType == Int128.class) {
+                    writeLongDecimal(output, (DecimalType) type, vector, index);
+                }
+                else {
+                    throw unsupportedType(type, vector);
+                }
+            }
+        }
+        catch (TrinoException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Failed to convert StarRocks Arrow field '%s' into Trino type '%s'".formatted(vector.getName(), type),
+                    e);
+        }
+    }
+
+    private void writeLongValue(BlockBuilder output, Type type, FieldVector vector, int index)
+    {
+        if (type == TINYINT) {
+            type.writeLong(output, readTinyint(vector, index));
+            return;
+        }
+        if (type == SMALLINT) {
+            type.writeLong(output, readSmallint(vector, index));
+            return;
+        }
+        if (type == INTEGER) {
+            type.writeLong(output, readInteger(vector, index));
+            return;
+        }
+        if (type == BIGINT) {
+            type.writeLong(output, readBigint(vector, index));
+            return;
+        }
+        if (type == REAL) {
+            type.writeLong(output, floatToRawIntBits(readFloat(vector, index)));
+            return;
+        }
+        if (type == DATE) {
+            type.writeLong(output, readDateValue(vector, index));
+            return;
+        }
+        if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+            type.writeLong(output, readTimestampMicros(vector, index, timestampType.getPrecision()));
+            return;
+        }
+        if (type instanceof DecimalType decimalType && decimalType.isShort()) {
+            decimalType.writeLong(output, encodeShortScaledValue(coerceDecimalValue(vector.getName(), readDecimalValue(vector, index), decimalType), decimalType.getScale()));
+            return;
+        }
+
+        throw unsupportedType(type, vector);
+    }
+
+    private void writeLongDecimal(BlockBuilder output, DecimalType decimalType, FieldVector vector, int index)
+    {
+        decimalType.writeObject(output, Decimals.encodeScaledValue(coerceDecimalValue(vector.getName(), readDecimalValue(vector, index), decimalType), decimalType.getScale()));
+    }
+
+    private void writeSliceValue(BlockBuilder output, Type type, FieldVector vector, int index)
+    {
+        if (type == VARBINARY) {
+            type.writeSlice(output, wrappedBuffer(readBinaryValue(vector, index)));
+            return;
+        }
+
+        Slice value = utf8Slice(readTextValue(vector, index));
+        if (type instanceof CharType charType) {
+            type.writeSlice(output, truncateToLengthAndTrimSpaces(value, charType));
+            return;
+        }
+        type.writeSlice(output, value);
+    }
+
+    private static boolean readBoolean(FieldVector vector, int index)
+    {
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index) == 1;
+        }
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index) != 0;
+        }
+        return Boolean.parseBoolean(readTextValue(vector, index));
+    }
+
+    private static long readTinyint(FieldVector vector, int index)
+    {
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index);
+        }
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static long readSmallint(FieldVector vector, int index)
+    {
+        if (vector instanceof SmallIntVector smallIntVector) {
+            return smallIntVector.get(index);
+        }
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index);
+        }
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static long readInteger(FieldVector vector, int index)
+    {
+        if (vector instanceof IntVector intVector) {
+            return intVector.get(index);
+        }
+        if (vector instanceof SmallIntVector smallIntVector) {
+            return smallIntVector.get(index);
+        }
+        if (vector instanceof TinyIntVector tinyIntVector) {
+            return tinyIntVector.get(index);
+        }
+        if (vector instanceof BitVector bitVector) {
+            return bitVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static long readBigint(FieldVector vector, int index)
+    {
+        if (vector instanceof BigIntVector bigIntVector) {
+            return bigIntVector.get(index);
+        }
+        if (vector instanceof IntVector intVector) {
+            return intVector.get(index);
+        }
+        return Long.parseLong(readTextValue(vector, index));
+    }
+
+    private static float readFloat(FieldVector vector, int index)
+    {
+        if (vector instanceof Float4Vector float4Vector) {
+            return float4Vector.get(index);
+        }
+        return Float.parseFloat(readTextValue(vector, index));
+    }
+
+    private static double readDouble(FieldVector vector, int index)
+    {
+        if (vector instanceof Float8Vector float8Vector) {
+            return float8Vector.get(index);
+        }
+        if (vector instanceof Float4Vector float4Vector) {
+            return float4Vector.get(index);
+        }
+        return Double.parseDouble(readTextValue(vector, index));
+    }
+
+    private static long readDateValue(FieldVector vector, int index)
+    {
+        if (vector instanceof DateDayVector dateDayVector) {
+            return dateDayVector.get(index);
+        }
+        return parseDateText(readTextValue(vector, index)).toEpochDay();
+    }
+
+    private static long readTimestampMicros(FieldVector vector, int index, int precision)
+    {
+        long epochMicros;
+        if (vector instanceof TimeStampVector timestampVector) {
+            epochMicros = readArrowTimestampMicros(timestampVector, index);
+        }
+        else {
+            epochMicros = toTrinoTimestampMicros(parseTimestampText(readTextValue(vector, index)));
+        }
+
+        if (precision == TIMESTAMP_MICROS.getPrecision()) {
+            return epochMicros;
+        }
+        return round(epochMicros, TIMESTAMP_MICROS.getPrecision() - precision);
+    }
+
+    private static long readArrowTimestampMicros(TimeStampVector timestampVector, int index)
+    {
+        long rawValue = timestampVector.get(index);
+        long normalizedValue = normalizeTimestamp(timestampVector, rawValue);
+        String timeZone = arrowTimestampTimeZone(timestampVector);
+        if (normalizedValue != rawValue) {
+            if (timeZone != null && !timeZone.isBlank()) {
+                return toTrinoTimestampMicros(timestampMicrosToLocalDateTime(normalizedValue, timeZone));
+            }
+            return normalizedValue;
+        }
+
+        Object timestampValue = timestampVector.getObject(index);
+        if (timestampValue instanceof LocalDateTime localDateTime) {
+            return toTrinoTimestampMicros(localDateTime);
+        }
+        if (timestampValue instanceof OffsetDateTime offsetDateTime) {
+            return toTrinoTimestampMicros(offsetDateTime.toLocalDateTime());
+        }
+        if (timeZone != null && !timeZone.isBlank()) {
+            return toTrinoTimestampMicros(timestampMicrosToLocalDateTime(normalizedValue, timeZone));
+        }
+        return normalizedValue;
+    }
+
+    private static BigDecimal readDecimalValue(FieldVector vector, int index)
+    {
+        if (vector instanceof Decimal256Vector decimal256Vector) {
+            return decimal256Vector.getObject(index);
+        }
+        if (vector instanceof DecimalVector decimalVector) {
+            return decimalVector.getObject(index);
+        }
+        if (vector instanceof FixedSizeBinaryVector fixedSizeBinaryVector) {
+            return new BigDecimal(decodeLittleEndianSignedInteger(fixedSizeBinaryVector.get(index)));
+        }
+        if (vector instanceof BigIntVector bigIntVector) {
+            return BigDecimal.valueOf(bigIntVector.get(index));
+        }
+        if (vector instanceof IntVector intVector) {
+            return BigDecimal.valueOf(intVector.get(index));
+        }
+        return new BigDecimal(readTextValue(vector, index));
+    }
+
+    private static byte[] readBinaryValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarBinaryVector varBinaryVector) {
+            return varBinaryVector.get(index);
+        }
+        if (vector instanceof LargeVarBinaryVector largeVarBinaryVector) {
+            return largeVarBinaryVector.get(index);
+        }
+        if (vector instanceof FixedSizeBinaryVector fixedSizeBinaryVector) {
+            return fixedSizeBinaryVector.get(index);
+        }
+        return readTextValue(vector, index).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String readTextValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarCharVector varCharVector) {
+            return new String(varCharVector.get(index), StandardCharsets.UTF_8);
+        }
+        if (vector instanceof LargeVarCharVector largeVarCharVector) {
+            return new String(largeVarCharVector.get(index), StandardCharsets.UTF_8);
+        }
+        if (vector instanceof FixedSizeBinaryVector fixedSizeBinaryVector) {
+            return decodeLittleEndianSignedInteger(fixedSizeBinaryVector.get(index)).toString();
+        }
+        if (vector instanceof Decimal256Vector decimal256Vector) {
+            return decimal256Vector.getObject(index).toPlainString();
+        }
+        if (vector instanceof DecimalVector decimalVector) {
+            return decimalVector.getObject(index).toPlainString();
+        }
+        if (vector instanceof DateDayVector dateDayVector) {
+            return LocalDate.ofEpochDay(dateDayVector.get(index)).format(DATE_FORMATTER);
+        }
+        if (vector instanceof TimeStampVector) {
+            return SqlTimestamp.newInstance(6, readTimestampMicros(vector, index, 6), 0).toString();
+        }
+
+        Object value = vector.getObject(index);
+        if (value != null) {
+            return value.toString();
+        }
+        throw unsupportedVector(vector);
+    }
+
+    private static long normalizeTimestamp(TimeStampVector timestampVector, long value)
+    {
+        if (timestampVector.getField().getType() instanceof ArrowType.Timestamp timestampType) {
+            return switch (timestampType.getUnit()) {
+                case SECOND -> multiplyExact(value, MICROSECONDS_PER_SECOND);
+                case MILLISECOND -> multiplyExact(value, MICROSECONDS_PER_MILLISECOND);
+                case MICROSECOND -> value;
+                case NANOSECOND -> Math.floorDiv(value, 1_000L);
+            };
+        }
+        return normalizeTimestampHeuristically(value);
+    }
+
+    private static long normalizeTimestampHeuristically(long value)
+    {
+        if (value > -MAX_SECONDS_MAGNITUDE && value < MAX_SECONDS_MAGNITUDE) {
+            return multiplyExact(value, MICROSECONDS_PER_SECOND);
+        }
+        if (value > -MAX_MILLIS_MAGNITUDE && value < MAX_MILLIS_MAGNITUDE) {
+            return multiplyExact(value, MICROSECONDS_PER_MILLISECOND);
+        }
+        return value;
+    }
+
+    private static long toTrinoTimestampMicros(LocalDateTime timestamp)
+    {
+        return multiplyExact(timestamp.toEpochSecond(UTC), MICROSECONDS_PER_SECOND) + (timestamp.getLong(ChronoField.NANO_OF_SECOND) / 1_000);
+    }
+
+    private static LocalDateTime timestampMicrosToLocalDateTime(long epochMicros, String timeZone)
+    {
+        long epochSeconds = Math.floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+        long microsOfSecond = Math.floorMod(epochMicros, MICROSECONDS_PER_SECOND);
+        return Instant.ofEpochSecond(epochSeconds, microsOfSecond * 1_000L)
+                .atZone(ZoneId.of(timeZone))
+                .toLocalDateTime();
+    }
+
+    private static String arrowTimestampTimeZone(TimeStampVector timestampVector)
+    {
+        if (timestampVector.getField().getType() instanceof ArrowType.Timestamp timestampType) {
+            return timestampType.getTimezone();
+        }
+        return null;
+    }
+
+    private static LocalDate parseDateText(String value)
+    {
+        String normalized = value.trim();
+        if (normalized.contains(" ") || normalized.contains("T")) {
+            return parseTimestampText(normalized).toLocalDate();
+        }
+        return LocalDate.parse(normalized, DATE_FORMATTER);
+    }
+
+    private static LocalDateTime parseTimestampText(String value)
+    {
+        String normalized = value.trim().replace('T', ' ');
+        if (normalized.length() == 10) {
+            normalized = normalized + " 00:00:00";
+        }
+        return LocalDateTime.parse(normalized, TIMESTAMP_FORMATTER);
+    }
+
+    private static BigDecimal coerceDecimalValue(String columnName, BigDecimal value, DecimalType decimalType)
+    {
+        BigDecimal scaledValue;
+        try {
+            scaledValue = value.setScale(decimalType.getScale(), UNNECESSARY);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "StarRocks value '%s' for column '%s' cannot be represented as %s without rounding".formatted(value.toPlainString(), columnName, decimalType),
+                    e);
+        }
+
+        if (overflows(scaledValue, decimalType.getPrecision())) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "StarRocks value '%s' for column '%s' exceeds Trino type %s".formatted(value.toPlainString(), columnName, decimalType));
+        }
+        return scaledValue;
+    }
+
+    private static BigInteger decodeLittleEndianSignedInteger(byte[] littleEndianBytes)
+    {
+        byte[] bigEndianBytes = littleEndianBytes.clone();
+        for (int left = 0, right = bigEndianBytes.length - 1; left < right; left++, right--) {
+            byte temp = bigEndianBytes[left];
+            bigEndianBytes[left] = bigEndianBytes[right];
+            bigEndianBytes[right] = temp;
+        }
+        return new BigInteger(bigEndianBytes);
+    }
+
+    private static IllegalArgumentException unsupportedVector(FieldVector vector)
+    {
+        return new IllegalArgumentException("Unsupported StarRocks Arrow vector: " + vector.getClass().getSimpleName());
+    }
+
+    private static IllegalArgumentException unsupportedType(Type type, FieldVector vector)
+    {
+        return new IllegalArgumentException("Unsupported Trino type %s for StarRocks Arrow vector %s".formatted(type, vector.getClass().getSimpleName()));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.starrocks;
 
+import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
@@ -57,7 +58,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.List;
+import java.util.Map;
 
+import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -69,6 +72,7 @@ import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
@@ -83,6 +87,7 @@ import static java.util.Objects.requireNonNull;
 
 public class StarRocksArrowToPageConverter
 {
+    private static final JsonCodec<Object> JSON_CODEC = jsonCodec(Object.class);
     private static final long MAX_SECONDS_MAGNITUDE = 10_000_000_000L;
     private static final long MAX_MILLIS_MAGNITUDE = 10_000_000_000_000L;
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
@@ -204,6 +209,10 @@ public class StarRocksArrowToPageConverter
     {
         if (type == VARBINARY) {
             type.writeSlice(output, wrappedBuffer(readBinaryValue(vector, index)));
+            return;
+        }
+        if (type.getBaseName().equals(JSON)) {
+            type.writeSlice(output, utf8Slice(readJsonTextValue(vector, index)));
             return;
         }
 
@@ -379,6 +388,49 @@ public class StarRocksArrowToPageConverter
             return fixedSizeBinaryVector.get(index);
         }
         return readTextValue(vector, index).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String readJsonTextValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarCharVector || vector instanceof LargeVarCharVector) {
+            return readTextValue(vector, index);
+        }
+
+        Object value = vector.getObject(index);
+        if (value instanceof Slice slice) {
+            return slice.toStringUtf8();
+        }
+        if (value instanceof CharSequence) {
+            return value.toString();
+        }
+        return JSON_CODEC.toJson(toJsonCompatibleValue(value));
+    }
+
+    private static Object toJsonCompatibleValue(Object value)
+    {
+        if (value == null ||
+                value instanceof Boolean ||
+                value instanceof Number ||
+                value instanceof CharSequence) {
+            return value;
+        }
+        if (value instanceof Slice slice) {
+            return slice.toStringUtf8();
+        }
+        if (value instanceof Map<?, ?> map) {
+            return map.entrySet().stream()
+                    .collect(java.util.stream.Collectors.toMap(
+                            entry -> entry.getKey().toString(),
+                            entry -> toJsonCompatibleValue(entry.getValue())));
+        }
+        if (value instanceof Iterable<?> iterable) {
+            java.util.ArrayList<Object> values = new java.util.ArrayList<>();
+            for (Object element : iterable) {
+                values.add(toJsonCompatibleValue(element));
+            }
+            return values;
+        }
+        return value.toString();
     }
 
     private static String readTextValue(FieldVector vector, int index)

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksArrowToPageConverter.java
@@ -18,11 +18,17 @@ import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
+import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
@@ -57,6 +63,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -84,6 +91,7 @@ import static java.lang.Math.multiplyExact;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
 
 public class StarRocksArrowToPageConverter
 {
@@ -146,6 +154,9 @@ public class StarRocksArrowToPageConverter
                 else if (javaType == Int128.class) {
                     writeLongDecimal(output, (DecimalType) type, vector, index);
                 }
+                else if (type instanceof ArrayType || type instanceof MapType || type instanceof RowType) {
+                    writeObjectValue(output, type, readComplexValue(vector, index));
+                }
                 else {
                     throw unsupportedType(type, vector);
                 }
@@ -205,6 +216,108 @@ public class StarRocksArrowToPageConverter
         decimalType.writeObject(output, Decimals.encodeScaledValue(coerceDecimalValue(vector.getName(), readDecimalValue(vector, index), decimalType), decimalType.getScale()));
     }
 
+    private void writeObjectValue(BlockBuilder output, Type type, Object value)
+    {
+        if (value == null) {
+            output.appendNull();
+            return;
+        }
+        if (type instanceof ArrayType arrayType) {
+            writeArrayValue(output, arrayType, value);
+            return;
+        }
+        if (type instanceof MapType mapType) {
+            writeMapValue(output, mapType, value);
+            return;
+        }
+        if (type instanceof RowType rowType) {
+            writeRowValue(output, rowType, value);
+            return;
+        }
+
+        Class<?> javaType = type.getJavaType();
+        if (javaType == boolean.class) {
+            type.writeBoolean(output, toBooleanValue(value));
+        }
+        else if (javaType == long.class) {
+            writeLongObject(output, type, value);
+        }
+        else if (javaType == double.class) {
+            type.writeDouble(output, ((Number) value).doubleValue());
+        }
+        else if (javaType == Slice.class) {
+            writeSliceObject(output, type, value);
+        }
+        else if (javaType == Int128.class) {
+            DecimalType decimalType = (DecimalType) type;
+            decimalType.writeObject(output, Decimals.encodeScaledValue(coerceDecimalValue(type.getDisplayName(), toBigDecimalValue(value), decimalType), decimalType.getScale()));
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported nested StarRocks value type: " + type);
+        }
+    }
+
+    private void writeArrayValue(BlockBuilder output, ArrayType arrayType, Object value)
+    {
+        if (!(value instanceof Iterable<?> iterable)) {
+            throw new IllegalArgumentException("Expected array value for " + arrayType + ": " + value);
+        }
+        ((ArrayBlockBuilder) output).buildEntry(elementBuilder -> {
+            for (Object element : iterable) {
+                writeObjectValue(elementBuilder, arrayType.getElementType(), element);
+            }
+        });
+    }
+
+    private void writeMapValue(BlockBuilder output, MapType mapType, Object value)
+    {
+        if (value instanceof Map<?, ?> map) {
+            ((MapBlockBuilder) output).buildEntry((keyBuilder, valueBuilder) -> {
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    writeObjectValue(keyBuilder, mapType.getKeyType(), entry.getKey());
+                    writeObjectValue(valueBuilder, mapType.getValueType(), entry.getValue());
+                }
+            });
+            return;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            ((MapBlockBuilder) output).buildEntry((keyBuilder, valueBuilder) -> {
+                for (Object element : iterable) {
+                    if (element instanceof Map<?, ?> entry && entry.containsKey("key") && entry.containsKey("value")) {
+                        writeObjectValue(keyBuilder, mapType.getKeyType(), entry.get("key"));
+                        writeObjectValue(valueBuilder, mapType.getValueType(), entry.get("value"));
+                    }
+                }
+            });
+            return;
+        }
+        throw new IllegalArgumentException("Expected map value for " + mapType + ": " + value);
+    }
+
+    private void writeRowValue(BlockBuilder output, RowType rowType, Object value)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        if (value instanceof Map<?, ?> map) {
+            ((RowBlockBuilder) output).buildEntry(fieldBuilders -> {
+                for (int index = 0; index < fields.size(); index++) {
+                    RowType.Field field = fields.get(index);
+                    writeObjectValue(fieldBuilders.get(index), field.getType(), map.get(field.getName().orElse("field" + index)));
+                }
+            });
+            return;
+        }
+        if (value instanceof List<?> list) {
+            ((RowBlockBuilder) output).buildEntry(fieldBuilders -> {
+                for (int index = 0; index < fields.size(); index++) {
+                    Object fieldValue = index < list.size() ? list.get(index) : null;
+                    writeObjectValue(fieldBuilders.get(index), fields.get(index).getType(), fieldValue);
+                }
+            });
+            return;
+        }
+        throw new IllegalArgumentException("Expected row value for " + rowType + ": " + value);
+    }
+
     private void writeSliceValue(BlockBuilder output, Type type, FieldVector vector, int index)
     {
         if (type == VARBINARY) {
@@ -222,6 +335,112 @@ public class StarRocksArrowToPageConverter
             return;
         }
         type.writeSlice(output, value);
+    }
+
+    private static void writeLongObject(BlockBuilder output, Type type, Object value)
+    {
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            type.writeLong(output, ((Number) value).longValue());
+            return;
+        }
+        if (type == REAL) {
+            type.writeLong(output, floatToRawIntBits(((Number) value).floatValue()));
+            return;
+        }
+        if (type == DATE) {
+            type.writeLong(output, toDateObject(value));
+            return;
+        }
+        if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+            long epochMicros = value instanceof Number number
+                    ? number.longValue()
+                    : toTrinoTimestampMicros(parseTimestampText(value.toString()));
+            if (timestampType.getPrecision() == TIMESTAMP_MICROS.getPrecision()) {
+                type.writeLong(output, epochMicros);
+                return;
+            }
+            type.writeLong(output, round(epochMicros, TIMESTAMP_MICROS.getPrecision() - timestampType.getPrecision()));
+            return;
+        }
+        if (type instanceof DecimalType decimalType && decimalType.isShort()) {
+            decimalType.writeLong(output, encodeShortScaledValue(coerceDecimalValue(type.getDisplayName(), toBigDecimalValue(value), decimalType), decimalType.getScale()));
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported nested StarRocks long value type: " + type);
+    }
+
+    private static void writeSliceObject(BlockBuilder output, Type type, Object value)
+    {
+        if (type == VARBINARY) {
+            type.writeSlice(output, wrappedBuffer(value instanceof byte[] bytes ? bytes : value.toString().getBytes(StandardCharsets.UTF_8)));
+            return;
+        }
+        if (type.getBaseName().equals(JSON)) {
+            String json = value instanceof CharSequence ? value.toString() : JSON_CODEC.toJson(toJsonCompatibleValue(value));
+            type.writeSlice(output, utf8Slice(json));
+            return;
+        }
+
+        Slice slice = utf8Slice(value instanceof Slice valueSlice ? valueSlice.toStringUtf8() : value.toString());
+        if (type instanceof CharType charType) {
+            type.writeSlice(output, truncateToLengthAndTrimSpaces(slice, charType));
+            return;
+        }
+        type.writeSlice(output, slice);
+    }
+
+    private static Object readComplexValue(FieldVector vector, int index)
+    {
+        if (vector instanceof VarCharVector || vector instanceof LargeVarCharVector) {
+            return JSON_CODEC.fromJson(readTextValue(vector, index));
+        }
+        Object value = vector.getObject(index);
+        if (value instanceof CharSequence) {
+            return JSON_CODEC.fromJson(value.toString());
+        }
+        if (value instanceof Slice slice) {
+            return JSON_CODEC.fromJson(slice.toStringUtf8());
+        }
+        return toJsonCompatibleValue(value);
+    }
+
+    private static boolean toBooleanValue(Object value)
+    {
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof Number number) {
+            return number.longValue() != 0;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    private static long toDateObject(Object value)
+    {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof LocalDate localDate) {
+            return localDate.toEpochDay();
+        }
+        return parseDateText(value.toString()).toEpochDay();
+    }
+
+    private static BigDecimal toBigDecimalValue(Object value)
+    {
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (value instanceof BigInteger integer) {
+            return new BigDecimal(integer);
+        }
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
+            return BigDecimal.valueOf(((Number) value).longValue());
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        return new BigDecimal(value.toString());
     }
 
     private static boolean readBoolean(FieldVector vector, int index)
@@ -419,12 +638,12 @@ public class StarRocksArrowToPageConverter
         }
         if (value instanceof Map<?, ?> map) {
             return map.entrySet().stream()
-                    .collect(java.util.stream.Collectors.toMap(
+                    .collect(toMap(
                             entry -> entry.getKey().toString(),
                             entry -> toJsonCompatibleValue(entry.getValue())));
         }
         if (value instanceof Iterable<?> iterable) {
-            java.util.ArrayList<Object> values = new java.util.ArrayList<>();
+            ArrayList<Object> values = new ArrayList<>();
             for (Object element : iterable) {
                 values.add(toJsonCompatibleValue(element));
             }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksColumnHandle.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksColumnHandle.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksColumnHandle(String columnName, String remoteColumnName, Type columnType, int ordinalPosition)
+        implements ColumnHandle
+{
+    public StarRocksColumnHandle
+    {
+        requireNonNull(columnName, "columnName is null");
+        requireNonNull(remoteColumnName, "remoteColumnName is null");
+        requireNonNull(columnType, "columnType is null");
+    }
+
+    public ColumnMetadata getColumnMetadata()
+    {
+        return new ColumnMetadata(columnName, columnType);
+    }
+
+    @Override
+    public String toString()
+    {
+        return columnName + ":" + columnType;
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.DataSize;
+import io.airlift.units.MinDataSize;
+import jakarta.validation.constraints.Min;
+
+import java.io.File;
+import java.util.Optional;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class StarRocksConfig
+{
+    private String jdbcUrl;
+    private String catalogName;
+    private String username;
+    private String password;
+    private String flightSqlHost;
+    private int flightSqlPort = 9408;
+    private boolean flightSqlTlsEnabled;
+    private File flightSqlTlsRootCertificate;
+    private boolean flightSqlTlsSkipVerify;
+    private String flightSqlTlsOverrideHostname;
+    private DataSize flightSqlMaxAllocation = DataSize.of(256, MEGABYTE);
+
+    public Optional<String> getJdbcUrl()
+    {
+        return Optional.ofNullable(jdbcUrl);
+    }
+
+    @Config("starrocks.jdbc-url")
+    @ConfigDescription("StarRocks JDBC URL used for metadata discovery")
+    public StarRocksConfig setJdbcUrl(String jdbcUrl)
+    {
+        this.jdbcUrl = jdbcUrl;
+        return this;
+    }
+
+    public Optional<String> getCatalogName()
+    {
+        return Optional.ofNullable(catalogName);
+    }
+
+    @Config("starrocks.catalog-name")
+    @ConfigDescription("StarRocks catalog name to expose through this Trino catalog")
+    public StarRocksConfig setCatalogName(String catalogName)
+    {
+        this.catalogName = catalogName;
+        return this;
+    }
+
+    public Optional<String> getUsername()
+    {
+        return Optional.ofNullable(username);
+    }
+
+    @Config("starrocks.username")
+    @ConfigDescription("StarRocks username")
+    public StarRocksConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    public Optional<String> getPassword()
+    {
+        return Optional.ofNullable(password);
+    }
+
+    @Config("starrocks.password")
+    @ConfigSecuritySensitive
+    public StarRocksConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    public Optional<String> getFlightSqlHost()
+    {
+        return Optional.ofNullable(flightSqlHost);
+    }
+
+    @Config("starrocks.flight-sql-host")
+    @ConfigDescription("StarRocks FE host used for Arrow Flight SQL reads")
+    public StarRocksConfig setFlightSqlHost(String flightSqlHost)
+    {
+        this.flightSqlHost = flightSqlHost;
+        return this;
+    }
+
+    @Min(1)
+    public int getFlightSqlPort()
+    {
+        return flightSqlPort;
+    }
+
+    @Config("starrocks.flight-sql-port")
+    @ConfigDescription("StarRocks FE Arrow Flight SQL port used for reads")
+    public StarRocksConfig setFlightSqlPort(int flightSqlPort)
+    {
+        this.flightSqlPort = flightSqlPort;
+        return this;
+    }
+
+    public boolean isFlightSqlTlsEnabled()
+    {
+        return flightSqlTlsEnabled;
+    }
+
+    @Config("starrocks.flight-sql.tls.enabled")
+    @ConfigDescription("Use TLS for Arrow Flight SQL connections")
+    public StarRocksConfig setFlightSqlTlsEnabled(boolean flightSqlTlsEnabled)
+    {
+        this.flightSqlTlsEnabled = flightSqlTlsEnabled;
+        return this;
+    }
+
+    public Optional<File> getFlightSqlTlsRootCertificate()
+    {
+        return Optional.ofNullable(flightSqlTlsRootCertificate);
+    }
+
+    @Config("starrocks.flight-sql.tls.root-certificate")
+    @ConfigDescription("Path to a PEM root certificate file for Arrow Flight SQL TLS")
+    public StarRocksConfig setFlightSqlTlsRootCertificate(File flightSqlTlsRootCertificate)
+    {
+        this.flightSqlTlsRootCertificate = flightSqlTlsRootCertificate;
+        return this;
+    }
+
+    public boolean isFlightSqlTlsSkipVerify()
+    {
+        return flightSqlTlsSkipVerify;
+    }
+
+    @Config("starrocks.flight-sql.tls.skip-verify")
+    @ConfigDescription("Skip Arrow Flight SQL TLS server certificate verification")
+    public StarRocksConfig setFlightSqlTlsSkipVerify(boolean flightSqlTlsSkipVerify)
+    {
+        this.flightSqlTlsSkipVerify = flightSqlTlsSkipVerify;
+        return this;
+    }
+
+    public Optional<String> getFlightSqlTlsOverrideHostname()
+    {
+        return Optional.ofNullable(flightSqlTlsOverrideHostname);
+    }
+
+    @Config("starrocks.flight-sql.tls.override-hostname")
+    @ConfigDescription("Hostname to use for Arrow Flight SQL TLS verification")
+    public StarRocksConfig setFlightSqlTlsOverrideHostname(String flightSqlTlsOverrideHostname)
+    {
+        this.flightSqlTlsOverrideHostname = flightSqlTlsOverrideHostname;
+        return this;
+    }
+
+    @MinDataSize("1MB")
+    public DataSize getFlightSqlMaxAllocation()
+    {
+        return flightSqlMaxAllocation;
+    }
+
+    @Config("starrocks.flight-sql.max-allocation")
+    @ConfigDescription("Maximum Arrow memory allocation per StarRocks Flight SQL stream")
+    public StarRocksConfig setFlightSqlMaxAllocation(DataSize flightSqlMaxAllocation)
+    {
+        this.flightSqlMaxAllocation = flightSqlMaxAllocation;
+        return this;
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.Min;
+
+import java.util.Optional;
+
+public class StarRocksConfig
+{
+    private String jdbcUrl;
+    private String username;
+    private String password;
+    private String flightSqlHost;
+    private int flightSqlPort = 9408;
+
+    public Optional<String> getJdbcUrl()
+    {
+        return Optional.ofNullable(jdbcUrl);
+    }
+
+    @Config("starrocks.jdbc-url")
+    @ConfigDescription("StarRocks JDBC URL used for metadata discovery")
+    public StarRocksConfig setJdbcUrl(String jdbcUrl)
+    {
+        this.jdbcUrl = jdbcUrl;
+        return this;
+    }
+
+    public Optional<String> getUsername()
+    {
+        return Optional.ofNullable(username);
+    }
+
+    @Config("starrocks.username")
+    @ConfigDescription("StarRocks username")
+    public StarRocksConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    public Optional<String> getPassword()
+    {
+        return Optional.ofNullable(password);
+    }
+
+    @Config("starrocks.password")
+    @ConfigSecuritySensitive
+    public StarRocksConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    public Optional<String> getFlightSqlHost()
+    {
+        return Optional.ofNullable(flightSqlHost);
+    }
+
+    @Config("starrocks.flight-sql-host")
+    @ConfigDescription("StarRocks FE host used for Arrow Flight SQL reads")
+    public StarRocksConfig setFlightSqlHost(String flightSqlHost)
+    {
+        this.flightSqlHost = flightSqlHost;
+        return this;
+    }
+
+    @Min(1)
+    public int getFlightSqlPort()
+    {
+        return flightSqlPort;
+    }
+
+    @Config("starrocks.flight-sql-port")
+    @ConfigDescription("StarRocks FE Arrow Flight SQL port used for reads")
+    public StarRocksConfig setFlightSqlPort(int flightSqlPort)
+    {
+        this.flightSqlPort = flightSqlPort;
+        return this;
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.Min;
 
+import java.io.File;
 import java.util.Optional;
 
 public class StarRocksConfig
@@ -28,6 +29,10 @@ public class StarRocksConfig
     private String password;
     private String flightSqlHost;
     private int flightSqlPort = 9408;
+    private boolean flightSqlTlsEnabled;
+    private File flightSqlTlsRootCertificate;
+    private boolean flightSqlTlsSkipVerify;
+    private String flightSqlTlsOverrideHostname;
 
     public Optional<String> getJdbcUrl()
     {
@@ -105,6 +110,58 @@ public class StarRocksConfig
     public StarRocksConfig setFlightSqlPort(int flightSqlPort)
     {
         this.flightSqlPort = flightSqlPort;
+        return this;
+    }
+
+    public boolean isFlightSqlTlsEnabled()
+    {
+        return flightSqlTlsEnabled;
+    }
+
+    @Config("starrocks.flight-sql.tls.enabled")
+    @ConfigDescription("Use TLS for Arrow Flight SQL connections")
+    public StarRocksConfig setFlightSqlTlsEnabled(boolean flightSqlTlsEnabled)
+    {
+        this.flightSqlTlsEnabled = flightSqlTlsEnabled;
+        return this;
+    }
+
+    public Optional<File> getFlightSqlTlsRootCertificate()
+    {
+        return Optional.ofNullable(flightSqlTlsRootCertificate);
+    }
+
+    @Config("starrocks.flight-sql.tls.root-certificate")
+    @ConfigDescription("Path to a PEM root certificate file for Arrow Flight SQL TLS")
+    public StarRocksConfig setFlightSqlTlsRootCertificate(File flightSqlTlsRootCertificate)
+    {
+        this.flightSqlTlsRootCertificate = flightSqlTlsRootCertificate;
+        return this;
+    }
+
+    public boolean isFlightSqlTlsSkipVerify()
+    {
+        return flightSqlTlsSkipVerify;
+    }
+
+    @Config("starrocks.flight-sql.tls.skip-verify")
+    @ConfigDescription("Skip Arrow Flight SQL TLS server certificate verification")
+    public StarRocksConfig setFlightSqlTlsSkipVerify(boolean flightSqlTlsSkipVerify)
+    {
+        this.flightSqlTlsSkipVerify = flightSqlTlsSkipVerify;
+        return this;
+    }
+
+    public Optional<String> getFlightSqlTlsOverrideHostname()
+    {
+        return Optional.ofNullable(flightSqlTlsOverrideHostname);
+    }
+
+    @Config("starrocks.flight-sql.tls.override-hostname")
+    @ConfigDescription("Hostname to use for Arrow Flight SQL TLS verification")
+    public StarRocksConfig setFlightSqlTlsOverrideHostname(String flightSqlTlsOverrideHostname)
+    {
+        this.flightSqlTlsOverrideHostname = flightSqlTlsOverrideHostname;
         return this;
     }
 }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConfig.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 public class StarRocksConfig
 {
     private String jdbcUrl;
+    private String catalogName;
     private String username;
     private String password;
     private String flightSqlHost;
@@ -38,6 +39,19 @@ public class StarRocksConfig
     public StarRocksConfig setJdbcUrl(String jdbcUrl)
     {
         this.jdbcUrl = jdbcUrl;
+        return this;
+    }
+
+    public Optional<String> getCatalogName()
+    {
+        return Optional.ofNullable(catalogName);
+    }
+
+    @Config("starrocks.catalog-name")
+    @ConfigDescription("StarRocks catalog name to expose through this Trino catalog")
+    public StarRocksConfig setCatalogName(String catalogName)
+    {
+        this.catalogName = catalogName;
         return this;
     }
 

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConnector.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConnector.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.transaction.IsolationLevel;
+
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final StarRocksMetadata metadata;
+    private final StarRocksSplitManager splitManager;
+    private final StarRocksPageSourceProvider pageSourceProvider;
+
+    @Inject
+    public StarRocksConnector(
+            LifeCycleManager lifeCycleManager,
+            StarRocksMetadata metadata,
+            StarRocksSplitManager splitManager,
+            StarRocksPageSourceProvider pageSourceProvider)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return StarRocksTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return pageSourceProvider;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConnectorFactory.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksConnectorFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.base.TypeDeserializerModule;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksConnectorFactory
+        implements ConnectorFactory
+{
+    private final Optional<Module> extension;
+
+    public StarRocksConnectorFactory()
+    {
+        this(Optional.empty());
+    }
+
+    StarRocksConnectorFactory(Optional<Module> extension)
+    {
+        this.extension = requireNonNull(extension, "extension is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return "starrocks";
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(requiredConfig, "requiredConfig is null");
+        checkStrictSpiVersionMatch(context, this);
+
+        Module starRocksModule = extension
+                .map(module -> Modules.override(new StarRocksModule()).with(module))
+                .orElseGet(StarRocksModule::new);
+
+        List<Module> modules = ImmutableList.of(
+                new JsonModule(),
+                new TypeDeserializerModule(),
+                new ConnectorContextModule(catalogName, context),
+                starRocksModule);
+
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.catalog." + catalogName,
+                modules);
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(requiredConfig)
+                .initialize();
+
+        return injector.getInstance(StarRocksConnector.class);
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlClient.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSession;
+
+import java.util.List;
+
+public interface StarRocksFlightSqlClient
+{
+    List<StarRocksSplit> getSplits(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            List<StarRocksColumnHandle> columns);
+
+    StarRocksFlightSqlResult openStream(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            StarRocksSplit split,
+            List<StarRocksColumnHandle> columns);
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlClient.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSession;
+
+import java.util.List;
+
+public interface StarRocksFlightSqlClient
+{
+    StarRocksFlightSqlResult openStream(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            StarRocksSplit split,
+            List<StarRocksColumnHandle> columns);
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlClient.java
@@ -19,6 +19,11 @@ import java.util.List;
 
 public interface StarRocksFlightSqlClient
 {
+    List<StarRocksSplit> getSplits(
+            ConnectorSession session,
+            StarRocksTableHandle tableHandle,
+            List<StarRocksColumnHandle> columns);
+
     StarRocksFlightSqlResult openStream(
             ConnectorSession session,
             StarRocksTableHandle tableHandle,

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlPageSource.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlPageSource.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.PageBuilder;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import java.util.List;
+import java.util.OptionalLong;
+
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksFlightSqlPageSource
+        implements ConnectorPageSource
+{
+    private final StarRocksFlightSqlResult result;
+    private final StarRocksArrowToPageConverter converter;
+    private final List<StarRocksColumnHandle> columns;
+    private final PageBuilder pageBuilder;
+
+    private long completedBytes;
+    private long completedPositions;
+    private long readTimeNanos;
+    private boolean finished;
+
+    public StarRocksFlightSqlPageSource(
+            StarRocksFlightSqlResult result,
+            StarRocksArrowToPageConverter converter,
+            List<StarRocksColumnHandle> columns)
+    {
+        this.result = requireNonNull(result, "result is null");
+        this.converter = requireNonNull(converter, "converter is null");
+        this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
+        this.pageBuilder = new PageBuilder(this.columns.stream()
+                .map(StarRocksColumnHandle::columnType)
+                .toList());
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        if (finished) {
+            return null;
+        }
+
+        LoadedPage currentPage = loadNextPage();
+        if (currentPage == null) {
+            finished = true;
+            return null;
+        }
+
+        completedPositions += currentPage.positionCount();
+        completedBytes += currentPage.completedBytes();
+        readTimeNanos += currentPage.readTimeNanos();
+        return currentPage.sourcePage();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return result.getMemoryUsage() + pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void close()
+    {
+        finished = true;
+        result.close();
+    }
+
+    private LoadedPage loadNextPage()
+    {
+        while (true) {
+            long start = System.nanoTime();
+            boolean hasBatch = result.loadNextBatch();
+            long batchReadTimeNanos = System.nanoTime() - start;
+
+            if (!hasBatch) {
+                return null;
+            }
+
+            VectorSchemaRoot root = result.getVectorSchemaRoot();
+            if (root.getRowCount() == 0) {
+                readTimeNanos += batchReadTimeNanos;
+                continue;
+            }
+
+            long batchBytes = root.getFieldVectors().stream()
+                    .mapToLong(FieldVector::getBufferSize)
+                    .sum();
+            return new LoadedPage(
+                    SourcePage.create(converter.convert(pageBuilder, columns, root)),
+                    root.getRowCount(),
+                    batchBytes,
+                    batchReadTimeNanos);
+        }
+    }
+
+    private record LoadedPage(SourcePage sourcePage, int positionCount, long completedBytes, long readTimeNanos) {}
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlResult.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksFlightSqlResult.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+interface StarRocksFlightSqlResult
+        extends AutoCloseable
+{
+    boolean loadNextBatch();
+
+    VectorSchemaRoot getVectorSchemaRoot();
+
+    long getMemoryUsage();
+
+    @Override
+    void close();
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksJdbcConnectionFactory.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksJdbcConnectionFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksJdbcConnectionFactory
+{
+    private final Driver driver;
+    private final String jdbcUrl;
+    private final Properties connectionProperties;
+
+    @Inject
+    public StarRocksJdbcConnectionFactory(StarRocksConfig config)
+    {
+        this(createDriver(),
+                requireNonNull(config, "config is null").getJdbcUrl()
+                        .orElseThrow(() -> new IllegalArgumentException("starrocks.jdbc-url must be set")),
+                createConnectionProperties(config));
+    }
+
+    StarRocksJdbcConnectionFactory(Driver driver, String jdbcUrl, Properties connectionProperties)
+    {
+        this.driver = requireNonNull(driver, "driver is null");
+        this.jdbcUrl = requireNonNull(jdbcUrl, "jdbcUrl is null");
+        this.connectionProperties = new Properties();
+        this.connectionProperties.putAll(requireNonNull(connectionProperties, "connectionProperties is null"));
+    }
+
+    public Connection openConnection()
+            throws SQLException
+    {
+        return openPhysicalConnection();
+    }
+
+    public Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return openConnection();
+    }
+
+    private Connection openPhysicalConnection()
+            throws SQLException
+    {
+        Properties properties = new Properties();
+        properties.putAll(connectionProperties);
+
+        Connection connection = driver.connect(jdbcUrl, properties);
+        if (connection == null) {
+            throw new SQLException("StarRocks JDBC driver refused configured URL");
+        }
+        connection.setReadOnly(true);
+        return connection;
+    }
+
+    private static Driver createDriver()
+    {
+        try {
+            return new com.starrocks.cj.jdbc.Driver();
+        }
+        catch (SQLException e) {
+            throw jdbcOperationFailed("Failed to initialize StarRocks JDBC driver", e);
+        }
+    }
+
+    static TrinoException jdbcOperationFailed(String message, SQLException cause)
+    {
+        return new TrinoException(GENERIC_INTERNAL_ERROR, message, cause);
+    }
+
+    private static Properties createConnectionProperties(StarRocksConfig config)
+    {
+        Properties connectionProperties = new Properties();
+        config.getUsername().ifPresent(value -> connectionProperties.setProperty("user", value));
+        config.getPassword().ifPresent(value -> connectionProperties.setProperty("password", value));
+        return connectionProperties;
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksJdbcConnectionFactory.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksJdbcConnectionFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksJdbcConnectionFactory
+{
+    private final Driver driver;
+    private final String jdbcUrl;
+    private final Properties connectionProperties;
+
+    @Inject
+    public StarRocksJdbcConnectionFactory(StarRocksConfig config)
+    {
+        this(
+                createDriver(),
+                requireNonNull(config, "config is null").getJdbcUrl()
+                        .orElseThrow(() -> new IllegalArgumentException("starrocks.jdbc-url must be set")),
+                createConnectionProperties(config));
+    }
+
+    StarRocksJdbcConnectionFactory(Driver driver, String jdbcUrl, Properties connectionProperties)
+    {
+        this.driver = requireNonNull(driver, "driver is null");
+        this.jdbcUrl = requireNonNull(jdbcUrl, "jdbcUrl is null");
+        this.connectionProperties = new Properties();
+        this.connectionProperties.putAll(requireNonNull(connectionProperties, "connectionProperties is null"));
+    }
+
+    public Connection openConnection()
+            throws SQLException
+    {
+        return openPhysicalConnection();
+    }
+
+    public Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return openConnection();
+    }
+
+    private Connection openPhysicalConnection()
+            throws SQLException
+    {
+        Properties properties = new Properties();
+        properties.putAll(connectionProperties);
+
+        Connection connection = driver.connect(jdbcUrl, properties);
+        if (connection == null) {
+            throw new SQLException("StarRocks JDBC driver refused URL: " + jdbcUrl);
+        }
+        connection.setReadOnly(true);
+        return connection;
+    }
+
+    private static Driver createDriver()
+    {
+        try {
+            return new com.starrocks.cj.jdbc.Driver();
+        }
+        catch (SQLException e) {
+            throw jdbcOperationFailed("Failed to initialize StarRocks JDBC driver", e);
+        }
+    }
+
+    static TrinoException jdbcOperationFailed(String message, SQLException cause)
+    {
+        return new TrinoException(GENERIC_INTERNAL_ERROR, message, cause);
+    }
+
+    private static Properties createConnectionProperties(StarRocksConfig config)
+    {
+        Properties connectionProperties = new Properties();
+        config.getUsername().ifPresent(value -> connectionProperties.setProperty("user", value));
+        config.getPassword().ifPresent(value -> connectionProperties.setProperty("password", value));
+        return connectionProperties;
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
@@ -1,0 +1,531 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.Assignment;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksMetadata
+        implements ConnectorMetadata
+{
+    private final StarRocksMetadataClient metadataClient;
+    private final StarRocksTypeMapper typeMapper;
+
+    @Inject
+    public StarRocksMetadata(StarRocksMetadataClient metadataClient, StarRocksTypeMapper typeMapper)
+    {
+        this.metadataClient = requireNonNull(metadataClient, "metadataClient is null");
+        this.typeMapper = requireNonNull(typeMapper, "typeMapper is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return metadataClient.listSchemaNames(session);
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion)
+    {
+        if (startVersion.isPresent() || endVersion.isPresent()) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support versioned tables");
+        }
+
+        return metadataClient.getTable(session, tableName)
+                .map(remoteTable -> new StarRocksTableHandle(
+                        tableName.getSchemaName(),
+                        tableName.getTableName(),
+                        remoteTable.remoteCatalogName(),
+                        remoteTable.remoteSchemaName(),
+                        remoteTable.remoteTableName(),
+                        remoteTable.relationType()))
+                .orElse(null);
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> optionalSchemaName)
+    {
+        return metadataClient.listTables(session, optionalSchemaName);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        StarRocksTableHandle tableHandle = (StarRocksTableHandle) table;
+        return getRemoteTable(session, tableHandle)
+                .map(this::toTableMetadata)
+                .orElse(null);
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        StarRocksTableHandle starRocksTableHandle = (StarRocksTableHandle) tableHandle;
+        StarRocksRemoteTable remoteTable = getRemoteTable(session, starRocksTableHandle)
+                .orElseThrow(() -> new TableNotFoundException(starRocksTableHandle.toSchemaTableName()));
+
+        Map<String, ColumnHandle> columnHandles = new LinkedHashMap<>();
+        for (StarRocksColumnHandle columnHandle : toColumnHandles(remoteTable.columns())) {
+            ColumnHandle previous = columnHandles.putIfAbsent(columnHandle.columnName(), columnHandle);
+            if (previous != null) {
+                throw new TrinoException(NOT_SUPPORTED, "Duplicate column after case folding: " + columnHandle.columnName());
+            }
+        }
+        return Collections.unmodifiableMap(columnHandles);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+
+        Map<SchemaTableName, List<ColumnMetadata>> tableColumns = new LinkedHashMap<>();
+        for (SchemaTableName tableName : listTables(session, prefix)) {
+            getRemoteTable(session, tableName).ifPresent(remoteTable -> tableColumns.put(tableName, toColumnMetadata(remoteTable.columns())));
+        }
+        return Collections.unmodifiableMap(tableColumns);
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return ((StarRocksColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.aggregation().isPresent() || !handle.constraint().isAll() || handle.limit().isPresent()) {
+            return TableStatistics.empty();
+        }
+
+        OptionalLong rowCount = metadataClient.getTableRowCount(session, handle.toSchemaTableName());
+        if (rowCount.isEmpty()) {
+            return TableStatistics.empty();
+        }
+
+        return TableStatistics.builder()
+                .setRowCount(Estimate.of((double) rowCount.getAsLong()))
+                .build();
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle table, long limit)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.limit().isPresent() && handle.limit().getAsLong() <= limit) {
+            return Optional.empty();
+        }
+        return Optional.of(new LimitApplicationResult<>(handle.withLimit(limit), true, false));
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.aggregation().isPresent() || handle.limit().isPresent() || !handle.sortOrder().isEmpty()) {
+            return Optional.empty();
+        }
+        if (constraint.getSummary().isNone()) {
+            if (handle.constraint().isNone()) {
+                return Optional.empty();
+            }
+            return Optional.of(new ConstraintApplicationResult<>(
+                    handle.withConstraint(TupleDomain.none()),
+                    TupleDomain.all(),
+                    constraint.getExpression(),
+                    false));
+        }
+
+        Map<StarRocksColumnHandle, Domain> supported = new LinkedHashMap<>();
+        Map<ColumnHandle, Domain> unsupported = new LinkedHashMap<>();
+        if (constraint.getSummary().getDomains().isPresent()) {
+            for (Map.Entry<ColumnHandle, Domain> entry : constraint.getSummary().getDomains().orElseThrow().entrySet()) {
+                if (entry.getKey() instanceof StarRocksColumnHandle columnHandle &&
+                        StarRocksQueryBuilder.buildColumnPredicate(columnHandle, entry.getValue()).isPresent()) {
+                    supported.put(columnHandle, entry.getValue());
+                }
+                else {
+                    unsupported.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        TupleDomain<StarRocksColumnHandle> newDomain = handle.constraint().intersect(TupleDomain.withColumnDomains(supported));
+        if (handle.constraint().equals(newDomain)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ConstraintApplicationResult<>(
+                handle.withConstraint(newDomain),
+                TupleDomain.withColumnDomains(unsupported),
+                constraint.getExpression(),
+                false));
+    }
+
+    @Override
+    public Optional<TopNApplicationResult<ConnectorTableHandle>> applyTopN(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            long topNCount,
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        List<StarRocksSortItem> sortOrder = toStarRocksSortOrder(sortItems, assignments);
+        if (sortOrder.isEmpty()) {
+            return Optional.empty();
+        }
+        if (handle.sortOrder().equals(sortOrder) && handle.limit().isPresent() && handle.limit().getAsLong() <= topNCount) {
+            return Optional.empty();
+        }
+        if (handle.limit().isPresent() || !handle.sortOrder().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new TopNApplicationResult<>(handle.withTopN(topNCount, sortOrder), true, false));
+    }
+
+    @Override
+    public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+
+        List<StarRocksColumnHandle> projectedColumns = new ArrayList<>(assignments.size());
+        List<Assignment> resultAssignments = new ArrayList<>(assignments.size());
+        for (Map.Entry<String, ColumnHandle> entry : assignments.entrySet()) {
+            if (!(entry.getValue() instanceof StarRocksColumnHandle columnHandle)) {
+                return Optional.empty();
+            }
+            projectedColumns.add(columnHandle);
+            resultAssignments.add(new Assignment(entry.getKey(), columnHandle, columnHandle.columnType()));
+        }
+
+        if (handle.projectedColumns().isPresent() && containSameElements(handle.projectedColumns().orElseThrow(), projectedColumns)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ProjectionApplicationResult<>(
+                handle.withProjectedColumns(projectedColumns),
+                projections,
+                resultAssignments,
+                false));
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            List<AggregateFunction> aggregates,
+            Map<String, ColumnHandle> assignments,
+            List<List<ColumnHandle>> groupingSets)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.aggregation().isPresent() || handle.limit().isPresent() || !handle.sortOrder().isEmpty()) {
+            return Optional.empty();
+        }
+        if (groupingSets.size() != 1) {
+            return Optional.empty();
+        }
+
+        List<StarRocksColumnHandle> groupingColumns = new ArrayList<>();
+        for (ColumnHandle groupingColumn : groupingSets.getFirst()) {
+            if (!(groupingColumn instanceof StarRocksColumnHandle starRocksColumnHandle)) {
+                return Optional.empty();
+            }
+            groupingColumns.add(starRocksColumnHandle);
+        }
+
+        List<ConnectorExpression> projections = new ArrayList<>(aggregates.size());
+        List<Assignment> resultAssignments = new ArrayList<>(aggregates.size());
+        List<StarRocksAggregateColumn> aggregateColumns = new ArrayList<>(aggregates.size());
+        for (int index = 0; index < aggregates.size(); index++) {
+            AggregateFunction aggregate = aggregates.get(index);
+            Optional<String> aggregateExpression = toAggregationExpression(aggregate, assignments);
+            if (aggregateExpression.isEmpty()) {
+                return Optional.empty();
+            }
+
+            String columnName = "_starrocks_agg_" + index;
+            StarRocksAggregateColumn aggregateColumn = new StarRocksAggregateColumn(columnName, aggregateExpression.orElseThrow(), aggregate.getOutputType());
+            StarRocksColumnHandle columnHandle = new StarRocksColumnHandle(columnName, columnName, aggregate.getOutputType(), groupingColumns.size() + index);
+            aggregateColumns.add(aggregateColumn);
+            projections.add(new Variable(columnName, aggregate.getOutputType()));
+            resultAssignments.add(new Assignment(columnName, columnHandle, aggregate.getOutputType()));
+        }
+
+        return Optional.of(new AggregationApplicationResult<>(
+                handle.withAggregation(new StarRocksAggregation(groupingColumns, aggregateColumns)),
+                projections,
+                resultAssignments,
+                Map.of(),
+                false));
+    }
+
+    private Optional<StarRocksRemoteTable> getRemoteTable(ConnectorSession session, StarRocksTableHandle tableHandle)
+    {
+        return getRemoteTable(session, tableHandle.toSchemaTableName());
+    }
+
+    private Optional<StarRocksRemoteTable> getRemoteTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return metadataClient.getTable(session, tableName);
+    }
+
+    private ConnectorTableMetadata toTableMetadata(StarRocksRemoteTable remoteTable)
+    {
+        return new ConnectorTableMetadata(remoteTable.schemaTableName(), toColumnMetadata(remoteTable.columns()));
+    }
+
+    private List<ColumnMetadata> toColumnMetadata(List<StarRocksRemoteColumn> columns)
+    {
+        List<ColumnMetadata> columnMetadata = new ArrayList<>(columns.size());
+        for (StarRocksRemoteColumn column : columns) {
+            if (!isReadableColumn(column)) {
+                continue;
+            }
+            columnMetadata.add(new ColumnMetadata(column.columnName(), typeMapper.toTrinoType(column)));
+        }
+        return List.copyOf(columnMetadata);
+    }
+
+    private List<StarRocksColumnHandle> toColumnHandles(List<StarRocksRemoteColumn> columns)
+    {
+        List<StarRocksColumnHandle> columnHandles = new ArrayList<>(columns.size());
+        for (StarRocksRemoteColumn column : columns) {
+            if (!isReadableColumn(column)) {
+                continue;
+            }
+            columnHandles.add(new StarRocksColumnHandle(
+                    column.columnName(),
+                    column.remoteColumnName(),
+                    typeMapper.toTrinoType(column),
+                    column.ordinalPosition() - 1));
+        }
+        return List.copyOf(columnHandles);
+    }
+
+    private static boolean isReadableColumn(StarRocksRemoteColumn column)
+    {
+        return !remoteBaseType(column).equals("HLL");
+    }
+
+    private static String remoteBaseType(StarRocksRemoteColumn column)
+    {
+        String typeDeclaration = column.typeDefinition()
+                .orElse(column.typeName())
+                .trim();
+        int parenthesisStart = typeDeclaration.indexOf('(');
+        int angleBracketStart = typeDeclaration.indexOf('<');
+        int typeParameterStart = parenthesisStart < 0 ? angleBracketStart : (angleBracketStart < 0 ? parenthesisStart : Math.min(parenthesisStart, angleBracketStart));
+        if (typeParameterStart >= 0) {
+            typeDeclaration = typeDeclaration.substring(0, typeParameterStart);
+        }
+        return typeDeclaration.trim()
+                .toUpperCase(Locale.ENGLISH)
+                .replace(' ', '_');
+    }
+
+    private static List<StarRocksSortItem> toStarRocksSortOrder(List<SortItem> sortItems, Map<String, ColumnHandle> assignments)
+    {
+        List<StarRocksSortItem> sortOrder = new ArrayList<>(sortItems.size());
+        for (SortItem sortItem : sortItems) {
+            ColumnHandle columnHandle = assignments.get(sortItem.getName());
+            if (!(columnHandle instanceof StarRocksColumnHandle starRocksColumnHandle) || !isTopNPushdownSupported(starRocksColumnHandle.columnType())) {
+                return List.of();
+            }
+            sortOrder.add(new StarRocksSortItem(starRocksColumnHandle.columnName(), starRocksColumnHandle.remoteColumnName(), sortItem.getSortOrder()));
+        }
+        return List.copyOf(sortOrder);
+    }
+
+    private static Optional<String> toAggregationExpression(AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
+    {
+        if (aggregate.isDistinct() ||
+                aggregate.getFilter().isPresent() ||
+                !aggregate.getSortItems().isEmpty()) {
+            return Optional.empty();
+        }
+        String functionName = aggregate.getFunctionName().toLowerCase(Locale.ENGLISH);
+        if (functionName.equals("count")) {
+            return toCountAggregationExpression(aggregate, assignments);
+        }
+        if (!List.of("avg", "max", "min", "sum").contains(functionName)) {
+            return Optional.empty();
+        }
+        if (aggregate.getArguments().size() != 1) {
+            return Optional.empty();
+        }
+
+        ConnectorExpression argument = aggregate.getArguments().getFirst();
+        if (!(argument instanceof Variable variable)) {
+            return Optional.empty();
+        }
+        ColumnHandle columnHandle = assignments.get(variable.getName());
+        if (!(columnHandle instanceof StarRocksColumnHandle starRocksColumnHandle)) {
+            return Optional.empty();
+        }
+        if (functionName.equals("avg") && !isAverageAggregationSupported(starRocksColumnHandle.columnType())) {
+            return Optional.empty();
+        }
+        if (functionName.equals("sum") && !isSumAggregationSupported(starRocksColumnHandle.columnType())) {
+            return Optional.empty();
+        }
+        if (List.of("max", "min").contains(functionName) && !isMinMaxAggregationSupported(starRocksColumnHandle.columnType())) {
+            return Optional.empty();
+        }
+
+        return Optional.of(functionName + "(" + StarRocksQueryBuilder.quoteIdentifier(starRocksColumnHandle.remoteColumnName()) + ")");
+    }
+
+    private static Optional<String> toCountAggregationExpression(AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
+    {
+        if (aggregate.getArguments().isEmpty()) {
+            return Optional.of("count(*)");
+        }
+        if (aggregate.getArguments().size() != 1) {
+            return Optional.empty();
+        }
+
+        ConnectorExpression argument = aggregate.getArguments().getFirst();
+        if (argument instanceof Variable variable) {
+            ColumnHandle columnHandle = assignments.get(variable.getName());
+            if (columnHandle instanceof StarRocksColumnHandle starRocksColumnHandle) {
+                return Optional.of("count(" + StarRocksQueryBuilder.quoteIdentifier(starRocksColumnHandle.remoteColumnName()) + ")");
+            }
+            return Optional.empty();
+        }
+        if (argument instanceof Constant constant) {
+            if (constant.getValue() == null) {
+                return Optional.of("count(NULL)");
+            }
+            return Optional.of("count(*)");
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isTopNPushdownSupported(Type type)
+    {
+        return isNumericType(type) ||
+                type == DATE ||
+                type instanceof TimestampType;
+    }
+
+    private static boolean isAverageAggregationSupported(Type type)
+    {
+        return isIntegerType(type) ||
+                type == REAL ||
+                type == DOUBLE;
+    }
+
+    private static boolean isSumAggregationSupported(Type type)
+    {
+        return isIntegerType(type) ||
+                type == REAL ||
+                type == DOUBLE;
+    }
+
+    private static boolean isMinMaxAggregationSupported(Type type)
+    {
+        return isNumericType(type) ||
+                type == DATE ||
+                type instanceof TimestampType;
+    }
+
+    private static boolean isNumericType(Type type)
+    {
+        return isIntegerType(type) ||
+                type == REAL ||
+                type == DOUBLE ||
+                type instanceof DecimalType;
+    }
+
+    private static boolean isIntegerType(Type type)
+    {
+        return type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT;
+    }
+
+    private static boolean containSameElements(List<StarRocksColumnHandle> left, List<StarRocksColumnHandle> right)
+    {
+        return left.size() == right.size() && new HashSet<>(left).equals(new HashSet<>(right));
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getTable().isPresent()) {
+            return List.of(prefix.toSchemaTableName());
+        }
+        return listTables(session, prefix.getSchema());
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
+import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
@@ -40,16 +41,26 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.util.Objects.requireNonNull;
 
 public class StarRocksMetadata
@@ -238,6 +249,36 @@ public class StarRocksMetadata
     }
 
     @Override
+    public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+
+        List<StarRocksColumnHandle> projectedColumns = new ArrayList<>(assignments.size());
+        List<Assignment> resultAssignments = new ArrayList<>(assignments.size());
+        for (Map.Entry<String, ColumnHandle> entry : assignments.entrySet()) {
+            if (!(entry.getValue() instanceof StarRocksColumnHandle columnHandle)) {
+                return Optional.empty();
+            }
+            projectedColumns.add(columnHandle);
+            resultAssignments.add(new Assignment(entry.getKey(), columnHandle, columnHandle.columnType()));
+        }
+
+        if (handle.projectedColumns().isPresent() && containSameElements(handle.projectedColumns().orElseThrow(), projectedColumns)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ProjectionApplicationResult<>(
+                handle.withProjectedColumns(projectedColumns),
+                projections,
+                resultAssignments,
+                false));
+    }
+
+    @Override
     public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
             ConnectorSession session,
             ConnectorTableHandle table,
@@ -339,12 +380,42 @@ public class StarRocksMetadata
 
     private static Optional<String> toAggregationExpression(AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
-        if (!aggregate.getFunctionName().equals("count") ||
-                aggregate.isDistinct() ||
+        if (aggregate.isDistinct() ||
                 aggregate.getFilter().isPresent() ||
                 !aggregate.getSortItems().isEmpty()) {
             return Optional.empty();
         }
+        String functionName = aggregate.getFunctionName().toLowerCase(Locale.ENGLISH);
+        if (functionName.equals("count")) {
+            return toCountAggregationExpression(aggregate, assignments);
+        }
+        if (!List.of("avg", "max", "min", "sum").contains(functionName)) {
+            return Optional.empty();
+        }
+        if (aggregate.getArguments().size() != 1) {
+            return Optional.empty();
+        }
+
+        ConnectorExpression argument = aggregate.getArguments().getFirst();
+        if (!(argument instanceof Variable variable)) {
+            return Optional.empty();
+        }
+        ColumnHandle columnHandle = assignments.get(variable.getName());
+        if (!(columnHandle instanceof StarRocksColumnHandle starRocksColumnHandle)) {
+            return Optional.empty();
+        }
+        if (List.of("avg", "sum").contains(functionName) && !isNumericAggregationSupported(starRocksColumnHandle.columnType())) {
+            return Optional.empty();
+        }
+        if (List.of("max", "min").contains(functionName) && !starRocksColumnHandle.columnType().isOrderable()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(functionName + "(" + StarRocksQueryBuilder.quoteIdentifier(starRocksColumnHandle.remoteColumnName()) + ")");
+    }
+
+    private static Optional<String> toCountAggregationExpression(AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
+    {
         if (aggregate.getArguments().isEmpty()) {
             return Optional.of("count(*)");
         }
@@ -367,6 +438,22 @@ public class StarRocksMetadata
             return Optional.of("count(*)");
         }
         return Optional.empty();
+    }
+
+    private static boolean isNumericAggregationSupported(Type type)
+    {
+        return type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT ||
+                type == REAL ||
+                type == DOUBLE ||
+                type instanceof DecimalType;
+    }
+
+    private static boolean containSameElements(List<StarRocksColumnHandle> left, List<StarRocksColumnHandle> right)
+    {
+        return left.size() == right.size() && new HashSet<>(left).equals(new HashSet<>(right));
     }
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
@@ -15,6 +15,9 @@ package io.trino.plugin.starrocks;
 
 import com.google.inject.Inject;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -22,9 +25,19 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.connector.TopNApplicationResult;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 
@@ -73,6 +86,7 @@ public class StarRocksMetadata
                 .map(remoteTable -> new StarRocksTableHandle(
                         tableName.getSchemaName(),
                         tableName.getTableName(),
+                        remoteTable.remoteCatalogName(),
                         remoteTable.remoteSchemaName(),
                         remoteTable.remoteTableName(),
                         remoteTable.relationType()))
@@ -134,6 +148,10 @@ public class StarRocksMetadata
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table)
     {
         StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.aggregation().isPresent() || !handle.constraint().isAll() || handle.limit().isPresent()) {
+            return TableStatistics.empty();
+        }
+
         OptionalLong rowCount = metadataClient.getTableRowCount(session, handle.toSchemaTableName());
         if (rowCount.isEmpty()) {
             return TableStatistics.empty();
@@ -142,6 +160,131 @@ public class StarRocksMetadata
         return TableStatistics.builder()
                 .setRowCount(Estimate.of((double) rowCount.getAsLong()))
                 .build();
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle table, long limit)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.limit().isPresent() && handle.limit().getAsLong() <= limit) {
+            return Optional.empty();
+        }
+        return Optional.of(new LimitApplicationResult<>(handle.withLimit(limit), true, false));
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.aggregation().isPresent()) {
+            return Optional.empty();
+        }
+        if (constraint.getSummary().isNone()) {
+            if (handle.constraint().isNone()) {
+                return Optional.empty();
+            }
+            return Optional.of(new ConstraintApplicationResult<>(
+                    handle.withConstraint(TupleDomain.none()),
+                    TupleDomain.all(),
+                    constraint.getExpression(),
+                    false));
+        }
+
+        Map<StarRocksColumnHandle, Domain> supported = new LinkedHashMap<>();
+        Map<ColumnHandle, Domain> unsupported = new LinkedHashMap<>();
+        if (constraint.getSummary().getDomains().isPresent()) {
+            for (Map.Entry<ColumnHandle, Domain> entry : constraint.getSummary().getDomains().orElseThrow().entrySet()) {
+                if (entry.getKey() instanceof StarRocksColumnHandle columnHandle &&
+                        StarRocksQueryBuilder.buildColumnPredicate(columnHandle, entry.getValue()).isPresent()) {
+                    supported.put(columnHandle, entry.getValue());
+                }
+                else {
+                    unsupported.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        TupleDomain<StarRocksColumnHandle> newDomain = handle.constraint().intersect(TupleDomain.withColumnDomains(supported));
+        if (handle.constraint().equals(newDomain)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ConstraintApplicationResult<>(
+                handle.withConstraint(newDomain),
+                TupleDomain.withColumnDomains(unsupported),
+                constraint.getExpression(),
+                false));
+    }
+
+    @Override
+    public Optional<TopNApplicationResult<ConnectorTableHandle>> applyTopN(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            long topNCount,
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        List<StarRocksSortItem> sortOrder = toStarRocksSortOrder(sortItems, assignments);
+        if (sortOrder.isEmpty()) {
+            return Optional.empty();
+        }
+        if (!handle.sortOrder().isEmpty() && !handle.sortOrder().equals(sortOrder)) {
+            return Optional.empty();
+        }
+        if (handle.sortOrder().equals(sortOrder) && handle.limit().isPresent() && handle.limit().getAsLong() <= topNCount) {
+            return Optional.empty();
+        }
+        return Optional.of(new TopNApplicationResult<>(handle.withTopN(topNCount, sortOrder), true, false));
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            List<AggregateFunction> aggregates,
+            Map<String, ColumnHandle> assignments,
+            List<List<ColumnHandle>> groupingSets)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        if (handle.aggregation().isPresent() || handle.limit().isPresent() || !handle.sortOrder().isEmpty()) {
+            return Optional.empty();
+        }
+        if (groupingSets.size() != 1) {
+            return Optional.empty();
+        }
+
+        List<StarRocksColumnHandle> groupingColumns = new ArrayList<>();
+        for (ColumnHandle groupingColumn : groupingSets.getFirst()) {
+            if (!(groupingColumn instanceof StarRocksColumnHandle starRocksColumnHandle)) {
+                return Optional.empty();
+            }
+            groupingColumns.add(starRocksColumnHandle);
+        }
+
+        List<ConnectorExpression> projections = new ArrayList<>(aggregates.size());
+        List<Assignment> resultAssignments = new ArrayList<>(aggregates.size());
+        List<StarRocksAggregateColumn> aggregateColumns = new ArrayList<>(aggregates.size());
+        for (int index = 0; index < aggregates.size(); index++) {
+            AggregateFunction aggregate = aggregates.get(index);
+            Optional<String> aggregateExpression = toAggregationExpression(aggregate, assignments);
+            if (aggregateExpression.isEmpty()) {
+                return Optional.empty();
+            }
+
+            String columnName = "_starrocks_agg_" + index;
+            StarRocksAggregateColumn aggregateColumn = new StarRocksAggregateColumn(columnName, aggregateExpression.orElseThrow(), aggregate.getOutputType());
+            StarRocksColumnHandle columnHandle = new StarRocksColumnHandle(columnName, columnName, aggregate.getOutputType(), groupingColumns.size() + index);
+            aggregateColumns.add(aggregateColumn);
+            projections.add(new Variable(columnName, aggregate.getOutputType()));
+            resultAssignments.add(new Assignment(columnName, columnHandle, aggregate.getOutputType()));
+        }
+
+        return Optional.of(new AggregationApplicationResult<>(
+                handle.withAggregation(new StarRocksAggregation(groupingColumns, aggregateColumns)),
+                projections,
+                resultAssignments,
+                Map.of(),
+                false));
     }
 
     private Optional<StarRocksRemoteTable> getRemoteTable(ConnectorSession session, StarRocksTableHandle tableHandle)
@@ -179,6 +322,51 @@ public class StarRocksMetadata
                     column.ordinalPosition() - 1));
         }
         return List.copyOf(columnHandles);
+    }
+
+    private static List<StarRocksSortItem> toStarRocksSortOrder(List<SortItem> sortItems, Map<String, ColumnHandle> assignments)
+    {
+        List<StarRocksSortItem> sortOrder = new ArrayList<>(sortItems.size());
+        for (SortItem sortItem : sortItems) {
+            ColumnHandle columnHandle = assignments.get(sortItem.getName());
+            if (!(columnHandle instanceof StarRocksColumnHandle starRocksColumnHandle) || !starRocksColumnHandle.columnType().isOrderable()) {
+                return List.of();
+            }
+            sortOrder.add(new StarRocksSortItem(starRocksColumnHandle.columnName(), starRocksColumnHandle.remoteColumnName(), sortItem.getSortOrder()));
+        }
+        return List.copyOf(sortOrder);
+    }
+
+    private static Optional<String> toAggregationExpression(AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
+    {
+        if (!aggregate.getFunctionName().equals("count") ||
+                aggregate.isDistinct() ||
+                aggregate.getFilter().isPresent() ||
+                !aggregate.getSortItems().isEmpty()) {
+            return Optional.empty();
+        }
+        if (aggregate.getArguments().isEmpty()) {
+            return Optional.of("count(*)");
+        }
+        if (aggregate.getArguments().size() != 1) {
+            return Optional.empty();
+        }
+
+        ConnectorExpression argument = aggregate.getArguments().getFirst();
+        if (argument instanceof Variable variable) {
+            ColumnHandle columnHandle = assignments.get(variable.getName());
+            if (columnHandle instanceof StarRocksColumnHandle starRocksColumnHandle) {
+                return Optional.of("count(" + StarRocksQueryBuilder.quoteIdentifier(starRocksColumnHandle.remoteColumnName()) + ")");
+            }
+            return Optional.empty();
+        }
+        if (argument instanceof Constant constant) {
+            if (constant.getValue() == null) {
+                return Optional.of("count(NULL)");
+            }
+            return Optional.of("count(*)");
+        }
+        return Optional.empty();
     }
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadata.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksMetadata
+        implements ConnectorMetadata
+{
+    private final StarRocksMetadataClient metadataClient;
+    private final StarRocksTypeMapper typeMapper;
+
+    @Inject
+    public StarRocksMetadata(StarRocksMetadataClient metadataClient, StarRocksTypeMapper typeMapper)
+    {
+        this.metadataClient = requireNonNull(metadataClient, "metadataClient is null");
+        this.typeMapper = requireNonNull(typeMapper, "typeMapper is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return metadataClient.listSchemaNames(session);
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion)
+    {
+        if (startVersion.isPresent() || endVersion.isPresent()) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support versioned tables");
+        }
+
+        return metadataClient.getTable(session, tableName)
+                .map(remoteTable -> new StarRocksTableHandle(
+                        tableName.getSchemaName(),
+                        tableName.getTableName(),
+                        remoteTable.remoteSchemaName(),
+                        remoteTable.remoteTableName(),
+                        remoteTable.relationType()))
+                .orElse(null);
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> optionalSchemaName)
+    {
+        return metadataClient.listTables(session, optionalSchemaName);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        StarRocksTableHandle tableHandle = (StarRocksTableHandle) table;
+        return getRemoteTable(session, tableHandle)
+                .map(this::toTableMetadata)
+                .orElse(null);
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        StarRocksTableHandle starRocksTableHandle = (StarRocksTableHandle) tableHandle;
+        StarRocksRemoteTable remoteTable = getRemoteTable(session, starRocksTableHandle)
+                .orElseThrow(() -> new TableNotFoundException(starRocksTableHandle.toSchemaTableName()));
+
+        Map<String, ColumnHandle> columnHandles = new LinkedHashMap<>();
+        for (StarRocksColumnHandle columnHandle : toColumnHandles(remoteTable.columns())) {
+            ColumnHandle previous = columnHandles.putIfAbsent(columnHandle.columnName(), columnHandle);
+            if (previous != null) {
+                throw new TrinoException(NOT_SUPPORTED, "Duplicate column after case folding: " + columnHandle.columnName());
+            }
+        }
+        return Collections.unmodifiableMap(columnHandles);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+
+        Map<SchemaTableName, List<ColumnMetadata>> tableColumns = new LinkedHashMap<>();
+        for (SchemaTableName tableName : listTables(session, prefix)) {
+            getRemoteTable(session, tableName).ifPresent(remoteTable -> tableColumns.put(tableName, toColumnMetadata(remoteTable.columns())));
+        }
+        return Collections.unmodifiableMap(tableColumns);
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return ((StarRocksColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table)
+    {
+        StarRocksTableHandle handle = (StarRocksTableHandle) table;
+        OptionalLong rowCount = metadataClient.getTableRowCount(session, handle.toSchemaTableName());
+        if (rowCount.isEmpty()) {
+            return TableStatistics.empty();
+        }
+
+        return TableStatistics.builder()
+                .setRowCount(Estimate.of((double) rowCount.getAsLong()))
+                .build();
+    }
+
+    private Optional<StarRocksRemoteTable> getRemoteTable(ConnectorSession session, StarRocksTableHandle tableHandle)
+    {
+        return getRemoteTable(session, tableHandle.toSchemaTableName());
+    }
+
+    private Optional<StarRocksRemoteTable> getRemoteTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return metadataClient.getTable(session, tableName);
+    }
+
+    private ConnectorTableMetadata toTableMetadata(StarRocksRemoteTable remoteTable)
+    {
+        return new ConnectorTableMetadata(remoteTable.schemaTableName(), toColumnMetadata(remoteTable.columns()));
+    }
+
+    private List<ColumnMetadata> toColumnMetadata(List<StarRocksRemoteColumn> columns)
+    {
+        List<ColumnMetadata> columnMetadata = new ArrayList<>(columns.size());
+        for (StarRocksRemoteColumn column : columns) {
+            columnMetadata.add(new ColumnMetadata(column.columnName(), typeMapper.toTrinoType(column)));
+        }
+        return List.copyOf(columnMetadata);
+    }
+
+    private List<StarRocksColumnHandle> toColumnHandles(List<StarRocksRemoteColumn> columns)
+    {
+        List<StarRocksColumnHandle> columnHandles = new ArrayList<>(columns.size());
+        for (StarRocksRemoteColumn column : columns) {
+            columnHandles.add(new StarRocksColumnHandle(
+                    column.columnName(),
+                    column.remoteColumnName(),
+                    typeMapper.toTrinoType(column),
+                    column.ordinalPosition() - 1));
+        }
+        return List.copyOf(columnHandles);
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getTable().isPresent()) {
+            return List.of(prefix.toSchemaTableName());
+        }
+        return listTables(session, prefix.getSchema());
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksMetadataClient.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+public interface StarRocksMetadataClient
+{
+    List<String> listSchemaNames(ConnectorSession session);
+
+    List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName);
+
+    Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName);
+
+    OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName);
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksModule.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksModule.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class StarRocksModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(StarRocksConnector.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksJdbcConnectionFactory.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksMetadataClient.class).to(JdbcStarRocksMetadataClient.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksTypeMapper.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksQueryBuilder.class).in(Scopes.SINGLETON);
+        binder.bind(AdbcStarRocksFlightSqlClient.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksFlightSqlClient.class).to(AdbcStarRocksFlightSqlClient.class);
+        binder.bind(StarRocksArrowToPageConverter.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(StarRocksPageSourceProvider.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(StarRocksConfig.class);
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksPageSourceProvider.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksPageSourceProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.DynamicFilter;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private final StarRocksFlightSqlClient flightSqlClient;
+    private final StarRocksArrowToPageConverter arrowToPageConverter;
+
+    @Inject
+    public StarRocksPageSourceProvider(StarRocksFlightSqlClient flightSqlClient, StarRocksArrowToPageConverter arrowToPageConverter)
+    {
+        this.flightSqlClient = requireNonNull(flightSqlClient, "flightSqlClient is null");
+        this.arrowToPageConverter = requireNonNull(arrowToPageConverter, "arrowToPageConverter is null");
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableHandle table,
+            Optional<ConnectorTableCredentials> tableCredentials,
+            List<ColumnHandle> columns,
+            DynamicFilter dynamicFilter)
+    {
+        StarRocksSplit starRocksSplit = (StarRocksSplit) split;
+        StarRocksTableHandle starRocksTable = (StarRocksTableHandle) table;
+        List<StarRocksColumnHandle> starRocksColumns = columns.stream()
+                .map(StarRocksColumnHandle.class::cast)
+                .toList();
+
+        return new StarRocksFlightSqlPageSource(
+                flightSqlClient.openStream(session, starRocksTable, starRocksSplit, starRocksColumns),
+                arrowToPageConverter,
+                starRocksColumns);
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksPlugin.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksPlugin.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Module;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksPlugin
+        implements Plugin
+{
+    private final Optional<Module> extension;
+
+    public StarRocksPlugin()
+    {
+        this(Optional.empty());
+    }
+
+    public StarRocksPlugin(Module extension)
+    {
+        this(Optional.of(requireNonNull(extension, "extension is null")));
+    }
+
+    private StarRocksPlugin(Optional<Module> extension)
+    {
+        this.extension = requireNonNull(extension, "extension is null");
+    }
+
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return List.of(new StarRocksConnectorFactory(extension));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
+
+public final class StarRocksQueryBuilder
+{
+    private static final int MAX_PUSHDOWN_DISCRETE_VALUES = 100;
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSSSSS");
+
+    public String buildSelectSql(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(columns, "columns is null");
+
+        StringBuilder sql = new StringBuilder("SELECT ")
+                .append(buildProjection(tableHandle, columns))
+                .append(" FROM ")
+                .append(qualifiedTableName(tableHandle));
+
+        buildWhereClause(tableHandle.constraint()).ifPresent(where -> sql.append(" WHERE ").append(where));
+        buildGroupByClause(tableHandle.aggregation()).ifPresent(groupBy -> sql.append(" GROUP BY ").append(groupBy));
+        buildOrderByClause(tableHandle.sortOrder()).ifPresent(orderBy -> sql.append(" ORDER BY ").append(orderBy));
+        tableHandle.limit().ifPresent(limit -> sql.append(" LIMIT ").append(limit));
+        return sql.toString();
+    }
+
+    static String quoteIdentifier(String value)
+    {
+        return "`" + value.replace("`", "``") + "`";
+    }
+
+    static Optional<String> buildWhereClause(TupleDomain<StarRocksColumnHandle> constraint)
+    {
+        requireNonNull(constraint, "constraint is null");
+        if (constraint.isNone()) {
+            return Optional.of("1 = 0");
+        }
+        if (constraint.isAll()) {
+            return Optional.empty();
+        }
+
+        List<String> predicates = new ArrayList<>();
+        for (Map.Entry<StarRocksColumnHandle, Domain> entry : constraint.getDomains().orElseThrow().entrySet()) {
+            buildColumnPredicate(entry.getKey(), entry.getValue()).ifPresent(predicates::add);
+        }
+        if (predicates.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(predicates.stream()
+                .map(predicate -> "(" + predicate + ")")
+                .collect(joining(" AND ")));
+    }
+
+    static Optional<String> buildColumnPredicate(StarRocksColumnHandle column, Domain domain)
+    {
+        requireNonNull(column, "column is null");
+        requireNonNull(domain, "domain is null");
+        try {
+            return buildColumnPredicateUnchecked(column, domain);
+        }
+        catch (IllegalArgumentException _) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> buildColumnPredicateUnchecked(StarRocksColumnHandle column, Domain domain)
+    {
+        String columnExpression = quoteIdentifier(column.remoteColumnName());
+        Type type = column.columnType();
+        if (domain.isNone()) {
+            return Optional.of("1 = 0");
+        }
+        if (domain.isAll()) {
+            return Optional.empty();
+        }
+        if (domain.isOnlyNull()) {
+            return Optional.of(columnExpression + " IS NULL");
+        }
+
+        ValueSet values = domain.getValues();
+        if (values.isAll()) {
+            if (domain.isNullAllowed()) {
+                return Optional.empty();
+            }
+            return Optional.of(columnExpression + " IS NOT NULL");
+        }
+        if (values.isDiscreteSet() && isDiscretePredicatePushdownSupported(type)) {
+            List<Object> discreteValues = values.getDiscreteSet();
+            if (discreteValues.size() > MAX_PUSHDOWN_DISCRETE_VALUES) {
+                return Optional.empty();
+            }
+            String valuesPredicate = discreteValues.size() == 1
+                    ? columnExpression + " = " + toSqlLiteral(type, discreteValues.getFirst())
+                    : columnExpression + " IN (" + discreteValues.stream()
+                                                   .map(value -> toSqlLiteral(type, value))
+                                                   .collect(joining(", ")) + ")";
+            if (domain.isNullAllowed()) {
+                return Optional.of("(" + valuesPredicate + " OR " + columnExpression + " IS NULL)");
+            }
+            return Optional.of(valuesPredicate);
+        }
+        if (isRangePredicatePushdownSupported(type)) {
+            List<String> rangePredicates = values.getRanges().getOrderedRanges().stream()
+                    .map(range -> buildRangePredicate(columnExpression, type, range))
+                    .toList();
+            if (rangePredicates.isEmpty()) {
+                return domain.isNullAllowed() ? Optional.of(columnExpression + " IS NULL") : Optional.empty();
+            }
+
+            String predicate = rangePredicates.size() == 1
+                    ? rangePredicates.getFirst()
+                    : rangePredicates.stream()
+                      .map(value -> "(" + value + ")")
+                      .collect(joining(" OR "));
+            if (domain.isNullAllowed()) {
+                predicate = predicate + " OR " + columnExpression + " IS NULL";
+            }
+            return Optional.of(predicate);
+        }
+        return Optional.empty();
+    }
+
+    private static String buildProjection(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
+    {
+        if (columns.isEmpty()) {
+            return "1";
+        }
+        if (tableHandle.aggregation().isPresent()) {
+            Map<String, StarRocksAggregateColumn> aggregateColumns = tableHandle.aggregation().orElseThrow().aggregateColumns().stream()
+                    .collect(toMap(StarRocksAggregateColumn::columnName, identity()));
+            return columns.stream()
+                    .map(column -> aggregateColumns.containsKey(column.columnName())
+                            ? aggregateColumns.get(column.columnName()).expression() + " AS " + quoteIdentifier(column.columnName())
+                            : quoteIdentifier(column.remoteColumnName()) + " AS " + quoteIdentifier(column.columnName()))
+                    .collect(joining(", "));
+        }
+        return columns.stream()
+                .map(column -> quoteIdentifier(column.remoteColumnName()) + " AS " + quoteIdentifier(column.columnName()))
+                .collect(joining(", "));
+    }
+
+    private static String qualifiedTableName(StarRocksTableHandle tableHandle)
+    {
+        return tableHandle.remoteCatalogName()
+                .map(catalog -> quoteIdentifier(catalog) + ".")
+                .orElse("") +
+                quoteIdentifier(tableHandle.remoteSchemaName()) +
+                "." +
+                quoteIdentifier(tableHandle.remoteTableName());
+    }
+
+    private static Optional<String> buildGroupByClause(Optional<StarRocksAggregation> aggregation)
+    {
+        if (aggregation.isEmpty() || aggregation.orElseThrow().groupingColumns().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(aggregation.orElseThrow().groupingColumns().stream()
+                .map(StarRocksColumnHandle::remoteColumnName)
+                .map(StarRocksQueryBuilder::quoteIdentifier)
+                .collect(joining(", ")));
+    }
+
+    private static Optional<String> buildOrderByClause(List<StarRocksSortItem> sortOrder)
+    {
+        if (sortOrder.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(sortOrder.stream()
+                .map(StarRocksQueryBuilder::toOrderByExpression)
+                .collect(joining(", ")));
+    }
+
+    private static String toOrderByExpression(StarRocksSortItem sortItem)
+    {
+        String column = quoteIdentifier(sortItem.remoteColumnName());
+        SortOrder sortOrder = sortItem.sortOrder();
+        String nullOrdering = sortOrder.isNullsFirst()
+                ? column + " IS NOT NULL ASC"
+                : column + " IS NULL ASC";
+        return nullOrdering + ", " + column + (sortOrder.isAscending() ? " ASC" : " DESC");
+    }
+
+    private static String buildRangePredicate(String columnExpression, Type type, Range range)
+    {
+        if (range.isSingleValue()) {
+            return columnExpression + " = " + toSqlLiteral(type, range.getSingleValue());
+        }
+
+        List<String> predicates = new ArrayList<>(2);
+        if (!range.isLowUnbounded()) {
+            predicates.add(columnExpression + (range.isLowInclusive() ? " >= " : " > ") + toSqlLiteral(type, range.getLowBoundedValue()));
+        }
+        if (!range.isHighUnbounded()) {
+            predicates.add(columnExpression + (range.isHighInclusive() ? " <= " : " < ") + toSqlLiteral(type, range.getHighBoundedValue()));
+        }
+        return predicates.stream().collect(joining(" AND "));
+    }
+
+    private static boolean isDiscretePredicatePushdownSupported(Type type)
+    {
+        return type == BOOLEAN ||
+                type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT ||
+                type == REAL ||
+                type == DOUBLE ||
+                type == DATE ||
+                type instanceof DecimalType ||
+                type instanceof TimestampType ||
+                type instanceof VarcharType ||
+                type instanceof CharType;
+    }
+
+    private static boolean isRangePredicatePushdownSupported(Type type)
+    {
+        return type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT ||
+                type == REAL ||
+                type == DOUBLE ||
+                type == DATE ||
+                type instanceof DecimalType ||
+                type instanceof TimestampType;
+    }
+
+    private static String toSqlLiteral(Type type, Object value)
+    {
+        if (value == null) {
+            return "NULL";
+        }
+        if (type == BOOLEAN) {
+            return (Boolean) value ? "TRUE" : "FALSE";
+        }
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            return value.toString();
+        }
+        if (type == REAL) {
+            float realValue = Float.intBitsToFloat(((Number) value).intValue());
+            if (!Float.isFinite(realValue)) {
+                throw new IllegalArgumentException("Unsupported StarRocks REAL literal: " + realValue);
+            }
+            return Float.toString(realValue);
+        }
+        if (type == DOUBLE) {
+            double doubleValue = ((Number) value).doubleValue();
+            if (!Double.isFinite(doubleValue)) {
+                throw new IllegalArgumentException("Unsupported StarRocks DOUBLE literal: " + doubleValue);
+            }
+            return Double.toString(doubleValue);
+        }
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Decimals.toString((long) value, decimalType.getScale());
+            }
+            return Decimals.toString((Int128) value, decimalType.getScale());
+        }
+        if (type == DATE) {
+            return "DATE " + quoteStringLiteral(LocalDate.ofEpochDay((long) value).toString());
+        }
+        if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+            long epochMicros = (long) value;
+            long epochSeconds = Math.floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+            long microsOfSecond = Math.floorMod(epochMicros, MICROSECONDS_PER_SECOND);
+            LocalDateTime timestamp = Instant.ofEpochSecond(epochSeconds, microsOfSecond * 1_000)
+                    .atZone(UTC)
+                    .toLocalDateTime();
+            return "TIMESTAMP " + quoteStringLiteral(timestamp.format(TIMESTAMP_FORMATTER));
+        }
+        if (type instanceof VarcharType || type instanceof CharType || type.getBaseName().equals(JSON)) {
+            return quoteStringLiteral(toTextValue(value));
+        }
+        throw new IllegalArgumentException("Unsupported StarRocks predicate literal type: " + type);
+    }
+
+    private static String toTextValue(Object value)
+    {
+        if (value instanceof Slice slice) {
+            return slice.toStringUtf8();
+        }
+        return value.toString();
+    }
+
+    private static String quoteStringLiteral(String value)
+    {
+        return "'" + value.replace("'", "''") + "'";
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
@@ -46,6 +46,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
@@ -296,7 +297,7 @@ public final class StarRocksQueryBuilder
             long epochSeconds = Math.floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
             long microsOfSecond = Math.floorMod(epochMicros, MICROSECONDS_PER_SECOND);
             LocalDateTime timestamp = Instant.ofEpochSecond(epochSeconds, microsOfSecond * 1_000)
-                    .atZone(java.time.ZoneOffset.UTC)
+                    .atZone(UTC)
                     .toLocalDateTime();
             return "TIMESTAMP " + quoteStringLiteral(timestamp.format(TIMESTAMP_FORMATTER));
         }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public final class StarRocksQueryBuilder
+{
+    public String buildSelectSql(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
+    {
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(columns, "columns is null");
+
+        String projection = columns.isEmpty()
+                ? "1"
+                : columns.stream()
+                        .map(column -> quoteIdentifier(column.remoteColumnName()) + " AS " + quoteIdentifier(column.columnName()))
+                        .collect(joining(", "));
+
+        return "SELECT " + projection +
+                " FROM " + quoteIdentifier(tableHandle.remoteSchemaName()) +
+                "." + quoteIdentifier(tableHandle.remoteTableName());
+    }
+
+    static String quoteIdentifier(String value)
+    {
+        return "`" + value.replace("`", "``") + "`";
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksQueryBuilder.java
@@ -13,31 +13,309 @@
  */
 package io.trino.plugin.starrocks;
 
-import java.util.List;
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
 
 public final class StarRocksQueryBuilder
 {
+    private static final int MAX_PUSHDOWN_DISCRETE_VALUES = 100;
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSSSSS");
+
     public String buildSelectSql(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
     {
         requireNonNull(tableHandle, "tableHandle is null");
         requireNonNull(columns, "columns is null");
 
-        String projection = columns.isEmpty()
-                ? "1"
-                : columns.stream()
-                        .map(column -> quoteIdentifier(column.remoteColumnName()) + " AS " + quoteIdentifier(column.columnName()))
-                        .collect(joining(", "));
+        StringBuilder sql = new StringBuilder("SELECT ")
+                .append(buildProjection(tableHandle, columns))
+                .append(" FROM ")
+                .append(qualifiedTableName(tableHandle));
 
-        return "SELECT " + projection +
-                " FROM " + quoteIdentifier(tableHandle.remoteSchemaName()) +
-                "." + quoteIdentifier(tableHandle.remoteTableName());
+        buildWhereClause(tableHandle.constraint()).ifPresent(where -> sql.append(" WHERE ").append(where));
+        buildGroupByClause(tableHandle.aggregation()).ifPresent(groupBy -> sql.append(" GROUP BY ").append(groupBy));
+        buildOrderByClause(tableHandle.sortOrder()).ifPresent(orderBy -> sql.append(" ORDER BY ").append(orderBy));
+        tableHandle.limit().ifPresent(limit -> sql.append(" LIMIT ").append(limit));
+        return sql.toString();
     }
 
     static String quoteIdentifier(String value)
     {
         return "`" + value.replace("`", "``") + "`";
+    }
+
+    static Optional<String> buildWhereClause(TupleDomain<StarRocksColumnHandle> constraint)
+    {
+        requireNonNull(constraint, "constraint is null");
+        if (constraint.isNone()) {
+            return Optional.of("1 = 0");
+        }
+        if (constraint.isAll()) {
+            return Optional.empty();
+        }
+
+        List<String> predicates = new ArrayList<>();
+        for (Map.Entry<StarRocksColumnHandle, Domain> entry : constraint.getDomains().orElseThrow().entrySet()) {
+            buildColumnPredicate(entry.getKey(), entry.getValue()).ifPresent(predicates::add);
+        }
+        if (predicates.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(predicates.stream()
+                .map(predicate -> "(" + predicate + ")")
+                .collect(joining(" AND ")));
+    }
+
+    static Optional<String> buildColumnPredicate(StarRocksColumnHandle column, Domain domain)
+    {
+        requireNonNull(column, "column is null");
+        requireNonNull(domain, "domain is null");
+
+        String columnExpression = quoteIdentifier(column.remoteColumnName());
+        Type type = column.columnType();
+        if (domain.isNone()) {
+            return Optional.of("1 = 0");
+        }
+        if (domain.isAll()) {
+            return Optional.empty();
+        }
+        if (domain.isOnlyNull()) {
+            return Optional.of(columnExpression + " IS NULL");
+        }
+
+        ValueSet values = domain.getValues();
+        if (values.isAll()) {
+            if (domain.isNullAllowed()) {
+                return Optional.empty();
+            }
+            return Optional.of(columnExpression + " IS NOT NULL");
+        }
+        if (values.isDiscreteSet() && isDiscretePredicatePushdownSupported(type)) {
+            List<Object> discreteValues = values.getDiscreteSet();
+            if (discreteValues.size() > MAX_PUSHDOWN_DISCRETE_VALUES) {
+                return Optional.empty();
+            }
+            String valuesPredicate = discreteValues.size() == 1
+                    ? columnExpression + " = " + toSqlLiteral(type, discreteValues.getFirst())
+                    : columnExpression + " IN (" + discreteValues.stream()
+                            .map(value -> toSqlLiteral(type, value))
+                            .collect(joining(", ")) + ")";
+            if (domain.isNullAllowed()) {
+                return Optional.of("(" + valuesPredicate + " OR " + columnExpression + " IS NULL)");
+            }
+            return Optional.of(valuesPredicate);
+        }
+        if (isRangePredicatePushdownSupported(type)) {
+            List<String> rangePredicates = values.getRanges().getOrderedRanges().stream()
+                    .map(range -> buildRangePredicate(columnExpression, type, range))
+                    .toList();
+            if (rangePredicates.isEmpty()) {
+                return domain.isNullAllowed() ? Optional.of(columnExpression + " IS NULL") : Optional.empty();
+            }
+
+            String predicate = rangePredicates.size() == 1
+                    ? rangePredicates.getFirst()
+                    : rangePredicates.stream()
+                            .map(value -> "(" + value + ")")
+                            .collect(joining(" OR "));
+            if (domain.isNullAllowed()) {
+                predicate = predicate + " OR " + columnExpression + " IS NULL";
+            }
+            return Optional.of(predicate);
+        }
+        return Optional.empty();
+    }
+
+    private static String buildProjection(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
+    {
+        if (columns.isEmpty()) {
+            return "1";
+        }
+        if (tableHandle.aggregation().isPresent()) {
+            Map<String, StarRocksAggregateColumn> aggregateColumns = tableHandle.aggregation().orElseThrow().aggregateColumns().stream()
+                    .collect(toMap(StarRocksAggregateColumn::columnName, identity()));
+            return columns.stream()
+                    .map(column -> aggregateColumns.containsKey(column.columnName())
+                            ? aggregateColumns.get(column.columnName()).expression() + " AS " + quoteIdentifier(column.columnName())
+                            : quoteIdentifier(column.remoteColumnName()) + " AS " + quoteIdentifier(column.columnName()))
+                    .collect(joining(", "));
+        }
+        return columns.stream()
+                .map(column -> quoteIdentifier(column.remoteColumnName()) + " AS " + quoteIdentifier(column.columnName()))
+                .collect(joining(", "));
+    }
+
+    private static String qualifiedTableName(StarRocksTableHandle tableHandle)
+    {
+        return tableHandle.remoteCatalogName()
+                .map(catalog -> quoteIdentifier(catalog) + ".")
+                .orElse("") +
+                quoteIdentifier(tableHandle.remoteSchemaName()) +
+                "." +
+                quoteIdentifier(tableHandle.remoteTableName());
+    }
+
+    private static Optional<String> buildGroupByClause(Optional<StarRocksAggregation> aggregation)
+    {
+        if (aggregation.isEmpty() || aggregation.orElseThrow().groupingColumns().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(aggregation.orElseThrow().groupingColumns().stream()
+                .map(StarRocksColumnHandle::remoteColumnName)
+                .map(StarRocksQueryBuilder::quoteIdentifier)
+                .collect(joining(", ")));
+    }
+
+    private static Optional<String> buildOrderByClause(List<StarRocksSortItem> sortOrder)
+    {
+        if (sortOrder.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(sortOrder.stream()
+                .map(StarRocksQueryBuilder::toOrderByExpression)
+                .collect(joining(", ")));
+    }
+
+    private static String toOrderByExpression(StarRocksSortItem sortItem)
+    {
+        String column = quoteIdentifier(sortItem.remoteColumnName());
+        SortOrder sortOrder = sortItem.sortOrder();
+        String nullOrdering = sortOrder.isNullsFirst()
+                ? column + " IS NOT NULL ASC"
+                : column + " IS NULL ASC";
+        return nullOrdering + ", " + column + (sortOrder.isAscending() ? " ASC" : " DESC");
+    }
+
+    private static String buildRangePredicate(String columnExpression, Type type, Range range)
+    {
+        if (range.isSingleValue()) {
+            return columnExpression + " = " + toSqlLiteral(type, range.getSingleValue());
+        }
+
+        List<String> predicates = new ArrayList<>(2);
+        if (!range.isLowUnbounded()) {
+            predicates.add(columnExpression + (range.isLowInclusive() ? " >= " : " > ") + toSqlLiteral(type, range.getLowBoundedValue()));
+        }
+        if (!range.isHighUnbounded()) {
+            predicates.add(columnExpression + (range.isHighInclusive() ? " <= " : " < ") + toSqlLiteral(type, range.getHighBoundedValue()));
+        }
+        return predicates.stream().collect(joining(" AND "));
+    }
+
+    private static boolean isDiscretePredicatePushdownSupported(Type type)
+    {
+        return type == BOOLEAN ||
+                type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT ||
+                type == REAL ||
+                type == DOUBLE ||
+                type == DATE ||
+                type instanceof DecimalType ||
+                type instanceof TimestampType ||
+                type instanceof VarcharType ||
+                type instanceof CharType;
+    }
+
+    private static boolean isRangePredicatePushdownSupported(Type type)
+    {
+        return type == TINYINT ||
+                type == SMALLINT ||
+                type == INTEGER ||
+                type == BIGINT ||
+                type == REAL ||
+                type == DOUBLE ||
+                type == DATE ||
+                type instanceof DecimalType ||
+                type instanceof TimestampType;
+    }
+
+    private static String toSqlLiteral(Type type, Object value)
+    {
+        if (value == null) {
+            return "NULL";
+        }
+        if (type == BOOLEAN) {
+            return (Boolean) value ? "TRUE" : "FALSE";
+        }
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            return value.toString();
+        }
+        if (type == REAL) {
+            return Float.toString(Float.intBitsToFloat(((Number) value).intValue()));
+        }
+        if (type == DOUBLE) {
+            return Double.toString(((Number) value).doubleValue());
+        }
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Decimals.toString((long) value, decimalType.getScale());
+            }
+            return Decimals.toString((Int128) value, decimalType.getScale());
+        }
+        if (type == DATE) {
+            return "DATE " + quoteStringLiteral(LocalDate.ofEpochDay((long) value).toString());
+        }
+        if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+            long epochMicros = (long) value;
+            long epochSeconds = Math.floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+            long microsOfSecond = Math.floorMod(epochMicros, MICROSECONDS_PER_SECOND);
+            LocalDateTime timestamp = Instant.ofEpochSecond(epochSeconds, microsOfSecond * 1_000)
+                    .atZone(java.time.ZoneOffset.UTC)
+                    .toLocalDateTime();
+            return "TIMESTAMP " + quoteStringLiteral(timestamp.format(TIMESTAMP_FORMATTER));
+        }
+        if (type instanceof VarcharType || type instanceof CharType || type.getBaseName().equals(JSON)) {
+            return quoteStringLiteral(toTextValue(value));
+        }
+        throw new IllegalArgumentException("Unsupported StarRocks predicate literal type: " + type);
+    }
+
+    private static String toTextValue(Object value)
+    {
+        if (value instanceof Slice slice) {
+            return slice.toStringUtf8();
+        }
+        return value.toString();
+    }
+
+    private static String quoteStringLiteral(String value)
+    {
+        return "'" + value.replace("'", "''") + "'";
     }
 }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRelationType.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRelationType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+enum StarRocksRelationType
+{
+    TABLE,
+    VIEW,
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRelationType.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRelationType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+enum StarRocksRelationType
+{
+    TABLE,
+    VIEW
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRemoteColumn.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRemoteColumn.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import java.util.Optional;
+
+record StarRocksRemoteColumn(
+        String columnName,
+        String remoteColumnName,
+        String typeName,
+        Optional<Integer> columnSize,
+        Optional<Integer> decimalDigits,
+        int ordinalPosition,
+        Optional<String> typeDefinition)
+{
+    StarRocksRemoteColumn
+    {
+        if (ordinalPosition <= 0) {
+            throw new IllegalArgumentException("ordinalPosition must be positive");
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRemoteTable.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRemoteTable.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.SchemaTableName;
+
+import java.util.List;
+import java.util.Optional;
+
+record StarRocksRemoteTable(
+        SchemaTableName schemaTableName,
+        Optional<String> remoteCatalogName,
+        String remoteSchemaName,
+        String remoteTableName,
+        StarRocksRelationType relationType,
+        List<StarRocksRemoteColumn> columns) {}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRemoteTable.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksRemoteTable.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.SchemaTableName;
+
+import java.util.List;
+
+record StarRocksRemoteTable(
+        SchemaTableName schemaTableName,
+        String remoteSchemaName,
+        String remoteTableName,
+        StarRocksRelationType relationType,
+        List<StarRocksRemoteColumn> columns) {}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSortItem.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSortItem.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.SortOrder;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksSortItem(String columnName, String remoteColumnName, SortOrder sortOrder)
+{
+    public StarRocksSortItem
+    {
+        requireNonNull(columnName, "columnName is null");
+        requireNonNull(remoteColumnName, "remoteColumnName is null");
+        requireNonNull(sortOrder, "sortOrder is null");
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSortItem.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSortItem.java
@@ -13,15 +13,16 @@
  */
 package io.trino.plugin.starrocks;
 
-import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortOrder;
 
-import java.util.List;
-import java.util.Optional;
+import static java.util.Objects.requireNonNull;
 
-record StarRocksRemoteTable(
-        SchemaTableName schemaTableName,
-        Optional<String> remoteCatalogName,
-        String remoteSchemaName,
-        String remoteTableName,
-        StarRocksRelationType relationType,
-        List<StarRocksRemoteColumn> columns) {}
+public record StarRocksSortItem(String columnName, String remoteColumnName, SortOrder sortOrder)
+{
+    public StarRocksSortItem
+    {
+        requireNonNull(columnName, "columnName is null");
+        requireNonNull(remoteColumnName, "remoteColumnName is null");
+        requireNonNull(sortOrder, "sortOrder is null");
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplit.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplit.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSplit;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksSplit(Optional<byte[]> partitionDescriptor)
+        implements ConnectorSplit
+{
+    public StarRocksSplit()
+    {
+        this(Optional.empty());
+    }
+
+    public StarRocksSplit
+    {
+        requireNonNull(partitionDescriptor, "partitionDescriptor is null");
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplit.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplit.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSplit;
+
+public record StarRocksSplit()
+        implements ConnectorSplit {}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplit.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplit.java
@@ -15,5 +15,20 @@ package io.trino.plugin.starrocks;
 
 import io.trino.spi.connector.ConnectorSplit;
 
-public record StarRocksSplit()
-        implements ConnectorSplit {}
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksSplit(Optional<byte[]> partitionDescriptor)
+        implements ConnectorSplit
+{
+    public StarRocksSplit()
+    {
+        this(Optional.empty());
+    }
+
+    public StarRocksSplit
+    {
+        requireNonNull(partitionDescriptor, "partitionDescriptor is null");
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplitManager.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplitManager.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksSplitManager
+        implements ConnectorSplitManager
+{
+    private final StarRocksFlightSqlClient flightSqlClient;
+
+    @Inject
+    public StarRocksSplitManager(StarRocksFlightSqlClient flightSqlClient)
+    {
+        this.flightSqlClient = requireNonNull(flightSqlClient, "flightSqlClient is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            DynamicFilter dynamicFilter,
+            Constraint constraint)
+    {
+        StarRocksTableHandle starRocksTable = (StarRocksTableHandle) tableHandle;
+        if (starRocksTable.projectedColumns().isEmpty()) {
+            return new FixedSplitSource(List.of(new StarRocksSplit()));
+        }
+        return new FixedSplitSource(flightSqlClient.getSplits(session, starRocksTable, starRocksTable.projectedColumns().orElseThrow()));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplitManager.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplitManager.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
+
+import java.util.List;
+
+public class StarRocksSplitManager
+        implements ConnectorSplitManager
+{
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            DynamicFilter dynamicFilter,
+            Constraint constraint)
+    {
+        return new FixedSplitSource(List.of(new StarRocksSplit()));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplitManager.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksSplitManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.starrocks;
 
+import com.google.inject.Inject;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -24,9 +25,19 @@ import io.trino.spi.connector.FixedSplitSource;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 public class StarRocksSplitManager
         implements ConnectorSplitManager
 {
+    private final StarRocksFlightSqlClient flightSqlClient;
+
+    @Inject
+    public StarRocksSplitManager(StarRocksFlightSqlClient flightSqlClient)
+    {
+        this.flightSqlClient = requireNonNull(flightSqlClient, "flightSqlClient is null");
+    }
+
     @Override
     public ConnectorSplitSource getSplits(
             ConnectorTransactionHandle transactionHandle,
@@ -35,6 +46,10 @@ public class StarRocksSplitManager
             DynamicFilter dynamicFilter,
             Constraint constraint)
     {
-        return new FixedSplitSource(List.of(new StarRocksSplit()));
+        StarRocksTableHandle starRocksTable = (StarRocksTableHandle) tableHandle;
+        if (starRocksTable.projectedColumns().isEmpty()) {
+            return new FixedSplitSource(List.of(new StarRocksSplit()));
+        }
+        return new FixedSplitSource(flightSqlClient.getSplits(session, starRocksTable, starRocksTable.projectedColumns().orElseThrow()));
     }
 }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksTableHandle(
+        String schemaName,
+        String tableName,
+        Optional<String> remoteCatalogName,
+        String remoteSchemaName,
+        String remoteTableName,
+        StarRocksRelationType relationType,
+        TupleDomain<StarRocksColumnHandle> constraint,
+        OptionalLong limit,
+        List<StarRocksSortItem> sortOrder,
+        Optional<StarRocksAggregation> aggregation,
+        Optional<List<StarRocksColumnHandle>> projectedColumns)
+        implements ConnectorTableHandle
+{
+    public StarRocksTableHandle(
+            String schemaName,
+            String tableName,
+            Optional<String> remoteCatalogName,
+            String remoteSchemaName,
+            String remoteTableName,
+            StarRocksRelationType relationType)
+    {
+        this(schemaName,
+                tableName,
+                remoteCatalogName,
+                remoteSchemaName,
+                remoteTableName,
+                relationType,
+                TupleDomain.all(),
+                OptionalLong.empty(),
+                List.of(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    public StarRocksTableHandle
+    {
+        requireNonNull(schemaName, "schemaName is null");
+        requireNonNull(tableName, "tableName is null");
+        requireNonNull(remoteCatalogName, "remoteCatalogName is null");
+        requireNonNull(remoteSchemaName, "remoteSchemaName is null");
+        requireNonNull(remoteTableName, "remoteTableName is null");
+        requireNonNull(relationType, "relationType is null");
+        requireNonNull(constraint, "constraint is null");
+        requireNonNull(limit, "limit is null");
+        sortOrder = List.copyOf(requireNonNull(sortOrder, "sortOrder is null"));
+        requireNonNull(aggregation, "aggregation is null");
+        projectedColumns = requireNonNull(projectedColumns, "projectedColumns is null")
+                .map(List::copyOf);
+    }
+
+    public SchemaTableName toSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+
+    public StarRocksTableHandle withConstraint(TupleDomain<StarRocksColumnHandle> constraint)
+    {
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, limit, sortOrder, aggregation, projectedColumns);
+    }
+
+    public StarRocksTableHandle withLimit(long limit)
+    {
+        OptionalLong newLimit = this.limit.isPresent() ? OptionalLong.of(Math.min(this.limit.getAsLong(), limit)) : OptionalLong.of(limit);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation, projectedColumns);
+    }
+
+    public StarRocksTableHandle withTopN(long limit, List<StarRocksSortItem> sortOrder)
+    {
+        OptionalLong newLimit = this.limit.isPresent() ? OptionalLong.of(Math.min(this.limit.getAsLong(), limit)) : OptionalLong.of(limit);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation, projectedColumns);
+    }
+
+    public StarRocksTableHandle withAggregation(StarRocksAggregation aggregation)
+    {
+        List<StarRocksColumnHandle> projectedColumns = new ArrayList<>(aggregation.groupingColumns());
+        for (int index = 0; index < aggregation.aggregateColumns().size(); index++) {
+            StarRocksAggregateColumn aggregateColumn = aggregation.aggregateColumns().get(index);
+            projectedColumns.add(new StarRocksColumnHandle(
+                    aggregateColumn.columnName(),
+                    aggregateColumn.columnName(),
+                    aggregateColumn.type(),
+                    aggregation.groupingColumns().size() + index));
+        }
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, OptionalLong.empty(), List.of(), Optional.of(aggregation), Optional.of(projectedColumns));
+    }
+
+    public StarRocksTableHandle withProjectedColumns(List<StarRocksColumnHandle> projectedColumns)
+    {
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, limit, sortOrder, aggregation, Optional.of(projectedColumns));
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
@@ -17,6 +17,7 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -33,7 +34,8 @@ public record StarRocksTableHandle(
         TupleDomain<StarRocksColumnHandle> constraint,
         OptionalLong limit,
         List<StarRocksSortItem> sortOrder,
-        Optional<StarRocksAggregation> aggregation)
+        Optional<StarRocksAggregation> aggregation,
+        Optional<List<StarRocksColumnHandle>> projectedColumns)
         implements ConnectorTableHandle
 {
     public StarRocksTableHandle(
@@ -54,6 +56,7 @@ public record StarRocksTableHandle(
                 TupleDomain.all(),
                 OptionalLong.empty(),
                 List.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -69,6 +72,8 @@ public record StarRocksTableHandle(
         requireNonNull(limit, "limit is null");
         sortOrder = List.copyOf(requireNonNull(sortOrder, "sortOrder is null"));
         requireNonNull(aggregation, "aggregation is null");
+        projectedColumns = requireNonNull(projectedColumns, "projectedColumns is null")
+                .map(List::copyOf);
     }
 
     public SchemaTableName toSchemaTableName()
@@ -78,23 +83,37 @@ public record StarRocksTableHandle(
 
     public StarRocksTableHandle withConstraint(TupleDomain<StarRocksColumnHandle> constraint)
     {
-        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, limit, sortOrder, aggregation);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, limit, sortOrder, aggregation, projectedColumns);
     }
 
     public StarRocksTableHandle withLimit(long limit)
     {
         OptionalLong newLimit = this.limit.isPresent() ? OptionalLong.of(Math.min(this.limit.getAsLong(), limit)) : OptionalLong.of(limit);
-        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation, projectedColumns);
     }
 
     public StarRocksTableHandle withTopN(long limit, List<StarRocksSortItem> sortOrder)
     {
         OptionalLong newLimit = this.limit.isPresent() ? OptionalLong.of(Math.min(this.limit.getAsLong(), limit)) : OptionalLong.of(limit);
-        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation, projectedColumns);
     }
 
     public StarRocksTableHandle withAggregation(StarRocksAggregation aggregation)
     {
-        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, OptionalLong.empty(), List.of(), Optional.of(aggregation));
+        List<StarRocksColumnHandle> projectedColumns = new ArrayList<>(aggregation.groupingColumns());
+        for (int index = 0; index < aggregation.aggregateColumns().size(); index++) {
+            StarRocksAggregateColumn aggregateColumn = aggregation.aggregateColumns().get(index);
+            projectedColumns.add(new StarRocksColumnHandle(
+                    aggregateColumn.columnName(),
+                    aggregateColumn.columnName(),
+                    aggregateColumn.type(),
+                    aggregation.groupingColumns().size() + index));
+        }
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, OptionalLong.empty(), List.of(), Optional.of(aggregation), Optional.of(projectedColumns));
+    }
+
+    public StarRocksTableHandle withProjectedColumns(List<StarRocksColumnHandle> projectedColumns)
+    {
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, limit, sortOrder, aggregation, Optional.of(projectedColumns));
     }
 }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
@@ -15,28 +15,86 @@ package io.trino.plugin.starrocks;
 
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
 
 public record StarRocksTableHandle(
         String schemaName,
         String tableName,
+        Optional<String> remoteCatalogName,
         String remoteSchemaName,
         String remoteTableName,
-        StarRocksRelationType relationType)
+        StarRocksRelationType relationType,
+        TupleDomain<StarRocksColumnHandle> constraint,
+        OptionalLong limit,
+        List<StarRocksSortItem> sortOrder,
+        Optional<StarRocksAggregation> aggregation)
         implements ConnectorTableHandle
 {
+    public StarRocksTableHandle(
+            String schemaName,
+            String tableName,
+            Optional<String> remoteCatalogName,
+            String remoteSchemaName,
+            String remoteTableName,
+            StarRocksRelationType relationType)
+    {
+        this(
+                schemaName,
+                tableName,
+                remoteCatalogName,
+                remoteSchemaName,
+                remoteTableName,
+                relationType,
+                TupleDomain.all(),
+                OptionalLong.empty(),
+                List.of(),
+                Optional.empty());
+    }
+
     public StarRocksTableHandle
     {
         requireNonNull(schemaName, "schemaName is null");
         requireNonNull(tableName, "tableName is null");
+        requireNonNull(remoteCatalogName, "remoteCatalogName is null");
         requireNonNull(remoteSchemaName, "remoteSchemaName is null");
         requireNonNull(remoteTableName, "remoteTableName is null");
         requireNonNull(relationType, "relationType is null");
+        requireNonNull(constraint, "constraint is null");
+        requireNonNull(limit, "limit is null");
+        sortOrder = List.copyOf(requireNonNull(sortOrder, "sortOrder is null"));
+        requireNonNull(aggregation, "aggregation is null");
     }
 
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
+    }
+
+    public StarRocksTableHandle withConstraint(TupleDomain<StarRocksColumnHandle> constraint)
+    {
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, limit, sortOrder, aggregation);
+    }
+
+    public StarRocksTableHandle withLimit(long limit)
+    {
+        OptionalLong newLimit = this.limit.isPresent() ? OptionalLong.of(Math.min(this.limit.getAsLong(), limit)) : OptionalLong.of(limit);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation);
+    }
+
+    public StarRocksTableHandle withTopN(long limit, List<StarRocksSortItem> sortOrder)
+    {
+        OptionalLong newLimit = this.limit.isPresent() ? OptionalLong.of(Math.min(this.limit.getAsLong(), limit)) : OptionalLong.of(limit);
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, newLimit, sortOrder, aggregation);
+    }
+
+    public StarRocksTableHandle withAggregation(StarRocksAggregation aggregation)
+    {
+        return new StarRocksTableHandle(schemaName, tableName, remoteCatalogName, remoteSchemaName, remoteTableName, relationType, constraint, OptionalLong.empty(), List.of(), Optional.of(aggregation));
     }
 }

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTableHandle.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+
+import static java.util.Objects.requireNonNull;
+
+public record StarRocksTableHandle(
+        String schemaName,
+        String tableName,
+        String remoteSchemaName,
+        String remoteTableName,
+        StarRocksRelationType relationType)
+        implements ConnectorTableHandle
+{
+    public StarRocksTableHandle
+    {
+        requireNonNull(schemaName, "schemaName is null");
+        requireNonNull(tableName, "tableName is null");
+        requireNonNull(remoteSchemaName, "remoteSchemaName is null");
+        requireNonNull(remoteTableName, "remoteTableName is null");
+        requireNonNull(relationType, "relationType is null");
+    }
+
+    public SchemaTableName toSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTransactionHandle.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+enum StarRocksTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Inject;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeSignature;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.MAX_PRECISION;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+public class StarRocksTypeMapper
+{
+    private static final int MAX_STARROCKS_TIMESTAMP_PRECISION = 6;
+
+    private final Type jsonType;
+
+    @Inject
+    public StarRocksTypeMapper(TypeManager typeManager)
+    {
+        this.jsonType = requireNonNull(typeManager, "typeManager is null").getType(new TypeSignature(StandardTypes.JSON));
+    }
+
+    public Type toTrinoType(StarRocksRemoteColumn column)
+    {
+        String normalizedType = normalizedBaseType(column);
+
+        return switch (normalizedType) {
+            case "BOOLEAN", "BOOL" -> BOOLEAN;
+            case "TINYINT" -> isUnsignedIntegral(column) ? SMALLINT : TINYINT;
+            case "SMALLINT" -> isUnsignedIntegral(column) ? INTEGER : SMALLINT;
+            case "INT", "INTEGER" -> isUnsignedIntegral(column) ? BIGINT : INTEGER;
+            case "BIGINT" -> isUnsignedIntegral(column) ? createUnboundedVarcharType() : BIGINT;
+            case "LARGEINT" -> createUnboundedVarcharType();
+            case "DECIMAL", "DECIMALV2", "DECIMALV3", "DECIMAL32", "DECIMAL64", "DECIMAL128", "DECIMAL128I", "DECIMAL256" -> toDecimalType(column);
+            case "FLOAT" -> REAL;
+            case "DOUBLE" -> DOUBLE;
+            case "CHAR" -> toCharType(column);
+            case "VARCHAR" -> toVarcharType(column);
+            case "JSON", "VARIANT" -> jsonType;
+            case "ARRAY", "MAP", "STRUCT" -> createUnboundedVarcharType();
+            case "STRING", "TEXT", "BITMAP", "HLL", "PERCENTILE", "PERCENTILE_UNION" -> createUnboundedVarcharType();
+            case "BINARY", "VARBINARY" -> VARBINARY;
+            case "DATE" -> DATE;
+            case "DATETIME", "DATETIMEV2", "TIMESTAMP" -> createTimestampType(timestampPrecision(column));
+            default -> createUnboundedVarcharType();
+        };
+    }
+
+    private static Type toDecimalType(StarRocksRemoteColumn column)
+    {
+        Optional<Integer> precision = declaredPrecision(column);
+        if (precision.isEmpty()) {
+            return createUnboundedVarcharType();
+        }
+
+        int scale = max(declaredScale(column), 0);
+        if (precision.orElseThrow() <= 0 || precision.orElseThrow() > MAX_PRECISION || scale > precision.orElseThrow()) {
+            return createUnboundedVarcharType();
+        }
+        return createDecimalType(precision.orElseThrow(), scale);
+    }
+
+    private static Type toCharType(StarRocksRemoteColumn column)
+    {
+        if (declaredLength(column).isEmpty() || declaredLength(column).orElseThrow() <= 0) {
+            return createUnboundedVarcharType();
+        }
+        return createCharType(min(declaredLength(column).orElseThrow(), CharType.MAX_LENGTH));
+    }
+
+    private static Type toVarcharType(StarRocksRemoteColumn column)
+    {
+        if (declaredLength(column).isEmpty() || declaredLength(column).orElseThrow() <= 0) {
+            return createUnboundedVarcharType();
+        }
+        int length = declaredLength(column).orElseThrow();
+        if (length >= VarcharType.MAX_LENGTH) {
+            return createUnboundedVarcharType();
+        }
+        return createVarcharType(length);
+    }
+
+    private static int timestampPrecision(StarRocksRemoteColumn column)
+    {
+        return min(max(column.decimalDigits().orElseGet(() -> typeParameters(column).stream().findFirst().orElse(0)), 0), MAX_STARROCKS_TIMESTAMP_PRECISION);
+    }
+
+    private static Optional<Integer> declaredPrecision(StarRocksRemoteColumn column)
+    {
+        if (column.columnSize().isPresent()) {
+            return column.columnSize();
+        }
+        return typeParameters(column).stream().findFirst();
+    }
+
+    private static int declaredScale(StarRocksRemoteColumn column)
+    {
+        if (column.decimalDigits().isPresent()) {
+            return column.decimalDigits().orElseThrow();
+        }
+        List<Integer> parameters = typeParameters(column);
+        if (parameters.size() >= 2) {
+            return parameters.get(1);
+        }
+        return 0;
+    }
+
+    private static Optional<Integer> declaredLength(StarRocksRemoteColumn column)
+    {
+        if (column.columnSize().isPresent()) {
+            return column.columnSize();
+        }
+        return typeParameters(column).stream().findFirst();
+    }
+
+    private static String normalizedBaseType(StarRocksRemoteColumn column)
+    {
+        String typeDeclaration = fullTypeDeclaration(column);
+        int parametersStart = firstTypeParameterStart(typeDeclaration);
+        if (parametersStart >= 0) {
+            typeDeclaration = typeDeclaration.substring(0, parametersStart);
+        }
+        String normalized = typeDeclaration.trim()
+                .toUpperCase(Locale.ENGLISH);
+        if (normalized.endsWith(" UNSIGNED")) {
+            normalized = normalized.substring(0, normalized.length() - " UNSIGNED".length());
+        }
+        return normalized
+                .replace(' ', '_');
+    }
+
+    private static boolean isUnsignedIntegral(StarRocksRemoteColumn column)
+    {
+        return fullTypeDeclaration(column)
+                .trim()
+                .toUpperCase(Locale.ENGLISH)
+                .contains("UNSIGNED");
+    }
+
+    private static String fullTypeDeclaration(StarRocksRemoteColumn column)
+    {
+        return column.typeDefinition()
+                .orElse(column.typeName())
+                .trim();
+    }
+
+    private static int firstTypeParameterStart(String typeDeclaration)
+    {
+        int parenthesisStart = typeDeclaration.indexOf('(');
+        int angleBracketStart = typeDeclaration.indexOf('<');
+        if (parenthesisStart < 0) {
+            return angleBracketStart;
+        }
+        if (angleBracketStart < 0) {
+            return parenthesisStart;
+        }
+        return min(parenthesisStart, angleBracketStart);
+    }
+
+    private static List<Integer> typeParameters(StarRocksRemoteColumn column)
+    {
+        String typeDeclaration = fullTypeDeclaration(column);
+        int parametersStart = typeDeclaration.indexOf('(');
+        int parametersEnd = typeDeclaration.lastIndexOf(')');
+        if (parametersStart < 0 || parametersEnd <= parametersStart) {
+            return List.of();
+        }
+
+        return Arrays.stream(typeDeclaration.substring(parametersStart + 1, parametersEnd).split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    }
+                    catch (NumberFormatException ignored) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.MAX_PRECISION;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+public class StarRocksTypeMapper
+{
+    private static final int MAX_STARROCKS_TIMESTAMP_PRECISION = 6;
+
+    public Type toTrinoType(StarRocksRemoteColumn column)
+    {
+        String normalizedType = normalizedBaseType(column);
+
+        return switch (normalizedType) {
+            case "BOOLEAN", "BOOL" -> BOOLEAN;
+            case "TINYINT" -> isBooleanAlias(column) ? BOOLEAN : (isUnsignedIntegral(column) ? SMALLINT : TINYINT);
+            case "SMALLINT" -> isUnsignedIntegral(column) ? INTEGER : SMALLINT;
+            case "INT", "INTEGER" -> isUnsignedIntegral(column) ? BIGINT : INTEGER;
+            case "BIGINT" -> isUnsignedIntegral(column) ? createUnboundedVarcharType() : BIGINT;
+            case "LARGEINT" -> createUnboundedVarcharType();
+            case "DECIMAL", "DECIMALV2", "DECIMALV3", "DECIMAL32", "DECIMAL64", "DECIMAL128", "DECIMAL128I", "DECIMAL256" -> toDecimalType(column);
+            case "FLOAT" -> REAL;
+            case "DOUBLE" -> DOUBLE;
+            case "CHAR" -> toCharType(column);
+            case "VARCHAR" -> toVarcharType(column);
+            case "STRING", "TEXT", "JSON", "BITMAP", "HLL", "PERCENTILE", "PERCENTILE_UNION", "ARRAY", "MAP", "STRUCT", "VARIANT" -> createUnboundedVarcharType();
+            case "BINARY", "VARBINARY" -> VARBINARY;
+            case "DATE" -> DATE;
+            case "DATETIME", "DATETIMEV2", "TIMESTAMP" -> createTimestampType(timestampPrecision(column));
+            default -> createUnboundedVarcharType();
+        };
+    }
+
+    private static boolean isBooleanAlias(StarRocksRemoteColumn column)
+    {
+        String typeDefinition = fullTypeDeclaration(column)
+                .trim()
+                .toUpperCase(Locale.ENGLISH);
+        return column.columnSize()
+                .filter(size -> size == 1)
+                .isPresent() ||
+                typeDefinition.equals("TINYINT(1)") ||
+                typeDefinition.equals("BOOLEAN") ||
+                typeDefinition.equals("BOOL");
+    }
+
+    private static Type toDecimalType(StarRocksRemoteColumn column)
+    {
+        Optional<Integer> precision = declaredPrecision(column);
+        if (precision.isEmpty()) {
+            return createUnboundedVarcharType();
+        }
+
+        int scale = max(declaredScale(column), 0);
+        if (precision.orElseThrow() <= 0 || precision.orElseThrow() > MAX_PRECISION || scale > precision.orElseThrow()) {
+            return createUnboundedVarcharType();
+        }
+        return createDecimalType(precision.orElseThrow(), scale);
+    }
+
+    private static Type toCharType(StarRocksRemoteColumn column)
+    {
+        if (declaredLength(column).isEmpty() || declaredLength(column).orElseThrow() <= 0) {
+            return createUnboundedVarcharType();
+        }
+        return createCharType(min(declaredLength(column).orElseThrow(), CharType.MAX_LENGTH));
+    }
+
+    private static Type toVarcharType(StarRocksRemoteColumn column)
+    {
+        if (declaredLength(column).isEmpty() || declaredLength(column).orElseThrow() <= 0) {
+            return createUnboundedVarcharType();
+        }
+        int length = declaredLength(column).orElseThrow();
+        if (length >= VarcharType.MAX_LENGTH) {
+            return createUnboundedVarcharType();
+        }
+        return createVarcharType(length);
+    }
+
+    private static int timestampPrecision(StarRocksRemoteColumn column)
+    {
+        return min(max(column.decimalDigits().orElseGet(() -> typeParameters(column).stream().findFirst().orElse(0)), 0), MAX_STARROCKS_TIMESTAMP_PRECISION);
+    }
+
+    private static Optional<Integer> declaredPrecision(StarRocksRemoteColumn column)
+    {
+        if (column.columnSize().isPresent()) {
+            return column.columnSize();
+        }
+        return typeParameters(column).stream().findFirst();
+    }
+
+    private static int declaredScale(StarRocksRemoteColumn column)
+    {
+        if (column.decimalDigits().isPresent()) {
+            return column.decimalDigits().orElseThrow();
+        }
+        List<Integer> parameters = typeParameters(column);
+        if (parameters.size() >= 2) {
+            return parameters.get(1);
+        }
+        return 0;
+    }
+
+    private static Optional<Integer> declaredLength(StarRocksRemoteColumn column)
+    {
+        if (column.columnSize().isPresent()) {
+            return column.columnSize();
+        }
+        return typeParameters(column).stream().findFirst();
+    }
+
+    private static String normalizedBaseType(StarRocksRemoteColumn column)
+    {
+        String typeDeclaration = fullTypeDeclaration(column);
+        int parametersStart = firstTypeParameterStart(typeDeclaration);
+        if (parametersStart >= 0) {
+            typeDeclaration = typeDeclaration.substring(0, parametersStart);
+        }
+        String normalized = typeDeclaration.trim()
+                .toUpperCase(Locale.ENGLISH);
+        if (normalized.endsWith(" UNSIGNED")) {
+            normalized = normalized.substring(0, normalized.length() - " UNSIGNED".length());
+        }
+        return normalized
+                .replace(' ', '_');
+    }
+
+    private static boolean isUnsignedIntegral(StarRocksRemoteColumn column)
+    {
+        return fullTypeDeclaration(column)
+                .trim()
+                .toUpperCase(Locale.ENGLISH)
+                .contains("UNSIGNED");
+    }
+
+    private static String fullTypeDeclaration(StarRocksRemoteColumn column)
+    {
+        return column.typeDefinition()
+                .orElse(column.typeName())
+                .trim();
+    }
+
+    private static int firstTypeParameterStart(String typeDeclaration)
+    {
+        int parenthesisStart = typeDeclaration.indexOf('(');
+        int angleBracketStart = typeDeclaration.indexOf('<');
+        if (parenthesisStart < 0) {
+            return angleBracketStart;
+        }
+        if (angleBracketStart < 0) {
+            return parenthesisStart;
+        }
+        return min(parenthesisStart, angleBracketStart);
+    }
+
+    private static List<Integer> typeParameters(StarRocksRemoteColumn column)
+    {
+        String typeDeclaration = fullTypeDeclaration(column);
+        int parametersStart = typeDeclaration.indexOf('(');
+        int parametersEnd = typeDeclaration.lastIndexOf(')');
+        if (parametersStart < 0 || parametersEnd <= parametersStart) {
+            return List.of();
+        }
+
+        return Arrays.stream(typeDeclaration.substring(parametersStart + 1, parametersEnd).split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    }
+                    catch (NumberFormatException ignored) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
@@ -14,13 +14,17 @@
 package io.trino.plugin.starrocks;
 
 import com.google.inject.Inject;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -44,16 +48,19 @@ import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
 
 public class StarRocksTypeMapper
 {
     private static final int MAX_STARROCKS_TIMESTAMP_PRECISION = 6;
 
+    private final TypeManager typeManager;
     private final Type jsonType;
 
     @Inject
     public StarRocksTypeMapper(TypeManager typeManager)
     {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
     }
 
@@ -74,7 +81,10 @@ public class StarRocksTypeMapper
             case "CHAR" -> toCharType(column);
             case "VARCHAR" -> toVarcharType(column);
             case "JSON", "VARIANT" -> jsonType;
-            case "STRING", "TEXT", "BITMAP", "HLL", "PERCENTILE", "PERCENTILE_UNION", "ARRAY", "MAP", "STRUCT" -> createUnboundedVarcharType();
+            case "ARRAY" -> toArrayType(column).orElseGet(VarcharType::createUnboundedVarcharType);
+            case "MAP" -> toMapType(column).orElseGet(VarcharType::createUnboundedVarcharType);
+            case "STRUCT" -> toRowType(column).orElseGet(VarcharType::createUnboundedVarcharType);
+            case "STRING", "TEXT", "BITMAP", "HLL", "PERCENTILE", "PERCENTILE_UNION" -> createUnboundedVarcharType();
             case "BINARY", "VARBINARY" -> VARBINARY;
             case "DATE" -> DATE;
             case "DATETIME", "DATETIMEV2", "TIMESTAMP" -> createTimestampType(timestampPrecision(column));
@@ -127,6 +137,68 @@ public class StarRocksTypeMapper
             return createUnboundedVarcharType();
         }
         return createVarcharType(length);
+    }
+
+    private Optional<Type> toArrayType(StarRocksRemoteColumn column)
+    {
+        return angleBracketParameters(column).stream()
+                .findFirst()
+                .map(this::toNestedType)
+                .map(ArrayType::new);
+    }
+
+    private Optional<Type> toMapType(StarRocksRemoteColumn column)
+    {
+        List<String> parameters = angleBracketParameters(column);
+        if (parameters.size() != 2) {
+            return Optional.empty();
+        }
+        Type keyType = toNestedType(parameters.get(0));
+        Type valueType = toNestedType(parameters.get(1));
+        if (!keyType.isComparable()) {
+            return Optional.empty();
+        }
+        return Optional.of(new MapType(keyType, valueType, typeManager.getTypeOperators()));
+    }
+
+    private Optional<Type> toRowType(StarRocksRemoteColumn column)
+    {
+        List<String> fieldDeclarations = angleBracketParameters(column);
+        if (fieldDeclarations.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<RowType.Field> fields = new ArrayList<>(fieldDeclarations.size());
+        for (int index = 0; index < fieldDeclarations.size(); index++) {
+            String declaration = fieldDeclarations.get(index).trim();
+            int separator = declaration.indexOf(':');
+            if (separator < 0) {
+                separator = firstTopLevelWhitespace(declaration);
+            }
+
+            Optional<String> fieldName = Optional.of("field" + index);
+            String fieldTypeDeclaration = declaration;
+            if (separator > 0 && separator < declaration.length() - 1) {
+                fieldName = Optional.of(unquoteIdentifier(declaration.substring(0, separator).trim()));
+                fieldTypeDeclaration = declaration.substring(separator + 1).trim();
+            }
+
+            fields.add(new RowType.Field(fieldName, toNestedType(fieldTypeDeclaration)));
+        }
+        return Optional.of(RowType.from(fields));
+    }
+
+    private Type toNestedType(String typeDeclaration)
+    {
+        String trimmedDeclaration = typeDeclaration.trim();
+        return toTrinoType(new StarRocksRemoteColumn(
+                "$nested",
+                "$nested",
+                nestedTypeName(trimmedDeclaration),
+                Optional.empty(),
+                Optional.empty(),
+                1,
+                Optional.of(trimmedDeclaration)));
     }
 
     private static int timestampPrecision(StarRocksRemoteColumn column)
@@ -204,6 +276,89 @@ public class StarRocksTypeMapper
             return parenthesisStart;
         }
         return min(parenthesisStart, angleBracketStart);
+    }
+
+    private static List<String> angleBracketParameters(StarRocksRemoteColumn column)
+    {
+        String typeDeclaration = fullTypeDeclaration(column);
+        int parametersStart = typeDeclaration.indexOf('<');
+        int parametersEnd = typeDeclaration.lastIndexOf('>');
+        if (parametersStart < 0 || parametersEnd <= parametersStart) {
+            return List.of();
+        }
+        return splitTopLevel(typeDeclaration.substring(parametersStart + 1, parametersEnd), ',');
+    }
+
+    private static List<String> splitTopLevel(String value, char delimiter)
+    {
+        List<String> parts = new ArrayList<>();
+        int angleDepth = 0;
+        int parenthesisDepth = 0;
+        int start = 0;
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            switch (current) {
+                case '<' -> angleDepth++;
+                case '>' -> angleDepth--;
+                case '(' -> parenthesisDepth++;
+                case ')' -> parenthesisDepth--;
+                default -> {
+                    if (current == delimiter && angleDepth == 0 && parenthesisDepth == 0) {
+                        addPart(parts, value.substring(start, index));
+                        start = index + 1;
+                    }
+                }
+            }
+        }
+        addPart(parts, value.substring(start));
+        return List.copyOf(parts);
+    }
+
+    private static void addPart(List<String> parts, String value)
+    {
+        String trimmed = value.trim();
+        if (!trimmed.isEmpty()) {
+            parts.add(trimmed);
+        }
+    }
+
+    private static String nestedTypeName(String typeDeclaration)
+    {
+        int parametersStart = firstTypeParameterStart(typeDeclaration);
+        if (parametersStart >= 0) {
+            return typeDeclaration.substring(0, parametersStart);
+        }
+        return typeDeclaration;
+    }
+
+    private static int firstTopLevelWhitespace(String value)
+    {
+        int angleDepth = 0;
+        int parenthesisDepth = 0;
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            switch (current) {
+                case '<' -> angleDepth++;
+                case '>' -> angleDepth--;
+                case '(' -> parenthesisDepth++;
+                case ')' -> parenthesisDepth--;
+                default -> {
+                    if (Character.isWhitespace(current) && angleDepth == 0 && parenthesisDepth == 0) {
+                        return index;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static String unquoteIdentifier(String value)
+    {
+        if ((value.startsWith("`") && value.endsWith("`")) ||
+                (value.startsWith("\"") && value.endsWith("\""))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     private static List<Integer> typeParameters(StarRocksRemoteColumn column)

--- a/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/main/java/io/trino/plugin/starrocks/StarRocksTypeMapper.java
@@ -13,8 +13,12 @@
  */
 package io.trino.plugin.starrocks;
 
+import com.google.inject.Inject;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 
 import java.util.Arrays;
@@ -45,6 +49,14 @@ public class StarRocksTypeMapper
 {
     private static final int MAX_STARROCKS_TIMESTAMP_PRECISION = 6;
 
+    private final Type jsonType;
+
+    @Inject
+    public StarRocksTypeMapper(TypeManager typeManager)
+    {
+        this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
+    }
+
     public Type toTrinoType(StarRocksRemoteColumn column)
     {
         String normalizedType = normalizedBaseType(column);
@@ -61,7 +73,8 @@ public class StarRocksTypeMapper
             case "DOUBLE" -> DOUBLE;
             case "CHAR" -> toCharType(column);
             case "VARCHAR" -> toVarcharType(column);
-            case "STRING", "TEXT", "JSON", "BITMAP", "HLL", "PERCENTILE", "PERCENTILE_UNION", "ARRAY", "MAP", "STRUCT", "VARIANT" -> createUnboundedVarcharType();
+            case "JSON", "VARIANT" -> jsonType;
+            case "STRING", "TEXT", "BITMAP", "HLL", "PERCENTILE", "PERCENTILE_UNION", "ARRAY", "MAP", "STRUCT" -> createUnboundedVarcharType();
             case "BINARY", "VARBINARY" -> VARBINARY;
             case "DATE" -> DATE;
             case "DATETIME", "DATETIMEV2", "TIMESTAMP" -> createTimestampType(timestampPrecision(column));

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/StarRocksIntegrationQueryRunner.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/StarRocksIntegrationQueryRunner.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.plugin.base.util.Closables;
+import io.trino.testing.DistributedQueryRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public final class StarRocksIntegrationQueryRunner
+{
+    private static final String DEFAULT_SCHEMA = System.getProperty("starrocks.test.schema", "starrocks_test");
+
+    private StarRocksIntegrationQueryRunner() {}
+
+    public static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog("starrocks")
+                        .setSchema(DEFAULT_SCHEMA)
+                        .build())
+                .build();
+
+        try {
+            queryRunner.installPlugin(new StarRocksPlugin());
+            queryRunner.createCatalog("starrocks", "starrocks", connectorProperties());
+            return queryRunner;
+        }
+        catch (Throwable t) {
+            Closables.closeAllSuppress(t, queryRunner);
+            throw t;
+        }
+    }
+
+    private static Map<String, String> connectorProperties()
+    {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("starrocks.jdbc-url", System.getProperty("starrocks.test.jdbc-url", "jdbc:starrocks://127.0.0.1:9030"));
+        properties.put("starrocks.username", System.getProperty("starrocks.test.username", "root"));
+        properties.put("starrocks.password", System.getProperty("starrocks.test.password", ""));
+        properties.put("starrocks.flight-sql-host", System.getProperty("starrocks.test.flight-sql-host", "127.0.0.1"));
+        properties.put("starrocks.flight-sql-port", System.getProperty("starrocks.test.flight-sql-port", "9408"));
+        return Map.copyOf(properties);
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/StarRocksQueryRunner.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/StarRocksQueryRunner.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.plugin.base.util.Closables;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.DistributedQueryRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+
+public final class StarRocksQueryRunner
+{
+    private StarRocksQueryRunner() {}
+
+    public static Builder builder(TestingStarRocksEnvironment environment)
+    {
+        return new Builder(environment);
+    }
+
+    public static class Builder
+            extends DistributedQueryRunner.Builder<Builder>
+    {
+        private final TestingStarRocksEnvironment environment;
+        private final Map<String, String> connectorProperties = new HashMap<>();
+
+        private Builder(TestingStarRocksEnvironment environment)
+        {
+            super(testSessionBuilder()
+                    .setCatalog("starrocks")
+                    .setSchema("tiny")
+                    .build());
+            this.environment = requireNonNull(environment, "environment is null");
+        }
+
+        public Builder addConnectorProperty(String key, String value)
+        {
+            connectorProperties.put(key, value);
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new StarRocksPlugin(environment.createModule()));
+
+                Map<String, String> properties = new HashMap<>();
+                properties.put("starrocks.jdbc-url", "jdbc:starrocks://127.0.0.1:9030");
+                properties.putAll(connectorProperties);
+
+                queryRunner.createCatalog("starrocks", "starrocks", properties);
+                return queryRunner;
+            }
+            catch (Throwable t) {
+                Closables.closeAllSuppress(t, queryRunner);
+                throw t;
+            }
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestArrowFlightRuntimeCompatibility.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestArrowFlightRuntimeCompatibility.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.grpc.netty.NettyChannelBuilder;
+import org.apache.arrow.adbc.core.AdbcException;
+import org.apache.arrow.flight.impl.Flight;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+final class TestArrowFlightRuntimeCompatibility
+{
+    @Test
+    void testFlightTicketClassInitializes()
+    {
+        assertThatCode(Flight.Ticket::getDefaultInstance)
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testGrpcNettyChannelBuilderClassInitializes()
+    {
+        assertThatCode(() -> NettyChannelBuilder.forAddress("localhost", 0).usePlaintext())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testOnlyUnsupportedPartitionPlanningFallsBackToSingleSplit()
+    {
+        assertThat(AdbcStarRocksFlightSqlClient.shouldFallbackToSingleSplit(AdbcException.notImplemented("partitioned execution is not supported")))
+                .isTrue();
+        assertThat(AdbcStarRocksFlightSqlClient.shouldFallbackToSingleSplit(AdbcException.invalidState("authentication failed")))
+                .isFalse();
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestArrowFlightRuntimeCompatibility.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestArrowFlightRuntimeCompatibility.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import org.apache.arrow.flight.impl.Flight;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+final class TestArrowFlightRuntimeCompatibility
+{
+    @Test
+    void testFlightTicketClassInitializes()
+    {
+        assertThatCode(Flight.Ticket::getDefaultInstance)
+                .doesNotThrowAnyException();
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
@@ -1,0 +1,518 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestJdbcStarRocksMetadataClient
+{
+    @Test
+    void testListSchemaNamesFallsBackToInformationSchemaWhenMetadataFails()
+    {
+        AtomicReference<String> preparedSql = new AtomicReference<>();
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
+                () -> {
+                    throw new SQLException("getSchemas failed");
+                },
+                (_, _, _) -> List.of(),
+                preparedSql::set,
+                List.of(List.of(
+                        row("SCHEMA_NAME", "analytics"),
+                        row("SCHEMA_NAME", "reporting"))),
+                new ArrayList<>()));
+
+        assertThat(client.listSchemaNames(SESSION)).containsExactly("analytics", "reporting");
+        assertThat(preparedSql.get()).contains("FROM INFORMATION_SCHEMA.SCHEMATA");
+    }
+
+    @Test
+    void testGetTablePrefersInformationSchemaColumnsAndPreservesRemoteNames()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
+                () -> createResultSet(List.of()),
+                (_, _, _) -> List.of(
+                        row(
+                                "COLUMN_NAME",
+                                "ignored_by_information_schema",
+                                "TYPE_NAME",
+                                "BIGINT",
+                                "COLUMN_SIZE",
+                                20,
+                                "DECIMAL_DIGITS",
+                                null,
+                                "ORDINAL_POSITION",
+                                1)),
+                preparedSql::add,
+                List.of(
+                        List.of(row("TABLE_SCHEMA", "Analytics", "TABLE_NAME", "EventsView", "TABLE_TYPE", "VIEW")),
+                        List.of(
+                                row(
+                                        "COLUMN_NAME",
+                                        "event_id",
+                                        "DATA_TYPE",
+                                        "BIGINT",
+                                        "COLUMN_TYPE",
+                                        "bigint",
+                                        "COLUMN_SIZE",
+                                        20,
+                                        "DECIMAL_DIGITS",
+                                        null,
+                                        "ORDINAL_POSITION",
+                                        1),
+                                row(
+                                        "COLUMN_NAME",
+                                        "created_at",
+                                        "DATA_TYPE",
+                                        "DATETIME",
+                                        "COLUMN_TYPE",
+                                        "datetimev2(3)",
+                                        "COLUMN_SIZE",
+                                        null,
+                                        "DECIMAL_DIGITS",
+                                        3,
+                                        "ORDINAL_POSITION",
+                                        2),
+                                row(
+                                        "COLUMN_NAME",
+                                        "largeint_summary",
+                                        "DATA_TYPE",
+                                        "DECIMAL",
+                                        "COLUMN_TYPE",
+                                        "largeint",
+                                        "COLUMN_SIZE",
+                                        null,
+                                        "DECIMAL_DIGITS",
+                                        null,
+                                        "ORDINAL_POSITION",
+                                        3))),
+                boundParameters));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "eventsview")).orElseThrow();
+
+        assertThat(table.remoteSchemaName()).isEqualTo("Analytics");
+        assertThat(table.remoteTableName()).isEqualTo("EventsView");
+        assertThat(table.relationType()).isEqualTo(StarRocksRelationType.VIEW);
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("event_id", "created_at", "largeint_summary");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::remoteColumnName)
+                .containsExactly("event_id", "created_at", "largeint_summary");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeDefinition)
+                .containsExactly(Optional.of("bigint"), Optional.of("datetimev2(3)"), Optional.of("largeint"));
+        assertThat(preparedSql.getFirst()).contains("FROM INFORMATION_SCHEMA.TABLES");
+        assertThat(preparedSql.get(1)).contains("FROM INFORMATION_SCHEMA.COLUMNS");
+        assertThat(boundParameters.get(0)).containsExactly("analytics");
+        assertThat(boundParameters.get(1)).containsExactly("Analytics", "EventsView");
+    }
+
+    @Test
+    void testGetTableFallsBackToJdbcMetadataColumnsWhenInformationSchemaReturnsNoColumns()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
+                () -> createResultSet(List.of()),
+                (_, _, _) -> List.of(
+                        row(
+                                "COLUMN_NAME",
+                                "metric_key",
+                                "TYPE_NAME",
+                                "BIGINT",
+                                "COLUMN_SIZE",
+                                20,
+                                "DECIMAL_DIGITS",
+                                null,
+                                "ORDINAL_POSITION",
+                                1),
+                        row(
+                                "COLUMN_NAME",
+                                "created_at",
+                                "TYPE_NAME",
+                                "DATETIME",
+                                "COLUMN_SIZE",
+                                null,
+                                "DECIMAL_DIGITS",
+                                6,
+                                "ORDINAL_POSITION",
+                                2)),
+                preparedSql::add,
+                List.of(
+                        List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "TABLE")),
+                        List.of()),
+                boundParameters));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.relationType()).isEqualTo(StarRocksRelationType.TABLE);
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("metric_key", "created_at");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeName)
+                .containsExactly("BIGINT", "DATETIME");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeDefinition)
+                .containsExactly(Optional.of("BIGINT"), Optional.of("DATETIME"));
+        assertThat(preparedSql.getFirst()).contains("FROM INFORMATION_SCHEMA.TABLES");
+        assertThat(preparedSql.get(1)).contains("FROM INFORMATION_SCHEMA.COLUMNS");
+        assertThat(boundParameters.get(0)).containsExactly("analytics");
+        assertThat(boundParameters.get(1)).containsExactly("analytics", "events");
+    }
+
+    @Test
+    void testGetTableUsesConfiguredCatalog()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = metadataClient(
+                connectionFactory(
+                        () -> createResultSet(List.of()),
+                        (_, _, _) -> List.of(),
+                        preparedSql::add,
+                        List.of(
+                                List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")),
+                                List.of(row(
+                                        "COLUMN_NAME",
+                                        "event_id",
+                                        "DATA_TYPE",
+                                        "BIGINT",
+                                        "COLUMN_TYPE",
+                                        "bigint",
+                                        "COLUMN_SIZE",
+                                        20,
+                                        "DECIMAL_DIGITS",
+                                        null,
+                                        "ORDINAL_POSITION",
+                                        1))),
+                        boundParameters),
+                new StarRocksConfig().setCatalogName("external_catalog"));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.remoteCatalogName()).contains("external_catalog");
+        assertThat(preparedSql.getFirst()).contains("TABLE_CATALOG = ?");
+        assertThat(preparedSql.get(1)).contains("TABLE_CATALOG = ?");
+        assertThat(boundParameters.get(0)).containsExactly("external_catalog", "analytics");
+        assertThat(boundParameters.get(1)).containsExactly("external_catalog", "analytics", "events");
+    }
+
+    @Test
+    void testGetTableWithConfiguredCatalogFallsBackWhenColumnsCatalogIsNull()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = metadataClient(
+                connectionFactory(
+                        () -> createResultSet(List.of()),
+                        (_, _, _) -> List.of(),
+                        preparedSql::add,
+                        List.of(
+                                List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "TABLE")),
+                                List.of(),
+                                List.of(row(
+                                        "Field",
+                                        "event_id",
+                                        "Type",
+                                        "bigint"))),
+                        boundParameters),
+                new StarRocksConfig().setCatalogName("external_catalog"));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.remoteCatalogName()).contains("external_catalog");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("event_id");
+        assertThat(preparedSql.get(1)).contains("TABLE_CATALOG = ?");
+        assertThat(preparedSql.get(2)).isEqualTo("SHOW FULL COLUMNS FROM `external_catalog`.`analytics`.`events`");
+        assertThat(boundParameters.get(1)).containsExactly("external_catalog", "analytics", "events");
+        assertThat(boundParameters.get(2)).isEmpty();
+    }
+
+    @Test
+    void testGetTableFallsBackToJdbcMetadataColumnsWhenInformationSchemaFails()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        List<List<Map<String, Object>>> rowsByStatement = new ArrayList<>();
+        rowsByStatement.add(List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")));
+        rowsByStatement.add(null);
+
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
+                () -> createResultSet(List.of()),
+                (_, _, _) -> List.of(
+                        row(
+                                "COLUMN_NAME",
+                                "metric_key",
+                                "TYPE_NAME",
+                                "BIGINT",
+                                "COLUMN_SIZE",
+                                20,
+                                "DECIMAL_DIGITS",
+                                null,
+                                "ORDINAL_POSITION",
+                                1),
+                        row(
+                                "COLUMN_NAME",
+                                "created_at",
+                                "TYPE_NAME",
+                                "DATETIME",
+                                "COLUMN_SIZE",
+                                null,
+                                "DECIMAL_DIGITS",
+                                6,
+                                "ORDINAL_POSITION",
+                                2)),
+                preparedSql::add,
+                rowsByStatement,
+                boundParameters));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("metric_key", "created_at");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeName)
+                .containsExactly("BIGINT", "DATETIME");
+        assertThat(preparedSql.getFirst()).contains("FROM INFORMATION_SCHEMA.TABLES");
+        assertThat(preparedSql.get(1)).contains("FROM INFORMATION_SCHEMA.COLUMNS");
+    }
+
+    private static StarRocksJdbcConnectionFactory connectionFactory(
+            ResultSetSupplier schemasSupplier,
+            ColumnsSupplier columnsSupplier,
+            Consumer<String> preparedSqlConsumer,
+            List<List<Map<String, Object>>> rowsByStatement,
+            List<List<String>> boundParameters)
+    {
+        AtomicInteger statementIndex = new AtomicInteger();
+        return new StarRocksJdbcConnectionFactory(new TestingDriver(), "jdbc:starrocks://example.invalid:9030", new Properties())
+        {
+            @Override
+            public Connection openConnection()
+            {
+                return createConnection(schemasSupplier, columnsSupplier, preparedSqlConsumer, rowsByStatement, boundParameters, statementIndex);
+            }
+
+            @Override
+            public Connection openConnection(ConnectorSession session)
+            {
+                return openConnection();
+            }
+        };
+    }
+
+    private static JdbcStarRocksMetadataClient metadataClient(StarRocksJdbcConnectionFactory connectionFactory)
+    {
+        return new JdbcStarRocksMetadataClient(connectionFactory, new StarRocksConfig());
+    }
+
+    private static JdbcStarRocksMetadataClient metadataClient(StarRocksJdbcConnectionFactory connectionFactory, StarRocksConfig config)
+    {
+        return new JdbcStarRocksMetadataClient(connectionFactory, config);
+    }
+
+    private static Connection createConnection(
+            ResultSetSupplier schemasSupplier,
+            ColumnsSupplier columnsSupplier,
+            Consumer<String> preparedSqlConsumer,
+            List<List<Map<String, Object>>> rowsByStatement,
+            List<List<String>> boundParameters,
+            AtomicInteger statementIndex)
+    {
+        return (Connection) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {Connection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getMetaData" -> createDatabaseMetadata(schemasSupplier, columnsSupplier);
+                    case "prepareStatement" -> {
+                        int index = statementIndex.getAndIncrement();
+                        preparedSqlConsumer.accept((String) args[0]);
+                        List<String> parameters = new ArrayList<>();
+                        boundParameters.add(parameters);
+                        yield createPreparedStatement(rowsByStatement.get(index), parameters);
+                    }
+                    case "getCatalog" -> null;
+                    case "close" -> null;
+                    case "isClosed" -> false;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestConnection";
+                    default -> throw new UnsupportedOperationException("Unexpected connection method: " + method.getName());
+                });
+    }
+
+    private static DatabaseMetaData createDatabaseMetadata(ResultSetSupplier schemasSupplier, ColumnsSupplier columnsSupplier)
+    {
+        return (DatabaseMetaData) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {DatabaseMetaData.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getSchemas" -> schemasSupplier.get();
+                    case "getTables" -> createResultSet(List.of());
+                    case "getColumns" -> createResultSet(columnsSupplier.get((String) args[0], (String) args[1], (String) args[2]));
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestDatabaseMetaData";
+                    default -> throw new UnsupportedOperationException("Unexpected metadata method: " + method.getName());
+                });
+    }
+
+    private static PreparedStatement createPreparedStatement(List<Map<String, Object>> rows, List<String> boundParameters)
+    {
+        return (PreparedStatement) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "setString" -> {
+                        boundParameters.add((String) args[1]);
+                        yield null;
+                    }
+                    case "executeQuery" -> {
+                        if (rows == null) {
+                            throw new SQLException("information schema query failed");
+                        }
+                        yield createResultSet(rows);
+                    }
+                    case "close" -> null;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestPreparedStatement";
+                    default -> throw new UnsupportedOperationException("Unexpected prepared statement method: " + method.getName());
+                });
+    }
+
+    private static ResultSet createResultSet(List<Map<String, Object>> rows)
+    {
+        AtomicInteger index = new AtomicInteger(-1);
+        AtomicBoolean wasNull = new AtomicBoolean();
+
+        return (ResultSet) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> index.incrementAndGet() < rows.size();
+                    case "getString" -> {
+                        Object value = rows.get(index.get()).get(args[0]);
+                        wasNull.set(value == null);
+                        yield value == null ? null : value.toString();
+                    }
+                    case "getInt" -> {
+                        Object value = rows.get(index.get()).get(args[0]);
+                        wasNull.set(value == null);
+                        yield value == null ? 0 : ((Number) value).intValue();
+                    }
+                    case "getLong" -> {
+                        Object value = rows.get(index.get()).get(args[0]);
+                        wasNull.set(value == null);
+                        yield value == null ? 0L : ((Number) value).longValue();
+                    }
+                    case "wasNull" -> wasNull.get();
+                    case "close" -> null;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestResultSet";
+                    default -> throw new UnsupportedOperationException("Unexpected result set method: " + method.getName());
+                });
+    }
+
+    private static Map<String, Object> row(Object... values)
+    {
+        LinkedHashMap<String, Object> row = new LinkedHashMap<>();
+        for (int index = 0; index < values.length; index += 2) {
+            row.put((String) values[index], values[index + 1]);
+        }
+        return row;
+    }
+
+    @FunctionalInterface
+    private interface ResultSetSupplier
+    {
+        ResultSet get()
+                throws SQLException;
+    }
+
+    @FunctionalInterface
+    private interface ColumnsSupplier
+    {
+        List<Map<String, Object>> get(String catalog, String schemaPattern, String tableNamePattern);
+    }
+
+    private static final class TestingDriver
+            implements Driver
+    {
+        @Override
+        public Connection connect(String url, Properties info)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean acceptsURL(String url)
+        {
+            return true;
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info)
+        {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion()
+        {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant()
+        {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger()
+        {
+            return Logger.getGlobal();
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
@@ -141,7 +141,7 @@ final class TestJdbcStarRocksMetadataClient
                                 "ORDINAL_POSITION", 2)),
                 preparedSql::add,
                 List.of(
-                        List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")),
+                        List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "TABLE")),
                         List.of()),
                 boundParameters));
 
@@ -189,6 +189,40 @@ final class TestJdbcStarRocksMetadataClient
         assertThat(preparedSql.get(1)).contains("TABLE_CATALOG = ?");
         assertThat(boundParameters.get(0)).containsExactly("external_catalog", "analytics");
         assertThat(boundParameters.get(1)).containsExactly("external_catalog", "analytics", "events");
+    }
+
+    @Test
+    void testGetTableWithConfiguredCatalogFallsBackWhenColumnsCatalogIsNull()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = metadataClient(
+                connectionFactory(
+                        () -> createResultSet(List.of()),
+                        (_, _, _) -> List.of(),
+                        preparedSql::add,
+                        List.of(
+                                List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "TABLE")),
+                                List.of(),
+                                List.of(row(
+                                        "COLUMN_NAME", "event_id",
+                                        "DATA_TYPE", "BIGINT",
+                                        "COLUMN_TYPE", "bigint",
+                                        "COLUMN_SIZE", 20,
+                                        "DECIMAL_DIGITS", null,
+                                        "ORDINAL_POSITION", 1))),
+                        boundParameters),
+                new StarRocksConfig().setCatalogName("external_catalog"));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.remoteCatalogName()).contains("external_catalog");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("event_id");
+        assertThat(preparedSql.get(1)).contains("TABLE_CATALOG = ?");
+        assertThat(preparedSql.get(2)).doesNotContain("TABLE_CATALOG = ?");
+        assertThat(boundParameters.get(1)).containsExactly("external_catalog", "analytics", "events");
+        assertThat(boundParameters.get(2)).containsExactly("analytics", "events");
     }
 
     @Test

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestJdbcStarRocksMetadataClient
+{
+    @Test
+    void testListSchemaNamesFallsBackToInformationSchemaWhenMetadataFails()
+    {
+        AtomicReference<String> preparedSql = new AtomicReference<>();
+        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+                () -> {
+                    throw new SQLException("getSchemas failed");
+                },
+                (_, _, _) -> List.of(),
+                preparedSql::set,
+                List.of(List.of(
+                        row("SCHEMA_NAME", "analytics"),
+                        row("SCHEMA_NAME", "reporting"))),
+                new ArrayList<>()));
+
+        assertThat(client.listSchemaNames(SESSION)).containsExactly("analytics", "reporting");
+        assertThat(preparedSql.get()).contains("FROM INFORMATION_SCHEMA.SCHEMATA");
+    }
+
+    @Test
+    void testGetTablePrefersInformationSchemaColumnsAndPreservesRemoteNames()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+                () -> createResultSet(List.of()),
+                (_, _, _) -> List.of(
+                        row(
+                                "COLUMN_NAME", "ignored_by_information_schema",
+                                "TYPE_NAME", "BIGINT",
+                                "COLUMN_SIZE", 20,
+                                "DECIMAL_DIGITS", null,
+                                "ORDINAL_POSITION", 1)),
+                preparedSql::add,
+                List.of(
+                        List.of(row("TABLE_SCHEMA", "Analytics", "TABLE_NAME", "EventsView", "TABLE_TYPE", "VIEW")),
+                        List.of(
+                                row(
+                                        "COLUMN_NAME", "event_id",
+                                        "DATA_TYPE", "BIGINT",
+                                        "COLUMN_TYPE", "bigint",
+                                        "COLUMN_SIZE", 20,
+                                        "DECIMAL_DIGITS", null,
+                                        "ORDINAL_POSITION", 1),
+                                row(
+                                        "COLUMN_NAME", "created_at",
+                                        "DATA_TYPE", "DATETIME",
+                                        "COLUMN_TYPE", "datetimev2(3)",
+                                        "COLUMN_SIZE", null,
+                                        "DECIMAL_DIGITS", 3,
+                                        "ORDINAL_POSITION", 2),
+                                row(
+                                        "COLUMN_NAME", "largeint_summary",
+                                        "DATA_TYPE", "DECIMAL",
+                                        "COLUMN_TYPE", "largeint",
+                                        "COLUMN_SIZE", null,
+                                        "DECIMAL_DIGITS", null,
+                                        "ORDINAL_POSITION", 3))),
+                boundParameters));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "eventsview")).orElseThrow();
+
+        assertThat(table.remoteSchemaName()).isEqualTo("Analytics");
+        assertThat(table.remoteTableName()).isEqualTo("EventsView");
+        assertThat(table.relationType()).isEqualTo(StarRocksRelationType.VIEW);
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("event_id", "created_at", "largeint_summary");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::remoteColumnName)
+                .containsExactly("event_id", "created_at", "largeint_summary");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeDefinition)
+                .containsExactly(Optional.of("bigint"), Optional.of("datetimev2(3)"), Optional.of("largeint"));
+        assertThat(preparedSql.getFirst()).contains("FROM INFORMATION_SCHEMA.TABLES");
+        assertThat(preparedSql.get(1)).contains("FROM INFORMATION_SCHEMA.COLUMNS");
+        assertThat(boundParameters.get(0)).containsExactly("analytics");
+        assertThat(boundParameters.get(1)).containsExactly("Analytics", "EventsView");
+    }
+
+    @Test
+    void testGetTableFallsBackToJdbcMetadataColumnsWhenInformationSchemaReturnsNoColumns()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+                () -> createResultSet(List.of()),
+                (_, _, _) -> List.of(
+                        row(
+                                "COLUMN_NAME", "metric_key",
+                                "TYPE_NAME", "BIGINT",
+                                "COLUMN_SIZE", 20,
+                                "DECIMAL_DIGITS", null,
+                                "ORDINAL_POSITION", 1),
+                        row(
+                                "COLUMN_NAME", "created_at",
+                                "TYPE_NAME", "DATETIME",
+                                "COLUMN_SIZE", null,
+                                "DECIMAL_DIGITS", 6,
+                                "ORDINAL_POSITION", 2)),
+                preparedSql::add,
+                List.of(
+                        List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")),
+                        List.of()),
+                boundParameters));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.relationType()).isEqualTo(StarRocksRelationType.TABLE);
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("metric_key", "created_at");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeName)
+                .containsExactly("BIGINT", "DATETIME");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeDefinition)
+                .containsExactly(Optional.of("BIGINT"), Optional.of("DATETIME"));
+        assertThat(preparedSql.getFirst()).contains("FROM INFORMATION_SCHEMA.TABLES");
+        assertThat(preparedSql.get(1)).contains("FROM INFORMATION_SCHEMA.COLUMNS");
+        assertThat(boundParameters.get(0)).containsExactly("analytics");
+        assertThat(boundParameters.get(1)).containsExactly("analytics", "events");
+    }
+
+    @Test
+    void testGetTableFallsBackToJdbcMetadataColumnsWhenInformationSchemaFails()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        List<List<Map<String, Object>>> rowsByStatement = new ArrayList<>();
+        rowsByStatement.add(List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")));
+        rowsByStatement.add(null);
+
+        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+                () -> createResultSet(List.of()),
+                (_, _, _) -> List.of(
+                        row(
+                                "COLUMN_NAME", "metric_key",
+                                "TYPE_NAME", "BIGINT",
+                                "COLUMN_SIZE", 20,
+                                "DECIMAL_DIGITS", null,
+                                "ORDINAL_POSITION", 1),
+                        row(
+                                "COLUMN_NAME", "created_at",
+                                "TYPE_NAME", "DATETIME",
+                                "COLUMN_SIZE", null,
+                                "DECIMAL_DIGITS", 6,
+                                "ORDINAL_POSITION", 2)),
+                preparedSql::add,
+                rowsByStatement,
+                boundParameters));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::columnName)
+                .containsExactly("metric_key", "created_at");
+        assertThat(table.columns()).extracting(StarRocksRemoteColumn::typeName)
+                .containsExactly("BIGINT", "DATETIME");
+        assertThat(preparedSql.getFirst()).contains("FROM INFORMATION_SCHEMA.TABLES");
+        assertThat(preparedSql.get(1)).contains("FROM INFORMATION_SCHEMA.COLUMNS");
+    }
+
+    private static StarRocksJdbcConnectionFactory connectionFactory(
+            ResultSetSupplier schemasSupplier,
+            ColumnsSupplier columnsSupplier,
+            Consumer<String> preparedSqlConsumer,
+            List<List<Map<String, Object>>> rowsByStatement,
+            List<List<String>> boundParameters)
+    {
+        AtomicInteger statementIndex = new AtomicInteger();
+        return new StarRocksJdbcConnectionFactory(new TestingDriver(), "jdbc:starrocks://example.invalid:9030", new Properties())
+        {
+            @Override
+            public Connection openConnection()
+            {
+                return createConnection(schemasSupplier, columnsSupplier, preparedSqlConsumer, rowsByStatement, boundParameters, statementIndex);
+            }
+
+            @Override
+            public Connection openConnection(ConnectorSession session)
+            {
+                return openConnection();
+            }
+        };
+    }
+
+    private static Connection createConnection(
+            ResultSetSupplier schemasSupplier,
+            ColumnsSupplier columnsSupplier,
+            Consumer<String> preparedSqlConsumer,
+            List<List<Map<String, Object>>> rowsByStatement,
+            List<List<String>> boundParameters,
+            AtomicInteger statementIndex)
+    {
+        return (Connection) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {Connection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getMetaData" -> createDatabaseMetadata(schemasSupplier, columnsSupplier);
+                    case "prepareStatement" -> {
+                        int index = statementIndex.getAndIncrement();
+                        preparedSqlConsumer.accept((String) args[0]);
+                        List<String> parameters = new ArrayList<>();
+                        boundParameters.add(parameters);
+                        yield createPreparedStatement(rowsByStatement.get(index), parameters);
+                    }
+                    case "getCatalog" -> null;
+                    case "close" -> null;
+                    case "isClosed" -> false;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestConnection";
+                    default -> throw new UnsupportedOperationException("Unexpected connection method: " + method.getName());
+                });
+    }
+
+    private static DatabaseMetaData createDatabaseMetadata(ResultSetSupplier schemasSupplier, ColumnsSupplier columnsSupplier)
+    {
+        return (DatabaseMetaData) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {DatabaseMetaData.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getSchemas" -> schemasSupplier.get();
+                    case "getTables" -> createResultSet(List.of());
+                    case "getColumns" -> createResultSet(columnsSupplier.get((String) args[0], (String) args[1], (String) args[2]));
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestDatabaseMetaData";
+                    default -> throw new UnsupportedOperationException("Unexpected metadata method: " + method.getName());
+                });
+    }
+
+    private static PreparedStatement createPreparedStatement(List<Map<String, Object>> rows, List<String> boundParameters)
+    {
+        return (PreparedStatement) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {PreparedStatement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "setString" -> {
+                        boundParameters.add((String) args[1]);
+                        yield null;
+                    }
+                    case "executeQuery" -> {
+                        if (rows == null) {
+                            throw new SQLException("information schema query failed");
+                        }
+                        yield createResultSet(rows);
+                    }
+                    case "close" -> null;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestPreparedStatement";
+                    default -> throw new UnsupportedOperationException("Unexpected prepared statement method: " + method.getName());
+                });
+    }
+
+    private static ResultSet createResultSet(List<Map<String, Object>> rows)
+    {
+        AtomicInteger index = new AtomicInteger(-1);
+        AtomicBoolean wasNull = new AtomicBoolean();
+
+        return (ResultSet) Proxy.newProxyInstance(
+                TestJdbcStarRocksMetadataClient.class.getClassLoader(),
+                new Class<?>[] {ResultSet.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "next" -> index.incrementAndGet() < rows.size();
+                    case "getString" -> {
+                        Object value = rows.get(index.get()).get(args[0]);
+                        wasNull.set(value == null);
+                        yield value == null ? null : value.toString();
+                    }
+                    case "getInt" -> {
+                        Object value = rows.get(index.get()).get(args[0]);
+                        wasNull.set(value == null);
+                        yield value == null ? 0 : ((Number) value).intValue();
+                    }
+                    case "getLong" -> {
+                        Object value = rows.get(index.get()).get(args[0]);
+                        wasNull.set(value == null);
+                        yield value == null ? 0L : ((Number) value).longValue();
+                    }
+                    case "wasNull" -> wasNull.get();
+                    case "close" -> null;
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    case "toString" -> "TestResultSet";
+                    default -> throw new UnsupportedOperationException("Unexpected result set method: " + method.getName());
+                });
+    }
+
+    private static Map<String, Object> row(Object... values)
+    {
+        LinkedHashMap<String, Object> row = new LinkedHashMap<>();
+        for (int index = 0; index < values.length; index += 2) {
+            row.put((String) values[index], values[index + 1]);
+        }
+        return row;
+    }
+
+    @FunctionalInterface
+    private interface ResultSetSupplier
+    {
+        ResultSet get()
+                throws SQLException;
+    }
+
+    @FunctionalInterface
+    private interface ColumnsSupplier
+    {
+        List<Map<String, Object>> get(String catalog, String schemaPattern, String tableNamePattern);
+    }
+
+    private static final class TestingDriver
+            implements Driver
+    {
+        @Override
+        public Connection connect(String url, Properties info)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean acceptsURL(String url)
+        {
+            return true;
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info)
+        {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion()
+        {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant()
+        {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger()
+        {
+            return Logger.getGlobal();
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestJdbcStarRocksMetadataClient.java
@@ -46,7 +46,7 @@ final class TestJdbcStarRocksMetadataClient
     void testListSchemaNamesFallsBackToInformationSchemaWhenMetadataFails()
     {
         AtomicReference<String> preparedSql = new AtomicReference<>();
-        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
                 () -> {
                     throw new SQLException("getSchemas failed");
                 },
@@ -66,7 +66,7 @@ final class TestJdbcStarRocksMetadataClient
     {
         List<String> preparedSql = new ArrayList<>();
         List<List<String>> boundParameters = new ArrayList<>();
-        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
                 () -> createResultSet(List.of()),
                 (_, _, _) -> List.of(
                         row(
@@ -124,7 +124,7 @@ final class TestJdbcStarRocksMetadataClient
     {
         List<String> preparedSql = new ArrayList<>();
         List<List<String>> boundParameters = new ArrayList<>();
-        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
                 () -> createResultSet(List.of()),
                 (_, _, _) -> List.of(
                         row(
@@ -161,6 +161,37 @@ final class TestJdbcStarRocksMetadataClient
     }
 
     @Test
+    void testGetTableUsesConfiguredCatalog()
+    {
+        List<String> preparedSql = new ArrayList<>();
+        List<List<String>> boundParameters = new ArrayList<>();
+        JdbcStarRocksMetadataClient client = metadataClient(
+                connectionFactory(
+                        () -> createResultSet(List.of()),
+                        (_, _, _) -> List.of(),
+                        preparedSql::add,
+                        List.of(
+                                List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")),
+                                List.of(row(
+                                        "COLUMN_NAME", "event_id",
+                                        "DATA_TYPE", "BIGINT",
+                                        "COLUMN_TYPE", "bigint",
+                                        "COLUMN_SIZE", 20,
+                                        "DECIMAL_DIGITS", null,
+                                        "ORDINAL_POSITION", 1))),
+                        boundParameters),
+                new StarRocksConfig().setCatalogName("external_catalog"));
+
+        StarRocksRemoteTable table = client.getTable(SESSION, new SchemaTableName("analytics", "events")).orElseThrow();
+
+        assertThat(table.remoteCatalogName()).contains("external_catalog");
+        assertThat(preparedSql.getFirst()).contains("TABLE_CATALOG = ?");
+        assertThat(preparedSql.get(1)).contains("TABLE_CATALOG = ?");
+        assertThat(boundParameters.get(0)).containsExactly("external_catalog", "analytics");
+        assertThat(boundParameters.get(1)).containsExactly("external_catalog", "analytics", "events");
+    }
+
+    @Test
     void testGetTableFallsBackToJdbcMetadataColumnsWhenInformationSchemaFails()
     {
         List<String> preparedSql = new ArrayList<>();
@@ -169,7 +200,7 @@ final class TestJdbcStarRocksMetadataClient
         rowsByStatement.add(List.of(row("TABLE_SCHEMA", "analytics", "TABLE_NAME", "events", "TABLE_TYPE", "BASE TABLE")));
         rowsByStatement.add(null);
 
-        JdbcStarRocksMetadataClient client = new JdbcStarRocksMetadataClient(connectionFactory(
+        JdbcStarRocksMetadataClient client = metadataClient(connectionFactory(
                 () -> createResultSet(List.of()),
                 (_, _, _) -> List.of(
                         row(
@@ -220,6 +251,16 @@ final class TestJdbcStarRocksMetadataClient
                 return openConnection();
             }
         };
+    }
+
+    private static JdbcStarRocksMetadataClient metadataClient(StarRocksJdbcConnectionFactory connectionFactory)
+    {
+        return new JdbcStarRocksMetadataClient(connectionFactory, new StarRocksConfig());
+    }
+
+    private static JdbcStarRocksMetadataClient metadataClient(StarRocksJdbcConnectionFactory connectionFactory, StarRocksConfig config)
+    {
+        return new JdbcStarRocksMetadataClient(connectionFactory, config);
     }
 
     private static Connection createConnection(

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.TimestampType;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.Decimal256Vector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static io.trino.type.JsonType.JSON;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksArrowToPageConverter
+{
+    private final StarRocksArrowToPageConverter converter = new StarRocksArrowToPageConverter();
+
+    @Test
+    void testConvertPrimitiveAndCharacterColumns()
+    {
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("flag", "flag", BOOLEAN, 0),
+                new StarRocksColumnHandle("tiny", "tiny", TINYINT, 1),
+                new StarRocksColumnHandle("small", "small", SMALLINT, 2),
+                new StarRocksColumnHandle("id", "id", BIGINT, 3),
+                new StarRocksColumnHandle("ratio", "ratio", REAL, 4),
+                new StarRocksColumnHandle("name", "name", createVarcharType(20), 5),
+                new StarRocksColumnHandle("code", "code", createCharType(3), 6),
+                new StarRocksColumnHandle("payload", "payload", JSON, 7));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                BitVector flag = new BitVector("flag", allocator);
+                TinyIntVector tiny = new TinyIntVector("tiny", allocator);
+                SmallIntVector small = new SmallIntVector("small", allocator);
+                BigIntVector id = new BigIntVector("id", allocator);
+                Float4Vector ratio = new Float4Vector("ratio", allocator);
+                VarCharVector name = new VarCharVector("name", allocator);
+                VarCharVector code = new VarCharVector("code", allocator);
+                VarCharVector payload = new VarCharVector("payload", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(flag, tiny, small, id, ratio, name, code, payload))) {
+            flag.allocateNew();
+            flag.setSafe(0, 1);
+            flag.setNull(1);
+            flag.setValueCount(2);
+
+            tiny.allocateNew();
+            tiny.setSafe(0, 7);
+            tiny.setNull(1);
+            tiny.setValueCount(2);
+
+            small.allocateNew();
+            small.setSafe(0, 123);
+            small.setNull(1);
+            small.setValueCount(2);
+
+            id.allocateNew();
+            id.setSafe(0, 456789L);
+            id.setNull(1);
+            id.setValueCount(2);
+
+            ratio.allocateNew();
+            ratio.setSafe(0, 1.5f);
+            ratio.setNull(1);
+            ratio.setValueCount(2);
+
+            name.allocateNew();
+            name.setSafe(0, "alpha".getBytes(UTF_8));
+            name.setNull(1);
+            name.setValueCount(2);
+
+            code.allocateNew();
+            code.setSafe(0, "xy   ".getBytes(UTF_8));
+            code.setNull(1);
+            code.setValueCount(2);
+
+            payload.allocateNew();
+            payload.setSafe(0, "{\"a\":1}".getBytes(UTF_8));
+            payload.setNull(1);
+            payload.setValueCount(2);
+
+            root.setRowCount(2);
+
+            Page page = convert(columns, root);
+
+            assertThat(BOOLEAN.getObjectValue(page.getBlock(0), 0)).isEqualTo(true);
+            assertThat(page.getBlock(0).isNull(1)).isTrue();
+            assertThat(TINYINT.getLong(page.getBlock(1), 0)).isEqualTo(7L);
+            assertThat(SMALLINT.getLong(page.getBlock(2), 0)).isEqualTo(123L);
+            assertThat(BIGINT.getLong(page.getBlock(3), 0)).isEqualTo(456789L);
+            assertThat(REAL.getFloat(page.getBlock(4), 0)).isEqualTo(1.5f);
+            assertThat(createVarcharType(20).getObjectValue(page.getBlock(5), 0)).isEqualTo("alpha");
+            assertThat(createCharType(3).getObjectValue(page.getBlock(6), 0)).isEqualTo("xy ");
+            assertThat(JSON.getObjectValue(page.getBlock(7), 0)).isEqualTo("{\"a\":1}");
+            assertThat(page.getBlock(7).isNull(1)).isTrue();
+        }
+    }
+
+    @Test
+    void testConvertTextualComplexColumns()
+    {
+        ArrayType tagsType = new ArrayType(createUnboundedVarcharType());
+        MapType scoresType = new MapType(createUnboundedVarcharType(), BIGINT, TESTING_TYPE_MANAGER.getTypeOperators());
+        RowType detailsType = rowType(
+                field("a", INTEGER),
+                field("b", createVarcharType(12)),
+                field("c", new ArrayType(BIGINT)));
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("tags", "tags", tagsType, 0),
+                new StarRocksColumnHandle("scores", "scores", scoresType, 1),
+                new StarRocksColumnHandle("details", "details", detailsType, 2));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VarCharVector tags = new VarCharVector("tags", allocator);
+                VarCharVector scores = new VarCharVector("scores", allocator);
+                VarCharVector details = new VarCharVector("details", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(tags, scores, details))) {
+            tags.allocateNew();
+            tags.setSafe(0, "[\"red\",\"blue\"]".getBytes(UTF_8));
+            tags.setValueCount(1);
+
+            scores.allocateNew();
+            scores.setSafe(0, "{\"x\":10,\"y\":20}".getBytes(UTF_8));
+            scores.setValueCount(1);
+
+            details.allocateNew();
+            details.setSafe(0, "{\"a\":7,\"b\":\"ok\",\"c\":[3,4]}".getBytes(UTF_8));
+            details.setValueCount(1);
+
+            root.setRowCount(1);
+
+            Page page = convert(columns, root);
+
+            assertThat(tagsType.getObjectValue(page.getBlock(0), 0)).isEqualTo(List.of("red", "blue"));
+            assertThat(scoresType.getObjectValue(page.getBlock(1), 0)).isEqualTo(Map.of("x", 10L, "y", 20L));
+            assertThat(detailsType.getObjectValue(page.getBlock(2), 0)).isEqualTo(List.of(7, "ok", List.of(3L, 4L)));
+        }
+    }
+
+    @Test
+    void testConvertTemporalDecimalAndLargeintFallbackColumns()
+    {
+        DecimalType shortDecimal = createDecimalType(18, 2);
+        TimestampType timestamp = createTimestampType(6);
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("created_on", "created_on", DATE, 0),
+                new StarRocksColumnHandle("created_at", "created_at", timestamp, 1),
+                new StarRocksColumnHandle("amount", "amount", shortDecimal, 2),
+                new StarRocksColumnHandle("largeint_summary", "largeint_summary", createUnboundedVarcharType(), 3));
+
+        LocalDate date = LocalDate.of(2024, 3, 20);
+        LocalDateTime timestampValue = LocalDateTime.of(2024, 7, 25, 10, 2, 23, 586_123_000);
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                DateDayVector createdOn = new DateDayVector("created_on", allocator);
+                TimeStampMicroVector createdAt = new TimeStampMicroVector("created_at", allocator);
+                DecimalVector amount = new DecimalVector("amount", allocator, 18, 2);
+                FixedSizeBinaryVector largeintSummary = new FixedSizeBinaryVector("largeint_summary", allocator, 16);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(createdOn, createdAt, amount, largeintSummary))) {
+            createdOn.allocateNew();
+            createdOn.setSafe(0, (int) date.toEpochDay());
+            createdOn.setSafe(1, (int) date.toEpochDay());
+            createdOn.setValueCount(2);
+
+            long epochMicros = timestampValue.toEpochSecond(UTC) * 1_000_000L + 586_123;
+            createdAt.allocateNew();
+            createdAt.setSafe(0, epochMicros);
+            createdAt.setNull(1);
+            createdAt.setValueCount(2);
+
+            amount.allocateNew();
+            amount.setSafe(0, new BigDecimal("12.34"));
+            amount.setNull(1);
+            amount.setValueCount(2);
+
+            largeintSummary.allocateNew();
+            largeintSummary.setSafe(0, toLittleEndianSignedInteger(new BigInteger("9223372036854775809")));
+            largeintSummary.setSafe(1, toLittleEndianSignedInteger(BigInteger.valueOf(-1)));
+            largeintSummary.setValueCount(2);
+
+            root.setRowCount(2);
+
+            Page page = convert(columns, root);
+
+            assertThat(DATE.getLong(page.getBlock(0), 0)).isEqualTo(date.toEpochDay());
+            assertThat(timestamp.getObjectValue(page.getBlock(1), 0).toString()).isEqualTo("2024-07-25 10:02:23.586123");
+            assertThat(page.getBlock(1).isNull(1)).isTrue();
+            assertThat(((SqlDecimal) shortDecimal.getObjectValue(page.getBlock(2), 0)).toString()).isEqualTo("12.34");
+            assertThat(page.getBlock(2).isNull(1)).isTrue();
+            assertThat(createUnboundedVarcharType().getObjectValue(page.getBlock(3), 0)).isEqualTo("9223372036854775809");
+            assertThat(createUnboundedVarcharType().getObjectValue(page.getBlock(3), 1)).isEqualTo("-1");
+        }
+    }
+
+    @Test
+    void testConvertTextualTemporalAndDecimal256FallbackColumns()
+    {
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("created_on", "created_on", DATE, 0),
+                new StarRocksColumnHandle("created_at", "created_at", createTimestampType(6), 1),
+                new StarRocksColumnHandle("oversized_amount", "oversized_amount", createUnboundedVarcharType(), 2));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VarCharVector createdOn = new VarCharVector("created_on", allocator);
+                VarCharVector createdAt = new VarCharVector("created_at", allocator);
+                Decimal256Vector oversizedAmount = new Decimal256Vector("oversized_amount", allocator, 76, 6);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(createdOn, createdAt, oversizedAmount))) {
+            createdOn.allocateNew();
+            createdOn.setSafe(0, "2024-03-20 00:00:00".getBytes(UTF_8));
+            createdOn.setValueCount(1);
+
+            createdAt.allocateNew();
+            createdAt.setSafe(0, " 2024-07-25T10:02:23.5 ".getBytes(UTF_8));
+            createdAt.setValueCount(1);
+
+            oversizedAmount.allocateNew();
+            oversizedAmount.setSafe(0, new BigDecimal("1234567890123456789012345678901234567890.123456"));
+            oversizedAmount.setValueCount(1);
+
+            root.setRowCount(1);
+
+            Page page = convert(columns, root);
+
+            assertThat(DATE.getLong(page.getBlock(0), 0)).isEqualTo(LocalDate.of(2024, 3, 20).toEpochDay());
+            assertThat(createTimestampType(6).getObjectValue(page.getBlock(1), 0).toString()).isEqualTo("2024-07-25 10:02:23.500000");
+            assertThat(createUnboundedVarcharType().getObjectValue(page.getBlock(2), 0)).isEqualTo("1234567890123456789012345678901234567890.123456");
+        }
+    }
+
+    @Test
+    void testConvertArrowTimestampUnits()
+    {
+        TimestampType timestamp = createTimestampType(6);
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("ts_sec", "ts_sec", timestamp, 0),
+                new StarRocksColumnHandle("ts_milli", "ts_milli", timestamp, 1),
+                new StarRocksColumnHandle("ts_micro", "ts_micro", timestamp, 2),
+                new StarRocksColumnHandle("ts_nano", "ts_nano", timestamp, 3));
+
+        LocalDateTime timestampValue = LocalDateTime.of(2024, 7, 25, 10, 2, 23, 586_123_000);
+        long epochSeconds = timestampValue.toEpochSecond(UTC);
+        long epochMicros = epochSeconds * 1_000_000L + 586_123L;
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                TimeStampSecVector tsSec = new TimeStampSecVector("ts_sec", allocator);
+                TimeStampMilliVector tsMilli = new TimeStampMilliVector("ts_milli", allocator);
+                TimeStampMicroVector tsMicro = new TimeStampMicroVector("ts_micro", allocator);
+                TimeStampNanoVector tsNano = new TimeStampNanoVector("ts_nano", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(tsSec, tsMilli, tsMicro, tsNano))) {
+            tsSec.allocateNew();
+            tsSec.setSafe(0, epochSeconds);
+            tsSec.setValueCount(1);
+
+            tsMilli.allocateNew();
+            tsMilli.setSafe(0, epochSeconds * 1_000L + 586L);
+            tsMilli.setValueCount(1);
+
+            tsMicro.allocateNew();
+            tsMicro.setSafe(0, epochMicros);
+            tsMicro.setValueCount(1);
+
+            tsNano.allocateNew();
+            tsNano.setSafe(0, epochSeconds * 1_000_000_000L + 586_123_000L);
+            tsNano.setValueCount(1);
+
+            root.setRowCount(1);
+
+            Page page = convert(columns, root);
+
+            assertThat(timestamp.getLong(page.getBlock(0), 0)).isEqualTo(epochSeconds * 1_000_000L);
+            assertThat(timestamp.getLong(page.getBlock(1), 0)).isEqualTo(epochSeconds * 1_000_000L + 586_000L);
+            assertThat(timestamp.getLong(page.getBlock(2), 0)).isEqualTo(epochMicros);
+            assertThat(timestamp.getLong(page.getBlock(3), 0)).isEqualTo(epochMicros);
+        }
+    }
+
+    private Page convert(List<StarRocksColumnHandle> columns, VectorSchemaRoot root)
+    {
+        return converter.convert(PageBuilder.withMaxPageSize(1024, columns.stream().map(StarRocksColumnHandle::columnType).toList()), columns, root);
+    }
+
+    private static byte[] toLittleEndianSignedInteger(BigInteger value)
+    {
+        byte[] bigEndian = value.toByteArray();
+        byte[] littleEndian = new byte[16];
+        byte fill = value.signum() < 0 ? (byte) 0xFF : 0;
+        for (int index = 0; index < littleEndian.length; index++) {
+            littleEndian[index] = fill;
+        }
+        for (int index = 0; index < bigEndian.length; index++) {
+            littleEndian[index] = bigEndian[bigEndian.length - 1 - index];
+        }
+        return littleEndian;
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
@@ -53,6 +53,7 @@ import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.JsonType.JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +72,8 @@ final class TestStarRocksArrowToPageConverter
                 new StarRocksColumnHandle("id", "id", BIGINT, 3),
                 new StarRocksColumnHandle("ratio", "ratio", REAL, 4),
                 new StarRocksColumnHandle("name", "name", createVarcharType(20), 5),
-                new StarRocksColumnHandle("code", "code", createCharType(3), 6));
+                new StarRocksColumnHandle("code", "code", createCharType(3), 6),
+                new StarRocksColumnHandle("payload", "payload", JSON, 7));
 
         try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
                 BitVector flag = new BitVector("flag", allocator);
@@ -81,7 +83,8 @@ final class TestStarRocksArrowToPageConverter
                 Float4Vector ratio = new Float4Vector("ratio", allocator);
                 VarCharVector name = new VarCharVector("name", allocator);
                 VarCharVector code = new VarCharVector("code", allocator);
-                VectorSchemaRoot root = new VectorSchemaRoot(List.of(flag, tiny, small, id, ratio, name, code))) {
+                VarCharVector payload = new VarCharVector("payload", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(flag, tiny, small, id, ratio, name, code, payload))) {
             flag.allocateNew();
             flag.setSafe(0, 1);
             flag.setNull(1);
@@ -117,6 +120,11 @@ final class TestStarRocksArrowToPageConverter
             code.setNull(1);
             code.setValueCount(2);
 
+            payload.allocateNew();
+            payload.setSafe(0, "{\"a\":1}".getBytes(UTF_8));
+            payload.setNull(1);
+            payload.setValueCount(2);
+
             root.setRowCount(2);
 
             Page page = convert(columns, root);
@@ -129,6 +137,8 @@ final class TestStarRocksArrowToPageConverter
             assertThat(REAL.getFloat(page.getBlock(4), 0)).isEqualTo(1.5f);
             assertThat(createVarcharType(20).getObjectValue(page.getBlock(5), 0)).isEqualTo("alpha");
             assertThat(createCharType(3).getObjectValue(page.getBlock(6), 0)).isEqualTo("xy ");
+            assertThat(JSON.getObjectValue(page.getBlock(7), 0)).isEqualTo("{\"a\":1}");
+            assertThat(page.getBlock(7).isNull(1)).isTrue();
         }
     }
 

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
@@ -15,7 +15,10 @@ package io.trino.plugin.starrocks;
 
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.SqlDecimal;
 import io.trino.spi.type.TimestampType;
 import org.apache.arrow.memory.RootAllocator;
@@ -41,18 +44,23 @@ import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.type.JsonType.JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneOffset.UTC;
@@ -139,6 +147,47 @@ final class TestStarRocksArrowToPageConverter
             assertThat(createCharType(3).getObjectValue(page.getBlock(6), 0)).isEqualTo("xy ");
             assertThat(JSON.getObjectValue(page.getBlock(7), 0)).isEqualTo("{\"a\":1}");
             assertThat(page.getBlock(7).isNull(1)).isTrue();
+        }
+    }
+
+    @Test
+    void testConvertTextualComplexColumns()
+    {
+        ArrayType tagsType = new ArrayType(createUnboundedVarcharType());
+        MapType scoresType = new MapType(createUnboundedVarcharType(), BIGINT, TESTING_TYPE_MANAGER.getTypeOperators());
+        RowType detailsType = rowType(
+                field("a", INTEGER),
+                field("b", createVarcharType(12)),
+                field("c", new ArrayType(BIGINT)));
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("tags", "tags", tagsType, 0),
+                new StarRocksColumnHandle("scores", "scores", scoresType, 1),
+                new StarRocksColumnHandle("details", "details", detailsType, 2));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VarCharVector tags = new VarCharVector("tags", allocator);
+                VarCharVector scores = new VarCharVector("scores", allocator);
+                VarCharVector details = new VarCharVector("details", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(tags, scores, details))) {
+            tags.allocateNew();
+            tags.setSafe(0, "[\"red\",\"blue\"]".getBytes(UTF_8));
+            tags.setValueCount(1);
+
+            scores.allocateNew();
+            scores.setSafe(0, "{\"x\":10,\"y\":20}".getBytes(UTF_8));
+            scores.setValueCount(1);
+
+            details.allocateNew();
+            details.setSafe(0, "{\"a\":7,\"b\":\"ok\",\"c\":[3,4]}".getBytes(UTF_8));
+            details.setValueCount(1);
+
+            root.setRowCount(1);
+
+            Page page = convert(columns, root);
+
+            assertThat(tagsType.getObjectValue(page.getBlock(0), 0)).isEqualTo(List.of("red", "blue"));
+            assertThat(scoresType.getObjectValue(page.getBlock(1), 0)).isEqualTo(Map.of("x", 10L, "y", 20L));
+            assertThat(detailsType.getObjectValue(page.getBlock(2), 0)).isEqualTo(List.of(7, "ok", List.of(3L, 4L)));
         }
     }
 

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksArrowToPageConverter.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.TimestampType;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.Decimal256Vector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksArrowToPageConverter
+{
+    private final StarRocksArrowToPageConverter converter = new StarRocksArrowToPageConverter();
+
+    @Test
+    void testConvertPrimitiveAndCharacterColumns()
+    {
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("flag", "flag", BOOLEAN, 0),
+                new StarRocksColumnHandle("tiny", "tiny", TINYINT, 1),
+                new StarRocksColumnHandle("small", "small", SMALLINT, 2),
+                new StarRocksColumnHandle("id", "id", BIGINT, 3),
+                new StarRocksColumnHandle("ratio", "ratio", REAL, 4),
+                new StarRocksColumnHandle("name", "name", createVarcharType(20), 5),
+                new StarRocksColumnHandle("code", "code", createCharType(3), 6));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                BitVector flag = new BitVector("flag", allocator);
+                TinyIntVector tiny = new TinyIntVector("tiny", allocator);
+                SmallIntVector small = new SmallIntVector("small", allocator);
+                BigIntVector id = new BigIntVector("id", allocator);
+                Float4Vector ratio = new Float4Vector("ratio", allocator);
+                VarCharVector name = new VarCharVector("name", allocator);
+                VarCharVector code = new VarCharVector("code", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(flag, tiny, small, id, ratio, name, code))) {
+            flag.allocateNew();
+            flag.setSafe(0, 1);
+            flag.setNull(1);
+            flag.setValueCount(2);
+
+            tiny.allocateNew();
+            tiny.setSafe(0, 7);
+            tiny.setNull(1);
+            tiny.setValueCount(2);
+
+            small.allocateNew();
+            small.setSafe(0, 123);
+            small.setNull(1);
+            small.setValueCount(2);
+
+            id.allocateNew();
+            id.setSafe(0, 456789L);
+            id.setNull(1);
+            id.setValueCount(2);
+
+            ratio.allocateNew();
+            ratio.setSafe(0, 1.5f);
+            ratio.setNull(1);
+            ratio.setValueCount(2);
+
+            name.allocateNew();
+            name.setSafe(0, "alpha".getBytes(UTF_8));
+            name.setNull(1);
+            name.setValueCount(2);
+
+            code.allocateNew();
+            code.setSafe(0, "xy   ".getBytes(UTF_8));
+            code.setNull(1);
+            code.setValueCount(2);
+
+            root.setRowCount(2);
+
+            Page page = convert(columns, root);
+
+            assertThat(BOOLEAN.getObjectValue(page.getBlock(0), 0)).isEqualTo(true);
+            assertThat(page.getBlock(0).isNull(1)).isTrue();
+            assertThat(TINYINT.getLong(page.getBlock(1), 0)).isEqualTo(7L);
+            assertThat(SMALLINT.getLong(page.getBlock(2), 0)).isEqualTo(123L);
+            assertThat(BIGINT.getLong(page.getBlock(3), 0)).isEqualTo(456789L);
+            assertThat(REAL.getFloat(page.getBlock(4), 0)).isEqualTo(1.5f);
+            assertThat(createVarcharType(20).getObjectValue(page.getBlock(5), 0)).isEqualTo("alpha");
+            assertThat(createCharType(3).getObjectValue(page.getBlock(6), 0)).isEqualTo("xy ");
+        }
+    }
+
+    @Test
+    void testConvertTemporalDecimalAndLargeintFallbackColumns()
+    {
+        DecimalType shortDecimal = createDecimalType(18, 2);
+        TimestampType timestamp = createTimestampType(6);
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("created_on", "created_on", DATE, 0),
+                new StarRocksColumnHandle("created_at", "created_at", timestamp, 1),
+                new StarRocksColumnHandle("amount", "amount", shortDecimal, 2),
+                new StarRocksColumnHandle("largeint_summary", "largeint_summary", createUnboundedVarcharType(), 3));
+
+        LocalDate date = LocalDate.of(2024, 3, 20);
+        LocalDateTime timestampValue = LocalDateTime.of(2024, 7, 25, 10, 2, 23, 586_123_000);
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                DateDayVector createdOn = new DateDayVector("created_on", allocator);
+                TimeStampMicroVector createdAt = new TimeStampMicroVector("created_at", allocator);
+                DecimalVector amount = new DecimalVector("amount", allocator, 18, 2);
+                FixedSizeBinaryVector largeintSummary = new FixedSizeBinaryVector("largeint_summary", allocator, 16);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(createdOn, createdAt, amount, largeintSummary))) {
+            createdOn.allocateNew();
+            createdOn.setSafe(0, (int) date.toEpochDay());
+            createdOn.setSafe(1, (int) date.toEpochDay());
+            createdOn.setValueCount(2);
+
+            long epochMicros = timestampValue.toEpochSecond(UTC) * 1_000_000L + 586_123;
+            createdAt.allocateNew();
+            createdAt.setSafe(0, epochMicros);
+            createdAt.setNull(1);
+            createdAt.setValueCount(2);
+
+            amount.allocateNew();
+            amount.setSafe(0, new BigDecimal("12.34"));
+            amount.setNull(1);
+            amount.setValueCount(2);
+
+            largeintSummary.allocateNew();
+            largeintSummary.setSafe(0, toLittleEndianSignedInteger(new BigInteger("9223372036854775809")));
+            largeintSummary.setSafe(1, toLittleEndianSignedInteger(BigInteger.valueOf(-1)));
+            largeintSummary.setValueCount(2);
+
+            root.setRowCount(2);
+
+            Page page = convert(columns, root);
+
+            assertThat(DATE.getLong(page.getBlock(0), 0)).isEqualTo(date.toEpochDay());
+            assertThat(timestamp.getObjectValue(page.getBlock(1), 0).toString()).isEqualTo("2024-07-25 10:02:23.586123");
+            assertThat(page.getBlock(1).isNull(1)).isTrue();
+            assertThat(((SqlDecimal) shortDecimal.getObjectValue(page.getBlock(2), 0)).toString()).isEqualTo("12.34");
+            assertThat(page.getBlock(2).isNull(1)).isTrue();
+            assertThat(createUnboundedVarcharType().getObjectValue(page.getBlock(3), 0)).isEqualTo("9223372036854775809");
+            assertThat(createUnboundedVarcharType().getObjectValue(page.getBlock(3), 1)).isEqualTo("-1");
+        }
+    }
+
+    @Test
+    void testConvertTextualTemporalAndDecimal256FallbackColumns()
+    {
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("created_on", "created_on", DATE, 0),
+                new StarRocksColumnHandle("created_at", "created_at", createTimestampType(6), 1),
+                new StarRocksColumnHandle("oversized_amount", "oversized_amount", createUnboundedVarcharType(), 2));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                VarCharVector createdOn = new VarCharVector("created_on", allocator);
+                VarCharVector createdAt = new VarCharVector("created_at", allocator);
+                Decimal256Vector oversizedAmount = new Decimal256Vector("oversized_amount", allocator, 76, 6);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(createdOn, createdAt, oversizedAmount))) {
+            createdOn.allocateNew();
+            createdOn.setSafe(0, "2024-03-20 00:00:00".getBytes(UTF_8));
+            createdOn.setValueCount(1);
+
+            createdAt.allocateNew();
+            createdAt.setSafe(0, " 2024-07-25T10:02:23.5 ".getBytes(UTF_8));
+            createdAt.setValueCount(1);
+
+            oversizedAmount.allocateNew();
+            oversizedAmount.setSafe(0, new BigDecimal("1234567890123456789012345678901234567890.123456"));
+            oversizedAmount.setValueCount(1);
+
+            root.setRowCount(1);
+
+            Page page = convert(columns, root);
+
+            assertThat(DATE.getLong(page.getBlock(0), 0)).isEqualTo(LocalDate.of(2024, 3, 20).toEpochDay());
+            assertThat(createTimestampType(6).getObjectValue(page.getBlock(1), 0).toString()).isEqualTo("2024-07-25 10:02:23.500000");
+            assertThat(createUnboundedVarcharType().getObjectValue(page.getBlock(2), 0)).isEqualTo("1234567890123456789012345678901234567890.123456");
+        }
+    }
+
+    @Test
+    void testConvertArrowTimestampUnits()
+    {
+        TimestampType timestamp = createTimestampType(6);
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("ts_sec", "ts_sec", timestamp, 0),
+                new StarRocksColumnHandle("ts_milli", "ts_milli", timestamp, 1),
+                new StarRocksColumnHandle("ts_micro", "ts_micro", timestamp, 2),
+                new StarRocksColumnHandle("ts_nano", "ts_nano", timestamp, 3));
+
+        LocalDateTime timestampValue = LocalDateTime.of(2024, 7, 25, 10, 2, 23, 586_123_000);
+        long epochSeconds = timestampValue.toEpochSecond(UTC);
+        long epochMicros = epochSeconds * 1_000_000L + 586_123L;
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                TimeStampSecVector tsSec = new TimeStampSecVector("ts_sec", allocator);
+                TimeStampMilliVector tsMilli = new TimeStampMilliVector("ts_milli", allocator);
+                TimeStampMicroVector tsMicro = new TimeStampMicroVector("ts_micro", allocator);
+                TimeStampNanoVector tsNano = new TimeStampNanoVector("ts_nano", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(tsSec, tsMilli, tsMicro, tsNano))) {
+            tsSec.allocateNew();
+            tsSec.setSafe(0, epochSeconds);
+            tsSec.setValueCount(1);
+
+            tsMilli.allocateNew();
+            tsMilli.setSafe(0, epochSeconds * 1_000L + 586L);
+            tsMilli.setValueCount(1);
+
+            tsMicro.allocateNew();
+            tsMicro.setSafe(0, epochMicros);
+            tsMicro.setValueCount(1);
+
+            tsNano.allocateNew();
+            tsNano.setSafe(0, epochSeconds * 1_000_000_000L + 586_123_000L);
+            tsNano.setValueCount(1);
+
+            root.setRowCount(1);
+
+            Page page = convert(columns, root);
+
+            assertThat(timestamp.getLong(page.getBlock(0), 0)).isEqualTo(epochSeconds * 1_000_000L);
+            assertThat(timestamp.getLong(page.getBlock(1), 0)).isEqualTo(epochSeconds * 1_000_000L + 586_000L);
+            assertThat(timestamp.getLong(page.getBlock(2), 0)).isEqualTo(epochMicros);
+            assertThat(timestamp.getLong(page.getBlock(3), 0)).isEqualTo(epochMicros);
+        }
+    }
+
+    private Page convert(List<StarRocksColumnHandle> columns, VectorSchemaRoot root)
+    {
+        return converter.convert(PageBuilder.withMaxPageSize(1024, columns.stream().map(StarRocksColumnHandle::columnType).toList()), columns, root);
+    }
+
+    private static byte[] toLittleEndianSignedInteger(BigInteger value)
+    {
+        byte[] bigEndian = value.toByteArray();
+        byte[] littleEndian = new byte[16];
+        byte fill = value.signum() < 0 ? (byte) 0xFF : 0;
+        for (int index = 0; index < littleEndian.length; index++) {
+            littleEndian[index] = fill;
+        }
+        for (int index = 0; index < bigEndian.length; index++) {
+            littleEndian[index] = bigEndian[bigEndian.length - 1 - index];
+        }
+        return littleEndian;
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+final class TestStarRocksConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(StarRocksConfig.class)
+                .setJdbcUrl(null)
+                .setCatalogName(null)
+                .setUsername(null)
+                .setPassword(null)
+                .setFlightSqlHost(null)
+                .setFlightSqlPort(9408)
+                .setFlightSqlTlsEnabled(false)
+                .setFlightSqlTlsRootCertificate(null)
+                .setFlightSqlTlsSkipVerify(false)
+                .setFlightSqlTlsOverrideHostname(null)
+                .setFlightSqlMaxAllocation(DataSize.of(256, MEGABYTE)));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = Map.ofEntries(
+                Map.entry("starrocks.jdbc-url", "jdbc:starrocks://fe.example.net:9030"),
+                Map.entry("starrocks.catalog-name", "external_catalog"),
+                Map.entry("starrocks.username", "trino"),
+                Map.entry("starrocks.password", "secret"),
+                Map.entry("starrocks.flight-sql-host", "flight.example.net"),
+                Map.entry("starrocks.flight-sql-port", "9500"),
+                Map.entry("starrocks.flight-sql.tls.enabled", "true"),
+                Map.entry("starrocks.flight-sql.tls.root-certificate", "/etc/trino/starrocks-ca.pem"),
+                Map.entry("starrocks.flight-sql.tls.skip-verify", "true"),
+                Map.entry("starrocks.flight-sql.tls.override-hostname", "fe.internal.example.net"),
+                Map.entry("starrocks.flight-sql.max-allocation", "512MB"));
+
+        StarRocksConfig expected = new StarRocksConfig()
+                .setJdbcUrl("jdbc:starrocks://fe.example.net:9030")
+                .setCatalogName("external_catalog")
+                .setUsername("trino")
+                .setPassword("secret")
+                .setFlightSqlHost("flight.example.net")
+                .setFlightSqlPort(9500)
+                .setFlightSqlTlsEnabled(true)
+                .setFlightSqlTlsRootCertificate(new File("/etc/trino/starrocks-ca.pem"))
+                .setFlightSqlTlsSkipVerify(true)
+                .setFlightSqlTlsOverrideHostname("fe.internal.example.net")
+                .setFlightSqlMaxAllocation(DataSize.of(512, MEGABYTE));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.starrocks;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -32,7 +33,11 @@ final class TestStarRocksConfig
                 .setUsername(null)
                 .setPassword(null)
                 .setFlightSqlHost(null)
-                .setFlightSqlPort(9408));
+                .setFlightSqlPort(9408)
+                .setFlightSqlTlsEnabled(false)
+                .setFlightSqlTlsRootCertificate(null)
+                .setFlightSqlTlsSkipVerify(false)
+                .setFlightSqlTlsOverrideHostname(null));
     }
 
     @Test
@@ -44,7 +49,11 @@ final class TestStarRocksConfig
                 Map.entry("starrocks.username", "trino"),
                 Map.entry("starrocks.password", "secret"),
                 Map.entry("starrocks.flight-sql-host", "flight.example.net"),
-                Map.entry("starrocks.flight-sql-port", "9500"));
+                Map.entry("starrocks.flight-sql-port", "9500"),
+                Map.entry("starrocks.flight-sql.tls.enabled", "true"),
+                Map.entry("starrocks.flight-sql.tls.root-certificate", "/etc/trino/starrocks-ca.pem"),
+                Map.entry("starrocks.flight-sql.tls.skip-verify", "true"),
+                Map.entry("starrocks.flight-sql.tls.override-hostname", "fe.internal.example.net"));
 
         StarRocksConfig expected = new StarRocksConfig()
                 .setJdbcUrl("jdbc:starrocks://fe.example.net:9030")
@@ -52,7 +61,11 @@ final class TestStarRocksConfig
                 .setUsername("trino")
                 .setPassword("secret")
                 .setFlightSqlHost("flight.example.net")
-                .setFlightSqlPort(9500);
+                .setFlightSqlPort(9500)
+                .setFlightSqlTlsEnabled(true)
+                .setFlightSqlTlsRootCertificate(new File("/etc/trino/starrocks-ca.pem"))
+                .setFlightSqlTlsSkipVerify(true)
+                .setFlightSqlTlsOverrideHostname("fe.internal.example.net");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
@@ -28,6 +28,7 @@ final class TestStarRocksConfig
     {
         assertRecordedDefaults(recordDefaults(StarRocksConfig.class)
                 .setJdbcUrl(null)
+                .setCatalogName(null)
                 .setUsername(null)
                 .setPassword(null)
                 .setFlightSqlHost(null)
@@ -39,6 +40,7 @@ final class TestStarRocksConfig
     {
         Map<String, String> properties = Map.ofEntries(
                 Map.entry("starrocks.jdbc-url", "jdbc:starrocks://fe.example.net:9030"),
+                Map.entry("starrocks.catalog-name", "external_catalog"),
                 Map.entry("starrocks.username", "trino"),
                 Map.entry("starrocks.password", "secret"),
                 Map.entry("starrocks.flight-sql-host", "flight.example.net"),
@@ -46,6 +48,7 @@ final class TestStarRocksConfig
 
         StarRocksConfig expected = new StarRocksConfig()
                 .setJdbcUrl("jdbc:starrocks://fe.example.net:9030")
+                .setCatalogName("external_catalog")
                 .setUsername("trino")
                 .setPassword("secret")
                 .setFlightSqlHost("flight.example.net")

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestStarRocksConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(StarRocksConfig.class)
+                .setJdbcUrl(null)
+                .setUsername(null)
+                .setPassword(null)
+                .setFlightSqlHost(null)
+                .setFlightSqlPort(9408));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = Map.ofEntries(
+                Map.entry("starrocks.jdbc-url", "jdbc:starrocks://fe.example.net:9030"),
+                Map.entry("starrocks.username", "trino"),
+                Map.entry("starrocks.password", "secret"),
+                Map.entry("starrocks.flight-sql-host", "flight.example.net"),
+                Map.entry("starrocks.flight-sql-port", "9500"));
+
+        StarRocksConfig expected = new StarRocksConfig()
+                .setJdbcUrl("jdbc:starrocks://fe.example.net:9030")
+                .setUsername("trino")
+                .setPassword("secret")
+                .setFlightSqlHost("flight.example.net")
+                .setFlightSqlPort(9500);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+final class TestStarRocksConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    private final TestingStarRocksEnvironment environment = new TestingStarRocksEnvironment(List.of(
+            new TestingStarRocksEnvironment.TableDefinition(
+                    new SchemaTableName("starrocks_test", "events"),
+                    "starrocks_test",
+                    "events",
+                    StarRocksRelationType.TABLE,
+                    List.of(
+                            new StarRocksRemoteColumn("id", "id", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                            new StarRocksRemoteColumn("created_at", "created_at", "DATETIME", Optional.empty(), Optional.empty(), 2, Optional.of("datetimev2(3)")),
+                            new StarRocksRemoteColumn("name", "name", "VARCHAR", Optional.of(20), Optional.empty(), 3, Optional.of("varchar(20)")),
+                            new StarRocksRemoteColumn("amount", "amount", "DECIMAL", Optional.of(18), Optional.of(2), 4, Optional.of("decimal(18,2)"))),
+                    List.of(
+                            Map.of("id", 1L, "created_at", "2024-01-01 10:15:30.125", "name", "alpha", "amount", new BigDecimal("12.34")),
+                            Map.of("id", 2L, "created_at", "2024-01-02 11:16:31.250", "name", "beta", "amount", new BigDecimal("56.78")),
+                            Map.of("id", 3L, "created_at", "2024-01-03 12:17:32.500", "name", "gamma", "amount", new BigDecimal("90.12")))),
+            new TestingStarRocksEnvironment.TableDefinition(
+                    new SchemaTableName("starrocks_test", "events_view"),
+                    "StarRocks_Test",
+                    "EventsView",
+                    StarRocksRelationType.VIEW,
+                    List.of(
+                            new StarRocksRemoteColumn("id", "id", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                            new StarRocksRemoteColumn("name", "name", "VARCHAR", Optional.of(20), Optional.empty(), 2, Optional.of("varchar(20)"))),
+                    List.of(
+                            Map.of("id", 1L, "name", "alpha"),
+                            Map.of("id", 2L, "name", "beta"))),
+            new TestingStarRocksEnvironment.TableDefinition(
+                    new SchemaTableName("starrocks_test", "starrocks_specific"),
+                    "starrocks_test",
+                    "starrocks_specific",
+                    StarRocksRelationType.TABLE,
+                    List.of(
+                            new StarRocksRemoteColumn("metric_key", "metric_key", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                            new StarRocksRemoteColumn("largeint_summary", "largeint_summary", "DECIMAL", Optional.empty(), Optional.empty(), 2, Optional.of("largeint")),
+                            new StarRocksRemoteColumn("bitmap_summary", "bitmap_summary", "BITMAP", Optional.empty(), Optional.empty(), 3, Optional.of("bitmap")),
+                            new StarRocksRemoteColumn("json_payload", "json_payload", "JSON", Optional.empty(), Optional.empty(), 4, Optional.of("json"))),
+                    List.of(
+                            Map.of("metric_key", 10L, "largeint_summary", "9223372036854775809", "bitmap_summary", "1,3,5", "json_payload", "{\"kind\":\"bitmap\",\"count\":3}"),
+                            Map.of("metric_key", 11L, "largeint_summary", "-1", "bitmap_summary", "2,4", "json_payload", "{\"kind\":\"bitmap\",\"count\":2}")))));
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return StarRocksQueryRunner.builder(environment).build();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR -> false;
+            case SUPPORTS_AGGREGATION_PUSHDOWN -> true;
+            case SUPPORTS_ADD_COLUMN,
+                 SUPPORTS_ARRAY,
+                 SUPPORTS_COMMENT_ON_COLUMN,
+                 SUPPORTS_COMMENT_ON_TABLE,
+                 SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_CREATE_SCHEMA,
+                 SUPPORTS_CREATE_TABLE,
+                 SUPPORTS_CREATE_VIEW,
+                 SUPPORTS_DELETE,
+                 SUPPORTS_DYNAMIC_FILTER_PUSHDOWN,
+                 SUPPORTS_INSERT,
+                 SUPPORTS_JOIN_PUSHDOWN,
+                 SUPPORTS_MAP_TYPE,
+                 SUPPORTS_MERGE,
+                 SUPPORTS_NATIVE_QUERY,
+                 SUPPORTS_NOT_NULL_CONSTRAINT,
+                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
+                 SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
+                 SUPPORTS_RENAME_COLUMN,
+                 SUPPORTS_RENAME_TABLE,
+                 SUPPORTS_ROW_TYPE,
+                 SUPPORTS_SET_COLUMN_TYPE,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT,
+                 SUPPORTS_UPDATE,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_STDDEV,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_VARIANCE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Test
+    void testStarRocksBasicRead()
+    {
+        assertQuery(
+                "SELECT nationkey, name FROM nation WHERE nationkey <= 2 ORDER BY nationkey",
+                "VALUES (0, 'ALGERIA'), (1, 'ARGENTINA'), (2, 'BRAZIL')");
+    }
+
+    @Test
+    void testStarRocksShowSchemas()
+    {
+        assertQuery("SHOW SCHEMAS FROM starrocks LIKE 'starrocks_test'", "VALUES 'starrocks_test'");
+    }
+
+    @Test
+    void testStarRocksShowTablesAndDescribe()
+    {
+        assertQuery(
+                "SHOW TABLES FROM starrocks.starrocks_test",
+                "VALUES 'events', 'events_view', 'starrocks_specific'");
+        assertQuery(
+                "DESCRIBE starrocks.starrocks_test.events",
+                """
+                VALUES
+                    ('id', 'bigint', '', ''),
+                    ('created_at', 'timestamp(3)', '', ''),
+                    ('name', 'varchar(20)', '', ''),
+                    ('amount', 'decimal(18,2)', '', '')
+                """);
+    }
+
+    @Test
+    void testStarRocksShowCreateTable()
+    {
+        assertThat((String) computeActual("SHOW CREATE TABLE starrocks.starrocks_test.events").getOnlyValue())
+                .contains("CREATE TABLE starrocks.starrocks_test.events")
+                .contains("created_at timestamp(3)")
+                .contains("name varchar(20)")
+                .contains("amount decimal(18, 2)");
+    }
+
+    @Test
+    void testStarRocksCountAndDatetimeReads()
+    {
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events", "VALUES 3");
+        assertQuery(
+                "SELECT id, created_at FROM starrocks.starrocks_test.events ORDER BY id",
+                """
+                VALUES
+                    (1, TIMESTAMP '2024-01-01 10:15:30.125'),
+                    (2, TIMESTAMP '2024-01-02 11:16:31.250'),
+                    (3, TIMESTAMP '2024-01-03 12:17:32.500')
+                """);
+    }
+
+    @Test
+    void testStarRocksViewsAndSpecificTypeFallbacks()
+    {
+        assertQuery(
+                "SELECT * FROM starrocks.starrocks_test.events_view ORDER BY id",
+                "VALUES (1, 'alpha'), (2, 'beta')");
+        assertQuery(
+                "SELECT metric_key, largeint_summary, bitmap_summary FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '9223372036854775809', '1,3,5'), (11, '-1', '2,4')");
+        assertQuery(
+                "SELECT metric_key, json_format(json_payload) FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '{\"kind\":\"bitmap\",\"count\":3}'), (11, '{\"kind\":\"bitmap\",\"count\":2}')");
+    }
+
+    @Test
+    void testStarRocksPushdowns()
+    {
+        assertQuery("SELECT id FROM starrocks.starrocks_test.events WHERE id >= 2 ORDER BY id DESC LIMIT 1", "VALUES 3");
+        TestingStarRocksEnvironment.Request topNRequest = environment.getLastRequest().orElseThrow();
+        assertThat(topNRequest.tableHandle().constraint().isAll()).isFalse();
+        assertThat(topNRequest.tableHandle().sortOrder()).hasSize(1);
+        assertThat(topNRequest.tableHandle().limit()).hasValue(1);
+
+        assertQuery("SELECT name FROM starrocks.starrocks_test.events ORDER BY name LIMIT 1", "VALUES 'alpha'");
+        TestingStarRocksEnvironment.Request stringTopNRequest = environment.getLastRequest().orElseThrow();
+        assertThat(stringTopNRequest.tableHandle().sortOrder()).isEmpty();
+
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events WHERE id >= 2", "VALUES 2");
+        TestingStarRocksEnvironment.Request countRequest = environment.getLastRequest().orElseThrow();
+        assertThat(countRequest.tableHandle().constraint().isAll()).isFalse();
+        assertThat(countRequest.tableHandle().aggregation()).isPresent();
+        assertThat(countRequest.tableHandle().projectedColumns()).isPresent();
+        assertThat(countRequest.tableHandle().projectedColumns().orElseThrow()).extracting(StarRocksColumnHandle::columnName)
+                .containsExactly("_starrocks_agg_0");
+        assertThat(countRequest.requestedColumns()).extracting(StarRocksColumnHandle::columnName)
+                .containsExactly("_starrocks_agg_0");
+    }
+
+    @Test
+    void testStarRocksAggregationPushdowns()
+    {
+        assertQuery(
+                "SELECT sum(id), avg(id), min(id), max(created_at) FROM starrocks.starrocks_test.events WHERE id >= 2",
+                "VALUES (5, 2.5, 2, TIMESTAMP '2024-01-03 12:17:32.500')");
+        TestingStarRocksEnvironment.Request aggregateRequest = environment.getLastRequest().orElseThrow();
+        assertThat(aggregateRequest.tableHandle().aggregation()).isPresent();
+        assertThat(aggregateRequest.tableHandle().aggregation().orElseThrow().aggregateColumns())
+                .extracting(StarRocksAggregateColumn::expression)
+                .containsExactly("sum(`id`)", "avg(`id`)", "min(`id`)", "max(`created_at`)");
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
@@ -66,10 +66,11 @@ final class TestStarRocksConnectorSmokeTest
                     List.of(
                             new StarRocksRemoteColumn("metric_key", "metric_key", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
                             new StarRocksRemoteColumn("largeint_summary", "largeint_summary", "DECIMAL", Optional.empty(), Optional.empty(), 2, Optional.of("largeint")),
-                            new StarRocksRemoteColumn("bitmap_summary", "bitmap_summary", "BITMAP", Optional.empty(), Optional.empty(), 3, Optional.of("bitmap"))),
+                            new StarRocksRemoteColumn("bitmap_summary", "bitmap_summary", "BITMAP", Optional.empty(), Optional.empty(), 3, Optional.of("bitmap")),
+                            new StarRocksRemoteColumn("json_payload", "json_payload", "JSON", Optional.empty(), Optional.empty(), 4, Optional.of("json"))),
                     List.of(
-                            Map.of("metric_key", 10L, "largeint_summary", "9223372036854775809", "bitmap_summary", "1,3,5"),
-                            Map.of("metric_key", 11L, "largeint_summary", "-1", "bitmap_summary", "2,4")))));
+                            Map.of("metric_key", 10L, "largeint_summary", "9223372036854775809", "bitmap_summary", "1,3,5", "json_payload", "{\"kind\":\"bitmap\",\"count\":3}"),
+                            Map.of("metric_key", 11L, "largeint_summary", "-1", "bitmap_summary", "2,4", "json_payload", "{\"kind\":\"bitmap\",\"count\":2}")))));
 
     @Override
     protected QueryRunner createQueryRunner()
@@ -82,6 +83,7 @@ final class TestStarRocksConnectorSmokeTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
+            case SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR -> true;
             case SUPPORTS_ADD_COLUMN,
                     SUPPORTS_ARRAY,
                     SUPPORTS_COMMENT_ON_COLUMN,
@@ -94,12 +96,11 @@ final class TestStarRocksConnectorSmokeTest
                     SUPPORTS_DYNAMIC_FILTER_PUSHDOWN,
                     SUPPORTS_INSERT,
                     SUPPORTS_JOIN_PUSHDOWN,
-                    SUPPORTS_LIMIT_PUSHDOWN,
                     SUPPORTS_MAP_TYPE,
                     SUPPORTS_MERGE,
                     SUPPORTS_NATIVE_QUERY,
                     SUPPORTS_NOT_NULL_CONSTRAINT,
-                    SUPPORTS_PREDICATE_PUSHDOWN,
+                    SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
                     SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
                     SUPPORTS_RENAME_COLUMN,
                     SUPPORTS_RENAME_TABLE,
@@ -107,8 +108,6 @@ final class TestStarRocksConnectorSmokeTest
                     SUPPORTS_SET_COLUMN_TYPE,
                     SUPPORTS_AGGREGATION_PUSHDOWN,
                     SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT,
-                    SUPPORTS_TOPN_PUSHDOWN,
-                    SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR,
                     SUPPORTS_UPDATE,
                     SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
                     SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE,
@@ -183,5 +182,25 @@ final class TestStarRocksConnectorSmokeTest
         assertQuery(
                 "SELECT metric_key, largeint_summary, bitmap_summary FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
                 "VALUES (10, '9223372036854775809', '1,3,5'), (11, '-1', '2,4')");
+        assertQuery(
+                "SELECT metric_key, json_format(json_payload) FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '{\"kind\":\"bitmap\",\"count\":3}'), (11, '{\"kind\":\"bitmap\",\"count\":2}')");
+    }
+
+    @Test
+    void testStarRocksPushdowns()
+    {
+        assertQuery("SELECT id FROM starrocks.starrocks_test.events WHERE id >= 2 ORDER BY id DESC LIMIT 1", "VALUES 3");
+        TestingStarRocksEnvironment.Request topNRequest = environment.getLastRequest().orElseThrow();
+        assertThat(topNRequest.tableHandle().constraint().isAll()).isFalse();
+        assertThat(topNRequest.tableHandle().sortOrder()).hasSize(1);
+        assertThat(topNRequest.tableHandle().limit()).hasValue(1);
+
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events WHERE id >= 2", "VALUES 2");
+        TestingStarRocksEnvironment.Request countRequest = environment.getLastRequest().orElseThrow();
+        assertThat(countRequest.tableHandle().constraint().isAll()).isFalse();
+        assertThat(countRequest.tableHandle().aggregation()).isPresent();
+        assertThat(countRequest.requestedColumns()).extracting(StarRocksColumnHandle::columnName)
+                .containsExactly("_starrocks_agg_0");
     }
 }

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+final class TestStarRocksConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    private final TestingStarRocksEnvironment environment = new TestingStarRocksEnvironment(List.of(
+            new TestingStarRocksEnvironment.TableDefinition(
+                    new SchemaTableName("starrocks_test", "events"),
+                    "starrocks_test",
+                    "events",
+                    StarRocksRelationType.TABLE,
+                    List.of(
+                            new StarRocksRemoteColumn("id", "id", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                            new StarRocksRemoteColumn("created_at", "created_at", "DATETIME", Optional.empty(), Optional.empty(), 2, Optional.of("datetimev2(3)")),
+                            new StarRocksRemoteColumn("name", "name", "VARCHAR", Optional.of(20), Optional.empty(), 3, Optional.of("varchar(20)")),
+                            new StarRocksRemoteColumn("amount", "amount", "DECIMAL", Optional.of(18), Optional.of(2), 4, Optional.of("decimal(18,2)"))),
+                    List.of(
+                            Map.of("id", 1L, "created_at", "2024-01-01 10:15:30.125", "name", "alpha", "amount", new BigDecimal("12.34")),
+                            Map.of("id", 2L, "created_at", "2024-01-02 11:16:31.250", "name", "beta", "amount", new BigDecimal("56.78")),
+                            Map.of("id", 3L, "created_at", "2024-01-03 12:17:32.500", "name", "gamma", "amount", new BigDecimal("90.12")))),
+            new TestingStarRocksEnvironment.TableDefinition(
+                    new SchemaTableName("starrocks_test", "events_view"),
+                    "StarRocks_Test",
+                    "EventsView",
+                    StarRocksRelationType.VIEW,
+                    List.of(
+                            new StarRocksRemoteColumn("id", "id", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                            new StarRocksRemoteColumn("name", "name", "VARCHAR", Optional.of(20), Optional.empty(), 2, Optional.of("varchar(20)"))),
+                    List.of(
+                            Map.of("id", 1L, "name", "alpha"),
+                            Map.of("id", 2L, "name", "beta"))),
+            new TestingStarRocksEnvironment.TableDefinition(
+                    new SchemaTableName("starrocks_test", "starrocks_specific"),
+                    "starrocks_test",
+                    "starrocks_specific",
+                    StarRocksRelationType.TABLE,
+                    List.of(
+                            new StarRocksRemoteColumn("metric_key", "metric_key", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                            new StarRocksRemoteColumn("largeint_summary", "largeint_summary", "DECIMAL", Optional.empty(), Optional.empty(), 2, Optional.of("largeint")),
+                            new StarRocksRemoteColumn("bitmap_summary", "bitmap_summary", "BITMAP", Optional.empty(), Optional.empty(), 3, Optional.of("bitmap"))),
+                    List.of(
+                            Map.of("metric_key", 10L, "largeint_summary", "9223372036854775809", "bitmap_summary", "1,3,5"),
+                            Map.of("metric_key", 11L, "largeint_summary", "-1", "bitmap_summary", "2,4")))));
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return StarRocksQueryRunner.builder(environment).build();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_ADD_COLUMN,
+                    SUPPORTS_ARRAY,
+                    SUPPORTS_COMMENT_ON_COLUMN,
+                    SUPPORTS_COMMENT_ON_TABLE,
+                    SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                    SUPPORTS_CREATE_SCHEMA,
+                    SUPPORTS_CREATE_TABLE,
+                    SUPPORTS_CREATE_VIEW,
+                    SUPPORTS_DELETE,
+                    SUPPORTS_DYNAMIC_FILTER_PUSHDOWN,
+                    SUPPORTS_INSERT,
+                    SUPPORTS_JOIN_PUSHDOWN,
+                    SUPPORTS_LIMIT_PUSHDOWN,
+                    SUPPORTS_MAP_TYPE,
+                    SUPPORTS_MERGE,
+                    SUPPORTS_NATIVE_QUERY,
+                    SUPPORTS_NOT_NULL_CONSTRAINT,
+                    SUPPORTS_PREDICATE_PUSHDOWN,
+                    SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
+                    SUPPORTS_RENAME_COLUMN,
+                    SUPPORTS_RENAME_TABLE,
+                    SUPPORTS_ROW_TYPE,
+                    SUPPORTS_SET_COLUMN_TYPE,
+                    SUPPORTS_AGGREGATION_PUSHDOWN,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT,
+                    SUPPORTS_TOPN_PUSHDOWN,
+                    SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR,
+                    SUPPORTS_UPDATE,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_STDDEV,
+                    SUPPORTS_AGGREGATION_PUSHDOWN_VARIANCE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Test
+    void testStarRocksBasicRead()
+    {
+        assertQuery(
+                "SELECT nationkey, name FROM nation WHERE nationkey <= 2 ORDER BY nationkey",
+                "VALUES (0, 'ALGERIA'), (1, 'ARGENTINA'), (2, 'BRAZIL')");
+    }
+
+    @Test
+    void testStarRocksShowSchemas()
+    {
+        assertQuery("SHOW SCHEMAS FROM starrocks LIKE 'starrocks_test'", "VALUES 'starrocks_test'");
+    }
+
+    @Test
+    void testStarRocksShowTablesAndDescribe()
+    {
+        assertQuery(
+                "SHOW TABLES FROM starrocks.starrocks_test",
+                "VALUES 'events', 'events_view', 'starrocks_specific'");
+        assertQuery(
+                "DESCRIBE starrocks.starrocks_test.events",
+                """
+                VALUES
+                    ('id', 'bigint', '', ''),
+                    ('created_at', 'timestamp(3)', '', ''),
+                    ('name', 'varchar(20)', '', ''),
+                    ('amount', 'decimal(18,2)', '', '')
+                """);
+    }
+
+    @Test
+    void testStarRocksShowCreateTable()
+    {
+        assertThat((String) computeActual("SHOW CREATE TABLE starrocks.starrocks_test.events").getOnlyValue())
+                .contains("CREATE TABLE starrocks.starrocks_test.events")
+                .contains("created_at timestamp(3)")
+                .contains("name varchar(20)")
+                .contains("amount decimal(18, 2)");
+    }
+
+    @Test
+    void testStarRocksCountAndDatetimeReads()
+    {
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events", "VALUES 3");
+        assertQuery(
+                "SELECT id, created_at FROM starrocks.starrocks_test.events ORDER BY id",
+                """
+                VALUES
+                    (1, TIMESTAMP '2024-01-01 10:15:30.125'),
+                    (2, TIMESTAMP '2024-01-02 11:16:31.250'),
+                    (3, TIMESTAMP '2024-01-03 12:17:32.500')
+                """);
+    }
+
+    @Test
+    void testStarRocksViewsAndSpecificTypeFallbacks()
+    {
+        assertQuery(
+                "SELECT * FROM starrocks.starrocks_test.events_view ORDER BY id",
+                "VALUES (1, 'alpha'), (2, 'beta')");
+        assertQuery(
+                "SELECT metric_key, largeint_summary, bitmap_summary FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '9223372036854775809', '1,3,5'), (11, '-1', '2,4')");
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksConnectorSmokeTest.java
@@ -84,6 +84,7 @@ final class TestStarRocksConnectorSmokeTest
     {
         return switch (connectorBehavior) {
             case SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR -> true;
+            case SUPPORTS_AGGREGATION_PUSHDOWN -> true;
             case SUPPORTS_ADD_COLUMN,
                     SUPPORTS_ARRAY,
                     SUPPORTS_COMMENT_ON_COLUMN,
@@ -106,7 +107,6 @@ final class TestStarRocksConnectorSmokeTest
                     SUPPORTS_RENAME_TABLE,
                     SUPPORTS_ROW_TYPE,
                     SUPPORTS_SET_COLUMN_TYPE,
-                    SUPPORTS_AGGREGATION_PUSHDOWN,
                     SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT,
                     SUPPORTS_UPDATE,
                     SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
@@ -200,7 +200,23 @@ final class TestStarRocksConnectorSmokeTest
         TestingStarRocksEnvironment.Request countRequest = environment.getLastRequest().orElseThrow();
         assertThat(countRequest.tableHandle().constraint().isAll()).isFalse();
         assertThat(countRequest.tableHandle().aggregation()).isPresent();
+        assertThat(countRequest.tableHandle().projectedColumns()).isPresent();
+        assertThat(countRequest.tableHandle().projectedColumns().orElseThrow()).extracting(StarRocksColumnHandle::columnName)
+                .containsExactly("_starrocks_agg_0");
         assertThat(countRequest.requestedColumns()).extracting(StarRocksColumnHandle::columnName)
                 .containsExactly("_starrocks_agg_0");
+    }
+
+    @Test
+    void testStarRocksAggregationPushdowns()
+    {
+        assertQuery(
+                "SELECT sum(id), avg(id), min(name), max(created_at) FROM starrocks.starrocks_test.events WHERE id >= 2",
+                "VALUES (5, 2.5, 'beta', TIMESTAMP '2024-01-03 12:17:32.500')");
+        TestingStarRocksEnvironment.Request aggregateRequest = environment.getLastRequest().orElseThrow();
+        assertThat(aggregateRequest.tableHandle().aggregation()).isPresent();
+        assertThat(aggregateRequest.tableHandle().aggregation().orElseThrow().aggregateColumns())
+                .extracting(StarRocksAggregateColumn::expression)
+                .containsExactly("sum(`id`)", "avg(`id`)", "min(`name`)", "max(`created_at`)");
     }
 }

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksFlightSqlPageSource.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksFlightSqlPageSource.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.SourcePage;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksFlightSqlPageSource
+{
+    @Test
+    void testPageSourceSkipsEmptyBatchesAndReadsRows()
+    {
+        List<StarRocksColumnHandle> columns = List.of(
+                new StarRocksColumnHandle("id", "id", BIGINT, 0),
+                new StarRocksColumnHandle("name", "name", createVarcharType(20), 1));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                BigIntVector emptyId = new BigIntVector("id", allocator);
+                VarCharVector emptyName = new VarCharVector("name", allocator);
+                VectorSchemaRoot emptyRoot = new VectorSchemaRoot(List.of(emptyId, emptyName));
+                BigIntVector firstBatchId = new BigIntVector("id", allocator);
+                VarCharVector firstBatchName = new VarCharVector("name", allocator);
+                VectorSchemaRoot firstBatchRoot = new VectorSchemaRoot(List.of(firstBatchId, firstBatchName));
+                BigIntVector secondBatchId = new BigIntVector("id", allocator);
+                VarCharVector secondBatchName = new VarCharVector("name", allocator);
+                VectorSchemaRoot secondBatchRoot = new VectorSchemaRoot(List.of(secondBatchId, secondBatchName))) {
+            emptyId.setValueCount(0);
+            emptyName.setValueCount(0);
+            emptyRoot.setRowCount(0);
+
+            firstBatchId.allocateNew();
+            firstBatchId.setSafe(0, 1L);
+            firstBatchId.setSafe(1, 2L);
+            firstBatchId.setValueCount(2);
+
+            firstBatchName.allocateNew();
+            firstBatchName.setSafe(0, "alpha".getBytes(UTF_8));
+            firstBatchName.setSafe(1, "beta".getBytes(UTF_8));
+            firstBatchName.setValueCount(2);
+            firstBatchRoot.setRowCount(2);
+
+            secondBatchId.allocateNew();
+            secondBatchId.setSafe(0, 3L);
+            secondBatchId.setValueCount(1);
+
+            secondBatchName.allocateNew();
+            secondBatchName.setSafe(0, "gamma".getBytes(UTF_8));
+            secondBatchName.setValueCount(1);
+            secondBatchRoot.setRowCount(1);
+
+            StarRocksFlightSqlPageSource pageSource = new StarRocksFlightSqlPageSource(
+                    new TestingStarRocksFlightSqlResult(List.of(emptyRoot, firstBatchRoot, secondBatchRoot)),
+                    new StarRocksArrowToPageConverter(),
+                    columns);
+
+            SourcePage firstPage = pageSource.getNextSourcePage();
+            assertThat(pageSource.isFinished()).isFalse();
+            assertThat(firstPage.getPositionCount()).isEqualTo(2);
+            assertThat(BIGINT.getLong(firstPage.getBlock(0), 0)).isEqualTo(1L);
+            assertThat(createVarcharType(20).getObjectValue(firstPage.getBlock(1), 1)).isEqualTo("beta");
+            assertThat(pageSource.getCompletedPositions().orElseThrow()).isEqualTo(2L);
+
+            SourcePage secondPage = pageSource.getNextSourcePage();
+            assertThat(pageSource.isFinished()).isFalse();
+            assertThat(secondPage.getPositionCount()).isEqualTo(1);
+            assertThat(BIGINT.getLong(secondPage.getBlock(0), 0)).isEqualTo(3L);
+            assertThat(createVarcharType(20).getObjectValue(secondPage.getBlock(1), 0)).isEqualTo("gamma");
+            assertThat(pageSource.getCompletedPositions().orElseThrow()).isEqualTo(3L);
+
+            assertThat(pageSource.getNextSourcePage()).isNull();
+            assertThat(pageSource.isFinished()).isTrue();
+        }
+    }
+
+    @Test
+    void testPageSourceDoesNotPrefetchEndOfStreamBeforeReturningCurrentPage()
+    {
+        List<StarRocksColumnHandle> columns = List.of(new StarRocksColumnHandle("id", "id", BIGINT, 0));
+
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                BigIntVector id = new BigIntVector("id", allocator);
+                VectorSchemaRoot root = new VectorSchemaRoot(List.of(id))) {
+            id.allocateNew();
+            id.setSafe(0, 99L);
+            id.setValueCount(1);
+            root.setRowCount(1);
+
+            TestingStarRocksFlightSqlResult result = new TestingStarRocksFlightSqlResult(List.of(root));
+            StarRocksFlightSqlPageSource pageSource = new StarRocksFlightSqlPageSource(result, new StarRocksArrowToPageConverter(), columns);
+
+            SourcePage firstPage = pageSource.getNextSourcePage();
+            assertThat(firstPage.getPositionCount()).isEqualTo(1);
+            assertThat(BIGINT.getLong(firstPage.getBlock(0), 0)).isEqualTo(99L);
+            assertThat(result.loadCalls()).isEqualTo(1);
+
+            assertThat(pageSource.getNextSourcePage()).isNull();
+            assertThat(result.loadCalls()).isEqualTo(2);
+        }
+    }
+
+    private static final class TestingStarRocksFlightSqlResult
+            implements StarRocksFlightSqlResult
+    {
+        private final List<VectorSchemaRoot> roots;
+        private final AtomicInteger loadCalls = new AtomicInteger();
+        private int index = -1;
+
+        private TestingStarRocksFlightSqlResult(List<VectorSchemaRoot> roots)
+        {
+            this.roots = new ArrayList<>(roots);
+        }
+
+        @Override
+        public boolean loadNextBatch()
+        {
+            loadCalls.incrementAndGet();
+            index++;
+            return index < roots.size();
+        }
+
+        @Override
+        public VectorSchemaRoot getVectorSchemaRoot()
+        {
+            return roots.get(index);
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            return roots.stream()
+                    .flatMap(root -> root.getFieldVectors().stream())
+                    .mapToLong(FieldVector::getBufferSize)
+                    .sum();
+        }
+
+        @Override
+        public void close() {}
+
+        private int loadCalls()
+        {
+            return loadCalls.get();
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "starrocks.test.integration.enabled", matches = "true")
+@Execution(ExecutionMode.SAME_THREAD)
+final class TestStarRocksIntegrationSmokeTest
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return StarRocksIntegrationQueryRunner.createQueryRunner();
+    }
+
+    @Test
+    void testShowSchemas()
+    {
+        assertQuery("SHOW SCHEMAS FROM starrocks LIKE 'starrocks_test'", "VALUES 'starrocks_test'");
+    }
+
+    @Test
+    void testShowTablesAndDescribe()
+    {
+        assertQuery(
+                "SHOW TABLES FROM starrocks.starrocks_test",
+                "VALUES 'events', 'events_view', 'starrocks_specific'");
+        assertQuery(
+                "DESCRIBE starrocks.starrocks_test.events",
+                """
+                VALUES
+                    ('id', 'bigint', '', ''),
+                    ('created_at', 'timestamp(0)', '', ''),
+                    ('name', 'varchar(20)', '', ''),
+                    ('amount', 'decimal(18,2)', '', '')
+                """);
+    }
+
+    @Test
+    void testShowCreateTable()
+    {
+        assertThat((String) computeActual("SHOW CREATE TABLE starrocks.starrocks_test.events").getOnlyValue())
+                .contains("CREATE TABLE starrocks.starrocks_test.events")
+                .contains("created_at timestamp(0)")
+                .contains("name varchar(20)")
+                .contains("amount decimal(18, 2)");
+    }
+
+    @Test
+    void testCountAndDatetimeReads()
+    {
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events", "VALUES 3");
+        assertQuery(
+                "SELECT sum(id), avg(id), min(id), max(created_at) FROM starrocks.starrocks_test.events WHERE id >= 2",
+                "VALUES (5, 2.5, 2, TIMESTAMP '2024-01-03 12:17:32')");
+        assertQuery(
+                "SELECT id, created_at FROM starrocks.starrocks_test.events ORDER BY id",
+                """
+                VALUES
+                    (1, TIMESTAMP '2024-01-01 10:15:30'),
+                    (2, TIMESTAMP '2024-01-02 11:16:31'),
+                    (3, TIMESTAMP '2024-01-03 12:17:32')
+                """);
+    }
+
+    @Test
+    void testViewsAndSpecificTypeFallbacks()
+    {
+        assertQuery(
+                "SELECT * FROM starrocks.starrocks_test.events_view ORDER BY id",
+                "VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')");
+        assertQuery(
+                "SELECT metric_key, largeint_summary FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '9223372036854775809'), (11, '-1')");
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "starrocks.test.integration.enabled", matches = "true")
+@Execution(ExecutionMode.SAME_THREAD)
+final class TestStarRocksIntegrationSmokeTest
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return StarRocksIntegrationQueryRunner.createQueryRunner();
+    }
+
+    @Test
+    void testShowSchemas()
+    {
+        assertQuery("SHOW SCHEMAS FROM starrocks LIKE 'starrocks_test'", "VALUES 'starrocks_test'");
+    }
+
+    @Test
+    void testShowTablesAndDescribe()
+    {
+        assertQuery(
+                "SHOW TABLES FROM starrocks.starrocks_test",
+                "VALUES 'events', 'events_view', 'starrocks_specific'");
+        assertQuery(
+                "DESCRIBE starrocks.starrocks_test.events",
+                """
+                VALUES
+                    ('id', 'bigint', '', ''),
+                    ('created_at', 'timestamp(0)', '', ''),
+                    ('name', 'varchar(20)', '', ''),
+                    ('amount', 'decimal(18,2)', '', '')
+                """);
+    }
+
+    @Test
+    void testShowCreateTable()
+    {
+        assertThat((String) computeActual("SHOW CREATE TABLE starrocks.starrocks_test.events").getOnlyValue())
+                .contains("CREATE TABLE starrocks.starrocks_test.events")
+                .contains("created_at timestamp(0)")
+                .contains("name varchar(20)")
+                .contains("amount decimal(18, 2)");
+    }
+
+    @Test
+    void testCountAndDatetimeReads()
+    {
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events", "VALUES 3");
+        assertQuery(
+                "SELECT id, created_at FROM starrocks.starrocks_test.events ORDER BY id",
+                """
+                VALUES
+                    (1, TIMESTAMP '2024-01-01 10:15:30'),
+                    (2, TIMESTAMP '2024-01-02 11:16:31'),
+                    (3, TIMESTAMP '2024-01-03 12:17:32')
+                """);
+    }
+
+    @Test
+    void testViewsAndSpecificTypeFallbacks()
+    {
+        assertQuery(
+                "SELECT * FROM starrocks.starrocks_test.events_view ORDER BY id",
+                "VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')");
+        assertQuery(
+                "SELECT metric_key, largeint_summary FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '9223372036854775809'), (11, '-1')");
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
@@ -72,6 +72,9 @@ final class TestStarRocksIntegrationSmokeTest
     {
         assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events", "VALUES 3");
         assertQuery(
+                "SELECT sum(id), avg(id), min(name), max(created_at) FROM starrocks.starrocks_test.events WHERE id >= 2",
+                "VALUES (5, 2.5, 'beta', TIMESTAMP '2024-01-03 12:17:32')");
+        assertQuery(
                 "SELECT id, created_at FROM starrocks.starrocks_test.events ORDER BY id",
                 """
                 VALUES

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksIntegrationSmokeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "starrocks.test.integration.enabled", matches = "true")
+@Execution(ExecutionMode.SAME_THREAD)
+final class TestStarRocksIntegrationSmokeTest
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return StarRocksIntegrationQueryRunner.createQueryRunner();
+    }
+
+    @Test
+    void testShowSchemas()
+    {
+        assertQuery("SHOW SCHEMAS FROM starrocks LIKE 'starrocks_test'", "VALUES 'starrocks_test'");
+    }
+
+    @Test
+    void testShowTablesAndDescribe()
+    {
+        assertQuery(
+                "SHOW TABLES FROM starrocks.starrocks_test",
+                "VALUES 'events', 'events_view', 'starrocks_specific'");
+        assertQuery(
+                "DESCRIBE starrocks.starrocks_test.events",
+                """
+                VALUES
+                    ('id', 'bigint', '', ''),
+                    ('created_at', 'timestamp(6)', '', ''),
+                    ('name', 'varchar(20)', '', ''),
+                    ('amount', 'decimal(18,2)', '', '')
+                """);
+    }
+
+    @Test
+    void testShowCreateTable()
+    {
+        assertThat((String) computeActual("SHOW CREATE TABLE starrocks.starrocks_test.events").getOnlyValue())
+                .contains("CREATE TABLE starrocks.starrocks_test.events")
+                .contains("created_at timestamp(6)")
+                .contains("name varchar(20)")
+                .contains("amount decimal(18, 2)");
+    }
+
+    @Test
+    void testCountAndDatetimeReads()
+    {
+        assertQuery("SELECT count(*) FROM starrocks.starrocks_test.events", "VALUES 3");
+        assertQuery(
+                "SELECT sum(id), avg(id), min(id), max(created_at) FROM starrocks.starrocks_test.events WHERE id >= 2",
+                "VALUES (5, 2.5, 2, TIMESTAMP '2024-01-03 12:17:32')");
+        assertQuery(
+                "SELECT id, created_at FROM starrocks.starrocks_test.events ORDER BY id",
+                """
+                VALUES
+                    (1, TIMESTAMP '2024-01-01 10:15:30'),
+                    (2, TIMESTAMP '2024-01-02 11:16:31'),
+                    (3, TIMESTAMP '2024-01-03 12:17:32')
+                """);
+    }
+
+    @Test
+    void testViewsAndSpecificTypeFallbacks()
+    {
+        assertQuery(
+                "SELECT * FROM starrocks.starrocks_test.events_view ORDER BY id",
+                "VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')");
+        assertQuery(
+                "SELECT metric_key, largeint_summary FROM starrocks.starrocks_test.starrocks_specific ORDER BY metric_key",
+                "VALUES (10, '9223372036854775809'), (11, '-1')");
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksMetadata.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.SortItem;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.TypeSignature;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksMetadata
+{
+    private static final class TestingStarRocksMetadataClient
+            implements StarRocksMetadataClient
+    {
+        private final Map<SchemaTableName, StarRocksRemoteTable> tables;
+
+        private TestingStarRocksMetadataClient(List<StarRocksRemoteTable> tables)
+        {
+            this.tables = tables.stream()
+                    .collect(Collectors.toUnmodifiableMap(StarRocksRemoteTable::schemaTableName, table -> table));
+        }
+
+        @Override
+        public List<String> listSchemaNames(ConnectorSession session)
+        {
+            return tables.keySet().stream()
+                    .map(SchemaTableName::getSchemaName)
+                    .distinct()
+                    .toList();
+        }
+
+        @Override
+        public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+        {
+            return tables.keySet().stream()
+                    .filter(table -> schemaName.isEmpty() || table.getSchemaName().equals(schemaName.orElseThrow()))
+                    .toList();
+        }
+
+        @Override
+        public Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName));
+        }
+
+        @Override
+        public OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName)
+        {
+            return tables.containsKey(tableName) ? OptionalLong.of(42) : OptionalLong.empty();
+        }
+    }
+
+    private static final StarRocksRemoteTable EVENTS = new StarRocksRemoteTable(
+            new SchemaTableName("analytics", "events"),
+            Optional.empty(),
+            "analytics",
+            "events",
+            StarRocksRelationType.TABLE,
+            List.of(
+                    new StarRocksRemoteColumn("event_id", "event_id", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                    new StarRocksRemoteColumn("created_at", "created_at", "DATETIME", Optional.empty(), Optional.empty(), 2, Optional.of("datetimev2(3)")),
+                    new StarRocksRemoteColumn("payload", "payload", "JSON", Optional.empty(), Optional.empty(), 3, Optional.of("json"))));
+
+    private static final StarRocksRemoteTable METRICS_VIEW = new StarRocksRemoteTable(
+            new SchemaTableName("analytics", "metrics_view"),
+            Optional.empty(),
+            "Analytics",
+            "MetricsView",
+            StarRocksRelationType.VIEW,
+            List.of(
+                    new StarRocksRemoteColumn("metric_key", "metric_key", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                    new StarRocksRemoteColumn("largeint_summary", "largeint_summary", "DECIMAL", Optional.empty(), Optional.empty(), 2, Optional.of("largeint")),
+                    new StarRocksRemoteColumn("amount", "amount", "DECIMAL", Optional.of(18), Optional.of(2), 3, Optional.of("decimal(18,2)")),
+                    new StarRocksRemoteColumn("hll_state", "hll_state", "HLL", Optional.empty(), Optional.empty(), 4, Optional.of("hll"))));
+
+    private final StarRocksMetadata metadata = new StarRocksMetadata(
+            new TestingStarRocksMetadataClient(List.of(EVENTS, METRICS_VIEW)),
+            new StarRocksTypeMapper(TESTING_TYPE_MANAGER));
+
+    @Test
+    void testListSchemaNamesAndTables()
+    {
+        assertThat(metadata.listSchemaNames(SESSION)).containsExactly("analytics");
+        assertThat(metadata.listTables(SESSION, Optional.empty())).containsExactlyInAnyOrder(EVENTS.schemaTableName(), METRICS_VIEW.schemaTableName());
+        assertThat(metadata.listTables(SESSION, Optional.of("analytics"))).containsExactlyInAnyOrder(EVENTS.schemaTableName(), METRICS_VIEW.schemaTableName());
+    }
+
+    @Test
+    void testGetTableHandleAndMetadata()
+    {
+        StarRocksTableHandle tableHandle = (StarRocksTableHandle) metadata.getTableHandle(SESSION, EVENTS.schemaTableName(), Optional.empty(), Optional.empty());
+
+        assertThat(tableHandle).isEqualTo(new StarRocksTableHandle("analytics", "events", Optional.empty(), "analytics", "events", StarRocksRelationType.TABLE));
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("analytics", "missing"), Optional.empty(), Optional.empty())).isNull();
+
+        ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(SESSION, tableHandle);
+        assertThat(tableMetadata.getTable()).isEqualTo(EVENTS.schemaTableName());
+        assertThat(tableMetadata.getColumns()).isEqualTo(List.of(
+                new ColumnMetadata("event_id", BIGINT),
+                new ColumnMetadata("created_at", createTimestampType(3)),
+                new ColumnMetadata("payload", TESTING_TYPE_MANAGER.getType(new TypeSignature(JSON)))));
+    }
+
+    @Test
+    void testRemoteNamesAndViewRelationTypeArePreserved()
+    {
+        StarRocksTableHandle tableHandle = (StarRocksTableHandle) metadata.getTableHandle(SESSION, METRICS_VIEW.schemaTableName(), Optional.empty(), Optional.empty());
+
+        assertThat(tableHandle.remoteSchemaName()).isEqualTo("Analytics");
+        assertThat(tableHandle.remoteTableName()).isEqualTo("MetricsView");
+        assertThat(tableHandle.relationType()).isEqualTo(StarRocksRelationType.VIEW);
+    }
+
+    @Test
+    void testColumnHandlesAndTableColumns()
+    {
+        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(SESSION, new StarRocksTableHandle("analytics", "metrics_view", Optional.empty(), "Analytics", "MetricsView", StarRocksRelationType.VIEW));
+
+        assertThat(columnHandles).isEqualTo(Map.of(
+                "metric_key", new StarRocksColumnHandle("metric_key", "metric_key", BIGINT, 0),
+                "largeint_summary", new StarRocksColumnHandle("largeint_summary", "largeint_summary", createUnboundedVarcharType(), 1),
+                "amount", new StarRocksColumnHandle("amount", "amount", createDecimalType(18, 2), 2)));
+
+        Map<SchemaTableName, List<ColumnMetadata>> tableColumns = metadata.listTableColumns(SESSION, new SchemaTablePrefix("analytics"));
+        assertThat(tableColumns).isEqualTo(Map.of(
+                EVENTS.schemaTableName(), List.of(
+                        new ColumnMetadata("event_id", BIGINT),
+                        new ColumnMetadata("created_at", createTimestampType(3)),
+                        new ColumnMetadata("payload", TESTING_TYPE_MANAGER.getType(new TypeSignature(JSON)))),
+                METRICS_VIEW.schemaTableName(), List.of(
+                        new ColumnMetadata("metric_key", BIGINT),
+                        new ColumnMetadata("largeint_summary", createUnboundedVarcharType()),
+                        new ColumnMetadata("amount", createDecimalType(18, 2)))));
+    }
+
+    @Test
+    void testTableStatisticsUsesRemoteRowCount()
+    {
+        assertThat(metadata.getTableStatistics(SESSION, new StarRocksTableHandle("analytics", "events", Optional.empty(), "analytics", "events", StarRocksRelationType.TABLE)).getRowCount().getValue())
+                .isEqualTo(42.0);
+    }
+
+    @Test
+    void testDoesNotPushFilterOrTopNAcrossExistingLimitBoundary()
+    {
+        StarRocksColumnHandle eventId = new StarRocksColumnHandle("event_id", "event_id", BIGINT, 0);
+        StarRocksTableHandle table = new StarRocksTableHandle("analytics", "events", Optional.empty(), "analytics", "events", StarRocksRelationType.TABLE);
+        StarRocksTableHandle limitedTable = table.withTopN(10, List.of(new StarRocksSortItem("event_id", "event_id", ASC_NULLS_LAST)));
+
+        assertThat(metadata.applyFilter(
+                SESSION,
+                limitedTable,
+                new Constraint(TupleDomain.withColumnDomains(Map.of(eventId, Domain.singleValue(BIGINT, 1L))))))
+                .isEmpty();
+
+        assertThat(metadata.applyTopN(
+                SESSION,
+                table.withLimit(10),
+                5,
+                List.of(new SortItem("event_id", ASC_NULLS_LAST)),
+                Map.of("event_id", eventId)))
+                .isEmpty();
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksMetadata.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.type.TypeSignature;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,9 +30,11 @@ import java.util.stream.Collectors;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestStarRocksMetadata
@@ -79,6 +82,7 @@ final class TestStarRocksMetadata
 
     private static final StarRocksRemoteTable EVENTS = new StarRocksRemoteTable(
             new SchemaTableName("analytics", "events"),
+            Optional.empty(),
             "analytics",
             "events",
             StarRocksRelationType.TABLE,
@@ -89,6 +93,7 @@ final class TestStarRocksMetadata
 
     private static final StarRocksRemoteTable METRICS_VIEW = new StarRocksRemoteTable(
             new SchemaTableName("analytics", "metrics_view"),
+            Optional.empty(),
             "Analytics",
             "MetricsView",
             StarRocksRelationType.VIEW,
@@ -99,7 +104,7 @@ final class TestStarRocksMetadata
 
     private final StarRocksMetadata metadata = new StarRocksMetadata(
             new TestingStarRocksMetadataClient(List.of(EVENTS, METRICS_VIEW)),
-            new StarRocksTypeMapper());
+            new StarRocksTypeMapper(TESTING_TYPE_MANAGER));
 
     @Test
     void testListSchemaNamesAndTables()
@@ -114,7 +119,7 @@ final class TestStarRocksMetadata
     {
         StarRocksTableHandle tableHandle = (StarRocksTableHandle) metadata.getTableHandle(SESSION, EVENTS.schemaTableName(), Optional.empty(), Optional.empty());
 
-        assertThat(tableHandle).isEqualTo(new StarRocksTableHandle("analytics", "events", "analytics", "events", StarRocksRelationType.TABLE));
+        assertThat(tableHandle).isEqualTo(new StarRocksTableHandle("analytics", "events", Optional.empty(), "analytics", "events", StarRocksRelationType.TABLE));
         assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("analytics", "missing"), Optional.empty(), Optional.empty())).isNull();
 
         ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(SESSION, tableHandle);
@@ -122,7 +127,7 @@ final class TestStarRocksMetadata
         assertThat(tableMetadata.getColumns()).isEqualTo(List.of(
                 new ColumnMetadata("event_id", BIGINT),
                 new ColumnMetadata("created_at", createTimestampType(3)),
-                new ColumnMetadata("payload", createUnboundedVarcharType())));
+                new ColumnMetadata("payload", TESTING_TYPE_MANAGER.getType(new TypeSignature(JSON)))));
     }
 
     @Test
@@ -138,7 +143,7 @@ final class TestStarRocksMetadata
     @Test
     void testColumnHandlesAndTableColumns()
     {
-        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(SESSION, new StarRocksTableHandle("analytics", "metrics_view", "Analytics", "MetricsView", StarRocksRelationType.VIEW));
+        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(SESSION, new StarRocksTableHandle("analytics", "metrics_view", Optional.empty(), "Analytics", "MetricsView", StarRocksRelationType.VIEW));
 
         assertThat(columnHandles).isEqualTo(Map.of(
                 "metric_key", new StarRocksColumnHandle("metric_key", "metric_key", BIGINT, 0),
@@ -151,7 +156,7 @@ final class TestStarRocksMetadata
                 List.of(
                         new ColumnMetadata("event_id", BIGINT),
                         new ColumnMetadata("created_at", createTimestampType(3)),
-                        new ColumnMetadata("payload", createUnboundedVarcharType())),
+                        new ColumnMetadata("payload", TESTING_TYPE_MANAGER.getType(new TypeSignature(JSON)))),
                 METRICS_VIEW.schemaTableName(),
                 List.of(
                         new ColumnMetadata("metric_key", BIGINT),
@@ -162,7 +167,7 @@ final class TestStarRocksMetadata
     @Test
     void testTableStatisticsUsesRemoteRowCount()
     {
-        assertThat(metadata.getTableStatistics(SESSION, new StarRocksTableHandle("analytics", "events", "analytics", "events", StarRocksRelationType.TABLE)).getRowCount().getValue())
+        assertThat(metadata.getTableStatistics(SESSION, new StarRocksTableHandle("analytics", "events", Optional.empty(), "analytics", "events", StarRocksRelationType.TABLE)).getRowCount().getValue())
                 .isEqualTo(42.0);
     }
 }

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksMetadata.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksMetadata.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksMetadata
+{
+    private static final class TestingStarRocksMetadataClient
+            implements StarRocksMetadataClient
+    {
+        private final Map<SchemaTableName, StarRocksRemoteTable> tables;
+
+        private TestingStarRocksMetadataClient(List<StarRocksRemoteTable> tables)
+        {
+            this.tables = tables.stream()
+                    .collect(Collectors.toUnmodifiableMap(StarRocksRemoteTable::schemaTableName, table -> table));
+        }
+
+        @Override
+        public List<String> listSchemaNames(ConnectorSession session)
+        {
+            return tables.keySet().stream()
+                    .map(SchemaTableName::getSchemaName)
+                    .distinct()
+                    .toList();
+        }
+
+        @Override
+        public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+        {
+            return tables.keySet().stream()
+                    .filter(table -> schemaName.isEmpty() || table.getSchemaName().equals(schemaName.orElseThrow()))
+                    .toList();
+        }
+
+        @Override
+        public Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName));
+        }
+
+        @Override
+        public OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName)
+        {
+            return tables.containsKey(tableName) ? OptionalLong.of(42) : OptionalLong.empty();
+        }
+    }
+
+    private static final StarRocksRemoteTable EVENTS = new StarRocksRemoteTable(
+            new SchemaTableName("analytics", "events"),
+            "analytics",
+            "events",
+            StarRocksRelationType.TABLE,
+            List.of(
+                    new StarRocksRemoteColumn("event_id", "event_id", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                    new StarRocksRemoteColumn("created_at", "created_at", "DATETIME", Optional.empty(), Optional.empty(), 2, Optional.of("datetimev2(3)")),
+                    new StarRocksRemoteColumn("payload", "payload", "JSON", Optional.empty(), Optional.empty(), 3, Optional.of("json"))));
+
+    private static final StarRocksRemoteTable METRICS_VIEW = new StarRocksRemoteTable(
+            new SchemaTableName("analytics", "metrics_view"),
+            "Analytics",
+            "MetricsView",
+            StarRocksRelationType.VIEW,
+            List.of(
+                    new StarRocksRemoteColumn("metric_key", "metric_key", "BIGINT", Optional.of(20), Optional.empty(), 1, Optional.empty()),
+                    new StarRocksRemoteColumn("largeint_summary", "largeint_summary", "DECIMAL", Optional.empty(), Optional.empty(), 2, Optional.of("largeint")),
+                    new StarRocksRemoteColumn("amount", "amount", "DECIMAL", Optional.of(18), Optional.of(2), 3, Optional.of("decimal(18,2)"))));
+
+    private final StarRocksMetadata metadata = new StarRocksMetadata(
+            new TestingStarRocksMetadataClient(List.of(EVENTS, METRICS_VIEW)),
+            new StarRocksTypeMapper());
+
+    @Test
+    void testListSchemaNamesAndTables()
+    {
+        assertThat(metadata.listSchemaNames(SESSION)).containsExactly("analytics");
+        assertThat(metadata.listTables(SESSION, Optional.empty())).containsExactlyInAnyOrder(EVENTS.schemaTableName(), METRICS_VIEW.schemaTableName());
+        assertThat(metadata.listTables(SESSION, Optional.of("analytics"))).containsExactlyInAnyOrder(EVENTS.schemaTableName(), METRICS_VIEW.schemaTableName());
+    }
+
+    @Test
+    void testGetTableHandleAndMetadata()
+    {
+        StarRocksTableHandle tableHandle = (StarRocksTableHandle) metadata.getTableHandle(SESSION, EVENTS.schemaTableName(), Optional.empty(), Optional.empty());
+
+        assertThat(tableHandle).isEqualTo(new StarRocksTableHandle("analytics", "events", "analytics", "events", StarRocksRelationType.TABLE));
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("analytics", "missing"), Optional.empty(), Optional.empty())).isNull();
+
+        ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(SESSION, tableHandle);
+        assertThat(tableMetadata.getTable()).isEqualTo(EVENTS.schemaTableName());
+        assertThat(tableMetadata.getColumns()).isEqualTo(List.of(
+                new ColumnMetadata("event_id", BIGINT),
+                new ColumnMetadata("created_at", createTimestampType(3)),
+                new ColumnMetadata("payload", createUnboundedVarcharType())));
+    }
+
+    @Test
+    void testRemoteNamesAndViewRelationTypeArePreserved()
+    {
+        StarRocksTableHandle tableHandle = (StarRocksTableHandle) metadata.getTableHandle(SESSION, METRICS_VIEW.schemaTableName(), Optional.empty(), Optional.empty());
+
+        assertThat(tableHandle.remoteSchemaName()).isEqualTo("Analytics");
+        assertThat(tableHandle.remoteTableName()).isEqualTo("MetricsView");
+        assertThat(tableHandle.relationType()).isEqualTo(StarRocksRelationType.VIEW);
+    }
+
+    @Test
+    void testColumnHandlesAndTableColumns()
+    {
+        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(SESSION, new StarRocksTableHandle("analytics", "metrics_view", "Analytics", "MetricsView", StarRocksRelationType.VIEW));
+
+        assertThat(columnHandles).isEqualTo(Map.of(
+                "metric_key", new StarRocksColumnHandle("metric_key", "metric_key", BIGINT, 0),
+                "largeint_summary", new StarRocksColumnHandle("largeint_summary", "largeint_summary", createUnboundedVarcharType(), 1),
+                "amount", new StarRocksColumnHandle("amount", "amount", createDecimalType(18, 2), 2)));
+
+        Map<SchemaTableName, List<ColumnMetadata>> tableColumns = metadata.listTableColumns(SESSION, new SchemaTablePrefix("analytics"));
+        assertThat(tableColumns).isEqualTo(Map.of(
+                EVENTS.schemaTableName(),
+                List.of(
+                        new ColumnMetadata("event_id", BIGINT),
+                        new ColumnMetadata("created_at", createTimestampType(3)),
+                        new ColumnMetadata("payload", createUnboundedVarcharType())),
+                METRICS_VIEW.schemaTableName(),
+                List.of(
+                        new ColumnMetadata("metric_key", BIGINT),
+                        new ColumnMetadata("largeint_summary", createUnboundedVarcharType()),
+                        new ColumnMetadata("amount", createDecimalType(18, 2)))));
+    }
+
+    @Test
+    void testTableStatisticsUsesRemoteRowCount()
+    {
+        assertThat(metadata.getTableStatistics(SESSION, new StarRocksTableHandle("analytics", "events", "analytics", "events", StarRocksRelationType.TABLE)).getRowCount().getValue())
+                .isEqualTo(42.0);
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksPlugin.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+
+final class TestStarRocksPlugin
+{
+    @Test
+    void testCreateConnector()
+    {
+        StarRocksPlugin plugin = new StarRocksPlugin();
+
+        Iterator<ConnectorFactory> factories = plugin.getConnectorFactories().iterator();
+        ConnectorFactory factory = factories.next();
+        factory.create(
+                        "test",
+                        Map.of(
+                                "bootstrap.quiet", "true",
+                                "starrocks.jdbc-url", "jdbc:starrocks://127.0.0.1:9030"),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksPlugin.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.testing.TestingConnectorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+
+final class TestStarRocksPlugin
+{
+    @Test
+    void testCreateConnector()
+    {
+        StarRocksPlugin plugin = new StarRocksPlugin();
+
+        Iterator<ConnectorFactory> factories = plugin.getConnectorFactories().iterator();
+        ConnectorFactory factory = factories.next();
+        factory.create(
+                "test",
+                Map.of(
+                        "bootstrap.quiet", "true",
+                        "starrocks.jdbc-url", "jdbc:starrocks://127.0.0.1:9030"),
+                new TestingConnectorContext())
+                .shutdown();
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import io.trino.spi.predicate.Domain;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static io.trino.spi.predicate.Range.range;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
+import static io.trino.spi.predicate.ValueSet.ofRanges;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksQueryBuilder
+{
+    @Test
+    void testBuildSqlUsesRemoteNames()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.empty(), "Sales", "Orders", StarRocksRelationType.TABLE);
+
+        assertThat(queryBuilder.buildSelectSql(
+                tableHandle,
+                List.of(
+                        new StarRocksColumnHandle("orderkey", "OrderKey", BIGINT, 0),
+                        new StarRocksColumnHandle("customer_name", "Customer``Name", createVarcharType(20), 1))))
+                .isEqualTo("SELECT `OrderKey` AS `orderkey`, `Customer````Name` AS `customer_name` FROM `Sales`.`Orders`");
+    }
+
+    @Test
+    void testBuildSelectSqlWithEmptyProjection()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+
+        assertThat(queryBuilder.buildSelectSql(
+                new StarRocksTableHandle("sales", "orders", Optional.empty(), "sales", "orders", StarRocksRelationType.TABLE),
+                List.of()))
+                .isEqualTo("SELECT 1 FROM `sales`.`orders`");
+    }
+
+    @Test
+    void testBuildSelectSqlWithCatalogPredicateSortAndLimit()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+        StarRocksColumnHandle orderKey = new StarRocksColumnHandle("orderkey", "OrderKey", BIGINT, 0);
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.of("external_catalog"), "Sales", "Orders", StarRocksRelationType.TABLE)
+                .withConstraint(withColumnDomains(Map.of(orderKey, Domain.create(ofRanges(range(BIGINT, 10L, true, 20L, false)), false))))
+                .withTopN(5, List.of(new StarRocksSortItem("orderkey", "OrderKey", ASC_NULLS_LAST)));
+
+        assertThat(queryBuilder.buildSelectSql(tableHandle, List.of(orderKey)))
+                .isEqualTo("SELECT `OrderKey` AS `orderkey` FROM `external_catalog`.`Sales`.`Orders` WHERE (`OrderKey` >= 10 AND `OrderKey` < 20) ORDER BY `OrderKey` IS NULL ASC, `OrderKey` ASC LIMIT 5");
+    }
+
+    @Test
+    void testBuildSelectSqlWithAggregation()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+        StarRocksColumnHandle aggregate = new StarRocksColumnHandle("_starrocks_agg_0", "_starrocks_agg_0", BIGINT, 0);
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.empty(), "sales", "orders", StarRocksRelationType.TABLE)
+                .withAggregation(new StarRocksAggregation(
+                        List.of(),
+                        List.of(new StarRocksAggregateColumn("_starrocks_agg_0", "count(*)", BIGINT))));
+
+        assertThat(queryBuilder.buildSelectSql(tableHandle, List.of(aggregate)))
+                .isEqualTo("SELECT count(*) AS `_starrocks_agg_0` FROM `sales`.`orders`");
+    }
+
+    @Test
+    void testUnsupportedFloatingPointPredicateLiteralIsNotPushedDown()
+    {
+        StarRocksColumnHandle ratio = new StarRocksColumnHandle("ratio", "ratio", DOUBLE, 0);
+
+        assertThat(StarRocksQueryBuilder.buildColumnPredicate(ratio, Domain.singleValue(DOUBLE, Double.POSITIVE_INFINITY)))
+                .isEmpty();
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
@@ -13,13 +13,14 @@
  */
 package io.trino.plugin.starrocks;
 
+import io.trino.spi.predicate.Domain;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
-import static io.trino.spi.predicate.Domain.create;
 import static io.trino.spi.predicate.Range.range;
 import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
 import static io.trino.spi.predicate.ValueSet.ofRanges;
@@ -60,7 +61,7 @@ final class TestStarRocksQueryBuilder
         StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
         StarRocksColumnHandle orderKey = new StarRocksColumnHandle("orderkey", "OrderKey", BIGINT, 0);
         StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.of("external_catalog"), "Sales", "Orders", StarRocksRelationType.TABLE)
-                .withConstraint(withColumnDomains(java.util.Map.of(orderKey, create(ofRanges(range(BIGINT, 10L, true, 20L, false)), false))))
+                .withConstraint(withColumnDomains(Map.of(orderKey, Domain.create(ofRanges(range(BIGINT, 10L, true, 20L, false)), false))))
                 .withTopN(5, List.of(new StarRocksSortItem("orderkey", "OrderKey", ASC_NULLS_LAST)));
 
         assertThat(queryBuilder.buildSelectSql(tableHandle, List.of(orderKey)))

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
@@ -16,7 +16,13 @@ package io.trino.plugin.starrocks;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static io.trino.spi.predicate.Domain.create;
+import static io.trino.spi.predicate.Range.range;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
+import static io.trino.spi.predicate.ValueSet.ofRanges;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +33,7 @@ final class TestStarRocksQueryBuilder
     void testBuildSqlUsesRemoteNames()
     {
         StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
-        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", "Sales", "Orders", StarRocksRelationType.TABLE);
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.empty(), "Sales", "Orders", StarRocksRelationType.TABLE);
 
         assertThat(queryBuilder.buildSelectSql(
                 tableHandle,
@@ -43,8 +49,35 @@ final class TestStarRocksQueryBuilder
         StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
 
         assertThat(queryBuilder.buildSelectSql(
-                new StarRocksTableHandle("sales", "orders", "sales", "orders", StarRocksRelationType.TABLE),
+                new StarRocksTableHandle("sales", "orders", Optional.empty(), "sales", "orders", StarRocksRelationType.TABLE),
                 List.of()))
                 .isEqualTo("SELECT 1 FROM `sales`.`orders`");
+    }
+
+    @Test
+    void testBuildSelectSqlWithCatalogPredicateSortAndLimit()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+        StarRocksColumnHandle orderKey = new StarRocksColumnHandle("orderkey", "OrderKey", BIGINT, 0);
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.of("external_catalog"), "Sales", "Orders", StarRocksRelationType.TABLE)
+                .withConstraint(withColumnDomains(java.util.Map.of(orderKey, create(ofRanges(range(BIGINT, 10L, true, 20L, false)), false))))
+                .withTopN(5, List.of(new StarRocksSortItem("orderkey", "OrderKey", ASC_NULLS_LAST)));
+
+        assertThat(queryBuilder.buildSelectSql(tableHandle, List.of(orderKey)))
+                .isEqualTo("SELECT `OrderKey` AS `orderkey` FROM `external_catalog`.`Sales`.`Orders` WHERE (`OrderKey` >= 10 AND `OrderKey` < 20) ORDER BY `OrderKey` IS NULL ASC, `OrderKey` ASC LIMIT 5");
+    }
+
+    @Test
+    void testBuildSelectSqlWithAggregation()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+        StarRocksColumnHandle aggregate = new StarRocksColumnHandle("_starrocks_agg_0", "_starrocks_agg_0", BIGINT, 0);
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", Optional.empty(), "sales", "orders", StarRocksRelationType.TABLE)
+                .withAggregation(new StarRocksAggregation(
+                        List.of(),
+                        List.of(new StarRocksAggregateColumn("_starrocks_agg_0", "count(*)", BIGINT))));
+
+        assertThat(queryBuilder.buildSelectSql(tableHandle, List.of(aggregate)))
+                .isEqualTo("SELECT count(*) AS `_starrocks_agg_0` FROM `sales`.`orders`");
     }
 }

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksQueryBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksQueryBuilder
+{
+    @Test
+    void testBuildSqlUsesRemoteNames()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+        StarRocksTableHandle tableHandle = new StarRocksTableHandle("sales", "orders", "Sales", "Orders", StarRocksRelationType.TABLE);
+
+        assertThat(queryBuilder.buildSelectSql(
+                tableHandle,
+                List.of(
+                        new StarRocksColumnHandle("orderkey", "OrderKey", BIGINT, 0),
+                        new StarRocksColumnHandle("customer_name", "Customer``Name", createVarcharType(20), 1))))
+                .isEqualTo("SELECT `OrderKey` AS `orderkey`, `Customer````Name` AS `customer_name` FROM `Sales`.`Orders`");
+    }
+
+    @Test
+    void testBuildSelectSqlWithEmptyProjection()
+    {
+        StarRocksQueryBuilder queryBuilder = new StarRocksQueryBuilder();
+
+        assertThat(queryBuilder.buildSelectSql(
+                new StarRocksTableHandle("sales", "orders", "sales", "orders", StarRocksRelationType.TABLE),
+                List.of()))
+                .isEqualTo("SELECT 1 FROM `sales`.`orders`");
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksTypeMapper
+{
+    private final StarRocksTypeMapper mapper = new StarRocksTypeMapper(TESTING_TYPE_MANAGER);
+
+    @Test
+    void testPrimitiveMappings()
+    {
+        assertThat(mapper.toTrinoType(column("is_enabled", "TINYINT", 1, null, 1, "tinyint(1)"))).isEqualTo(TINYINT);
+        assertThat(mapper.toTrinoType(column("flag", "BOOLEAN", null, null, 2))).isEqualTo(BOOLEAN);
+        assertThat(mapper.toTrinoType(column("flag_alias", "BOOL", null, null, 2))).isEqualTo(BOOLEAN);
+        assertThat(mapper.toTrinoType(column("retry_count", "TINYINT", 4, null, 3, "tinyint(4)"))).isEqualTo(TINYINT);
+        assertThat(mapper.toTrinoType(column("retry_count_unsigned", "TINYINT", 4, null, 4, "tinyint(4) unsigned"))).isEqualTo(SMALLINT);
+        assertThat(mapper.toTrinoType(column("user_id", "INT", 11, null, 4))).isEqualTo(INTEGER);
+        assertThat(mapper.toTrinoType(column("user_id_unsigned", "INT", 11, null, 5, "int(11) unsigned"))).isEqualTo(BIGINT);
+        assertThat(mapper.toTrinoType(column("total", "BIGINT", 20, null, 5))).isEqualTo(BIGINT);
+        assertThat(mapper.toTrinoType(column("total_unsigned", "BIGINT UNSIGNED", 39, null, 6, "bigint(20) unsigned"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("score", "FLOAT", null, null, 6))).isEqualTo(REAL);
+        assertThat(mapper.toTrinoType(column("ratio", "DOUBLE", null, null, 7))).isEqualTo(DOUBLE);
+    }
+
+    @Test
+    void testDecimalAndCharacterMappings()
+    {
+        assertThat(mapper.toTrinoType(column("amount", "DECIMAL", 18, 4, 1, "decimal(18,4)"))).isEqualTo(createDecimalType(18, 4));
+        assertThat(mapper.toTrinoType(column("oversized_amount", "DECIMAL256", 76, 18, 2, "decimal256(76,18)"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("code", "CHAR", 8, null, 3, "char(8)"))).isEqualTo(createCharType(8));
+        assertThat(mapper.toTrinoType(column("name", "VARCHAR", 32, null, 4, "varchar(32)"))).isEqualTo(createVarcharType(32));
+        assertThat(mapper.toTrinoType(column("description", "VARCHAR", null, null, 5))).isEqualTo(createUnboundedVarcharType());
+    }
+
+    @Test
+    void testTemporalAndBinaryMappings()
+    {
+        assertThat(mapper.toTrinoType(column("event_date", "DATE", null, null, 1))).isEqualTo(DATE);
+        assertThat(mapper.toTrinoType(column("created_at", "DATETIME", null, null, 2, "datetimev2(3)"))).isEqualTo(createTimestampType(3));
+        assertThat(mapper.toTrinoType(column("updated_at", "TIMESTAMP", null, 6, 3))).isEqualTo(createTimestampType(6));
+        assertThat(mapper.toTrinoType(column("payload", "VARBINARY", null, null, 4))).isEqualTo(VARBINARY);
+    }
+
+    @Test
+    void testStarRocksSpecificAndUnknownTypesFallbackToVarchar()
+    {
+        assertThat(mapper.toTrinoType(column("json_payload", "JSON", null, null, 1, "json")).getBaseName()).isEqualTo(JSON);
+        assertThat(mapper.toTrinoType(column("variant_payload", "VARIANT", null, null, 2, "variant")).getBaseName()).isEqualTo(JSON);
+        assertThat(mapper.toTrinoType(column("large_id", "DECIMAL", null, null, 1, "largeint"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("bitmap_summary", "BITMAP", null, null, 3, "bitmap"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("mystery", "GEOGRAPHY", null, null, 5))).isEqualTo(createUnboundedVarcharType());
+    }
+
+    @Test
+    void testComplexTypeMappings()
+    {
+        assertThat(mapper.toTrinoType(column("tags", "ARRAY", null, null, 1, "array<varchar(12)>")))
+                .isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("scores", "MAP", null, null, 2, "map<varchar(8),array<int>>")))
+                .isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("details", "STRUCT", null, null, 3, "struct<a:int,b:varchar(12),c:array<bigint>>")))
+                .isEqualTo(createUnboundedVarcharType());
+    }
+
+    private static StarRocksRemoteColumn column(String name, String type, Integer size, Integer scale, int ordinalPosition)
+    {
+        return column(name, type, size, scale, ordinalPosition, null);
+    }
+
+    private static StarRocksRemoteColumn column(String name, String type, Integer size, Integer scale, int ordinalPosition, String typeDefinition)
+    {
+        return new StarRocksRemoteColumn(
+                name,
+                name,
+                type,
+                Optional.ofNullable(size),
+                Optional.ofNullable(scale),
+                ordinalPosition,
+                Optional.ofNullable(typeDefinition));
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStarRocksTypeMapper
+{
+    private final StarRocksTypeMapper mapper = new StarRocksTypeMapper();
+
+    @Test
+    void testPrimitiveMappings()
+    {
+        assertThat(mapper.toTrinoType(column("is_enabled", "TINYINT", 1, null, 1, "tinyint(1)"))).isEqualTo(BOOLEAN);
+        assertThat(mapper.toTrinoType(column("flag", "BOOLEAN", null, null, 2))).isEqualTo(BOOLEAN);
+        assertThat(mapper.toTrinoType(column("retry_count", "TINYINT", 4, null, 3, "tinyint(4)"))).isEqualTo(TINYINT);
+        assertThat(mapper.toTrinoType(column("retry_count_unsigned", "TINYINT", 4, null, 4, "tinyint(4) unsigned"))).isEqualTo(SMALLINT);
+        assertThat(mapper.toTrinoType(column("user_id", "INT", 11, null, 4))).isEqualTo(INTEGER);
+        assertThat(mapper.toTrinoType(column("user_id_unsigned", "INT", 11, null, 5, "int(11) unsigned"))).isEqualTo(BIGINT);
+        assertThat(mapper.toTrinoType(column("total", "BIGINT", 20, null, 5))).isEqualTo(BIGINT);
+        assertThat(mapper.toTrinoType(column("total_unsigned", "BIGINT UNSIGNED", 39, null, 6, "bigint(20) unsigned"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("score", "FLOAT", null, null, 6))).isEqualTo(REAL);
+        assertThat(mapper.toTrinoType(column("ratio", "DOUBLE", null, null, 7))).isEqualTo(DOUBLE);
+    }
+
+    @Test
+    void testDecimalAndCharacterMappings()
+    {
+        assertThat(mapper.toTrinoType(column("amount", "DECIMAL", 18, 4, 1, "decimal(18,4)"))).isEqualTo(createDecimalType(18, 4));
+        assertThat(mapper.toTrinoType(column("oversized_amount", "DECIMAL256", 76, 18, 2, "decimal256(76,18)"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("code", "CHAR", 8, null, 3, "char(8)"))).isEqualTo(createCharType(8));
+        assertThat(mapper.toTrinoType(column("name", "VARCHAR", 32, null, 4, "varchar(32)"))).isEqualTo(createVarcharType(32));
+        assertThat(mapper.toTrinoType(column("description", "VARCHAR", null, null, 5))).isEqualTo(createUnboundedVarcharType());
+    }
+
+    @Test
+    void testTemporalAndBinaryMappings()
+    {
+        assertThat(mapper.toTrinoType(column("event_date", "DATE", null, null, 1))).isEqualTo(DATE);
+        assertThat(mapper.toTrinoType(column("created_at", "DATETIME", null, null, 2, "datetimev2(3)"))).isEqualTo(createTimestampType(3));
+        assertThat(mapper.toTrinoType(column("updated_at", "TIMESTAMP", null, 6, 3))).isEqualTo(createTimestampType(6));
+        assertThat(mapper.toTrinoType(column("payload", "VARBINARY", null, null, 4))).isEqualTo(VARBINARY);
+    }
+
+    @Test
+    void testStarRocksSpecificAndUnknownTypesFallbackToVarchar()
+    {
+        assertThat(mapper.toTrinoType(column("large_id", "DECIMAL", null, null, 1, "largeint"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("bitmap_summary", "BITMAP", null, null, 2, "bitmap"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("details", "STRUCT", null, null, 3, "struct<a:int,b:varchar(12)>"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("mystery", "GEOGRAPHY", null, null, 4))).isEqualTo(createUnboundedVarcharType());
+    }
+
+    private static StarRocksRemoteColumn column(String name, String type, Integer size, Integer scale, int ordinalPosition)
+    {
+        return column(name, type, size, scale, ordinalPosition, null);
+    }
+
+    private static StarRocksRemoteColumn column(String name, String type, Integer size, Integer scale, int ordinalPosition, String typeDefinition)
+    {
+        return new StarRocksRemoteColumn(
+                name,
+                name,
+                type,
+                Optional.ofNullable(size),
+                Optional.ofNullable(scale),
+                ordinalPosition,
+                Optional.ofNullable(typeDefinition));
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.starrocks;
 
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -25,6 +27,8 @@ import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimestampType.createTimestampType;
@@ -80,8 +84,21 @@ final class TestStarRocksTypeMapper
         assertThat(mapper.toTrinoType(column("variant_payload", "VARIANT", null, null, 2, "variant")).getBaseName()).isEqualTo(JSON);
         assertThat(mapper.toTrinoType(column("large_id", "DECIMAL", null, null, 1, "largeint"))).isEqualTo(createUnboundedVarcharType());
         assertThat(mapper.toTrinoType(column("bitmap_summary", "BITMAP", null, null, 3, "bitmap"))).isEqualTo(createUnboundedVarcharType());
-        assertThat(mapper.toTrinoType(column("details", "STRUCT", null, null, 4, "struct<a:int,b:varchar(12)>"))).isEqualTo(createUnboundedVarcharType());
         assertThat(mapper.toTrinoType(column("mystery", "GEOGRAPHY", null, null, 5))).isEqualTo(createUnboundedVarcharType());
+    }
+
+    @Test
+    void testComplexTypeMappings()
+    {
+        assertThat(mapper.toTrinoType(column("tags", "ARRAY", null, null, 1, "array<varchar(12)>")))
+                .isEqualTo(new ArrayType(createVarcharType(12)));
+        assertThat(mapper.toTrinoType(column("scores", "MAP", null, null, 2, "map<varchar(8),array<int>>")))
+                .isEqualTo(new MapType(createVarcharType(8), new ArrayType(INTEGER), TESTING_TYPE_MANAGER.getTypeOperators()));
+        assertThat(mapper.toTrinoType(column("details", "STRUCT", null, null, 3, "struct<a:int,b:varchar(12),c:array<bigint>>")))
+                .isEqualTo(rowType(
+                        field("a", INTEGER),
+                        field("b", createVarcharType(12)),
+                        field("c", new ArrayType(BIGINT))));
     }
 
     private static StarRocksRemoteColumn column(String name, String type, Integer size, Integer scale, int ordinalPosition)

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestStarRocksTypeMapper.java
@@ -26,16 +26,18 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestStarRocksTypeMapper
 {
-    private final StarRocksTypeMapper mapper = new StarRocksTypeMapper();
+    private final StarRocksTypeMapper mapper = new StarRocksTypeMapper(TESTING_TYPE_MANAGER);
 
     @Test
     void testPrimitiveMappings()
@@ -74,10 +76,12 @@ final class TestStarRocksTypeMapper
     @Test
     void testStarRocksSpecificAndUnknownTypesFallbackToVarchar()
     {
+        assertThat(mapper.toTrinoType(column("json_payload", "JSON", null, null, 1, "json")).getBaseName()).isEqualTo(JSON);
+        assertThat(mapper.toTrinoType(column("variant_payload", "VARIANT", null, null, 2, "variant")).getBaseName()).isEqualTo(JSON);
         assertThat(mapper.toTrinoType(column("large_id", "DECIMAL", null, null, 1, "largeint"))).isEqualTo(createUnboundedVarcharType());
-        assertThat(mapper.toTrinoType(column("bitmap_summary", "BITMAP", null, null, 2, "bitmap"))).isEqualTo(createUnboundedVarcharType());
-        assertThat(mapper.toTrinoType(column("details", "STRUCT", null, null, 3, "struct<a:int,b:varchar(12)>"))).isEqualTo(createUnboundedVarcharType());
-        assertThat(mapper.toTrinoType(column("mystery", "GEOGRAPHY", null, null, 4))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("bitmap_summary", "BITMAP", null, null, 3, "bitmap"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("details", "STRUCT", null, null, 4, "struct<a:int,b:varchar(12)>"))).isEqualTo(createUnboundedVarcharType());
+        assertThat(mapper.toTrinoType(column("mystery", "GEOGRAPHY", null, null, 5))).isEqualTo(createUnboundedVarcharType());
     }
 
     private static StarRocksRemoteColumn column(String name, String type, Integer size, Integer scale, int ordinalPosition)

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
@@ -1,0 +1,965 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Module;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.trino.plugin.tpch.DecimalTypeMapping;
+import io.trino.plugin.tpch.TpchMetadata;
+import io.trino.plugin.tpch.TpchRecordSet;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchEntity;
+import io.trino.tpch.TpchTable;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.encodeShortScaledValue;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+
+final class TestingStarRocksEnvironment
+{
+    private static final JsonCodec<Object> JSON_CODEC = jsonCodec(Object.class);
+    private static final String TPCH_SCHEMA = TpchMetadata.TINY_SCHEMA_NAME;
+    private static final double TPCH_SCALE_FACTOR = TpchMetadata.TINY_SCALE_FACTOR;
+
+    private final Map<SchemaTableName, TestingTable> tables;
+    private final AtomicReference<Request> lastRequest = new AtomicReference<>();
+
+    public TestingStarRocksEnvironment()
+    {
+        this(List.of());
+    }
+
+    public TestingStarRocksEnvironment(List<TableDefinition> additionalTables)
+    {
+        tables = createTables(additionalTables);
+    }
+
+    public Module createModule()
+    {
+        TestingStarRocksMetadataClient metadataClient = new TestingStarRocksMetadataClient(tables);
+        TestingStarRocksFlightSqlClient flightSqlClient = new TestingStarRocksFlightSqlClient(tables, lastRequest);
+
+        return binder -> {
+            binder.bind(StarRocksMetadataClient.class).toInstance(metadataClient);
+            binder.bind(StarRocksFlightSqlClient.class).toInstance(flightSqlClient);
+        };
+    }
+
+    public Optional<Request> getLastRequest()
+    {
+        return Optional.ofNullable(lastRequest.get());
+    }
+
+    private static Map<SchemaTableName, TestingTable> createTables(List<TableDefinition> additionalTables)
+    {
+        Map<SchemaTableName, TestingTable> tableMap = new LinkedHashMap<>();
+        for (TpchTable<?> table : List.of(TpchTable.NATION, TpchTable.REGION, TpchTable.CUSTOMER, TpchTable.ORDERS)) {
+            TestingTable testingTable = createTpchTable(table);
+            tableMap.put(testingTable.schemaTableName(), testingTable);
+        }
+        for (TableDefinition additionalTable : additionalTables) {
+            TestingTable testingTable = additionalTable.toTestingTable();
+            tableMap.put(testingTable.schemaTableName(), testingTable);
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(tableMap));
+    }
+
+    private static <E extends TpchEntity> TestingTable createTpchTable(TpchTable<E> table)
+    {
+        List<TpchColumn<E>> columns = table.getColumns();
+        List<StarRocksRemoteColumn> remoteColumns = new ArrayList<>(columns.size());
+        for (int index = 0; index < columns.size(); index++) {
+            remoteColumns.add(toRemoteColumn(columns.get(index), index + 1));
+        }
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        try (RecordCursor cursor = TpchRecordSet.createTpchRecordSet(table, TPCH_SCALE_FACTOR).cursor()) {
+            while (cursor.advanceNextPosition()) {
+                Map<String, Object> row = new LinkedHashMap<>();
+                for (int index = 0; index < columns.size(); index++) {
+                    TpchColumn<E> column = columns.get(index);
+                    Type columnType = TpchMetadata.getTrinoType(column, DecimalTypeMapping.DOUBLE);
+                    row.put(column.getSimplifiedColumnName(), getCursorValue(cursor, index, columnType));
+                }
+                rows.add(Map.copyOf(row));
+            }
+        }
+
+        return new TestingTable(
+                new SchemaTableName(TPCH_SCHEMA, table.getTableName()),
+                TPCH_SCHEMA,
+                table.getTableName(),
+                StarRocksRelationType.TABLE,
+                remoteColumns,
+                rows);
+    }
+
+    private static <E extends TpchEntity> StarRocksRemoteColumn toRemoteColumn(TpchColumn<E> column, int ordinalPosition)
+    {
+        String columnName = column.getSimplifiedColumnName();
+        return switch (column.getType().getBase()) {
+            case IDENTIFIER -> new StarRocksRemoteColumn(columnName, columnName, "BIGINT", Optional.of(20), Optional.empty(), ordinalPosition, Optional.empty());
+            case INTEGER -> new StarRocksRemoteColumn(columnName, columnName, "INT", Optional.of(11), Optional.empty(), ordinalPosition, Optional.empty());
+            case DATE -> new StarRocksRemoteColumn(columnName, columnName, "DATE", Optional.empty(), Optional.empty(), ordinalPosition, Optional.empty());
+            case DOUBLE -> new StarRocksRemoteColumn(columnName, columnName, "DOUBLE", Optional.empty(), Optional.empty(), ordinalPosition, Optional.empty());
+            case VARCHAR -> new StarRocksRemoteColumn(
+                    columnName,
+                    columnName,
+                    "VARCHAR",
+                    column.getType().getPrecision().map(Math::toIntExact),
+                    Optional.empty(),
+                    ordinalPosition,
+                    column.getType().getPrecision().map(precision -> "varchar(%s)".formatted(precision)));
+        };
+    }
+
+    private static Object getCursorValue(RecordCursor cursor, int field, Type columnType)
+    {
+        if (columnType.getJavaType() == long.class) {
+            return cursor.getLong(field);
+        }
+        if (columnType.getJavaType() == double.class) {
+            return cursor.getDouble(field);
+        }
+        if (columnType.getJavaType() == Slice.class) {
+            return cursor.getSlice(field);
+        }
+        throw new IllegalArgumentException("Unsupported TPCH testing column type: " + columnType);
+    }
+
+    public record Request(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> requestedColumns)
+    {
+        public Request
+        {
+            requireNonNull(tableHandle, "tableHandle is null");
+            requestedColumns = List.copyOf(requireNonNull(requestedColumns, "requestedColumns is null"));
+        }
+    }
+
+    public record TableDefinition(
+            SchemaTableName schemaTableName,
+            String remoteSchemaName,
+            String remoteTableName,
+            StarRocksRelationType relationType,
+            List<StarRocksRemoteColumn> columns,
+            List<Map<String, Object>> rows)
+    {
+        public TableDefinition
+        {
+            requireNonNull(schemaTableName, "schemaTableName is null");
+            requireNonNull(remoteSchemaName, "remoteSchemaName is null");
+            requireNonNull(remoteTableName, "remoteTableName is null");
+            requireNonNull(relationType, "relationType is null");
+            columns = List.copyOf(requireNonNull(columns, "columns is null"));
+            rows = List.copyOf(requireNonNull(rows, "rows is null").stream()
+                    .map(LinkedHashMap::new)
+                    .map(Collections::unmodifiableMap)
+                    .toList());
+        }
+
+        private TestingTable toTestingTable()
+        {
+            return new TestingTable(schemaTableName, remoteSchemaName, remoteTableName, relationType, columns, rows);
+        }
+    }
+
+    private record TestingTable(
+            SchemaTableName schemaTableName,
+            String remoteSchemaName,
+            String remoteTableName,
+            StarRocksRelationType relationType,
+            List<StarRocksRemoteColumn> columns,
+            List<Map<String, Object>> rows)
+    {
+        private TestingTable
+        {
+            requireNonNull(schemaTableName, "schemaTableName is null");
+            requireNonNull(remoteSchemaName, "remoteSchemaName is null");
+            requireNonNull(remoteTableName, "remoteTableName is null");
+            requireNonNull(relationType, "relationType is null");
+            columns = List.copyOf(requireNonNull(columns, "columns is null"));
+            rows = List.copyOf(requireNonNull(rows, "rows is null"));
+        }
+
+        private StarRocksRemoteTable toRemoteTable()
+        {
+            return new StarRocksRemoteTable(schemaTableName, Optional.empty(), remoteSchemaName, remoteTableName, relationType, columns);
+        }
+    }
+
+    private static final class TestingStarRocksMetadataClient
+            implements StarRocksMetadataClient
+    {
+        private final Map<SchemaTableName, TestingTable> tables;
+
+        private TestingStarRocksMetadataClient(Map<SchemaTableName, TestingTable> tables)
+        {
+            this.tables = requireNonNull(tables, "tables is null");
+        }
+
+        @Override
+        public List<String> listSchemaNames(ConnectorSession session)
+        {
+            return tables.keySet().stream()
+                    .map(SchemaTableName::getSchemaName)
+                    .distinct()
+                    .toList();
+        }
+
+        @Override
+        public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+        {
+            return tables.keySet().stream()
+                    .filter(table -> schemaName.isEmpty() || table.getSchemaName().equals(schemaName.orElseThrow()))
+                    .toList();
+        }
+
+        @Override
+        public Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName)).map(TestingTable::toRemoteTable);
+        }
+
+        @Override
+        public OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName))
+                    .map(table -> OptionalLong.of(table.rows().size()))
+                    .orElseGet(OptionalLong::empty);
+        }
+    }
+
+    private static final class TestingStarRocksFlightSqlClient
+            implements StarRocksFlightSqlClient
+    {
+        private final Map<SchemaTableName, TestingTable> tables;
+        private final AtomicReference<Request> lastRequest;
+
+        private TestingStarRocksFlightSqlClient(Map<SchemaTableName, TestingTable> tables, AtomicReference<Request> lastRequest)
+        {
+            this.tables = requireNonNull(tables, "tables is null");
+            this.lastRequest = requireNonNull(lastRequest, "lastRequest is null");
+        }
+
+        @Override
+        public List<StarRocksSplit> getSplits(ConnectorSession session, StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
+        {
+            if (tableHandle.aggregation().isPresent() || tableHandle.limit().isPresent() || !tableHandle.sortOrder().isEmpty()) {
+                return List.of(new StarRocksSplit());
+            }
+            return List.of(
+                    new StarRocksSplit(Optional.of("0".getBytes(UTF_8))),
+                    new StarRocksSplit(Optional.of("1".getBytes(UTF_8))));
+        }
+
+        @Override
+        public StarRocksFlightSqlResult openStream(ConnectorSession session, StarRocksTableHandle tableHandle, StarRocksSplit split, List<StarRocksColumnHandle> columns)
+        {
+            lastRequest.set(new Request(tableHandle, columns));
+
+            TestingTable table = tables.get(tableHandle.toSchemaTableName());
+            List<Map<String, Object>> rows = table == null ? List.of() : applySplit(split, applyTableHandle(tableHandle, table.rows()));
+            return createResult(table, columns, rows);
+        }
+
+        private static List<Map<String, Object>> applySplit(StarRocksSplit split, List<Map<String, Object>> rows)
+        {
+            if (split.partitionDescriptor().isEmpty()) {
+                return rows;
+            }
+
+            int partition = Integer.parseInt(new String(split.partitionDescriptor().orElseThrow(), UTF_8));
+            List<Map<String, Object>> partitionRows = new ArrayList<>();
+            for (int index = 0; index < rows.size(); index++) {
+                if (index % 2 == partition) {
+                    partitionRows.add(rows.get(index));
+                }
+            }
+            return List.copyOf(partitionRows);
+        }
+
+        private static List<Map<String, Object>> applyTableHandle(StarRocksTableHandle tableHandle, List<Map<String, Object>> rows)
+        {
+            List<Map<String, Object>> filteredRows = applyConstraint(tableHandle.constraint(), rows);
+            List<Map<String, Object>> projectedRows = tableHandle.aggregation()
+                    .map(aggregation -> applyAggregation(aggregation, filteredRows))
+                    .orElse(filteredRows);
+            List<Map<String, Object>> sortedRows = applySort(tableHandle.sortOrder(), projectedRows);
+            if (tableHandle.limit().isEmpty()) {
+                return sortedRows;
+            }
+            return sortedRows.stream()
+                    .limit(tableHandle.limit().getAsLong())
+                    .toList();
+        }
+
+        private static List<Map<String, Object>> applyConstraint(TupleDomain<StarRocksColumnHandle> constraint, List<Map<String, Object>> rows)
+        {
+            if (constraint.isNone()) {
+                return List.of();
+            }
+            if (constraint.isAll() || constraint.getDomains().isEmpty()) {
+                return rows;
+            }
+
+            return rows.stream()
+                    .filter(row -> matchesConstraint(row, constraint.getDomains().orElseThrow()))
+                    .toList();
+        }
+
+        private static boolean matchesConstraint(Map<String, Object> row, Map<StarRocksColumnHandle, Domain> domains)
+        {
+            for (Map.Entry<StarRocksColumnHandle, Domain> entry : domains.entrySet()) {
+                StarRocksColumnHandle column = entry.getKey();
+                if (!entry.getValue().includesNullableValue(toDomainValue(row.get(column.columnName()), column.columnType()))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static List<Map<String, Object>> applyAggregation(StarRocksAggregation aggregation, List<Map<String, Object>> rows)
+        {
+            Map<List<Object>, List<Map<String, Object>>> groups = rows.stream()
+                    .collect(Collectors.groupingBy(
+                            row -> aggregation.groupingColumns().stream()
+                                    .map(column -> row.get(column.columnName()))
+                                    .toList(),
+                            LinkedHashMap::new,
+                            Collectors.toList()));
+            if (groups.isEmpty() && aggregation.groupingColumns().isEmpty()) {
+                groups = Map.of(List.of(), List.of());
+            }
+
+            List<Map<String, Object>> results = new ArrayList<>(groups.size());
+            for (Map.Entry<List<Object>, List<Map<String, Object>>> group : groups.entrySet()) {
+                LinkedHashMap<String, Object> row = new LinkedHashMap<>();
+                for (int index = 0; index < aggregation.groupingColumns().size(); index++) {
+                    row.put(aggregation.groupingColumns().get(index).columnName(), group.getKey().get(index));
+                }
+                for (StarRocksAggregateColumn aggregateColumn : aggregation.aggregateColumns()) {
+                    row.put(aggregateColumn.columnName(), evaluateAggregate(aggregateColumn, group.getValue()));
+                }
+                results.add(Collections.unmodifiableMap(row));
+            }
+            return List.copyOf(results);
+        }
+
+        private static Object evaluateAggregate(StarRocksAggregateColumn aggregateColumn, List<Map<String, Object>> rows)
+        {
+            String expression = aggregateColumn.expression();
+            String normalized = expression.trim().toLowerCase(Locale.ENGLISH);
+            if (normalized.equals("count(*)")) {
+                return rows.size();
+            }
+            if (normalized.equals("count(null)")) {
+                return 0L;
+            }
+            if (normalized.startsWith("count(`") && normalized.endsWith("`)")) {
+                String columnName = quotedAggregationArgument(expression, "count");
+                return rows.stream()
+                        .filter(row -> row.get(columnName) != null)
+                        .count();
+            }
+            if (normalized.startsWith("sum(`") && normalized.endsWith("`)")) {
+                String columnName = quotedAggregationArgument(expression, "sum");
+                BigDecimal sum = rows.stream()
+                        .map(row -> row.get(columnName))
+                        .filter(Objects::nonNull)
+                        .map(TestingStarRocksFlightSqlClient::toBigDecimalValue)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+                if (aggregateColumn.type().getJavaType() == long.class) {
+                    return sum.longValueExact();
+                }
+                if (aggregateColumn.type().getJavaType() == double.class) {
+                    return sum.doubleValue();
+                }
+                return sum;
+            }
+            if (normalized.startsWith("avg(`") && normalized.endsWith("`)")) {
+                String columnName = quotedAggregationArgument(expression, "avg");
+                List<BigDecimal> values = rows.stream()
+                        .map(row -> row.get(columnName))
+                        .filter(Objects::nonNull)
+                        .map(TestingStarRocksFlightSqlClient::toBigDecimalValue)
+                        .toList();
+                if (values.isEmpty()) {
+                    return null;
+                }
+                BigDecimal sum = values.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+                BigDecimal average = sum.divide(BigDecimal.valueOf(values.size()), 12, RoundingMode.HALF_UP);
+                if (aggregateColumn.type().getJavaType() == double.class) {
+                    return average.doubleValue();
+                }
+                return average;
+            }
+            if ((normalized.startsWith("min(`") || normalized.startsWith("max(`")) && normalized.endsWith("`)")) {
+                String functionName = normalized.startsWith("min(`") ? "min" : "max";
+                String columnName = quotedAggregationArgument(expression, functionName);
+                Comparator<Object> comparator = Comparator.comparing(TestingStarRocksFlightSqlClient::toComparableValue, TestingStarRocksFlightSqlClient::compareComparableValues);
+                return rows.stream()
+                        .map(row -> row.get(columnName))
+                        .filter(Objects::nonNull)
+                        .min(functionName.equals("min") ? comparator : comparator.reversed())
+                        .orElse(null);
+            }
+            throw new IllegalArgumentException("Unsupported testing aggregate expression: " + expression);
+        }
+
+        private static String quotedAggregationArgument(String expression, String functionName)
+        {
+            return expression.substring((functionName + "(`").length(), expression.length() - "`)".length()).replace("``", "`");
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static int compareComparableValues(Object left, Object right)
+        {
+            return ((Comparable) left).compareTo(right);
+        }
+
+        private static List<Map<String, Object>> applySort(List<StarRocksSortItem> sortOrder, List<Map<String, Object>> rows)
+        {
+            if (sortOrder.isEmpty()) {
+                return rows;
+            }
+
+            Comparator<Map<String, Object>> comparator = (left, right) -> {
+                for (StarRocksSortItem sortItem : sortOrder) {
+                    int result = compareValues(left.get(sortItem.columnName()), right.get(sortItem.columnName()), sortItem);
+                    if (result != 0) {
+                        return result;
+                    }
+                }
+                return 0;
+            };
+            return rows.stream()
+                    .sorted(comparator)
+                    .toList();
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static int compareValues(Object left, Object right, StarRocksSortItem sortItem)
+        {
+            if (left == null || right == null) {
+                if (left == right) {
+                    return 0;
+                }
+                return (left == null) == sortItem.sortOrder().isNullsFirst() ? -1 : 1;
+            }
+
+            Object comparableLeft = toComparableValue(left);
+            Object comparableRight = toComparableValue(right);
+            int result = ((Comparable) comparableLeft).compareTo(comparableRight);
+            return sortItem.sortOrder().isAscending() ? result : -result;
+        }
+
+        private static Object toComparableValue(Object value)
+        {
+            if (value instanceof Slice slice) {
+                return slice.toStringUtf8();
+            }
+            return value;
+        }
+
+        private static Object toDomainValue(Object value, Type type)
+        {
+            if (value == null) {
+                return null;
+            }
+            if (type == BOOLEAN) {
+                return toBooleanValue(value);
+            }
+            if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+                return toLong(value);
+            }
+            if (type == REAL) {
+                return (long) floatToRawIntBits(((Number) value).floatValue());
+            }
+            if (type == DOUBLE) {
+                return ((Number) value).doubleValue();
+            }
+            if (type == DATE) {
+                return toEpochDay(value);
+            }
+            if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+                return toTimestampMicros(value);
+            }
+            if (type instanceof DecimalType decimalType) {
+                BigDecimal decimal = toBigDecimalValue(value);
+                if (decimalType.isShort()) {
+                    return encodeShortScaledValue(decimal, decimalType.getScale());
+                }
+            }
+            if (type instanceof VarcharType || type instanceof CharType || type.getBaseName().equals(JSON)) {
+                if (value instanceof Slice slice) {
+                    return slice;
+                }
+                return utf8Slice(value.toString());
+            }
+            return value;
+        }
+
+        private static long toTimestampMicros(Object value)
+        {
+            if (value instanceof LocalDateTime dateTime) {
+                return dateTime.toEpochSecond(UTC) * MICROSECONDS_PER_SECOND + dateTime.getLong(ChronoField.MICRO_OF_SECOND);
+            }
+            String text = value.toString().trim().replace(' ', 'T');
+            LocalDateTime dateTime = LocalDateTime.parse(text);
+            return dateTime.toEpochSecond(UTC) * MICROSECONDS_PER_SECOND + dateTime.getLong(ChronoField.MICRO_OF_SECOND);
+        }
+
+        private static StarRocksFlightSqlResult createResult(TestingTable table, List<StarRocksColumnHandle> columns, List<Map<String, Object>> rows)
+        {
+            RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+            List<FieldVector> vectors = new ArrayList<>(columns.size());
+            Map<String, StarRocksRemoteColumn> remoteColumns = table == null ? Map.of() : table.columns().stream()
+                                                                                          .collect(Collectors.toUnmodifiableMap(StarRocksRemoteColumn::columnName, column -> column));
+
+            try {
+                for (StarRocksColumnHandle column : columns) {
+                    vectors.add(createVector(column, remoteColumns.get(column.columnName()), rows, allocator));
+                }
+
+                VectorSchemaRoot root = new VectorSchemaRoot(vectors);
+                root.setRowCount(rows.size());
+                return new TestingStarRocksFlightSqlResult(allocator, root);
+            }
+            catch (RuntimeException e) {
+                vectors.forEach(FieldVector::close);
+                allocator.close();
+                throw e;
+            }
+        }
+
+        private static FieldVector createVector(StarRocksColumnHandle column, StarRocksRemoteColumn remoteColumn, List<Map<String, Object>> rows, RootAllocator allocator)
+        {
+            String name = column.columnName();
+            Type type = column.columnType();
+            String remoteType = remoteColumn == null ? "" : normalizeTypeName(remoteColumn.typeName());
+
+            if (type == BOOLEAN) {
+                if (remoteType.equals("TINYINT")) {
+                    TinyIntVector vector = new TinyIntVector(name, allocator);
+                    vector.allocateNew(rows.size());
+                    for (int i = 0; i < rows.size(); i++) {
+                        Object value = rows.get(i).get(name);
+                        if (value == null) {
+                            vector.setNull(i);
+                        }
+                        else {
+                            vector.setSafe(i, toBooleanValue(value) ? 1 : 0);
+                        }
+                    }
+                    vector.setValueCount(rows.size());
+                    return vector;
+                }
+
+                BitVector vector = new BitVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toBooleanValue(value) ? 1 : 0);
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == TINYINT) {
+                TinyIntVector vector = new TinyIntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toLong(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == SMALLINT) {
+                SmallIntVector vector = new SmallIntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toLong(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == BIGINT) {
+                BigIntVector vector = new BigIntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toLong(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == INTEGER) {
+                IntVector vector = new IntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toLong(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == REAL) {
+                Float4Vector vector = new Float4Vector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, ((Number) value).floatValue());
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == DOUBLE) {
+                Float8Vector vector = new Float8Vector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, ((Number) value).doubleValue());
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == DATE) {
+                if (rows.stream()
+                        .map(row -> row.get(name))
+                        .filter(Objects::nonNull)
+                        .anyMatch(value -> value instanceof LocalDate || value instanceof CharSequence)) {
+                    VarCharVector vector = new VarCharVector(name, allocator);
+                    vector.allocateNew();
+                    for (int i = 0; i < rows.size(); i++) {
+                        Object value = rows.get(i).get(name);
+                        if (value == null) {
+                            vector.setNull(i);
+                        }
+                        else {
+                            vector.setSafe(i, toTextBytes(value));
+                        }
+                    }
+                    vector.setValueCount(rows.size());
+                    return vector;
+                }
+
+                DateDayVector vector = new DateDayVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toEpochDay(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+                VarCharVector vector = new VarCharVector(name, allocator);
+                vector.allocateNew();
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toTextBytes(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type instanceof DecimalType decimalType) {
+                DecimalVector vector = new DecimalVector(name, allocator, decimalType.getPrecision(), decimalType.getScale());
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toBigDecimalValue(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type instanceof VarcharType || type instanceof CharType || type.getBaseName().equals(JSON)) {
+                VarCharVector vector = new VarCharVector(name, allocator);
+                vector.allocateNew();
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, type.getBaseName().equals(JSON) ? toJsonBytes(value) : toTextBytes(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == VARBINARY) {
+                VarBinaryVector vector = new VarBinaryVector(name, allocator);
+                vector.allocateNew();
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toBinaryBytes(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+
+            throw new IllegalArgumentException("Unsupported testing column type: " + type);
+        }
+
+        private static boolean toBooleanValue(Object value)
+        {
+            if (value instanceof Boolean booleanValue) {
+                return booleanValue;
+            }
+            if (value instanceof Number number) {
+                return number.longValue() != 0;
+            }
+            return Boolean.parseBoolean(value.toString());
+        }
+
+        private static long toEpochDay(Object value)
+        {
+            if (value instanceof LocalDate date) {
+                return date.toEpochDay();
+            }
+            return toLong(value);
+        }
+
+        private static long toLong(Object value)
+        {
+            return ((Number) value).longValue();
+        }
+
+        private static BigDecimal toBigDecimalValue(Object value)
+        {
+            if (value instanceof BigDecimal decimal) {
+                return decimal;
+            }
+            if (value instanceof BigInteger integer) {
+                return new BigDecimal(integer);
+            }
+            if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
+                return BigDecimal.valueOf(((Number) value).longValue());
+            }
+            if (value instanceof Number number) {
+                return BigDecimal.valueOf(number.doubleValue());
+            }
+            return new BigDecimal(value.toString());
+        }
+
+        private static byte[] toTextBytes(Object value)
+        {
+            if (value instanceof Slice slice) {
+                return slice.getBytes();
+            }
+            if (value instanceof BigDecimal decimal) {
+                return decimal.toPlainString().getBytes(UTF_8);
+            }
+            if (value instanceof LocalDateTime dateTime) {
+                return dateTime.toString().replace('T', ' ').getBytes(UTF_8);
+            }
+            return value.toString().getBytes(UTF_8);
+        }
+
+        private static byte[] toJsonBytes(Object value)
+        {
+            if (value instanceof Slice slice) {
+                return slice.getBytes();
+            }
+            if (value instanceof CharSequence) {
+                return value.toString().getBytes(UTF_8);
+            }
+            return JSON_CODEC.toJson(value).getBytes(UTF_8);
+        }
+
+        private static byte[] toBinaryBytes(Object value)
+        {
+            if (value instanceof byte[] bytes) {
+                return bytes;
+            }
+            if (value instanceof Slice slice) {
+                return slice.getBytes();
+            }
+            return value.toString().getBytes(UTF_8);
+        }
+
+        private static String normalizeTypeName(String dataType)
+        {
+            return dataType.trim()
+                    .toUpperCase(Locale.ENGLISH)
+                    .replace(' ', '_');
+        }
+    }
+
+    private static final class TestingStarRocksFlightSqlResult
+            implements StarRocksFlightSqlResult
+    {
+        private final RootAllocator allocator;
+        private final VectorSchemaRoot root;
+        private boolean loaded;
+        private boolean closed;
+
+        private TestingStarRocksFlightSqlResult(RootAllocator allocator, VectorSchemaRoot root)
+        {
+            this.allocator = requireNonNull(allocator, "allocator is null");
+            this.root = requireNonNull(root, "root is null");
+        }
+
+        @Override
+        public boolean loadNextBatch()
+        {
+            if (closed || loaded || root.getRowCount() == 0) {
+                return false;
+            }
+            loaded = true;
+            return true;
+        }
+
+        @Override
+        public VectorSchemaRoot getVectorSchemaRoot()
+        {
+            return root;
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            return root.getFieldVectors().stream()
+                    .mapToLong(FieldVector::getBufferSize)
+                    .sum();
+        }
+
+        @Override
+        public void close()
+        {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            root.close();
+            allocator.close();
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
@@ -49,8 +49,10 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -81,6 +83,7 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 
 final class TestingStarRocksEnvironment
@@ -310,6 +313,12 @@ final class TestingStarRocksEnvironment
         }
 
         @Override
+        public List<StarRocksSplit> getSplits(ConnectorSession session, StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> columns)
+        {
+            return List.of(new StarRocksSplit());
+        }
+
+        @Override
         public StarRocksFlightSqlResult openStream(ConnectorSession session, StarRocksTableHandle tableHandle, StarRocksSplit split, List<StarRocksColumnHandle> columns)
         {
             lastRequest.set(new Request(tableHandle, columns));
@@ -378,15 +387,16 @@ final class TestingStarRocksEnvironment
                     row.put(aggregation.groupingColumns().get(index).columnName(), group.getKey().get(index));
                 }
                 for (StarRocksAggregateColumn aggregateColumn : aggregation.aggregateColumns()) {
-                    row.put(aggregateColumn.columnName(), evaluateAggregate(aggregateColumn.expression(), group.getValue()));
+                    row.put(aggregateColumn.columnName(), evaluateAggregate(aggregateColumn, group.getValue()));
                 }
                 results.add(Collections.unmodifiableMap(row));
             }
             return List.copyOf(results);
         }
 
-        private static long evaluateAggregate(String expression, List<Map<String, Object>> rows)
+        private static Object evaluateAggregate(StarRocksAggregateColumn aggregateColumn, List<Map<String, Object>> rows)
         {
+            String expression = aggregateColumn.expression();
             String normalized = expression.trim().toLowerCase(Locale.ENGLISH);
             if (normalized.equals("count(*)")) {
                 return rows.size();
@@ -395,12 +405,65 @@ final class TestingStarRocksEnvironment
                 return 0L;
             }
             if (normalized.startsWith("count(`") && normalized.endsWith("`)")) {
-                String columnName = normalized.substring("count(`".length(), normalized.length() - "`)".length()).replace("``", "`");
+                String columnName = quotedAggregationArgument(expression, "count");
                 return rows.stream()
                         .filter(row -> row.get(columnName) != null)
                         .count();
             }
+            if (normalized.startsWith("sum(`") && normalized.endsWith("`)")) {
+                String columnName = quotedAggregationArgument(expression, "sum");
+                BigDecimal sum = rows.stream()
+                        .map(row -> row.get(columnName))
+                        .filter(Objects::nonNull)
+                        .map(TestingStarRocksFlightSqlClient::toBigDecimalValue)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+                if (aggregateColumn.type().getJavaType() == long.class) {
+                    return sum.longValueExact();
+                }
+                if (aggregateColumn.type().getJavaType() == double.class) {
+                    return sum.doubleValue();
+                }
+                return sum;
+            }
+            if (normalized.startsWith("avg(`") && normalized.endsWith("`)")) {
+                String columnName = quotedAggregationArgument(expression, "avg");
+                List<BigDecimal> values = rows.stream()
+                        .map(row -> row.get(columnName))
+                        .filter(Objects::nonNull)
+                        .map(TestingStarRocksFlightSqlClient::toBigDecimalValue)
+                        .toList();
+                if (values.isEmpty()) {
+                    return null;
+                }
+                BigDecimal sum = values.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+                BigDecimal average = sum.divide(BigDecimal.valueOf(values.size()), 12, RoundingMode.HALF_UP);
+                if (aggregateColumn.type().getJavaType() == double.class) {
+                    return average.doubleValue();
+                }
+                return average;
+            }
+            if ((normalized.startsWith("min(`") || normalized.startsWith("max(`")) && normalized.endsWith("`)")) {
+                String functionName = normalized.startsWith("min(`") ? "min" : "max";
+                String columnName = quotedAggregationArgument(expression, functionName);
+                Comparator<Object> comparator = Comparator.comparing(TestingStarRocksFlightSqlClient::toComparableValue, TestingStarRocksFlightSqlClient::compareComparableValues);
+                return rows.stream()
+                        .map(row -> row.get(columnName))
+                        .filter(Objects::nonNull)
+                        .min(functionName.equals("min") ? comparator : comparator.reversed())
+                        .orElse(null);
+            }
             throw new IllegalArgumentException("Unsupported testing aggregate expression: " + expression);
+        }
+
+        private static String quotedAggregationArgument(String expression, String functionName)
+        {
+            return expression.substring((functionName + "(`").length(), expression.length() - "`)".length()).replace("``", "`");
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static int compareComparableValues(Object left, Object right)
+        {
+            return ((Comparable) left).compareTo(right);
         }
 
         private static List<Map<String, Object>> applySort(List<StarRocksSortItem> sortOrder, List<Map<String, Object>> rows)
@@ -488,11 +551,11 @@ final class TestingStarRocksEnvironment
         private static long toTimestampMicros(Object value)
         {
             if (value instanceof LocalDateTime dateTime) {
-                return dateTime.toEpochSecond(java.time.ZoneOffset.UTC) * MICROSECONDS_PER_SECOND + (dateTime.getNano() / 1_000);
+                return dateTime.toEpochSecond(UTC) * MICROSECONDS_PER_SECOND + dateTime.getLong(ChronoField.MICRO_OF_SECOND);
             }
             String text = value.toString().trim().replace(' ', 'T');
             LocalDateTime dateTime = LocalDateTime.parse(text);
-            return dateTime.toEpochSecond(java.time.ZoneOffset.UTC) * MICROSECONDS_PER_SECOND + (dateTime.getNano() / 1_000);
+            return dateTime.toEpochSecond(UTC) * MICROSECONDS_PER_SECOND + dateTime.getLong(ChronoField.MICRO_OF_SECOND);
         }
 
         private static StarRocksFlightSqlResult createResult(TestingTable table, List<StarRocksColumnHandle> columns, List<Map<String, Object>> rows)

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
@@ -1,0 +1,682 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.starrocks;
+
+import com.google.inject.Module;
+import io.airlift.slice.Slice;
+import io.trino.plugin.tpch.DecimalTypeMapping;
+import io.trino.plugin.tpch.TpchMetadata;
+import io.trino.plugin.tpch.TpchRecordSet;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchEntity;
+import io.trino.tpch.TpchTable;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+final class TestingStarRocksEnvironment
+{
+    private static final String TPCH_SCHEMA = TpchMetadata.TINY_SCHEMA_NAME;
+    private static final double TPCH_SCALE_FACTOR = TpchMetadata.TINY_SCALE_FACTOR;
+
+    private final Map<SchemaTableName, TestingTable> tables;
+    private final AtomicReference<Request> lastRequest = new AtomicReference<>();
+
+    public TestingStarRocksEnvironment()
+    {
+        this(List.of());
+    }
+
+    public TestingStarRocksEnvironment(List<TableDefinition> additionalTables)
+    {
+        tables = createTables(additionalTables);
+    }
+
+    public Module createModule()
+    {
+        TestingStarRocksMetadataClient metadataClient = new TestingStarRocksMetadataClient(tables);
+        TestingStarRocksFlightSqlClient flightSqlClient = new TestingStarRocksFlightSqlClient(tables, lastRequest);
+
+        return binder -> {
+            binder.bind(StarRocksMetadataClient.class).toInstance(metadataClient);
+            binder.bind(StarRocksFlightSqlClient.class).toInstance(flightSqlClient);
+        };
+    }
+
+    public Optional<Request> getLastRequest()
+    {
+        return Optional.ofNullable(lastRequest.get());
+    }
+
+    private static Map<SchemaTableName, TestingTable> createTables(List<TableDefinition> additionalTables)
+    {
+        Map<SchemaTableName, TestingTable> tableMap = new LinkedHashMap<>();
+        for (TpchTable<?> table : List.of(TpchTable.NATION, TpchTable.REGION, TpchTable.CUSTOMER, TpchTable.ORDERS)) {
+            TestingTable testingTable = createTpchTable(table);
+            tableMap.put(testingTable.schemaTableName(), testingTable);
+        }
+        for (TableDefinition additionalTable : additionalTables) {
+            TestingTable testingTable = additionalTable.toTestingTable();
+            tableMap.put(testingTable.schemaTableName(), testingTable);
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(tableMap));
+    }
+
+    private static <E extends TpchEntity> TestingTable createTpchTable(TpchTable<E> table)
+    {
+        List<TpchColumn<E>> columns = table.getColumns();
+        List<StarRocksRemoteColumn> remoteColumns = new ArrayList<>(columns.size());
+        for (int index = 0; index < columns.size(); index++) {
+            remoteColumns.add(toRemoteColumn(columns.get(index), index + 1));
+        }
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        try (RecordCursor cursor = TpchRecordSet.createTpchRecordSet(table, TPCH_SCALE_FACTOR).cursor()) {
+            while (cursor.advanceNextPosition()) {
+                Map<String, Object> row = new LinkedHashMap<>();
+                for (int index = 0; index < columns.size(); index++) {
+                    TpchColumn<E> column = columns.get(index);
+                    Type columnType = TpchMetadata.getTrinoType(column, DecimalTypeMapping.DOUBLE);
+                    row.put(column.getSimplifiedColumnName(), getCursorValue(cursor, index, columnType));
+                }
+                rows.add(Map.copyOf(row));
+            }
+        }
+
+        return new TestingTable(
+                new SchemaTableName(TPCH_SCHEMA, table.getTableName()),
+                TPCH_SCHEMA,
+                table.getTableName(),
+                StarRocksRelationType.TABLE,
+                remoteColumns,
+                rows);
+    }
+
+    private static <E extends TpchEntity> StarRocksRemoteColumn toRemoteColumn(TpchColumn<E> column, int ordinalPosition)
+    {
+        String columnName = column.getSimplifiedColumnName();
+        return switch (column.getType().getBase()) {
+            case IDENTIFIER -> new StarRocksRemoteColumn(columnName, columnName, "BIGINT", Optional.of(20), Optional.empty(), ordinalPosition, Optional.empty());
+            case INTEGER -> new StarRocksRemoteColumn(columnName, columnName, "INT", Optional.of(11), Optional.empty(), ordinalPosition, Optional.empty());
+            case DATE -> new StarRocksRemoteColumn(columnName, columnName, "DATE", Optional.empty(), Optional.empty(), ordinalPosition, Optional.empty());
+            case DOUBLE -> new StarRocksRemoteColumn(columnName, columnName, "DOUBLE", Optional.empty(), Optional.empty(), ordinalPosition, Optional.empty());
+            case VARCHAR -> new StarRocksRemoteColumn(
+                    columnName,
+                    columnName,
+                    "VARCHAR",
+                    column.getType().getPrecision().map(Math::toIntExact),
+                    Optional.empty(),
+                    ordinalPosition,
+                    column.getType().getPrecision().map(precision -> "varchar(%s)".formatted(precision)));
+        };
+    }
+
+    private static Object getCursorValue(RecordCursor cursor, int field, Type columnType)
+    {
+        if (columnType.getJavaType() == long.class) {
+            return cursor.getLong(field);
+        }
+        if (columnType.getJavaType() == double.class) {
+            return cursor.getDouble(field);
+        }
+        if (columnType.getJavaType() == Slice.class) {
+            return cursor.getSlice(field);
+        }
+        throw new IllegalArgumentException("Unsupported TPCH testing column type: " + columnType);
+    }
+
+    public record Request(StarRocksTableHandle tableHandle, List<StarRocksColumnHandle> requestedColumns)
+    {
+        public Request
+        {
+            requireNonNull(tableHandle, "tableHandle is null");
+            requestedColumns = List.copyOf(requireNonNull(requestedColumns, "requestedColumns is null"));
+        }
+    }
+
+    public record TableDefinition(
+            SchemaTableName schemaTableName,
+            String remoteSchemaName,
+            String remoteTableName,
+            StarRocksRelationType relationType,
+            List<StarRocksRemoteColumn> columns,
+            List<Map<String, Object>> rows)
+    {
+        public TableDefinition
+        {
+            requireNonNull(schemaTableName, "schemaTableName is null");
+            requireNonNull(remoteSchemaName, "remoteSchemaName is null");
+            requireNonNull(remoteTableName, "remoteTableName is null");
+            requireNonNull(relationType, "relationType is null");
+            columns = List.copyOf(requireNonNull(columns, "columns is null"));
+            rows = List.copyOf(requireNonNull(rows, "rows is null").stream()
+                    .map(LinkedHashMap::new)
+                    .map(Collections::unmodifiableMap)
+                    .toList());
+        }
+
+        private TestingTable toTestingTable()
+        {
+            return new TestingTable(schemaTableName, remoteSchemaName, remoteTableName, relationType, columns, rows);
+        }
+    }
+
+    private record TestingTable(
+            SchemaTableName schemaTableName,
+            String remoteSchemaName,
+            String remoteTableName,
+            StarRocksRelationType relationType,
+            List<StarRocksRemoteColumn> columns,
+            List<Map<String, Object>> rows)
+    {
+        private TestingTable
+        {
+            requireNonNull(schemaTableName, "schemaTableName is null");
+            requireNonNull(remoteSchemaName, "remoteSchemaName is null");
+            requireNonNull(remoteTableName, "remoteTableName is null");
+            requireNonNull(relationType, "relationType is null");
+            columns = List.copyOf(requireNonNull(columns, "columns is null"));
+            rows = List.copyOf(requireNonNull(rows, "rows is null"));
+        }
+
+        private StarRocksRemoteTable toRemoteTable()
+        {
+            return new StarRocksRemoteTable(schemaTableName, remoteSchemaName, remoteTableName, relationType, columns);
+        }
+    }
+
+    private static final class TestingStarRocksMetadataClient
+            implements StarRocksMetadataClient
+    {
+        private final Map<SchemaTableName, TestingTable> tables;
+
+        private TestingStarRocksMetadataClient(Map<SchemaTableName, TestingTable> tables)
+        {
+            this.tables = requireNonNull(tables, "tables is null");
+        }
+
+        @Override
+        public List<String> listSchemaNames(ConnectorSession session)
+        {
+            return tables.keySet().stream()
+                    .map(SchemaTableName::getSchemaName)
+                    .distinct()
+                    .toList();
+        }
+
+        @Override
+        public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+        {
+            return tables.keySet().stream()
+                    .filter(table -> schemaName.isEmpty() || table.getSchemaName().equals(schemaName.orElseThrow()))
+                    .toList();
+        }
+
+        @Override
+        public Optional<StarRocksRemoteTable> getTable(ConnectorSession session, SchemaTableName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName)).map(TestingTable::toRemoteTable);
+        }
+
+        @Override
+        public OptionalLong getTableRowCount(ConnectorSession session, SchemaTableName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName))
+                    .map(table -> OptionalLong.of(table.rows().size()))
+                    .orElseGet(OptionalLong::empty);
+        }
+    }
+
+    private static final class TestingStarRocksFlightSqlClient
+            implements StarRocksFlightSqlClient
+    {
+        private final Map<SchemaTableName, TestingTable> tables;
+        private final AtomicReference<Request> lastRequest;
+
+        private TestingStarRocksFlightSqlClient(Map<SchemaTableName, TestingTable> tables, AtomicReference<Request> lastRequest)
+        {
+            this.tables = requireNonNull(tables, "tables is null");
+            this.lastRequest = requireNonNull(lastRequest, "lastRequest is null");
+        }
+
+        @Override
+        public StarRocksFlightSqlResult openStream(ConnectorSession session, StarRocksTableHandle tableHandle, StarRocksSplit split, List<StarRocksColumnHandle> columns)
+        {
+            lastRequest.set(new Request(tableHandle, columns));
+
+            TestingTable table = tables.get(tableHandle.toSchemaTableName());
+            List<Map<String, Object>> rows = table == null ? List.of() : table.rows();
+            return createResult(table, columns, rows);
+        }
+
+        private static StarRocksFlightSqlResult createResult(TestingTable table, List<StarRocksColumnHandle> columns, List<Map<String, Object>> rows)
+        {
+            RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+            List<FieldVector> vectors = new ArrayList<>(columns.size());
+            Map<String, StarRocksRemoteColumn> remoteColumns = table == null ? Map.of() : table.columns().stream()
+                    .collect(Collectors.toUnmodifiableMap(StarRocksRemoteColumn::columnName, column -> column));
+
+            try {
+                for (StarRocksColumnHandle column : columns) {
+                    vectors.add(createVector(column, remoteColumns.get(column.columnName()), rows, allocator));
+                }
+
+                VectorSchemaRoot root = new VectorSchemaRoot(vectors);
+                root.setRowCount(rows.size());
+                return new TestingStarRocksFlightSqlResult(allocator, root);
+            }
+            catch (RuntimeException e) {
+                vectors.forEach(FieldVector::close);
+                allocator.close();
+                throw e;
+            }
+        }
+
+        private static FieldVector createVector(StarRocksColumnHandle column, StarRocksRemoteColumn remoteColumn, List<Map<String, Object>> rows, RootAllocator allocator)
+        {
+            String name = column.columnName();
+            Type type = column.columnType();
+            String remoteType = remoteColumn == null ? "" : normalizeTypeName(remoteColumn.typeName());
+
+            if (type == BOOLEAN) {
+                if (remoteType.equals("TINYINT")) {
+                    TinyIntVector vector = new TinyIntVector(name, allocator);
+                    vector.allocateNew(rows.size());
+                    for (int i = 0; i < rows.size(); i++) {
+                        Object value = rows.get(i).get(name);
+                        if (value == null) {
+                            vector.setNull(i);
+                        }
+                        else {
+                            vector.setSafe(i, toBooleanValue(value) ? 1 : 0);
+                        }
+                    }
+                    vector.setValueCount(rows.size());
+                    return vector;
+                }
+
+                BitVector vector = new BitVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toBooleanValue(value) ? 1 : 0);
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == TINYINT) {
+                TinyIntVector vector = new TinyIntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toLong(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == SMALLINT) {
+                SmallIntVector vector = new SmallIntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toLong(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == BIGINT) {
+                BigIntVector vector = new BigIntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toLong(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == INTEGER) {
+                IntVector vector = new IntVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toLong(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == REAL) {
+                Float4Vector vector = new Float4Vector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, ((Number) value).floatValue());
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == DOUBLE) {
+                Float8Vector vector = new Float8Vector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, ((Number) value).doubleValue());
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == DATE) {
+                if (rows.stream()
+                        .map(row -> row.get(name))
+                        .filter(Objects::nonNull)
+                        .anyMatch(value -> value instanceof LocalDate || value instanceof CharSequence)) {
+                    VarCharVector vector = new VarCharVector(name, allocator);
+                    vector.allocateNew();
+                    for (int i = 0; i < rows.size(); i++) {
+                        Object value = rows.get(i).get(name);
+                        if (value == null) {
+                            vector.setNull(i);
+                        }
+                        else {
+                            vector.setSafe(i, toTextBytes(value));
+                        }
+                    }
+                    vector.setValueCount(rows.size());
+                    return vector;
+                }
+
+                DateDayVector vector = new DateDayVector(name, allocator);
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toIntExact(toEpochDay(value)));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+                VarCharVector vector = new VarCharVector(name, allocator);
+                vector.allocateNew();
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toTextBytes(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type instanceof DecimalType decimalType) {
+                DecimalVector vector = new DecimalVector(name, allocator, decimalType.getPrecision(), decimalType.getScale());
+                vector.allocateNew(rows.size());
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toBigDecimalValue(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type instanceof VarcharType || type instanceof CharType) {
+                VarCharVector vector = new VarCharVector(name, allocator);
+                vector.allocateNew();
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toTextBytes(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+            if (type == VARBINARY) {
+                VarBinaryVector vector = new VarBinaryVector(name, allocator);
+                vector.allocateNew();
+                for (int i = 0; i < rows.size(); i++) {
+                    Object value = rows.get(i).get(name);
+                    if (value == null) {
+                        vector.setNull(i);
+                    }
+                    else {
+                        vector.setSafe(i, toBinaryBytes(value));
+                    }
+                }
+                vector.setValueCount(rows.size());
+                return vector;
+            }
+
+            throw new IllegalArgumentException("Unsupported testing column type: " + type);
+        }
+
+        private static boolean toBooleanValue(Object value)
+        {
+            if (value instanceof Boolean booleanValue) {
+                return booleanValue;
+            }
+            if (value instanceof Number number) {
+                return number.longValue() != 0;
+            }
+            return Boolean.parseBoolean(value.toString());
+        }
+
+        private static long toEpochDay(Object value)
+        {
+            if (value instanceof LocalDate date) {
+                return date.toEpochDay();
+            }
+            return toLong(value);
+        }
+
+        private static long toLong(Object value)
+        {
+            return ((Number) value).longValue();
+        }
+
+        private static BigDecimal toBigDecimalValue(Object value)
+        {
+            if (value instanceof BigDecimal decimal) {
+                return decimal;
+            }
+            if (value instanceof BigInteger integer) {
+                return new BigDecimal(integer);
+            }
+            if (value instanceof Byte || value instanceof Short || value instanceof Integer || value instanceof Long) {
+                return BigDecimal.valueOf(((Number) value).longValue());
+            }
+            if (value instanceof Number number) {
+                return BigDecimal.valueOf(number.doubleValue());
+            }
+            return new BigDecimal(value.toString());
+        }
+
+        private static byte[] toTextBytes(Object value)
+        {
+            if (value instanceof Slice slice) {
+                return slice.getBytes();
+            }
+            if (value instanceof BigDecimal decimal) {
+                return decimal.toPlainString().getBytes(UTF_8);
+            }
+            if (value instanceof LocalDateTime dateTime) {
+                return dateTime.toString().replace('T', ' ').getBytes(UTF_8);
+            }
+            return value.toString().getBytes(UTF_8);
+        }
+
+        private static byte[] toBinaryBytes(Object value)
+        {
+            if (value instanceof byte[] bytes) {
+                return bytes;
+            }
+            if (value instanceof Slice slice) {
+                return slice.getBytes();
+            }
+            return value.toString().getBytes(UTF_8);
+        }
+
+        private static String normalizeTypeName(String dataType)
+        {
+            return dataType.trim()
+                    .toUpperCase(Locale.ENGLISH)
+                    .replace(' ', '_');
+        }
+    }
+
+    private static final class TestingStarRocksFlightSqlResult
+            implements StarRocksFlightSqlResult
+    {
+        private final RootAllocator allocator;
+        private final VectorSchemaRoot root;
+        private boolean loaded;
+        private boolean closed;
+
+        private TestingStarRocksFlightSqlResult(RootAllocator allocator, VectorSchemaRoot root)
+        {
+            this.allocator = requireNonNull(allocator, "allocator is null");
+            this.root = requireNonNull(root, "root is null");
+        }
+
+        @Override
+        public boolean loadNextBatch()
+        {
+            if (closed || loaded || root.getRowCount() == 0) {
+                return false;
+            }
+            loaded = true;
+            return true;
+        }
+
+        @Override
+        public VectorSchemaRoot getVectorSchemaRoot()
+        {
+            return root;
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            return root.getFieldVectors().stream()
+                    .mapToLong(FieldVector::getBufferSize)
+                    .sum();
+        }
+
+        @Override
+        public void close()
+        {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            root.close();
+            allocator.close();
+        }
+    }
+}

--- a/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
+++ b/plugin/trino-starrocks/src/test/java/io/trino/plugin/starrocks/TestingStarRocksEnvironment.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.starrocks;
 
 import com.google.inject.Module;
+import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchMetadata;
@@ -21,6 +22,8 @@ import io.trino.plugin.tpch.TpchRecordSet;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.TimestampType;
@@ -50,6 +53,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -60,21 +64,28 @@ import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.encodeShortScaledValue;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 final class TestingStarRocksEnvironment
 {
+    private static final JsonCodec<Object> JSON_CODEC = jsonCodec(Object.class);
     private static final String TPCH_SCHEMA = TpchMetadata.TINY_SCHEMA_NAME;
     private static final double TPCH_SCALE_FACTOR = TpchMetadata.TINY_SCALE_FACTOR;
 
@@ -240,7 +251,7 @@ final class TestingStarRocksEnvironment
 
         private StarRocksRemoteTable toRemoteTable()
         {
-            return new StarRocksRemoteTable(schemaTableName, remoteSchemaName, remoteTableName, relationType, columns);
+            return new StarRocksRemoteTable(schemaTableName, Optional.empty(), remoteSchemaName, remoteTableName, relationType, columns);
         }
     }
 
@@ -304,8 +315,184 @@ final class TestingStarRocksEnvironment
             lastRequest.set(new Request(tableHandle, columns));
 
             TestingTable table = tables.get(tableHandle.toSchemaTableName());
-            List<Map<String, Object>> rows = table == null ? List.of() : table.rows();
+            List<Map<String, Object>> rows = table == null ? List.of() : applyTableHandle(tableHandle, table.rows());
             return createResult(table, columns, rows);
+        }
+
+        private static List<Map<String, Object>> applyTableHandle(StarRocksTableHandle tableHandle, List<Map<String, Object>> rows)
+        {
+            List<Map<String, Object>> filteredRows = applyConstraint(tableHandle.constraint(), rows);
+            List<Map<String, Object>> projectedRows = tableHandle.aggregation()
+                    .map(aggregation -> applyAggregation(aggregation, filteredRows))
+                    .orElse(filteredRows);
+            List<Map<String, Object>> sortedRows = applySort(tableHandle.sortOrder(), projectedRows);
+            if (tableHandle.limit().isEmpty()) {
+                return sortedRows;
+            }
+            return sortedRows.stream()
+                    .limit(tableHandle.limit().getAsLong())
+                    .toList();
+        }
+
+        private static List<Map<String, Object>> applyConstraint(TupleDomain<StarRocksColumnHandle> constraint, List<Map<String, Object>> rows)
+        {
+            if (constraint.isNone()) {
+                return List.of();
+            }
+            if (constraint.isAll() || constraint.getDomains().isEmpty()) {
+                return rows;
+            }
+
+            return rows.stream()
+                    .filter(row -> matchesConstraint(row, constraint.getDomains().orElseThrow()))
+                    .toList();
+        }
+
+        private static boolean matchesConstraint(Map<String, Object> row, Map<StarRocksColumnHandle, Domain> domains)
+        {
+            for (Map.Entry<StarRocksColumnHandle, Domain> entry : domains.entrySet()) {
+                StarRocksColumnHandle column = entry.getKey();
+                if (!entry.getValue().includesNullableValue(toDomainValue(row.get(column.columnName()), column.columnType()))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static List<Map<String, Object>> applyAggregation(StarRocksAggregation aggregation, List<Map<String, Object>> rows)
+        {
+            Map<List<Object>, List<Map<String, Object>>> groups = rows.stream()
+                    .collect(Collectors.groupingBy(row -> aggregation.groupingColumns().stream()
+                                    .map(column -> row.get(column.columnName()))
+                                    .toList(),
+                            LinkedHashMap::new,
+                            Collectors.toList()));
+            if (groups.isEmpty() && aggregation.groupingColumns().isEmpty()) {
+                groups = Map.of(List.of(), List.of());
+            }
+
+            List<Map<String, Object>> results = new ArrayList<>(groups.size());
+            for (Map.Entry<List<Object>, List<Map<String, Object>>> group : groups.entrySet()) {
+                LinkedHashMap<String, Object> row = new LinkedHashMap<>();
+                for (int index = 0; index < aggregation.groupingColumns().size(); index++) {
+                    row.put(aggregation.groupingColumns().get(index).columnName(), group.getKey().get(index));
+                }
+                for (StarRocksAggregateColumn aggregateColumn : aggregation.aggregateColumns()) {
+                    row.put(aggregateColumn.columnName(), evaluateAggregate(aggregateColumn.expression(), group.getValue()));
+                }
+                results.add(Collections.unmodifiableMap(row));
+            }
+            return List.copyOf(results);
+        }
+
+        private static long evaluateAggregate(String expression, List<Map<String, Object>> rows)
+        {
+            String normalized = expression.trim().toLowerCase(Locale.ENGLISH);
+            if (normalized.equals("count(*)")) {
+                return rows.size();
+            }
+            if (normalized.equals("count(null)")) {
+                return 0L;
+            }
+            if (normalized.startsWith("count(`") && normalized.endsWith("`)")) {
+                String columnName = normalized.substring("count(`".length(), normalized.length() - "`)".length()).replace("``", "`");
+                return rows.stream()
+                        .filter(row -> row.get(columnName) != null)
+                        .count();
+            }
+            throw new IllegalArgumentException("Unsupported testing aggregate expression: " + expression);
+        }
+
+        private static List<Map<String, Object>> applySort(List<StarRocksSortItem> sortOrder, List<Map<String, Object>> rows)
+        {
+            if (sortOrder.isEmpty()) {
+                return rows;
+            }
+
+            Comparator<Map<String, Object>> comparator = (left, right) -> {
+                for (StarRocksSortItem sortItem : sortOrder) {
+                    int result = compareValues(left.get(sortItem.columnName()), right.get(sortItem.columnName()), sortItem);
+                    if (result != 0) {
+                        return result;
+                    }
+                }
+                return 0;
+            };
+            return rows.stream()
+                    .sorted(comparator)
+                    .toList();
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private static int compareValues(Object left, Object right, StarRocksSortItem sortItem)
+        {
+            if (left == null || right == null) {
+                if (left == right) {
+                    return 0;
+                }
+                return (left == null) == sortItem.sortOrder().isNullsFirst() ? -1 : 1;
+            }
+
+            Object comparableLeft = toComparableValue(left);
+            Object comparableRight = toComparableValue(right);
+            int result = ((Comparable) comparableLeft).compareTo(comparableRight);
+            return sortItem.sortOrder().isAscending() ? result : -result;
+        }
+
+        private static Object toComparableValue(Object value)
+        {
+            if (value instanceof Slice slice) {
+                return slice.toStringUtf8();
+            }
+            return value;
+        }
+
+        private static Object toDomainValue(Object value, Type type)
+        {
+            if (value == null) {
+                return null;
+            }
+            if (type == BOOLEAN) {
+                return toBooleanValue(value);
+            }
+            if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+                return toLong(value);
+            }
+            if (type == REAL) {
+                return (long) floatToRawIntBits(((Number) value).floatValue());
+            }
+            if (type == DOUBLE) {
+                return ((Number) value).doubleValue();
+            }
+            if (type == DATE) {
+                return toEpochDay(value);
+            }
+            if (type instanceof TimestampType timestampType && timestampType.isShort()) {
+                return toTimestampMicros(value);
+            }
+            if (type instanceof DecimalType decimalType) {
+                BigDecimal decimal = toBigDecimalValue(value);
+                if (decimalType.isShort()) {
+                    return encodeShortScaledValue(decimal, decimalType.getScale());
+                }
+            }
+            if (type instanceof VarcharType || type instanceof CharType || type.getBaseName().equals(JSON)) {
+                if (value instanceof Slice slice) {
+                    return slice;
+                }
+                return utf8Slice(value.toString());
+            }
+            return value;
+        }
+
+        private static long toTimestampMicros(Object value)
+        {
+            if (value instanceof LocalDateTime dateTime) {
+                return dateTime.toEpochSecond(java.time.ZoneOffset.UTC) * MICROSECONDS_PER_SECOND + (dateTime.getNano() / 1_000);
+            }
+            String text = value.toString().trim().replace(' ', 'T');
+            LocalDateTime dateTime = LocalDateTime.parse(text);
+            return dateTime.toEpochSecond(java.time.ZoneOffset.UTC) * MICROSECONDS_PER_SECOND + (dateTime.getNano() / 1_000);
         }
 
         private static StarRocksFlightSqlResult createResult(TestingTable table, List<StarRocksColumnHandle> columns, List<Map<String, Object>> rows)
@@ -522,7 +709,7 @@ final class TestingStarRocksEnvironment
                 vector.setValueCount(rows.size());
                 return vector;
             }
-            if (type instanceof VarcharType || type instanceof CharType) {
+            if (type instanceof VarcharType || type instanceof CharType || type.getBaseName().equals(JSON)) {
                 VarCharVector vector = new VarCharVector(name, allocator);
                 vector.allocateNew();
                 for (int i = 0; i < rows.size(); i++) {
@@ -531,7 +718,7 @@ final class TestingStarRocksEnvironment
                         vector.setNull(i);
                     }
                     else {
-                        vector.setSafe(i, toTextBytes(value));
+                        vector.setSafe(i, type.getBaseName().equals(JSON) ? toJsonBytes(value) : toTextBytes(value));
                     }
                 }
                 vector.setValueCount(rows.size());
@@ -609,6 +796,17 @@ final class TestingStarRocksEnvironment
                 return dateTime.toString().replace('T', ' ').getBytes(UTF_8);
             }
             return value.toString().getBytes(UTF_8);
+        }
+
+        private static byte[] toJsonBytes(Object value)
+        {
+            if (value instanceof Slice slice) {
+                return slice.getBytes();
+            }
+            if (value instanceof CharSequence) {
+                return value.toString().getBytes(UTF_8);
+            }
+            return JSON_CODEC.toJson(value).getBytes(UTF_8);
         }
 
         private static byte[] toBinaryBytes(Object value)

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <module>plugin/trino-snowflake</module>
         <module>plugin/trino-spooling-filesystem</module>
         <module>plugin/trino-sqlserver</module>
+        <module>plugin/trino-starrocks</module>
         <module>plugin/trino-teradata-functions</module>
         <module>plugin/trino-thrift</module>
         <module>plugin/trino-thrift-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <module>plugin/trino-snowflake</module>
         <module>plugin/trino-spooling-filesystem</module>
         <module>plugin/trino-sqlserver</module>
+        <module>plugin/trino-starrocks</module>
         <module>plugin/trino-teradata-functions</module>
         <module>plugin/trino-thrift</module>
         <module>plugin/trino-thrift-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <module>plugin/trino-snowflake</module>
         <module>plugin/trino-spooling-filesystem</module>
         <module>plugin/trino-sqlserver</module>
+        <module>plugin/trino-starrocks</module>
         <module>plugin/trino-teradata-functions</module>
         <module>plugin/trino-thrift</module>
         <module>plugin/trino-thrift-api</module>


### PR DESCRIPTION
## Description

Add an initial native read-only StarRocks connector.

The connector uses the StarRocks JDBC driver for metadata discovery and Apache Arrow Flight SQL for reads. This avoids MySQL-specific metadata assumptions that can break on StarRocks, such as relying on JDBC `COLUMN_SIZE` being present during type discovery.

The initial implementation includes:
- schema, table, view, and column introspection
- `DESCRIBE` and `SHOW CREATE TABLE` support
- read-only `SELECT` queries over Arrow Flight SQL
- predicate, limit, numeric and temporal TopN, and basic aggregation pushdown
- Flight SQL partitioned split planning with a safe single-split fallback
- optional TLS configuration for Flight SQL connections
- bounded Arrow memory allocation per Flight SQL stream
- StarRocks-aware scalar type mapping with conservative handling for unsupported or partially supported types

Out of scope for v1:
- writes and schema mutations
- connector-managed DDL for complex types
- native decoding for `ARRAY`, `MAP`, and `STRUCT`
- direct reads of StarRocks `HLL` state columns
- optimizations beyond StarRocks Flight SQL partition descriptors and the pushdowns implemented in this PR

## Additional context and related issues

This work follows the design direction discussed in #28735 and is informed by the Doris Flight SQL connector in #29120, while remaining a StarRocks-specific implementation rather than extending the generic MySQL connector path.

Prior StarRocks-specific work for context:
- #17330
- #24720

The main StarRocks-specific choices in this PR are:
- metadata comes from the StarRocks JDBC driver and StarRocks `INFORMATION_SCHEMA` rather than MySQL connector metadata code
- reads use Arrow Flight SQL rather than the MySQL wire protocol
- catalog-aware metadata supports `starrocks.catalog-name`, with a fully qualified `SHOW FULL COLUMNS` fallback for StarRocks versions where `INFORMATION_SCHEMA.COLUMNS.TABLE_CATALOG` is absent or not populated
- unsupported aggregate forms, risky ordering semantics, and unproven complex values fall back to Trino execution or conservative type mapping instead of breaking table introspection

Known v1 limitations:
- empty databases inside a configured StarRocks catalog may not be listed if StarRocks does not expose catalog information for empty schemas
- `HLL` state columns are not exposed because StarRocks does not support direct reads of HLL values
- `ARRAY`, `MAP`, and `STRUCT` are mapped conservatively to `VARCHAR`

## Testing

This PR adds coverage for:
- connector configuration and type mapping
- StarRocks metadata fallback behavior
- Arrow value conversion
- SQL generation for pushdown
- split planning and page source behavior
- connector smoke tests following the `BaseConnectorSmokeTest` pattern
- opt-in integration smoke tests against a live StarRocks instance

Validated locally with:
- `./mvnw -pl plugin/trino-starrocks test`
- `./mvnw -pl plugin/trino-starrocks clean compile test-compile -DskipTests -Dair.check.skip-all=true -P errorprone-compiler`
- the gated StarRocks integration smoke test against a live StarRocks instance outside the repository

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## StarRocks connector
* Add the native read-only StarRocks connector backed by StarRocks JDBC metadata and Arrow Flight SQL reads. ({issue}`28735`)
```
