### PR TITLE
Properly pass the branch name to deny* methods in ReadOnlyAccessControl

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
@@ -156,19 +156,19 @@ public class ReadOnlyAccessControl
     @Override
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
-        denyInsertTable(tableName.toString());
+        denyInsertTable(tableName.toString(), branch);
     }
 
     @Override
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch)
     {
-        denyDeleteTable(tableName.toString());
+        denyDeleteTable(tableName.toString(), branch);
     }
 
     @Override
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Optional<String> branch, Set<String> updatedColumns)
     {
-        denyUpdateTableColumns(tableName.toString(), updatedColumns);
+        denyUpdateTableColumns(tableName.toString(), branch, updatedColumns);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

All the other access control implementations do this, we should do this here for completeness too.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Should have been part of trinodb/trino#29179

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

Well technically it is user-visible but extremely niche. And no users of a released version would be affected.

( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
