### PR TITLE
Check table existence in BigQuery type mapping test

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryTypeMapping.java
@@ -808,7 +808,8 @@ public abstract class BaseBigQueryTypeMapping
 
     private DataSetup trinoCreateAsSelect(Session session, String tableNamePrefix)
     {
-        return new CreateAsSelectDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+        CreateAsSelectDataSetup dataSetup = new CreateAsSelectDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+        return new BigQueryDataSetup(getQueryRunner(), dataSetup);
     }
 
     private DataSetup trinoCreateAndInsert(String tableNamePrefix)
@@ -818,7 +819,8 @@ public abstract class BaseBigQueryTypeMapping
 
     private DataSetup trinoCreateAndInsert(Session session, String tableNamePrefix)
     {
-        return new CreateAndInsertDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+        CreateAndInsertDataSetup dataSetup = new CreateAndInsertDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+        return new BigQueryDataSetup(getQueryRunner(), dataSetup);
     }
 
     private DataSetup bigqueryCreateAndInsert(String tableNamePrefix)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryDataSetup.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryDataSetup.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import io.trino.testing.QueryRunner;
+import io.trino.testing.datatype.ColumnSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.sql.TemporaryRelation;
+
+import java.util.List;
+
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BigQueryDataSetup
+        implements DataSetup
+{
+    private final QueryRunner queryRunner;
+    private final DataSetup delegate;
+
+    public BigQueryDataSetup(QueryRunner queryRunner, DataSetup delegate)
+    {
+        this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
+    {
+        TemporaryRelation relation = delegate.setupTemporaryRelation(inputs);
+        waitForTableVisibility(relation.getName());
+        return relation;
+    }
+
+    private void waitForTableVisibility(String tableName)
+    {
+        assertEventually(() -> assertThat(queryRunner.execute("DESCRIBE " + tableName).getRowCount()).isPositive());
+    }
+}


### PR DESCRIPTION
## Description

Hopuflly fixes flaky tests:

```
io.trino.testing.QueryFailedException: line 1:25: Table 'bigquery.test.timestamp_tz6lejjytzfo' does not exist
    at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
    at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:642)
    at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:618)
    at io.trino.testing.datatype.SqlDataTypeTest.verifyPredicate(SqlDataTypeTest.java:130)
    at io.trino.testing.datatype.SqlDataTypeTest.execute(SqlDataTypeTest.java:92)
    at io.trino.testing.datatype.SqlDataTypeTest.execute(SqlDataTypeTest.java:84)
    at io.trino.plugin.bigquery.BaseBigQueryTypeMapping.testTimestampWithTimeZone(BaseBigQueryTypeMapping.java:558)
    at io.trino.plugin.bigquery.BaseBigQueryTypeMapping.testTimestampWithTimeZone(BaseBigQueryTypeMapping.java:547)
Caused by: io.trino.spi.TrinoException: line 1:25: Table 'bigquery.test.timestamp_tz6lejjytzfo' does not exist
    at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:58)
    at io.trino.sql.analyzer.StatementAnalyzer.Visitor.visitTable(StatementAnalyzer.java:2405)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
