### PR TITLE
Use consistent error codes for failed numeric casts

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonOperators.java
@@ -33,7 +33,6 @@ import java.math.BigDecimal;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.StandardTypes.BIGINT;
 import static io.trino.spi.type.StandardTypes.BOOLEAN;
@@ -115,12 +114,6 @@ public final class JsonOperators
             checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, "Cannot cast input json to INTEGER"); // check no trailing token
             return result;
         }
-        catch (TrinoException e) {
-            if (e.getErrorCode().equals(NUMERIC_VALUE_OUT_OF_RANGE.toErrorCode())) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", json.toStringUtf8(), INTEGER), e.getCause());
-            }
-            throw e;
-        }
         catch (ArithmeticException | IOException | JsonCastException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", json.toStringUtf8(), INTEGER), e);
         }
@@ -137,12 +130,6 @@ public final class JsonOperators
             checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, "Cannot cast input json to SMALLINT"); // check no trailing token
             return result;
         }
-        catch (TrinoException e) {
-            if (e.getErrorCode().equals(NUMERIC_VALUE_OUT_OF_RANGE.toErrorCode())) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", json.toStringUtf8(), INTEGER), e.getCause());
-            }
-            throw e;
-        }
         catch (IllegalArgumentException | IOException | JsonCastException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", json.toStringUtf8(), SMALLINT), e);
         }
@@ -158,12 +145,6 @@ public final class JsonOperators
             Long result = currentTokenAsTinyint(parser);
             checkCondition(parser.nextToken() == null, INVALID_CAST_ARGUMENT, "Cannot cast input json to TINYINT"); // check no trailing token
             return result;
-        }
-        catch (TrinoException e) {
-            if (e.getErrorCode().equals(NUMERIC_VALUE_OUT_OF_RANGE.toErrorCode())) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", json.toStringUtf8(), INTEGER), e.getCause());
-            }
-            throw e;
         }
         catch (IllegalArgumentException | IOException | JsonCastException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", json.toStringUtf8(), TINYINT), e);

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -41,10 +41,10 @@ import io.trino.util.variant.VariantUtil;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Optional;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
@@ -237,7 +237,7 @@ public final class DecimalCasts
             return rescale(decimal, DecimalConversions.intScale(-scale)).toLongExact();
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to BIGINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
         }
     }
 
@@ -247,12 +247,12 @@ public final class DecimalCasts
         try {
             long decimal = multiplyExact(value, tenToScale);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return decimal;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -262,12 +262,12 @@ public final class DecimalCasts
         try {
             Int128 result = multiply(tenToScale, value);
             if (overflows(result, (int) precision)) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return result;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast BIGINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -281,7 +281,7 @@ public final class DecimalCasts
         }
 
         if (!isLongToIntExact(longResult)) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INTEGER", longResult));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to INTEGER", longResult));
         }
         return (int) longResult;
     }
@@ -293,7 +293,7 @@ public final class DecimalCasts
             return toIntExact(rescale(decimal, DecimalConversions.intScale(-scale)).toLongExact());
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INTEGER", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to INTEGER", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
         }
     }
 
@@ -303,12 +303,12 @@ public final class DecimalCasts
         try {
             long decimal = multiplyExact(value, tenToScale);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return decimal;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -318,12 +318,12 @@ public final class DecimalCasts
         try {
             Int128 result = multiply(tenToScale, value);
             if (overflows(result, (int) precision)) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return result;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast INTEGER '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -337,7 +337,7 @@ public final class DecimalCasts
         }
 
         if (!isLongToShortExact(longResult)) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", longResult));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to SMALLINT", longResult));
         }
         return (short) longResult;
     }
@@ -350,7 +350,7 @@ public final class DecimalCasts
             return Shorts.checkedCast(decimal1.toLongExact());
         }
         catch (ArithmeticException | IllegalArgumentException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to SMALLINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
         }
     }
 
@@ -360,12 +360,12 @@ public final class DecimalCasts
         try {
             long decimal = multiplyExact(value, tenToScale);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return decimal;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -375,12 +375,12 @@ public final class DecimalCasts
         try {
             Int128 result = multiply(tenToScale, value);
             if (overflows(result, (int) precision)) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return result;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast SMALLINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -394,7 +394,7 @@ public final class DecimalCasts
         }
 
         if (!isLongToByteExact(longResult)) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", longResult));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to TINYINT", longResult));
         }
         return (byte) longResult;
     }
@@ -406,7 +406,7 @@ public final class DecimalCasts
             return SignedBytes.checkedCast(rescale(decimal, DecimalConversions.intScale(-scale)).toLongExact());
         }
         catch (ArithmeticException | IllegalArgumentException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to TINYINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));
         }
     }
 
@@ -416,12 +416,12 @@ public final class DecimalCasts
         try {
             long decimal = multiplyExact(value, tenToScale);
             if (overflows(decimal, DecimalConversions.intScale(precision))) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return decimal;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -431,12 +431,12 @@ public final class DecimalCasts
         try {
             Int128 result = multiply(tenToScale, value);
             if (overflows(result, (int) precision)) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return result;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast TINYINT '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -505,18 +505,21 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static long numberToShortDecimal(TrinoNumber value, long precision, long scale, long tenToScale)
     {
-        BigDecimal bigDecimal = numberToBigDecimal(value)
-                .orElseThrow(() -> new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", value, precision, scale)));
+        BigDecimal bigDecimal = switch (value.toBigDecimal()) {
+            case TrinoNumber.NotANumber _ -> throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            case TrinoNumber.Infinity _ -> throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            case TrinoNumber.BigDecimalValue(BigDecimal v) -> v;
+        };
         BigDecimal result;
         try {
             result = bigDecimal.setScale(DecimalConversions.intScale(scale), HALF_UP);
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
         }
 
         if (overflows(result, precision)) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
         }
 
         return result.unscaledValue().longValue();
@@ -525,29 +528,24 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static Int128 numberToLongDecimal(TrinoNumber value, long precision, long scale, Int128 tenToScale)
     {
-        BigDecimal bigDecimal = numberToBigDecimal(value)
-                .orElseThrow(() -> new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", value, precision, scale)));
+        BigDecimal bigDecimal = switch (value.toBigDecimal()) {
+            case TrinoNumber.NotANumber _ -> throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            case TrinoNumber.Infinity _ -> throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            case TrinoNumber.BigDecimalValue(BigDecimal v) -> v;
+        };
         BigDecimal result;
         try {
             result = bigDecimal.setScale(DecimalConversions.intScale(scale), HALF_UP);
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
         }
 
         if (overflows(result, precision)) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast NUMBER '%s' to DECIMAL(%s, %s)", bigDecimal, precision, scale));
         }
 
         return Int128.valueOf(result.unscaledValue());
-    }
-
-    private static Optional<BigDecimal> numberToBigDecimal(TrinoNumber value)
-    {
-        return switch (value.toBigDecimal()) {
-            case TrinoNumber.NotANumber _, TrinoNumber.Infinity _ -> Optional.empty();
-            case TrinoNumber.BigDecimalValue(BigDecimal bigDecimal) -> Optional.of(bigDecimal);
-        };
     }
 
     @UsedByGeneratedCode

--- a/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
@@ -158,11 +158,14 @@ public final class DoubleOperators
     @SqlType(StandardTypes.BIGINT)
     public static long castToLong(@SqlType(StandardTypes.DOUBLE) double value)
     {
+        if (Double.isNaN(value)) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Cannot cast double NaN to bigint");
+        }
         try {
             return DoubleMath.roundToLong(value, HALF_UP);
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to bigint", value), e);
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for bigint: " + value, e);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/type/NumberOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/NumberOperators.java
@@ -195,6 +195,9 @@ public final class NumberOperators
     public static long castToTinyint(@SqlType(StandardTypes.NUMBER) TrinoNumber value)
     {
         AsBigDecimal asBigDecimal = value.toBigDecimal();
+        if (asBigDecimal instanceof NotANumber) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to TINYINT", asBigDecimal));
+        }
         try {
             if (asBigDecimal instanceof BigDecimalValue(BigDecimal bigDecimal)) {
                 long valueAsLong = bigDecimal.setScale(0, RoundingMode.HALF_UP).longValueExact();
@@ -214,6 +217,9 @@ public final class NumberOperators
     public static long castToSmallint(@SqlType(StandardTypes.NUMBER) TrinoNumber value)
     {
         AsBigDecimal asBigDecimal = value.toBigDecimal();
+        if (asBigDecimal instanceof NotANumber) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to SMALLINT", asBigDecimal));
+        }
         try {
             if (asBigDecimal instanceof BigDecimalValue(BigDecimal bigDecimal)) {
                 long valueAsLong = bigDecimal.setScale(0, RoundingMode.HALF_UP).longValueExact();
@@ -233,6 +239,9 @@ public final class NumberOperators
     public static long castToInteger(@SqlType(StandardTypes.NUMBER) TrinoNumber value)
     {
         AsBigDecimal asBigDecimal = value.toBigDecimal();
+        if (asBigDecimal instanceof NotANumber) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to INTEGER", asBigDecimal));
+        }
         try {
             if (asBigDecimal instanceof BigDecimalValue(BigDecimal bigDecimal)) {
                 long valueAsLong = bigDecimal.setScale(0, RoundingMode.HALF_UP).longValueExact();
@@ -252,6 +261,9 @@ public final class NumberOperators
     public static long castToBigint(@SqlType(StandardTypes.NUMBER) TrinoNumber value)
     {
         AsBigDecimal asBigDecimal = value.toBigDecimal();
+        if (asBigDecimal instanceof NotANumber) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast NUMBER '%s' to BIGINT", asBigDecimal));
+        }
         try {
             if (asBigDecimal instanceof BigDecimalValue(BigDecimal bigDecimal)) {
                 return bigDecimal.setScale(0, RoundingMode.HALF_UP).longValueExact();

--- a/core/trino-main/src/main/java/io/trino/type/RealOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/RealOperators.java
@@ -46,6 +46,7 @@ import static java.lang.runtime.ExactConversionsSupport.isLongToByteExact;
 import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
 import static java.lang.runtime.ExactConversionsSupport.isLongToShortExact;
 import static java.math.RoundingMode.FLOOR;
+import static java.math.RoundingMode.HALF_UP;
 import static java.util.Locale.ENGLISH;
 
 public final class RealOperators
@@ -146,7 +147,12 @@ public final class RealOperators
         if (Float.isNaN(floatValue)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Cannot cast real NaN to bigint");
         }
-        return (long) MathFunctions.round(floatValue);
+        try {
+            return DoubleMath.roundToLong(floatValue, HALF_UP);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for bigint: " + floatValue, e);
+        }
     }
 
     @ScalarOperator(CAST)

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -85,8 +85,8 @@ import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.util.JsonUtils.jsonFactoryBuilder;
-import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -897,8 +897,7 @@ public final class JsonUtil
         }
 
         if (result.precision() > precision) {
-            // TODO: Should we use NUMERIC_VALUE_OUT_OF_RANGE instead?
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast input json to DECIMAL(%s,%s)", precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast input json to DECIMAL(%s,%s)", precision, scale));
         }
         return result;
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.SqlDecimal.decimal;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -204,32 +205,32 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "BIGINT '10'").evaluate())
                 .hasMessage("Cannot cast BIGINT '10' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,10))")
                 .binding("a", "BIGINT '1234567890'").evaluate())
                 .hasMessage("Cannot cast BIGINT '1234567890' to DECIMAL(17, 10)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "BIGINT '123'").evaluate())
                 .hasMessage("Cannot cast BIGINT '123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "BIGINT '-123'").evaluate())
                 .hasMessage("Cannot cast BIGINT '-123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,1))")
                 .binding("a", "BIGINT '123456789012345678'").evaluate())
                 .hasMessage("Cannot cast BIGINT '123456789012345678' to DECIMAL(17, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20, 10))")
                 .binding("a", "BIGINT '12345678901'").evaluate())
                 .hasMessage("Cannot cast BIGINT '12345678901' to DECIMAL(20, 10)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -278,22 +279,22 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "INTEGER '10'").evaluate())
                 .hasMessage("Cannot cast INTEGER '10' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,10))")
                 .binding("a", "INTEGER '1234567890'").evaluate())
                 .hasMessage("Cannot cast INTEGER '1234567890' to DECIMAL(17, 10)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "INTEGER '123'").evaluate())
                 .hasMessage("Cannot cast INTEGER '123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "INTEGER '-123'").evaluate())
                 .hasMessage("Cannot cast INTEGER '-123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -342,22 +343,22 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "SMALLINT '10'").evaluate())
                 .hasMessage("Cannot cast SMALLINT '10' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,14))")
                 .binding("a", "SMALLINT '1234'").evaluate())
                 .hasMessage("Cannot cast SMALLINT '1234' to DECIMAL(17, 14)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "SMALLINT '123'").evaluate())
                 .hasMessage("Cannot cast SMALLINT '123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "SMALLINT '-123'").evaluate())
                 .hasMessage("Cannot cast SMALLINT '-123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -406,22 +407,22 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "TINYINT '10'").evaluate())
                 .hasMessage("Cannot cast TINYINT '10' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,15))")
                 .binding("a", "TINYINT '123'").evaluate())
                 .hasMessage("Cannot cast TINYINT '123' to DECIMAL(17, 15)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "TINYINT '123'").evaluate())
                 .hasMessage("Cannot cast TINYINT '123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,1))")
                 .binding("a", "TINYINT '-123'").evaluate())
                 .hasMessage("Cannot cast TINYINT '-123' to DECIMAL(2, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -502,7 +503,7 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
                 .binding("a", "DECIMAL '12345678901234567890'").evaluate())
                 .hasMessage("Cannot cast '12345678901234567890' to BIGINT")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -579,7 +580,7 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
                 .binding("a", "DECIMAL '12345678901234567890'").evaluate())
                 .hasMessage("Cannot cast '12345678901234567890' to INTEGER")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -656,7 +657,7 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
                 .binding("a", "DECIMAL '12345678901234567890'").evaluate())
                 .hasMessage("Cannot cast '12345678901234567890' to SMALLINT")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -733,7 +734,7 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
                 .binding("a", "DECIMAL '12345678901234567890'").evaluate())
                 .hasMessage("Cannot cast '12345678901234567890' to TINYINT")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -831,27 +832,27 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,16))")
                 .binding("a", "DOUBLE '100.02'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '100.02' to DECIMAL(17, 16)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,0))")
                 .binding("a", "DOUBLE '234.0'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '234.0' to DECIMAL(2, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(5,2))")
                 .binding("a", "DOUBLE '1000.01'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '1000.01' to DECIMAL(5, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,0))")
                 .binding("a", "DOUBLE '-234.0'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '-234.0' to DECIMAL(2, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,16))")
                 .binding("a", "infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE 'Infinity' to DECIMAL(17, 16)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(10,5))")
                 .binding("a", "nan()").evaluate())
@@ -861,12 +862,12 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(10,1))")
                 .binding("a", "infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE 'Infinity' to DECIMAL(10, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(1,1))")
                 .binding("a", "-infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE '-Infinity' to DECIMAL(1, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -983,32 +984,32 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "DOUBLE '100.02'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '100.02' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,0))")
                 .binding("a", "DOUBLE '234000000000000000000.0'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '2.34E20' to DECIMAL(20, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,2))")
                 .binding("a", "DOUBLE '1000000000000000000.01'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '1.0E18' to DECIMAL(20, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,0))")
                 .binding("a", "DOUBLE '-234000000000000000000.0'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '-2.34E20' to DECIMAL(20, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20, 10))")
                 .binding("a", "DOUBLE '12345678901.1'").evaluate())
                 .hasMessage("Cannot cast DOUBLE '1.23456789011E10' to DECIMAL(20, 10)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE 'Infinity' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,10))")
                 .binding("a", "nan()").evaluate())
@@ -1018,12 +1019,12 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,2))")
                 .binding("a", "infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE 'Infinity' to DECIMAL(38, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,1))")
                 .binding("a", "-infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE '-Infinity' to DECIMAL(38, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(10,5))")
                 .binding("a", "nan()").evaluate())
@@ -1033,12 +1034,12 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(10,1))")
                 .binding("a", "infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE 'Infinity' to DECIMAL(10, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(1,1))")
                 .binding("a", "-infinity()").evaluate())
                 .hasMessage("Cannot cast DOUBLE '-Infinity' to DECIMAL(1, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -1198,32 +1199,32 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "REAL '100.02'").evaluate())
                 .hasMessage("Cannot cast REAL '100.02' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,16))")
                 .binding("a", "REAL '100.02'").evaluate())
                 .hasMessage("Cannot cast REAL '100.02' to DECIMAL(17, 16)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,0))")
                 .binding("a", "REAL '234.0'").evaluate())
                 .hasMessage("Cannot cast REAL '234.0' to DECIMAL(2, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(5,2))")
                 .binding("a", "REAL '1000.01'").evaluate())
                 .hasMessage("Cannot cast REAL '1000.01' to DECIMAL(5, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,0))")
                 .binding("a", "REAL '-234.0'").evaluate())
                 .hasMessage("Cannot cast REAL '-234.0' to DECIMAL(2, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20, 10))")
                 .binding("a", "REAL '98765430784.0'").evaluate())
                 .hasMessage("Cannot cast REAL '9.876543E10' to DECIMAL(20, 10)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a AS DECIMAL(10,5))")
                 .binding("a", "CAST(nan() as REAL)").evaluate())
@@ -1233,12 +1234,12 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a AS DECIMAL(10,1))")
                 .binding("a", "CAST(infinity() as REAL)").evaluate())
                 .hasMessage("Cannot cast REAL 'Infinity' to DECIMAL(10, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a AS DECIMAL(1,1))")
                 .binding("a", "CAST(-infinity() as REAL)").evaluate())
                 .hasMessage("Cannot cast REAL '-Infinity' to DECIMAL(1, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a AS DECIMAL(38,10))")
                 .binding("a", "CAST(nan() as REAL)").evaluate())
@@ -1248,12 +1249,12 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a AS DECIMAL(38,2))")
                 .binding("a", "CAST(infinity() as REAL)").evaluate())
                 .hasMessage("Cannot cast REAL 'Infinity' to DECIMAL(38, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a AS DECIMAL(38,1))")
                 .binding("a", "CAST(-infinity() as REAL)").evaluate())
                 .hasMessage("Cannot cast REAL '-Infinity' to DECIMAL(38, 1)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -1415,22 +1416,22 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(17,16))")
                 .binding("a", "NUMBER '100.02'").evaluate())
                 .hasMessage("Cannot cast NUMBER '100.02' to DECIMAL(17, 16)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,0))")
                 .binding("a", "NUMBER '234.0'").evaluate())
                 .hasMessage("Cannot cast NUMBER '234' to DECIMAL(2, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(5,2))")
                 .binding("a", "NUMBER '1000.01'").evaluate())
                 .hasMessage("Cannot cast NUMBER '1000.01' to DECIMAL(5, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(2,0))")
                 .binding("a", "NUMBER '-234.0'").evaluate())
                 .hasMessage("Cannot cast NUMBER '-234' to DECIMAL(2, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -1547,27 +1548,27 @@ public class TestDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(38,37))")
                 .binding("a", "NUMBER '100.02'").evaluate())
                 .hasMessage("Cannot cast NUMBER '100.02' to DECIMAL(38, 37)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,0))")
                 .binding("a", "NUMBER '234000000000000000000.0'").evaluate())
                 .hasMessage("Cannot cast NUMBER '2.34E+20' to DECIMAL(20, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,2))")
                 .binding("a", "NUMBER '1000000000000000000.01'").evaluate())
                 .hasMessage("Cannot cast NUMBER '1000000000000000000.01' to DECIMAL(20, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,0))")
                 .binding("a", "NUMBER '-234000000000000000000.0'").evaluate())
                 .hasMessage("Cannot cast NUMBER '-2.34E+20' to DECIMAL(20, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20, 10))")
                 .binding("a", "NUMBER '12345678901.1'").evaluate())
                 .hasMessage("Cannot cast NUMBER '12345678901.1' to DECIMAL(20, 10)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalToDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalToDecimalCasts.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
-import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.SqlDecimal.decimal;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -113,22 +113,22 @@ public class TestDecimalToDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(4,0))")
                 .binding("a", "DECIMAL '12345.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(6, 1) '12345.6' to DECIMAL(4, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(4,0))")
                 .binding("a", "DECIMAL '-12345.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(6, 1) '-12345.6' to DECIMAL(4, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(4,2))")
                 .binding("a", "DECIMAL '12345.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(6, 1) '12345.6' to DECIMAL(4, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(4,2))")
                 .binding("a", "DECIMAL '-12345.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(6, 1) '-12345.6' to DECIMAL(4, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -221,21 +221,21 @@ public class TestDecimalToDecimalCasts
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,0))")
                 .binding("a", "DECIMAL '1234500000000000000000000.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(26, 1) '1234500000000000000000000.6' to DECIMAL(20, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(20,0))")
                 .binding("a", "DECIMAL '-1234500000000000000000000.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(26, 1) '-1234500000000000000000000.6' to DECIMAL(20, 0)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(22,2))")
                 .binding("a", "DECIMAL '1234500000000000000000000.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(26, 1) '1234500000000000000000000.6' to DECIMAL(22, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(22,2))")
                 .binding("a", "DECIMAL '-1234500000000000000000000.6'").evaluate())
                 .hasMessage("Cannot cast DECIMAL(26, 1) '-1234500000000000000000000.6' to DECIMAL(22, 2)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
@@ -655,15 +656,15 @@ public class TestDoubleOperators
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", Double.toString(0x1.0p63))
                 .evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", Double.toString(Math.nextUp(0x1.0p63))).evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", Double.toString(Math.nextDown(-0x1.0p63))).evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as bigint)")
                 .binding("a", Double.toString(-0x1.0p63)))
@@ -676,22 +677,22 @@ public class TestDoubleOperators
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", "9.3E18")
                 .evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", "-9.3E18")
                 .evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", "infinity()")
                 .evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", "-infinity()")
                 .evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as bigint)")
                 .binding("a", "nan()")

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_LITERAL;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
@@ -98,7 +99,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
                 .binding("a", "JSON '12345678901234567890.0'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as BIGINT)")
                 .binding("a", "JSON '1e-324'"))
@@ -106,7 +107,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
                 .binding("a", "JSON '1e309'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as BIGINT)")
                 .binding("a", "JSON 'true'"))
@@ -179,7 +180,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
                 .binding("a", "JSON '12345678901.0'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as INTEGER)")
                 .binding("a", "JSON '1e-324'"))
@@ -187,7 +188,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
                 .binding("a", "JSON '1e309'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as INTEGER)")
                 .binding("a", "JSON 'true'"))
@@ -252,7 +253,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
                 .binding("a", "JSON '123456.0'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as SMALLINT)")
                 .binding("a", "JSON '1e-324'"))
@@ -260,7 +261,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
                 .binding("a", "JSON '1e309'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as SMALLINT)")
                 .binding("a", "JSON 'true'"))
@@ -325,7 +326,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
                 .binding("a", "JSON '1234.0'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as TINYINT)")
                 .binding("a", "JSON '1e-324'"))
@@ -333,7 +334,7 @@ public class TestJsonOperators
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
                 .binding("a", "JSON '1e309'").evaluate())
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.expression("cast(a as TINYINT)")
                 .binding("a", "JSON 'true'"))
@@ -733,7 +734,7 @@ public class TestJsonOperators
                 .binding("a", "JSON '1234567890123456'")
                 .evaluate())
                 .hasMessage("Cannot cast input json to DECIMAL(10,3)")
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as DECIMAL(10,3))")
                 .binding("a", "JSON '{ \"x\" : 123}'")

--- a/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
@@ -33,6 +33,7 @@ import java.util.function.BiPredicate;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.DIVIDE;
@@ -3516,7 +3517,7 @@ public class TestNumberOperators
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as tinyint)")
                 .binding("a", "NUMBER 'NaN'")::evaluate)
-                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
                 .hasMessage("Cannot cast NUMBER 'NaN' to TINYINT");
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as tinyint)")
@@ -3576,7 +3577,7 @@ public class TestNumberOperators
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as smallint)")
                 .binding("a", "NUMBER 'NaN'")::evaluate)
-                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
                 .hasMessage("Cannot cast NUMBER 'NaN' to SMALLINT");
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as smallint)")
@@ -3636,7 +3637,7 @@ public class TestNumberOperators
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as integer)")
                 .binding("a", "NUMBER 'NaN'")::evaluate)
-                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
                 .hasMessage("Cannot cast NUMBER 'NaN' to INTEGER");
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as integer)")
@@ -3701,7 +3702,7 @@ public class TestNumberOperators
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as bigint)")
                 .binding("a", "NUMBER 'NaN'")::evaluate)
-                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
                 .hasMessage("Cannot cast NUMBER 'NaN' to BIGINT");
 
         assertTrinoExceptionThrownBy(assertions.expression("cast(a as bigint)")

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
@@ -620,6 +621,26 @@ public class TestRealOperators
                 .binding("a", "REAL 'NaN'")
                 .evaluate())
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
+                .binding("a", "CAST(infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
+                .binding("a", "CAST(-infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
+                .binding("a", "REAL '1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as BIGINT)")
+                .binding("a", "REAL '-1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -645,6 +666,26 @@ public class TestRealOperators
                 .binding("a", "REAL 'NaN'")
                 .evaluate())
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
+                .binding("a", "CAST(infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
+                .binding("a", "CAST(-infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
+                .binding("a", "REAL '1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as INTEGER)")
+                .binding("a", "REAL '-1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -670,6 +711,26 @@ public class TestRealOperators
                 .binding("a", "REAL 'NaN'")
                 .evaluate())
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
+                .binding("a", "CAST(infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
+                .binding("a", "CAST(-infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
+                .binding("a", "REAL '1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as SMALLINT)")
+                .binding("a", "REAL '-1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test
@@ -695,6 +756,26 @@ public class TestRealOperators
                 .binding("a", "REAL 'NaN'")
                 .evaluate())
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
+                .binding("a", "CAST(infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
+                .binding("a", "CAST(-infinity() AS REAL)")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
+                .binding("a", "REAL '1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as TINYINT)")
+                .binding("a", "REAL '-1e30'")
+                .evaluate())
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.Int128Math.compareAbsolute;
 import static io.trino.spi.type.Int128Math.rescale;
@@ -103,8 +104,11 @@ public final class DecimalConversions
 
     private static Int128 internalDoubleToLongDecimal(double value, long precision, long scale)
     {
-        if (Double.isInfinite(value) || Double.isNaN(value)) {
+        if (Double.isNaN(value)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+        }
+        if (Double.isInfinite(value)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
 
         try {
@@ -112,12 +116,12 @@ public final class DecimalConversions
             BigDecimal bigDecimal = BigDecimal.valueOf(value).setScale(intScale(scale), HALF_UP);
             Int128 decimal = Decimals.valueOf(bigDecimal);
             if (Decimals.overflows(decimal, intScale(precision))) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
             }
             return decimal;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast DOUBLE '%s' to DECIMAL(%s, %s)", value, precision, scale));
         }
     }
 
@@ -136,8 +140,11 @@ public final class DecimalConversions
 
     public static Int128 realToLongDecimal(float floatValue, long precision, long scale)
     {
-        if (Float.isInfinite(floatValue) || Float.isNaN(floatValue)) {
+        if (Float.isNaN(floatValue)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
+        }
+        if (Float.isInfinite(floatValue)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
         }
 
         try {
@@ -145,12 +152,12 @@ public final class DecimalConversions
             BigDecimal bigDecimal = new BigDecimal(String.valueOf(floatValue)).setScale(intScale(scale), HALF_UP);
             Int128 decimal = Decimals.valueOf(bigDecimal);
             if (Decimals.overflows(decimal, intScale(precision))) {
-                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
             }
             return decimal;
         }
         catch (ArithmeticException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast REAL '%s' to DECIMAL(%s, %s)", floatValue, precision, scale));
         }
     }
 
@@ -231,7 +238,7 @@ public final class DecimalConversions
 
     private static TrinoException throwCastException(long value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
     {
-        return new TrinoException(INVALID_CAST_ARGUMENT,
+        return new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE,
                 format("Cannot cast DECIMAL(%d, %d) '%s' to DECIMAL(%d, %d)",
                         sourcePrecision,
                         sourceScale,
@@ -242,7 +249,7 @@ public final class DecimalConversions
 
     private static TrinoException throwCastException(BigInteger value, long sourcePrecision, long sourceScale, long resultPrecision, long resultScale)
     {
-        return new TrinoException(INVALID_CAST_ARGUMENT,
+        return new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE,
                 format("Cannot cast DECIMAL(%d, %d) '%s' to DECIMAL(%d, %d)",
                         sourcePrecision,
                         sourceScale,

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCastPushdown.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCastPushdown.java
@@ -320,28 +320,22 @@ final class TestPostgreSqlCastPushdown
                         .add(new InvalidCastTestCase("c_infinity_real_1", "tinyint", "Out of range for tinyint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_1", "smallint", "Out of range for smallint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_1", "integer", "Out of range for integer: Infinity"))
+                        .add(new InvalidCastTestCase("c_infinity_real_1", "bigint", "Out of range for bigint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_2", "tinyint", "Out of range for tinyint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_2", "smallint", "Out of range for smallint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_2", "integer", "Out of range for integer: -Infinity"))
+                        .add(new InvalidCastTestCase("c_infinity_real_2", "bigint", "Out of range for bigint: -Infinity"))
 
                         // No pushdown for double precision datatype to integral types
                         .add(new InvalidCastTestCase("c_infinity_double_1", "tinyint", "Out of range for tinyint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_1", "smallint", "Out of range for smallint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_1", "integer", "Out of range for integer: Infinity"))
-                        .add(new InvalidCastTestCase("c_infinity_double_1", "bigint", "Unable to cast Infinity to bigint"))
+                        .add(new InvalidCastTestCase("c_infinity_double_1", "bigint", "Out of range for bigint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_2", "tinyint", "Out of range for tinyint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_2", "smallint", "Out of range for smallint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_2", "integer", "Out of range for integer: -Infinity"))
-                        .add(new InvalidCastTestCase("c_infinity_double_2", "bigint", "Unable to cast -Infinity to bigint"))
+                        .add(new InvalidCastTestCase("c_infinity_double_2", "bigint", "Out of range for bigint: -Infinity"))
                         .build());
-    }
-
-    @Test
-    void testCastRealInfinityValueToBigint()
-    {
-        assertThat(query("SELECT CAST(c_Infinity_real AS BIGINT) FROM %s".formatted(leftTable())))
-                .matches("VALUES (BIGINT '9223372036854775807'), (BIGINT '-9223372036854775808'), (null)")
-                .isNotFullyPushedDown(ProjectNode.class);
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftCastPushdown.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftCastPushdown.java
@@ -365,28 +365,22 @@ final class TestRedshiftCastPushdown
                         .add(new InvalidCastTestCase("c_infinity_real_1", "tinyint", "Out of range for tinyint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_1", "smallint", "Out of range for smallint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_1", "integer", "Out of range for integer: Infinity"))
+                        .add(new InvalidCastTestCase("c_infinity_real_1", "bigint", "Out of range for bigint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_2", "tinyint", "Out of range for tinyint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_2", "smallint", "Out of range for smallint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_real_2", "integer", "Out of range for integer: -Infinity"))
+                        .add(new InvalidCastTestCase("c_infinity_real_2", "bigint", "Out of range for bigint: -Infinity"))
 
                         // No pushdown for double precision datatype to integral types
                         .add(new InvalidCastTestCase("c_infinity_double_1", "tinyint", "Out of range for tinyint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_1", "smallint", "Out of range for smallint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_1", "integer", "Out of range for integer: Infinity"))
-                        .add(new InvalidCastTestCase("c_infinity_double_1", "bigint", "Unable to cast Infinity to bigint"))
+                        .add(new InvalidCastTestCase("c_infinity_double_1", "bigint", "Out of range for bigint: Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_2", "tinyint", "Out of range for tinyint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_2", "smallint", "Out of range for smallint: -Infinity"))
                         .add(new InvalidCastTestCase("c_infinity_double_2", "integer", "Out of range for integer: -Infinity"))
-                        .add(new InvalidCastTestCase("c_infinity_double_2", "bigint", "Unable to cast -Infinity to bigint"))
+                        .add(new InvalidCastTestCase("c_infinity_double_2", "bigint", "Out of range for bigint: -Infinity"))
                         .build());
-    }
-
-    @Test
-    void testCastRealInfinityValueToBigint()
-    {
-        assertThat(query("SELECT CAST(c_Infinity_real AS BIGINT) FROM %s".formatted(leftTable())))
-                .matches("VALUES (BIGINT '9223372036854775807'), (BIGINT '-9223372036854775808'), (null)")
-                .isNotFullyPushedDown(ProjectNode.class);
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -61,6 +61,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.SystemSessionProperties.IGNORE_DOWNSTREAM_PREFERENCES;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -6730,6 +6731,71 @@ public abstract class AbstractTestEngineOnlyQueries
                 .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
         assertThat(query("SELECT CAST(-0x8000000000000000 AS bigint) / BIGINT '-1'"))
                 .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+    }
+
+    @Test
+    public void testCastNumericOutOfRange()
+    {
+        // Rule:
+        //   NaN cast to a target type that has no NaN representation -> INVALID_CAST_ARGUMENT.
+        //   Any other "value cannot be represented in target type"  -> NUMERIC_VALUE_OUT_OF_RANGE.
+        // Targets without NaN/Infinity are: TINYINT, SMALLINT, INTEGER, BIGINT and DECIMAL (any precision/scale).
+
+        // Short decimal: precision <= 18; long decimal: precision > 18.
+        List<String> targetTypesWithoutNan = List.of(
+                "tinyint",
+                "smallint",
+                "integer",
+                "bigint",
+                "decimal(2, 0)",
+                "decimal(20, 0)");
+
+        // Sources that can produce NaN, +/-Infinity, and finite-but-out-of-range values.
+        // Each row: source label, NaN literal, +Infinity literal, -Infinity literal, large positive finite, large negative finite.
+        List<List<String>> floatingSources = List.of(
+                List.of("DOUBLE", "nan()", "infinity()", "-infinity()", "DOUBLE '1e300'", "DOUBLE '-1e300'"),
+                List.of("REAL", "CAST(nan() AS REAL)", "CAST(infinity() AS REAL)", "CAST(-infinity() AS REAL)", "REAL '1e30'", "REAL '-1e30'"),
+                List.of("NUMBER", "NUMBER 'NaN'", "NUMBER '+Infinity'", "NUMBER '-Infinity'", "NUMBER '1e300'", "NUMBER '-1e300'"));
+
+        for (List<String> source : floatingSources) {
+            String nan = source.get(1);
+            String positiveInfinity = source.get(2);
+            String negativeInfinity = source.get(3);
+            String largePositive = source.get(4);
+            String largeNegative = source.get(5);
+            for (String target : targetTypesWithoutNan) {
+                assertThat(query("SELECT CAST(" + nan + " AS " + target + ")"))
+                        .failure().hasErrorCode(INVALID_CAST_ARGUMENT);
+                assertThat(query("SELECT CAST(" + positiveInfinity + " AS " + target + ")"))
+                        .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+                assertThat(query("SELECT CAST(" + negativeInfinity + " AS " + target + ")"))
+                        .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+                assertThat(query("SELECT CAST(" + largePositive + " AS " + target + ")"))
+                        .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+                assertThat(query("SELECT CAST(" + largeNegative + " AS " + target + ")"))
+                        .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+            }
+        }
+
+        // Sources without NaN/Infinity, only finite overflow.
+        // Each row: source expression that is too large for the targets that follow it.
+        List<List<String>> finiteOverflowCases = List.of(
+                List.of("BIGINT '9223372036854775807'", "tinyint", "smallint", "integer", "decimal(2, 0)"),
+                List.of("INTEGER '2147483647'", "tinyint", "smallint", "decimal(2, 0)"),
+                List.of("SMALLINT '32767'", "tinyint", "decimal(2, 0)"),
+                List.of(
+                        "DECIMAL '99999999999999999999999999999999999999'", // DECIMAL(38, 0) max
+                        "tinyint", "smallint", "integer", "bigint", "decimal(2, 0)", "decimal(20, 0)"),
+                List.of(
+                        "DECIMAL '99999999999999999999'", // DECIMAL(20, 0) max — long decimal source
+                        "tinyint", "smallint", "integer", "bigint", "decimal(2, 0)"));
+        for (List<String> finiteCase : finiteOverflowCases) {
+            String sourceExpression = finiteCase.get(0);
+            for (String target : finiteCase.subList(1, finiteCase.size())) {
+                assertThat(query("SELECT CAST(" + sourceExpression + " AS " + target + ")"))
+                        .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+            }
+        }
     }
 
     private static int getNumberMaxDecimalPrecision()

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -360,9 +360,9 @@ public abstract class AbstractTestEngineOnlyQueries
     {
         // with implicit coercions
         assertQuery("SELECT * FROM (VALUES" +
-                "   CAST(NULL AS char(3)), " +
-                "   CAST('   ' AS char(3))) t(x) " +
-                "WHERE x = CAST('  ' AS varchar(2))",
+                        "   CAST(NULL AS char(3)), " +
+                        "   CAST('   ' AS char(3))) t(x) " +
+                        "WHERE x = CAST('  ' AS varchar(2))",
                 // H2 returns '' on CAST char(3) to varchar(2)
                 "SELECT '   '");
 
@@ -836,7 +836,7 @@ public abstract class AbstractTestEngineOnlyQueries
                     // There currently is no coercion between number and real/double/decimal
                     boolean unsupported =
                             both.contains("number") &&
-                            (both.contains("real") || both.contains("double"));
+                                    (both.contains("real") || both.contains("double"));
                     if (unsupported) {
                         assertThat(query(add)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* \\+ .*");
                         assertThat(query(subtract)).failure().hasMessageMatching("line 1:\\d+: Cannot apply operator: .* - .*");


### PR DESCRIPTION
NaN cast to a target type without NaN throws INVALID_CAST_ARGUMENT; any other "value cannot be represented in target type" — Infinity or finite overflow — throws NUMERIC_VALUE_OUT_OF_RANGE.

Also fix REAL to BIGINT, which was silently saturating on Infinity and finite overflow rather than throwing.

- fixes https://github.com/trinodb/trino/issues/29281