### PR TITLE
Add request timeout and max idle time to Azure FS connection pool

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-azure.md
+++ b/docs/src/main/sphinx/object-storage/file-system-azure.md
@@ -48,6 +48,12 @@ system support:
     Azure from every node. Defaults to double the number of processors on the
     node. Minimum `1`. Use this property to reduce the number of requests when
     you encounter rate limiting issues.
+* - `azure.connection-pool-max-idle-time`
+  - [Duration](prop-type-duration) that a connection can remain idle in the
+    connection pool before it is closed. Defaults to `5m`.
+* - `azure.http-request-timeout`
+  - [Duration](prop-type-duration) for HTTP request timeouts, including the
+    time taken by the Azure SDK to retry a request. Defaults to `10m`.
 * - `azure.application-id`
   - Specify the application identifier appended to the `User-Agent` header
     for all requests sent to Azure Storage. Defaults to `Trino`. 

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -17,11 +17,14 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
+import io.airlift.units.Duration;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.Math.max;
 
@@ -45,6 +48,8 @@ public class AzureFileSystemConfig
      * Matches {@link reactor.netty.resources.ConnectionProvider#DEFAULT_POOL_MAX_CONNECTIONS}
      */
     private int maxHttpConnections = 2 * max(Runtime.getRuntime().availableProcessors(), 8);
+    private Duration connectionPoolMaxIdleTime = new Duration(5, TimeUnit.MINUTES);
+    private Duration httpRequestTimeout = new Duration(10, TimeUnit.MINUTES);
     private String applicationId = "Trino";
     private boolean multipartWriteEnabled;
 
@@ -151,6 +156,34 @@ public class AzureFileSystemConfig
     public AzureFileSystemConfig setMaxHttpConnections(int maxHttpConnections)
     {
         this.maxHttpConnections = maxHttpConnections;
+        return this;
+    }
+
+    @NotNull
+    public Duration getConnectionPoolMaxIdleTime()
+    {
+        return connectionPoolMaxIdleTime;
+    }
+
+    @Config("azure.connection-pool-max-idle-time")
+    @ConfigDescription("Maximum idle time for pooled HTTP connections")
+    public AzureFileSystemConfig setConnectionPoolMaxIdleTime(Duration connectionPoolMaxIdleTime)
+    {
+        this.connectionPoolMaxIdleTime = connectionPoolMaxIdleTime;
+        return this;
+    }
+
+    @NotNull
+    public Duration getHttpRequestTimeout()
+    {
+        return httpRequestTimeout;
+    }
+
+    @Config("azure.http-request-timeout")
+    @ConfigDescription("Maximum time for an HTTP request to complete")
+    public AzureFileSystemConfig setHttpRequestTimeout(Duration httpRequestTimeout)
+    {
+        this.httpRequestTimeout = httpRequestTimeout;
         return this;
     }
 

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -21,6 +21,7 @@ import com.azure.core.util.HttpClientOptions;
 import com.azure.core.util.TracingOptions;
 import com.google.inject.Inject;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
@@ -73,6 +74,8 @@ public class AzureFileSystemFactory
                 config.getMaxSingleUploadSize(),
                 config.getMaxHttpRequests(),
                 config.getMaxHttpConnections(),
+                config.getConnectionPoolMaxIdleTime(),
+                config.getHttpRequestTimeout(),
                 config.getApplicationId(),
                 config.isMultipartWriteEnabled());
     }
@@ -87,6 +90,8 @@ public class AzureFileSystemFactory
             DataSize maxSingleUploadSize,
             int maxHttpRequests,
             int maxHttpConnections,
+            Duration connectionPoolMaxIdleTime,
+            Duration httpRequestTimeout,
             String applicationId,
             boolean multipart)
     {
@@ -97,8 +102,13 @@ public class AzureFileSystemFactory
         checkArgument(maxWriteConcurrency >= 0, "maxWriteConcurrency is negative");
         this.maxWriteConcurrency = maxWriteConcurrency;
         this.maxSingleUploadSize = requireNonNull(maxSingleUploadSize, "maxSingleUploadSize is null");
+        requireNonNull(connectionPoolMaxIdleTime, "connectionPoolMaxIdleTime is null");
+        requireNonNull(httpRequestTimeout, "httpRequestTimeout is null");
         this.tracingOptions = new OpenTelemetryTracingOptions().setOpenTelemetry(openTelemetry);
-        this.connectionProvider = ConnectionProvider.create(applicationId, maxHttpConnections);
+        this.connectionProvider = ConnectionProvider.builder(applicationId)
+                .maxConnections(maxHttpConnections)
+                .maxIdleTime(connectionPoolMaxIdleTime.toJavaTime())
+                .build();
         this.eventLoopGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
         HttpClientOptions clientOptions = new HttpClientOptions();
         clientOptions.setTracingOptions(tracingOptions);
@@ -106,7 +116,9 @@ public class AzureFileSystemFactory
         clientOptions.setMaximumConnectionPoolSize(maxHttpConnections);
         httpClient = createAzureHttpClient(connectionProvider, eventLoopGroup, clientOptions);
         this.multipart = multipart;
-        this.concurrencyPolicy = new ConcurrencyLimitHttpPipelinePolicy(maxHttpRequests);
+        this.concurrencyPolicy = new ConcurrencyLimitHttpPipelinePolicy(
+                maxHttpRequests,
+                httpRequestTimeout.toJavaTime());
     }
 
     @PreDestroy

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/ConcurrencyLimitHttpPipelinePolicy.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/ConcurrencyLimitHttpPipelinePolicy.java
@@ -19,19 +19,23 @@ import com.azure.core.http.HttpResponse;
 import com.azure.core.http.policy.HttpPipelinePolicy;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.concurrent.Semaphore;
 
 import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
 
 public final class ConcurrencyLimitHttpPipelinePolicy
         implements HttpPipelinePolicy
 {
     private final Semaphore semaphore;
+    private final Duration requestTimeout;
 
-    public ConcurrencyLimitHttpPipelinePolicy(int maxHttpRequests)
+    public ConcurrencyLimitHttpPipelinePolicy(int maxHttpRequests, Duration requestTimeout)
     {
         verify(maxHttpRequests > 0, "maxHttpRequests must be greater than 0");
         this.semaphore = new Semaphore(maxHttpRequests);
+        this.requestTimeout = requireNonNull(requestTimeout, "requestTimeout is null");
     }
 
     @Override
@@ -44,6 +48,8 @@ public final class ConcurrencyLimitHttpPipelinePolicy
             Thread.currentThread().interrupt();
             return Mono.error(e);
         }
-        return next.process().doFinally(_ -> semaphore.release());
+        return next.process()
+                .timeout(requestTimeout)
+                .doFinally(_ -> semaphore.release());
     }
 }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.azure;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
+import io.airlift.units.Duration;
 import io.trino.filesystem.azure.AzureFileSystemConfig.AuthType;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static java.lang.Math.max;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 class TestAzureFileSystemConfig
 {
@@ -40,6 +42,8 @@ class TestAzureFileSystemConfig
                 .setMaxSingleUploadSize(DataSize.of(4, Unit.MEGABYTE))
                 .setMaxHttpRequests(2 * Runtime.getRuntime().availableProcessors())
                 .setMaxHttpConnections(2 * max(8, Runtime.getRuntime().availableProcessors()))
+                .setConnectionPoolMaxIdleTime(new Duration(5, MINUTES))
+                .setHttpRequestTimeout(new Duration(10, MINUTES))
                 .setApplicationId("Trino")
                 .setMultipartWriteEnabled(false));
     }
@@ -56,6 +60,8 @@ class TestAzureFileSystemConfig
                 .put("azure.max-single-upload-size", "7MB")
                 .put("azure.max-http-requests", "128")
                 .put("azure.max-http-connections", "128")
+                .put("azure.connection-pool-max-idle-time", "1m")
+                .put("azure.http-request-timeout", "1m")
                 .put("azure.application-id", "application id")
                 .put("azure.multipart-write-enabled", "true")
                 .buildOrThrow();
@@ -69,6 +75,8 @@ class TestAzureFileSystemConfig
                 .setMaxSingleUploadSize(DataSize.of(7, Unit.MEGABYTE))
                 .setMaxHttpRequests(128)
                 .setMaxHttpConnections(128)
+                .setConnectionPoolMaxIdleTime(new Duration(1, MINUTES))
+                .setHttpRequestTimeout(new Duration(1, MINUTES))
                 .setApplicationId("application id")
                 .setMultipartWriteEnabled(true);
 


### PR DESCRIPTION
## Description

Adds two config properties for the Azure FS:
- `azure.connection-pool-max-idle-time`: sets max idle time for the `ConnectionProvider`. Defaults to 5m, which should outlive the 4m default idle timeouts of Azure load balancers (more on that below)
- `azure.http-request-timeout`: Sets timeout for the request, including Azure SDK retries. Defaults to 10m, which should be enough to exhaust retries with exponential backoff.

I'm open to changing these defaults, they're somewhat arbitrary.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

We're occasionally seeing clusters get stuck after transient Azure network issues (related to load balancer idle timeouts) cause half-dead connections in the pool. Azure load balancers may hit their idle timeout, but [never send a close notification](https://github.com/reactor/reactor-netty/issues/764#issuecomment-1011373248), which causes reactor-netty to [neither throw an error or time out itself](https://github.com/reactor/reactor-netty/issues/1764).

Requests stalled in this way will hold on to permits from [this semaphore](https://github.com/trinodb/trino/blob/master/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/ConcurrencyLimitHttpPipelinePolicy.java#L41) indefinitely, blocking any other queued requests. All blocked queries will eventually time out after 4 hours, but remain hanging in the meantime. A JVM restart will unstick the cluster. This PR follows the reactor-netty maintainer's suggestion of adding a `maxIdleTime`, and adds a separate request timeout to ensure stuck connections will eventually release their semaphore permits.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Azure
* Adds two new Azure file system configuration properties for the connection pool max idle time and request timeout.
```
