### PR TITLE
Fix Field#rebuild to copy the original field's branch

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Field.java
@@ -232,6 +232,7 @@ public class Field
             this.type = field.type;
             this.hidden = field.hidden;
             this.originTable = field.originTable;
+            this.originBranch = field.originBranch;
             this.originColumnName = field.originColumnName;
             this.aliased = field.aliased;
         }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -846,7 +846,7 @@ public class TestingAccessControlManager
             this(actorName, (entity, branch) -> entityPredicate.test(entity), type);
         }
 
-        private TestingPrivilege(Optional<String> actorName, BiPredicate<String, Optional<String>> entityPredicate, TestingPrivilegeType type)
+        public TestingPrivilege(Optional<String> actorName, BiPredicate<String, Optional<String>> entityPredicate, TestingPrivilegeType type)
         {
             this.actorName = requireNonNull(actorName, "actorName is null");
             this.entityPredicate = requireNonNull(entityPredicate, "entityPredicate is null");

--- a/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
@@ -24,6 +24,7 @@ import io.trino.spi.type.BigintType;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.StandaloneQueryRunner;
+import io.trino.testing.TestingAccessControlManager.TestingPrivilege;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -97,6 +98,16 @@ final class TestBranchingAccessControl
         assertAccessAllowed(
                 "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'main'",
                 branchPrivilege("nation", "dev", SELECT_COLUMN));
+
+        // corner case: SELECT * creates a synthetic scope:
+        // if branch information is not copied correctly between scopes, it will try to access table with no branch
+        assertAccessAllowed(
+                "SELECT * FROM mock.tiny.nation FOR VERSION AS OF 'main'",
+                new TestingPrivilege(
+                        Optional.empty(),
+                        // deny everywhere except main branch
+                        (entity, branch) -> "nation".equals(entity) && !Optional.of("main").equals(branch),
+                        SELECT_COLUMN));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The `Field.Builder(Field)` constructor did not copy the origin branch from the original field. This is a result of a failed rebase - the builder was added in #29183, which was created after #29179, but merged earlier than it.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
  * NOTE: This is a fix for an unreleased change so it doesn't change anything from the user's perspective

( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
