### PR TITLE
Add drop with purge by catalog property to iceberg rest catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -536,7 +536,10 @@ following properties:
 * - `iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl`
   - [Duration](prop-type-duration) for which case-insensitive namespace, table, 
     and view names are cached. Defaults to `1m`.
-  :::
+* - `iceberg.rest-catalog.drop-with-purge-by-catalog-enabled`
+  - Controls whether REST Catalog should handle drop with purge operation. Defaults to `true`. This property must only be set as a workaround for [this
+    issue](https://github.com/apache/polaris/issues/3695).   
+    :::
 
 The following example shows a minimal catalog configuration using an Iceberg
 REST metadata catalog:

--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -538,8 +538,8 @@ following properties:
     and view names are cached. Defaults to `1m`.
 * - `iceberg.rest-catalog.drop-with-purge-by-catalog-enabled`
   - Controls whether REST Catalog should handle drop with purge operation. Defaults to `true`. This property must only be set as a workaround for [this
-    issue](https://github.com/apache/polaris/issues/3695).   
-    :::
+      issue](https://github.com/apache/polaris/issues/3695).
+  :::
 
 The following example shows a minimal catalog configuration using an Iceberg
 REST metadata catalog:

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -60,6 +60,7 @@ public class IcebergRestCatalogConfig
     private boolean viewEndpointsEnabled = true;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+    private boolean dropWithPurgeByCatalogEnabled = true;
 
     @NotNull
     public URI getBaseUri()
@@ -236,6 +237,19 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
     {
         this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
+        return this;
+    }
+
+    public boolean isDropWithPurgeByCatalogEnabled()
+    {
+        return dropWithPurgeByCatalogEnabled;
+    }
+
+    @Config("iceberg.rest-catalog.drop-with-purge-by-catalog-enabled")
+    @ConfigDescription("Enable purge operation by rest catalog")
+    public IcebergRestCatalogConfig setDropWithPurgeByCatalogEnabled(boolean purgeByCatalogEnabled)
+    {
+        this.dropWithPurgeByCatalogEnabled = purgeByCatalogEnabled;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -73,6 +73,7 @@ public class TrinoIcebergRestCatalogFactory
     private final boolean caseInsensitiveNameMatching;
     private final Cache<Namespace, Namespace> remoteNamespaceMappingCache;
     private final Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache;
+    private final boolean dropWithPurgeByCatalogEnabled;
 
     @GuardedBy("this")
     private RESTSessionCatalog icebergCatalog;
@@ -117,6 +118,7 @@ public class TrinoIcebergRestCatalogFactory
                 .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
                 .build();
+        this.dropWithPurgeByCatalogEnabled = restConfig.isDropWithPurgeByCatalogEnabled();
     }
 
     @Override
@@ -174,6 +176,7 @@ public class TrinoIcebergRestCatalogFactory
                 caseInsensitiveNameMatching,
                 remoteNamespaceMappingCache,
                 remoteTableMappingCache,
-                viewEndpointsEnabled);
+                viewEndpointsEnabled,
+                dropWithPurgeByCatalogEnabled);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -130,6 +130,7 @@ public class TrinoRestCatalog
     private final Cache<Namespace, Namespace> remoteNamespaceMappingCache;
     private final Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache;
     private final boolean viewEndpointsEnabled;
+    private final boolean dropWithPurgeByCatalogEnabled;
 
     private final Cache<SchemaTableName, BaseTable> tableCache = EvictableCacheBuilder.newBuilder()
             .maximumSize(PER_QUERY_CACHE_SIZE)
@@ -149,7 +150,8 @@ public class TrinoRestCatalog
             boolean caseInsensitiveNameMatching,
             Cache<Namespace, Namespace> remoteNamespaceMappingCache,
             Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache,
-            boolean viewEndpointsEnabled)
+            boolean viewEndpointsEnabled,
+            boolean dropWithPurgeByCatalogEnabled)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.restSessionCatalog = requireNonNull(restSessionCatalog, "restSessionCatalog is null");
@@ -165,6 +167,7 @@ public class TrinoRestCatalog
         this.remoteNamespaceMappingCache = requireNonNull(remoteNamespaceMappingCache, "remoteNamespaceMappingCache is null");
         this.remoteTableMappingCache = requireNonNull(remoteTableMappingCache, "remoteTableMappingCache is null");
         this.viewEndpointsEnabled = viewEndpointsEnabled;
+        this.dropWithPurgeByCatalogEnabled = dropWithPurgeByCatalogEnabled;
     }
 
     @Override
@@ -484,8 +487,8 @@ public class TrinoRestCatalog
     @Override
     public void dropTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        if (security == Security.GOOGLE) {
-            purgeBigLakeTable(session, schemaTableName);
+        if (security == Security.GOOGLE || !dropWithPurgeByCatalogEnabled) {
+            purgeTableInternally(session, schemaTableName);
         }
         else {
             purgeTable(session, schemaTableName);
@@ -494,7 +497,7 @@ public class TrinoRestCatalog
         invalidateTableMappingCache(schemaTableName);
     }
 
-    private void purgeBigLakeTable(ConnectorSession session, SchemaTableName schemaTableName)
+    private void purgeTableInternally(ConnectorSession session, SchemaTableName schemaTableName)
     {
         BaseTable table = loadTable(session, schemaTableName);
         unregisterTable(session, schemaTableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -107,6 +107,7 @@ public class TestTrinoRestCatalog
                 false,
                 EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
                 EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
+                true,
                 true);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Addressing feature proposal: https://github.com/trinodb/trino/issues/29243.
Add new Iceberg Rest catalog property that controls whether REST Catalog should handle drop with purge operation. Defaults to `true`. This property must only be set as a workaround for https://github.com/apache/polaris/issues/3695.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/apache/polaris/issues/3695
It's hard to use Trino with Apache Polaris 1.4.0 release if 'drop table' is required.
Root cause is in Apache Polaris TableCleanupTaskHandler implementation that does not work well with few GB tables and more.
Apache Polaris contributors verdict for now:

> It's likely purge workload saturates storage/credential HTTP clients, Polaris stops answering liveness in time, Kubernetes restarts it. We will need a delegation service for drop-by-purge, which isn't there yet. We have to build it. As a workaround, try not to have Polaris handle it, use engines(spark/trino) for purging table instead.

This PR is addressing their suggestion.

PR details: table purge is reusing existing logic from REST catalog + Security == GOOGLE. To don't duplicate code but make method name consistent with when it's executing I rename purgeBigLakeTable to purgeTableInternally (means purge internally by Trino). Not sure that naming is good so please feel free to make suggestions here.
Thanks!

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`29243`)
```
