### PR TITLE
Use DELTA_LENGTH_BYTE_ARRAY encoding in the parquet writer

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -78,6 +78,12 @@ with Parquet files performed by supported object storage connectors:
   - Maximum number of rows processed by the parquet writer in a batch.
     The equivalent catalog session property is `parquet_writer_batch_size`.
   - `10000`
+* - `parquet.writer.delta-length-byte-array-encoding-enabled`
+  - Use `DELTA_LENGTH_BYTE_ARRAY` encoding for `BYTE_ARRAY` columns when
+    the Parquet dictionary encoding is not effective. Defaults to `false`
+    for the Iceberg connector because iceberg-arrow's vectorized parquet
+    reader does not support this encoding in older iceberg versions.
+  - `true` (Hive, Delta Lake); `false` (Iceberg)
 * - `parquet.use-bloom-filter`
   - Whether bloom filters are used for predicate pushdown when reading Parquet
     files. Set this property to `false` to disable the usage of bloom filters by

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -33,6 +33,7 @@ public class ParquetWriterOptions
     public static final int DEFAULT_BATCH_SIZE = 10_000;
     public static final DataSize DEFAULT_MAX_BLOOM_FILTER_SIZE = DataSize.of(1, MEGABYTE);
     public static final double DEFAULT_BLOOM_FILTER_FPP = 0.05;
+    public static final boolean DEFAULT_USE_DELTA_LENGTH_BYTE_ARRAY_ENCODING = true;
 
     public static ParquetWriterOptions.Builder builder()
     {
@@ -47,6 +48,7 @@ public class ParquetWriterOptions
     private final double bloomFilterFpp;
     // Set of column dot paths to columns with bloom filters
     private final Set<String> bloomFilterColumns;
+    private final boolean useDeltaLengthByteArrayEncoding;
 
     private ParquetWriterOptions(
             DataSize maxBlockSize,
@@ -55,7 +57,8 @@ public class ParquetWriterOptions
             int batchSize,
             DataSize maxBloomFilterSize,
             double bloomFilterFpp,
-            Set<String> bloomFilterColumns)
+            Set<String> bloomFilterColumns,
+            boolean useDeltaLengthByteArrayEncoding)
     {
         this.maxRowGroupSize = Ints.saturatedCast(maxBlockSize.toBytes());
         this.maxPageSize = Ints.saturatedCast(maxPageSize.toBytes());
@@ -64,6 +67,7 @@ public class ParquetWriterOptions
         this.maxBloomFilterSize = Ints.saturatedCast(maxBloomFilterSize.toBytes());
         this.bloomFilterFpp = bloomFilterFpp;
         this.bloomFilterColumns = ImmutableSet.copyOf(bloomFilterColumns);
+        this.useDeltaLengthByteArrayEncoding = useDeltaLengthByteArrayEncoding;
         checkArgument(this.bloomFilterFpp > 0.0 && this.bloomFilterFpp < 1.0, "bloomFilterFpp should be > 0.0 & < 1.0");
     }
 
@@ -102,6 +106,11 @@ public class ParquetWriterOptions
         return bloomFilterFpp;
     }
 
+    public boolean isUseDeltaLengthByteArrayEncoding()
+    {
+        return useDeltaLengthByteArrayEncoding;
+    }
+
     public static class Builder
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
@@ -111,6 +120,7 @@ public class ParquetWriterOptions
         private DataSize maxBloomFilterSize = DEFAULT_MAX_BLOOM_FILTER_SIZE;
         private Set<String> bloomFilterColumns = ImmutableSet.of();
         private double bloomFilterFpp = DEFAULT_BLOOM_FILTER_FPP;
+        private boolean useDeltaLengthByteArrayEncoding = DEFAULT_USE_DELTA_LENGTH_BYTE_ARRAY_ENCODING;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -154,6 +164,12 @@ public class ParquetWriterOptions
             return this;
         }
 
+        public Builder setUseDeltaLengthByteArrayEncoding(boolean useDeltaLengthByteArrayEncoding)
+        {
+            this.useDeltaLengthByteArrayEncoding = useDeltaLengthByteArrayEncoding;
+            return this;
+        }
+
         public ParquetWriterOptions build()
         {
             return new ParquetWriterOptions(
@@ -163,7 +179,8 @@ public class ParquetWriterOptions
                     batchSize,
                     maxBloomFilterSize,
                     bloomFilterFpp,
-                    bloomFilterColumns);
+                    bloomFilterColumns,
+                    useDeltaLengthByteArrayEncoding);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -182,7 +182,7 @@ final class ParquetWriters
             ParquetWriterOptions writerOptions,
             Optional<DateTimeZone> parquetTimeZone)
     {
-        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(writerOptions.getMaxPageSize(), DEFAULT_DICTIONARY_PAGE_SIZE);
+        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(writerOptions, DEFAULT_DICTIONARY_PAGE_SIZE);
         WriteBuilder writeBuilder = new WriteBuilder(
                 messageType,
                 trinoTypes,

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TrinoValuesWriterFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TrinoValuesWriterFactory.java
@@ -13,11 +13,13 @@
  */
 package io.trino.parquet.writer.valuewriter;
 
+import io.trino.parquet.writer.ParquetWriterOptions;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
 import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
 import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
@@ -37,11 +39,13 @@ public class TrinoValuesWriterFactory
 
     private final int maxPageSize;
     private final int maxDictionaryPageSize;
+    private final boolean useDeltaLengthByteArrayEncoding;
 
-    public TrinoValuesWriterFactory(int maxPageSize, int maxDictionaryPageSize)
+    public TrinoValuesWriterFactory(ParquetWriterOptions writerOptions, int maxDictionaryPageSize)
     {
-        this.maxPageSize = maxPageSize;
+        this.maxPageSize = writerOptions.getMaxPageSize();
         this.maxDictionaryPageSize = maxDictionaryPageSize;
+        this.useDeltaLengthByteArrayEncoding = writerOptions.isUseDeltaLengthByteArrayEncoding();
     }
 
     public ValuesWriter newValuesWriter(ColumnDescriptor descriptor, Optional<BloomFilter> bloomFilter)
@@ -66,7 +70,13 @@ public class TrinoValuesWriterFactory
 
     private ValuesWriter getBinaryValuesWriter(ColumnDescriptor path, Optional<BloomFilter> bloomFilter)
     {
-        ValuesWriter fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        ValuesWriter fallbackWriter;
+        if (useDeltaLengthByteArrayEncoding) {
+            fallbackWriter = new DeltaLengthByteArrayValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        }
+        else {
+            fallbackWriter = new PlainValuesWriter(INITIAL_SLAB_SIZE, maxPageSize, new HeapByteBufferAllocator());
+        }
         return createBloomFilterValuesWriter(dictWriterWithFallBack(path, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter), bloomFilter);
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderTest.java
@@ -53,7 +53,6 @@ import java.util.OptionalLong;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetEncoding.BIT_PACKED;
-import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetEncoding.RLE;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
@@ -239,13 +238,13 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, true);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1});
-        DataPage page1 = createDataPage(version, PLAIN, writer, 1);
+        DataPage page1 = createDataPage(version, writer, 1);
         T[] values2 = format.resetAndWrite(writer, new Integer[] {2, 3});
-        DataPage page2 = createDataPage(version, PLAIN, writer, 2);
+        DataPage page2 = createDataPage(version, writer, 2);
         T[] values3 = format.resetAndWrite(writer, new Integer[] {4});
-        DataPage page3 = createDataPage(version, PLAIN, writer, 1);
+        DataPage page3 = createDataPage(version, writer, 1);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         Block actual1 = readBlock(reader, 1); // Parquet/Trino page size the same
@@ -271,11 +270,11 @@ public abstract class AbstractColumnReaderTest
         ColumnReader reader = createColumnReader(field);
         // Write data
         DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(dictionaryWriter, new Integer[] {1, 1});
         DataPage page1 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 2);
         T[] values2 = format.write(writer, new Integer[] {2});
-        DataPage page2 = createDataPage(version, PLAIN, writer, 1);
+        DataPage page2 = createDataPage(version, writer, 1);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2), dictionaryPage), Optional.empty());
@@ -296,11 +295,11 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, false);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {null});
-        DataPage page1 = createNullableDataPage(version, PLAIN, writer, field, true);
+        DataPage page1 = createNullableDataPage(version, writer, field, true);
         T[] values2 = format.write(writer, new Integer[] {null, null});
-        DataPage page2 = createNullableDataPage(version, PLAIN, writer, field, true, true);
+        DataPage page2 = createNullableDataPage(version, writer, field, true, true);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
@@ -324,13 +323,13 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, false);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {null, 1});
-        DataPage page1 = createNullableDataPage(version, PLAIN, writer, field, true, false);
+        DataPage page1 = createNullableDataPage(version, writer, field, true, false);
         T[] values2 = format.resetAndWrite(writer, new Integer[] {null, 2, null});
-        DataPage page2 = createNullableDataPage(version, PLAIN, writer, field, true, false, true);
+        DataPage page2 = createNullableDataPage(version, writer, field, true, false, true);
         T[] values3 = format.resetAndWrite(writer, new Integer[] {3, null, 4});
-        DataPage page3 = createNullableDataPage(version, PLAIN, writer, field, false, true, false);
+        DataPage page3 = createNullableDataPage(version, writer, field, false, true, false);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
@@ -401,9 +400,9 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, false);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1, 2});
-        DataPage page1 = createNullableDataPage(version, PLAIN, writer, field, false, false);
+        DataPage page1 = createNullableDataPage(version, writer, field, false, false);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
@@ -422,9 +421,9 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, false);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1, 2});
-        DataPage page1 = createNullableDataPage(version, PLAIN, writer, field, false, false);
+        DataPage page1 = createNullableDataPage(version, writer, field, false, false);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1), null, true), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
@@ -445,9 +444,9 @@ public abstract class AbstractColumnReaderTest
         DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
         T[] values1 = format.write(dictionaryWriter, new Integer[] {1, 2, 3});
         DataPage page1 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 3);
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values2 = format.resetAndWrite(writer, new Integer[] {4, 5, 6});
-        DataPage page2 = createDataPage(version, PLAIN, writer, 3);
+        DataPage page2 = createDataPage(version, writer, 3);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2), dictionaryPage), Optional.empty());
@@ -505,13 +504,13 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, false);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1});
-        DataPage page1 = createNullableDataPage(version, PLAIN, writer, field, false);
+        DataPage page1 = createNullableDataPage(version, writer, field, false);
         T[] values2 = format.resetAndWrite(writer, new Integer[] {null});
-        DataPage page2 = createNullableDataPage(version, PLAIN, writer, field, true);
+        DataPage page2 = createNullableDataPage(version, writer, field, true);
         T[] values3 = format.resetAndWrite(writer, new Integer[] {2});
-        DataPage page3 = createNullableDataPage(version, PLAIN, writer, field, false);
+        DataPage page3 = createNullableDataPage(version, writer, field, false);
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         // Deliberate mismatch between Trino/Parquet page sizes
@@ -532,10 +531,10 @@ public abstract class AbstractColumnReaderTest
         PrimitiveField field = createField(format, true);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         DictionaryValuesWriter dictionaryWriter = format.getDictionaryWriter();
         T[] values1 = format.write(writer, new Integer[] {1, 2, 3});
-        DataPage page1 = createDataPage(version, PLAIN, writer, 3);
+        DataPage page1 = createDataPage(version, writer, 3);
         T[] values2 = format.resetAndWrite(dictionaryWriter, new Integer[] {4, 5, 6});
         DataPage page2 = createDataPage(version, RLE_DICTIONARY, dictionaryWriter, 3);
         DictionaryPage dictionaryPage = getDictionaryPage(dictionaryWriter);
@@ -627,6 +626,12 @@ public abstract class AbstractColumnReaderTest
                 0);
     }
 
+    protected DataPage createNullableDataPage(DataPageVersion version, ValuesWriter writer, PrimitiveField field, boolean... isNull)
+            throws IOException
+    {
+        return createNullableDataPage(version, getParquetEncoding(writer.getEncoding()), writer, field, isNull);
+    }
+
     protected DataPage createNullableDataPage(DataPageVersion version, ParquetEncoding encoding, ValuesWriter writer, PrimitiveField field, boolean... isNull)
             throws IOException
     {
@@ -637,6 +642,17 @@ public abstract class AbstractColumnReaderTest
             }
         }
         return createDataPage(version, encoding, writer, field, new int[0], definitionLevels);
+    }
+
+    protected static DataPage createDataPage(
+            DataPageVersion version,
+            ValuesWriter writer,
+            PrimitiveField field,
+            int[] repetition,
+            int[] definition)
+            throws IOException
+    {
+        return createDataPage(version, getParquetEncoding(writer.getEncoding()), writer, field, repetition, definition);
     }
 
     protected static DataPage createDataPage(
@@ -669,6 +685,7 @@ public abstract class AbstractColumnReaderTest
         byte[] repetitionBytes = repetitionWriter.getBytes().toByteArray();
         byte[] definitionBytes = definitionWriter.getBytes().toByteArray();
         byte[] valueBytes = writer.getBytes().toByteArray();
+        writer.reset();
 
         if (version == V1) {
             Slice slice = Slices.wrappedBuffer(Bytes.concat(repetitionBytes, definitionBytes, valueBytes));
@@ -726,6 +743,12 @@ public abstract class AbstractColumnReaderTest
                 -1);
     }
 
+    private DataPage createDataPage(DataPageVersion version, ValuesWriter writer, int valueCount)
+            throws IOException
+    {
+        return createDataPage(version, getParquetEncoding(writer.getEncoding()), writer, valueCount, OptionalLong.empty());
+    }
+
     private DataPage createDataPage(DataPageVersion version, ParquetEncoding encoding, ValuesWriter writer, int valueCount)
             throws IOException
     {
@@ -735,7 +758,9 @@ public abstract class AbstractColumnReaderTest
     private DataPage createDataPage(DataPageVersion version, ParquetEncoding encoding, ValuesWriter writer, int valueCount, OptionalLong firstRowIndex)
             throws IOException
     {
-        Slice slice = Slices.wrappedBuffer(writer.getBytes().toByteArray());
+        byte[] valueBytes = writer.getBytes().toByteArray();
+        writer.reset();
+        Slice slice = Slices.wrappedBuffer(valueBytes);
         if (version == V1) {
             return new DataPageV1(slice, valueCount, slice.length(), firstRowIndex, RLE, BIT_PACKED, encoding, 0);
         }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestNestedColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestNestedColumnReader.java
@@ -15,7 +15,6 @@ package io.trino.parquet.reader;
 
 import io.trino.parquet.DataPage;
 import io.trino.parquet.DictionaryPage;
-import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.PrimitiveField;
 import io.trino.spi.block.Block;
@@ -30,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
-import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static io.trino.parquet.reader.TestingColumnReader.ColumnReaderFormat;
 import static io.trino.parquet.reader.TestingColumnReader.DataPageVersion;
@@ -91,7 +89,7 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, true, 1, 0);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1, 2});
         DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1});
         T[] values2 = format.resetAndWrite(writer, new Integer[] {3, 4, 5});
@@ -119,10 +117,10 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, false, 0, 2);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {null, 1});
         // First value is ignored, the second is null and the third is an actual value
-        DataPage page1 = createDataPage(version, PLAIN, writer, field, new int[0], new int[] {0, 1, 2});
+        DataPage page1 = createDataPage(version, writer, field, new int[0], new int[] {0, 1, 2});
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1), null), Optional.empty());
         Block actual1 = readBlock(reader, 3, 2);
@@ -139,10 +137,10 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, false, 0, 2);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1});
         // First two values are ignored, and the third is an actual value
-        DataPage page1 = createDataPage(version, PLAIN, writer, field, new int[0], new int[] {0, 0, 2});
+        DataPage page1 = createDataPage(version, writer, field, new int[0], new int[] {0, 0, 2});
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1), null), Optional.empty());
         Block actual1 = readBlock(reader, 3, 1);
@@ -159,10 +157,10 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, true, 0, 2);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1});
         // First two values are ignored and the third is an actual value
-        DataPage page1 = createDataPage(version, PLAIN, writer, field, new int[0], new int[] {0, 1, 2});
+        DataPage page1 = createDataPage(version, writer, field, new int[0], new int[] {0, 1, 2});
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1), null), Optional.empty());
         Block actual1 = readBlock(reader, 3, 1);
@@ -242,7 +240,7 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, true, 1, 0);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1, 2});
         DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1});
         T[] values2 = format.resetAndWrite(writer, new Integer[] {3, 4, 5});
@@ -267,13 +265,13 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, false, 1, 2);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {null});
-        DataPage page1 = createDataPage(version, PLAIN, writer, field, new int[] {0, 1}, new int[] {0, 1});
+        DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1}, new int[] {0, 1});
         T[] values2 = format.resetAndWrite(writer, new Integer[] {1, null});
-        DataPage page2 = createDataPage(version, PLAIN, writer, field, new int[] {1, 1, 0}, new int[] {2, 0, 1});
+        DataPage page2 = createDataPage(version, writer, field, new int[] {1, 1, 0}, new int[] {2, 0, 1});
         T[] values3 = format.resetAndWrite(writer, new Integer[] {2, null});
-        DataPage page3 = createDataPage(version, PLAIN, writer, field, new int[] {1, 0, 1}, new int[] {2, 0, 1});
+        DataPage page3 = createDataPage(version, writer, field, new int[] {1, 0, 1}, new int[] {2, 0, 1});
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         Block actual1 = readBlock(reader, 3, 5);
@@ -292,7 +290,7 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, true, 1, 0);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {1, 2});
         DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1});
         T[] values2 = format.resetAndWrite(writer, new Integer[] {3, 4, 5});
@@ -317,13 +315,13 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, false, 1, 2);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         T[] values1 = format.write(writer, new Integer[] {null});
-        DataPage page1 = createDataPage(version, PLAIN, writer, field, new int[] {0, 1}, new int[] {0, 1});
+        DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1}, new int[] {0, 1});
         T[] values2 = format.resetAndWrite(writer, new Integer[] {1, null});
-        DataPage page2 = createDataPage(version, PLAIN, writer, field, new int[] {1, 1, 1}, new int[] {2, 0, 1});
+        DataPage page2 = createDataPage(version, writer, field, new int[] {1, 1, 1}, new int[] {2, 0, 1});
         T[] values3 = format.resetAndWrite(writer, new Integer[] {2, null});
-        DataPage page3 = createDataPage(version, PLAIN, writer, field, new int[] {1, 0, 1}, new int[] {2, 0, 1});
+        DataPage page3 = createDataPage(version, writer, field, new int[] {1, 0, 1}, new int[] {2, 0, 1});
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         Block actual1 = readBlock(reader, 2, 5);
@@ -342,7 +340,7 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, true, 1, 0);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         format.write(writer, new Integer[] {1, 2});
         DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1});
         format.resetAndWrite(writer, new Integer[] {3, 4, 5});
@@ -366,13 +364,13 @@ public class TestNestedColumnReader
         PrimitiveField field = createField(format, false, 1, 2);
         ColumnReader reader = createColumnReader(field);
         // Write data
-        ValuesWriter writer = format.getPlainWriter();
+        ValuesWriter writer = format.getValuesWriter(version);
         format.write(writer, new Integer[] {null});
-        DataPage page1 = createDataPage(version, PLAIN, writer, field, new int[] {0, 1}, new int[] {0, 1});
+        DataPage page1 = createDataPage(version, writer, field, new int[] {0, 1}, new int[] {0, 1});
         format.resetAndWrite(writer, new Integer[] {1, null});
-        DataPage page2 = createDataPage(version, PLAIN, writer, field, new int[] {1, 1, 1}, new int[] {2, 0, 1});
+        DataPage page2 = createDataPage(version, writer, field, new int[] {1, 1, 1}, new int[] {2, 0, 1});
         T[] values3 = format.resetAndWrite(writer, new Integer[] {2, null});
-        DataPage page3 = createDataPage(version, PLAIN, writer, field, new int[] {1, 0, 1}, new int[] {2, 0, 1});
+        DataPage page3 = createDataPage(version, writer, field, new int[] {1, 0, 1}, new int[] {2, 0, 1});
         // Read and assert
         reader.setPageReader(getPageReaderMock(List.of(page1, page2, page3), null), Optional.empty());
         reader.prepareNextRead(1); // Skip first value
@@ -388,6 +386,6 @@ public class TestNestedColumnReader
             int[] repetition)
             throws IOException
     {
-        return createDataPage(version, ParquetEncoding.PLAIN, writer, field, repetition, new int[0]);
+        return createDataPage(version, writer, field, repetition, new int[0]);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingColumnReader.java
@@ -20,6 +20,7 @@ import com.google.common.primitives.Longs;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.parquet.DictionaryPage;
+import io.trino.parquet.ParquetEncoding;
 import io.trino.plugin.base.type.DecodedTimestamp;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ByteArrayBlock;
@@ -43,19 +44,8 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Timestamps;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
-import org.apache.parquet.bytes.HeapByteBufferAllocator;
-import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
-import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
-import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
-import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -65,11 +55,16 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.IntFunction;
+import java.util.OptionalInt;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.DELTA_BYTE_ARRAY;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.RLE;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static io.trino.parquet.ParquetTestUtils.toTrinoDictionaryPage;
 import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -147,24 +142,6 @@ public class TestingColumnReader
             .put(UUID, Int128ArrayBlock.class)
             .buildOrThrow();
 
-    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_INT_WRITER =
-            _ -> new PlainIntegerDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-    public static final IntFunction<DictionaryValuesWriter> DICTIONARY_LONG_WRITER =
-            _ -> new PlainLongDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_FIXED_LENGTH_WRITER =
-            length -> new PlainFixedLenArrayDictionaryValuesWriter(Integer.MAX_VALUE, length, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_FLOAT_WRITER =
-            _ -> new PlainFloatDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_DOUBLE_WRITER =
-            _ -> new PlainDoubleDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-    private static final IntFunction<DictionaryValuesWriter> DICTIONARY_BINARY_WRITER =
-            _ -> new PlainBinaryDictionaryValuesWriter(Integer.MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-
-    private static final IntFunction<ValuesWriter> BOOLEAN_WRITER = _ -> new BooleanPlainValuesWriter();
-    private static final IntFunction<ValuesWriter> FIXED_LENGTH_WRITER =
-            length -> new FixedLenByteArrayPlainValuesWriter(length, 1024, 1024, HeapByteBufferAllocator.getInstance());
-    public static final IntFunction<ValuesWriter> PLAIN_WRITER =
-            _ -> new PlainValuesWriter(1024, 1024, HeapByteBufferAllocator.getInstance());
     private static final Writer<Number> WRITE_BOOLEAN = (writer, values) -> {
         Number[] result = new Number[values.length];
         for (int i = 0; i < values.length; i++) {
@@ -673,7 +650,7 @@ public class TestingColumnReader
         return cartesianProduct(
                 Stream.of(DataPageVersion.V1, DataPageVersion.V2).collect(toDataProvider()),
                 Arrays.stream(TestingColumnReader.columnReaders())
-                        .filter(reader -> reader.dictionaryWriterProvider != null)
+                        .filter(ColumnReaderFormat::hasDictionarySupport)
                         .collect(toDataProvider()));
     }
 
@@ -695,98 +672,98 @@ public class TestingColumnReader
     private static ColumnReaderFormat<?>[] columnReaders()
     {
         return new ColumnReaderFormat[] {
-                new ColumnReaderFormat<>(BOOLEAN, BooleanType.BOOLEAN, BOOLEAN_WRITER, null, WRITE_BOOLEAN, ASSERT_BOOLEAN),
-                new ColumnReaderFormat<>(FLOAT, REAL, PLAIN_WRITER, DICTIONARY_FLOAT_WRITER, WRITE_FLOAT, ASSERT_FLOAT),
+                new ColumnReaderFormat<>(BOOLEAN, BooleanType.BOOLEAN, PLAIN, RLE, WRITE_BOOLEAN, ASSERT_BOOLEAN),
+                new ColumnReaderFormat<>(FLOAT, REAL, PLAIN, PLAIN, WRITE_FLOAT, ASSERT_FLOAT),
                 // FLOAT parquet primitive type can be read as a DOUBLE or REAL type in Trino
-                new ColumnReaderFormat<>(FLOAT, DoubleType.DOUBLE, PLAIN_WRITER, DICTIONARY_FLOAT_WRITER, WRITE_FLOAT, ASSERT_DOUBLE_STORED_AS_FLOAT),
-                new ColumnReaderFormat<>(DOUBLE, DoubleType.DOUBLE, PLAIN_WRITER, DICTIONARY_DOUBLE_WRITER, WRITE_DOUBLE, ASSERT_DOUBLE),
-                new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(FLOAT, DoubleType.DOUBLE, PLAIN, PLAIN, WRITE_FLOAT, ASSERT_DOUBLE_STORED_AS_FLOAT),
+                new ColumnReaderFormat<>(DOUBLE, DoubleType.DOUBLE, PLAIN, PLAIN, WRITE_DOUBLE, ASSERT_DOUBLE),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_LONG),
                 // INT32 can be read as a ShortDecimalType in Trino without decimal logical type annotation as well
-                new ColumnReaderFormat<>(INT32, createDecimalType(8, 0), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT32, createDecimalType(8, 2), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, assertShortDecimal(createDecimalType(8, 2))),
-                new ColumnReaderFormat<>(INT32, BIGINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT32, INTEGER, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
-                new ColumnReaderFormat<>(INT32, SMALLINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_SHORT, ASSERT_SHORT),
-                new ColumnReaderFormat<>(INT32, TINYINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_BYTE, ASSERT_BYTE),
-                new ColumnReaderFormat<>(BINARY, VARCHAR, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY, ASSERT_BINARY),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, null, VARCHAR, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeFixedWidthBinary(8), ASSERT_BINARY),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 16), createDecimalType(16), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT64, BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT64, INTEGER, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_INT),
-                new ColumnReaderFormat<>(INT64, SMALLINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_SHORT),
-                new ColumnReaderFormat<>(INT64, TINYINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_BYTE),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), createDecimalType(2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_LONG),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(2, 38), createDecimalType(38, 2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), new Int128Assertion(createDecimalType(38, 2))),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, uuidType(), UUID, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_UUID, assertUuid()),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, null, UUID, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_UUID, assertUuid()),
+                new ColumnReaderFormat<>(INT32, createDecimalType(8, 0), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, createDecimalType(8, 2), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, assertShortDecimal(createDecimalType(8, 2))),
+                new ColumnReaderFormat<>(INT32, BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, INTEGER, PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, SMALLINT, PLAIN, DELTA_BINARY_PACKED, WRITE_SHORT, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT32, TINYINT, PLAIN, DELTA_BINARY_PACKED, WRITE_BYTE, ASSERT_BYTE),
+                new ColumnReaderFormat<>(BINARY, VARCHAR, PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY, ASSERT_BINARY),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, null, VARCHAR, PLAIN, DELTA_BYTE_ARRAY, writeFixedWidthBinary(8), ASSERT_BINARY),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 16), createDecimalType(16), PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, INTEGER, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_INT),
+                new ColumnReaderFormat<>(INT64, SMALLINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT64, TINYINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_BYTE),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), createDecimalType(2), PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(2, 38), createDecimalType(38, 2), PLAIN, DELTA_BYTE_ARRAY, writeLongDecimal(16), new Int128Assertion(createDecimalType(38, 2))),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, uuidType(), UUID, PLAIN, DELTA_BYTE_ARRAY, WRITE_UUID, assertUuid()),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, null, UUID, PLAIN, DELTA_BYTE_ARRAY, WRITE_UUID, assertUuid()),
                 // Trino type precision is irrelevant since the data is always stored as picoseconds
-                new ColumnReaderFormat<>(INT32, timeType(false, MILLIS), TIME_MILLIS, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, assertTime(TIME_MICROS, 9)),
-                new ColumnReaderFormat<>(INT64, timeType(false, MICROS), TIME_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, assertTime(TIME_MICROS, 6)),
+                new ColumnReaderFormat<>(INT32, timeType(false, MILLIS), TIME_MILLIS, PLAIN, DELTA_BINARY_PACKED, WRITE_INT, assertTime(TIME_MICROS, 9)),
+                new ColumnReaderFormat<>(INT64, timeType(false, MICROS), TIME_MICROS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, assertTime(TIME_MICROS, 6)),
                 // Reading a column TimeLogicalTypeAnnotation as a BIGINT
-                new ColumnReaderFormat<>(INT64, timeType(false, MICROS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, timeType(false, MICROS), BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_LONG),
                 // Short decimals
-                new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), createDecimalType(8), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_LONG),
                 // INT32 values can be read as zero scale decimals provided the precision is at least 10 to accommodate the largest possible integer
-                new ColumnReaderFormat<>(INT32, createDecimalType(10), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT32, decimalType(0, 8), BIGINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT32, decimalType(0, 8), INTEGER, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, ASSERT_INT),
-                new ColumnReaderFormat<>(INT32, decimalType(0, 8), SMALLINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_SHORT, ASSERT_SHORT),
-                new ColumnReaderFormat<>(INT32, decimalType(0, 8), TINYINT, PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_BYTE, ASSERT_BYTE),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 8), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 8), INTEGER, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_INT),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 8), SMALLINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_SHORT),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 8), TINYINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, ASSERT_BYTE),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), createDecimalType(2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_LONG),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), BIGINT, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_LONG),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), INTEGER, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_INT),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), SMALLINT, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_SHORT),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), TINYINT, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, ASSERT_BYTE),
-                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), createDecimalType(8), PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_LONG),
-                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), BIGINT, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_LONG),
-                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), INTEGER, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_INT),
-                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), SMALLINT, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_SHORT),
-                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), TINYINT, PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_DECIMAL, ASSERT_BYTE),
+                new ColumnReaderFormat<>(INT32, createDecimalType(10), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), INTEGER, PLAIN, DELTA_BINARY_PACKED, WRITE_INT, ASSERT_INT),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), SMALLINT, PLAIN, DELTA_BINARY_PACKED, WRITE_SHORT, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 8), TINYINT, PLAIN, DELTA_BINARY_PACKED, WRITE_BYTE, ASSERT_BYTE),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), createDecimalType(8), PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), INTEGER, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_INT),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), SMALLINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_SHORT),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 8), TINYINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, ASSERT_BYTE),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), createDecimalType(2), PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), BIGINT, PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), INTEGER, PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, ASSERT_INT),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), SMALLINT, PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, ASSERT_SHORT),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 2), TINYINT, PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, ASSERT_BYTE),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), createDecimalType(8), PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), BIGINT, PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY_DECIMAL, ASSERT_LONG),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), INTEGER, PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY_DECIMAL, ASSERT_INT),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), SMALLINT, PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY_DECIMAL, ASSERT_SHORT),
+                new ColumnReaderFormat<>(BINARY, decimalType(0, 8), TINYINT, PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY_DECIMAL, ASSERT_BYTE),
                 // Long decimals
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(2, 38), createDecimalType(38, 2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), new Int128Assertion(createDecimalType(38, 2))),
-                new ColumnReaderFormat<>(BINARY, 16, decimalType(2, 38), createDecimalType(38, 2), PLAIN_WRITER, DICTIONARY_BINARY_WRITER, WRITE_BINARY_LONG_DECIMAL, new Int128Assertion(createDecimalType(38, 2))),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(2, 38), createDecimalType(38, 2), PLAIN, DELTA_BYTE_ARRAY, writeLongDecimal(16), new Int128Assertion(createDecimalType(38, 2))),
+                new ColumnReaderFormat<>(BINARY, 16, decimalType(2, 38), createDecimalType(38, 2), PLAIN, DELTA_BYTE_ARRAY, WRITE_BINARY_LONG_DECIMAL, new Int128Assertion(createDecimalType(38, 2))),
                 // Rescaled decimals
-                new ColumnReaderFormat<>(INT32, decimalType(0, 7), createDecimalType(8, 1), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, assertShortDecimal(createDecimalType(8, 1))),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 7), createDecimalType(8, 2), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, assertShortDecimal(createDecimalType(8, 2))),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 7), createDecimalType(8, 3), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, assertShortDecimal(createDecimalType(8, 3))),
-                new ColumnReaderFormat<>(INT32, decimalType(0, 7), createDecimalType(30, 1), PLAIN_WRITER, DICTIONARY_INT_WRITER, WRITE_INT, assertLongDecimal(createDecimalType(30, 1))),
-                new ColumnReaderFormat<>(INT64, decimalType(0, 7), createDecimalType(30, 2), PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG, assertLongDecimal(createDecimalType(30, 2))),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 7), createDecimalType(30, 3), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_SHORT_DECIMAL, assertLongDecimal(createDecimalType(30, 3))),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(0, 38), createDecimalType(8, 1), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), assertLongToShortRescaled(createDecimalType(8, 1))),
-                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(0, 38), createDecimalType(37, 2), FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, writeLongDecimal(16), assertLongRescaled(createDecimalType(37, 2))),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 7), createDecimalType(8, 1), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, assertShortDecimal(createDecimalType(8, 1))),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 7), createDecimalType(8, 2), PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, assertShortDecimal(createDecimalType(8, 2))),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 7), createDecimalType(8, 3), PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, assertShortDecimal(createDecimalType(8, 3))),
+                new ColumnReaderFormat<>(INT32, decimalType(0, 7), createDecimalType(30, 1), PLAIN, DELTA_BINARY_PACKED, WRITE_INT, assertLongDecimal(createDecimalType(30, 1))),
+                new ColumnReaderFormat<>(INT64, decimalType(0, 7), createDecimalType(30, 2), PLAIN, DELTA_BINARY_PACKED, WRITE_LONG, assertLongDecimal(createDecimalType(30, 2))),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 8, decimalType(0, 7), createDecimalType(30, 3), PLAIN, DELTA_BYTE_ARRAY, WRITE_SHORT_DECIMAL, assertLongDecimal(createDecimalType(30, 3))),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(0, 38), createDecimalType(8, 1), PLAIN, DELTA_BYTE_ARRAY, writeLongDecimal(16), assertLongToShortRescaled(createDecimalType(8, 1))),
+                new ColumnReaderFormat<>(FIXED_LEN_BYTE_ARRAY, 16, decimalType(0, 38), createDecimalType(37, 2), PLAIN, DELTA_BYTE_ARRAY, writeLongDecimal(16), assertLongRescaled(createDecimalType(37, 2))),
                 // Timestamps.
                 //  The `precision` and `rounding` arguments at the end of every assertion may be difficult to understand. They are a direct
                 // consequence of various Trino timestamp representations.
-                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(TIME_MILLIS, 3)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_PICOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampNanos(9)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_TZ_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZoneMillis(0)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(TIME_MICROS, 0, 3)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(TIME_MICROS, 0)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampNanos(6)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_TZ_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZoneMillis(-3, 3)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_TZ_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertLongTimestampWithTimeZoneNanos(6)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(TIME_NANOS, -3, 6)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_MICROS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTime(TIME_NANOS, -3)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampNanos(3)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_TZ_MILLIS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZoneMillis(-6, 3)),
-                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_TZ_NANOS, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, assertLongTimestampWithTimeZoneNanos(3)),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_MILLIS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampMicros(6)),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_MICROS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampMicros(3)),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_NANOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampNanos()),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_PICOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampNanos()),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MILLIS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertTimestampWithTimeZoneMillis()),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MICROS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96LongTimestampWithTimeZone(6)),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_NANOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96LongTimestampWithTimeZone(9)),
-                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_PICOS, FIXED_LENGTH_WRITER, DICTIONARY_FIXED_LENGTH_WRITER, WRITE_INT96, assertInt96LongTimestampWithTimeZone(12)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_MICROS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTime(TIME_MILLIS, 3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_PICOS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTimestampNanos(9)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), TIMESTAMP_TZ_MILLIS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZoneMillis(0)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_MILLIS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTime(TIME_MICROS, 0, 3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_MICROS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTime(TIME_MICROS, 0)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_NANOS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTimestampNanos(6)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_TZ_MILLIS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZoneMillis(-3, 3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), TIMESTAMP_TZ_NANOS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertLongTimestampWithTimeZoneNanos(6)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_MILLIS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTime(TIME_NANOS, -3, 6)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_MICROS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTime(TIME_NANOS, -3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_NANOS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTimestampNanos(3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_TZ_MILLIS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertTimestampWithTimeZoneMillis(-6, 3)),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), TIMESTAMP_TZ_NANOS, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, assertLongTimestampWithTimeZoneNanos(3)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_MILLIS, PLAIN, PLAIN, WRITE_INT96, assertTimestampMicros(6)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_MICROS, PLAIN, PLAIN, WRITE_INT96, assertTimestampMicros(3)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_NANOS, PLAIN, PLAIN, WRITE_INT96, assertTimestampNanos()),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_PICOS, PLAIN, PLAIN, WRITE_INT96, assertTimestampNanos()),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MILLIS, PLAIN, PLAIN, WRITE_INT96, assertTimestampWithTimeZoneMillis()),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_MICROS, PLAIN, PLAIN, WRITE_INT96, assertInt96LongTimestampWithTimeZone(6)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_NANOS, PLAIN, PLAIN, WRITE_INT96, assertInt96LongTimestampWithTimeZone(9)),
+                new ColumnReaderFormat<>(INT96, 12, null, TIMESTAMP_TZ_PICOS, PLAIN, PLAIN, WRITE_INT96, assertInt96LongTimestampWithTimeZone(12)),
                 // timestamps read as bigint
-                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
-                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), BIGINT, PLAIN_WRITER, DICTIONARY_LONG_WRITER, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MILLIS), BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, timestampType(false, MICROS), BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
+                new ColumnReaderFormat<>(INT64, timestampType(false, NANOS), BIGINT, PLAIN, DELTA_BINARY_PACKED, WRITE_LONG_TIMESTAMP, ASSERT_LONG),
         };
     }
 
@@ -836,33 +813,32 @@ public class TestingColumnReader
         @Nullable
         private final LogicalTypeAnnotation logicalTypeAnnotation;
         private final Type trinoType;
-        private final IntFunction<ValuesWriter> plainWriterProvider;
-        @Nullable
-        private final IntFunction<DictionaryValuesWriter> dictionaryWriterProvider;
+        private final ParquetEncoding v1Encoding;
+        private final ParquetEncoding v2Encoding;
         private final Writer<T> writerFunction;
         private final Assertion<T> assertion;
 
         public ColumnReaderFormat(
                 PrimitiveTypeName typeName,
                 Type trinoType,
-                IntFunction<ValuesWriter> plainWriterProvider,
-                @Nullable IntFunction<DictionaryValuesWriter> dictionaryWriterProvider,
+                ParquetEncoding v1Encoding,
+                ParquetEncoding v2Encoding,
                 Writer<T> writerFunction,
                 Assertion<T> assertion)
         {
-            this(typeName, null, trinoType, plainWriterProvider, dictionaryWriterProvider, writerFunction, assertion);
+            this(typeName, -1, null, trinoType, v1Encoding, v2Encoding, writerFunction, assertion);
         }
 
         public ColumnReaderFormat(
                 PrimitiveTypeName typeName,
                 @Nullable LogicalTypeAnnotation logicalTypeAnnotation,
                 Type trinoType,
-                IntFunction<ValuesWriter> plainWriterProvider,
-                @Nullable IntFunction<DictionaryValuesWriter> dictionaryWriterProvider,
+                ParquetEncoding v1Encoding,
+                ParquetEncoding v2Encoding,
                 Writer<T> writerFunction,
                 Assertion<T> assertion)
         {
-            this(typeName, -1, logicalTypeAnnotation, trinoType, plainWriterProvider, dictionaryWriterProvider, writerFunction, assertion);
+            this(typeName, -1, logicalTypeAnnotation, trinoType, v1Encoding, v2Encoding, writerFunction, assertion);
         }
 
         public ColumnReaderFormat(
@@ -870,8 +846,8 @@ public class TestingColumnReader
                 int typeLengthInBytes,
                 @Nullable LogicalTypeAnnotation logicalTypeAnnotation,
                 Type trinoType,
-                IntFunction<ValuesWriter> plainWriterProvider,
-                @Nullable IntFunction<DictionaryValuesWriter> dictionaryWriterProvider,
+                ParquetEncoding v1Encoding,
+                ParquetEncoding v2Encoding,
                 Writer<T> writerFunction,
                 Assertion<T> assertion)
         {
@@ -879,8 +855,8 @@ public class TestingColumnReader
             this.typeLengthInBytes = typeLengthInBytes;
             this.logicalTypeAnnotation = logicalTypeAnnotation;
             this.trinoType = requireNonNull(trinoType, "trinoType is null");
-            this.plainWriterProvider = requireNonNull(plainWriterProvider, "plainWriterSupplier is null");
-            this.dictionaryWriterProvider = dictionaryWriterProvider;
+            this.v1Encoding = requireNonNull(v1Encoding, "v1Encoding is null");
+            this.v2Encoding = requireNonNull(v2Encoding, "v2Encoding is null");
             this.writerFunction = requireNonNull(writerFunction, "writerFunction is null");
             this.assertion = requireNonNull(assertion, "assertion is null");
         }
@@ -888,6 +864,11 @@ public class TestingColumnReader
         public PrimitiveTypeName getTypeName()
         {
             return typeName;
+        }
+
+        public boolean hasDictionarySupport()
+        {
+            return typeName != PrimitiveTypeName.BOOLEAN;
         }
 
         public int getTypeLengthInBytes()
@@ -906,14 +887,18 @@ public class TestingColumnReader
             return trinoType;
         }
 
-        public ValuesWriter getPlainWriter()
+        public ValuesWriter getValuesWriter(DataPageVersion version)
         {
-            return plainWriterProvider.apply(typeLengthInBytes);
+            ParquetEncoding encoding = version == DataPageVersion.V2 ? v2Encoding : v1Encoding;
+            return TestingValuesWriters.getValuesWriter(encoding, typeName, typeLengthInBytes < 0 ? OptionalInt.empty() : OptionalInt.of(typeLengthInBytes));
         }
 
         public DictionaryValuesWriter getDictionaryWriter()
         {
-            return requireNonNull(dictionaryWriterProvider, "dictionaryWriterProvider is null").apply(typeLengthInBytes);
+            return (DictionaryValuesWriter) TestingValuesWriters.getValuesWriter(
+                    RLE_DICTIONARY,
+                    typeName,
+                    typeLengthInBytes < 0 ? OptionalInt.empty() : OptionalInt.of(typeLengthInBytes));
         }
 
         @Override

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingValuesWriters.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingValuesWriters.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.ParquetEncoding;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
+import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
+import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+import java.util.OptionalInt;
+
+import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
+import static io.trino.parquet.ParquetEncoding.DELTA_BYTE_ARRAY;
+import static io.trino.parquet.ParquetEncoding.DELTA_LENGTH_BYTE_ARRAY;
+import static io.trino.parquet.ParquetEncoding.PLAIN;
+import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
+import static io.trino.parquet.ParquetEncoding.RLE;
+import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.String.format;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+
+public final class TestingValuesWriters
+{
+    private static final int MAX_DATA_SIZE = 1_000_000;
+
+    private TestingValuesWriters() {}
+
+    public static ValuesWriter getValuesWriter(ParquetEncoding encoding, PrimitiveTypeName typeName, OptionalInt typeLength)
+    {
+        if (encoding.equals(RLE)) {
+            if (typeName.equals(BOOLEAN)) {
+                return new RunLengthBitPackingHybridValuesWriter(1, MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+            }
+            throw new IllegalArgumentException("RLE encoding writer is not supported for type " + typeName);
+        }
+        if (encoding.equals(PLAIN)) {
+            return switch (typeName) {
+                case BOOLEAN -> new BooleanPlainValuesWriter();
+                case FIXED_LEN_BYTE_ARRAY -> new FixedLenByteArrayPlainValuesWriter(typeLength.orElseThrow(), MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                case BINARY, INT32, INT64, DOUBLE, FLOAT -> new PlainValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                case INT96 -> new FixedLenByteArrayPlainValuesWriter(12, MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+            };
+        }
+        if (encoding.equals(RLE_DICTIONARY) || encoding.equals(PLAIN_DICTIONARY)) {
+            return switch (typeName) {
+                case BINARY -> new PlainBinaryDictionaryValuesWriter(MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case FIXED_LEN_BYTE_ARRAY -> new PlainFixedLenArrayDictionaryValuesWriter(MAX_VALUE, typeLength.orElseThrow(), Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case INT32 -> new PlainIntegerDictionaryValuesWriter(MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case INT64 -> new PlainLongDictionaryValuesWriter(MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case FLOAT -> new PlainFloatDictionaryValuesWriter(MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case DOUBLE -> new PlainDoubleDictionaryValuesWriter(MAX_VALUE, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                case INT96 -> new PlainFixedLenArrayDictionaryValuesWriter(MAX_VALUE, 12, Encoding.RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
+                default -> throw new IllegalArgumentException("Dictionary encoding writer is not supported for type " + typeName);
+            };
+        }
+        if (encoding.equals(DELTA_BINARY_PACKED)) {
+            return switch (typeName) {
+                case INT32 -> new DeltaBinaryPackingValuesWriterForInteger(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                case INT64 -> new DeltaBinaryPackingValuesWriterForLong(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+                default -> throw new IllegalArgumentException("Delta binary packing encoding writer is not supported for type " + typeName);
+            };
+        }
+        if (encoding.equals(DELTA_LENGTH_BYTE_ARRAY)) {
+            if (typeName.equals(BINARY)) {
+                return new DeltaLengthByteArrayValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+            }
+            throw new IllegalArgumentException("Delta length byte array encoding writer is not supported for type " + typeName);
+        }
+        if (encoding.equals(DELTA_BYTE_ARRAY)) {
+            if (typeName.equals(BINARY) || typeName.equals(FIXED_LEN_BYTE_ARRAY)) {
+                return new DeltaByteArrayWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
+            }
+            throw new IllegalArgumentException("Delta byte array encoding writer is not supported for type " + typeName);
+        }
+        throw new UnsupportedOperationException(format("Encoding %s is not supported", encoding));
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
@@ -21,26 +21,17 @@ import io.trino.parquet.ParquetTestUtils;
 import io.trino.parquet.PrimitiveField;
 import io.trino.parquet.dictionary.Dictionary;
 import io.trino.parquet.reader.SimpleSliceInputStream;
+import io.trino.parquet.reader.TestingValuesWriters;
 import io.trino.parquet.reader.flat.ColumnAdapter;
 import io.trino.parquet.reader.flat.DictionaryDecoder;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 import org.apache.parquet.bytes.ByteBufferInputStream;
-import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
-import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
-import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
-import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
-import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
-import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
-import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
-import org.apache.parquet.column.values.plain.PlainValuesWriter;
-import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
@@ -64,9 +55,6 @@ import java.util.stream.Stream;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.parquet.ParquetEncoding.DELTA_BINARY_PACKED;
-import static io.trino.parquet.ParquetEncoding.DELTA_BYTE_ARRAY;
-import static io.trino.parquet.ParquetEncoding.DELTA_LENGTH_BYTE_ARRAY;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
@@ -75,29 +63,15 @@ import static io.trino.parquet.reader.decoders.ValueDecoder.ValueDecodersProvide
 import static io.trino.testing.DataProviders.cartesianProduct;
 import static io.trino.testing.DataProviders.concat;
 import static io.trino.testing.DataProviders.toDataProvider;
-import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.column.Encoding.RLE;
-import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
-import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
-import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
-import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
-import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
-import static org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
 public abstract class AbstractValueDecodersTest
 {
-    private static final int MAX_DATA_SIZE = 1_000_000;
-
     private static final Object[][] SMALL_SIZE_RUNNERS = Stream.of(
                     ImmutableList.of(fullDecoder()),
                     generateRunnerForBatchSize(AbstractValueDecodersTest::batchDecode, 1, 12),
@@ -134,7 +108,7 @@ public abstract class AbstractValueDecodersTest
     {
         PrimitiveField field = testType.field();
         PrimitiveType primitiveType = field.getDescriptor().getPrimitiveType();
-        ValuesWriter valuesWriter = getValuesWriter(encoding, primitiveType.getPrimitiveTypeName(), OptionalInt.of(primitiveType.getTypeLength()));
+        ValuesWriter valuesWriter = TestingValuesWriters.getValuesWriter(encoding, primitiveType.getPrimitiveTypeName(), OptionalInt.of(primitiveType.getTypeLength()));
         DataBuffer dataBuffer = inputDataProvider.write(valuesWriter, dataSize);
 
         Optional<io.trino.parquet.DictionaryPage> dictionaryPage = Optional.ofNullable(dataBuffer.dictionaryPage())
@@ -360,55 +334,5 @@ public abstract class AbstractValueDecodersTest
         return Arrays.stream(batchSizes)
                 .map(runnerProvider)
                 .collect(toImmutableList());
-    }
-
-    private static ValuesWriter getValuesWriter(ParquetEncoding encoding, PrimitiveTypeName typeName, OptionalInt typeLength)
-    {
-        if (encoding.equals(ParquetEncoding.RLE)) {
-            if (typeName.equals(BOOLEAN)) {
-                return new RunLengthBitPackingHybridValuesWriter(1, MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-            }
-            throw new IllegalArgumentException("RLE encoding writer is not supported for type " + typeName);
-        }
-        if (encoding.equals(PLAIN)) {
-            return switch (typeName) {
-                case BOOLEAN -> new BooleanPlainValuesWriter();
-                case FIXED_LEN_BYTE_ARRAY -> new FixedLenByteArrayPlainValuesWriter(typeLength.orElseThrow(), MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-                case BINARY, INT32, INT64, DOUBLE, FLOAT -> new PlainValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-                case INT96 -> new FixedLenByteArrayPlainValuesWriter(12, MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-            };
-        }
-        if (encoding.equals(RLE_DICTIONARY) || encoding.equals(PLAIN_DICTIONARY)) {
-            return switch (typeName) {
-                case BINARY -> new PlainBinaryDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                case FIXED_LEN_BYTE_ARRAY -> new PlainFixedLenArrayDictionaryValuesWriter(MAX_VALUE, typeLength.orElseThrow(), RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                case INT32 -> new PlainIntegerDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                case INT64 -> new PlainLongDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                case FLOAT -> new PlainFloatDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                case DOUBLE -> new PlainDoubleDictionaryValuesWriter(MAX_VALUE, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                case INT96 -> new PlainFixedLenArrayDictionaryValuesWriter(MAX_VALUE, 12, RLE, Encoding.PLAIN, HeapByteBufferAllocator.getInstance());
-                default -> throw new IllegalArgumentException("Dictionary encoding writer is not supported for type " + typeName);
-            };
-        }
-        if (encoding.equals(DELTA_BINARY_PACKED)) {
-            return switch (typeName) {
-                case INT32 -> new DeltaBinaryPackingValuesWriterForInteger(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-                case INT64 -> new DeltaBinaryPackingValuesWriterForLong(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-                default -> throw new IllegalArgumentException("Delta binary packing encoding writer is not supported for type " + typeName);
-            };
-        }
-        if (encoding.equals(DELTA_LENGTH_BYTE_ARRAY)) {
-            if (typeName.equals(BINARY)) {
-                return new DeltaLengthByteArrayValuesWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-            }
-            throw new IllegalArgumentException("Delta length byte array encoding writer is not supported for type " + typeName);
-        }
-        if (encoding.equals(DELTA_BYTE_ARRAY)) {
-            if (typeName.equals(BINARY) || typeName.equals(FIXED_LEN_BYTE_ARRAY)) {
-                return new DeltaByteArrayWriter(MAX_DATA_SIZE, MAX_DATA_SIZE, HeapByteBufferAllocator.getInstance());
-            }
-            throw new IllegalArgumentException("Delta byte array encoding writer is not supported for type " + typeName);
-        }
-        throw new UnsupportedOperationException(format("Encoding %s is not supported", encoding));
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestFlatColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/flat/TestFlatColumnReader.java
@@ -36,13 +36,14 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetEncoding.BIT_PACKED;
 import static io.trino.parquet.ParquetEncoding.PLAIN;
 import static io.trino.parquet.ParquetEncoding.RLE;
-import static io.trino.parquet.reader.TestingColumnReader.PLAIN_WRITER;
+import static io.trino.parquet.reader.TestingValuesWriters.getValuesWriter;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static org.apache.parquet.format.CompressionCodec.UNCOMPRESSED;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
@@ -127,7 +128,7 @@ public class TestFlatColumnReader
     private static PageReader getSimplePageReaderMock(ParquetEncoding encoding)
             throws IOException
     {
-        ValuesWriter writer = PLAIN_WRITER.apply(1);
+        ValuesWriter writer = getValuesWriter(PLAIN, INT32, OptionalInt.empty());
         writer.writeInteger(42);
         byte[] valueBytes = writer.getBytes().toByteArray();
         List<DataPage> pages = ImmutableList.of(new DataPageV1(

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/AbstractColumnWriterBenchmark.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/AbstractColumnWriterBenchmark.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.writer;
 
+import io.airlift.units.DataSize;
 import io.trino.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.trino.parquet.writer.valuewriter.TrinoValuesWriterFactory;
 import io.trino.spi.block.Block;
@@ -94,7 +95,12 @@ public abstract class AbstractColumnWriterBenchmark
 
     private PrimitiveValueWriter createValuesWriter()
     {
-        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(1024 * 1024, maxDictionaryPageSize);
+        TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(
+                ParquetWriterOptions.builder()
+                        .setMaxPageSize(DataSize.ofBytes(1024 * 1024))
+                        .setUseDeltaLengthByteArrayEncoding(false)
+                        .build(),
+                maxDictionaryPageSize);
         ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"test"}, getParquetType(), 0, 0);
         return getValueWriter(valuesWriterFactory.newValuesWriter(columnDescriptor, bloomFilterType.getBloomFilter(columnDescriptor)), getTrinoType(), columnDescriptor.getPrimitiveType(), Optional.empty());
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -44,6 +44,7 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import org.apache.parquet.VersionParser;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.PageType;
@@ -63,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -70,6 +72,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -604,6 +607,54 @@ public class TestParquetWriter
         assertThat(chunkMetaData.getEncodingStats().hasDictionaryEncodedPages()).isTrue();
         assertThat(chunkMetaData.getEncodingStats().hasNonDictionaryEncodedPages()).isTrue();
         assertThat(hasBloomFilter(chunkMetaData)).isTrue();
+    }
+
+    @Test
+    public void testDeltaLengthByteArrayFallbackIsWritten()
+            throws Exception
+    {
+        // High-cardinality VARCHAR values force the dictionary writer to fall back: the
+        // compression check fires after the first page because random UUIDs offer no
+        // dictionary compression, so the writer switches to DELTA_LENGTH_BYTE_ARRAY.
+        // 5000 values is comfortably above the empirical fallback threshold (~2000).
+        List<Slice> sliceValues = IntStream.range(0, 5_000)
+                .mapToObj(_ -> Slices.utf8Slice("row-" + UUID.randomUUID()))
+                .collect(toImmutableList());
+
+        List<String> columnNames = ImmutableList.of("column");
+        List<Type> types = ImmutableList.of(VARCHAR);
+
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setUseDeltaLengthByteArrayEncoding(true)
+                                .build(),
+                        types,
+                        columnNames,
+                        generateInputPages(types, 1000, sliceValues)),
+                ParquetReaderOptions.defaultOptions());
+
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+
+        // Assert that DELTA_LENGTH_BYTE_ARRAY encoding appears in at least one column chunk
+        Set<Encoding> allEncodings = parquetMetadata.getBlocks().stream()
+                .flatMap(block -> block.columns().stream())
+                .flatMap(column -> column.getEncodings().stream())
+                .collect(toImmutableSet());
+        assertThat(allEncodings).contains(Encoding.DELTA_LENGTH_BYTE_ARRAY);
+
+        // Round-trip: read back values and verify they equal the written values
+        ImmutableList.Builder<Slice> readBackBuilder = ImmutableList.builder();
+        try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, types, columnNames)) {
+            SourcePage page;
+            while ((page = reader.nextPage()) != null) {
+                Block block = page.getBlock(0);
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    readBackBuilder.add(VARCHAR.getSlice(block, i));
+                }
+            }
+        }
+        assertThat(readBackBuilder.build()).isEqualTo(sliceValues);
     }
 
     public static Stream<Arguments> testWriteBloomFiltersParams()

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestTrinoValuesWriterFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestTrinoValuesWriterFactory.java
@@ -13,12 +13,14 @@
  */
 package io.trino.parquet.writer;
 
+import io.airlift.units.DataSize;
 import io.trino.parquet.writer.valuewriter.BloomFilterValuesWriter;
 import io.trino.parquet.writer.valuewriter.DictionaryFallbackValuesWriter;
 import io.trino.parquet.writer.valuewriter.TrinoValuesWriterFactory;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainDoubleDictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFixedLenArrayDictionaryValuesWriter;
@@ -52,21 +54,43 @@ public class TestTrinoValuesWriterFactory
     }
 
     @Test
-    public void testBinary()
+    public void testBinaryWithoutDeltaLengthEncoding()
     {
         testValueWriter(
                 PrimitiveTypeName.BINARY,
+                false,
                 PlainBinaryDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
     }
 
     @Test
-    public void testBinaryBloomFilter()
+    public void testBinaryWithDeltaLengthEncoding()
+    {
+        testValueWriter(
+                PrimitiveTypeName.BINARY,
+                true,
+                PlainBinaryDictionaryValuesWriter.class,
+                DeltaLengthByteArrayValuesWriter.class);
+    }
+
+    @Test
+    public void testBinaryBloomFilterWithoutDeltaLengthEncoding()
     {
         testValueWriterBloomFilter(
                 PrimitiveTypeName.BINARY,
+                false,
                 PlainBinaryDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
+    }
+
+    @Test
+    public void testBinaryBloomFilterWithDeltaLengthEncoding()
+    {
+        testValueWriterBloomFilter(
+                PrimitiveTypeName.BINARY,
+                true,
+                PlainBinaryDictionaryValuesWriter.class,
+                DeltaLengthByteArrayValuesWriter.class);
     }
 
     @Test
@@ -74,6 +98,7 @@ public class TestTrinoValuesWriterFactory
     {
         testValueWriter(
                 PrimitiveTypeName.INT32,
+                false,
                 PlainIntegerDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
     }
@@ -83,6 +108,7 @@ public class TestTrinoValuesWriterFactory
     {
         testValueWriter(
                 PrimitiveTypeName.INT64,
+                false,
                 PlainLongDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
     }
@@ -92,6 +118,7 @@ public class TestTrinoValuesWriterFactory
     {
         testValueWriterBloomFilter(
                 PrimitiveTypeName.INT64,
+                false,
                 PlainLongDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
     }
@@ -101,6 +128,7 @@ public class TestTrinoValuesWriterFactory
     {
         testValueWriter(
                 PrimitiveTypeName.INT96,
+                false,
                 PlainFixedLenArrayDictionaryValuesWriter.class,
                 FixedLenByteArrayPlainValuesWriter.class);
     }
@@ -110,6 +138,7 @@ public class TestTrinoValuesWriterFactory
     {
         testValueWriter(
                 PrimitiveTypeName.DOUBLE,
+                false,
                 PlainDoubleDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
     }
@@ -119,6 +148,7 @@ public class TestTrinoValuesWriterFactory
     {
         testValueWriter(
                 PrimitiveTypeName.FLOAT,
+                false,
                 PlainFloatDictionaryValuesWriter.class,
                 PlainValuesWriter.class);
     }
@@ -126,28 +156,46 @@ public class TestTrinoValuesWriterFactory
     private void testValueWriter(PrimitiveTypeName typeName, Class<? extends ValuesWriter> expectedValueWriterClass)
     {
         ColumnDescriptor mockPath = createColumnDescriptor(typeName);
-        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(1024, 1024);
+        TrinoValuesWriterFactory factory = createFactory(false);
         ValuesWriter writer = factory.newValuesWriter(mockPath, Optional.empty());
 
         validateWriterType(writer, expectedValueWriterClass);
     }
 
-    private void testValueWriter(PrimitiveTypeName typeName, Class<? extends ValuesWriter> initialValueWriterClass, Class<? extends ValuesWriter> fallbackValueWriterClass)
+    private void testValueWriter(
+            PrimitiveTypeName typeName,
+            boolean useDeltaLengthByteArrayEncoding,
+            Class<? extends ValuesWriter> initialValueWriterClass,
+            Class<? extends ValuesWriter> fallbackValueWriterClass)
     {
         ColumnDescriptor mockPath = createColumnDescriptor(typeName);
-        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(1024, 1024);
+        TrinoValuesWriterFactory factory = createFactory(useDeltaLengthByteArrayEncoding);
         ValuesWriter writer = factory.newValuesWriter(mockPath, Optional.empty());
 
         validateFallbackWriter(writer, initialValueWriterClass, fallbackValueWriterClass);
     }
 
-    private void testValueWriterBloomFilter(PrimitiveTypeName typeName, Class<? extends ValuesWriter> initialValueWriterClass, Class<? extends ValuesWriter> fallbackValueWriterClass)
+    private void testValueWriterBloomFilter(
+            PrimitiveTypeName typeName,
+            boolean useDeltaLengthByteArrayEncoding,
+            Class<? extends ValuesWriter> initialValueWriterClass,
+            Class<? extends ValuesWriter> fallbackValueWriterClass)
     {
         ColumnDescriptor mockPath = createColumnDescriptor(typeName);
-        TrinoValuesWriterFactory factory = new TrinoValuesWriterFactory(1024, 1024);
+        TrinoValuesWriterFactory factory = createFactory(useDeltaLengthByteArrayEncoding);
         ValuesWriter writer = factory.newValuesWriter(mockPath, Optional.of(new BlockSplitBloomFilter(1024, 1024)));
 
         validateFallbackWriterBloomFilter(writer, initialValueWriterClass, fallbackValueWriterClass);
+    }
+
+    private static TrinoValuesWriterFactory createFactory(boolean useDeltaLengthByteArrayEncoding)
+    {
+        return new TrinoValuesWriterFactory(
+                ParquetWriterOptions.builder()
+                        .setMaxPageSize(DataSize.ofBytes(1024))
+                        .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)
+                        .build(),
+                1024);
     }
 
     private ColumnDescriptor createColumnDescriptor(PrimitiveTypeName typeName)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -108,6 +108,7 @@ public abstract class AbstractDeltaLakePageSink
     private final List<Boolean> activeWriters = new ArrayList<>();
     protected final ImmutableList.Builder<DataFileInfo> dataFileInfos = ImmutableList.builder();
     private final DeltaLakeParquetSchemaMapping parquetSchemaMapping;
+    private final boolean useDeltaLengthByteArrayEncoding;
     private long currentOpenWriters;
 
     public AbstractDeltaLakePageSink(
@@ -124,7 +125,8 @@ public abstract class AbstractDeltaLakePageSink
             ConnectorSession session,
             DeltaLakeWriterStats stats,
             String trinoVersion,
-            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping,
+            boolean useDeltaLengthByteArrayEncoding)
     {
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
         requireNonNull(inputColumns, "inputColumns is null");
@@ -191,6 +193,7 @@ public abstract class AbstractDeltaLakePageSink
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
         this.targetMaxFileSize = DeltaLakeSessionProperties.getTargetMaxFileSize(session);
         this.idleWriterMinFileSize = DeltaLakeSessionProperties.getIdleWriterMinFileSize(session);
+        this.useDeltaLengthByteArrayEncoding = useDeltaLengthByteArrayEncoding;
     }
 
     protected abstract void processSynthesizedColumn(DeltaLakeColumnHandle column);
@@ -466,6 +469,7 @@ public abstract class AbstractDeltaLakePageSink
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxPageValueCount(getParquetWriterPageValueCount(session))
+                .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)
                 .build();
         CompressionCodec compressionCodec = toCompressionCodec(getCompressionCodec(session)).getParquetCompressionCodec()
                 .orElseThrow(); // validated on the session property level

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeCdfPageSink.java
@@ -44,7 +44,8 @@ public class DeltaLakeCdfPageSink
             ConnectorSession session,
             DeltaLakeWriterStats stats,
             String trinoVersion,
-            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping,
+            boolean useDeltaLengthByteArrayEncoding)
     {
         super(typeOperators,
                 inputColumns,
@@ -59,7 +60,8 @@ public class DeltaLakeCdfPageSink
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                useDeltaLengthByteArrayEncoding);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -134,6 +134,7 @@ public class DeltaLakeMergeSink
     private final Map<String, DeletionVectorEntry> deletionVectors;
     private final int randomPrefixLength;
     private final Optional<String> shallowCloneSourceTableLocation;
+    private final boolean useDeltaLengthByteArrayEncoding;
     private long writtenBytes;
 
     @Nullable
@@ -161,7 +162,8 @@ public class DeltaLakeMergeSink
             boolean deletionVectorEnabled,
             Map<String, DeletionVectorEntry> deletionVectors,
             int randomPrefixLength,
-            Optional<String> shallowCloneSourceTableLocation)
+            Optional<String> shallowCloneSourceTableLocation,
+            boolean useDeltaLengthByteArrayEncoding)
     {
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
         this.session = requireNonNull(session, "session is null");
@@ -191,6 +193,7 @@ public class DeltaLakeMergeSink
         this.deletionVectors = ImmutableMap.copyOf(requireNonNull(deletionVectors, "deletionVectors is null"));
         this.randomPrefixLength = randomPrefixLength;
         this.shallowCloneSourceTableLocation = requireNonNull(shallowCloneSourceTableLocation, "shallowCloneSourceTableLocation is null");
+        this.useDeltaLengthByteArrayEncoding = useDeltaLengthByteArrayEncoding;
 
         dataColumnsIndices = new int[tableColumnCount];
         dataAndRowIdColumnsIndices = new int[tableColumnCount + 1];
@@ -517,6 +520,7 @@ public class DeltaLakeMergeSink
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxPageValueCount(getParquetWriterPageValueCount(session))
+                .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)
                 .build();
         CompressionCodec compressionCodec = toCompressionCodec(getCompressionCodec(session)).getParquetCompressionCodec()
                 .orElseThrow(); // validated on the session property level

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSink.java
@@ -40,7 +40,8 @@ public class DeltaLakePageSink
             ConnectorSession session,
             DeltaLakeWriterStats stats,
             String trinoVersion,
-            DeltaLakeParquetSchemaMapping parquetSchemaMapping)
+            DeltaLakeParquetSchemaMapping parquetSchemaMapping,
+            boolean useDeltaLengthByteArrayEncoding)
     {
         super(typeOperators,
                 inputColumns,
@@ -55,7 +56,8 @@ public class DeltaLakePageSink
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                useDeltaLengthByteArrayEncoding);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -24,6 +24,7 @@ import io.trino.plugin.deltalake.procedure.DeltaTableOptimizeHandle;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
@@ -74,6 +75,7 @@ public class DeltaLakePageSinkProvider
     private final TypeManager typeManager;
     private final String trinoVersion;
     private final int domainCompactionThreshold;
+    private final boolean useDeltaLengthByteArrayEncoding;
 
     @Inject
     public DeltaLakePageSinkProvider(
@@ -85,6 +87,7 @@ public class DeltaLakePageSinkProvider
             FileFormatDataSourceStats fileFormatDataSourceStats,
             DeltaLakeConfig deltaLakeConfig,
             ParquetReaderConfig parquetReaderConfig,
+            ParquetWriterConfig parquetWriterConfig,
             TypeManager typeManager,
             NodeVersion nodeVersion)
     {
@@ -98,6 +101,7 @@ public class DeltaLakePageSinkProvider
         this.maxPartitionsPerWriter = deltaLakeConfig.getMaxPartitionsPerWriter();
         this.parquetDateTimeZone = deltaLakeConfig.getParquetDateTimeZone();
         this.domainCompactionThreshold = deltaLakeConfig.getDomainCompactionThreshold();
+        this.useDeltaLengthByteArrayEncoding = parquetWriterConfig.isDeltaLengthByteArrayEncodingEnabled();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.trinoVersion = nodeVersion.toString();
     }
@@ -129,7 +133,8 @@ public class DeltaLakePageSinkProvider
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                useDeltaLengthByteArrayEncoding);
     }
 
     @Override
@@ -156,7 +161,8 @@ public class DeltaLakePageSinkProvider
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                useDeltaLengthByteArrayEncoding);
     }
 
     @Override
@@ -185,7 +191,8 @@ public class DeltaLakePageSinkProvider
                         session,
                         stats,
                         trinoVersion,
-                        parquetSchemaMapping);
+                        parquetSchemaMapping,
+                        useDeltaLengthByteArrayEncoding);
             }
             default -> throw new IllegalArgumentException("Unknown procedure: " + executeHandle.procedureId());
         };
@@ -226,7 +233,8 @@ public class DeltaLakePageSinkProvider
                 isDeletionVectorEnabled(tableHandle.metadataEntry(), tableHandle.protocolEntry()),
                 merge.deletionVectors(),
                 getRandomPrefixLength(tableHandle.metadataEntry()),
-                merge.shallowCloneSourceTableLocation());
+                merge.shallowCloneSourceTableLocation(),
+                useDeltaLengthByteArrayEncoding);
     }
 
     private DeltaLakeCdfPageSink createCdfPageSink(
@@ -275,6 +283,7 @@ public class DeltaLakePageSinkProvider
                 session,
                 stats,
                 trinoVersion,
-                parquetSchemaMapping);
+                parquetSchemaMapping,
+                useDeltaLengthByteArrayEncoding);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -97,12 +97,12 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.writeCache", "00000000000000000002.json", 0, 658))
                         .add(new CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p2/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p2/", 0, 229))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p2/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p2/", 0, 230))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
@@ -116,8 +116,8 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.length", "00000000000000000002.crc"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 229))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 230))
                         .build());
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p3', '3-xyz')", 1);
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p4', '4-xyz')", 1);
@@ -143,17 +143,17 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.length", "00000000000000000005.crc"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000006.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p3/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p4/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p5/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p3/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p4/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p5/", 0, 229))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p3/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p4/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p5/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p3/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p4/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p5/", 0, 230))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
@@ -173,11 +173,11 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.length", "00000000000000000005.crc"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000006.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 229), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 229), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 229), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 229), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 229), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 230), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 230), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 230), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 230), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 230), 1)
                         .build());
     }
 
@@ -708,12 +708,12 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.writeCache", "00000000000000000002.json", 0, 658))
                         .add(new CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Input.readFully", "key=p2/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p1/", 0, 229))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p2/", 0, 229))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Input.readFully", "key=p2/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p1/", 0, 230))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p2/", 0, 230))
                         .build());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMutableTransactionLog.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMutableTransactionLog.java
@@ -80,12 +80,12 @@ public class TestDeltaLakeAlluxioCacheMutableTransactionLog
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "00000000000000000002.crc"))
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 229))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 229))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p1/", 0, 229))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p2/", 0, 229))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p1/", 0, 229))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p2/", 0, 229))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 230))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 230))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p1/", 0, 230))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p2/", 0, 230))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p1/", 0, 230))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p2/", 0, 230))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_transaction_log_not_cached",
@@ -95,8 +95,8 @@ public class TestDeltaLakeAlluxioCacheMutableTransactionLog
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "00000000000000000002.crc"))
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 229))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 229))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 230))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 230))
                         .build());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -27,6 +27,7 @@ import io.trino.plugin.deltalake.metastore.NoOpVendedCredentialsProvider;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
@@ -193,6 +194,7 @@ public class TestDeltaLakePageSink
                 new FileFormatDataSourceStats(),
                 deltaLakeConfig,
                 new ParquetReaderConfig(),
+                new ParquetWriterConfig(),
                 TESTING_TYPE_MANAGER,
                 new NodeVersion("test-version"));
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -69,6 +69,7 @@ public class ParquetFileWriterFactory
     private final NodeVersion nodeVersion;
     private final TypeManager typeManager;
     private final DateTimeZone parquetTimeZone;
+    private final boolean useDeltaLengthByteArrayEncoding;
     private final FileFormatDataSourceStats readStats;
 
     @Inject
@@ -77,12 +78,14 @@ public class ParquetFileWriterFactory
             NodeVersion nodeVersion,
             TypeManager typeManager,
             HiveConfig hiveConfig,
+            ParquetWriterConfig parquetWriterConfig,
             FileFormatDataSourceStats readStats)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.parquetTimeZone = hiveConfig.getParquetDateTimeZone();
+        this.useDeltaLengthByteArrayEncoding = parquetWriterConfig.isDeltaLengthByteArrayEncodingEnabled();
         this.readStats = requireNonNull(readStats, "readStats is null");
     }
 
@@ -109,6 +112,7 @@ public class ParquetFileWriterFactory
                 .setMaxBlockSize(HiveSessionProperties.getParquetWriterBlockSize(session))
                 .setBatchSize(HiveSessionProperties.getParquetBatchSize(session))
                 .setBloomFilterColumns(getParquetBloomFilterColumns(schema))
+                .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)
                 .build();
 
         List<String> fileColumnNames = getColumnNames(schema);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
@@ -49,6 +49,7 @@ public class ParquetWriterConfig
     private int pageValueCount = ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT;
     private int batchSize = ParquetWriterOptions.DEFAULT_BATCH_SIZE;
     private double validationPercentage = 5;
+    private boolean deltaLengthByteArrayEncodingEnabled = true;
 
     @MaxDataSize(PARQUET_WRITER_MAX_BLOCK_SIZE)
     public DataSize getBlockSize()
@@ -116,6 +117,19 @@ public class ParquetWriterConfig
     public ParquetWriterConfig setValidationPercentage(double validationPercentage)
     {
         this.validationPercentage = validationPercentage;
+        return this;
+    }
+
+    public boolean isDeltaLengthByteArrayEncodingEnabled()
+    {
+        return deltaLengthByteArrayEncodingEnabled;
+    }
+
+    @Config("parquet.writer.delta-length-byte-array-encoding-enabled")
+    @ConfigDescription("Use DELTA_LENGTH_BYTE_ARRAY encoding instead of PLAIN as the non-dictionary fallback for BYTE_ARRAY columns")
+    public ParquetWriterConfig setDeltaLengthByteArrayEncodingEnabled(boolean deltaLengthByteArrayEncodingEnabled)
+    {
+        this.deltaLengthByteArrayEncodingEnabled = deltaLengthByteArrayEncodingEnabled;
         return this;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
@@ -162,7 +162,7 @@ public final class HiveTestUtils
                 .add(new AvroFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER, nodeVersion))
                 .add(new RcFileFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER, nodeVersion, hiveConfig))
                 .add(new OrcFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER, nodeVersion, new FileFormatDataSourceStats(), new OrcWriterConfig()))
-                .add(new ParquetFileWriterFactory(fileSystemFactory, nodeVersion, TESTING_TYPE_MANAGER, hiveConfig, new FileFormatDataSourceStats()))
+                .add(new ParquetFileWriterFactory(fileSystemFactory, nodeVersion, TESTING_TYPE_MANAGER, hiveConfig, new ParquetWriterConfig(), new FileFormatDataSourceStats()))
                 .build();
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -606,7 +606,7 @@ public final class TestHiveFileFormats
                 .withSession(session)
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
-                .withFileWriterFactory(fileSystemFactory -> new ParquetFileWriterFactory(fileSystemFactory, new NodeVersion("test-version"), TESTING_TYPE_MANAGER, new HiveConfig(), STATS))
+                .withFileWriterFactory(fileSystemFactory -> new ParquetFileWriterFactory(fileSystemFactory, new NodeVersion("test-version"), TESTING_TYPE_MANAGER, new HiveConfig(), new ParquetWriterConfig(), STATS))
                 .isReadableByPageSource(fileSystemFactory -> new ParquetPageSourceFactory(fileSystemFactory, STATS, Optional.empty(), new ParquetReaderConfig(), new HiveConfig()));
     }
 
@@ -652,7 +652,7 @@ public final class TestHiveFileFormats
                 // Since this is not a valid scenario for Trino parquet writer, we disable parquet writer validation to avoid test failures
                 .withSession(getHiveSession(createParquetHiveConfig(true), new ParquetWriterConfig().setValidationPercentage(0)))
                 .withRowsCount(rowCount)
-                .withFileWriterFactory(fileSystemFactory -> new ParquetFileWriterFactory(fileSystemFactory, new NodeVersion("test-version"), TESTING_TYPE_MANAGER, new HiveConfig(), STATS))
+                .withFileWriterFactory(fileSystemFactory -> new ParquetFileWriterFactory(fileSystemFactory, new NodeVersion("test-version"), TESTING_TYPE_MANAGER, new HiveConfig(), new ParquetWriterConfig(), STATS))
                 .isReadableByPageSource(fileSystemFactory -> new ParquetPageSourceFactory(fileSystemFactory, STATS, Optional.empty(), new ParquetReaderConfig(), new HiveConfig()));
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
@@ -35,7 +35,8 @@ public class TestParquetWriterConfig
                 .setPageSize(DataSize.ofBytes(ParquetProperties.DEFAULT_PAGE_SIZE))
                 .setPageValueCount(ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT)
                 .setBatchSize(ParquetWriterOptions.DEFAULT_BATCH_SIZE)
-                .setValidationPercentage(5));
+                .setValidationPercentage(5)
+                .setDeltaLengthByteArrayEncodingEnabled(true));
     }
 
     @Test
@@ -46,14 +47,16 @@ public class TestParquetWriterConfig
                 "parquet.writer.page-size", "6MB",
                 "parquet.writer.page-value-count", "10000",
                 "parquet.writer.batch-size", "100",
-                "parquet.writer.validation-percentage", "10");
+                "parquet.writer.validation-percentage", "10",
+                "parquet.writer.delta-length-byte-array-encoding-enabled", "false");
 
         ParquetWriterConfig expected = new ParquetWriterConfig()
                 .setBlockSize(DataSize.of(234, MEGABYTE))
                 .setPageSize(DataSize.of(6, MEGABYTE))
                 .setPageValueCount(10_000)
                 .setBatchSize(100)
-                .setValidationPercentage(10);
+                .setValidationPercentage(10)
+                .setDeltaLengthByteArrayEncodingEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -73,6 +73,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMinSt
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterValidateMode;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBatchSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBlockSize;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterDeltaLengthByteArrayEncodingEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
@@ -183,6 +184,7 @@ public class IcebergFileWriterFactory
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
                     .setBatchSize(getParquetWriterBatchSize(session))
                     .setBloomFilterColumns(getParquetBloomFilterColumns(storageProperties))
+                    .setUseDeltaLengthByteArrayEncoding(getParquetWriterDeltaLengthByteArrayEncodingEnabled(session))
                     .build();
 
             HiveCompressionCodec compressionCodec = getHiveCompressionCodec(PARQUET, storageProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -99,6 +99,12 @@ public class IcebergModule
 
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);
+        // iceberg-arrow's vectorized parquet reader does not support DELTA_LENGTH_BYTE_ARRAY
+        // encoded byte arrays in iceberg <= 1.10.x; default to PLAIN until apache/iceberg#15362
+        // (in iceberg >= 1.11) is on the classpath. Users can re-enable per catalog by setting
+        // parquet.writer.delta-length-byte-array-encoding-enabled=true.
+        configBinder(binder).bindConfigDefaults(ParquetWriterConfig.class, config ->
+                config.setDeltaLengthByteArrayEncodingEnabled(false));
 
         binder.bind(ForwardingFileIoFactory.class).in(Scopes.SINGLETON);
         binder.bind(TableStatisticsReader.class).in(Scopes.SINGLETON);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -90,6 +90,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
+    private static final String PARQUET_WRITER_DELTA_LENGTH_BYTE_ARRAY_ENCODING_ENABLED = "parquet_writer_delta_length_byte_array_encoding_enabled";
     public static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String STATISTICS_ENABLED = "statistics_enabled";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
@@ -289,6 +290,11 @@ public final class IcebergSessionProperties
                         PARQUET_WRITER_BATCH_SIZE,
                         "Parquet: Maximum number of rows passed to the writer in each batch",
                         parquetWriterConfig.getBatchSize(),
+                        false))
+                .add(booleanProperty(
+                        PARQUET_WRITER_DELTA_LENGTH_BYTE_ARRAY_ENCODING_ENABLED,
+                        "Parquet: Use DELTA_LENGTH_BYTE_ARRAY encoding for binary and string columns",
+                        parquetWriterConfig.isDeltaLengthByteArrayEncodingEnabled(),
                         false))
                 .add(durationProperty(
                         DYNAMIC_FILTERING_WAIT_TIMEOUT,
@@ -545,6 +551,11 @@ public final class IcebergSessionProperties
     public static int getParquetWriterBatchSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
+    }
+
+    public static boolean getParquetWriterDeltaLengthByteArrayEncodingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_DELTA_LENGTH_BYTE_ARRAY_ENCODING_ENABLED, Boolean.class);
     }
 
     public static boolean useParquetBloomFilter(ConnectorSession session)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeInsertCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeInsertCompatibility.java
@@ -20,6 +20,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -35,6 +36,7 @@ import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICK
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.dropDeltaTableWithRetry;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -429,6 +431,46 @@ public class TestDeltaLakeInsertCompatibility
                 {"ZSTD"},
                 {"GZIP"},
         };
+    }
+
+    @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testTrinoCreatedTableWithDeltaLengthByteArrayCompatibility()
+    {
+        String tableName = "test_dl_delta_length_byte_array_compat_" + randomNameSuffix();
+        String trinoTableName = "delta.default." + tableName;
+        String location = "s3://" + bucketName + "/databricks-compatibility-test-" + tableName;
+
+        onTrino().executeQuery(format(
+                "CREATE TABLE %s (id INTEGER, str VARCHAR, bin VARBINARY) WITH (location = '%s')",
+                trinoTableName,
+                location));
+
+        try {
+            // Force DELTA_LENGTH_BYTE_ARRAY fallback by inserting 5000 high-cardinality
+            // UUID-derived rows. The dictionary writer falls back at first-page flush via the
+            // compression ratio check (random UUIDs offer no dictionary compression);
+            // 5000 rows is comfortably above the empirical threshold pinned by
+            // TestParquetWriter#testDeltaLengthByteArrayFallbackIsWritten.
+            StringBuilder values = new StringBuilder();
+            for (int i = 0; i < 5000; i++) {
+                String uuid = UUID.randomUUID().toString();
+                if (i > 0) {
+                    values.append(", ");
+                }
+                values.append(format("(%d, '%s', X'%s')", i, uuid, uuid.replace("-", "")));
+            }
+            onTrino().executeQuery(format("INSERT INTO %s VALUES %s", trinoTableName, values));
+
+            assertThat(onDelta().executeQuery("SELECT count(*) FROM default." + tableName))
+                    .containsOnly(row(5000L));
+            assertThat(onDelta().executeQuery("SELECT count(DISTINCT str) FROM default." + tableName))
+                    .containsOnly(row(5000L));
+            assertThat(onDelta().executeQuery("SELECT count(DISTINCT bin) FROM default." + tableName))
+                    .containsOnly(row(5000L));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
     }
 
     @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tempto.assertions.QueryAssert.Row;
@@ -360,6 +361,48 @@ public class TestHiveSparkCompatibility
             for (String trinoTable : trinoTables) {
                 onTrino().executeQuery("DROP TABLE IF EXISTS " + trinoTable);
             }
+        }
+    }
+
+    @Test(groups = {HIVE_SPARK, PROFILE_SPECIFIC_TESTS})
+    public void testTrinoSparkParquetDeltaLengthByteArrayCompatibility()
+    {
+        String trinoTableName = "test_trino_spark_parquet_delta_length_compat_" + randomNameSuffix();
+        String fullyQualifiedTrinoTableName = format("%s.default.%s", TRINO_CATALOG, trinoTableName);
+        try {
+            onTrino().executeQuery(format(
+                    "CREATE TABLE %s (id INTEGER, str VARCHAR, bin VARBINARY) WITH (format = 'PARQUET')",
+                    fullyQualifiedTrinoTableName));
+
+            // Force the DELTA_LENGTH_BYTE_ARRAY fallback with high-cardinality UUID-derived
+            // values. The dictionary writer falls back at first-page flush via the compression
+            // ratio check (random UUIDs offer no dictionary compression); 5000 rows is
+            // comfortably above the empirical threshold pinned by
+            // TestParquetWriter#testDeltaLengthByteArrayFallbackIsWritten.
+            StringBuilder values = new StringBuilder();
+            for (int i = 0; i < 5000; i++) {
+                String uuid = UUID.randomUUID().toString();
+                if (i > 0) {
+                    values.append(", ");
+                }
+                values.append(format("(%d, '%s', X'%s')", i, uuid, uuid.replace("-", "")));
+            }
+            onTrino().executeQuery(format("INSERT INTO %s VALUES %s", fullyQualifiedTrinoTableName, values));
+
+            // Hive read
+            assertThat(onHive().executeQuery(format("SELECT count(*) FROM default.%s", trinoTableName)))
+                    .containsOnly(row(5000));
+
+            // Spark on the Hive catalog
+            assertThat(onSpark().executeQuery(format("SELECT count(*) FROM default.%s", trinoTableName)))
+                    .containsOnly(row(5000L));
+            assertThat(onSpark().executeQuery(format("SELECT count(DISTINCT str) FROM default.%s", trinoTableName)))
+                    .containsOnly(row(5000L));
+            assertThat(onSpark().executeQuery(format("SELECT count(DISTINCT bin) FROM default.%s", trinoTableName)))
+                    .containsOnly(row(5000L));
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE IF EXISTS " + fullyQualifiedTrinoTableName);
         }
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -3604,6 +3605,48 @@ public class TestIcebergSparkCompatibility
         assertSparkBloomFilterTableSelectResult(sparkTableName);
 
         onTrino().executeQuery("DROP TABLE " + trinoTableName);
+    }
+
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE}, description = "Sentinel: asserts iceberg-arrow's vectorized parquet reader fails on DELTA_LENGTH_BYTE_ARRAY pages. When iceberg-arrow gains support, this assertion fails, signaling that the Iceberg connector should flip parquet.writer.delta-length-byte-array-encoding-enabled to true by default.")
+    public void testTrinoSparkParquetDeltaLengthByteArrayCompatibility()
+    {
+        String baseTableName = "test_trino_spark_iceberg_delta_length_compat_" + randomNameSuffix();
+        String trinoTableName = trinoTableName(baseTableName);
+        String sparkTableName = sparkTableName(baseTableName);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + trinoTableName);
+
+        onTrino().executeQuery(format(
+                "CREATE TABLE %s (id INTEGER, str VARCHAR, bin VARBINARY) WITH (format = 'PARQUET')",
+                trinoTableName));
+        try {
+            // Force DELTA_LENGTH_BYTE_ARRAY fallback with high-cardinality UUID-derived
+            // values. The dictionary writer falls back at first-page flush via the compression
+            // ratio check (random UUIDs offer no dictionary compression); 5000 rows is
+            // comfortably above the empirical threshold pinned by
+            // TestParquetWriter#testDeltaLengthByteArrayFallbackIsWritten.
+            StringBuilder values = new StringBuilder();
+            for (int i = 0; i < 5000; i++) {
+                String uuid = UUID.randomUUID().toString();
+                if (i > 0) {
+                    values.append(", ");
+                }
+                values.append(format("(%d, '%s', X'%s')", i, uuid, uuid.replace("-", "")));
+            }
+            // The connector default is false so that Spark+Iceberg reads of small tables
+            // stay healthy; opt in explicitly here to trigger the iceberg-arrow vectorized
+            // read failure that this sentinel test asserts.
+            onTrino().executeQuery("SET SESSION iceberg.parquet_writer_delta_length_byte_array_encoding_enabled = true");
+            onTrino().executeQuery(format("INSERT INTO %s VALUES %s", trinoTableName, values));
+
+            // iceberg-arrow's vectorized parquet reader does not support DELTA_LENGTH_BYTE_ARRAY
+            // in older iceberg versions; reading should fail.
+            assertQueryFailure(() -> onSpark().executeQuery(format("SELECT count(DISTINCT str) FROM %s", sparkTableName)))
+                    .hasMessageContaining("Cannot support vectorized reads")
+                    .hasMessageContaining("DELTA_LENGTH_BYTE_ARRAY");
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + trinoTableName);
+        }
     }
 
     private static void assertTrinoBloomFilterTableSelectResult(String trinoTable)


### PR DESCRIPTION
## Summary

Make the Trino Parquet writer use `DELTA_LENGTH_BYTE_ARRAY` (Parquet encoding 6) instead of `PLAIN` as the non-dictionary fallback for `BYTE_ARRAY` columns, behind a new `parquet.writer.delta-length-byte-array-encoding-enabled` config flag. The Parquet specification recommends this encoding over `PLAIN`: lengths are encoded with `DELTA_BINARY_PACKED` and the byte data is concatenated separately, typically yielding smaller encoded size and better post-compression ratio.

## Default per connector

| Connector | Default | Override |
|---|---|---|
| Hive | enabled | `parquet.writer.delta-length-byte-array-encoding-enabled` config property |
| Delta Lake | enabled | same |
| Iceberg | disabled¹ | per-catalog config; per-query session property `iceberg.parquet_writer_delta_length_byte_array_encoding_enabled` |

¹ The Iceberg connector overrides the default to `false` because iceberg-arrow's vectorized parquet reader does not support `DELTA_LENGTH_BYTE_ARRAY` pages in iceberg ≤ 1.10.x. The fix is in [apache/iceberg#15362](https://github.com/apache/iceberg/pull/15362), expected to land in iceberg 1.11+. The default should be flipped to `true` for Iceberg once the dependency is bumped — `TestIcebergSparkCompatibility#testTrinoSparkParquetDeltaLengthByteArrayCompatibility` is a sentinel that will start failing when the iceberg-arrow path supports the encoding.

Note: Some versions of Apache Spark contain a bug in their vectorized parquet reader which cause failure to read columns with DELTA_LENGTH_BYTE_ARRAY encoding, this has been fixed by https://issues.apache.org/jira/browse/SPARK-52240 in versions 4.1.0, 4.0.1 and 3.5.7

## Benchmarks

### `BenchmarkBinaryColumnReader` — read throughput, ops/s

Realistic data shapes only (the synthetic CHAR-with-padding cases are absent from typical workloads).

| positionLength | type | data shape | PLAIN | DELTA_LENGTH | speedup |
|---|---|---|--:|--:|--:|
| VARIABLE_0_100 | UNBOUNDED | unbounded binary, length ≤ 100 B | 64.9 | 452.9 | **6.97×** |
| VARIABLE_0_100 | VARCHAR_ASCII_BOUND_EXACT | bounded VARCHAR, length ≤ 100 chars | 55.7 | 505.8 | **9.08×** |
| VARIABLE_0_1000 | UNBOUNDED | unbounded binary, length ≤ 1000 B | 15,976 | 182,538 | **11.42×** |
| VARIABLE_0_1000 | VARCHAR_ASCII_BOUND_EXACT | bounded VARCHAR, length ≤ 1000 chars | 14,440 | 205,584 | **14.24×** |
| FIXED_10 | VARCHAR_ASCII_BOUND_EXACT | bounded VARCHAR, fixed length 10 chars | 92 | 1,006 | **10.92×** |
| FIXED_100 | VARCHAR_ASCII_BOUND_EXACT | bounded VARCHAR, fixed length 100 chars | 4,189 | 121,255 | **28.95×** |

20 samples per combo (5 warmup + 10 measurement iterations × 2 forks).

### `BenchmarkParquetFormat` — write LINEITEM with SNAPPY

| `useDeltaLengthByteArrayEncoding` | ops/s | bytes/file | MB/s |
|---|--:|--:|--:|
| `true` (DELTA_LENGTH) | **5.97 ± 0.45** | 12,326,852 | **298.4 ± 22.4** |
| `false` (PLAIN) | 4.86 ± 0.98 | 12,738,816 | 243.1 ± 49.1 |

20 samples (10 warmup + 10 measurement iterations × 2 forks). +23% throughput, −3% file size on the write path.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* Improve compression and read performance for high-cardinality string columns in Parquet files by using `DELTA_LENGTH_BYTE_ARRAY` encoding. This can be disabled via the `parquet.writer.delta-length-byte-array-encoding-enabled` config property. ({issue}`29246`)

## Delta Lake connector
* Improve compression and read performance for high-cardinality string columns in Parquet files by using `DELTA_LENGTH_BYTE_ARRAY` encoding. This can be disabled via the `parquet.writer.delta-length-byte-array-encoding-enabled` config property. ({issue}`29246`)
```
