### PR TITLE
Address flakiness in failure recovery tests

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -65,6 +65,7 @@ import static io.trino.execution.FailureInjector.InjectedFailureType.TASK_MANAGE
 import static io.trino.plugin.base.TemporaryTables.temporaryTableNamePrefix;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.NATION;
 import static io.trino.tpch.TpchTable.ORDERS;
@@ -449,42 +450,49 @@ public abstract class BaseFailureRecoveryTest
     // Provided as a protected method here in case this is not a one-sized-fits-all solution
     protected void checkTemporaryTables(Set<String> queryIds)
     {
-        // queryId -> temporary table names
-        Map<String, Set<String>> remainingTemporaryTables = new HashMap<>();
-        // queryId -> assertion messages
-        Map<String, Set<String>> assertionErrorMessages = new HashMap<>();
-        for (String queryId : queryIds) {
-            String temporaryTablePrefix = temporaryTableNamePrefix(queryId);
-            MaterializedResult temporaryTablesResult = getQueryRunner()
-                    .execute("SHOW TABLES LIKE '%s%%' ESCAPE '\\'".formatted(temporaryTablePrefix.replace("_", "\\_")));
-            // Unfortunately, information_schema is not strictly consistent with recently dropped tables,
-            // and for some connectors, it can return tables that have been recently dropped. Therefore,
-            // we can't rely simply on SHOW TABLES LIKE returning no results - we have to try to query the table
-            for (MaterializedRow temporaryTableRow : temporaryTablesResult.getMaterializedRows()) {
-                String temporaryTableName = (String) temporaryTableRow.getField(0);
-                try {
-                    assertThatThrownBy(() -> getQueryRunner().execute("SELECT 1 FROM %s WHERE 1 = 0".formatted(temporaryTableName)))
-                            .hasMessageContaining(".%s' does not exist", temporaryTableName);
-                }
-                catch (AssertionError e) {
-                    remainingTemporaryTables.computeIfAbsent(queryId, _ -> new HashSet<>()).add(temporaryTableName);
-                    assertionErrorMessages.computeIfAbsent(queryId, _ -> new HashSet<>()).add(e.getMessage());
-                }
-            }
+        if (!checkNoRemainingTmpTables()) {
+            return;
         }
 
-        if (checkNoRemainingTmpTables()) {
-            assertThat(remainingTemporaryTables.isEmpty())
-                    .as("There should be no remaining tmp_trino tables that are queryable. They are:\n%s",
-                            remainingTemporaryTables.entrySet().stream()
-                                    .map(entry -> "\tFor queryId [%s] (prefix [%s]) remaining tables: [%s]\n\t\tWith errors: [%s]".formatted(
-                                            entry.getKey(),
-                                            temporaryTableNamePrefix(entry.getKey()),
-                                            Joiner.on(",").join(entry.getValue()),
-                                            Joiner.on("],\n[").join(assertionErrorMessages.get(entry.getKey())).replace("\n", "\n\t\t\t")))
-                                    .collect(joining("\n")))
-                    .isTrue();
-        }
+        assertEventually(
+                new Duration(30, SECONDS),
+                new Duration(1, SECONDS),
+                () -> {
+                    // queryId -> temporary table names
+                    Map<String, Set<String>> remainingTemporaryTables = new HashMap<>();
+                    // queryId -> assertion messages
+                    Map<String, Set<String>> assertionErrorMessages = new HashMap<>();
+                    for (String queryId : queryIds) {
+                        String temporaryTablePrefix = temporaryTableNamePrefix(queryId);
+                        MaterializedResult temporaryTablesResult = getQueryRunner()
+                                .execute("SHOW TABLES LIKE '%s%%' ESCAPE '\\'".formatted(temporaryTablePrefix.replace("_", "\\_")));
+                        // Unfortunately, information_schema is not strictly consistent with recently dropped tables,
+                        // and for some connectors, it can return tables that have been recently dropped. Therefore,
+                        // we can't rely simply on SHOW TABLES LIKE returning no results - we have to try to query the table
+                        for (MaterializedRow temporaryTableRow : temporaryTablesResult.getMaterializedRows()) {
+                            String temporaryTableName = (String) temporaryTableRow.getField(0);
+                            try {
+                                assertThatThrownBy(() -> getQueryRunner().execute("SELECT 1 FROM %s WHERE 1 = 0".formatted(temporaryTableName)))
+                                        .hasMessageContaining(".%s' does not exist", temporaryTableName);
+                            }
+                            catch (AssertionError e) {
+                                remainingTemporaryTables.computeIfAbsent(queryId, _ -> new HashSet<>()).add(temporaryTableName);
+                                assertionErrorMessages.computeIfAbsent(queryId, _ -> new HashSet<>()).add(e.getMessage());
+                            }
+                        }
+                    }
+
+                    assertThat(remainingTemporaryTables.isEmpty())
+                            .as("There should be no remaining tmp_trino tables that are queryable. They are:\n%s",
+                                    remainingTemporaryTables.entrySet().stream()
+                                            .map(entry -> "\tFor queryId [%s] (prefix [%s]) remaining tables: [%s]\n\t\tWith errors: [%s]".formatted(
+                                                    entry.getKey(),
+                                                    temporaryTableNamePrefix(entry.getKey()),
+                                                    Joiner.on(",").join(entry.getValue()),
+                                                    Joiner.on("],\n[").join(assertionErrorMessages.get(entry.getKey())).replace("\n", "\n\t\t\t")))
+                                            .collect(joining("\n")))
+                            .isTrue();
+                });
     }
 
     protected boolean checkNoRemainingTmpTables()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

We've seen flakiness in tests inheriting `BaseFailureRecoveryTest` when checking that temp tables have been cleaned. On query failure, this check does not wait on the catalog's `abort` call, so we may be performing this check before the drops have completed. These can surface as "Expecting code to raise a throwable" when the table existence check fails (i.e. the table still exists).

Hide whitespace for a much cleaner diff.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
