### PR TITLE
Fix column-level permissions in SQL Server connector

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -80,7 +80,6 @@ import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
@@ -137,6 +136,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -571,27 +571,25 @@ public class SqlServerClient
     @Override
     protected Map<String, CaseSensitivity> getCaseSensitivityForColumns(ConnectorSession session, Connection connection, SchemaTableName schemaTableName, RemoteTableName remoteTableName)
     {
-        PreparedQuery preparedQuery = new PreparedQuery(format("SELECT * FROM %s", quoted(remoteTableName)), ImmutableList.of());
+        return Jdbi.open(connection).createQuery("""
+                                                 SELECT c.name AS column_name, c.collation_name FROM sys.columns c
+                                                 INNER JOIN sys.tables t ON c.object_id = t.object_id
+                                                 INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                                                 WHERE s.name = :schema_name AND t.name = :table_name
+                                                 """)
+                .bind("schema_name", remoteTableName.getSchemaName().orElseThrow())
+                .bind("table_name", remoteTableName.getTableName())
+                .collectRows(toImmutableMap(rowView -> rowView.getColumn("column_name", String.class),
+                        rowView -> toCaseSensitivity(rowView.getColumn("collation_name", String.class))));
+    }
 
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery, Optional.empty())) {
-            ResultSetMetaData metadata = preparedStatement.getMetaData();
-            ImmutableMap.Builder<String, CaseSensitivity> columns = ImmutableMap.builder();
-            for (int column = 1; column <= metadata.getColumnCount(); column++) {
-                String name = metadata.getColumnName(column);
-                columns.put(name, metadata.isCaseSensitive(column) ? CASE_SENSITIVE : CASE_INSENSITIVE);
-            }
-            return columns.buildOrThrow();
+    private static CaseSensitivity toCaseSensitivity(String collation)
+    {
+        if (collation == null || collation.isEmpty()) {
+            return CASE_INSENSITIVE;
         }
-        catch (SQLException e) {
-            if (e instanceof SQLServerException sqlServerException && sqlServerException.getSQLServerError().getErrorNumber() == 208) {
-                // The 208 indicates that the object doesn't exist or lack of permission.
-                // Throw TableNotFoundException because users shouldn't see such tables if they don't have the permission.
-                // TableNotFoundException will be suppressed when listing information_schema.
-                // https://learn.microsoft.com/sql/relational-databases/errors-events/mssqlserver-208-database-engine-error
-                throw new TableNotFoundException(schemaTableName);
-            }
-            throw new TrinoException(JDBC_ERROR, "Failed to get case sensitivity for columns. " + requireNonNullElse(e.getMessage(), e), e);
-        }
+        // https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support
+        return collation.contains("_BIN") || collation.contains("_BIN2") || collation.contains("_CS") ? CASE_SENSITIVE : CASE_INSENSITIVE;
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerColumnLevelPermissions.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerColumnLevelPermissions.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.sqlserver;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+
+final class TestSqlServerColumnLevelPermissions
+        extends AbstractTestQueryFramework
+{
+    private TestTable testTable;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingSqlServer sqlServer = closeAfterClass(new TestingSqlServer());
+
+        String limitedUser = "limited_user" + randomNameSuffix();
+        String password = "A_sTr0nG_p4s$word";
+        sqlServer.execute("CREATE LOGIN %s WITH PASSWORD = '%s'".formatted(limitedUser, password));
+        sqlServer.execute("CREATE USER %s FOR LOGIN %s".formatted(limitedUser, limitedUser));
+
+        testTable = closeAfterClass(
+                new TestTable(sqlServer::execute, "test_column_permissions",
+                        "(id INT, allowed_column VARCHAR(50), denied_column VARCHAR(50))",
+                        ImmutableList.of("1, 'foo', 'secret'")));
+        sqlServer.execute("GRANT SELECT ON dbo.%s TO %s".formatted(testTable.getName(), limitedUser));
+        sqlServer.execute("DENY SELECT ON dbo.%s (denied_column) TO %s".formatted(testTable.getName(), limitedUser));
+
+        return SqlServerQueryRunner.builder(sqlServer)
+                .addConnectorProperties(Map.of(
+                        "connection-user", limitedUser,
+                        "connection-password", password))
+                .build();
+    }
+
+    @Test
+    void testSelectPermittedColumn()
+    {
+        assertQuery("SELECT allowed_column FROM " + testTable.getName(), "VALUES ('foo')");
+    }
+
+    @Test
+    void testSelectStarFails()
+    {
+        assertQueryFails("SELECT * FROM " + testTable.getName(), ".*SELECT permission was denied.*");
+    }
+
+    @Test
+    void testSelectDeniedColumnFails()
+    {
+        assertQueryFails("SELECT denied_column FROM " + testTable.getName(), ".*SELECT permission was denied.*");
+    }
+
+    @Test
+    void testDescribe()
+    {
+        assertQuery("DESCRIBE " + testTable.getName(), """
+                                                       VALUES ('id', 'integer', '', ''),
+                                                              ('allowed_column', 'varchar(50)', '', ''),
+                                                              ('denied_column', 'varchar(50)', '', '')
+                                                       """);
+    }
+}


### PR DESCRIPTION
## Description

When the connection user has a DENY permission on some columns in a particular table, any query from that table fails, even when querying only allowed columns. Errors look like:

```
Failed to get case sensitivity for columns.
The SELECT permission was denied on the column 'sensitive_data'
```

This happens because `getCaseSensitivityForColumns` tries to get metadata for the query `SELECT * FROM <table>`.

To fix this, we can query `sys.columns` instead.

## Additional context and related issues

- https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-columns-transact-sql
- Same issue in MySQL connector: https://github.com/trinodb/trino/issues/20270

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SQL Server connector
* Fix permission failure when reading tables. ({issue}`29244`)
```
