### PR TITLE
Skip worker availability check for coordinator-only queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
@@ -125,11 +126,15 @@ public class LocalDispatchQuery
     {
         // wait for query execution to finish construction
         addSuccessCallback(queryExecutionFuture, queryExecution -> {
-            Session session = stateMachine.getSession();
-            int executionMinCount = 1; // always wait for 1 node to be up
-            if (queryExecution.shouldWaitForMinWorkers()) {
-                executionMinCount = getRequiredWorkers(session);
+            if (!queryExecution.shouldWaitForMinWorkers()) {
+                // Queries targeting only internal/system catalogs run entirely on the
+                // coordinator and must not wait for workers.  See trinodb/trino#4130.
+                addSuccessCallback(immediateVoidFuture(), () -> startExecution(queryExecution), queryExecutor);
+                return;
             }
+
+            Session session = stateMachine.getSession();
+            int executionMinCount = getRequiredWorkers(session);
             ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
             // when worker requirement is met, start the execution
             addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution), queryExecutor);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMinWorkerRequirement.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMinWorkerRequirement.java
@@ -108,6 +108,23 @@ public class TestMinWorkerRequirement
     }
 
     @Test
+    public void testSystemQueryDispatchesWithoutWorkers()
+            throws Exception
+    {
+        try (QueryRunner queryRunner = TpchQueryRunner.builder()
+                .setCoordinatorProperties(ImmutableMap.<String, String>builder()
+                        .put("node-scheduler.include-coordinator", "false")
+                        .put("query-manager.required-workers", "1")
+                        .put("query-manager.required-workers-max-wait", "1ns")
+                        .buildOrThrow())
+                .setWorkerCount(0)
+                .build()) {
+            queryRunner.execute("SELECT * FROM system.runtime.queries");
+            queryRunner.execute("SELECT * FROM system.runtime.nodes");
+        }
+    }
+
+    @Test
     @Timeout(60)
     public void testInsufficientWorkerNodesAfterDrop()
             throws Exception


### PR DESCRIPTION
## Description

On coordinator-only clusters (`node-scheduler.include-coordinator=false`, zero workers), admin queries like `SELECT * FROM system.runtime.queries` stall indefinitely in `WAITING_FOR_RESOURCES`. `LocalDispatchQuery.waitForMinimumWorkers` unconditionally waits for at least one countable node before dispatch, even though `SqlQueryExecution.shouldWaitForMinWorkers` already reports `false` for queries that only reference internal/system catalogs.

This short-circuits the minimum-worker wait when `shouldWaitForMinWorkers()` returns `false`, matching the existing intent of that predicate.

Added an integration test in `TestMinWorkerRequirement` that runs `SELECT * FROM system.runtime.queries` and `SELECT * FROM system.runtime.nodes` against a coordinator-only cluster with zero workers and asserts they dispatch successfully.

## Additional context and related issues

Fixes #4130 (open since 2020). Related: #4131 (same issue for `EXPLAIN`, not addressed here).

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix admin queries against `system.runtime` tables getting stuck in `WAITING_FOR_RESOURCES` on coordinator-only clusters. ({issue}`4130`)
```
