### PR TITLE
Add support for match_only_text field type in OpenSearch

### DIFF
--- a/docs/src/main/sphinx/connector/opensearch.md
+++ b/docs/src/main/sphinx/connector/opensearch.md
@@ -215,6 +215,9 @@ according to the following table:
 * - `TEXT`
   - `VARCHAR`
   -
+* - `MATCH_ONLY_TEXT`
+  - `VARCHAR`
+  -
 * - `DATE`
   - `TIMESTAMP`
   - For more information, see [](opensearch-date-types).

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -296,7 +296,7 @@ public class OpenSearchMetadata
                 case "short" -> new TypeAndDecoder(SMALLINT, new SmallintDecoder.Descriptor(path));
                 case "integer" -> new TypeAndDecoder(INTEGER, new IntegerDecoder.Descriptor(path));
                 case "long" -> new TypeAndDecoder(BIGINT, new BigintDecoder.Descriptor(path));
-                case "text", "keyword" -> new TypeAndDecoder(VARCHAR, new VarcharDecoder.Descriptor(path));
+                case "text", "match_only_text", "keyword" -> new TypeAndDecoder(VARCHAR, new VarcharDecoder.Descriptor(path));
                 case "ip" -> new TypeAndDecoder(ipAddressType, new IpAddressDecoder.Descriptor(path, ipAddressType));
                 case "boolean" -> new TypeAndDecoder(BOOLEAN, new BooleanDecoder.Descriptor(path));
                 case "binary" -> new TypeAndDecoder(VARBINARY, new VarbinaryDecoder.Descriptor(path));

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -297,7 +297,7 @@ public class OpenSearchMetadata
                 case "short" -> new TypeAndDecoder(SMALLINT, new SmallintDecoder.Descriptor(path));
                 case "integer" -> new TypeAndDecoder(INTEGER, new IntegerDecoder.Descriptor(path));
                 case "long" -> new TypeAndDecoder(BIGINT, new BigintDecoder.Descriptor(path));
-                case "text", "keyword" -> new TypeAndDecoder(VARCHAR, new VarcharDecoder.Descriptor(path));
+                case "text", "match_only_text", "keyword" -> new TypeAndDecoder(VARCHAR, new VarcharDecoder.Descriptor(path));
                 case "ip" -> new TypeAndDecoder(ipAddressType, new IpAddressDecoder.Descriptor(path, ipAddressType));
                 case "boolean" -> new TypeAndDecoder(BOOLEAN, new BooleanDecoder.Descriptor(path));
                 case "binary" -> new TypeAndDecoder(VARBINARY, new VarbinaryDecoder.Descriptor(path));

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -1254,6 +1254,31 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testMatchOnlyTextDataType()
+            throws IOException
+    {
+        // match_only_text was introduced in OpenSearch 2.12
+        String indexName = "match_only_text_type";
+
+        @Language("JSON")
+        String mappings =
+                """
+                {
+                    "properties": {
+                        "match_only_text_column": { "type": "match_only_text" }
+                    }
+                }
+                """;
+
+        createIndex(indexName, mappings);
+
+        index(indexName, ImmutableMap.of("match_only_text_column", "some text"));
+
+        assertThat(query("SELECT match_only_text_column FROM " + indexName))
+                .matches("VALUES VARCHAR 'some text'");
+    }
+
+    @Test
     public void testTableWithUnsupportedTypes()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -1253,6 +1253,31 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testMatchOnlyTextDataType()
+            throws IOException
+    {
+        // match_only_text was introduced in OpenSearch 2.12
+        String indexName = "match_only_text_type";
+
+        @Language("JSON")
+        String mappings =
+                """
+                {
+                    "properties": {
+                        "match_only_text_column": { "type": "match_only_text" }
+                    }
+                }
+                """;
+
+        createIndex(indexName, mappings);
+
+        index(indexName, ImmutableMap.of("match_only_text_column", "some text"));
+
+        assertThat(query("SELECT match_only_text_column FROM " + indexName))
+                .matches("VALUES VARCHAR 'some text'");
+    }
+
+    @Test
     public void testTableWithUnsupportedTypes()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchConnectorTest.java
@@ -13,6 +13,9 @@
  */
 package io.trino.plugin.opensearch;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 public class TestOpenSearchConnectorTest
         extends BaseOpenSearchConnectorTest
 {
@@ -21,4 +24,9 @@ public class TestOpenSearchConnectorTest
         // 1.0.0 and 1.0.1 causes NotSslRecordException during the initialization
         super("opensearchproject/opensearch:1.1.0");
     }
+
+    @Test
+    @Disabled("match_only_text field type was introduced in OpenSearch 2.12")
+    @Override
+    public void testMatchOnlyTextDataType() {}
 }


### PR DESCRIPTION
## Description

Map the `match_only_text` OpenSearch field type to `VARCHAR`, alongside the
existing `text` and `keyword` mappings. Fields of this type are now exposed in
the table schema and readable from Trino.

`match_only_text` is a storage-optimized variant of `text` introduced in
OpenSearch 2.12. It returns identical values to `text` (plain strings from
`_source`), so the existing `VarcharDecoder` can be reused as-is.

## Additional context and related issues

- Fixes #29165

Before this change, columns declared as `match_only_text` were silently dropped
from the table schema, forcing users to fall back to `raw_query` (which returns
JSON blobs and is capped at 10,000 rows) and preventing standard SQL operations
such as JOINs and aggregations.

The new `testMatchOnlyTextDataType` test is `@Disabled` in
`TestOpenSearchConnectorTest` because the field type is not available in
OpenSearch 1.1.0; it runs on the 2.19.4, 3.0.0, and `latest` images.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## OpenSearch connector
* Add support for the `match_only_text` field type. ({issue}`29165`)

