### PR TITLE
Use getBranch to get the branch name for table and view accounting

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2445,7 +2445,7 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
                     .build();
             analyzeFiltersAndMasks(table, targetTableName, new RelationType(outputFields), accessControlScope);
-            analysis.registerTable(table, tableHandle, targetTableName, table.getBranch().map(Identifier::getValue), session.getIdentity().getUser(), accessControlScope, Optional.empty());
+            analysis.registerTable(table, tableHandle, targetTableName, getBranchName(table), session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             Scope tableScope = createAndAssignScope(table, scope, outputFields);
 
@@ -2750,7 +2750,7 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(viewFields))
                     .build();
             analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
-            analysis.registerTable(table, freshStorageTable, name, table.getBranch().map(Identifier::getValue), session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
+            analysis.registerTable(table, freshStorageTable, name, getBranchName(table), session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
             viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow()))));
             return createAndAssignScope(table, scope, viewFields);
         }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -182,6 +182,14 @@ public class TestingAccessControlManager
         return new TestingPrivilege(Optional.of(actorName), entityName, Optional.of(branchName), type);
     }
 
+    public static TestingPrivilege allExceptBranchPrivilege(String entityName, String branchName, TestingPrivilegeType type)
+    {
+        return new TestingPrivilege(
+                Optional.empty(),
+                (entity, branch) -> entityName.equals(entity) && !Optional.of(branchName).equals(branch),
+                type);
+    }
+
     public void deny(TestingPrivilege... deniedPrivileges)
     {
         Collections.addAll(this.denyPrivileges, deniedPrivileges);

--- a/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
@@ -246,4 +246,45 @@ final class TestBranchingAccessControl
                 "View owner does not have sufficient privileges: View owner 'owner' cannot create view that selects from branch dev in mock.tiny.nation",
                 privilege("owner", "nation", CREATE_VIEW_WITH_SELECT_COLUMNS));
     }
+
+    @Test
+    void testSelectFromViewBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation_view FOR VERSION AS OF 'dev'",
+                "Cannot select from columns \\[nationkey] in branch dev in table mock.tiny.nation_view",
+                branchPrivilege("nation_view", "dev", SELECT_COLUMN));
+
+        // SELECT from view without branch specifier is still allowed
+        assertAccessAllowed(
+                "SELECT nationkey FROM mock.tiny.nation_view",
+                branchPrivilege("nation_view", "dev", SELECT_COLUMN));
+
+        // SELECT from view with a different branch is still allowed
+        assertAccessAllowed(
+                "SELECT nationkey FROM mock.tiny.nation_view FOR VERSION AS OF 'main'",
+                branchPrivilege("nation_view", "dev", SELECT_COLUMN));
+
+        // only grant on branch allows access
+        assertAccessAllowed(
+                "SELECT nationkey FROM mock.tiny.nation_view FOR VERSION AS OF 'main'",
+                allExceptBranchPrivilege("nation_view", "main", SELECT_COLUMN));
+
+        // corner case: SELECT * creates a synthetic scope:
+        // if branch information is not copied correctly between scopes, it will try to access table with no branch
+        assertAccessAllowed(
+                "SELECT * FROM mock.tiny.nation_view FOR VERSION AS OF 'main'",
+                allExceptBranchPrivilege("nation_view", "main", SELECT_COLUMN));
+    }
+
+    @Test
+    void testSelectFromViewBranchDeniedByTablePrivilege()
+    {
+        // Denying without branch blocks all access, including branch access
+        // (This actually depends on specific semantics of the access control, but at least we'll test the error messages)
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation_view FOR VERSION AS OF 'dev'",
+                "Cannot select from columns \\[nationkey] in branch dev in table mock.tiny.nation_view",
+                privilege("nation_view", SELECT_COLUMN));
+    }
 }

--- a/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
@@ -24,7 +24,6 @@ import io.trino.spi.type.BigintType;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.StandaloneQueryRunner;
-import io.trino.testing.TestingAccessControlManager.TestingPrivilege;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -37,6 +36,7 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
+import static io.trino.testing.TestingAccessControlManager.allExceptBranchPrivilege;
 import static io.trino.testing.TestingAccessControlManager.branchPrivilege;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 
@@ -99,15 +99,16 @@ final class TestBranchingAccessControl
                 "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'main'",
                 branchPrivilege("nation", "dev", SELECT_COLUMN));
 
+        // only grant on branch allows access
+        assertAccessAllowed(
+                "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'main'",
+                allExceptBranchPrivilege("nation", "main", SELECT_COLUMN));
+
         // corner case: SELECT * creates a synthetic scope:
         // if branch information is not copied correctly between scopes, it will try to access table with no branch
         assertAccessAllowed(
                 "SELECT * FROM mock.tiny.nation FOR VERSION AS OF 'main'",
-                new TestingPrivilege(
-                        Optional.empty(),
-                        // deny everywhere except main branch
-                        (entity, branch) -> "nation".equals(entity) && !Optional.of("main").equals(branch),
-                        SELECT_COLUMN));
+                allExceptBranchPrivilege("nation", "main", SELECT_COLUMN));
     }
 
     @Test
@@ -138,6 +139,11 @@ final class TestBranchingAccessControl
         assertAccessAllowed(
                 "INSERT INTO mock.tiny.nation @ main VALUES (101, 'POLAND', 0, 'No comment')",
                 branchPrivilege("nation", "dev", INSERT_TABLE));
+
+        // only grant on branch allows access
+        assertAccessAllowed(
+                "INSERT INTO mock.tiny.nation @ main VALUES (101, 'POLAND', 0, 'No comment')",
+                allExceptBranchPrivilege("nation", "main", INSERT_TABLE));
     }
 
     @Test
@@ -168,6 +174,11 @@ final class TestBranchingAccessControl
         assertAccessAllowed(
                 "DELETE FROM mock.tiny.nation @ main WHERE nationkey < 0",
                 branchPrivilege("nation", "dev", DELETE_TABLE));
+
+        // only grant on branch allows access
+        assertAccessAllowed(
+                "DELETE FROM mock.tiny.nation @ main WHERE nationkey < 0",
+                allExceptBranchPrivilege("nation", "main", DELETE_TABLE));
     }
 
     @Test
@@ -198,6 +209,11 @@ final class TestBranchingAccessControl
         assertAccessAllowed(
                 "UPDATE mock.tiny.nation @ main SET regionkey = 0 WHERE nationkey < 0",
                 branchPrivilege("nation", "dev", UPDATE_TABLE));
+
+        // only grant on branch allows access
+        assertAccessAllowed(
+                "UPDATE mock.tiny.nation @ main SET regionkey = 0 WHERE nationkey < 0",
+                allExceptBranchPrivilege("nation", "main", UPDATE_TABLE));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This is not used for access control, it's only meant to properly account for tables referenced by the query - and the view. If we improperly register the branch, then it won't be found in the `tableColumnReferences` collection in `Analysis#getReferencedTables` and the query will be reported in `QueryStateMachine#referencedTables` as querying no columns in the affected table or view.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #29179

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

  * This is a fix to unreleased code

( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
