### PR TITLE
Disable flaky test in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeLocalConcurrentWritesTest.java
@@ -449,6 +449,7 @@ public class TestDeltaLakeLocalConcurrentWritesTest
     }
 
     @Test
+    @Disabled // TODO https://github.com/trinodb/trino/issues/22455 Fix flaky test
     public void testConcurrentInsertsSelectingFromDifferentPartitionsOfSameTable()
             throws Exception
     {


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/actions/runs/25100285928/job/73547587239
```
Error:    TestDeltaLakeLocalConcurrentWritesTest.lambda$testConcurrentInsertsSelectingFromDifferentPartitionsOfSameTable$1:473 » QueryFailed Failed to write Delta Lake transaction log entry
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
