### PR TITLE
Improve Databricks product test retry for OSS JDBC driver errors

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DeltaLakeTestUtils.java
@@ -48,8 +48,12 @@ public final class DeltaLakeTestUtils
             "\\Q[Databricks][\\E(DatabricksJDBCDriver|JDBCDriver)\\Q](500593) Communication link failure. Failed to connect to server. Reason: \\E" +
                     "(" +
                     "(HTTP retry after response received with no Retry-After header, error: HTTP Response code: 503|HTTP Response code: 504), Error message: Unknown." +
-                    "|java.net.SocketTimeoutException: Read timed out." +
-                    ")";
+                    ")" +
+                    "|504 Gateway Timeout" +
+                    "|SocketTimeoutException: Read timed out" +
+                    "|Error while closing operation" +
+                    "|HTTP request failed by code: 50[02]" +
+                    "|HTTP response code: 503";
     private static final RetryPolicy<QueryResult> DATABRICKS_COMMUNICATION_FAILURE_RETRY_POLICY = RetryPolicy.<QueryResult>builder()
             .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof SQLException)
             .handleIf(throwable -> Pattern.compile(DATABRICKS_COMMUNICATION_FAILURE_MATCH).matcher(Throwables.getRootCause(throwable).getMessage()).find())

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryExecutors.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryExecutors.java
@@ -13,6 +13,7 @@
  */
 package io.trino.tests.product.utils;
 
+import com.google.common.base.Throwables;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
@@ -21,6 +22,7 @@ import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 
 import java.sql.Connection;
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
 import static io.trino.tempto.context.ThreadLocalTestContextHolder.testContext;
@@ -123,9 +125,17 @@ public final class QueryExecutors
         // while keeping costs to a minimum.
 
         RetryPolicy<QueryResult> databricksRetryPolicy = RetryPolicy.<QueryResult>builder()
-                .handleIf(throwable -> throwable.getMessage().contains("HTTP Response code: 502"))
-                .withBackoff(1, 10, ChronoUnit.SECONDS)
-                .withMaxRetries(60)
+                // Retry on 503 may lead to unexpected test results: https://github.com/trinodb/trino/pull/14392#issuecomment-1264041917
+                .handleIf(throwable -> {
+                    String stackTrace = Throwables.getStackTraceAsString(throwable);
+                    // Don't retry if the error occurred during statement close — the statement already executed successfully
+                    if (stackTrace.contains("closeStatement") || stackTrace.contains("CloseOperation")) {
+                        return false;
+                    }
+                    return stackTrace.contains("HTTP Response code: 502") || stackTrace.contains("The current cluster state is Pending") || stackTrace.contains("The current cluster state is Terminated");
+                })
+                .withDelay(Duration.of(30, ChronoUnit.SECONDS))
+                .withMaxRetries(40)
                 .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))
                 .build();
 


### PR DESCRIPTION
## Description
                                                                       
  The OSS Databricks JDBC driver (which replaced the proprietary driver) wraps errors differently, causing both the `onDelta()` statement-level retry and `@Flaky` test-level retry to miss transient Databricks failures.                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                     
  Three issues fixed:                                                                                                                                                                                                                                                                                                                                                                
                                                                       
  ### 1. `onDelta()` missed errors buried in the exception cause chain                                                                                                                                                                                                                                                                                                               
   
  The retry predicate used `throwable.getMessage()` which only checked the top-level message. The OSS driver wraps the actual HTTP error inside `SQLException: Preparatory statement failed: USE default`, hiding the retryable cause:                                                                                                                                               
                                                                       
```
  java.sql.SQLException: Preparatory statement failed: USE default                                                                                                                                                                                                                                                                                                                   
  Caused by: com.databricks.jdbc.exception.DatabricksHttpException: Error while receiving response from Thrift server...
  Caused by: com.databricks.internal.apache.thrift.transport.TTransportException: ...                                                                                                                                                                                                                                                                                                
  Caused by: com.databricks.jdbc.exception.DatabricksHttpException: HTTP Response code: 503     
```                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                     
  Fixed by switching to `Throwables.getStackTraceAsString(throwable)` to inspect the full cause chain.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                     
  ### 2. `onDelta()` unsafely retried statements that already executed                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                     
  When the Databricks cluster returns an error during `CloseOperation` (after the statement has already executed), the retry policy re-executed the statement, causing `TABLE_OR_VIEW_ALREADY_EXISTS` or duplicate data:                                                                                                                                                             
```
                                                                       
  com.databricks.jdbc.exception.DatabricksHttpException: Error while closing operation...                                                                                                                                                                                                                                                                                            
    HTTP request failed by code: 504, status line: HTTP/1.1 504 Gateway Timeout
      at com.databricks.jdbc.core.DatabricksStatement.closeStatement(DatabricksStatement.java:266)   
```                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                     
  Fixed by checking for `closeStatement`/`CloseOperation` in the stack trace and skipping retry.                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                     
  ### 3. `@Flaky` pattern did not cover OSS JDBC driver error formats  
                                                                                                                                                                                                                                                                                                                                                                                     
  The `DATABRICKS_COMMUNICATION_FAILURE_MATCH` regex only matched the proprietary driver's `[Databricks][DatabricksJDBCDriver](500593)` format. OSS driver errors like these went unmatched:                                                                                                                                                                                         
   
```
  com.databricks.jdbc.exception.DatabricksHttpException: Error while receiving response from Thrift server.                                                                                                                                                                                                                                                                          
    Request {TExecuteStatementReq(...)},                               
    Error {Failed to flush data to server: HTTP request failed by code: 502,                                                                                                                                                                                                                                                                                                         
      status line: HTTP/1.1 502 Bad Gateway.}                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                     
  com.databricks.jdbc.exception.DatabricksHttpException: Error while closing operation.                                                                                                                                                                                                                                                                                              
    Request {TCloseOperationReq(...)},                                                                                                                                                                                                                                                                                                                                               
    Error {HTTP request failed by code: 500, status line: HTTP/1.1 500 Internal Server Error.                                                                                                                                                                                                                                                                                        
      Thrift Header: javax.servlet.ServletException:                                                                                                                                                                                                                                                                                                                                 
      java.util.concurrent.RejectedExecutionException}      
```                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                     
  Extended the pattern with: `504 Gateway Timeout`, `SocketTimeoutException: Read timed out`, `Error while closing operation`, `HTTP request failed by code: 50[02]`.
                                                                                                                                                                                                                                                                                                                                                                                     



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
