### PR TITLE
Fix thread-safety issue in ExtraCredentialsBasedIdentityCacheMapping

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedIdentityCacheMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedIdentityCacheMapping.java
@@ -13,13 +13,13 @@
  */
 package io.trino.plugin.jdbc;
 
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
 import io.trino.plugin.base.cache.identity.IdentityCacheMapping;
 import io.trino.plugin.jdbc.credential.ExtraCredentialConfig;
 import io.trino.spi.connector.ConnectorSession;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -29,19 +29,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public final class ExtraCredentialsBasedIdentityCacheMapping
         implements IdentityCacheMapping
 {
-    private final MessageDigest sha256;
+    private static final HashFunction SHA256 = Hashing.sha256();
+
     private final Optional<String> userCredentialName;
     private final Optional<String> passwordCredentialName;
 
     @Inject
     public ExtraCredentialsBasedIdentityCacheMapping(ExtraCredentialConfig config)
     {
-        try {
-            sha256 = MessageDigest.getInstance("SHA-256");
-        }
-        catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
         userCredentialName = config.getUserCredentialName();
         passwordCredentialName = config.getPasswordCredentialName();
     }
@@ -59,7 +54,7 @@ public final class ExtraCredentialsBasedIdentityCacheMapping
 
     private byte[] hash(String value)
     {
-        return sha256.digest(value.getBytes(UTF_8));
+        return SHA256.hashString(value, UTF_8).asBytes();
     }
 
     private static final class ExtraCredentialsBasedIdentityCacheKey


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`ExtraCredentialsBasedIdentityCacheMapping` stores a `MessageDigest` instance as a                                                                                                                                                                                                                                                                                                 
  singleton field and calls `sha256.digest()` from multiple threads concurrently.
  `MessageDigest` is not thread-safe per [JDK-8009635](https://bugs.openjdk.org/browse/JDK-8009635),                                                                                                                                                                                                                                                                                 
  so concurrent access corrupts the internal buffer state, producing an                                                                                                                                                                                                                                                                                                              
  `ArrayIndexOutOfBoundsException` with a negative `arraycopy` length during                                                                                                                                                                                                                                                                                                         
  query planning when extra credentials are in use.                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                     
  The fix                                                                                                                                                                                                                                                                                 drop the shared field and call `MessageDigest.getInstance("SHA-256")` inside `hash()`                                                                                                                                                                                                                                                                                              
  so each invocation gets a fresh, unshared instance.                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                     
  ## Stack trace                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                     
 ```
 java.lang.ArrayIndexOutOfBoundsException: arraycopy: length -40 is negative
        at java.base/java.lang.System.arraycopy(Native Method)
        at java.base/sun.security.provider.DigestBase.engineUpdate(DigestBase.java:117)                                                                                                                                                                                                                                                                                              
        at java.base/sun.security.provider.SHA2.implDigest(SHA2.java:110)
        at java.base/sun.security.provider.DigestBase.engineDigest(DigestBase.java:205)                                                                                                                                                                                                                                                                                              
        at java.base/sun.security.provider.DigestBase.engineDigest(DigestBase.java:185)
        at java.base/java.security.MessageDigest$Delegate.engineDigest(MessageDigest.java:675)                                                                                                                                                                                                                                                                                       
        at java.base/java.security.MessageDigest.digest(MessageDigest.java:387)
        at java.base/java.security.MessageDigest.digest(MessageDigest.java:433)                                                                                                                                                                                                                                                                                                      
        at io.trino.plugin.jdbc.ExtraCredentialsBasedIdentityCacheMapping.hash(ExtraCredentialsBasedIdentityCacheMapping.java:61)
        at java.base/java.util.Optional.map(Optional.java:260)                                                                                                                                                                                                                                                                                                                       
        at io.trino.plugin.jdbc.ExtraCredentialsBasedIdentityCacheMapping.getRemoteUserCacheKey(ExtraCredentialsBasedIdentityCacheMapping.java:54)
        at io.trino.plugin.jdbc.CachingJdbcClient.getIdentityKey(CachingJdbcClient.java:688)                                                                                                                                                                                                                                                                                         
        at io.trino.plugin.jdbc.CachingJdbcClient.getColumns(CachingJdbcClient.java:181)
        at io.trino.plugin.jdbc.DefaultJdbcMetadata.getTableSchema(DefaultJdbcMetadata.java:1047)                                                                                                                                                                                                                                                                                    
        at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getTableSchema(ClassLoaderSafeConnectorMetadata.java:265)
        at io.trino.tracing.TracingConnectorMetadata.getTableSchema(TracingConnectorMetadata.java:233)                                                                                                                                                                                                                                                                               
        at io.trino.metadata.MetadataManager.getTableSchema(MetadataManager.java:473)                                                                                                                                                                                                                                                                                                
        at io.trino.tracing.TracingMetadata.getTableSchema(TracingMetadata.java:295)                                                                                                                                                                                                                                                                                                 
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:2300)                                                                                                                                                                                                                                                                                   
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:522)                                                                                                                                                                                                                                                                                    
        at io.trino.sql.tree.Table.accept(Table.java:60)                                                                                                                                                                                                                                                                                                                             
        at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)                                                                                                                                                                                                                                                                                                                  
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:541)                                                                                                                                                                                                                                                                                       
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:4922)                                                                                                                                                                                                                                                                                  
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:3098)
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:522)                                                                                                                                                                                                                                                                       
        at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)                                                                                                                                                                                                                                                                                                  
        at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)                                                                                                                                                                                                                                                                                                                  
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:541)                                                                                                                                                                                                                                                                                       
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:549)                                                                                                                                                                                                                                                                                       
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1565)
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:522)                                                                                                                                                                                                                                                                                    
        at io.trino.sql.tree.Query.accept(Query.java:130)                                                                                                                                                                                                                                                                                                                            
        at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)                                                                                                                                                                                                                                                                                                                  
        at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:541)                                                                                                                                                                                                                                                                                       
        at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:501)                                                                                                                                                                                                                                                                                               
        at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:490)
        at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:98)                                                                                                                                                                                                                                                                                                                  
        at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:87)
        at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:326)                                                                                                                                                                                                                                                                                                  
        at io.trino.execution.SqlQueryExecution.(SqlQueryExecution.java:234)
        at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:953)                                                                                                                                                                                                                                                            
        at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:160)                                                                                                                                                                                                                                                            
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)                                                                                                                                                                                                                       
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)                                                                                                                                                                                                                                                                                        
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)                                                                                                                                                                                                                                                                    
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)                                                                                                                                                                                                                                                                                 
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
        at java.base/java.lang.Thread.run(Thread.java:1447)  
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
