### PR TITLE
Add support for full text queries in OpenSearch

### DIFF
--- a/docs/src/main/sphinx/connector/opensearch.md
+++ b/docs/src/main/sphinx/connector/opensearch.md
@@ -390,6 +390,16 @@ The following hidden columns are available:
   - The source of the original document.
 :::
 
+(opensearch-full-text-queries)=
+## Full text queries
+
+Trino SQL queries can be combined with OpenSearch queries by providing the [full text query]
+as part of the table name, separated by a colon. For example:
+
+```sql
+SELECT * FROM "tweets: +trino SQL^2"
+```
+
 (opensearch-sql-support)=
 ## SQL support
 

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -180,8 +180,15 @@ public class OpenSearchMetadata
         requireNonNull(tableName, "tableName is null");
 
         if (tableName.getSchemaName().equals(schemaName)) {
-            if (client.indexExists(tableName.getTableName()) && !client.getIndexMetadata(tableName.getTableName()).schema().fields().isEmpty()) {
-                return new OpenSearchTableHandle(OpenSearchTableHandle.Type.SCAN, schemaName, tableName.getTableName(), Optional.empty());
+            String[] parts = tableName.getTableName().split(":", 2);
+            String table = parts[0];
+            Optional<String> query = Optional.empty();
+            if (parts.length == 2) {
+                query = Optional.of(parts[1]);
+            }
+
+            if (client.indexExists(table) && !client.getIndexMetadata(table).schema().fields().isEmpty()) {
+                return new OpenSearchTableHandle(OpenSearchTableHandle.Type.SCAN, schemaName, table, query);
             }
         }
 

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -1822,6 +1822,13 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testQueryString()
+    {
+        assertThat(query("SELECT count(*) FROM \"orders: +packages -slyly\""))
+                .matches("VALUES BIGINT '1639'");
+    }
+
+    @Test
     public void testMixedCase()
             throws IOException
     {
@@ -1857,6 +1864,13 @@ public abstract class BaseOpenSearchConnectorTest
                 .matches("VALUES VARCHAR '20'");
         assertThat(query("SELECT numeric_keyword FROM numeric_keyword where numeric_keyword = '20'"))
                 .matches("VALUES VARCHAR '20'");
+    }
+
+    @Test
+    public void testQueryStringError()
+    {
+        assertQueryFails("SELECT orderkey FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");
+        assertQueryFails("SELECT count(*) FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");
     }
 
     @Test


### PR DESCRIPTION
## Description

Allow combining Trino SQL queries with OpenSearch full text queries by embedding
a [query_string](https://opensearch.org/docs/latest/query-dsl/full-text/query-string/) expression in the table name after a colon:

```sql
SELECT * FROM "tweets: +trino SQL^2"
```

The colon-separated fragment is parsed in `OpenSearchMetadata#getTableHandle`,
stored in `OpenSearchTableHandle.query`, and pushed down as a
`QueryStringQueryBuilder` by the existing `OpenSearchQueryBuilder`. This mirrors
the behaviour already available in the Elasticsearch connector.

## Additional context and related issues

Fixes #29164.

The downstream machinery was already in place: `OpenSearchTableHandle` carries
an `Optional<String> query` and `OpenSearchQueryBuilder` already wraps that
value in a `QueryStringQueryBuilder`. Only `getTableHandle` needed to parse the
table name and propagate the query fragment, so this PR is a small,
self-contained port of the Elasticsearch feature.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## OpenSearch
* Add support for full text queries by appending a Lucene `query_string`
  expression to the table name after a colon, e.g.
  `SELECT * FROM "tweets: +trino SQL^2"`. ({issue}`29164`)
```