### PR TITLE
Improve Parquet file and row group size estimates

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -115,6 +115,11 @@ with Parquet files performed by supported object storage connectors:
     This prevents workers from going into full GC or crashing due to poorly
     configured Parquet writers.
   - `15MB`
+* - `parquet.footer-read-size`
+  - Sets the expected Parquet footer size used for the initial file-tail read.
+    If the actual footer is larger, Trino reads the footer again using the
+    actual size.
+  - `48kB`
 * - `parquet.max-page-read-size`
   - Maximum allowed size of a parquet page during reads. Files with parquet pages
     larger than this will generate an exception on read.

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -16,6 +16,7 @@ package io.trino.parquet;
 import io.airlift.units.DataSize;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
@@ -26,6 +27,7 @@ public class ParquetReaderOptions
     private static final DataSize DEFAULT_MAX_MERGE_DISTANCE = DataSize.of(1, MEGABYTE);
     private static final DataSize DEFAULT_MAX_BUFFER_SIZE = DataSize.of(8, MEGABYTE);
     private static final DataSize DEFAULT_SMALL_FILE_THRESHOLD = DataSize.of(3, MEGABYTE);
+    public static final DataSize DEFAULT_FOOTER_READ_SIZE = DataSize.of(48, KILOBYTE);
     private static final DataSize DEFAULT_MAX_FOOTER_READ_SIZE = DataSize.of(15, MEGABYTE);
     private static final DataSize DEFAULT_MAX_PAGE_READ_SIZE = DataSize.of(500, MEGABYTE);
 
@@ -38,6 +40,7 @@ public class ParquetReaderOptions
     private final boolean useBloomFilter;
     private final DataSize smallFileThreshold;
     private final boolean vectorizedDecodingEnabled;
+    private final DataSize footerReadSize;
     private final DataSize maxFooterReadSize;
     private final DataSize maxPageReadSize;
 
@@ -52,6 +55,7 @@ public class ParquetReaderOptions
         useBloomFilter = true;
         smallFileThreshold = DEFAULT_SMALL_FILE_THRESHOLD;
         vectorizedDecodingEnabled = true;
+        footerReadSize = DEFAULT_FOOTER_READ_SIZE;
         maxFooterReadSize = DEFAULT_MAX_FOOTER_READ_SIZE;
         maxPageReadSize = DEFAULT_MAX_PAGE_READ_SIZE;
     }
@@ -66,6 +70,7 @@ public class ParquetReaderOptions
             boolean useBloomFilter,
             DataSize smallFileThreshold,
             boolean vectorizedDecodingEnabled,
+            DataSize footerReadSize,
             DataSize maxFooterReadSize,
             DataSize maxPageReadSize)
     {
@@ -79,6 +84,8 @@ public class ParquetReaderOptions
         this.useBloomFilter = useBloomFilter;
         this.smallFileThreshold = requireNonNull(smallFileThreshold, "smallFileThreshold is null");
         this.vectorizedDecodingEnabled = vectorizedDecodingEnabled;
+        this.footerReadSize = requireNonNull(footerReadSize, "footerReadSize is null");
+        checkArgument(footerReadSize.toBytes() >= 8, "footerReadSize must be at least 8 bytes");
         this.maxFooterReadSize = requireNonNull(maxFooterReadSize, "maxFooterReadSize is null");
         this.maxPageReadSize = requireNonNull(maxPageReadSize, "maxPageReadSize is null");
     }
@@ -148,6 +155,11 @@ public class ParquetReaderOptions
         return maxFooterReadSize;
     }
 
+    public DataSize getFooterReadSize()
+    {
+        return footerReadSize;
+    }
+
     public DataSize getMaxPageReadSize()
     {
         return maxPageReadSize;
@@ -164,6 +176,7 @@ public class ParquetReaderOptions
         private boolean useBloomFilter;
         private DataSize smallFileThreshold;
         private boolean vectorizedDecodingEnabled;
+        private DataSize footerReadSize;
         private DataSize maxFooterReadSize;
         private DataSize maxPageReadSize;
 
@@ -179,6 +192,7 @@ public class ParquetReaderOptions
             this.useBloomFilter = parquetReaderOptions.useBloomFilter;
             this.smallFileThreshold = parquetReaderOptions.smallFileThreshold;
             this.vectorizedDecodingEnabled = parquetReaderOptions.vectorizedDecodingEnabled;
+            this.footerReadSize = parquetReaderOptions.footerReadSize;
             this.maxFooterReadSize = parquetReaderOptions.maxFooterReadSize;
             this.maxPageReadSize = parquetReaderOptions.maxPageReadSize;
         }
@@ -243,6 +257,12 @@ public class ParquetReaderOptions
             return this;
         }
 
+        public Builder withFooterReadSize(DataSize footerReadSize)
+        {
+            this.footerReadSize = requireNonNull(footerReadSize, "footerReadSize is null");
+            return this;
+        }
+
         public Builder withMaxPageReadSize(DataSize maxPageReadSize)
         {
             this.maxPageReadSize = requireNonNull(maxPageReadSize, "maxPageSize is null");
@@ -261,6 +281,7 @@ public class ParquetReaderOptions
                     useBloomFilter,
                     smallFileThreshold,
                     vectorizedDecodingEnabled,
+                    footerReadSize,
                     maxFooterReadSize,
                     maxPageReadSize);
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.reader;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.Slices;
@@ -20,6 +21,7 @@ import io.airlift.units.DataSize;
 import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetDataSourceId;
+import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.ParquetWriteValidation;
 import io.trino.parquet.crypto.AesCipherUtils;
 import io.trino.parquet.crypto.AesGcmEncryptor;
@@ -41,6 +43,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static io.trino.parquet.ParquetMetadataConverter.fromParquetStatistics;
+import static io.trino.parquet.ParquetReaderOptions.DEFAULT_FOOTER_READ_SIZE;
 import static io.trino.parquet.ParquetValidationUtils.validateParquet;
 import static io.trino.parquet.ParquetValidationUtils.validateParquetCrypto;
 import static io.trino.parquet.crypto.AesCipherUtils.GCM_TAG_LENGTH;
@@ -50,6 +53,7 @@ import static java.lang.Boolean.TRUE;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.System.arraycopy;
+import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.format.Util.readFileCryptoMetaData;
 import static org.apache.parquet.format.Util.readFileMetaData;
 
@@ -58,24 +62,24 @@ public final class MetadataReader
     private static final Slice MAGIC = Slices.utf8Slice("PAR1");
     private static final Slice EMAGIC = Slices.utf8Slice("PARE");
     private static final int POST_SCRIPT_SIZE = Integer.BYTES + MAGIC.length();
-    // Typical 1GB files produced by Trino were found to have footer size between 30-40KB
-    private static final int EXPECTED_FOOTER_SIZE = 48 * 1024;
 
     private MetadataReader() {}
 
+    @VisibleForTesting
     public static ParquetMetadata readFooter(ParquetDataSource dataSource, Optional<FileDecryptionProperties> fileDecryptionProperties)
             throws IOException
     {
-        return readFooter(dataSource, Optional.empty(), Optional.empty(), fileDecryptionProperties);
+        return readFooter(dataSource, DEFAULT_FOOTER_READ_SIZE, Optional.empty(), Optional.empty(), fileDecryptionProperties);
     }
 
-    public static ParquetMetadata readFooter(ParquetDataSource dataSource, DataSize maxFooterReadSize, Optional<FileDecryptionProperties> fileDecryptionProperties)
+    public static ParquetMetadata readFooter(ParquetDataSource dataSource, ParquetReaderOptions options, Optional<ParquetWriteValidation> parquetWriteValidation, Optional<FileDecryptionProperties> fileDecryptionProperties)
             throws IOException
     {
-        return readFooter(dataSource, Optional.of(maxFooterReadSize), Optional.empty(), fileDecryptionProperties);
+        requireNonNull(options, "options is null");
+        return readFooter(dataSource, options.getFooterReadSize(), Optional.of(options.getMaxFooterReadSize()), parquetWriteValidation, fileDecryptionProperties);
     }
 
-    public static ParquetMetadata readFooter(ParquetDataSource dataSource, Optional<DataSize> maxFooterReadSize, Optional<ParquetWriteValidation> parquetWriteValidation, Optional<FileDecryptionProperties> fileDecryptionProperties)
+    public static ParquetMetadata readFooter(ParquetDataSource dataSource, DataSize footerReadSize, Optional<DataSize> maxFooterReadSize, Optional<ParquetWriteValidation> parquetWriteValidation, Optional<FileDecryptionProperties> fileDecryptionProperties)
             throws IOException
     {
         // Parquet File Layout:
@@ -90,7 +94,9 @@ public final class MetadataReader
 
         // Read the tail of the file
         long estimatedFileSize = dataSource.getEstimatedSize();
-        long expectedReadSize = min(estimatedFileSize, EXPECTED_FOOTER_SIZE);
+        long footerReadSizeInBytes = footerReadSize.toBytes();
+        validateParquet(footerReadSizeInBytes >= POST_SCRIPT_SIZE, dataSource.getId(), "Parquet footer read size must be at least %s bytes", POST_SCRIPT_SIZE);
+        long expectedReadSize = min(estimatedFileSize, footerReadSizeInBytes);
         Slice buffer = dataSource.readTail(toIntExact(expectedReadSize));
 
         Slice magic = buffer.slice(buffer.length() - MAGIC.length(), MAGIC.length());

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ArrayColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ArrayColumnWriter.java
@@ -73,9 +73,15 @@ public class ArrayColumnWriter
     }
 
     @Override
-    public long getBufferedBytes()
+    public long getEstimatedBufferedBytes(CompressionStats compressionStats)
     {
-        return elementWriter.getBufferedBytes();
+        return elementWriter.getEstimatedBufferedBytes(compressionStats);
+    }
+
+    @Override
+    public CompressionStats getCompressionStats()
+    {
+        return elementWriter.getCompressionStats();
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnWriter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static java.lang.Math.addExact;
 import static java.util.Objects.requireNonNull;
 
 public interface ColumnWriter
@@ -33,9 +34,26 @@ public interface ColumnWriter
     List<BufferData> getBuffer()
             throws IOException;
 
-    long getBufferedBytes();
+    long getEstimatedBufferedBytes(CompressionStats compressionStats);
+
+    default CompressionStats getCompressionStats()
+    {
+        return CompressionStats.EMPTY;
+    }
 
     long getRetainedBytes();
+
+    record CompressionStats(long compressedSize, long uncompressedSize)
+    {
+        static final CompressionStats EMPTY = new CompressionStats(0, 0);
+
+        CompressionStats add(CompressionStats compressionStats)
+        {
+            return new CompressionStats(
+                    addExact(this.compressedSize, compressionStats.compressedSize()),
+                    addExact(this.uncompressedSize, compressionStats.uncompressedSize()));
+        }
+    }
 
     class BufferData
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MapColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MapColumnWriter.java
@@ -77,9 +77,17 @@ public class MapColumnWriter
     }
 
     @Override
-    public long getBufferedBytes()
+    public long getEstimatedBufferedBytes(CompressionStats compressionStats)
     {
-        return keyWriter.getBufferedBytes() + valueWriter.getBufferedBytes();
+        return keyWriter.getEstimatedBufferedBytes(compressionStats) + valueWriter.getEstimatedBufferedBytes(compressionStats);
+    }
+
+    @Override
+    public CompressionStats getCompressionStats()
+    {
+        CompressionStats keyStats = keyWriter.getCompressionStats();
+        CompressionStats valueStats = valueWriter.getCompressionStats();
+        return keyStats.add(valueStats);
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -32,6 +32,7 @@ import io.trino.parquet.reader.MetadataReader;
 import io.trino.parquet.reader.ParquetReader;
 import io.trino.parquet.reader.RowGroupInfo;
 import io.trino.parquet.writer.ColumnWriter.BufferData;
+import io.trino.parquet.writer.ColumnWriter.CompressionStats;
 import io.trino.spi.Page;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.type.Type;
@@ -112,7 +113,8 @@ public class ParquetWriter
 
     private List<ColumnWriter> columnWriters;
     private int rows;
-    private long bufferedBytes;
+    private long estimatedBufferedBytes;
+    private CompressionStats previousCompressionStats = CompressionStats.EMPTY;
     private OptionalInt footerReadSize = OptionalInt.empty();
     private boolean closed;
     private boolean writeHeader;
@@ -148,14 +150,9 @@ public class ParquetWriter
         this.chunkMaxBytes = max(1, writerOption.getMaxRowGroupSize() / 2);
     }
 
-    public long getWrittenBytes()
+    public long getEstimatedWrittenBytes()
     {
-        return outputStream.longSize();
-    }
-
-    public long getBufferedBytes()
-    {
-        return bufferedBytes;
+        return outputStream.longSize() + estimatedBufferedBytes;
     }
 
     public long getRetainedBytes()
@@ -196,20 +193,19 @@ public class ParquetWriter
     private void writeChunk(Page page)
             throws IOException
     {
-        bufferedBytes = 0;
         for (int channel = 0; channel < page.getChannelCount(); channel++) {
             ColumnWriter writer = columnWriters.get(channel);
             writer.writeBlock(new ColumnChunk(page.getBlock(channel)));
-            bufferedBytes += writer.getBufferedBytes();
         }
         rows += page.getPositionCount();
+        updateEstimatedBufferedBytes();
 
-        if (bufferedBytes >= writerOption.getMaxRowGroupSize()) {
+        if (estimatedBufferedBytes >= writerOption.getMaxRowGroupSize()) {
             columnWriters.forEach(ColumnWriter::close);
             flush();
             initColumnWriters();
             rows = 0;
-            bufferedBytes = columnWriters.stream().mapToLong(ColumnWriter::getBufferedBytes).sum();
+            updateEstimatedBufferedBytes();
         }
     }
 
@@ -230,7 +226,7 @@ public class ParquetWriter
             writeBloomFilters(fileMetaData.getRow_groups(), bloomFilterGroups.build());
             writeFooter();
         }
-        bufferedBytes = 0;
+        estimatedBufferedBytes = 0;
     }
 
     public void validate(ParquetDataSource input)
@@ -416,10 +412,21 @@ public class ParquetWriter
     {
         long totalCompressedBytes = columnMetaData.stream().mapToLong(ColumnMetaData::getTotal_compressed_size).sum();
         long totalBytes = columnMetaData.stream().mapToLong(ColumnMetaData::getTotal_uncompressed_size).sum();
+        previousCompressionStats = previousCompressionStats.add(new CompressionStats(totalCompressedBytes, totalBytes));
         List<org.apache.parquet.format.ColumnChunk> columnChunks = columnMetaData.stream().map(ParquetWriter::toColumnChunk).collect(toImmutableList());
         fileFooter.addRowGroup(new RowGroup(columnChunks, totalBytes, rows)
                 .setTotal_compressed_size(totalCompressedBytes)
                 .setFile_offset(fileOffset));
+    }
+
+    private void updateEstimatedBufferedBytes()
+    {
+        CompressionStats compressionStats = columnWriters.stream()
+                .map(ColumnWriter::getCompressionStats)
+                .reduce(previousCompressionStats, CompressionStats::add);
+        estimatedBufferedBytes = columnWriters.stream()
+                .mapToLong(columnWriter -> columnWriter.getEstimatedBufferedBytes(compressionStats))
+                .sum();
     }
 
     private static Slice serializeFooter(FileMetaData fileMetaData)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -19,6 +19,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import io.trino.parquet.Column;
 import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
@@ -112,6 +113,7 @@ public class ParquetWriter
     private List<ColumnWriter> columnWriters;
     private int rows;
     private long bufferedBytes;
+    private OptionalInt footerReadSize = OptionalInt.empty();
     private boolean closed;
     private boolean writeHeader;
     @Nullable
@@ -237,7 +239,8 @@ public class ParquetWriter
         checkState(validationBuilder.isPresent(), "validation is not enabled");
         ParquetWriteValidation writeValidation = validationBuilder.get().build();
         try {
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(input, Optional.empty(), Optional.of(writeValidation), Optional.empty());
+            checkState(footerReadSize.isPresent(), "footer has not been written");
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(input, DataSize.ofBytes(footerReadSize.getAsInt()), Optional.empty(), Optional.of(writeValidation), Optional.empty());
             try (ParquetReader parquetReader = createParquetReader(input, parquetMetadata, writeValidation)) {
                 for (SourcePage page = parquetReader.nextPage(); page != null; page = parquetReader.nextPage()) {
                     // fully load the page
@@ -373,6 +376,7 @@ public class ParquetWriter
         createDataOutput(footerSize).writeData(outputStream);
 
         createDataOutput(MAGIC).writeData(outputStream);
+        footerReadSize = OptionalInt.of(footer.length() + SIZE_OF_INT + MAGIC.length());
     }
 
     private void writeBloomFilters(List<RowGroup> rowGroups, List<List<Optional<BloomFilter>>> rowGroupBloomFilters)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.writer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
 import io.trino.parquet.ParquetMetadataConverter;
@@ -69,6 +70,8 @@ public class PrimitiveColumnWriter
     private static final int INSTANCE_SIZE = instanceSize(PrimitiveColumnWriter.class);
     private static final int MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 8 * 1024;
     private static final int MAXIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 2 * 1024 * 1024;
+    private static final int MINIMUM_COMPRESSION_RATIO_SAMPLE_SIZE = 1024 * 1024;
+    private static final double MAX_COMPRESSION_EXPANSION_RATIO = 1.5;
     // ParquetMetadataConverter.MAX_STATS_SIZE is 4096, we need a value which would guarantee that min and max
     // don't add up to 4096 (so less than 2048). Using 1K as that is big enough for most use cases.
     private static final int MAX_STATISTICS_LENGTH_IN_BYTES = 1024;
@@ -107,9 +110,7 @@ public class PrimitiveColumnWriter
     private final int pageSizeThreshold;
     private final int pageValueCountLimit;
 
-    // Total size of compressed parquet pages and the current uncompressed page buffered in memory
-    // Used by ParquetWriter to decide when a row group is big enough to flush
-    private long bufferedBytes;
+    // Total size of compressed parquet pages
     private long pageBufferedBytes;
 
     public PrimitiveColumnWriter(
@@ -167,9 +168,6 @@ public class PrimitiveColumnWriter
         long currentPageBufferedBytes = getCurrentPageBufferedBytes();
         if (valueCount >= pageValueCountLimit || currentPageBufferedBytes >= pageSizeThreshold) {
             flushCurrentPageToBuffer();
-        }
-        else {
-            updateBufferedBytes(currentPageBufferedBytes);
         }
     }
 
@@ -279,7 +277,6 @@ public class PrimitiveColumnWriter
         repetitionLevelWriter.reset();
         definitionLevelWriter.reset();
         primitiveValueWriter.reset();
-        updateBufferedBytes(getCurrentPageBufferedBytes());
     }
 
     private DataStreams getDataStreams()
@@ -324,9 +321,18 @@ public class PrimitiveColumnWriter
     }
 
     @Override
-    public long getBufferedBytes()
+    public long getEstimatedBufferedBytes(CompressionStats compressionStats)
     {
-        return bufferedBytes;
+        long pendingBufferedBytesEstimate = definitionLevelWriter.getBufferedSize() +
+                repetitionLevelWriter.getBufferedSize() +
+                primitiveValueWriter.getEstimatedBufferedSize();
+        return pageBufferedBytes + estimateCompressedSize(pendingBufferedBytesEstimate, compressionStats);
+    }
+
+    @Override
+    public CompressionStats getCompressionStats()
+    {
+        return new CompressionStats(totalCompressedSize, totalUnCompressedSize);
     }
 
     @Override
@@ -339,16 +345,36 @@ public class PrimitiveColumnWriter
                 repetitionLevelWriter.getAllocatedSize();
     }
 
-    private void updateBufferedBytes(long currentPageBufferedBytes)
-    {
-        bufferedBytes = pageBufferedBytes + currentPageBufferedBytes;
-    }
-
     private long getCurrentPageBufferedBytes()
     {
         return definitionLevelWriter.getBufferedSize() +
                 repetitionLevelWriter.getBufferedSize() +
                 primitiveValueWriter.getBufferedSize();
+    }
+
+    private long estimateCompressedSize(long uncompressedSize, CompressionStats compressionStats)
+    {
+        // If the current write has a reasonable compression sample size, use the compression ratio from the current
+        // writer, otherwise use the compression stats from other columns in this file. Also, verify the overall
+        // compression stats has a reasonable compression sample size before use.
+        if (totalUnCompressedSize >= MINIMUM_COMPRESSION_RATIO_SAMPLE_SIZE || compressionStats.uncompressedSize() < MINIMUM_COMPRESSION_RATIO_SAMPLE_SIZE) {
+            return estimateCompressedSize(uncompressedSize, totalCompressedSize, totalUnCompressedSize);
+        }
+        return estimateCompressedSize(uncompressedSize, compressionStats.compressedSize(), compressionStats.uncompressedSize());
+    }
+
+    @VisibleForTesting
+    static long estimateCompressedSize(long uncompressedSize, long totalCompressedSize, long totalUnCompressedSize)
+    {
+        if (uncompressedSize == 0 || totalUnCompressedSize == 0) {
+            return uncompressedSize;
+        }
+        double compressionRatio = Math.min((double) totalCompressedSize / totalUnCompressedSize, MAX_COMPRESSION_EXPANSION_RATIO);
+        double estimatedSize = Math.ceil(uncompressedSize * compressionRatio);
+        if (estimatedSize >= Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return (long) estimatedSize;
     }
 
     private static PageHeader dataPageV1Header(

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/StructColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/StructColumnWriter.java
@@ -84,14 +84,24 @@ public class StructColumnWriter
     }
 
     @Override
-    public long getBufferedBytes()
+    public long getEstimatedBufferedBytes(CompressionStats compressionStats)
     {
         // Avoid using streams here for performance reasons
         long bufferedBytes = 0;
         for (ColumnWriter columnWriter : columnWriters) {
-            bufferedBytes += columnWriter.getBufferedBytes();
+            bufferedBytes += columnWriter.getEstimatedBufferedBytes(compressionStats);
         }
         return bufferedBytes;
+    }
+
+    @Override
+    public CompressionStats getCompressionStats()
+    {
+        CompressionStats compressionStats = CompressionStats.EMPTY;
+        for (ColumnWriter columnWriter : columnWriters) {
+            compressionStats = compressionStats.add(columnWriter.getCompressionStats());
+        }
+        return compressionStats;
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/VariantColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/VariantColumnWriter.java
@@ -94,9 +94,17 @@ public class VariantColumnWriter
     }
 
     @Override
-    public long getBufferedBytes()
+    public long getEstimatedBufferedBytes(CompressionStats compressionStats)
     {
-        return metadataColumnWriter.getBufferedBytes() + valueColumnWriter.getBufferedBytes();
+        return metadataColumnWriter.getEstimatedBufferedBytes(compressionStats) + valueColumnWriter.getEstimatedBufferedBytes(compressionStats);
+    }
+
+    @Override
+    public CompressionStats getCompressionStats()
+    {
+        CompressionStats metadataStats = metadataColumnWriter.getCompressionStats();
+        CompressionStats valueStats = valueColumnWriter.getCompressionStats();
+        return metadataStats.add(valueStats);
     }
 
     @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BloomFilterValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/BloomFilterValuesWriter.java
@@ -55,6 +55,14 @@ public class BloomFilterValuesWriter
         return writer.getBufferedSize();
     }
 
+    public long getEstimatedBufferedSize()
+    {
+        return switch (writer) {
+            case DictionaryFallbackValuesWriter dictionaryFallbackValuesWriter -> dictionaryFallbackValuesWriter.getEstimatedBufferedSize();
+            default -> writer.getBufferedSize();
+        };
+    }
+
     @Override
     public BytesInput getBytes()
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DictionaryFallbackValuesWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/DictionaryFallbackValuesWriter.java
@@ -63,6 +63,16 @@ public class DictionaryFallbackValuesWriter
         return rawDataByteSize;
     }
 
+    public long getEstimatedBufferedSize()
+    {
+        long estimatedBufferedSize = currentWriter.getBufferedSize();
+        if (!fellBackAlready && firstPage && initialWriter != null &&
+                !initialWriter.isCompressionSatisfying(rawDataByteSize, estimatedBufferedSize)) {
+            return rawDataByteSize;
+        }
+        return estimatedBufferedSize;
+    }
+
     @Override
     public BytesInput getBytes()
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/PrimitiveValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/PrimitiveValueWriter.java
@@ -58,6 +58,15 @@ public abstract class PrimitiveValueWriter
         return valuesWriter.getBufferedSize();
     }
 
+    public long getEstimatedBufferedSize()
+    {
+        return switch (valuesWriter) {
+            case DictionaryFallbackValuesWriter dictionaryFallbackValuesWriter -> dictionaryFallbackValuesWriter.getEstimatedBufferedSize();
+            case BloomFilterValuesWriter bloomFilterValuesWriter -> bloomFilterValuesWriter.getEstimatedBufferedSize();
+            default -> valuesWriter.getBufferedSize();
+        };
+    }
+
     @Override
     public BytesInput getBytes()
     {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/crypto/TestParquetEncryption.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/crypto/TestParquetEncryption.java
@@ -242,7 +242,7 @@ public final class TestParquetEncryption
                             Optional.empty()))
                     .withCheckFooterIntegrity(encryptFooter)
                     .build();
-            ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(properties));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(properties));
             assertThat(metadata.getBlocks().size()).isGreaterThan(1);
         }
 
@@ -331,7 +331,7 @@ public final class TestParquetEncryption
                     .withKeyRetriever(new TestingKeyRetriever(Optional.of(KEY_FOOT), Optional.of(KEY_AGE), Optional.empty()))
                     .build();
 
-            ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(properties));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(properties));
 
             // first (and only) row‑group → column‑chunk for "age"
             ColumnChunkMetadata chunk =
@@ -458,8 +458,7 @@ public final class TestParquetEncryption
                     .withCheckFooterIntegrity(true)
                     .build();
 
-            ParquetMetadata metadata = MetadataReader.readFooter(
-                    source, Optional.empty(), Optional.empty(), Optional.of(props));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(props));
 
             ColumnDescriptor age = new ColumnDescriptor(
                     new String[] {"age"},
@@ -535,7 +534,7 @@ public final class TestParquetEncryption
                     .withCheckFooterIntegrity(true)
                     .build();
 
-            ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(props));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(props));
 
             ColumnDescriptor age = new ColumnDescriptor(
                     new String[] {"age"},
@@ -737,7 +736,7 @@ public final class TestParquetEncryption
                     .withCheckFooterIntegrity(true)
                     .build();
 
-            ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(properties));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(properties));
 
             ColumnChunkMetadata age = metadata.getBlocks().getFirst().columns().stream()
                     .filter(context -> context.getPath().equals(AGE_PATH))
@@ -820,7 +819,7 @@ public final class TestParquetEncryption
                     .withCheckFooterIntegrity(true)
                     .build();
 
-            ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(properties));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(properties));
 
             ColumnChunkMetadata age = metadata.getBlocks().getFirst().columns().stream()
                     .filter(context -> context.getPath().equals(AGE_PATH))
@@ -854,8 +853,7 @@ public final class TestParquetEncryption
                 .withCheckFooterIntegrity(checkFooterIntegrity);
         aadPrefix.ifPresent(properties::withAadPrefix);
 
-        ParquetMetadata metadata = MetadataReader.readFooter(
-                source, Optional.empty(), Optional.empty(), Optional.of(properties.build()));
+        ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(properties.build()));
 
         ColumnDescriptor descriptor = new ColumnDescriptor(
                 new String[] {"age"},
@@ -919,7 +917,7 @@ public final class TestParquetEncryption
         FileDecryptionProperties properties = FileDecryptionProperties
                 .builder().withKeyRetriever(retriever).withCheckFooterIntegrity(true).build();
 
-        ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(properties));
+        ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(properties));
 
         ColumnDescriptor ageDescriptor = new ColumnDescriptor(
                 new String[] {"age"},

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
@@ -15,10 +15,14 @@ package io.trino.parquet.reader;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.io.Resources;
+import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.parquet.DiskRange;
 import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetDataSourceId;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
@@ -40,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -55,6 +60,8 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -239,8 +246,37 @@ public class TestParquetReader
                         generateInputPages(types, 10, 50)),
                 ParquetReaderOptions.defaultOptions());
 
-        assertThatThrownBy(() -> MetadataReader.readFooter(dataSource, DataSize.ofBytes(1000), Optional.empty()))
+        ParquetReaderOptions readerOptions = ParquetReaderOptions.builder()
+                .withMaxFooterReadSize(DataSize.ofBytes(1000))
+                .build();
+
+        assertThatThrownBy(() -> MetadataReader.readFooter(dataSource, readerOptions, Optional.empty(), Optional.empty()))
                 .hasMessageMatching(".* Parquet footer size .* exceeds maximum allowed size .*");
+    }
+
+    @Test
+    void testFooterReadSize()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("columna", "columnb");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT);
+
+        RecordingParquetDataSource dataSource = new RecordingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setMaxBlockSize(DataSize.ofBytes(10))
+                                .build(),
+                        types,
+                        columnNames,
+                        generateInputPages(types, 10, 50)));
+
+        ParquetReaderOptions readerOptions = ParquetReaderOptions.builder()
+                .withFooterReadSize(DataSize.ofBytes(128))
+                .build();
+
+        MetadataReader.readFooter(dataSource, readerOptions, Optional.empty(), Optional.empty());
+
+        assertThat(dataSource.getTailReadLengths()).startsWith(128);
     }
 
     private void testReadingOldParquetFiles(File file, List<String> columnNames, Type columnType, List<?> expectedValues)
@@ -263,6 +299,71 @@ public class TestParquetReader
             assertThat(expected.hasNext())
                     .describedAs("Read fewer values than expected")
                     .isFalse();
+        }
+    }
+
+    private static class RecordingParquetDataSource
+            implements ParquetDataSource
+    {
+        private final ParquetDataSourceId id = new ParquetDataSourceId("recording");
+        private final Slice input;
+        private final List<Integer> tailReadLengths = new ArrayList<>();
+        private long readBytes;
+
+        public RecordingParquetDataSource(Slice input)
+        {
+            this.input = input;
+        }
+
+        @Override
+        public ParquetDataSourceId getId()
+        {
+            return id;
+        }
+
+        @Override
+        public long getReadBytes()
+        {
+            return readBytes;
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return input.length();
+        }
+
+        @Override
+        public Slice readTail(int length)
+        {
+            tailReadLengths.add(length);
+            int readSize = toIntExact(min(input.length(), length));
+            readBytes += readSize;
+            return input.slice(input.length() - readSize, readSize);
+        }
+
+        @Override
+        public Slice readFully(long position, int length)
+        {
+            readBytes += length;
+            return input.slice(toIntExact(position), length);
+        }
+
+        @Override
+        public <K> Map<K, ChunkedInputStream> planRead(ListMultimap<K, DiskRange> diskRanges, AggregatedMemoryContext memoryContext)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        public List<Integer> getTailReadLengths()
+        {
+            return tailReadLengths;
         }
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -36,6 +36,7 @@ import io.trino.parquet.reader.ParquetReader;
 import io.trino.parquet.reader.TestingParquetDataSource;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
@@ -63,12 +64,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.scalar.CharacterStringCasts.varcharToVarcharSaturatedFloorCast;
 import static io.trino.parquet.BloomFilterStore.hasBloomFilter;
@@ -123,7 +127,7 @@ public class TestParquetWriter
         ParquetDataSource dataSource = new TestingParquetDataSource(
                 writeParquetFile(
                         ParquetWriterOptions.builder()
-                                .setMaxPageSize(DataSize.ofBytes(20 * 1024))
+                                .setMaxPageSize(DataSize.of(20, KILOBYTE))
                                 .build(),
                         types,
                         columnNames,
@@ -291,7 +295,7 @@ public class TestParquetWriter
         ParquetDataSource dataSource = new TestingParquetDataSource(
                 writeParquetFile(
                         ParquetWriterOptions.builder()
-                                .setMaxBlockSize(DataSize.ofBytes(20 * 1024))
+                                .setMaxBlockSize(DataSize.of(12, KILOBYTE))
                                 .build(),
                         types,
                         columnNames,
@@ -319,7 +323,7 @@ public class TestParquetWriter
         ParquetWriter writer = createParquetWriter(
                 new ByteArrayOutputStream(),
                 ParquetWriterOptions.builder()
-                        .setMaxPageSize(DataSize.ofBytes(1024))
+                        .setMaxPageSize(DataSize.of(1, KILOBYTE))
                         .build(),
                 types,
                 columnNames,
@@ -337,6 +341,78 @@ public class TestParquetWriter
         assertThat(previousRetainedBytes).isGreaterThanOrEqualTo(2 * Integer.BYTES * 1000 * 100);
         writer.close();
         assertThat(previousRetainedBytes - writer.getRetainedBytes()).isGreaterThanOrEqualTo(2 * Integer.BYTES * 1000 * 100);
+    }
+
+    @Test
+    public void testEstimatedWrittenBytesUsesEncodedCompressedSize()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("column");
+        List<Type> types = ImmutableList.of(VARCHAR);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ParquetWriter writer = createParquetWriter(
+                outputStream,
+                ParquetWriterOptions.builder()
+                        .setMaxPageSize(DataSize.of(2, MEGABYTE))
+                        .setMaxBlockSize(DataSize.of(64, MEGABYTE))
+                        .build(),
+                types,
+                columnNames,
+                CompressionCodec.SNAPPY);
+
+        writer.write(repeatedVarcharPage(4096, 1024));
+        writer.write(repeatedVarcharPage(1024, 1024));
+
+        long compressedBufferedEstimate = writer.getEstimatedWrittenBytes();
+
+        writer.close();
+        long actualWrittenBytes = outputStream.size();
+
+        assertThat(Math.abs(compressedBufferedEstimate - actualWrittenBytes)).isLessThan(DataSize.of(64, KILOBYTE).toBytes());
+    }
+
+    @Test
+    public void testEstimatedWrittenBytesUsesAggregateCompressionRatioForSmallColumnSamples()
+            throws IOException
+    {
+        int columnCount = 24;
+        List<String> columnNames = IntStream.range(0, columnCount)
+                .mapToObj("column_%s"::formatted)
+                .collect(toImmutableList());
+        List<Type> types = Collections.nCopies(columnCount, VARCHAR);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ParquetWriter writer = createParquetWriter(
+                outputStream,
+                ParquetWriterOptions.builder()
+                        .setMaxPageSize(DataSize.of(1, MEGABYTE))
+                        .setMaxBlockSize(DataSize.of(128, MEGABYTE))
+                        .build(),
+                types,
+                columnNames,
+                CompressionCodec.SNAPPY);
+
+        Page page = mixedVarcharPage(4096, columnCount);
+        long targetEstimatedWrittenBytes = DataSize.of(16, MEGABYTE).toBytes();
+        long estimatedWrittenBytes = 0;
+        for (int writes = 0; estimatedWrittenBytes < targetEstimatedWrittenBytes && writes < 512; writes++) {
+            writer.write(page);
+            estimatedWrittenBytes = writer.getEstimatedWrittenBytes();
+        }
+        assertThat(estimatedWrittenBytes).isGreaterThanOrEqualTo(targetEstimatedWrittenBytes);
+
+        writer.close();
+        long actualWrittenBytes = outputStream.size();
+
+        assertThat(estimatedWrittenBytes).isCloseTo(actualWrittenBytes, Percentage.withPercentage(10));
+    }
+
+    @Test
+    public void testCompressedSizeEstimateCapsExpansionRatio()
+    {
+        assertThat(PrimitiveColumnWriter.estimateCompressedSize(1024, 40, 10)).isEqualTo(1536);
+        assertThat(PrimitiveColumnWriter.estimateCompressedSize(1024, 5, 10)).isEqualTo(512);
+        assertThat(PrimitiveColumnWriter.estimateCompressedSize(0, 40, 10)).isEqualTo(0);
+        assertThat(PrimitiveColumnWriter.estimateCompressedSize(1024, 0, 0)).isEqualTo(1024);
     }
 
     @Test
@@ -436,7 +512,7 @@ public class TestParquetWriter
         ParquetDataSource dataSource = new TestingParquetDataSource(
                 writeParquetFile(
                         ParquetWriterOptions.builder()
-                                .setMaxBlockSize(DataSize.ofBytes(4 * 1024))
+                                .setMaxBlockSize(DataSize.of(4, KILOBYTE))
                                 .setBloomFilterColumns(ImmutableSet.copyOf(columnNames))
                                 .build(),
                         types,
@@ -550,5 +626,32 @@ public class TestParquetWriter
         List<Long> shuffledData = LongStream.range(0, size).boxed().collect(toList());
         Collections.shuffle(shuffledData, random);
         return shuffledData;
+    }
+
+    private static Page repeatedVarcharPage(int positionCount, int valueSize)
+    {
+        Slice value = Slices.utf8Slice("x".repeat(valueSize));
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, positionCount);
+        for (int position = 0; position < positionCount; position++) {
+            VARCHAR.writeSlice(blockBuilder, value);
+        }
+        return new Page(blockBuilder.build());
+    }
+
+    private static Page mixedVarcharPage(int positionCount, int columnCount)
+    {
+        Block[] blocks = new Block[columnCount];
+        String payload = "x".repeat(256);
+        for (int column = 0; column < columnCount; column++) {
+            BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                String value = column == 0
+                        ? "payload-%s-%s".formatted(position % 4096, payload)
+                        : "dimension-%s-%s".formatted(column, position % 32);
+                VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice(value));
+            }
+            blocks[column] = blockBuilder.build();
+        }
+        return new Page(blocks);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -400,7 +400,7 @@ public class DeltaLakeMergeSink
         }
         TrinoInputFile inputFile = fileSystem.newInputFile(Location.of(path.toStringUtf8()));
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, parquetReaderOptions, fileFormatDataSourceStats)) {
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, parquetReaderOptions, Optional.empty(), Optional.empty());
             long rowCount = parquetMetadata.getBlocks().stream().map(BlockMetadata::rowCount).mapToLong(Long::longValue).sum();
             RoaringBitmapArray rowsRetained = new RoaringBitmapArray();
             rowsRetained.addRange(0, rowCount - 1);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -367,7 +367,7 @@ public class DeltaLakePageSourceProvider
     private Map<Integer, String> loadParquetIdAndNameMapping(TrinoInputFile inputFile, ParquetReaderOptions options)
     {
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, options, fileFormatDataSourceStats)) {
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize(), Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty());
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -117,7 +117,7 @@ public final class ParquetFileWriter
     @Override
     public long getWrittenBytes()
     {
-        return parquetWriter.getWrittenBytes() + parquetWriter.getBufferedBytes();
+        return parquetWriter.getEstimatedWrittenBytes();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -236,7 +236,7 @@ public class ParquetPageSourceFactory
             AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
             dataSource = createDataSource(inputFile, estimatedFileSize, options, memoryContext, stats);
 
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.of(options.getMaxFooterReadSize()), parquetWriteValidation, fileDecryptionProperties);
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, parquetWriteValidation, fileDecryptionProperties);
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             fileSchema = fileMetaData.getSchema();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -191,6 +191,24 @@ public class ParquetReaderConfig
         return options.getMaxFooterReadSize();
     }
 
+    @Config("parquet.footer-read-size")
+    @ConfigDescription("Expected size of the Parquet footer to read before falling back to a second read")
+    public ParquetReaderConfig setFooterReadSize(DataSize footerReadSize)
+    {
+        options = ParquetReaderOptions.builder(options)
+                .withFooterReadSize(footerReadSize)
+                .build();
+        return this;
+    }
+
+    @NotNull
+    @MinDataSize("8B")
+    @MaxDataSize("128MB")
+    public DataSize getFooterReadSize()
+    {
+        return options.getFooterReadSize();
+    }
+
     @Config("parquet.max-page-read-size")
     @ConfigDescription("Maximum allowed size of a parquet page during reads. Files with parquet pages larger than this will generate an exception on read")
     public ParquetReaderConfig setMaxPageReadSize(DataSize maxPageSize)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/crypto/TestHiveParquetEncryption.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/crypto/TestHiveParquetEncryption.java
@@ -286,7 +286,7 @@ public class TestHiveParquetEncryption
                     .withKeyRetriever(new TestHiveParquetEncryption.TestingParquetEncryptionModule(
                             FOOTER_KEY, Optional.of(COLUMN_KEY_AGE), Optional.of(COLUMN_KEY_ID)))
                     .build();
-            ParquetMetadata metadata = MetadataReader.readFooter(source, Optional.empty(), Optional.empty(), Optional.of(dec));
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.of(dec));
 
             ColumnChunkMetadata ageChunk = metadata.getBlocks().getFirst().columns().stream()
                     .filter(column -> column.getPath().equals(AGE_PATH))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -40,6 +40,7 @@ public class TestParquetReaderConfig
                 .setUseBloomFilter(true)
                 .setSmallFileThreshold(DataSize.of(3, MEGABYTE))
                 .setVectorizedDecodingEnabled(true)
+                .setFooterReadSize(DataSize.of(48, KILOBYTE))
                 .setMaxFooterReadSize(DataSize.of(15, MEGABYTE))
                 .setMaxPageReadSize(DataSize.of(500, MEGABYTE)));
     }
@@ -57,6 +58,7 @@ public class TestParquetReaderConfig
                 .put("parquet.use-bloom-filter", "false")
                 .put("parquet.small-file-threshold", "1kB")
                 .put("parquet.experimental.vectorized-decoding.enabled", "false")
+                .put("parquet.footer-read-size", "57kB")
                 .put("parquet.max-footer-read-size", "25MB")
                 .put("parquet.max-page-read-size", "123MB")
                 .buildOrThrow();
@@ -71,6 +73,7 @@ public class TestParquetReaderConfig
                 .setUseBloomFilter(false)
                 .setSmallFileThreshold(DataSize.of(1, KILOBYTE))
                 .setVectorizedDecodingEnabled(false)
+                .setFooterReadSize(DataSize.of(57, KILOBYTE))
                 .setMaxFooterReadSize(DataSize.of(25, MEGABYTE))
                 .setMaxPageReadSize(DataSize.of(123, MEGABYTE));
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -232,7 +232,7 @@ public class HudiPageSourceProvider
         try {
             AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
             dataSource = createDataSource(inputFile, OptionalLong.of(hudiSplit.fileSize()), options, memoryContext, dataSourceStats);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize(), Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty());
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -1013,7 +1013,7 @@ public class IcebergPageSourceProvider
         ParquetDataSource dataSource = null;
         try {
             dataSource = createDataSource(inputFile, OptionalLong.of(fileSize), options, memoryContext, fileFormatDataSourceStats);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize(), Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty());
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
             if (nameMapping.isPresent() && !ParquetSchemaUtil.hasIds(fileSchema)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
@@ -155,7 +155,7 @@ public final class MigrationUtils
     {
         ParquetReaderOptions options = ParquetReaderOptions.defaultOptions();
         try (ParquetDataSource dataSource = new TrinoParquetDataSource(file, ParquetReaderOptions.defaultOptions(), new FileFormatDataSourceStats())) {
-            ParquetMetadata metadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize(), Optional.empty());
+            ParquetMetadata metadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty());
             return ParquetUtil.footerMetrics(metadata, Stream.empty(), metricsConfig, nameMapping);
         }
         catch (IOException e) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5476,7 +5476,7 @@ public abstract class BaseIcebergConnectorTest
                                         nCopies(100, testSetup.getHighValueLiteral()).stream())
                                 .map(value -> "(" + value + ", rand())")
                                 .collect(joining(", "));
-                assertUpdate(withSmallRowGroups(getSession()), "INSERT INTO " + tableName + " VALUES " + values, 200);
+                assertUpdate(withSplitPruningRowGroups(getSession()), "INSERT INTO " + tableName + " VALUES " + values, 200);
 
                 String query = "SELECT * FROM " + tableName + " WHERE col = " + testSetup.getSampleValueLiteral();
                 verifyPredicatePushdownDataRead(query, supportsRowGroupStatistics(testSetup.getTrinoTypeName()));
@@ -5485,6 +5485,13 @@ public abstract class BaseIcebergConnectorTest
     }
 
     protected abstract boolean supportsRowGroupStatistics(String typeName);
+
+    private static Session withSplitPruningRowGroups(Session session)
+    {
+        return Session.builder(withSmallRowGroups(session))
+                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "256B")
+                .build();
+    }
 
     private void verifySplitCount(String query, int expectedSplitCount)
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergParquetConnectorTest.java
@@ -173,7 +173,7 @@ public abstract class BaseIcebergParquetConnectorTest
                 "AS SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem WITH NO DATA")) {
             long initialSnapshot = getMostRecentSnapshotId(table.getName());
             assertUpdate(
-                    withSmallRowGroups(getSession()),
+                    withTableChangesRowGroups(getSession()),
                     "INSERT INTO %s SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem".formatted(table.getName()),
                     60175L);
             long snapshotAfterInsert = getMostRecentSnapshotId(table.getName());
@@ -185,8 +185,8 @@ public abstract class BaseIcebergParquetConnectorTest
             String filePath = getOnlyTableFilePath(table.getName());
             ParquetMetadata parquetMetadata = getParquetFileMetadata(fileSystem.newInputFile(Location.of(filePath)));
             int blocksSize = parquetMetadata.getBlocks().size();
-            int splitBatchSize = new QueryManagerConfig().getScheduleSplitBatchSize();
-            assertThat(blocksSize > splitBatchSize && blocksSize % splitBatchSize != 0).isTrue();
+            int splitBatchSize = getTableChangesSplitBatchSize();
+            assertThat(blocksSize).isGreaterThan(splitBatchSize);
 
             assertQuery(
                     """
@@ -195,6 +195,18 @@ public abstract class BaseIcebergParquetConnectorTest
                     """.formatted(table.getName(), initialSnapshot, snapshotAfterInsert),
                     "SELECT orderkey, partkey, suppkey, 'insert', %s, '%s', 0 FROM lineitem".formatted(snapshotAfterInsert, snapshotAfterInsertTime));
         }
+    }
+
+    protected Session withTableChangesRowGroups(Session session)
+    {
+        return Session.builder(withSmallRowGroups(session))
+                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "256B")
+                .build();
+    }
+
+    protected int getTableChangesSplitBatchSize()
+    {
+        return new QueryManagerConfig().getScheduleSplitBatchSize();
     }
 
     private String getOnlyTableFilePath(String tableName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
@@ -14,12 +14,25 @@
 package io.trino.plugin.iceberg;
 
 import io.trino.Session;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.parquet.metadata.BlockMetadata;
+import io.trino.parquet.metadata.ParquetMetadata;
 import io.trino.testing.BaseComplexTypesPredicatePushDownTest;
 import io.trino.testing.QueryRunner;
+import org.apache.parquet.column.statistics.Statistics;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.plugin.iceberg.IcebergTestUtils.SESSION;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getParquetFileMetadata;
 import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIcebergParquetComplexTypesPredicatePushDown
         extends BaseComplexTypesPredicatePushDownTest
@@ -45,18 +58,62 @@ public class TestIcebergParquetComplexTypesPredicatePushDown
     // The test increased the number of row groups and introduced predicates that are within the file statistics but outside the statistics of the row groups.
     @Test
     public void testIcebergParquetRowTypeRowGroupPruning()
+            throws IOException
     {
         String tableName = "test_nested_column_pruning_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " (col1Row ROW(a BIGINT, b BIGINT), col2 BIGINT) WITH (sorted_by=ARRAY['col2'])");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM unnest(transform(SEQUENCE(1, 10000), x -> ROW(ROW(x*2, 100), x)))", 10000);
 
-        // col1Row.a only contains even numbers, in the range of [2, 20000].
-        // The test has roughly 50 rows per row group due to withSmallRowGroups, [2, 100], [102, 200], ... [19902, 20000]
-        // 101 is a value between [2, 20000] but is an odd number, so won't be discarded by Iceberg table's statistics.
-        // At the same time, 101 is not within the bound of any row group. So can be discarded by Parquet's row group statistics.
-        assertNoDataRead("SELECT * FROM " + tableName + " WHERE col1Row.a = 101");
+        long valueBetweenRowGroups = getValueBetweenRowGroups(tableName, "col1row.a");
+        assertNoDataRead("SELECT * FROM " + tableName + " WHERE col1Row.a = " + valueBetweenRowGroups);
         assertNoDataRead("SELECT * FROM " + tableName + " WHERE col1Row.a IS NULL");
 
         assertUpdate("DROP TABLE " + tableName);
+    }
+
+    // Find a value that is between the max of one row group and the min of the next row group,
+    // so the value is within the file statistics but outside every row group's statistics.
+    private long getValueBetweenRowGroups(String tableName, String columnPath)
+            throws IOException
+    {
+        String filePath = (String) computeScalar("SELECT file_path FROM \"" + tableName + "$files\"");
+        TrinoFileSystem fileSystem = getFileSystemFactory(getDistributedQueryRunner()).create(SESSION);
+        ParquetMetadata parquetMetadata = getParquetFileMetadata(fileSystem.newInputFile(Location.of(filePath)));
+        List<BlockMetadata> blocks = parquetMetadata.getBlocks();
+        assertThat(blocks).hasSizeGreaterThan(1);
+
+        long previousMax = getColumnMax(blocks.getFirst(), columnPath);
+        for (BlockMetadata block : blocks.subList(1, blocks.size())) {
+            long nextMin = getColumnMin(block, columnPath);
+            if (previousMax + 1 < nextMin) {
+                return previousMax + 1;
+            }
+            previousMax = getColumnMax(block, columnPath);
+        }
+        throw new AssertionError("No gap between row group statistics for " + columnPath);
+    }
+
+    private static long getColumnMin(BlockMetadata block, String columnPath)
+    {
+        Object min = getColumnStatistics(block, columnPath).genericGetMin();
+        assertThat(min).isInstanceOf(Long.class);
+        return (long) min;
+    }
+
+    private static long getColumnMax(BlockMetadata block, String columnPath)
+    {
+        Object max = getColumnStatistics(block, columnPath).genericGetMax();
+        assertThat(max).isInstanceOf(Long.class);
+        return (long) max;
+    }
+
+    private static Statistics<?> getColumnStatistics(BlockMetadata block, String columnPath)
+    {
+        Statistics<?> statistics = block.columns().stream()
+                .filter(column -> column.getPath().toDotString().equals(columnPath))
+                .collect(onlyElement())
+                .getStatistics();
+        assertThat(statistics.hasNonNullValue()).isTrue();
+        return statistics;
     }
 }

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSourceProvider.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftPageSourceProvider.java
@@ -106,7 +106,7 @@ public class RedshiftPageSourceProvider
     {
         ParquetReaderOptions options = ParquetReaderOptions.defaultOptions();
         TrinoParquetDataSource dataSource = new TrinoParquetDataSource(inputFile, options, fileFormatDataSourceStats);
-        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options.getMaxFooterReadSize(), Optional.empty());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty());
         MessageType fileSchema = parquetMetadata.getFileMetaData().getSchema();
         MessageColumnIO messageColumn = getColumnIO(fileSchema, fileSchema);
         Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.faulttolerant.iceberg;
 
+import io.trino.Session;
 import io.trino.filesystem.Location;
 import io.trino.plugin.exchange.filesystem.containers.MinioStorage;
 import io.trino.plugin.iceberg.BaseIcebergParquetConnectorTest;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
 import static io.trino.testing.FaultTolerantExecutionConnectorTestHelper.getExtraProperties;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -90,6 +92,20 @@ public class TestIcebergParquetFaultTolerantExecutionConnectorTest
     protected boolean isFileSorted(String path, String sortColumnName)
     {
         return checkParquetFileSorting(fileSystem.newInputFile(Location.of(path)), sortColumnName);
+    }
+
+    @Override
+    protected Session withTableChangesRowGroups(Session session)
+    {
+        return Session.builder(withSmallRowGroups(session))
+                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "16kB")
+                .build();
+    }
+
+    @Override
+    protected int getTableChangesSplitBatchSize()
+    {
+        return 2;
     }
 
     @AfterAll


### PR DESCRIPTION
## Description

Estimate pending Parquet writer bytes using compressed page history instead of
raw buffered bytes. The estimate now uses per-column compression ratios when
enough data exists, falls back to aggregate file compression stats for small
samples, and caps compression expansion at 1.5x. Row group rollover and
file-size reporting now share the same compression-aware estimate.

Experimented with a 350 MB Parquet file using ZSTD. The tables show average
non-tail output sizes in MB before and after this change. I tested one run
with a very large row group target so each output file had one row group,
and another with row groups set to one quarter of the target file size.
Non-tail files and row groups are typically within a couple percent of the
target after the change; the smallest row group target tested, 8 MB, averaged
about 12% too small.

Single-row-group output:

| Target size | RG target | Before file | After file |
|-------------|-----------|------------:|-----------:|
| 32 MB       | 1024 MB   |      4.8 MB |    31.4 MB |
| 64 MB       | 1024 MB   |     21.5 MB |    63.9 MB |
| 128 MB      | 1024 MB   |     87.2 MB |   126.9 MB |
| 256 MB      | 1024 MB   |    210.8 MB |   254.6 MB |

Quarter-size row group target:

| Target size | RG target | Before file | After file | Before RG | After RG |
|-------------|-----------|------------:|-----------:|----------:|---------:|
| 32 MB       | 8 MB      |     30.0 MB |    32.6 MB |    0.9 MB |   7.1 MB |
| 64 MB       | 16 MB     |     55.9 MB |    64.6 MB |    2.1 MB |  16.2 MB |
| 128 MB      | 32 MB     |    105.1 MB |   128.5 MB |    4.8 MB |  31.3 MB |
| 256 MB      | 64 MB     |    221.4 MB |   256.6 MB |   21.4 MB |  63.9 MB |


Also, there is a small initial commit to make the parquet footer read size configurable.  The hard coded value is too small for wide tables.

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Improve Parquet file and row group size estimates. ({issue}`issuenumber`)
* Add `parquet.footer-read-size` configuration property. ({issue}`issuenumber`)
```
