### PR TITLE
Detect division overflow for MIN_VALUE / -1

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
@@ -41,6 +41,7 @@ import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
+import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
 import static java.lang.runtime.ExactConversionsSupport.isLongToShortExact;
 
 public final class IntegerOperators
@@ -88,7 +89,11 @@ public final class IntegerOperators
     public static long divide(@SqlType(StandardTypes.INTEGER) long left, @SqlType(StandardTypes.INTEGER) long right)
     {
         try {
-            return left / right;
+            long result = left / right;
+            if (!isLongToIntExact(result)) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("integer division overflow: %s / %s", left, right));
+            }
+            return result;
         }
         catch (ArithmeticException e) {
             throw new TrinoException(DIVISION_BY_ZERO, "Division by zero", e);

--- a/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
@@ -84,7 +84,11 @@ public final class SmallintOperators
     public static long divide(@SqlType(StandardTypes.SMALLINT) long left, @SqlType(StandardTypes.SMALLINT) long right)
     {
         try {
-            return left / right;
+            long result = left / right;
+            if (!isLongToShortExact(result)) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("smallint division overflow: %s / %s", left, right));
+            }
+            return result;
         }
         catch (ArithmeticException e) {
             throw new TrinoException(DIVISION_BY_ZERO, "Division by zero", e);

--- a/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
@@ -81,7 +81,11 @@ public final class TinyintOperators
     public static long divide(@SqlType(StandardTypes.TINYINT) long left, @SqlType(StandardTypes.TINYINT) long right)
     {
         try {
-            return left / right;
+            long result = left / right;
+            if (!isLongToByteExact(result)) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("tinyint division overflow: %s / %s", left, right));
+            }
+            return result;
         }
         catch (ArithmeticException e) {
             throw new TrinoException(DIVISION_BY_ZERO, "Division by zero", e);

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -61,6 +61,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.SystemSessionProperties.IGNORE_DOWNSTREAM_PREFERENCES;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -6716,6 +6717,19 @@ public abstract class AbstractTestEngineOnlyQueries
                 .isEqualTo(Double.NEGATIVE_INFINITY);
         assertThat(computeActual("SELECT NUMBER 'NaN'").getOnlyValue())
                 .isEqualTo(Double.NaN);
+    }
+
+    @Test
+    public void testDivisionOverflow()
+    {
+        assertThat(query("SELECT CAST(-0x80 AS tinyint) / TINYINT '-1'"))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+        assertThat(query("SELECT CAST(-0x8000 AS smallint) / SMALLINT '-1'"))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+        assertThat(query("SELECT CAST(-0x80000000 AS integer) / INTEGER '-1'"))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+        assertThat(query("SELECT CAST(-0x8000000000000000 AS bigint) / BIGINT '-1'"))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     private static int getNumberMaxDecimalPrecision()


### PR DESCRIPTION
Detect overflow when dividing minimal TINYINT/SMALLINT/INTEGER value by -1.

Before the changes, when division was sole operation, it would
eventually produce GENERIC_INTERNAL_ERROR. When it was part of complex
expression, it could go unnoticed and produce arbitrary results.

- fixes https://github.com/trinodb/trino/issues/29251