### PR TITLE
Add totalSnapshots to IcebergInputInfo

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergInputInfo.java
@@ -26,6 +26,7 @@ public record IcebergInputInfo(
         OptionalLong snapshotId,
         List<String> partitionFields,
         String tableDefaultFileFormat,
+        String totalSnapshots,
         Optional<String> totalRecords,
         Optional<String> deletedRecords,
         Optional<String> totalDataFiles,
@@ -38,6 +39,7 @@ public record IcebergInputInfo(
         requireNonNull(snapshotId, "snapshotId is null");
         partitionFields = ImmutableList.copyOf(partitionFields);
         requireNonNull(tableDefaultFileFormat, "tableDefaultFileFormat is null");
+        requireNonNull(totalSnapshots, "totalSnapshots is null");
         requireNonNull(totalRecords, "totalRecords is null");
         requireNonNull(deletedRecords, "deletedRecords is null");
         requireNonNull(totalDataFiles, "totalDataFiles is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2745,9 +2745,11 @@ public class IcebergMetadata
                         .collect(toImmutableList()) : ImmutableList.of();
 
         Map<String, String> summary = ImmutableMap.of();
+        long totalSnapshots = 0;
         if (icebergTableHandle.getSnapshotId().isPresent()) {
             Table table = catalog.loadTable(session, icebergTableHandle.getSchemaTableName());
             summary = table.snapshot(icebergTableHandle.getSnapshotId().getAsLong()).summary();
+            totalSnapshots = Iterables.size(table.snapshots());
         }
         Optional<String> totalRecords = Optional.ofNullable(summary.get(TOTAL_RECORDS_PROP));
         Optional<String> deletedRecords = Optional.ofNullable(summary.get(DELETED_RECORDS_PROP));
@@ -2761,6 +2763,7 @@ public class IcebergMetadata
                 icebergTableHandle.getSnapshotId(),
                 partitionFields,
                 getFileFormat(icebergTableHandle.getStorageProperties()).name(),
+                String.valueOf(totalSnapshots),
                 totalRecords,
                 deletedRecords,
                 totalDataFiles,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
@@ -49,11 +49,21 @@ public class TestIcebergInputInfo
     }
 
     @Test
+    public void testEmptyTable()
+    {
+        String tableName = "test_input_info_empty_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + "(nationkey BIGINT, name VARCHAR, regionkey BIGINT)");
+        // trino generates an empty snapshot if creating a table with no data
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 0, 0, 0, 0);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testInputWithPartitioning()
     {
         String tableName = "test_input_info_with_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey', 'truncate(name, 1)']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, ImmutableList.of("regionkey: identity", "name_trunc: truncate[1]"), "PARQUET", 9, 0, 0);
+        assertInputInfo(tableName, ImmutableList.of("regionkey: identity", "name_trunc: truncate[1]"), "PARQUET", 1, 10, 9, 0, 0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -62,7 +72,7 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_without_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 0, 0);
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 10, 1, 0, 0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -71,7 +81,7 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_with_orc_file_format_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'ORC') AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, ImmutableList.of(), "ORC", 1, 0, 0);
+        assertInputInfo(tableName, ImmutableList.of(), "ORC", 1, 10, 1, 0, 0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -82,7 +92,7 @@ public class TestIcebergInputInfo
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
         assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 1", 1);
 
-        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 1, 0);
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 2, 10, 1, 1, 0);
 
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -97,12 +107,12 @@ public class TestIcebergInputInfo
         BaseTable table = loadTable(tableName, getHiveMetastore(getQueryRunner()), fileSystemFactory, "iceberg", "tpch");
         writeEqualityDeleteForTable(table, fileSystemFactory, Optional.empty(), Optional.empty(), ImmutableMap.of("nationkey", 1L), Optional.empty());
 
-        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 1, 0, 1);
+        assertInputInfo(tableName, ImmutableList.of(), "PARQUET", 2, 10, 1, 0, 1);
 
         assertUpdate("DROP TABLE " + tableName);
     }
 
-    private void assertInputInfo(String tableName, List<String> partitionFields, String expectedFileFormat, long dataFiles, long positionDeleteFiles, long equalityDeleteFiles)
+    private void assertInputInfo(String tableName, List<String> partitionFields, String expectedFileFormat, long totalSnapshots, long totalRecords, long dataFiles, long positionDeleteFiles, long equalityDeleteFiles)
     {
         inTransaction(session -> {
             Metadata metadata = getQueryRunner().getPlannerContext().getMetadata();
@@ -120,7 +130,8 @@ public class TestIcebergInputInfo
                     icebergInputInfo.snapshotId(),
                     partitionFields,
                     expectedFileFormat,
-                    Optional.of("10"),
+                    String.valueOf(totalSnapshots),
+                    Optional.of(String.valueOf(totalRecords)),
                     Optional.empty(),
                     Optional.of(String.valueOf(dataFiles)),
                     Optional.of(String.valueOf(positionDeleteFiles + equalityDeleteFiles)),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Tracks snapshot count for tables for better observability


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Related PR: https://github.com/trinodb/trino/pull/28814


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Add information about snapshot count to IcebergInputInfo
