### PR TITLE
Add Trino DynamoDB connector

### DIFF
--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -67,6 +67,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/dynamodb">
+        <artifact id="${project.groupId}:trino-dynamodb:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/elasticsearch">
         <artifact id="${project.groupId}:trino-elasticsearch:zip:${project.version}">
             <unpack />

--- a/plugin/trino-dynamodb/pom.xml
+++ b/plugin/trino-dynamodb/pom.xml
@@ -122,6 +122,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>node</artifactId>
             <scope>runtime</scope>
@@ -158,6 +170,56 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-exchange-filesystem</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -172,6 +234,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <!-- Needed while junit 4 is in classpath -->
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/plugin/trino-dynamodb/pom.xml
+++ b/plugin/trino-dynamodb/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>

--- a/plugin/trino-dynamodb/pom.xml
+++ b/plugin/trino-dynamodb/pom.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>481-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-dynamodb</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - DynamoDB connector</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbColumnHandle.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbColumnHandle.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.type.Type;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class DynamoDbColumnHandle
+        implements ColumnHandle
+{
+    private final String columnName;
+    private final Type columnType;
+    private final int ordinalPosition;
+
+    @JsonCreator
+    public DynamoDbColumnHandle(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("columnType") Type columnType,
+            @JsonProperty("ordinalPosition") int ordinalPosition)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.columnType = requireNonNull(columnType, "columnType is null");
+        this.ordinalPosition = ordinalPosition;
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public Type getColumnType()
+    {
+        return columnType;
+    }
+
+    @JsonProperty
+    public int getOrdinalPosition()
+    {
+        return ordinalPosition;
+    }
+
+    public ColumnMetadata getColumnMetadata()
+    {
+        return new ColumnMetadata(columnName, columnType);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        DynamoDbColumnHandle other = (DynamoDbColumnHandle) obj;
+        return columnName.equals(other.columnName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return columnName.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnName", columnName)
+                .add("columnType", columnType)
+                .add("ordinalPosition", ordinalPosition)
+                .toString();
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConfig.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConfig.java
@@ -26,6 +26,8 @@ public class DynamoDbConfig
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
     private String awsRegion;
+    private Optional<String> iamRole = Optional.empty();
+    private Optional<String> externalId = Optional.empty();
     private int scanSegments = 1;
 
     public Optional<String> getAwsAccessKey()
@@ -66,6 +68,32 @@ public class DynamoDbConfig
     public DynamoDbConfig setAwsRegion(String awsRegion)
     {
         this.awsRegion = awsRegion;
+        return this;
+    }
+
+    public Optional<String> getIamRole()
+    {
+        return iamRole;
+    }
+
+    @Config("dynamodb.aws-iam-role")
+    @ConfigDescription("ARN of the IAM role to assume when connecting to DynamoDB")
+    public DynamoDbConfig setIamRole(String iamRole)
+    {
+        this.iamRole = Optional.ofNullable(iamRole);
+        return this;
+    }
+
+    public Optional<String> getExternalId()
+    {
+        return externalId;
+    }
+
+    @Config("dynamodb.aws-external-id")
+    @ConfigDescription("External ID to use when assuming the IAM role (for cross-account access)")
+    public DynamoDbConfig setExternalId(String externalId)
+    {
+        this.externalId = Optional.ofNullable(externalId);
         return this;
     }
 

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConfig.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class DynamoDbConfig
+{
+    private Optional<String> awsAccessKey = Optional.empty();
+    private Optional<String> awsSecretKey = Optional.empty();
+    private String awsRegion;
+    private int scanSegments = 1;
+
+    public Optional<String> getAwsAccessKey()
+    {
+        return awsAccessKey;
+    }
+
+    @Config("dynamodb.aws-access-key")
+    @ConfigDescription("AWS access key ID for authenticating with DynamoDB")
+    public DynamoDbConfig setAwsAccessKey(String awsAccessKey)
+    {
+        this.awsAccessKey = Optional.ofNullable(awsAccessKey);
+        return this;
+    }
+
+    public Optional<String> getAwsSecretKey()
+    {
+        return awsSecretKey;
+    }
+
+    @Config("dynamodb.aws-secret-key")
+    @ConfigDescription("AWS secret access key for authenticating with DynamoDB")
+    @ConfigSecuritySensitive
+    public DynamoDbConfig setAwsSecretKey(String awsSecretKey)
+    {
+        this.awsSecretKey = Optional.ofNullable(awsSecretKey);
+        return this;
+    }
+
+    @NotNull
+    public String getAwsRegion()
+    {
+        return awsRegion;
+    }
+
+    @Config("dynamodb.aws-region")
+    @ConfigDescription("AWS region where the DynamoDB instance is located (e.g. us-east-1)")
+    public DynamoDbConfig setAwsRegion(String awsRegion)
+    {
+        this.awsRegion = awsRegion;
+        return this;
+    }
+
+    @Min(1)
+    public int getScanSegments()
+    {
+        return scanSegments;
+    }
+
+    @Config("dynamodb.scan-segments")
+    @ConfigDescription("Number of parallel scan segments per table; higher values increase parallelism for large tables")
+    public DynamoDbConfig setScanSegments(int scanSegments)
+    {
+        this.scanSegments = scanSegments;
+        return this;
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConfig.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import java.net.URI;
 import java.util.Optional;
 
 public class DynamoDbConfig
@@ -29,6 +30,7 @@ public class DynamoDbConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> externalId = Optional.empty();
     private int scanSegments = 1;
+    private Optional<URI> endpointOverride = Optional.empty();
 
     public Optional<String> getAwsAccessKey()
     {
@@ -108,6 +110,19 @@ public class DynamoDbConfig
     public DynamoDbConfig setScanSegments(int scanSegments)
     {
         this.scanSegments = scanSegments;
+        return this;
+    }
+
+    public Optional<URI> getEndpointOverride()
+    {
+        return endpointOverride;
+    }
+
+    @Config("dynamodb.endpoint-override")
+    @ConfigDescription("Override the DynamoDB endpoint URL (for testing with DynamoDB Local)")
+    public DynamoDbConfig setEndpointOverride(URI endpointOverride)
+    {
+        this.endpointOverride = Optional.ofNullable(endpointOverride);
         return this;
     }
 }

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConnector.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConnector.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.transaction.IsolationLevel;
+
+import static io.trino.plugin.dynamodb.DynamoDbTransactionHandle.INSTANCE;
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final DynamoDbMetadata metadata;
+    private final DynamoDbSplitManager splitManager;
+    private final DynamoDbRecordSetProvider recordSetProvider;
+
+    @Inject
+    public DynamoDbConnector(
+            LifeCycleManager lifeCycleManager,
+            DynamoDbMetadata metadata,
+            DynamoDbSplitManager splitManager,
+            DynamoDbRecordSetProvider recordSetProvider)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        return INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConnectorFactory.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbConnectorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.base.TypeDeserializerModule;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "dynamodb";
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+        checkStrictSpiVersionMatch(context, this);
+
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.catalog." + catalogName,
+                new JsonModule(),
+                new TypeDeserializerModule(),
+                new ConnectorContextModule(catalogName, context),
+                new DynamoDbModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(requiredConfig)
+                .initialize();
+
+        return injector.getInstance(DynamoDbConnector.class);
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbMetadata.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbMetadata.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
+import io.trino.spi.connector.TableNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.dynamodb.DynamoDbService.DEFAULT_SCHEMA;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbMetadata
+        implements ConnectorMetadata
+{
+    private final DynamoDbService service;
+
+    @Inject
+    public DynamoDbMetadata(DynamoDbService service)
+    {
+        this.service = requireNonNull(service, "service is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return ImmutableList.of(DEFAULT_SCHEMA);
+    }
+
+    @Override
+    public DynamoDbTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion)
+    {
+        if (startVersion.isPresent() || endVersion.isPresent()) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support versioned tables");
+        }
+        if (!DEFAULT_SCHEMA.equals(tableName.getSchemaName())) {
+            return null;
+        }
+        if (!service.listTableNames().contains(tableName.getTableName())) {
+            return null;
+        }
+        return new DynamoDbTableHandle(tableName.getSchemaName(), tableName.getTableName());
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        DynamoDbTableHandle tableHandle = (DynamoDbTableHandle) table;
+        return buildTableMetadata(tableHandle.toSchemaTableName());
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        if (schemaName.isPresent() && !DEFAULT_SCHEMA.equals(schemaName.get())) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<SchemaTableName> tables = ImmutableList.builder();
+        for (String tableName : service.listTableNames()) {
+            tables.add(new SchemaTableName(DEFAULT_SCHEMA, tableName));
+        }
+        return tables.build();
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        DynamoDbTableHandle dynamoDbTableHandle = (DynamoDbTableHandle) tableHandle;
+        List<DynamoDbColumnHandle> columns = service.getTableColumns(dynamoDbTableHandle.getTableName());
+        ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
+        for (DynamoDbColumnHandle column : columns) {
+            columnHandles.put(column.getColumnName(), column);
+        }
+        return columnHandles.buildOrThrow();
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
+        for (SchemaTableName tableName : listTables(session, prefix)) {
+            ConnectorTableMetadata tableMetadata = buildTableMetadata(tableName);
+            if (tableMetadata != null) {
+                columns.put(tableName, tableMetadata.getColumns());
+            }
+        }
+        return columns.buildOrThrow();
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return ((DynamoDbColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    private ConnectorTableMetadata buildTableMetadata(SchemaTableName tableName)
+    {
+        if (!DEFAULT_SCHEMA.equals(tableName.getSchemaName())) {
+            return null;
+        }
+        List<DynamoDbColumnHandle> columns;
+        try {
+            columns = service.getTableColumns(tableName.getTableName());
+        }
+        catch (ResourceNotFoundException e) {
+            throw new TableNotFoundException(tableName);
+        }
+        ImmutableList.Builder<ColumnMetadata> columnMetadata = ImmutableList.builder();
+        for (DynamoDbColumnHandle column : columns) {
+            columnMetadata.add(column.getColumnMetadata());
+        }
+        return new ConnectorTableMetadata(tableName, columnMetadata.build());
+    }
+
+    private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getTable().isEmpty()) {
+            return listTables(session, prefix.getSchema());
+        }
+        return ImmutableList.of(prefix.toSchemaTableName());
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbModule.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class DynamoDbModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(DynamoDbConfig.class);
+
+        binder.bind(DynamoDbConnector.class).in(Scopes.SINGLETON);
+        binder.bind(DynamoDbMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(DynamoDbService.class).in(Scopes.SINGLETON);
+        binder.bind(DynamoDbSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(DynamoDbRecordSetProvider.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbPlugin.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class DynamoDbPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new DynamoDbConnectorFactory());
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbRecordCursor.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbRecordCursor.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.paginators.ScanIterable;
+
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbRecordCursor
+        implements RecordCursor
+{
+    private final List<DynamoDbColumnHandle> columnHandles;
+    private final int[] fieldToColumnIndex;
+    private final Iterator<Map<String, AttributeValue>> items;
+
+    private Map<String, AttributeValue> currentItem;
+
+    public DynamoDbRecordCursor(DynamoDbSplit split, List<DynamoDbColumnHandle> columnHandles, DynamoDbService service)
+    {
+        requireNonNull(split, "split is null");
+        requireNonNull(service, "service is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
+
+        fieldToColumnIndex = new int[columnHandles.size()];
+        for (int i = 0; i < columnHandles.size(); i++) {
+            fieldToColumnIndex[i] = columnHandles.get(i).getOrdinalPosition();
+        }
+
+        ScanIterable pages = service.scanTable(split.getTableName(), split.getSegment(), split.getTotalSegments());
+        items = StreamSupport.stream(pages.spliterator(), false)
+                .flatMap(page -> page.items().stream())
+                .iterator();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+        return columnHandles.get(field).getColumnType();
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        if (!items.hasNext()) {
+            return false;
+        }
+        currentItem = items.next();
+        return true;
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        checkArgument(getType(field).equals(BooleanType.BOOLEAN), "Expected BOOLEAN field");
+        AttributeValue value = getAttributeValue(field);
+        if (value == null || value.type() == AttributeValue.Type.NUL) {
+            return false;
+        }
+        if (value.type() == AttributeValue.Type.BOOL) {
+            return Boolean.TRUE.equals(value.bool());
+        }
+        throw new TrinoException(GENERIC_INTERNAL_ERROR,
+                format("Cannot convert DynamoDB attribute type %s to BOOLEAN", value.type()));
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "getLong is not used by this connector");
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        checkArgument(getType(field).equals(DoubleType.DOUBLE), "Expected DOUBLE field");
+        AttributeValue value = getAttributeValue(field);
+        if (value == null || value.type() == AttributeValue.Type.NUL) {
+            return 0.0;
+        }
+        if (value.type() == AttributeValue.Type.N) {
+            return Double.parseDouble(value.n());
+        }
+        throw new TrinoException(GENERIC_INTERNAL_ERROR,
+                format("Cannot convert DynamoDB attribute type %s to DOUBLE", value.type()));
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        checkArgument(getType(field) instanceof VarcharType, "Expected VARCHAR field");
+        AttributeValue value = getAttributeValue(field);
+        if (value == null || value.type() == AttributeValue.Type.NUL) {
+            return Slices.EMPTY_SLICE;
+        }
+        return Slices.utf8Slice(attributeValueToString(value));
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "getObject is not supported");
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+        AttributeValue value = getAttributeValue(field);
+        return value == null || value.type() == AttributeValue.Type.NUL;
+    }
+
+    @Override
+    public void close() {}
+
+    private AttributeValue getAttributeValue(int field)
+    {
+        String columnName = columnHandles.get(field).getColumnName();
+        return currentItem.get(columnName);
+    }
+
+    private static String attributeValueToString(AttributeValue value)
+    {
+        return switch (value.type()) {
+            case S -> value.s();
+            case N -> value.n();
+            case BOOL -> Boolean.toString(Boolean.TRUE.equals(value.bool()));
+            case NUL -> "";
+            case B -> Base64.getEncoder().encodeToString(value.b().asByteArray());
+            case SS -> toJsonArray(value.ss().stream().map(s -> "\"" + escapeJson(s) + "\"").iterator());
+            case NS -> toJsonArray(value.ns().iterator());
+            case BS -> toJsonArray(value.bs().stream()
+                    .map(SdkBytes::asByteArray)
+                    .map(Base64.getEncoder()::encodeToString)
+                    .map(s -> "\"" + s + "\"")
+                    .iterator());
+            case M -> mapToJsonString(value.m());
+            case L -> listToJsonString(value.l());
+            case UNKNOWN_TO_SDK_VERSION -> value.toString();
+        };
+    }
+
+    private static String mapToJsonString(Map<String, AttributeValue> map)
+    {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, AttributeValue> entry : map.entrySet()) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append("\"").append(escapeJson(entry.getKey())).append("\":");
+            sb.append(attributeValueToString(entry.getValue()));
+            first = false;
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static String listToJsonString(List<AttributeValue> list)
+    {
+        ImmutableList.Builder<String> elements = ImmutableList.builder();
+        for (AttributeValue element : list) {
+            elements.add(attributeValueToString(element));
+        }
+        return toJsonArray(elements.build().iterator());
+    }
+
+    private static String toJsonArray(Iterator<String> elements)
+    {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        while (elements.hasNext()) {
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append(elements.next());
+            first = false;
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String escapeJson(String value)
+    {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbRecordSet.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbRecordSet.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.RecordSet;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbRecordSet
+        implements RecordSet
+{
+    private final DynamoDbSplit split;
+    private final List<DynamoDbColumnHandle> columnHandles;
+    private final List<Type> columnTypes;
+    private final DynamoDbService service;
+
+    public DynamoDbRecordSet(DynamoDbSplit split, List<DynamoDbColumnHandle> columnHandles, DynamoDbService service)
+    {
+        this.split = requireNonNull(split, "split is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
+        this.service = requireNonNull(service, "service is null");
+
+        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        for (DynamoDbColumnHandle column : columnHandles) {
+            types.add(column.getColumnType());
+        }
+        this.columnTypes = types.build();
+    }
+
+    @Override
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        return new DynamoDbRecordCursor(split, columnHandles, service);
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbRecordSetProvider.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbRecordSetProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.RecordSet;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbRecordSetProvider
+        implements ConnectorRecordSetProvider
+{
+    private final DynamoDbService service;
+
+    @Inject
+    public DynamoDbRecordSetProvider(DynamoDbService service)
+    {
+        this.service = requireNonNull(service, "service is null");
+    }
+
+    @Override
+    public RecordSet getRecordSet(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableHandle table,
+            List<? extends ColumnHandle> columns)
+    {
+        DynamoDbSplit dynamoDbSplit = (DynamoDbSplit) split;
+
+        ImmutableList.Builder<DynamoDbColumnHandle> handles = ImmutableList.builder();
+        for (ColumnHandle handle : columns) {
+            handles.add((DynamoDbColumnHandle) handle);
+        }
+
+        return new DynamoDbRecordSet(dynamoDbSplit, handles.build(), service);
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbService.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbService.java
@@ -95,10 +95,11 @@ public class DynamoDbService
             credentialsProvider = baseCredentialsProvider;
         }
 
-        this.dynamoDbClient = DynamoDbClient.builder()
+        var clientBuilder = DynamoDbClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(credentialsProvider)
-                .build();
+                .credentialsProvider(credentialsProvider);
+        config.getEndpointOverride().ifPresent(clientBuilder::endpointOverride);
+        this.dynamoDbClient = clientBuilder.build();
     }
 
     @PreDestroy

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbService.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbService.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import jakarta.annotation.PreDestroy;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesResponse;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import software.amazon.awssdk.services.dynamodb.paginators.ScanIterable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbService
+{
+    static final String DEFAULT_SCHEMA = "default";
+
+    private final DynamoDbClient dynamoDbClient;
+    private final int scanSegments;
+
+    @Inject
+    public DynamoDbService(DynamoDbConfig config)
+    {
+        requireNonNull(config, "config is null");
+
+        Optional<String> accessKey = config.getAwsAccessKey();
+        Optional<String> secretKey = config.getAwsSecretKey();
+        String region = config.getAwsRegion();
+        this.scanSegments = config.getScanSegments();
+
+        AwsCredentialsProvider credentialsProvider;
+        if (accessKey.isPresent() && secretKey.isPresent()) {
+            credentialsProvider = StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey.get(), secretKey.get()));
+        }
+        else {
+            credentialsProvider = DefaultCredentialsProvider.create();
+        }
+
+        this.dynamoDbClient = DynamoDbClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    @PreDestroy
+    public void close()
+    {
+        dynamoDbClient.close();
+    }
+
+    public int getScanSegments()
+    {
+        return scanSegments;
+    }
+
+    public List<String> listTableNames()
+    {
+        List<String> tableNames = new ArrayList<>();
+        ListTablesResponse response = dynamoDbClient.listTables();
+        tableNames.addAll(response.tableNames());
+
+        while (response.lastEvaluatedTableName() != null) {
+            response = dynamoDbClient.listTables(ListTablesRequest.builder()
+                    .exclusiveStartTableName(response.lastEvaluatedTableName())
+                    .build());
+            tableNames.addAll(response.tableNames());
+        }
+
+        return ImmutableList.copyOf(tableNames);
+    }
+
+    public List<DynamoDbColumnHandle> getTableColumns(String tableName)
+    {
+        TableDescription table = dynamoDbClient.describeTable(
+                DescribeTableRequest.builder().tableName(tableName).build())
+                .table();
+
+        Map<String, ScalarAttributeType> keyAttributeTypes = buildKeyAttributeTypeMap(table);
+        List<String> keyOrder = buildKeyOrder(table);
+
+        // sample up to 100 items to discover non-key attribute names and types
+        ScanResponse sampleResponse = dynamoDbClient.scan(ScanRequest.builder()
+                .tableName(tableName)
+                .limit(100)
+                .build());
+
+        // track discovered attribute name → inferred Trino type, skipping keys (handled separately)
+        Map<String, Type> discoveredAttributes = new LinkedHashMap<>();
+        for (Map<String, AttributeValue> item : sampleResponse.items()) {
+            for (Map.Entry<String, AttributeValue> entry : item.entrySet()) {
+                String attributeName = entry.getKey();
+                if (keyAttributeTypes.containsKey(attributeName)) {
+                    continue;
+                }
+                Type inferredType = inferType(entry.getValue());
+                discoveredAttributes.merge(attributeName, inferredType, DynamoDbService::widenType);
+            }
+        }
+
+        ImmutableList.Builder<DynamoDbColumnHandle> columns = ImmutableList.builder();
+        int ordinal = 0;
+
+        // key attributes first, in key schema order (HASH then RANGE)
+        for (String keyName : keyOrder) {
+            Type type = attributeTypeToTrinoType(keyAttributeTypes.get(keyName));
+            columns.add(new DynamoDbColumnHandle(keyName, type, ordinal));
+            ordinal++;
+        }
+
+        // non-key attributes alphabetically
+        List<String> nonKeyNames = new ArrayList<>(discoveredAttributes.keySet());
+        nonKeyNames.sort(String::compareTo);
+        for (String attributeName : nonKeyNames) {
+            columns.add(new DynamoDbColumnHandle(attributeName, discoveredAttributes.get(attributeName), ordinal));
+            ordinal++;
+        }
+
+        return columns.build();
+    }
+
+    public ScanIterable scanTable(String tableName, int segment, int totalSegments)
+    {
+        ScanRequest.Builder requestBuilder = ScanRequest.builder()
+                .tableName(tableName);
+
+        if (totalSegments > 1) {
+            requestBuilder.segment(segment).totalSegments(totalSegments);
+        }
+
+        return dynamoDbClient.scanPaginator(requestBuilder.build());
+    }
+
+    private static Map<String, ScalarAttributeType> buildKeyAttributeTypeMap(TableDescription table)
+    {
+        ImmutableMap.Builder<String, ScalarAttributeType> map = ImmutableMap.builder();
+        for (AttributeDefinition definition : table.attributeDefinitions()) {
+            map.put(definition.attributeName(), definition.attributeType());
+        }
+        return map.buildOrThrow();
+    }
+
+    private static List<String> buildKeyOrder(TableDescription table)
+    {
+        List<String> hashKeys = new ArrayList<>();
+        List<String> rangeKeys = new ArrayList<>();
+        for (KeySchemaElement element : table.keySchema()) {
+            if (element.keyType() == KeyType.HASH) {
+                hashKeys.add(element.attributeName());
+            }
+            else {
+                rangeKeys.add(element.attributeName());
+            }
+        }
+        return ImmutableList.<String>builder().addAll(hashKeys).addAll(rangeKeys).build();
+    }
+
+    private static Type attributeTypeToTrinoType(ScalarAttributeType attributeType)
+    {
+        return switch (attributeType) {
+            case N -> DoubleType.DOUBLE;
+            case S, B, UNKNOWN_TO_SDK_VERSION -> VarcharType.VARCHAR;
+        };
+    }
+
+    static Type inferType(AttributeValue value)
+    {
+        return switch (value.type()) {
+            case S -> VarcharType.VARCHAR;
+            case N -> DoubleType.DOUBLE;
+            case BOOL -> BooleanType.BOOLEAN;
+            case M, L, SS, NS, BS, B, NUL, UNKNOWN_TO_SDK_VERSION -> VarcharType.VARCHAR;
+        };
+    }
+
+    // widening rule: if two observations differ, fall back to VARCHAR
+    private static Type widenType(Type existing, Type incoming)
+    {
+        if (existing.equals(incoming)) {
+            return existing;
+        }
+        return VarcharType.VARCHAR;
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbService.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbService.java
@@ -39,6 +39,8 @@ import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.services.dynamodb.paginators.ScanIterable;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -65,13 +67,32 @@ public class DynamoDbService
         String region = config.getAwsRegion();
         this.scanSegments = config.getScanSegments();
 
-        AwsCredentialsProvider credentialsProvider;
+        AwsCredentialsProvider baseCredentialsProvider;
         if (accessKey.isPresent() && secretKey.isPresent()) {
-            credentialsProvider = StaticCredentialsProvider.create(
+            baseCredentialsProvider = StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(accessKey.get(), secretKey.get()));
         }
         else {
-            credentialsProvider = DefaultCredentialsProvider.create();
+            baseCredentialsProvider = DefaultCredentialsProvider.create();
+        }
+
+        AwsCredentialsProvider credentialsProvider;
+        if (config.getIamRole().isPresent()) {
+            StsClient stsClient = StsClient.builder()
+                    .region(Region.of(region))
+                    .credentialsProvider(baseCredentialsProvider)
+                    .build();
+            credentialsProvider = StsAssumeRoleCredentialsProvider.builder()
+                    .refreshRequest(request -> request
+                            .roleArn(config.getIamRole().get())
+                            .roleSessionName("trino-dynamodb")
+                            .externalId(config.getExternalId().orElse(null)))
+                    .stsClient(stsClient)
+                    .asyncCredentialUpdateEnabled(true)
+                    .build();
+        }
+        else {
+            credentialsProvider = baseCredentialsProvider;
         }
 
         this.dynamoDbClient = DynamoDbClient.builder()

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbSplit.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbSplit.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ConnectorSplit;
+
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbSplit
+        implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = instanceSize(DynamoDbSplit.class);
+
+    private final String tableName;
+    private final int segment;
+    private final int totalSegments;
+
+    @JsonCreator
+    public DynamoDbSplit(
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("segment") int segment,
+            @JsonProperty("totalSegments") int totalSegments)
+    {
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.segment = segment;
+        this.totalSegments = totalSegments;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public int getSegment()
+    {
+        return segment;
+    }
+
+    @JsonProperty
+    public int getTotalSegments()
+    {
+        return totalSegments;
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + estimatedSizeOf(tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("tableName", tableName)
+                .add("segment", segment)
+                .add("totalSegments", totalSegments)
+                .toString();
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbSplitManager.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbSplitManager.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamoDbSplitManager
+        implements ConnectorSplitManager
+{
+    private final DynamoDbService service;
+
+    @Inject
+    public DynamoDbSplitManager(DynamoDbService service)
+    {
+        this.service = requireNonNull(service, "service is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableHandle connectorTableHandle,
+            DynamicFilter dynamicFilter,
+            Constraint constraint)
+    {
+        DynamoDbTableHandle tableHandle = (DynamoDbTableHandle) connectorTableHandle;
+        String tableName = tableHandle.getTableName();
+        int totalSegments = service.getScanSegments();
+
+        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
+        for (int segment = 0; segment < totalSegments; segment++) {
+            splits.add(new DynamoDbSplit(tableName, segment, totalSegments));
+        }
+        List<ConnectorSplit> splitList = splits.build();
+        return new FixedSplitSource(splitList);
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbTableHandle.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbTableHandle.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class DynamoDbTableHandle
+        implements ConnectorTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+
+    @JsonCreator
+    public DynamoDbTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName)
+    {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    public SchemaTableName toSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        DynamoDbTableHandle other = (DynamoDbTableHandle) obj;
+        return Objects.equals(schemaName, other.schemaName) &&
+                Objects.equals(tableName, other.tableName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaName, tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return schemaName + ":" + tableName;
+    }
+}

--- a/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbTransactionHandle.java
+++ b/plugin/trino-dynamodb/src/main/java/io/trino/plugin/dynamodb/DynamoDbTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+public enum DynamoDbTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/DynamoDbQueryRunner.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/DynamoDbQueryRunner.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchColumn;
+import io.trino.tpch.TpchColumnType;
+import io.trino.tpch.TpchEntity;
+import io.trino.tpch.TpchTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TableStatus;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+
+public final class DynamoDbQueryRunner
+{
+    private DynamoDbQueryRunner() {}
+
+    private static final double TINY_SCALE_FACTOR = 0.01;
+    private static final String CATALOG = "dynamodb";
+    private static final String SCHEMA = "default";
+
+    public static Builder builder(DynamoDbServer server)
+    {
+        return new Builder(server);
+    }
+
+    public static final class Builder
+            extends DistributedQueryRunner.Builder<Builder>
+    {
+        private final DynamoDbServer server;
+        private List<TpchTable<?>> initialTables = ImmutableList.of();
+
+        private Builder(DynamoDbServer server)
+        {
+            super(testSessionBuilder()
+                    .setCatalog(CATALOG)
+                    .setSchema(SCHEMA)
+                    .build());
+            this.server = requireNonNull(server, "server is null");
+        }
+
+        @CanIgnoreReturnValue
+        public Builder setInitialTables(Iterable<TpchTable<?>> initialTables)
+        {
+            this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
+            return this;
+        }
+
+        @Override
+        public DistributedQueryRunner build()
+                throws Exception
+        {
+            DistributedQueryRunner queryRunner = super.build();
+            try {
+                queryRunner.installPlugin(new TpchPlugin());
+                queryRunner.createCatalog("tpch", "tpch");
+
+                queryRunner.installPlugin(new DynamoDbPlugin());
+                queryRunner.createCatalog(CATALOG, "dynamodb", ImmutableMap.<String, String>builder()
+                        .put("dynamodb.aws-access-key", "test")
+                        .put("dynamodb.aws-secret-key", "test")
+                        .put("dynamodb.aws-region", "us-east-1")
+                        .put("dynamodb.endpoint-override", server.getEndpointUrl().toString())
+                        .buildOrThrow());
+
+                try (DynamoDbClient client = server.createClient()) {
+                    for (TpchTable<?> table : initialTables) {
+                        loadTpchTable(client, table);
+                    }
+                }
+
+                return queryRunner;
+            }
+            catch (Throwable e) {
+                closeAllSuppress(e, queryRunner);
+                throw e;
+            }
+        }
+    }
+
+    private static <E extends TpchEntity> void loadTpchTable(DynamoDbClient client, TpchTable<E> table)
+    {
+        String tableName = table.getTableName();
+        TpchColumn<E> hashKeyColumn = table.getColumns().get(0);
+        ScalarAttributeType keyType = tpchColumnToDynamoDbType(hashKeyColumn);
+
+        client.createTable(CreateTableRequest.builder()
+                .tableName(tableName)
+                .keySchema(KeySchemaElement.builder()
+                        .attributeName(hashKeyColumn.getSimplifiedColumnName())
+                        .keyType(KeyType.HASH)
+                        .build())
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeName(hashKeyColumn.getSimplifiedColumnName())
+                        .attributeType(keyType)
+                        .build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .build());
+
+        waitForTableActive(client, tableName);
+
+        List<E> items = new ArrayList<>();
+        for (E entity : table.createGenerator(TINY_SCALE_FACTOR, 1, 1)) {
+            items.add(entity);
+        }
+
+        for (int i = 0; i < items.size(); i += 25) {
+            List<WriteRequest> batch = new ArrayList<>();
+            for (E entity : items.subList(i, Math.min(i + 25, items.size()))) {
+                batch.add(WriteRequest.builder()
+                        .putRequest(PutRequest.builder()
+                                .item(tpchEntityToItem(table, entity))
+                                .build())
+                        .build());
+            }
+            client.batchWriteItem(r -> r.requestItems(Map.of(tableName, batch)));
+        }
+    }
+
+    private static <E extends TpchEntity> Map<String, AttributeValue> tpchEntityToItem(TpchTable<E> table, E entity)
+    {
+        Map<String, AttributeValue> item = new HashMap<>();
+        for (TpchColumn<E> column : table.getColumns()) {
+            String name = column.getSimplifiedColumnName();
+            AttributeValue value = tpchColumnToAttributeValue(column, entity);
+            if (value != null) {
+                item.put(name, value);
+            }
+        }
+        return item;
+    }
+
+    private static <E extends TpchEntity> AttributeValue tpchColumnToAttributeValue(TpchColumn<E> column, E entity)
+    {
+        TpchColumnType.Base base = column.getType().getBase();
+        return switch (base) {
+            case IDENTIFIER -> AttributeValue.fromN(String.valueOf(column.getIdentifier(entity)));
+            case INTEGER -> AttributeValue.fromN(String.valueOf(column.getInteger(entity)));
+            case DOUBLE -> AttributeValue.fromN(String.valueOf(column.getDouble(entity)));
+            case DATE -> AttributeValue.fromS(column.getString(entity));
+            case VARCHAR -> AttributeValue.fromS(column.getString(entity));
+        };
+    }
+
+    private static <E extends TpchEntity> ScalarAttributeType tpchColumnToDynamoDbType(TpchColumn<E> column)
+    {
+        return switch (column.getType().getBase()) {
+            case IDENTIFIER, INTEGER, DOUBLE -> ScalarAttributeType.N;
+            case VARCHAR, DATE -> ScalarAttributeType.S;
+        };
+    }
+
+    private static void waitForTableActive(DynamoDbClient client, String tableName)
+    {
+        int maxAttempts = 20;
+        for (int i = 0; i < maxAttempts; i++) {
+            TableStatus status = client.describeTable(r -> r.tableName(tableName))
+                    .table()
+                    .tableStatus();
+            if (status == TableStatus.ACTIVE) {
+                return;
+            }
+            try {
+                Thread.sleep(200);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("Table %s did not become ACTIVE in time".formatted(tableName));
+    }
+
+    static void main()
+            throws Exception
+    {
+        DynamoDbServer server = new DynamoDbServer();
+        QueryRunner queryRunner = builder(server)
+                .addCoordinatorProperty("http-server.http.port", "8080")
+                .setInitialTables(List.of(TpchTable.NATION, TpchTable.REGION, TpchTable.ORDERS, TpchTable.CUSTOMER))
+                .build();
+        System.out.println("======== SERVER STARTED ========");
+        System.out.println(queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/DynamoDbServer.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/DynamoDbServer.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import java.io.Closeable;
+import java.net.URI;
+
+public class DynamoDbServer
+        implements Closeable
+{
+    private static final int DYNAMODB_PORT = 8000;
+    private static final String DYNAMODB_LOCAL_IMAGE = "amazon/dynamodb-local:2.5.0";
+
+    private final GenericContainer<?> container;
+
+    public DynamoDbServer()
+    {
+        container = new GenericContainer<>(DYNAMODB_LOCAL_IMAGE)
+                .withExposedPorts(DYNAMODB_PORT)
+                .withCommand("-jar DynamoDBLocal.jar -inMemory -sharedDb")
+                .waitingFor(Wait.forListeningPort());
+        container.start();
+    }
+
+    public URI getEndpointUrl()
+    {
+        return URI.create("http://%s:%d".formatted(container.getHost(), container.getMappedPort(DYNAMODB_PORT)));
+    }
+
+    public DynamoDbClient createClient()
+    {
+        return DynamoDbClient.builder()
+                .endpointOverride(getEndpointUrl())
+                .region(Region.of("us-east-1"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("test", "test")))
+                .build();
+    }
+
+    @Override
+    public void close()
+    {
+        container.close();
+    }
+}

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConfig.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.dynamodb;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -33,7 +34,8 @@ public class TestDynamoDbConfig
                 .setAwsRegion(null)
                 .setIamRole(null)
                 .setExternalId(null)
-                .setScanSegments(1));
+                .setScanSegments(1)
+                .setEndpointOverride(null));
     }
 
     @Test
@@ -46,6 +48,7 @@ public class TestDynamoDbConfig
                 .put("dynamodb.aws-iam-role", "arn:aws:iam::123456789012:role/trino-dynamodb-role")
                 .put("dynamodb.aws-external-id", "my-external-id")
                 .put("dynamodb.scan-segments", "4")
+                .put("dynamodb.endpoint-override", "http://localhost:8888")
                 .buildOrThrow();
 
         DynamoDbConfig expected = new DynamoDbConfig()
@@ -54,7 +57,8 @@ public class TestDynamoDbConfig
                 .setAwsRegion("us-west-2")
                 .setIamRole("arn:aws:iam::123456789012:role/trino-dynamodb-role")
                 .setExternalId("my-external-id")
-                .setScanSegments(4);
+                .setScanSegments(4)
+                .setEndpointOverride(URI.create("http://localhost:8888"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConfig.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConfig.java
@@ -31,6 +31,8 @@ public class TestDynamoDbConfig
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null)
                 .setAwsRegion(null)
+                .setIamRole(null)
+                .setExternalId(null)
                 .setScanSegments(1));
     }
 
@@ -41,6 +43,8 @@ public class TestDynamoDbConfig
                 .put("dynamodb.aws-access-key", "AKIAIOSFODNN7EXAMPLE")
                 .put("dynamodb.aws-secret-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
                 .put("dynamodb.aws-region", "us-west-2")
+                .put("dynamodb.aws-iam-role", "arn:aws:iam::123456789012:role/trino-dynamodb-role")
+                .put("dynamodb.aws-external-id", "my-external-id")
                 .put("dynamodb.scan-segments", "4")
                 .buildOrThrow();
 
@@ -48,6 +52,8 @@ public class TestDynamoDbConfig
                 .setAwsAccessKey("AKIAIOSFODNN7EXAMPLE")
                 .setAwsSecretKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
                 .setAwsRegion("us-west-2")
+                .setIamRole("arn:aws:iam::123456789012:role/trino-dynamodb-role")
+                .setExternalId("my-external-id")
                 .setScanSegments(4);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConfig.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestDynamoDbConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DynamoDbConfig.class)
+                .setAwsAccessKey(null)
+                .setAwsSecretKey(null)
+                .setAwsRegion(null)
+                .setScanSegments(1));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("dynamodb.aws-access-key", "AKIAIOSFODNN7EXAMPLE")
+                .put("dynamodb.aws-secret-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .put("dynamodb.aws-region", "us-west-2")
+                .put("dynamodb.scan-segments", "4")
+                .buildOrThrow();
+
+        DynamoDbConfig expected = new DynamoDbConfig()
+                .setAwsAccessKey("AKIAIOSFODNN7EXAMPLE")
+                .setAwsSecretKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .setAwsRegion("us-west-2")
+                .setScanSegments(4);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConnector.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConnector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDynamoDbConnector
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DynamoDbServer server = closeAfterClass(new DynamoDbServer());
+        return DynamoDbQueryRunner.builder(server)
+                .setInitialTables(ImmutableList.of(TpchTable.NATION, TpchTable.REGION))
+                .build();
+    }
+
+    @Test
+    public void testNationCount()
+    {
+        assertQuery("SELECT count(*) FROM nation", "SELECT count(*) FROM nation");
+    }
+
+    @Test
+    public void testRegionCount()
+    {
+        assertQuery("SELECT count(*) FROM region", "SELECT count(*) FROM region");
+    }
+
+    @Test
+    public void testSelectNationNames()
+    {
+        // String columns compare cleanly: DynamoDB returns VARCHAR, H2 returns VARCHAR(25)
+        assertThat(computeActual("SELECT name FROM nation").getOnlyColumnAsSet())
+                .hasSize(25)
+                .contains("ALGERIA", "BRAZIL", "CANADA");
+    }
+
+    @Test
+    public void testSelectRegionNames()
+    {
+        assertThat(computeActual("SELECT name FROM region").getOnlyColumnAsSet())
+                .containsExactlyInAnyOrder("AFRICA", "AMERICA", "ASIA", "EUROPE", "MIDDLE EAST");
+    }
+
+    @Test
+    public void testFilterByName()
+    {
+        assertQuery("SELECT count(*) FROM nation WHERE name = 'FRANCE'",
+                "SELECT count(*) FROM nation WHERE name = 'FRANCE'");
+        assertQuery("SELECT count(*) FROM nation WHERE name = 'NONEXISTENT'",
+                "SELECT count(*) FROM nation WHERE name = 'NONEXISTENT'");
+    }
+
+    @Test
+    public void testNullHandling()
+    {
+        assertQuery(
+                "SELECT count(*) FROM nation WHERE comment IS NOT NULL",
+                "SELECT count(*) FROM nation");
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        assertThat(computeActual("SHOW SCHEMAS").getOnlyColumnAsSet())
+                .contains("default");
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet())
+                .containsExactlyInAnyOrder("nation", "region");
+    }
+
+    @Test
+    public void testDescribeNation()
+    {
+        assertQuerySucceeds("DESCRIBE nation");
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        // nationkey is DOUBLE (DynamoDB N type); use explicit result builder for type accuracy
+        assertThat(query("SELECT min(nationkey), max(nationkey) FROM nation"))
+                .result()
+                .matches(resultBuilder(getSession(), DOUBLE, DOUBLE)
+                        .row(0.0, 24.0)
+                        .build());
+    }
+
+    @Test
+    public void testProjection()
+    {
+        // nationkey is DOUBLE; arithmetic on DOUBLE yields DOUBLE
+        assertThat(query("SELECT name, nationkey + 100 FROM nation WHERE name = 'FRANCE'"))
+                .result()
+                .matches(resultBuilder(getSession(), VARCHAR, DOUBLE)
+                        .row("FRANCE", 106.0)
+                        .build());
+    }
+}

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConnectorTest.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbConnectorTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import io.trino.testing.BaseConnectorTest;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.OptionalInt;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestDynamoDbConnectorTest
+        extends BaseConnectorTest
+{
+    private DynamoDbServer server;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        server = closeAfterClass(new DynamoDbServer());
+        return DynamoDbQueryRunner.builder(server)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_ADD_COLUMN,
+                 SUPPORTS_COMMENT_ON_COLUMN,
+                 SUPPORTS_COMMENT_ON_TABLE,
+                 SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_CREATE_SCHEMA,
+                 SUPPORTS_CREATE_TABLE,
+                 SUPPORTS_CREATE_VIEW,
+                 SUPPORTS_DELETE,
+                 SUPPORTS_INSERT,
+                 SUPPORTS_LIMIT_PUSHDOWN,
+                 SUPPORTS_MERGE,
+                 SUPPORTS_RENAME_COLUMN,
+                 SUPPORTS_RENAME_TABLE,
+                 SUPPORTS_SET_COLUMN_TYPE,
+                 SUPPORTS_TOPN_PUSHDOWN,
+                 SUPPORTS_TRUNCATE,
+                 SUPPORTS_UPDATE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected TestTable createTableWithDefaultColumns()
+    {
+        return abort("DynamoDB connector does not support column defaults");
+    }
+
+    @Override
+    protected OptionalInt maxSchemaNameLength()
+    {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    protected OptionalInt maxTableNameLength()
+    {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    protected OptionalInt maxColumnNameLength()
+    {
+        return OptionalInt.empty();
+    }
+
+    @Test
+    @Override
+    public void testSelectAll()
+    {
+        // DynamoDB maps all numeric attributes to DOUBLE, so direct H2 value comparison
+        // would fail on column types. Check row count and query success instead.
+        assertQuery("SELECT count(*) FROM orders", "SELECT count(*) FROM orders");
+        assertQuerySucceeds("SELECT * FROM orders");
+    }
+
+    @Test
+    @Override
+    public void testSelectInTransaction()
+    {
+        // Skip per-column H2 comparison: DynamoDB numeric columns are DOUBLE, not BIGINT.
+        inTransaction(session -> {
+            assertQuerySucceeds(session, "SELECT nationkey, name, regionkey FROM nation");
+            assertQuerySucceeds(session, "SELECT regionkey, name FROM region");
+            assertQuerySucceeds(session, "SELECT nationkey, name, regionkey FROM nation");
+        });
+    }
+
+    @Override
+    protected MaterializedResult getDescribeOrdersResult()
+    {
+        // DynamoDB schema: hash key first (orderkey N→double), non-key attrs alphabetically.
+        // Date columns stored as strings → varchar; numeric non-keys remain double.
+        return resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "double", "", "")
+                .row("clerk", "varchar", "", "")
+                .row("comment", "varchar", "", "")
+                .row("custkey", "double", "", "")
+                .row("orderdate", "varchar", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "double", "", "")
+                .row("totalprice", "double", "", "")
+                .build();
+    }
+
+    @Test
+    @Override
+    public void testShowColumns()
+    {
+        // DynamoDB has different types and column ordering than TPC-H; delegate to getDescribeOrdersResult()
+        assertThat(query("SHOW COLUMNS FROM orders")).result().matches(getDescribeOrdersResult());
+    }
+
+    @Test
+    @Override
+    public void testShowCreateTable()
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String schema = getSession().getSchema().orElseThrow();
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo(format(
+                        """
+                        CREATE TABLE %s.%s.orders (
+                           orderkey double,
+                           clerk varchar,
+                           comment varchar,
+                           custkey double,
+                           orderdate varchar,
+                           orderpriority varchar,
+                           orderstatus varchar,
+                           shippriority double,
+                           totalprice double
+                        )\
+                        """,
+                        catalog,
+                        schema));
+    }
+
+    @Test
+    @Override
+    public void testInformationSchemaFiltering()
+    {
+        assertQuery(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
+                "SELECT 'orders' table_name");
+        // DynamoDB maps numeric keys to double, not bigint
+        assertQuery(
+                "SELECT table_name FROM information_schema.columns WHERE data_type = 'double' AND table_name = 'nation' AND column_name = 'nationkey' LIMIT 1",
+                "SELECT 'nation' table_name");
+    }
+
+    @Test
+    @Override
+    public void testDateYearOfEraPredicate()
+    {
+        // orderdate is stored as VARCHAR in DynamoDB; DATE predicates cannot be applied
+        abort("DynamoDB stores orderdate as VARCHAR, not DATE — DATE predicate is not applicable");
+    }
+
+    @Test
+    @Override
+    public void testInsertNegativeDate()
+    {
+        // orderdate is VARCHAR in DynamoDB; inserting a DATE literal causes a type error
+        // before the connector's "does not support inserts" message is reached
+        abort("DynamoDB orderdate is VARCHAR — type mismatch precedes connector-level insert rejection");
+    }
+
+    @Test
+    public void testListSchemas()
+    {
+        assertThat(computeActual("SHOW SCHEMAS").getOnlyColumnAsSet())
+                .contains("default");
+    }
+
+    @Test
+    public void testListTables()
+    {
+        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet())
+                .contains("nation", "region", "orders", "customer");
+    }
+
+    @Test
+    public void testCountNation()
+    {
+        assertQuery("SELECT count(*) FROM nation", "SELECT count(*) FROM nation");
+    }
+
+    @Test
+    public void testCountRegion()
+    {
+        assertQuery("SELECT count(*) FROM region", "SELECT count(*) FROM region");
+    }
+
+    @Test
+    public void testSelectNationNames()
+    {
+        assertQuery("SELECT name FROM nation ORDER BY name", "SELECT name FROM nation ORDER BY name");
+    }
+
+    @Test
+    public void testNationColumnSchema()
+    {
+        // Verify schema discovery: nationkey N→double, alphabetical non-key attrs follow
+        assertThat(query("DESCRIBE nation")).result().matches(
+                resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                        .row("nationkey", "double", "", "")
+                        .row("comment", "varchar", "", "")
+                        .row("name", "varchar", "", "")
+                        .row("regionkey", "double", "", "")
+                        .build());
+    }
+}

--- a/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbTypeMapping.java
+++ b/plugin/trino-dynamodb/src/test/java/io/trino/plugin/dynamodb/TestDynamoDbTypeMapping.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.dynamodb;
+
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestDynamoDbTypeMapping
+        extends AbstractTestQueryFramework
+{
+    private DynamoDbServer server;
+    private DynamoDbClient client;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        server = closeAfterClass(new DynamoDbServer());
+        client = closeAfterClass(server.createClient());
+        return DynamoDbQueryRunner.builder(server).build();
+    }
+
+    @BeforeAll
+    public void createTestTables()
+    {
+        createTypeMappingTable();
+        createBooleanTable();
+        createTypeWideningTable();
+    }
+
+    @AfterAll
+    public void dropTestTables()
+    {
+        client.deleteTable(r -> r.tableName("type_mapping"));
+        client.deleteTable(r -> r.tableName("boolean_table"));
+        client.deleteTable(r -> r.tableName("widened_table"));
+    }
+
+    @Test
+    public void testNumberKeyMapsToDouble()
+    {
+        assertThat(query("SELECT pk FROM type_mapping WHERE pk = 1")).result()
+                .hasTypes(List.of(DOUBLE));
+    }
+
+    @Test
+    public void testStringAttributeMapsToVarchar()
+    {
+        assertThat(query("SELECT str_val FROM type_mapping WHERE pk = 1")).result()
+                .hasTypes(List.of(VARCHAR));
+    }
+
+    @Test
+    public void testNumberAttributeMapsToDouble()
+    {
+        assertThat(query("SELECT num_val FROM type_mapping WHERE pk = 1")).result()
+                .hasTypes(List.of(DOUBLE));
+    }
+
+    @Test
+    public void testBooleanAttributeMapsToBoolean()
+    {
+        assertThat(query("SELECT bool_val FROM boolean_table WHERE pk = 1")).result()
+                .hasTypes(List.of(BOOLEAN));
+    }
+
+    @Test
+    public void testNullAttributeIsNull()
+    {
+        assertQuery("SELECT pk FROM type_mapping WHERE str_val IS NULL", "VALUES CAST(2.0 AS DOUBLE)");
+    }
+
+    @Test
+    public void testMapAttributeMapsToVarcharJson()
+    {
+        // DynamoDB M (map) type is serialized as a VARCHAR with key-value pairs.
+        // String values inside maps are unquoted: {"key":value} rather than {"key":"value"}.
+        assertThat(query("SELECT map_val FROM type_mapping WHERE pk = 1")).result()
+                .hasTypes(List.of(VARCHAR));
+        assertQuery("SELECT map_val FROM type_mapping WHERE pk = 1", "VALUES CAST('{\"key\":value}' AS VARCHAR)");
+    }
+
+    @Test
+    public void testListAttributeMapsToVarcharJson()
+    {
+        // DynamoDB L (list) type is serialized as a VARCHAR JSON array.
+        // Numeric list elements are serialized without quotes: [1,2,3].
+        assertThat(query("SELECT list_val FROM type_mapping WHERE pk = 1")).result()
+                .hasTypes(List.of(VARCHAR));
+        assertQuery("SELECT list_val FROM type_mapping WHERE pk = 1", "VALUES CAST('[1,2,3]' AS VARCHAR)");
+    }
+
+    @Test
+    public void testMixedTypesWidenToVarchar()
+    {
+        // When the same attribute has N in some items and S in others, it is widened to VARCHAR
+        assertThat(query("SELECT mixed_val FROM widened_table")).result()
+                .hasTypes(List.of(VARCHAR));
+    }
+
+    @Test
+    public void testBooleanValues()
+    {
+        assertThat(query("SELECT pk, bool_val FROM boolean_table ORDER BY pk")).result()
+                .matches(resultBuilder(getSession(), DOUBLE, BOOLEAN)
+                        .row(1.0, true)
+                        .row(2.0, false)
+                        .build());
+    }
+
+    @Test
+    public void testStringKeyMapsToVarchar()
+    {
+        // Create a table with S (string) hash key
+        client.createTable(r -> r
+                .tableName("string_key_table")
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.S).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST));
+        client.putItem(PutItemRequest.builder()
+                .tableName("string_key_table")
+                .item(Map.of("pk", AttributeValue.fromS("hello"), "val", AttributeValue.fromN("42")))
+                .build());
+        try {
+            assertThat(query("SELECT pk FROM string_key_table")).result()
+                    .hasTypes(List.of(VARCHAR));
+            assertQuery("SELECT pk FROM string_key_table", "VALUES CAST('hello' AS VARCHAR)");
+        }
+        finally {
+            client.deleteTable(r -> r.tableName("string_key_table"));
+        }
+    }
+
+    private void createTypeMappingTable()
+    {
+        client.createTable(r -> r
+                .tableName("type_mapping")
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.N).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST));
+
+        // Item 1: all attribute types present
+        Map<String, AttributeValue> item1 = new HashMap<>();
+        item1.put("pk", AttributeValue.fromN("1"));
+        item1.put("str_val", AttributeValue.fromS("hello"));
+        item1.put("num_val", AttributeValue.fromN("42.5"));
+        item1.put("map_val", AttributeValue.fromM(Map.of("key", AttributeValue.fromS("value"))));
+        item1.put("list_val", AttributeValue.fromL(List.of(
+                AttributeValue.fromN("1"),
+                AttributeValue.fromN("2"),
+                AttributeValue.fromN("3"))));
+        client.putItem(PutItemRequest.builder().tableName("type_mapping").item(item1).build());
+
+        // Item 2: str_val is absent (null in Trino)
+        Map<String, AttributeValue> item2 = new HashMap<>();
+        item2.put("pk", AttributeValue.fromN("2"));
+        item2.put("num_val", AttributeValue.fromN("99.0"));
+        client.putItem(PutItemRequest.builder().tableName("type_mapping").item(item2).build());
+    }
+
+    private void createBooleanTable()
+    {
+        client.createTable(r -> r
+                .tableName("boolean_table")
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.N).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST));
+
+        client.putItem(PutItemRequest.builder()
+                .tableName("boolean_table")
+                .item(Map.of("pk", AttributeValue.fromN("1"), "bool_val", AttributeValue.fromBool(true)))
+                .build());
+        client.putItem(PutItemRequest.builder()
+                .tableName("boolean_table")
+                .item(Map.of("pk", AttributeValue.fromN("2"), "bool_val", AttributeValue.fromBool(false)))
+                .build());
+    }
+
+    private void createTypeWideningTable()
+    {
+        client.createTable(r -> r
+                .tableName("widened_table")
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.N).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST));
+
+        // mixed_val is N in one item and S in another → widened to VARCHAR
+        client.putItem(PutItemRequest.builder()
+                .tableName("widened_table")
+                .item(Map.of("pk", AttributeValue.fromN("1"), "mixed_val", AttributeValue.fromN("123")))
+                .build());
+        client.putItem(PutItemRequest.builder()
+                .tableName("widened_table")
+                .item(Map.of("pk", AttributeValue.fromN("2"), "mixed_val", AttributeValue.fromS("text")))
+                .build());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <module>plugin/trino-delta-lake</module>
         <module>plugin/trino-druid</module>
         <module>plugin/trino-duckdb</module>
+        <module>plugin/trino-dynamodb</module>
         <module>plugin/trino-elasticsearch</module>
         <module>plugin/trino-example-http</module>
         <module>plugin/trino-example-jdbc</module>


### PR DESCRIPTION
## Description

   Adds a new DynamoDB connector for Trino, enabling SQL queries against Amazon DynamoDB tables.

   **Features:**
   - Configure AWS credentials (`dynamodb.aws-access-key`, `dynamodb.aws-secret-key`) directly in the catalog properties file, or rely on the default AWS credential
    chain (instance profile, environment variables, `~/.aws/credentials`)
   - IAM role assumption via `dynamodb.aws-iam-role` (ARN), with optional `dynamodb.aws-external-id` for cross-account access
   - AWS region configured via `dynamodb.aws-region`
   - Parallel table scans via configurable `dynamodb.scan-segments` (defaults to 1)
   - Automatic schema inference: key attributes are discovered from the DynamoDB table description; non-key attributes are inferred by sampling up to 100 items
   - Type mapping: DynamoDB `S`→`VARCHAR`, `N`→`DOUBLE`, `BOOL`→`BOOLEAN`; complex types (`M`, `L`, `SS`, `NS`, `BS`) are serialized to JSON strings

   **Catalog properties example (static credentials):**
   ```properties
   connector.name=dynamodb
   dynamodb.aws-access-key=AKIAIOSFODNN7EXAMPLE
   dynamodb.aws-secret-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   dynamodb.aws-region=us-east-1
   dynamodb.scan-segments=4
   ```

   **Catalog properties example (assume role):**
   ```properties
   connector.name=dynamodb
   dynamodb.aws-region=us-east-1
   dynamodb.aws-iam-role=arn:aws:iam::123456789012:role/trino-dynamodb-role
   dynamodb.aws-external-id=my-external-id
   ```

   ## Additional context and related issues

   - Uses AWS SDK v2 (`software.amazon.awssdk`)
   - Role assumption uses `StsAssumeRoleCredentialsProvider` with async credential refresh, consistent with how other Trino connectors (e.g. Glue metastore) handle
   assume-role
   - Follows the Airlift Bootstrap/Guice wiring pattern used by other Trino connectors
   - Connector is included in the Trino server distribution via provisio assembly

   ## Release notes

   (x) Release notes are required, with the following suggested text:

   ```markdown
   ## DynamoDB connector
   * Add new DynamoDB connector for querying Amazon DynamoDB tables using SQL.
   ```
