### PR TITLE
Update docs for Java 25 requirement

### DIFF
--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -165,7 +165,7 @@ evenly and each receive 50% of the queries in a given timeframe.
 The selector rules for pattern matching use Java's regular expression
 capabilities. Java implements regular expressions through the `java.util.regex`
 package. For more information, see the [Java
-documentation](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/util/regex/Pattern.html).
+documentation](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/regex/Pattern.html).
 
 - `user` (optional): Java regex to match against username.
 

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -30,10 +30,10 @@
 (requirements-java)=
 ### Java runtime environment
 
-Trino requires a 64-bit version of Java 24, with a minimum required version of
-24.0.1 and a recommendation to use the latest patch version. Earlier versions
-such as Java 8, Java 11, Java 17, Java 21 or Java 23 do not work.
-Newer versions such as Java 25 are not supported -- they may work, but are not tested.
+Trino requires a 64-bit version of Java 25, with a minimum required version of
+25.0.1 and a recommendation to use the latest patch version. Earlier versions
+such as Java 8, Java 11, Java 17, Java 21 or Java 24 do not work.
+Newer versions such as Java 26 are not supported -- they may work, but are not tested.
 
 We recommend using the Eclipse Temurin OpenJDK distribution from
 [Adoptium](https://adoptium.net/) as the JDK for Trino, as Trino is tested
@@ -138,6 +138,7 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+--add-modules=jdk.incubator.vector
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`

--- a/docs/src/main/sphinx/security/tls.md
+++ b/docs/src/main/sphinx/security/tls.md
@@ -25,8 +25,8 @@ using TLS 1.2 and TLS 1.3 certificates. The server rejects TLS 1.1, TLS 1.0, and
 all SSL format certificates.
 
 The Trino server does not specify a set of supported ciphers, instead deferring
-to the defaults set by the JVM version in use. The documentation for Java 24
-lists its [supported cipher suites](https://docs.oracle.com/en/java/javase/24/security/oracle-providers.html#GUID-7093246A-31A3-4304-AC5F-5FB6400405E2__SUNJSSE_CIPHER_SUITES).
+to the defaults set by the JVM version in use. The documentation for Java 25
+lists its [supported cipher suites](https://docs.oracle.com/en/java/javase/25/security/oracle-providers.html#GUID-7093246A-31A3-4304-AC5F-5FB6400405E2__SUNJSSE_CIPHER_SUITES).
 
 Run the following two-line code on the same JVM from the same vendor as
 configured on the coordinator to determine that JVM's default cipher list.
@@ -55,7 +55,7 @@ considered in conjunction with your organization's security managers. Using a
 different suite may require downloading and installing a different SunJCE
 implementation package. Some locales may have export restrictions on cipher
 suites. See the discussion in Java documentation that begins with [Customizing
-the Encryption Algorithm Providers](https://docs.oracle.com/en/java/javase/24/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-316FB978-7588-442E-B829-B4973DB3B584).
+the Encryption Algorithm Providers](https://docs.oracle.com/en/java/javase/25/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-316FB978-7588-442E-B829-B4973DB3B584).
 
 :::{note}
 If you manage the coordinator's direct TLS implementation, monitor the CPU


### PR DESCRIPTION
Release 479 upgraded the minimum JDK from 24 to 25 but several documentation pages were not updated.

  - Update Java requirement from 24 to 25 in deployment guide
  - Add `--add-modules=jdk.incubator.vector` to example `jvm.config`
  - Update Java documentation links from `javase/24` to `javase/25` in TLS and resource groups pages

  ## Description

  The JDK 25 requirement is enforced in `pom.xml` (`air.java.version=25.0.1`), `TrinoSystemRequirements.java` (`Version.parse("25")`), and CI (default JDK `25.0.2`). However, `deployment.md` still stated Java 24 was required and Java 25 was "not supported".

  Additionally, the documented example `jvm.config` was missing `--add-modules=jdk.incubator.vector`. Without this flag, `TrinoSystemRequirements.verifyVectorApiEnabled()` causes Trino to exit with code 100 at startup. The Vector API is still an incubator module in Java 25 and must be explicitly enabled.

  Oracle Java documentation links in `tls.md` and `resource-groups.md` also pointed to `javase/24` instead of `javase/25`.

  ## Additional context and related issues

  Fixes #29220

  The JDK 25 upgrade was introduced in release 479 (#27171). These documentation pages were not updated as part of that change.

  Files changed:
  - `docs/src/main/sphinx/installation/deployment.md`
  - `docs/src/main/sphinx/security/tls.md`
  - `docs/src/main/sphinx/admin/resource-groups.md`

  ## Release notes

  [x] This is not user-visible or is docs only, and no release notes are required.