### PR TITLE
Fix $entries NPE on null sort_order_id

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/EntriesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/EntriesTable.java
@@ -242,8 +242,14 @@ public class EntriesTable
                     // data files don't have equality ids
                     fieldBuilders.get(++position).appendNull();
 
+                    // sort_order_id is optional per the Iceberg spec — null means "unsorted"
                     Integer sortOrderId = dataFile.get(++position, Integer.class);
-                    INTEGER.writeLong(fieldBuilders.get(position), Long.valueOf(sortOrderId));
+                    if (sortOrderId == null) {
+                        fieldBuilders.get(position).appendNull();
+                    }
+                    else {
+                        INTEGER.writeLong(fieldBuilders.get(position), sortOrderId.longValue());
+                    }
                 }
                 case POSITION_DELETE -> {
                     // position delete files don't have equality ids
@@ -258,7 +264,12 @@ public class EntriesTable
                     appendIntegerArray((ArrayBlockBuilder) fieldBuilders.get(position), equalityIds);
 
                     Integer sortOrderId = dataFile.get(++position, Integer.class);
-                    INTEGER.writeLong(fieldBuilders.get(position), Long.valueOf(sortOrderId));
+                    if (sortOrderId == null) {
+                        fieldBuilders.get(position).appendNull();
+                    }
+                    else {
+                        INTEGER.writeLong(fieldBuilders.get(position), sortOrderId.longValue());
+                    }
                 }
             }
         });

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -25,7 +25,10 @@ import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.intellij.lang.annotations.Language;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -789,6 +793,45 @@ public abstract class BaseIcebergSystemTables
                             "dt":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},\
                             "id":{"column_size":51,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1}\
                             }""");
+        }
+    }
+
+    @Test
+    void testEntriesTableWithNullSortOrderId()
+            throws Exception
+    {
+        // Iceberg spec (table spec v1/v2/v3) marks data_file.sort_order_id as optional: a null value
+        // is a valid on-disk state meaning "unsorted", and readers must tolerate it. Writers such as
+        // PyIceberg emit null here on default appends. Trino's own writer populates 0, which is why
+        // reaching the code path from SQL is impossible — commit a DataFile directly through the
+        // Iceberg Java API to produce a manifest entry with sort_order_id unset.
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_entries_null_sort_order", "AS SELECT 1 id")) {
+            Table icebergTable = loadTable(table.getName());
+            DataFile dataFile = DataFiles.builder(icebergTable.spec())
+                    .withPath(icebergTable.location() + "/data/synthetic-no-sort-order." + format.name().toLowerCase(ENGLISH))
+                    .withFormat(FileFormat.fromString(format.name()))
+                    .withFileSizeInBytes(1234)
+                    .withRecordCount(1)
+                    .build();
+            // DataFiles.Builder defaults sort_order_id to SortOrder.unsorted().orderId() (== 0).
+            // The spec-valid null state is what PyIceberg emits; reach it by clearing the inherited
+            // BaseFile.sortOrderId field so the manifest row is written with the column unset.
+            Field sortOrderIdField = dataFile.getClass().getSuperclass().getDeclaredField("sortOrderId");
+            sortOrderIdField.setAccessible(true);
+            sortOrderIdField.set(dataFile, null);
+            assertThat(dataFile.sortOrderId()).isNull();
+
+            icebergTable.newAppend().appendFile(dataFile).commit();
+            long appendedSnapshotId = icebergTable.currentSnapshot().snapshotId();
+
+            // Reading $entries must not throw and must surface the null as SQL NULL.
+            assertThat(computeScalar("SELECT data_file.sort_order_id FROM \"" + table.getName() + "$entries\"" +
+                    " WHERE snapshot_id = " + appendedSnapshotId))
+                    .isNull();
+            // $all_entries shares the same code path and must also tolerate the null.
+            assertThat(computeScalar("SELECT data_file.sort_order_id FROM \"" + table.getName() + "$all_entries\"" +
+                    " WHERE snapshot_id = " + appendedSnapshotId))
+                    .isNull();
         }
     }
 


### PR DESCRIPTION
## Description

Fix `NullPointerException` when reading the Iceberg `$entries` or `$all_entries` system table on a table whose manifest contains any data file or equality delete file with `sort_order_id = null`. A single null anywhere in the selected manifests currently fails the whole query with `Cannot invoke "java.lang.Integer.intValue()" because "sortOrderId" is null`.

The Iceberg table spec marks `data_file.sort_order_id` as optional in v1, v2, and v3: *"If sort order ID is missing or unknown, then the order is assumed to be unsorted"*. Trino's writer now always populates `0` (PR #28091), but tables written by spec-compliant clients such as PyIceberg — which unconditionally sets `sort_order_id = null` on every data-file write — still trip the NPE when read through `$entries` / `$all_entries`.

`EntriesTable#appendDataFile` auto-unboxed the boxed `Integer` via `Long.valueOf(sortOrderId)` in both the `DATA` and `EQUALITY_DELETE` branches. This PR null-checks both sites and emits SQL `NULL` when the field is unset, matching the existing `key_metadata` idiom a few lines above in the same method.

A regression test (`BaseIcebergSystemTables#testEntriesTableWithNullSortOrderId`, run on both the Parquet and ORC subclasses) commits a `DataFile` directly via the Iceberg Java API. Since both Trino's writer and iceberg-java's `DataFiles.Builder` hard-default `sort_order_id` to `0` — `Builder`'s no-arg constructor sets `SortOrder.unsorted().orderId()` — the test reflectively clears the inherited `BaseFile.sortOrderId` field before `appendFile(...).commit()` to reach the spec-valid null state. Before this fix the test throws the exact NPE above; after, it returns a row with `data_file.sort_order_id IS NULL`.

## Additional context and related issues

- Fixes #29211.
- `$entries` was introduced in `4db417903d` (released in 469) and `$all_entries` in `47720cbf04` (released in 469). The NPE has been present in both since those commits and was carried through the refactor in `3efd8349ab1` (fix for #24775, released in 470). All Trino releases **469 through current master (480+)** are affected.
- Related but distinct: PR #28091 addressed the **writer** side (Trino's own writer now populates `sort_order_id`); this PR addresses the **reader** side for manifests produced by any other spec-compliant writer.
- Related prior NPE in the same file on a different code path: #24775 (fixed in `3efd8349ab1`). This PR takes the same minimal null-tolerance approach.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix `NullPointerException` when reading the `$entries` or `$all_entries`. ({issue}`29211`)
```
