### PR TITLE
Replace deprecated QueryAssert.assertThat in TestExasol

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/exasol/TestExasol.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/exasol/TestExasol.java
@@ -19,12 +19,12 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.EXASOL;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onExasol;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestExasol
         extends ProductTest


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
