### PR TITLE
Improve exception thrown when ParametricScalar java types do not match

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ParametricScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ParametricScalar.java
@@ -38,7 +38,9 @@ import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_MISSING;
 import static io.trino.util.Failures.checkCondition;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 public class ParametricScalar
         extends SqlScalarFunction
@@ -130,7 +132,13 @@ public class ParametricScalar
         ParametricScalarImplementation exactImplementation = implementations.getExactImplementations().get(boundSignature.toSignature());
         if (exactImplementation != null) {
             Optional<SpecializedSqlScalarFunction> scalarFunctionImplementation = exactImplementation.specialize(functionBinding, functionDependencies);
-            checkCondition(scalarFunctionImplementation.isPresent(), FUNCTION_IMPLEMENTATION_ERROR, "Exact implementation of %s do not match expected java types", boundSignature.getName());
+            if (scalarFunctionImplementation.isEmpty()) {
+                String expectedTypes = boundSignature.getArgumentTypes().stream()
+                        .map(type -> "@SqlType(%s) %s".formatted(type.getTypeSignature().toString().toUpperCase(ENGLISH), type.getJavaType().getSimpleName()))
+                        .collect(joining(", "));
+                throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "Expected implementation %s(%s):%s but java types do not match".formatted(
+                        boundSignature.getName(), expectedTypes, boundSignature.getReturnType().getJavaType().getSimpleName()));
+            }
             return scalarFunctionImplementation.get();
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestParametricScalar.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestParametricScalar.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.spi.block.Block;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.QueryFailedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.StandardTypes.BIGINT;
+import static io.trino.spi.type.StandardTypes.INTEGER;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestParametricScalar
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder()
+                .scalars(InvalidParametricScalarFunctions.class)
+                .build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testException()
+    {
+        assertThatThrownBy(() -> assertions.expression("incompatible_argument_type(1)").evaluate())
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessage("Expected implementation system.builtin.incompatible_argument_type(@SqlType(BIGINT) long):long but java types do not match");
+
+        assertThatThrownBy(() -> assertions.expression("incompatible_noargs()").evaluate())
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessage("Expected implementation system.builtin.incompatible_noargs():long but java types do not match");
+
+        assertThatThrownBy(() -> assertions.expression("incompatible_return_bigint(1)").evaluate())
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessage("Expected implementation system.builtin.incompatible_return_bigint(@SqlType(BIGINT) long):long but java types do not match");
+
+        assertThatThrownBy(() -> assertions.expression("incompatible_return_row_array()").evaluate())
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessage("Expected implementation system.builtin.incompatible_return_row_array():Block but java types do not match");
+    }
+
+    public static class InvalidParametricScalarFunctions
+    {
+        @SqlType(BIGINT)
+        @ScalarFunction("incompatible_argument_type")
+        public long incompatibleArgumentType(@SqlType(BIGINT) int value)
+        {
+            return 0;
+        }
+
+        @SqlType(INTEGER)
+        @ScalarFunction("incompatible_noargs")
+        public Block incompatibleNoArgs()
+        {
+            return null;
+        }
+
+        @SqlType(BIGINT)
+        @ScalarFunction("incompatible_return_bigint")
+        public Block incompatibleReturn(@SqlType(BIGINT) long value)
+        {
+            return null;
+        }
+
+        @SqlType("array(row(varchar))")
+        @ScalarFunction("incompatible_return_row_array")
+        public int rowArray()
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Description
Improved exception message for udf developers.

Instead of:
```
Exact implementation of %s do not match expected java types
```

Throw:
```
Expected implementation system.builtin.incompatible_return(@SqlType(BIGINT) long):long but java types do not match
```

## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
