### PR TITLE
Add search table function to OpenSearch connector

### DIFF
--- a/docs/src/main/sphinx/connector/opensearch.md
+++ b/docs/src/main/sphinx/connector/opensearch.md
@@ -462,6 +462,113 @@ FROM
 ```{include} query-table-function-ordering.fragment
 ```
 
+(opensearch-search-function)=
+#### `search(varchar, varchar, varchar) -> table`
+
+The `search` function runs any [OpenSearch Query DSL](https://opensearch.org/docs/latest/query-dsl/index/) query and returns
+typed rows based on the target index mapping. Unlike `raw_query`, the result
+is a regular table that composes naturally with SQL joins, aggregations,
+`WHERE` clauses, and `LIMIT`. The connector pushes these filters and the
+full-text query into a single OpenSearch request, and uses scroll internally,
+so results are not bound by `index.max_result_window`.
+
+The `search` function requires three parameters:
+
+- `schema`: The schema in the catalog that the query is to be executed on.
+- `index`: The index or alias in OpenSearch to search.
+- `query`: A JSON object containing the contents of the `"query"` field of an
+  OpenSearch `_search` body (for example `{"match": {"field": "value"}}`).
+  Must not contain top-level `_search` body keys such as `size`, `from`,
+  `sort`, `aggs`, `highlight`, or `_source` — use `raw_query` if those are
+  needed.
+
+For example, use `search` to fetch rows from the `orders` index where the
+comment matches a term, ordered by relevance:
+
+```sql
+SELECT orderkey, comment, "_score"
+FROM TABLE(
+    example.system.search(
+        schema => 'sales',
+        index => 'orders',
+        query => '{"match": {"comment": "urgent"}}'
+    )
+);
+```
+
+Combine with an SQL predicate — the filter is pushed down together with the
+full-text query into the same OpenSearch request:
+
+```sql
+SELECT orderkey, comment
+FROM TABLE(
+    example.system.search(
+        schema => 'sales',
+        index => 'orders',
+        query => '{"match": {"comment": "urgent"}}'
+    )
+)
+WHERE orderstatus = 'O';
+```
+
+Use a `bool` query to combine multiple conditions in OpenSearch:
+
+```sql
+SELECT orderkey
+FROM TABLE(
+    example.system.search(
+        schema => 'sales',
+        index => 'orders',
+        query => '{"bool": {"must": [
+                      {"match": {"comment": "urgent"}},
+                      {"range": {"totalprice": {"gte": 100}}}
+                  ]}}'
+    )
+);
+```
+
+Join OpenSearch results with data from another catalog:
+
+```sql
+SELECT t.orderkey, t.comment, c.name
+FROM TABLE(
+    example.system.search(
+        schema => 'sales',
+        index => 'orders',
+        query => '{"match": {"comment": "urgent"}}'
+    )
+) t
+JOIN postgres.public.customers c ON t.custkey = c.custkey;
+```
+
+Results are ordered by relevance (`_score`) by default. Use an `ORDER BY` in
+SQL to override the ordering — Trino sorts after the rows are retrieved:
+
+```sql
+SELECT orderkey
+FROM TABLE(
+    example.system.search(
+        schema => 'sales',
+        index => 'orders',
+        query => '{"match": {"comment": "urgent"}}'
+    )
+)
+ORDER BY orderdate DESC;
+```
+
+The builtin columns `_id`, `_score`, and `_source` are available on the
+result alongside the mapped fields.
+
+`search` and `raw_query` cover different use cases:
+
+| | `search` | `raw_query` |
+|---|---|---|
+| Returns | Typed rows | Single `VARCHAR` row with the full JSON response |
+| Pagination | Scroll (no `max_result_window` cap) | Single `_search` (bounded by `index.max_result_window`) |
+| Combines with `WHERE` / `JOIN` | Yes, with pushdown | No (single blob column) |
+| Aggregations / highlighting | Use SQL `GROUP BY`, etc. | Yes (native `aggs` / `highlight`) |
+| Input | Query clause object | Full `_search` body |
+
 ## Performance
 
 The connector includes a number of performance improvements, detailed in the

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchConnectorModule.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchConnectorModule.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.opensearch.client.OpenSearchClient;
 import io.trino.plugin.opensearch.ptf.RawQuery;
+import io.trino.plugin.opensearch.ptf.Search;
 import io.trino.spi.function.table.ConnectorTableFunction;
 
 import java.util.Optional;
@@ -50,6 +51,7 @@ public class OpenSearchConnectorModule
 
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(OpenSearchSessionProperties.class).in(Scopes.SINGLETON);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(RawQuery.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Search.class).in(Scopes.SINGLETON);
 
         Optional<OpenSearchConfig.Security> security = buildConfigObject(OpenSearchConfig.class).getSecurity();
         if (security.isPresent()) {

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -41,6 +41,7 @@ import io.trino.plugin.opensearch.decoders.TinyintDecoder;
 import io.trino.plugin.opensearch.decoders.VarbinaryDecoder;
 import io.trino.plugin.opensearch.decoders.VarcharDecoder;
 import io.trino.plugin.opensearch.ptf.RawQuery.RawQueryFunctionHandle;
+import io.trino.plugin.opensearch.ptf.Search.SearchFunctionHandle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
@@ -775,13 +776,17 @@ public class OpenSearchMetadata
     @Override
     public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
     {
-        if (!(handle instanceof RawQueryFunctionHandle rawQueryFunctionHandle)) {
-            return Optional.empty();
+        if (handle instanceof RawQueryFunctionHandle rawQueryFunctionHandle) {
+            ConnectorTableHandle tableHandle = rawQueryFunctionHandle.getTableHandle();
+            List<ColumnHandle> columnHandles = ImmutableList.copyOf(getColumnHandles(session, tableHandle).values());
+            return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
         }
-
-        ConnectorTableHandle tableHandle = rawQueryFunctionHandle.getTableHandle();
-        List<ColumnHandle> columnHandles = ImmutableList.copyOf(getColumnHandles(session, tableHandle).values());
-        return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
+        if (handle instanceof SearchFunctionHandle searchFunctionHandle) {
+            ConnectorTableHandle tableHandle = searchFunctionHandle.getTableHandle();
+            List<ColumnHandle> columnHandles = ImmutableList.copyOf(getColumnHandles(session, tableHandle).values());
+            return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
+        }
+        return Optional.empty();
     }
 
     private static boolean supportsPredicates(IndexMetadata.Type type, Type trinoType)

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -41,6 +41,7 @@ import io.trino.plugin.opensearch.decoders.TinyintDecoder;
 import io.trino.plugin.opensearch.decoders.VarbinaryDecoder;
 import io.trino.plugin.opensearch.decoders.VarcharDecoder;
 import io.trino.plugin.opensearch.ptf.RawQuery.RawQueryFunctionHandle;
+import io.trino.plugin.opensearch.ptf.Search.SearchFunctionHandle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
@@ -773,13 +774,17 @@ public class OpenSearchMetadata
     @Override
     public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
     {
-        if (!(handle instanceof RawQueryFunctionHandle rawQueryFunctionHandle)) {
-            return Optional.empty();
+        if (handle instanceof RawQueryFunctionHandle rawQueryFunctionHandle) {
+            ConnectorTableHandle tableHandle = rawQueryFunctionHandle.getTableHandle();
+            List<ColumnHandle> columnHandles = ImmutableList.copyOf(getColumnHandles(session, tableHandle).values());
+            return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
         }
-
-        ConnectorTableHandle tableHandle = rawQueryFunctionHandle.getTableHandle();
-        List<ColumnHandle> columnHandles = ImmutableList.copyOf(getColumnHandles(session, tableHandle).values());
-        return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
+        if (handle instanceof SearchFunctionHandle searchFunctionHandle) {
+            ConnectorTableHandle tableHandle = searchFunctionHandle.getTableHandle();
+            List<ColumnHandle> columnHandles = ImmutableList.copyOf(getColumnHandles(session, tableHandle).values());
+            return Optional.of(new TableFunctionApplicationResult<>(tableHandle, columnHandles));
+        }
+        return Optional.empty();
     }
 
     private static boolean supportsPredicates(IndexMetadata.Type type, Type trinoType)

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchQueryBuilder.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchQueryBuilder.java
@@ -23,10 +23,10 @@ import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.QueryStringQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.RegexpQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WrapperQueryBuilder;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -73,7 +73,7 @@ public final class OpenSearchQueryBuilder
 
         regexes.forEach((name, value) -> queryBuilder.filter(new BoolQueryBuilder().must(new RegexpQueryBuilder(name, value))));
 
-        query.map(QueryStringQueryBuilder::new)
+        query.map(WrapperQueryBuilder::new)
                 .ifPresent(queryBuilder::must);
 
         if (queryBuilder.hasClauses()) {

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/ptf/Search.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/ptf/Search.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.opensearch.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.slice.Slice;
+import io.trino.plugin.opensearch.OpenSearchColumnHandle;
+import io.trino.plugin.opensearch.OpenSearchMetadata;
+import io.trino.plugin.opensearch.OpenSearchTableHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class Search
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "search";
+
+    // ObjectMapper is thread-safe for reads once configured; we never mutate it after construction.
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static final Set<String> RESERVED_SEARCH_BODY_KEYS = ImmutableSet.of(
+            "size",
+            "from",
+            "sort",
+            "aggs",
+            "aggregations",
+            "highlight",
+            "_source",
+            "track_total_hits",
+            "search_after",
+            "timeout",
+            "terminate_after");
+
+    private final OpenSearchMetadata metadata;
+
+    @Inject
+    public Search(OpenSearchMetadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new SearchFunction(metadata);
+    }
+
+    public static class SearchFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final OpenSearchMetadata metadata;
+
+        public SearchFunction(OpenSearchMetadata metadata)
+        {
+            super(SCHEMA_NAME,
+                    NAME,
+                    List.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name("SCHEMA")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("INDEX")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("QUERY")
+                                    .type(VARCHAR)
+                                    .build()),
+                    GENERIC_TABLE,
+                    "Returns rows from an OpenSearch index matching a query DSL clause");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(
+                ConnectorSession session,
+                ConnectorTransactionHandle transaction,
+                Map<String, Argument> arguments,
+                ConnectorAccessControl accessControl)
+        {
+            String schema = readArgument(arguments, "SCHEMA");
+            String index = readArgument(arguments, "INDEX");
+            String query = readArgument(arguments, "QUERY");
+
+            validateQueryJson(query);
+
+            OpenSearchTableHandle tableHandle = new OpenSearchTableHandle(
+                    OpenSearchTableHandle.Type.SCAN,
+                    schema,
+                    index,
+                    Optional.of(query));
+
+            ConnectorTableSchema tableSchema = metadata.getTableSchema(session, tableHandle);
+            Map<String, ColumnHandle> columnsByName = metadata.getColumnHandles(session, tableHandle);
+            List<ColumnHandle> columns = tableSchema.getColumns().stream()
+                    .map(ColumnSchema::getName)
+                    .map(columnsByName::get)
+                    .collect(toImmutableList());
+
+            if (columns.isEmpty()) {
+                throw new TrinoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        format("Index '%s' has no mapped fields", index));
+            }
+
+            Descriptor returnedType = new Descriptor(columns.stream()
+                    .map(OpenSearchColumnHandle.class::cast)
+                    .map(column -> new Descriptor.Field(column.name(), Optional.of(column.type())))
+                    .collect(toImmutableList()));
+
+            SearchFunctionHandle handle = new SearchFunctionHandle(tableHandle);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+
+        private static String readArgument(Map<String, Argument> arguments, String name)
+        {
+            Argument argument = arguments.get(name);
+            if (argument == null) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Argument '%s' is required", name));
+            }
+            Object value = ((ScalarArgument) argument).getValue();
+            if (value == null) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Argument '%s' must not be null", name));
+            }
+            String text = ((Slice) value).toStringUtf8();
+            if (text.isEmpty()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Argument '%s' must not be empty", name));
+            }
+            return text;
+        }
+
+        private static void validateQueryJson(String query)
+        {
+            JsonNode node;
+            try {
+                node = JSON.readTree(query);
+            }
+            catch (JsonProcessingException e) {
+                throw new TrinoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        format("'query' must be a valid JSON object: %s", e.getOriginalMessage()));
+            }
+            if (node == null || !node.isObject()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'query' must be a JSON object");
+            }
+            if (node.isEmpty()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'query' must not be empty");
+            }
+            node.fieldNames().forEachRemaining(field -> {
+                if (RESERVED_SEARCH_BODY_KEYS.contains(field)) {
+                    throw new TrinoException(
+                            INVALID_FUNCTION_ARGUMENT,
+                            format(
+                                    "'query' must be a query object, not a full _search body; unexpected key '%s' (use raw_query for full _search bodies)",
+                                    field));
+                }
+            });
+        }
+    }
+
+    public static class SearchFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final OpenSearchTableHandle tableHandle;
+
+        @JsonCreator
+        public SearchFunctionHandle(@JsonProperty("tableHandle") OpenSearchTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/ptf/Search.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/ptf/Search.java
@@ -26,12 +26,9 @@ import io.trino.plugin.opensearch.OpenSearchColumnHandle;
 import io.trino.plugin.opensearch.OpenSearchMetadata;
 import io.trino.plugin.opensearch.OpenSearchTableHandle;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
-import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.function.table.AbstractConnectorTableFunction;
 import io.trino.spi.function.table.Argument;
@@ -136,11 +133,10 @@ public class Search
                     index,
                     Optional.of(query));
 
-            ConnectorTableSchema tableSchema = metadata.getTableSchema(session, tableHandle);
-            Map<String, ColumnHandle> columnsByName = metadata.getColumnHandles(session, tableHandle);
-            List<ColumnHandle> columns = tableSchema.getColumns().stream()
-                    .map(ColumnSchema::getName)
-                    .map(columnsByName::get)
+            // ColumnMetadata lowercases names, while the handle map preserves the OpenSearch mapping case,
+            // so resolving ColumnSchema names against the map would miss any mixed-case field (e.g. `createdAt`).
+            List<OpenSearchColumnHandle> columns = metadata.getColumnHandles(session, tableHandle).values().stream()
+                    .map(OpenSearchColumnHandle.class::cast)
                     .collect(toImmutableList());
 
             if (columns.isEmpty()) {
@@ -150,7 +146,6 @@ public class Search
             }
 
             Descriptor returnedType = new Descriptor(columns.stream()
-                    .map(OpenSearchColumnHandle.class::cast)
                     .map(column -> new Descriptor.Field(column.name(), Optional.of(column.type())))
                     .collect(toImmutableList()));
 

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/ptf/Search.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/ptf/Search.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.opensearch.ptf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.slice.Slice;
+import io.trino.plugin.opensearch.OpenSearchColumnHandle;
+import io.trino.plugin.opensearch.OpenSearchMetadata;
+import io.trino.plugin.opensearch.OpenSearchTableHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class Search
+        implements Provider<ConnectorTableFunction>
+{
+    public static final String SCHEMA_NAME = "system";
+    public static final String NAME = "search";
+
+    // ObjectMapper is thread-safe for reads once configured; we never mutate it after construction.
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static final Set<String> RESERVED_SEARCH_BODY_KEYS = ImmutableSet.of(
+            "size",
+            "from",
+            "sort",
+            "aggs",
+            "aggregations",
+            "highlight",
+            "_source",
+            "track_total_hits",
+            "search_after",
+            "timeout",
+            "terminate_after");
+
+    private final OpenSearchMetadata metadata;
+
+    @Inject
+    public Search(OpenSearchMetadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get()
+    {
+        return new SearchFunction(metadata);
+    }
+
+    public static class SearchFunction
+            extends AbstractConnectorTableFunction
+    {
+        private final OpenSearchMetadata metadata;
+
+        public SearchFunction(OpenSearchMetadata metadata)
+        {
+            super(
+                    SCHEMA_NAME,
+                    NAME,
+                    List.of(
+                            ScalarArgumentSpecification.builder()
+                                    .name("SCHEMA")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("INDEX")
+                                    .type(VARCHAR)
+                                    .build(),
+                            ScalarArgumentSpecification.builder()
+                                    .name("QUERY")
+                                    .type(VARCHAR)
+                                    .build()),
+                    GENERIC_TABLE);
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public TableFunctionAnalysis analyze(
+                ConnectorSession session,
+                ConnectorTransactionHandle transaction,
+                Map<String, Argument> arguments,
+                ConnectorAccessControl accessControl)
+        {
+            String schema = readArgument(arguments, "SCHEMA");
+            String index = readArgument(arguments, "INDEX");
+            String query = readArgument(arguments, "QUERY");
+
+            validateQueryJson(query);
+
+            OpenSearchTableHandle tableHandle = new OpenSearchTableHandle(
+                    OpenSearchTableHandle.Type.SCAN,
+                    schema,
+                    index,
+                    Optional.of(query));
+
+            ConnectorTableSchema tableSchema = metadata.getTableSchema(session, tableHandle);
+            Map<String, ColumnHandle> columnsByName = metadata.getColumnHandles(session, tableHandle);
+            List<ColumnHandle> columns = tableSchema.getColumns().stream()
+                    .map(ColumnSchema::getName)
+                    .map(columnsByName::get)
+                    .collect(toImmutableList());
+
+            if (columns.isEmpty()) {
+                throw new TrinoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        format("Index '%s' has no mapped fields", index));
+            }
+
+            Descriptor returnedType = new Descriptor(columns.stream()
+                    .map(OpenSearchColumnHandle.class::cast)
+                    .map(column -> new Descriptor.Field(column.name(), Optional.of(column.type())))
+                    .collect(toImmutableList()));
+
+            SearchFunctionHandle handle = new SearchFunctionHandle(tableHandle);
+
+            return TableFunctionAnalysis.builder()
+                    .returnedType(returnedType)
+                    .handle(handle)
+                    .build();
+        }
+
+        private static String readArgument(Map<String, Argument> arguments, String name)
+        {
+            Argument argument = arguments.get(name);
+            if (argument == null) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Argument '%s' is required", name));
+            }
+            Object value = ((ScalarArgument) argument).getValue();
+            if (value == null) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Argument '%s' must not be null", name));
+            }
+            String text = ((Slice) value).toStringUtf8();
+            if (text.isEmpty()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Argument '%s' must not be empty", name));
+            }
+            return text;
+        }
+
+        private static void validateQueryJson(String query)
+        {
+            JsonNode node;
+            try {
+                node = JSON.readTree(query);
+            }
+            catch (JsonProcessingException e) {
+                throw new TrinoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        format("'query' must be a valid JSON object: %s", e.getOriginalMessage()));
+            }
+            if (node == null || !node.isObject()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'query' must be a JSON object");
+            }
+            if (node.isEmpty()) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'query' must not be empty");
+            }
+            node.fieldNames().forEachRemaining(field -> {
+                if (RESERVED_SEARCH_BODY_KEYS.contains(field)) {
+                    throw new TrinoException(
+                            INVALID_FUNCTION_ARGUMENT,
+                            format(
+                                    "'query' must be a query object, not a full _search body; unexpected key '%s' (use raw_query for full _search bodies)",
+                                    field));
+                }
+            });
+        }
+    }
+
+    public static class SearchFunctionHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final OpenSearchTableHandle tableHandle;
+
+        @JsonCreator
+        public SearchFunctionHandle(@JsonProperty("tableHandle") OpenSearchTableHandle tableHandle)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        }
+
+        @JsonProperty
+        public ConnectorTableHandle getTableHandle()
+        {
+            return tableHandle;
+        }
+    }
+}

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2012,6 +2012,66 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchMatchQuery()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey, name FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match\": {\"name\": \"ALGERIA\"}}'))",
+                catalogName)))
+                .matches("VALUES (BIGINT '0', VARCHAR 'ALGERIA')");
+    }
+
+    @Test
+    public void testSearchCombinedWithPredicate()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match_all\": {}}')) " +
+                        "WHERE name = 'ALGERIA'",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchWithLimit()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT count(*) FROM (" +
+                        "  SELECT * FROM TABLE(%s.system.search(" +
+                        "    schema => 'tpch', " +
+                        "    index => 'nation', " +
+                        "    query => '{\"match_all\": {}}')) " +
+                        "  LIMIT 3" +
+                        ")",
+                catalogName)))
+                .matches("VALUES BIGINT '3'");
+    }
+
+    @Test
+    public void testSearchCount()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT count(*) FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"range\": {\"nationkey\": {\"gte\": 0, \"lte\": 3}}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '4'");
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2154,6 +2154,75 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchInvalidJson()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nation', query => 'not json'))",
+                catalogName)))
+                .failure().hasMessageContaining("'query' must be a valid JSON object");
+    }
+
+    @Test
+    public void testSearchQueryNotObject()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nation', query => '[1, 2, 3]'))",
+                catalogName)))
+                .failure().hasMessageContaining("'query' must be a JSON object");
+    }
+
+    @Test
+    public void testSearchEmptyQuery()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nation', query => '{}'))",
+                catalogName)))
+                .failure().hasMessageContaining("'query' must not be empty");
+    }
+
+    @Test
+    public void testSearchInvalidIndex()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        // If this substring check proves unstable across OpenSearch versions, drop the specific
+        // substring and just assert the query fails.
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nonexistent_index_xyz', query => '{\"match_all\":{}}'))",
+                catalogName)))
+                .failure().hasMessageContaining("nonexistent_index_xyz");
+    }
+
+    @Test
+    public void testSearchRejectsTopLevelSearchBodyKeys()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        for (String key : List.of("size", "from", "sort", "aggs", "aggregations", "highlight", "_source", "track_total_hits")) {
+            String json = format("{\"%s\": {}}", key);
+            assertThat(query(format(
+                    "SELECT * FROM TABLE(%s.system.search(" +
+                            "schema => 'tpch', index => 'nation', query => '%s'))",
+                    catalogName,
+                    json)))
+                    .as("reserved key: %s", key)
+                    .failure()
+                    .hasMessageContaining("use raw_query for full _search bodies")
+                    .hasMessageContaining(key);
+        }
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2243,6 +2243,45 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchWithCaseSensitiveField()
+            throws IOException
+    {
+        // Regression test: the search PTF must handle indexes whose fields use mixed-case names.
+        // ConnectorTableMetadata lowercases column names, while OpenSearch preserves the mapping
+        // case, so any lookup that joins the schema names against the column-handle map by the
+        // lowercased name fails and the query aborts with GENERIC_INTERNAL_ERROR.
+        String indexName = "search_case_sensitive_" + randomNameSuffix();
+        @Language("JSON")
+        String properties =
+                """
+                {
+                    "properties": {
+                        "id": {"type": "long"},
+                        "createdAt": {"type": "keyword"},
+                        "labelText": {"type": "keyword"}
+                    }
+                }
+                """;
+        createIndex(indexName, properties);
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("id", 1L)
+                .put("createdAt", "2026-04-23")
+                .put("labelText", "alpha")
+                .buildOrThrow());
+
+        String catalogName = getSession().getCatalog().orElseThrow();
+        assertThat(query(format(
+                "SELECT id, createdat, labeltext FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => '%s', " +
+                        "query => '{\"match_all\": {}}'))",
+                catalogName, indexName)))
+                .matches("VALUES (BIGINT '1', VARCHAR '2026-04-23', VARCHAR 'alpha')");
+
+        deleteIndex(indexName);
+    }
+
+    @Test
     public void testRawQueryStillWorks()
     {
         String catalogName = getSession().getCatalog().orElseThrow();

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2205,6 +2205,58 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchReturnsMoreThanMaxResultWindow()
+            throws IOException
+    {
+        String indexName = "search_scroll_test_" + randomNameSuffix();
+        @Language("JSON")
+        String body = "" +
+                "{" +
+                "  \"settings\": {\"index\": {\"max_result_window\": 100}}," +
+                "  \"mappings\": {" +
+                "    \"properties\": {" +
+                "      \"id\": {\"type\": \"long\"}," +
+                "      \"body\": {\"type\": \"text\"}" +
+                "    }" +
+                "  }" +
+                "}";
+        Request createIndexRequest = new Request("PUT", "/" + indexName);
+        createIndexRequest.setJsonEntity(body);
+        client.getLowLevelClient().performRequest(createIndexRequest);
+
+        for (int i = 0; i < 250; i++) {
+            index(indexName, ImmutableMap.<String, Object>builder()
+                    .put("id", i)
+                    .put("body", "common")
+                    .buildOrThrow());
+        }
+        client.getLowLevelClient().performRequest(new Request("POST", "/" + indexName + "/_refresh"));
+
+        String catalogName = getSession().getCatalog().orElseThrow();
+        assertThat(query(format(
+                "SELECT count(*) FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => '%s', " +
+                        "query => '{\"match\": {\"body\": \"common\"}}'))",
+                catalogName, indexName)))
+                .matches("VALUES BIGINT '250'");
+    }
+
+    @Test
+    public void testRawQueryStillWorks()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        MaterializedResult result = computeActual(format(
+                "SELECT result FROM TABLE(%s.system.raw_query(" +
+                        "schema => 'tpch', index => 'nation', " +
+                        "query => '{\"query\": {\"match\": {\"name\": \"ALGERIA\"}}}'))",
+                catalogName));
+        assertThat(result.getRowCount()).isEqualTo(1);
+        assertThat(result.getTypes().getFirst()).isInstanceOf(VarcharType.class);
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2029,6 +2029,66 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchMatchQuery()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey, name FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match\": {\"name\": \"ALGERIA\"}}'))",
+                catalogName)))
+                .matches("VALUES (BIGINT '0', VARCHAR 'ALGERIA')");
+    }
+
+    @Test
+    public void testSearchCombinedWithPredicate()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match_all\": {}}')) " +
+                        "WHERE name = 'ALGERIA'",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchWithLimit()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT count(*) FROM (" +
+                        "  SELECT * FROM TABLE(%s.system.search(" +
+                        "    schema => 'tpch', " +
+                        "    index => 'nation', " +
+                        "    query => '{\"match_all\": {}}')) " +
+                        "  LIMIT 3" +
+                        ")",
+                catalogName)))
+                .matches("VALUES BIGINT '3'");
+    }
+
+    @Test
+    public void testSearchCount()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT count(*) FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"range\": {\"nationkey\": {\"gte\": 0, \"lte\": 3}}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '4'");
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2137,6 +2137,74 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchInvalidJson()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nation', query => 'not json'))",
+                catalogName)))
+                .failure().hasMessageContaining("'query' must be a valid JSON object");
+    }
+
+    @Test
+    public void testSearchQueryNotObject()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nation', query => '[1, 2, 3]'))",
+                catalogName)))
+                .failure().hasMessageContaining("'query' must be a JSON object");
+    }
+
+    @Test
+    public void testSearchEmptyQuery()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nation', query => '{}'))",
+                catalogName)))
+                .failure().hasMessageContaining("'query' must not be empty");
+    }
+
+    @Test
+    public void testSearchInvalidIndex()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        // If this substring check proves unstable across OpenSearch versions, drop the specific
+        // substring and just assert the query fails.
+        assertThat(query(format(
+                "SELECT * FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', index => 'nonexistent_index_xyz', query => '{\"match_all\":{}}'))",
+                catalogName)))
+                .failure().hasMessageContaining("nonexistent_index_xyz");
+    }
+
+    @Test
+    public void testSearchRejectsTopLevelSearchBodyKeys()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        for (String key : List.of("size", "from", "sort", "aggs", "aggregations", "highlight", "_source", "track_total_hits")) {
+            String json = format("{\"%s\": {}}", key);
+            assertThat(query(format(
+                    "SELECT * FROM TABLE(%s.system.search(" +
+                            "schema => 'tpch', index => 'nation', query => '%s'))",
+                    catalogName, json)))
+                    .as("reserved key: %s", key)
+                    .failure()
+                    .hasMessageContaining("use raw_query for full _search bodies")
+                    .hasMessageContaining(key);
+        }
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2072,6 +2072,71 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchBoolQuery()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"bool\": {\"must\": [" +
+                        "{\"match\": {\"name\": \"ALGERIA\"}}, " +
+                        "{\"range\": {\"regionkey\": {\"gte\": 0}}}" +
+                        "]}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchMatchPhrase()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match_phrase\": {\"name\": \"ALGERIA\"}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchQueryString()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"query_string\": {\"query\": \"name:ALGERIA\"}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchEmitsDefaultRelevanceSort()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        // With a scored query (match), `_score` on the result row must be non-null and positive.
+        // That only happens when OpenSearch does NOT use sort=_doc (which would set _score=null).
+        // BuiltinColumns.SCORE is typed as REAL → surfaces in materialized rows as Float.
+        MaterializedResult result = computeActual(format(
+                "SELECT nationkey, \"_score\" FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match\": {\"name\": \"ALGERIA\"}}'))",
+                catalogName));
+        assertThat(result.getRowCount()).isEqualTo(1);
+        Float score = (Float) result.getMaterializedRows().get(0).getField(1);
+        assertThat(score).isNotNull();
+        assertThat(score).isGreaterThan(0.0f);
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2223,6 +2223,59 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchReturnsMoreThanMaxResultWindow()
+            throws IOException
+    {
+        String indexName = "search_scroll_test_" + randomNameSuffix();
+        @Language("JSON")
+        String body = "" +
+                "{" +
+                "  \"settings\": {\"index\": {\"max_result_window\": 100}}," +
+                "  \"mappings\": {" +
+                "    \"properties\": {" +
+                "      \"id\": {\"type\": \"long\"}," +
+                "      \"body\": {\"type\": \"text\"}" +
+                "    }" +
+                "  }" +
+                "}";
+        Request createIndexRequest = new Request("PUT", "/" + indexName);
+        createIndexRequest.setJsonEntity(body);
+        client.getLowLevelClient().performRequest(createIndexRequest);
+
+        for (int i = 0; i < 250; i++) {
+            index(indexName, ImmutableMap.<String, Object>builder()
+                    .put("id", i)
+                    .put("body", "common")
+                    .buildOrThrow());
+        }
+        client.getLowLevelClient().performRequest(new Request("POST", "/" + indexName + "/_refresh"));
+
+        String catalogName = getSession().getCatalog().orElseThrow();
+        assertThat(query(format(
+                "SELECT count(*) FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => '%s', " +
+                        "query => '{\"match\": {\"body\": \"common\"}}'))",
+                catalogName,
+                indexName)))
+                .matches("VALUES BIGINT '250'");
+    }
+
+    @Test
+    public void testRawQueryStillWorks()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        MaterializedResult result = computeActual(format(
+                "SELECT result FROM TABLE(%s.system.raw_query(" +
+                        "schema => 'tpch', index => 'nation', " +
+                        "query => '{\"query\": {\"match\": {\"name\": \"ALGERIA\"}}}'))",
+                catalogName));
+        assertThat(result.getRowCount()).isEqualTo(1);
+        assertThat(result.getTypes().getFirst()).isInstanceOf(VarcharType.class);
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2089,6 +2089,71 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchBoolQuery()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"bool\": {\"must\": [" +
+                        "{\"match\": {\"name\": \"ALGERIA\"}}, " +
+                        "{\"range\": {\"regionkey\": {\"gte\": 0}}}" +
+                        "]}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchMatchPhrase()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match_phrase\": {\"name\": \"ALGERIA\"}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchQueryString()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        assertThat(query(format(
+                "SELECT nationkey FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"query_string\": {\"query\": \"name:ALGERIA\"}}'))",
+                catalogName)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testSearchEmitsDefaultRelevanceSort()
+    {
+        String catalogName = getSession().getCatalog().orElseThrow();
+
+        // With a scored query (match), `_score` on the result row must be non-null and positive.
+        // That only happens when OpenSearch does NOT use sort=_doc (which would set _score=null).
+        // BuiltinColumns.SCORE is typed as REAL → surfaces in materialized rows as Float.
+        MaterializedResult result = computeActual(format(
+                "SELECT nationkey, \"_score\" FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => 'nation', " +
+                        "query => '{\"match\": {\"name\": \"ALGERIA\"}}'))",
+                catalogName));
+        assertThat(result.getRowCount()).isEqualTo(1);
+        Float score = (Float) result.getMaterializedRows().get(0).getField(1);
+        assertThat(score).isNotNull();
+        assertThat(score).isGreaterThan(0.0f);
+    }
+
+    @Test
     public void testSimpleProjectionPushdown()
             throws IOException
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/BaseOpenSearchConnectorTest.java
@@ -2262,6 +2262,46 @@ public abstract class BaseOpenSearchConnectorTest
     }
 
     @Test
+    public void testSearchWithCaseSensitiveField()
+            throws IOException
+    {
+        // Regression test: the search PTF must handle indexes whose fields use mixed-case names.
+        // ConnectorTableMetadata lowercases column names, while OpenSearch preserves the mapping
+        // case, so any lookup that joins the schema names against the column-handle map by the
+        // lowercased name fails and the query aborts with GENERIC_INTERNAL_ERROR.
+        String indexName = "search_case_sensitive_" + randomNameSuffix();
+        @Language("JSON")
+        String properties =
+                """
+                {
+                    "properties": {
+                        "id": {"type": "long"},
+                        "createdAt": {"type": "keyword"},
+                        "labelText": {"type": "keyword"}
+                    }
+                }
+                """;
+        createIndex(indexName, properties);
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("id", 1L)
+                .put("createdAt", "2026-04-23")
+                .put("labelText", "alpha")
+                .buildOrThrow());
+
+        String catalogName = getSession().getCatalog().orElseThrow();
+        assertThat(query(format(
+                "SELECT id, createdat, labeltext FROM TABLE(%s.system.search(" +
+                        "schema => 'tpch', " +
+                        "index => '%s', " +
+                        "query => '{\"match_all\": {}}'))",
+                catalogName,
+                indexName)))
+                .matches("VALUES (BIGINT '1', VARCHAR '2026-04-23', VARCHAR 'alpha')");
+
+        deleteIndex(indexName);
+    }
+
+    @Test
     public void testRawQueryStillWorks()
     {
         String catalogName = getSession().getCatalog().orElseThrow();

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchQueryBuilder.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchQueryBuilder.java
@@ -30,6 +30,7 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WrapperQueryBuilder;
 
 import java.util.Map;
 import java.util.Optional;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOpenSearchQueryBuilder
@@ -134,5 +136,38 @@ public class TestOpenSearchQueryBuilder
     {
         QueryBuilder actual = OpenSearchQueryBuilder.buildSearchQuery(TupleDomain.withColumnDomains(domains), Optional.empty(), Map.of());
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testQueryOnlyUsesWrapper()
+    {
+        String json = "{\"match\":{\"name\":\"ALGERIA\"}}";
+        QueryBuilder built = OpenSearchQueryBuilder.buildSearchQuery(TupleDomain.all(), Optional.of(json), ImmutableMap.of());
+
+        assertThat(built).isInstanceOf(BoolQueryBuilder.class);
+        BoolQueryBuilder bool = (BoolQueryBuilder) built;
+        assertThat(bool.must()).hasSize(1);
+        assertThat(bool.must().get(0)).isInstanceOf(WrapperQueryBuilder.class);
+        WrapperQueryBuilder wrapper = (WrapperQueryBuilder) bool.must().get(0);
+        assertThat(new String(wrapper.source(), UTF_8)).isEqualTo(json);
+        assertThat(bool.filter()).isEmpty();
+    }
+
+    @Test
+    public void testQueryCombinesWithConstraintAndRegexes()
+    {
+        String json = "{\"match\":{\"name\":\"foo\"}}";
+        TupleDomain<OpenSearchColumnHandle> constraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(AGE, Domain.singleValue(INTEGER, 5L)));
+        Map<String, String> regexes = ImmutableMap.of("name", "fo.*");
+
+        QueryBuilder built = OpenSearchQueryBuilder.buildSearchQuery(constraint, Optional.of(json), regexes);
+
+        assertThat(built).isInstanceOf(BoolQueryBuilder.class);
+        BoolQueryBuilder bool = (BoolQueryBuilder) built;
+        assertThat(bool.must()).hasSize(1);
+        assertThat(bool.must().get(0)).isInstanceOf(WrapperQueryBuilder.class);
+        // filter contains term (age=5) and a bool wrapping regexp (name ~= fo.*)
+        assertThat(bool.filter()).hasSize(2);
     }
 }

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchQueryBuilder.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchQueryBuilder.java
@@ -30,6 +30,7 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WrapperQueryBuilder;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,6 +39,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOpenSearchQueryBuilder
@@ -135,5 +137,38 @@ public class TestOpenSearchQueryBuilder
     {
         QueryBuilder actual = OpenSearchQueryBuilder.buildSearchQuery(TupleDomain.withColumnDomains(domains), Optional.empty(), Map.of());
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testQueryOnlyUsesWrapper()
+    {
+        String json = "{\"match\":{\"name\":\"ALGERIA\"}}";
+        QueryBuilder built = OpenSearchQueryBuilder.buildSearchQuery(TupleDomain.all(), Optional.of(json), ImmutableMap.of());
+
+        assertThat(built).isInstanceOf(BoolQueryBuilder.class);
+        BoolQueryBuilder bool = (BoolQueryBuilder) built;
+        assertThat(bool.must()).hasSize(1);
+        assertThat(bool.must().get(0)).isInstanceOf(WrapperQueryBuilder.class);
+        WrapperQueryBuilder wrapper = (WrapperQueryBuilder) bool.must().get(0);
+        assertThat(new String(wrapper.source(), UTF_8)).isEqualTo(json);
+        assertThat(bool.filter()).isEmpty();
+    }
+
+    @Test
+    public void testQueryCombinesWithConstraintAndRegexes()
+    {
+        String json = "{\"match\":{\"name\":\"foo\"}}";
+        TupleDomain<OpenSearchColumnHandle> constraint = TupleDomain.withColumnDomains(
+                ImmutableMap.of(AGE, Domain.singleValue(INTEGER, 5L)));
+        Map<String, String> regexes = ImmutableMap.of("name", "fo.*");
+
+        QueryBuilder built = OpenSearchQueryBuilder.buildSearchQuery(constraint, Optional.of(json), regexes);
+
+        assertThat(built).isInstanceOf(BoolQueryBuilder.class);
+        BoolQueryBuilder bool = (BoolQueryBuilder) built;
+        assertThat(bool.must()).hasSize(1);
+        assertThat(bool.must().get(0)).isInstanceOf(WrapperQueryBuilder.class);
+        // filter contains term (age=5) and a bool wrapping regexp (name ~= fo.*)
+        assertThat(bool.filter()).hasSize(2);
     }
 }


### PR DESCRIPTION
## Description

Add a new `opensearch.system.search(schema, index, query)` table function that runs any [OpenSearch Query DSL](https://opensearch.org/docs/latest/query-dsl/) query and returns typed rows based on the target index mapping. Unlike the existing `raw_query`, `search` composes naturally with SQL joins, aggregations, `WHERE` clauses, and `LIMIT`: the full text query and any pushdown-capable SQL predicates are combined into a single `bool` query sent to OpenSearch, and results stream back via scroll, so they are not bound by `index.max_result_window`.

```sql
SELECT t.orderkey, t.comment, c.name
FROM TABLE(
    example.system.search(
        schema => 'sales',
        index => 'orders',
        query => '{"match": {"comment": "urgent"}}'
    )
) t
JOIN postgres.public.customers c ON t.custkey = c.custkey
WHERE t.orderstatus = 'O';
```

The `query` argument is the contents of the `"query"` field of a `_search` body. Top-level keys that only make sense in a full `_search` body (`size`, `from`, `sort`, `aggs`, `highlight`, `_source`, ...) are rejected at plan time with a pointer to `raw_query` for those cases.

`raw_query` is left untouched and remains the right tool when the user needs features the SCAN path does not model (custom aggregations, highlighting, full `_search` body).

## Additional context and related issues

- Fixes #29215

Internally the PTF emits an `OpenSearchTableHandle` of `Type.SCAN` carrying the DSL query. `OpenSearchQueryBuilder` wraps the JSON with OpenSearch's built-in `WrapperQueryBuilder` and adds it as a `must` clause of the existing bool query, next to the `filter` clauses derived from `applyFilter` / `applyLimit`. Sort falls back from `_doc` to the server default (`_score`) whenever a query is present — this code path existed already but was unreachable because no `SCAN` handle carried a query. `CountQueryPageSource` already forwards `table.query()` into the builder, so `COUNT(*)` over the PTF counts exactly the matching hits.

Alternative approaches considered during design (see the issue):

- Named convenience PTFs (`match`, `match_phrase`, `query_string`): the   OpenSearch DSL JSON covers all of them and the delta is purely syntactic, so a single `search` PTF has a smaller API surface. Named wrappers can be layered on top later if demand appears.
- Modifying `raw_query` to return typed rows: would be a breaking change for existing users and drops features that don't map onto rows (`aggs`, `highlight`, custom `sort`). Keeping both functions preserves those cases.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## OpenSearch connector
* Add the {ref}`search table function <opensearch-search-function>` which
  returns typed rows from an OpenSearch DSL query, enabling JOINs, predicate
  pushdown, and scroll-based pagination beyond `index.max_result_window`.
  ({issue}`29215`)
```
