### PR TITLE
Speed up DATE component extraction with fast-date-64 algorithm

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -76,13 +76,8 @@ public final class DateTimeFunctions
 
     private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
     private static final DateTimeField DAY_OF_WEEK = UTC_CHRONOLOGY.dayOfWeek();
-    private static final DateTimeField DAY_OF_MONTH = UTC_CHRONOLOGY.dayOfMonth();
-    private static final DateTimeField DAY_OF_YEAR = UTC_CHRONOLOGY.dayOfYear();
     private static final DateTimeField WEEK_OF_YEAR = UTC_CHRONOLOGY.weekOfWeekyear();
     private static final DateTimeField YEAR_OF_WEEK = UTC_CHRONOLOGY.weekyear();
-    private static final DateTimeField MONTH_OF_YEAR = UTC_CHRONOLOGY.monthOfYear();
-    private static final DateTimeField QUARTER = QUARTER_OF_YEAR.getField(UTC_CHRONOLOGY);
-    private static final DateTimeField YEAR = UTC_CHRONOLOGY.year();
     private static final int MILLISECONDS_IN_SECOND = 1000;
     private static final int MILLISECONDS_IN_MINUTE = 60 * MILLISECONDS_IN_SECOND;
     private static final int MILLISECONDS_IN_HOUR = 60 * MILLISECONDS_IN_MINUTE;

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -493,7 +493,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long dayFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return DAY_OF_MONTH.get(DAYS.toMillis(date));
+        return DateTimeUtils.FastDate.dayOf((int) date);
     }
 
     @Description("Day of the month of the given interval")
@@ -509,8 +509,8 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.DATE)
     public static long lastDayOfMonthFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        long millis = UTC_CHRONOLOGY.monthOfYear().roundCeiling(DAYS.toMillis(date) + 1) - MILLISECONDS_IN_DAY;
-        return MILLISECONDS.toDays(millis);
+        int days = (int) date;
+        return (long) days - DateTimeUtils.FastDate.dayOf(days) + DateTimeUtils.FastDate.daysInMonthOf(days);
     }
 
     @Description("Day of the year of the given date")
@@ -518,7 +518,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long dayOfYearFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return DAY_OF_YEAR.get(DAYS.toMillis(date));
+        return DateTimeUtils.FastDate.dayOfYearOf((int) date);
     }
 
     @Description("Week of the year of the given date")
@@ -542,7 +542,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long monthFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return MONTH_OF_YEAR.get(DAYS.toMillis(date));
+        return DateTimeUtils.FastDate.monthOf((int) date);
     }
 
     @Description("Month of the year of the given interval")
@@ -558,7 +558,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long quarterFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return QUARTER.get(DAYS.toMillis(date));
+        return DateTimeUtils.FastDate.quarterOf((int) date);
     }
 
     @Description("Year of the given date")
@@ -566,7 +566,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long yearFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return YEAR.get(DAYS.toMillis(date));
+        return DateTimeUtils.FastDate.yearOf((int) date);
     }
 
     @Description("Year of the given interval")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -30,6 +30,7 @@ import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.type.DateTimes;
 import io.trino.util.DateTimeUtils;
+import io.trino.util.FastDate;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeField;
 import org.joda.time.Days;
@@ -76,13 +77,8 @@ public final class DateTimeFunctions
 
     private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
     private static final DateTimeField DAY_OF_WEEK = UTC_CHRONOLOGY.dayOfWeek();
-    private static final DateTimeField DAY_OF_MONTH = UTC_CHRONOLOGY.dayOfMonth();
-    private static final DateTimeField DAY_OF_YEAR = UTC_CHRONOLOGY.dayOfYear();
     private static final DateTimeField WEEK_OF_YEAR = UTC_CHRONOLOGY.weekOfWeekyear();
     private static final DateTimeField YEAR_OF_WEEK = UTC_CHRONOLOGY.weekyear();
-    private static final DateTimeField MONTH_OF_YEAR = UTC_CHRONOLOGY.monthOfYear();
-    private static final DateTimeField QUARTER = QUARTER_OF_YEAR.getField(UTC_CHRONOLOGY);
-    private static final DateTimeField YEAR = UTC_CHRONOLOGY.year();
     private static final int MILLISECONDS_IN_SECOND = 1000;
     private static final int MILLISECONDS_IN_MINUTE = 60 * MILLISECONDS_IN_SECOND;
     private static final int MILLISECONDS_IN_HOUR = 60 * MILLISECONDS_IN_MINUTE;
@@ -493,7 +489,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long dayFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return DAY_OF_MONTH.get(DAYS.toMillis(date));
+        return FastDate.dayOf((int) date);
     }
 
     @Description("Day of the month of the given interval")
@@ -509,8 +505,8 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.DATE)
     public static long lastDayOfMonthFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        long millis = UTC_CHRONOLOGY.monthOfYear().roundCeiling(DAYS.toMillis(date) + 1) - MILLISECONDS_IN_DAY;
-        return MILLISECONDS.toDays(millis);
+        int days = (int) date;
+        return (long) days - FastDate.dayOf(days) + FastDate.daysInMonthOf(days);
     }
 
     @Description("Day of the year of the given date")
@@ -518,7 +514,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long dayOfYearFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return DAY_OF_YEAR.get(DAYS.toMillis(date));
+        return FastDate.dayOfYearOf((int) date);
     }
 
     @Description("Week of the year of the given date")
@@ -542,7 +538,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long monthFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return MONTH_OF_YEAR.get(DAYS.toMillis(date));
+        return FastDate.monthOf((int) date);
     }
 
     @Description("Month of the year of the given interval")
@@ -558,7 +554,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long quarterFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return QUARTER.get(DAYS.toMillis(date));
+        return FastDate.quarterOf((int) date);
     }
 
     @Description("Year of the given date")
@@ -566,7 +562,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long yearFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        return YEAR.get(DAYS.toMillis(date));
+        return FastDate.yearOf((int) date);
     }
 
     @Description("Year of the given interval")

--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -39,7 +39,7 @@ import org.joda.time.format.PeriodParser;
 
 import java.time.DateTimeException;
 import java.time.Duration;
-import java.time.LocalDate;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -107,8 +107,25 @@ public final class DateTimeUtils
             return OptionalInt.empty();
         }
 
-        LocalDate date = LocalDate.of(year.getAsInt(), month.getAsInt(), day.getAsInt());
-        return OptionalInt.of(toIntExact(date.toEpochDay()));
+        int y = year.getAsInt();
+        int m = month.getAsInt();
+        int d = day.getAsInt();
+        // Mirror LocalDate.of's validation order and exception messages so that callers
+        // observing DateTimeException.getMessage() see the same text.
+        if (m < 1 || m > 12) {
+            throw new DateTimeException("Invalid value for MonthOfYear (valid values 1 - 12): " + m);
+        }
+        if (d < 1 || d > 31) {
+            throw new DateTimeException("Invalid value for DayOfMonth (valid values 1 - 28/31): " + d);
+        }
+        int monthLength = FastDate.daysInMonth(y, m);
+        if (d > monthLength) {
+            if (d == 29 && m == 2) {
+                throw new DateTimeException("Invalid date 'February 29' as '" + y + "' is not a leap year");
+            }
+            throw new DateTimeException("Invalid date '" + Month.of(m).name() + " " + d + "'");
+        }
+        return OptionalInt.of(FastDate.daysFromYmd(y, m, d));
     }
 
     /**
@@ -133,7 +150,25 @@ public final class DateTimeUtils
 
     public static String printDate(int days)
     {
-        return DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(days));
+        long ymd = FastDate.ymdFromEpochDay(days);
+        int year = (int) (ymd >> 32);
+        if (year < 0 || year > 9999) {
+            return DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(days));
+        }
+        int month = (int) ((ymd >> 8) & 0xFF);
+        int day = (int) (ymd & 0xFF);
+        char[] buf = new char[10];
+        buf[0] = (char) ('0' + year / 1000);
+        buf[1] = (char) ('0' + (year / 100) % 10);
+        buf[2] = (char) ('0' + (year / 10) % 10);
+        buf[3] = (char) ('0' + year % 10);
+        buf[4] = '-';
+        buf[5] = (char) ('0' + month / 10);
+        buf[6] = (char) ('0' + month % 10);
+        buf[7] = '-';
+        buf[8] = (char) ('0' + day / 10);
+        buf[9] = (char) ('0' + day % 10);
+        return new String(buf);
     }
 
     private static final DateTimeFormatter TIMESTAMP_WITH_OR_WITHOUT_TIME_ZONE_FORMATTER;

--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -40,6 +40,7 @@ import org.joda.time.format.PeriodParser;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -107,8 +108,25 @@ public final class DateTimeUtils
             return OptionalInt.empty();
         }
 
-        LocalDate date = LocalDate.of(year.getAsInt(), month.getAsInt(), day.getAsInt());
-        return OptionalInt.of(toIntExact(date.toEpochDay()));
+        int y = year.getAsInt();
+        int m = month.getAsInt();
+        int d = day.getAsInt();
+        // Mirror LocalDate.of's validation order and exception messages so that callers
+        // observing DateTimeException.getMessage() see the same text.
+        if (m < 1 || m > 12) {
+            throw new DateTimeException("Invalid value for MonthOfYear (valid values 1 - 12): " + m);
+        }
+        if (d < 1 || d > 31) {
+            throw new DateTimeException("Invalid value for DayOfMonth (valid values 1 - 28/31): " + d);
+        }
+        int monthLength = FastDate.daysInMonth(y, m);
+        if (d > monthLength) {
+            if (d == 29 && m == 2) {
+                throw new DateTimeException("Invalid date 'February 29' as '" + y + "' is not a leap year");
+            }
+            throw new DateTimeException("Invalid date '" + Month.of(m).name() + " " + d + "'");
+        }
+        return OptionalInt.of(FastDate.daysFromYmd(y, m, d));
     }
 
     /**
@@ -133,7 +151,166 @@ public final class DateTimeUtils
 
     public static String printDate(int days)
     {
-        return DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(days));
+        long ymd = FastDate.ymdFromEpochDay(days);
+        int year = (int) (ymd >> 32);
+        if (year < 0 || year > 9999) {
+            return DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(days));
+        }
+        int month = (int) ((ymd >> 8) & 0xFF);
+        int day = (int) (ymd & 0xFF);
+        char[] buf = new char[10];
+        buf[0] = (char) ('0' + year / 1000);
+        buf[1] = (char) ('0' + (year / 100) % 10);
+        buf[2] = (char) ('0' + (year / 10) % 10);
+        buf[3] = (char) ('0' + year % 10);
+        buf[4] = '-';
+        buf[5] = (char) ('0' + month / 10);
+        buf[6] = (char) ('0' + month % 10);
+        buf[7] = '-';
+        buf[8] = (char) ('0' + day / 10);
+        buf[9] = (char) ('0' + day % 10);
+        return new String(buf);
+    }
+
+    /**
+     * Fast civil-from-days (year/month/day from days-since-1970-01-01) using Ben Joffe's
+     * 64-bit algorithm: <a href="https://www.benjoffe.com/fast-date-64">www.benjoffe.com/fast-date-64</a>.
+     * Reference C++ implementation (Boost Software License 1.0):
+     * <a href="https://github.com/benjoffe/fast-date-benchmarks/blob/main/algorithms/benjoffe_fast64.hpp">benjoffe_fast64.hpp</a>.
+     * <p>
+     * Math.unsignedMultiplyHigh is intrinsified by HotSpot to {@code mulq}/{@code umulh},
+     * so each mul-shift-by-64 step is a single machine instruction. Operates on the x86 SCALE=32
+     * variant of the algorithm — the ARM variant differs only in immediate-encoding efficiency.
+     */
+    public static final class FastDate
+    {
+        private FastDate() {}
+
+        private static final long ERAS = 14704L;
+        private static final long D_SHIFT = 146097L * ERAS - 719469L;
+        private static final long Y_SHIFT = 400L * ERAS - 1L;
+        private static final long C1 = 505_054_698_555_331L;
+        private static final long C2 = 50_504_432_782_230_121L;
+        private static final long C3 = 8_619_973_866_219_416L;
+        private static final long YPT_MULT = 782_432L;
+        private static final long BUMP_THRESHOLD = 126_464L;
+        private static final long SHIFT_NO_BUMP = 977_792L;
+        private static final long SHIFT_BUMP = 191_360L;
+
+        // The choice of ERAS=14704 maximizes the algorithm's safe range while keeping D_SHIFT
+        // within uint32. Below this bound, the (D_SHIFT - days) computation overflows uint32
+        // and corrupts every downstream value. Affects only ~7172 days at the very bottom of
+        // the int DATE range — dates around year -5,877,660, far outside any realistic use.
+        private static final int FAST_MIN_DAYS = (int) (D_SHIFT - 0xFFFFFFFFL);   // = -2_147_476_476
+
+        // Cumulative days before the start of each civil month, indexed 1..12 (0 unused).
+        private static final int[] DOY_PREFIX_NON_LEAP = {0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+        private static final int[] DOY_PREFIX_LEAP = {0, 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335};
+
+        // Days-in-month, indexed by civil month 1..12 (0 unused).
+        private static final int[] DAYS_IN_MONTH_NON_LEAP = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        private static final int[] DAYS_IN_MONTH_LEAP = {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+        /**
+         * Returns {@code (year << 32) | (month << 8) | day} where year is signed,
+         * month is 1..12, and day is 1..31. Valid for the entire {@code int} range of
+         * days-since-epoch (≈ ±5.88M years).
+         */
+        public static long ymdFromEpochDay(int days)
+        {
+            if (days < FAST_MIN_DAYS) {
+                LocalDate date = LocalDate.ofEpochDay(days);
+                return ((long) date.getYear() << 32) | ((long) date.getMonthValue() << 8) | date.getDayOfMonth();
+            }
+            // Mirror the C++ uint32 wraparound by zero-extending into a long.
+            long rev = (D_SHIFT - days) & 0xFFFFFFFFL;
+            long cen = Math.unsignedMultiplyHigh(C1, rev);
+            long jul = rev + cen - (cen >>> 2);
+            long numLow = C2 * jul;
+            long numHigh = Math.unsignedMultiplyHigh(C2, jul);
+            long yrs = (Y_SHIFT - numHigh) & 0xFFFFFFFFL;
+            long ypt = Math.unsignedMultiplyHigh(YPT_MULT, numLow);
+            long bump = (ypt < BUMP_THRESHOLD) ? 1L : 0L;
+            long shift = (bump != 0) ? SHIFT_BUMP : SHIFT_NO_BUMP;
+            long n = (yrs & 3L) * 512L + shift - ypt;
+            long month = n >>> 16;
+            long day = Math.unsignedMultiplyHigh(C3, n & 0xFFFFL) + 1L;
+            int year = (int) (yrs + bump);
+            return ((long) year << 32) | (month << 8) | day;
+        }
+
+        public static int yearOf(int days)
+        {
+            return (int) (ymdFromEpochDay(days) >> 32);
+        }
+
+        public static int monthOf(int days)
+        {
+            return (int) ((ymdFromEpochDay(days) >> 8) & 0xFF);
+        }
+
+        public static int dayOf(int days)
+        {
+            return (int) (ymdFromEpochDay(days) & 0xFF);
+        }
+
+        public static int quarterOf(int days)
+        {
+            return (monthOf(days) - 1) / 3 + 1;
+        }
+
+        public static int dayOfYearOf(int days)
+        {
+            long ymd = ymdFromEpochDay(days);
+            int year = (int) (ymd >> 32);
+            int month = (int) ((ymd >> 8) & 0xFF);
+            int day = (int) (ymd & 0xFF);
+            return (isLeap(year) ? DOY_PREFIX_LEAP : DOY_PREFIX_NON_LEAP)[month] + day;
+        }
+
+        public static int daysInMonthOf(int days)
+        {
+            long ymd = ymdFromEpochDay(days);
+            int year = (int) (ymd >> 32);
+            int month = (int) ((ymd >> 8) & 0xFF);
+            return (isLeap(year) ? DAYS_IN_MONTH_LEAP : DAYS_IN_MONTH_NON_LEAP)[month];
+        }
+
+        /**
+         * Civil days in {@code month} of {@code year}. {@code month} is 1..12.
+         */
+        public static int daysInMonth(int year, int month)
+        {
+            return (isLeap(year) ? DAYS_IN_MONTH_LEAP : DAYS_IN_MONTH_NON_LEAP)[month];
+        }
+
+        public static boolean isLeap(int year)
+        {
+            // Java % returns same sign as dividend; (year & 3) == 0 is equivalent to
+            // year % 4 == 0 for both signs in two's complement.
+            return ((year & 3) == 0) && (year % 100 != 0 || year % 400 == 0);
+        }
+
+        /**
+         * Days-since-1970-01-01 from civil (year, month, day) using Ben Joffe's {@code to_rata_die}.
+         * <p>
+         * Precondition: the input is a valid civil date. No range or leap-day validation is
+         * performed. Safe across the full {@code int} days range (year shift of 5,880,000 covers
+         * roughly ±5.88M years centred on the UNIX epoch).
+         * <p>
+         * The {@code yrs / 100} division lowers to a single mul-shift on HotSpot since 100 is a
+         * compile-time constant; all other divisions are by powers of two.
+         */
+        public static int daysFromYmd(int year, int month, int day)
+        {
+            long bump = month <= 2 ? 1L : 0L;
+            long yrs = (year + 5_880_000L) - bump;
+            long cen = yrs / 100L;
+            long shift = bump != 0 ? 8829L : -2919L;
+            long yearDays = yrs * 365L + (yrs >>> 2) - cen + (cen >>> 2);
+            long monthDays = (979L * month + shift) >> 5;
+            return (int) (yearDays + monthDays + day - 2_148_345_369L);
+        }
     }
 
     private static final DateTimeFormatter TIMESTAMP_WITH_OR_WITHOUT_TIME_ZONE_FORMATTER;

--- a/core/trino-main/src/main/java/io/trino/util/FastDate.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastDate.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import java.time.LocalDate;
+
+/**
+ * Fast civil-from-days (year/month/day from days-since-1970-01-01) using Ben Joffe's
+ * 64-bit algorithm: <a href="https://www.benjoffe.com/fast-date-64">www.benjoffe.com/fast-date-64</a>.
+ * Reference C++ implementation (Boost Software License 1.0):
+ * <a href="https://github.com/benjoffe/fast-date-benchmarks/blob/main/algorithms/benjoffe_fast64.hpp">benjoffe_fast64.hpp</a>.
+ * <p>
+ * Math.unsignedMultiplyHigh is intrinsified by HotSpot to {@code mulq}/{@code umulh},
+ * so each mul-shift-by-64 step is a single machine instruction. Operates on the x86 SCALE=32
+ * variant of the algorithm — the ARM variant differs only in immediate-encoding efficiency.
+ */
+public final class FastDate
+{
+    private FastDate() {}
+
+    private static final long ERAS = 14704L;
+    private static final long D_SHIFT = 146097L * ERAS - 719469L;
+    private static final long Y_SHIFT = 400L * ERAS - 1L;
+    private static final long C1 = 505_054_698_555_331L;
+    private static final long C2 = 50_504_432_782_230_121L;
+    private static final long C3 = 8_619_973_866_219_416L;
+    private static final long YPT_MULT = 782_432L;
+    private static final long BUMP_THRESHOLD = 126_464L;
+    private static final long SHIFT_NO_BUMP = 977_792L;
+    private static final long SHIFT_BUMP = 191_360L;
+
+    // The choice of ERAS=14704 maximizes the algorithm's safe range while keeping D_SHIFT
+    // within uint32. Below this bound, the (D_SHIFT - days) computation overflows uint32
+    // and corrupts every downstream value. Affects only ~7172 days at the very bottom of
+    // the int DATE range — dates around year -5,877,660, far outside any realistic use.
+    private static final int FAST_MIN_DAYS = (int) (D_SHIFT - 0xFFFFFFFFL);   // = -2_147_476_476
+
+    // Cumulative days before the start of each civil month, indexed 1..12 (0 unused).
+    private static final int[] DOY_PREFIX_NON_LEAP = {0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+    private static final int[] DOY_PREFIX_LEAP = {0, 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335};
+
+    // Days-in-month, indexed by civil month 1..12 (0 unused).
+    private static final int[] DAYS_IN_MONTH_NON_LEAP = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    private static final int[] DAYS_IN_MONTH_LEAP = {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    /**
+     * Returns {@code (year << 32) | (month << 8) | day} where year is signed,
+     * month is 1..12, and day is 1..31. Valid for the entire {@code int} range of
+     * days-since-epoch (≈ ±5.88M years).
+     */
+    public static long ymdFromEpochDay(int days)
+    {
+        if (days < FAST_MIN_DAYS) {
+            LocalDate date = LocalDate.ofEpochDay(days);
+            return ((long) date.getYear() << 32) | ((long) date.getMonthValue() << 8) | date.getDayOfMonth();
+        }
+        // Mirror the C++ uint32 wraparound by zero-extending into a long.
+        long rev = (D_SHIFT - days) & 0xFFFFFFFFL;
+        long cen = Math.unsignedMultiplyHigh(C1, rev);
+        long jul = rev + cen - (cen >>> 2);
+        long numLow = C2 * jul;
+        long numHigh = Math.unsignedMultiplyHigh(C2, jul);
+        long yrs = (Y_SHIFT - numHigh) & 0xFFFFFFFFL;
+        long ypt = Math.unsignedMultiplyHigh(YPT_MULT, numLow);
+        long bump = (ypt < BUMP_THRESHOLD) ? 1L : 0L;
+        long shift = (bump != 0) ? SHIFT_BUMP : SHIFT_NO_BUMP;
+        long n = (yrs & 3L) * 512L + shift - ypt;
+        long month = n >>> 16;
+        long day = Math.unsignedMultiplyHigh(C3, n & 0xFFFFL) + 1L;
+        int year = (int) (yrs + bump);
+        return ((long) year << 32) | (month << 8) | day;
+    }
+
+    public static int yearOf(int days)
+    {
+        return (int) (ymdFromEpochDay(days) >> 32);
+    }
+
+    public static int monthOf(int days)
+    {
+        return (int) ((ymdFromEpochDay(days) >> 8) & 0xFF);
+    }
+
+    public static int dayOf(int days)
+    {
+        return (int) (ymdFromEpochDay(days) & 0xFF);
+    }
+
+    public static int quarterOf(int days)
+    {
+        return (monthOf(days) - 1) / 3 + 1;
+    }
+
+    public static int dayOfYearOf(int days)
+    {
+        long ymd = ymdFromEpochDay(days);
+        int year = (int) (ymd >> 32);
+        int month = (int) ((ymd >> 8) & 0xFF);
+        int day = (int) (ymd & 0xFF);
+        return (isLeap(year) ? DOY_PREFIX_LEAP : DOY_PREFIX_NON_LEAP)[month] + day;
+    }
+
+    public static int daysInMonthOf(int days)
+    {
+        long ymd = ymdFromEpochDay(days);
+        int year = (int) (ymd >> 32);
+        int month = (int) ((ymd >> 8) & 0xFF);
+        return (isLeap(year) ? DAYS_IN_MONTH_LEAP : DAYS_IN_MONTH_NON_LEAP)[month];
+    }
+
+    /**
+     * Civil days in {@code month} of {@code year}. {@code month} is 1..12.
+     */
+    public static int daysInMonth(int year, int month)
+    {
+        return (isLeap(year) ? DAYS_IN_MONTH_LEAP : DAYS_IN_MONTH_NON_LEAP)[month];
+    }
+
+    public static boolean isLeap(int year)
+    {
+        // Java % returns same sign as dividend; (year & 3) == 0 is equivalent to
+        // year % 4 == 0 for both signs in two's complement.
+        return ((year & 3) == 0) && (year % 100 != 0 || year % 400 == 0);
+    }
+
+    /**
+     * Days-since-1970-01-01 from civil (year, month, day) using Ben Joffe's {@code to_rata_die}.
+     * <p>
+     * Precondition: the input is a valid civil date. No range or leap-day validation is
+     * performed. Safe across the full {@code int} days range (year shift of 5,880,000 covers
+     * roughly ±5.88M years centred on the UNIX epoch).
+     * <p>
+     * The {@code yrs / 100} division lowers to a single mul-shift on HotSpot since 100 is a
+     * compile-time constant; all other divisions are by powers of two.
+     */
+    public static int daysFromYmd(int year, int month, int day)
+    {
+        long bump = month <= 2 ? 1L : 0L;
+        long yrs = (year + 5_880_000L) - bump;
+        long cen = yrs / 100L;
+        long shift = bump != 0 ? 8829L : -2919L;
+        long yearDays = yrs * 365L + (yrs >>> 2) - cen + (cen >>> 2);
+        long monthDays = (979L * month + shift) >> 5;
+        return (int) (yearDays + monthDays + day - 2_148_345_369L);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkDateExtraction.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkDateExtraction.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import io.trino.operator.scalar.QuarterOfYearDateTimeField;
+import io.trino.util.DateTimeUtils.FastDate;
+import org.joda.time.DateTimeField;
+import org.joda.time.chrono.ISOChronology;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.Throughput;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Throughput)
+@Fork(1)
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkDateExtraction
+{
+    private static final ISOChronology UTC = ISOChronology.getInstanceUTC();
+    private static final DateTimeField YEAR = UTC.year();
+    private static final DateTimeField MONTH = UTC.monthOfYear();
+    private static final DateTimeField DAY = UTC.dayOfMonth();
+    private static final DateTimeField DAY_OF_YEAR = UTC.dayOfYear();
+    private static final DateTimeField QUARTER = QuarterOfYearDateTimeField.QUARTER_OF_YEAR.getField(UTC);
+    private static final long MILLIS_PER_DAY = 86_400_000L;
+
+    @State(Thread)
+    public static class BenchmarkData
+    {
+        // realistic ≈ 1970-01-01 to 2100-12-31 (≈ daily-business range)
+        // wide ≈ across the algorithm's safe range; stresses branch predictor
+        @Param({"realistic", "wide"})
+        public String distribution;
+
+        int[] dates;
+
+        @Setup
+        public void setup()
+        {
+            Random r = new Random(42);
+            dates = new int[1024];
+            if ("realistic".equals(distribution)) {
+                int lo = 0;
+                int hi = (int) LocalDate.of(2100, 12, 31).toEpochDay();
+                for (int i = 0; i < dates.length; i++) {
+                    dates[i] = lo + r.nextInt(hi - lo);
+                }
+            }
+            else {
+                // Full int range — exercises both the fast path and the rare fallback
+                // (~7000 days at the very bottom of the range).
+                for (int i = 0; i < dates.length; i++) {
+                    dates[i] = r.nextInt();
+                }
+            }
+        }
+    }
+
+    // ---- year ----
+
+    @Benchmark
+    public long jodaYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += YEAR.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getYear();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.yearOf(d);
+        }
+        return sum;
+    }
+
+    // ---- month ----
+
+    @Benchmark
+    public long jodaMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += MONTH.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getMonthValue();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.monthOf(d);
+        }
+        return sum;
+    }
+
+    // ---- day-of-month ----
+
+    @Benchmark
+    public long jodaDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += DAY.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getDayOfMonth();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.dayOf(d);
+        }
+        return sum;
+    }
+
+    // ---- day-of-year ----
+
+    @Benchmark
+    public long jodaDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += DAY_OF_YEAR.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getDayOfYear();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.dayOfYearOf(d);
+        }
+        return sum;
+    }
+
+    // ---- quarter ----
+
+    @Benchmark
+    public long jodaQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += QUARTER.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (LocalDate.ofEpochDay(d).getMonthValue() - 1) / 3 + 1;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.quarterOf(d);
+        }
+        return sum;
+    }
+
+    // ---- last_day_of_month ----
+
+    @Benchmark
+    public long jodaLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long millis = UTC.monthOfYear().roundCeiling(d * MILLIS_PER_DAY + 1) - MILLIS_PER_DAY;
+            sum += millis / MILLIS_PER_DAY;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).with(TemporalAdjusters.lastDayOfMonth()).toEpochDay();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (long) d - FastDate.dayOf(d) + FastDate.daysInMonthOf(d);
+        }
+        return sum;
+    }
+
+    // ---- year+month+day combined (defeats DCE of unused fields) ----
+
+    @Benchmark
+    public long jodaYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ms = d * MILLIS_PER_DAY;
+            sum += YEAR.get(ms) + MONTH.get(ms) + DAY.get(ms);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            LocalDate ld = LocalDate.ofEpochDay(d);
+            sum += ld.getYear() + ld.getMonthValue() + ld.getDayOfMonth();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = FastDate.ymdFromEpochDay(d);
+            sum += (int) (ymd >> 32) + (int) ((ymd >> 8) & 0xFF) + (int) (ymd & 0xFF);
+        }
+        return sum;
+    }
+
+    // ---- Neri-Schneider reference (impl in NeriSchneiderDate; cited in the PR algorithm-choice discussion) ----
+
+    @Benchmark
+    public long nsYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (int) (NeriSchneiderDate.ymdFromEpochDay(d) >> 32);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (int) ((NeriSchneiderDate.ymdFromEpochDay(d) >> 8) & 0xFF);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (int) (NeriSchneiderDate.ymdFromEpochDay(d) & 0xFF);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = NeriSchneiderDate.ymdFromEpochDay(d);
+            sum += (int) (ymd >> 32) + (int) ((ymd >> 8) & 0xFF) + (int) (ymd & 0xFF);
+        }
+        return sum;
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        benchmark(BenchmarkDateExtraction.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkDateExtraction.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkDateExtraction.java
@@ -316,6 +316,10 @@ public class BenchmarkDateExtraction
 
     // ---- Neri-Schneider reference (impl in NeriSchneiderDate; cited in the PR algorithm-choice discussion) ----
 
+    // Day-of-year prefix tables (algorithm-independent — same lookup as FastDate uses internally).
+    private static final int[] DOY_PREFIX_NON_LEAP = {0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+    private static final int[] DOY_PREFIX_LEAP = {0, 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335};
+
     @Benchmark
     public long nsYear(BenchmarkData data)
     {
@@ -342,6 +346,45 @@ public class BenchmarkDateExtraction
         long sum = 0;
         for (int d : data.dates) {
             sum += (int) (NeriSchneiderDate.ymdFromEpochDay(d) & 0xFF);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = NeriSchneiderDate.ymdFromEpochDay(d);
+            int year = (int) (ymd >> 32);
+            int month = (int) ((ymd >> 8) & 0xFF);
+            int day = (int) (ymd & 0xFF);
+            sum += (FastDate.isLeap(year) ? DOY_PREFIX_LEAP : DOY_PREFIX_NON_LEAP)[month] + day;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            int month = (int) ((NeriSchneiderDate.ymdFromEpochDay(d) >> 8) & 0xFF);
+            sum += (month - 1) / 3 + 1;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = NeriSchneiderDate.ymdFromEpochDay(d);
+            int year = (int) (ymd >> 32);
+            int month = (int) ((ymd >> 8) & 0xFF);
+            int dayOfMonth = (int) (ymd & 0xFF);
+            sum += (long) d - dayOfMonth + FastDate.daysInMonth(year, month);
         }
         return sum;
     }

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkDateExtraction.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkDateExtraction.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import io.trino.operator.scalar.QuarterOfYearDateTimeField;
+import org.joda.time.DateTimeField;
+import org.joda.time.chrono.ISOChronology;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Random;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.Throughput;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Throughput)
+@Fork(1)
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkDateExtraction
+{
+    private static final ISOChronology UTC = ISOChronology.getInstanceUTC();
+    private static final DateTimeField YEAR = UTC.year();
+    private static final DateTimeField MONTH = UTC.monthOfYear();
+    private static final DateTimeField DAY = UTC.dayOfMonth();
+    private static final DateTimeField DAY_OF_YEAR = UTC.dayOfYear();
+    private static final DateTimeField QUARTER = QuarterOfYearDateTimeField.QUARTER_OF_YEAR.getField(UTC);
+    private static final long MILLIS_PER_DAY = 86_400_000L;
+
+    @State(Thread)
+    public static class BenchmarkData
+    {
+        // realistic    ≈ 1970-01-01 to 2100-12-31 (≈ daily-business range)
+        // ns_reference ≈ 1900-01-01 to 2050-01-01, matches the distribution used by
+        //                #29291's BenchmarkDateTimeExtraction for direct apples-to-apples
+        //                comparison ("bulk of analytical workloads")
+        // wide         ≈ across the algorithm's safe range; stresses branch predictor
+        @Param({"realistic", "ns_reference", "wide"})
+        public String distribution;
+
+        int[] dates;
+
+        @Setup
+        public void setup()
+        {
+            dates = new int[1024];
+            if ("realistic".equals(distribution)) {
+                Random r = new Random(42);
+                int lo = 0;
+                int hi = (int) LocalDate.of(2100, 12, 31).toEpochDay();
+                for (int i = 0; i < dates.length; i++) {
+                    dates[i] = lo + r.nextInt(hi - lo);
+                }
+            }
+            else if ("ns_reference".equals(distribution)) {
+                // Match #29291's BenchmarkDateTimeExtraction setup exactly.
+                SplittableRandom random = new SplittableRandom(42);
+                int min = -25567; // 1900-01-01
+                int max = 29220;  // 2050-01-01
+                for (int i = 0; i < dates.length; i++) {
+                    dates[i] = min + random.nextInt(max - min);
+                }
+            }
+            else {
+                // Full int range — exercises both the fast path and the rare fallback
+                // (~7000 days at the very bottom of the range).
+                Random r = new Random(42);
+                for (int i = 0; i < dates.length; i++) {
+                    dates[i] = r.nextInt();
+                }
+            }
+        }
+    }
+
+    // ---- year ----
+
+    @Benchmark
+    public long jodaYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += YEAR.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getYear();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.yearOf(d);
+        }
+        return sum;
+    }
+
+    // ---- month ----
+
+    @Benchmark
+    public long jodaMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += MONTH.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getMonthValue();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.monthOf(d);
+        }
+        return sum;
+    }
+
+    // ---- day-of-month ----
+
+    @Benchmark
+    public long jodaDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += DAY.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getDayOfMonth();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.dayOf(d);
+        }
+        return sum;
+    }
+
+    // ---- day-of-year ----
+
+    @Benchmark
+    public long jodaDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += DAY_OF_YEAR.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).getDayOfYear();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.dayOfYearOf(d);
+        }
+        return sum;
+    }
+
+    // ---- quarter ----
+
+    @Benchmark
+    public long jodaQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += QUARTER.get(d * MILLIS_PER_DAY);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (LocalDate.ofEpochDay(d).getMonthValue() - 1) / 3 + 1;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += FastDate.quarterOf(d);
+        }
+        return sum;
+    }
+
+    // ---- last_day_of_month ----
+
+    @Benchmark
+    public long jodaLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long millis = UTC.monthOfYear().roundCeiling(d * MILLIS_PER_DAY + 1) - MILLIS_PER_DAY;
+            sum += millis / MILLIS_PER_DAY;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += LocalDate.ofEpochDay(d).with(TemporalAdjusters.lastDayOfMonth()).toEpochDay();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (long) d - FastDate.dayOf(d) + FastDate.daysInMonthOf(d);
+        }
+        return sum;
+    }
+
+    // ---- year+month+day combined (defeats DCE of unused fields) ----
+
+    @Benchmark
+    public long jodaYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ms = d * MILLIS_PER_DAY;
+            sum += YEAR.get(ms) + MONTH.get(ms) + DAY.get(ms);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long jdkYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            LocalDate ld = LocalDate.ofEpochDay(d);
+            sum += ld.getYear() + ld.getMonthValue() + ld.getDayOfMonth();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long fastYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = FastDate.ymdFromEpochDay(d);
+            sum += (int) (ymd >> 32) + (int) ((ymd >> 8) & 0xFF) + (int) (ymd & 0xFF);
+        }
+        return sum;
+    }
+
+    // ---- Neri-Schneider reference (impl in NeriSchneiderDate; cited in the PR algorithm-choice discussion) ----
+
+    // Day-of-year prefix tables (algorithm-independent — same lookup as FastDate uses internally).
+    private static final int[] DOY_PREFIX_NON_LEAP = {0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+    private static final int[] DOY_PREFIX_LEAP = {0, 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335};
+
+    @Benchmark
+    public long nsYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (int) (NeriSchneiderDate.ymdFromEpochDay(d) >> 32);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (int) ((NeriSchneiderDate.ymdFromEpochDay(d) >> 8) & 0xFF);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsDay(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            sum += (int) (NeriSchneiderDate.ymdFromEpochDay(d) & 0xFF);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsDayOfYear(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = NeriSchneiderDate.ymdFromEpochDay(d);
+            int year = (int) (ymd >> 32);
+            int month = (int) ((ymd >> 8) & 0xFF);
+            int day = (int) (ymd & 0xFF);
+            sum += (FastDate.isLeap(year) ? DOY_PREFIX_LEAP : DOY_PREFIX_NON_LEAP)[month] + day;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsQuarter(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            int month = (int) ((NeriSchneiderDate.ymdFromEpochDay(d) >> 8) & 0xFF);
+            sum += (month - 1) / 3 + 1;
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsLastDayOfMonth(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = NeriSchneiderDate.ymdFromEpochDay(d);
+            int year = (int) (ymd >> 32);
+            int month = (int) ((ymd >> 8) & 0xFF);
+            int dayOfMonth = (int) (ymd & 0xFF);
+            sum += (long) d - dayOfMonth + FastDate.daysInMonth(year, month);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long nsYmd(BenchmarkData data)
+    {
+        long sum = 0;
+        for (int d : data.dates) {
+            long ymd = NeriSchneiderDate.ymdFromEpochDay(d);
+            sum += (int) (ymd >> 32) + (int) ((ymd >> 8) & 0xFF) + (int) (ymd & 0xFF);
+        }
+        return sum;
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        benchmark(BenchmarkDateExtraction.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkDateProjection.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkDateProjection.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.SequencePageBuilder;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.project.PageProcessor;
+import io.trino.spi.Page;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.TypeManager;
+import io.trino.sql.gen.ExpressionCompiler;
+import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.ir.IrExpressions.call;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDateProjection
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution(
+            InternalFunctionBundle.builder()
+                    .scalars(LegacyJodaDateTimeFunctions.class)
+                    .scalars(JdkDateTimeFunctions.class)
+                    .build());
+    private static final Metadata METADATA = FUNCTIONS.getMetadata();
+    private static final TypeManager TYPE_MANAGER = FUNCTIONS.getPlannerContext().getTypeManager();
+    private static final FunctionManager FUNCTION_MANAGER = FUNCTIONS.getPlannerContext().getFunctionManager();
+
+    private static final ResolvedFunction YEAR_FAST = FUNCTIONS.resolveFunction("year", fromTypes(DATE));
+    private static final ResolvedFunction MONTH_FAST = FUNCTIONS.resolveFunction("month", fromTypes(DATE));
+    private static final ResolvedFunction DAY_FAST = FUNCTIONS.resolveFunction("day", fromTypes(DATE));
+    private static final ResolvedFunction YEAR_JODA = FUNCTIONS.resolveFunction("legacy_year", fromTypes(DATE));
+    private static final ResolvedFunction MONTH_JODA = FUNCTIONS.resolveFunction("legacy_month", fromTypes(DATE));
+    private static final ResolvedFunction DAY_JODA = FUNCTIONS.resolveFunction("legacy_day", fromTypes(DATE));
+    private static final ResolvedFunction YEAR_JDK = FUNCTIONS.resolveFunction("jdk_year", fromTypes(DATE));
+    private static final ResolvedFunction MONTH_JDK = FUNCTIONS.resolveFunction("jdk_month", fromTypes(DATE));
+    private static final ResolvedFunction DAY_JDK = FUNCTIONS.resolveFunction("jdk_day", fromTypes(DATE));
+    private static final ResolvedFunction MULTIPLY_BIGINT = FUNCTIONS.resolveOperator(OperatorType.MULTIPLY, ImmutableList.of(BIGINT, BIGINT));
+    private static final ResolvedFunction ADD_BIGINT = FUNCTIONS.resolveOperator(OperatorType.ADD, ImmutableList.of(BIGINT, BIGINT));
+
+    private static final int POSITIONS = 1024;
+
+    @Param({"identity", "year", "yearMonthDay", "combined"})
+    String projection;
+
+    @Param({"fast", "joda", "jdk"})
+    String impl;
+
+    private PageProcessor pageProcessor;
+    private Page inputPage;
+
+    @Setup
+    public void setup()
+    {
+        Reference dateRef = new Reference(DATE, "d");
+        ResolvedFunction year;
+        ResolvedFunction month;
+        ResolvedFunction day;
+        switch (impl) {
+            case "fast" -> {
+                year = YEAR_FAST;
+                month = MONTH_FAST;
+                day = DAY_FAST;
+            }
+            case "joda" -> {
+                year = YEAR_JODA;
+                month = MONTH_JODA;
+                day = DAY_JODA;
+            }
+            case "jdk" -> {
+                year = YEAR_JDK;
+                month = MONTH_JDK;
+                day = DAY_JDK;
+            }
+            default -> throw new IllegalArgumentException(impl);
+        }
+
+        List<Expression> projections = switch (projection) {
+            case "identity" -> ImmutableList.of(dateRef);
+            case "year" -> ImmutableList.of(call(year, dateRef));
+            case "yearMonthDay" -> ImmutableList.of(call(year, dateRef), call(month, dateRef), call(day, dateRef));
+            // year * 10000 + month * 100 + day — single column, all three functions in one expression.
+            case "combined" -> ImmutableList.of(
+                    call(ADD_BIGINT,
+                            call(ADD_BIGINT,
+                                    call(MULTIPLY_BIGINT, call(year, dateRef), new Constant(BIGINT, 10000L)),
+                                    call(MULTIPLY_BIGINT, call(month, dateRef), new Constant(BIGINT, 100L))),
+                            call(day, dateRef)));
+            default -> throw new IllegalArgumentException(projection);
+        };
+
+        Map<Symbol, Integer> sourceLayout = new HashMap<>();
+        sourceLayout.put(new Symbol(DATE, "d"), 0);
+
+        PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(FUNCTION_MANAGER, METADATA, TYPE_MANAGER, 0);
+        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(FUNCTIONS.getPlannerContext(), 0);
+
+        inputPage = SequencePageBuilder.createSequencePage(ImmutableList.of(DATE), POSITIONS);
+        pageProcessor = new ExpressionCompiler(pageFunctionCompiler, columnarFilterCompiler)
+                .compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, sourceLayout, Optional.empty(), OptionalInt.empty())
+                .apply(DynamicFilter.EMPTY);
+    }
+
+    @Benchmark
+    public List<Optional<Page>> project()
+    {
+        return ImmutableList.copyOf(
+                pageProcessor.process(
+                        null,
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        SourcePage.create(inputPage)));
+    }
+
+    @Test
+    void testBenchmark()
+    {
+        for (String p : ImmutableList.of("identity", "year", "yearMonthDay", "combined")) {
+            for (String i : ImmutableList.of("fast", "joda", "jdk")) {
+                BenchmarkDateProjection bench = new BenchmarkDateProjection();
+                bench.projection = p;
+                bench.impl = i;
+                bench.setup();
+                bench.project();
+            }
+        }
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        benchmark(BenchmarkDateProjection.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkDateProjection.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkDateProjection.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.SequencePageBuilder;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.project.PageProcessor;
+import io.trino.spi.Page;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.TypeManager;
+import io.trino.sql.gen.ExpressionCompiler;
+import io.trino.sql.gen.PageFunctionCompiler;
+import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.IrExpressions.call;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDateProjection
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution(
+            InternalFunctionBundle.builder()
+                    .scalars(LegacyJodaDateTimeFunctions.class)
+                    .scalars(JdkDateTimeFunctions.class)
+                    .build());
+    private static final Metadata METADATA = FUNCTIONS.getMetadata();
+    private static final TypeManager TYPE_MANAGER = FUNCTIONS.getPlannerContext().getTypeManager();
+    private static final FunctionManager FUNCTION_MANAGER = FUNCTIONS.getPlannerContext().getFunctionManager();
+
+    private static final ResolvedFunction YEAR_FAST = FUNCTIONS.resolveFunction("year", fromTypes(DATE));
+    private static final ResolvedFunction MONTH_FAST = FUNCTIONS.resolveFunction("month", fromTypes(DATE));
+    private static final ResolvedFunction DAY_FAST = FUNCTIONS.resolveFunction("day", fromTypes(DATE));
+    private static final ResolvedFunction YEAR_JODA = FUNCTIONS.resolveFunction("legacy_year", fromTypes(DATE));
+    private static final ResolvedFunction MONTH_JODA = FUNCTIONS.resolveFunction("legacy_month", fromTypes(DATE));
+    private static final ResolvedFunction DAY_JODA = FUNCTIONS.resolveFunction("legacy_day", fromTypes(DATE));
+    private static final ResolvedFunction YEAR_JDK = FUNCTIONS.resolveFunction("jdk_year", fromTypes(DATE));
+    private static final ResolvedFunction MONTH_JDK = FUNCTIONS.resolveFunction("jdk_month", fromTypes(DATE));
+    private static final ResolvedFunction DAY_JDK = FUNCTIONS.resolveFunction("jdk_day", fromTypes(DATE));
+    private static final ResolvedFunction MULTIPLY_BIGINT = FUNCTIONS.resolveOperator(OperatorType.MULTIPLY, ImmutableList.of(BIGINT, BIGINT));
+    private static final ResolvedFunction ADD_BIGINT = FUNCTIONS.resolveOperator(OperatorType.ADD, ImmutableList.of(BIGINT, BIGINT));
+
+    private static final int POSITIONS = 1024;
+
+    @Param({"identity", "year", "yearMonthDay", "combined"})
+    String projection;
+
+    @Param({"fast", "joda", "jdk"})
+    String impl;
+
+    private PageProcessor pageProcessor;
+    private Page inputPage;
+
+    @Setup
+    public void setup()
+    {
+        Reference dateRef = new Reference(DATE, "d");
+        ResolvedFunction year;
+        ResolvedFunction month;
+        ResolvedFunction day;
+        switch (impl) {
+            case "fast" -> {
+                year = YEAR_FAST;
+                month = MONTH_FAST;
+                day = DAY_FAST;
+            }
+            case "joda" -> {
+                year = YEAR_JODA;
+                month = MONTH_JODA;
+                day = DAY_JODA;
+            }
+            case "jdk" -> {
+                year = YEAR_JDK;
+                month = MONTH_JDK;
+                day = DAY_JDK;
+            }
+            default -> throw new IllegalArgumentException(impl);
+        }
+
+        List<Expression> projections = switch (projection) {
+            case "identity" -> ImmutableList.of(dateRef);
+            case "year" -> ImmutableList.of(call(year, dateRef));
+            case "yearMonthDay" -> ImmutableList.of(call(year, dateRef), call(month, dateRef), call(day, dateRef));
+            // year * 10000 + month * 100 + day — single column, all three functions in one expression.
+            case "combined" -> ImmutableList.of(
+                    call(ADD_BIGINT,
+                            call(ADD_BIGINT,
+                                    call(MULTIPLY_BIGINT, call(year, dateRef), new Constant(BIGINT, 10000L)),
+                                    call(MULTIPLY_BIGINT, call(month, dateRef), new Constant(BIGINT, 100L))),
+                            call(day, dateRef)));
+            default -> throw new IllegalArgumentException(projection);
+        };
+
+        Map<Symbol, Integer> sourceLayout = new HashMap<>();
+        sourceLayout.put(new Symbol(DATE, "d"), 0);
+
+        PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(FUNCTION_MANAGER, METADATA, TYPE_MANAGER, 0);
+        ColumnarFilterCompiler columnarFilterCompiler = new ColumnarFilterCompiler(FUNCTIONS.getPlannerContext(), 0);
+
+        inputPage = SequencePageBuilder.createSequencePage(ImmutableList.of(DATE), POSITIONS);
+        pageProcessor = new ExpressionCompiler(pageFunctionCompiler, columnarFilterCompiler)
+                .compilePageProcessor(true, true, Optional.empty(), Optional.empty(), projections, sourceLayout, Optional.empty(), OptionalInt.empty())
+                .apply(DynamicFilter.EMPTY);
+    }
+
+    @Benchmark
+    public List<Optional<Page>> project()
+    {
+        return ImmutableList.copyOf(
+                pageProcessor.process(
+                        null,
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        SourcePage.create(inputPage)));
+    }
+
+    @Test
+    void testBenchmark()
+    {
+        for (String p : ImmutableList.of("identity", "year", "yearMonthDay", "combined")) {
+            for (String i : ImmutableList.of("fast", "joda", "jdk")) {
+                BenchmarkDateProjection bench = new BenchmarkDateProjection();
+                bench.projection = p;
+                bench.impl = i;
+                bench.setup();
+                bench.project();
+            }
+        }
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        benchmark(BenchmarkDateProjection.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
@@ -13,6 +13,9 @@
  */
 package io.trino.util;
 
+import io.trino.util.DateTimeUtils.FastDate;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -24,6 +27,8 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.RunnerException;
 
+import java.time.LocalDate;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 
 import static io.trino.jmh.Benchmarks.benchmark;
@@ -47,20 +52,108 @@ public class BenchmarkParseDate
         }
     }
 
+    @Benchmark
+    public void parseDateBaseline(BenchmarkData data, Blackhole blackhole)
+    {
+        // Replicates the pre-PR DateTimeUtils.parseIfIso8601DateFormat structure exactly
+        // (length and separator checks, OptionalInt-style digit parsing) but with the original
+        // LocalDate.of(y, m, d).toEpochDay() conversion. Apples-to-apples end-to-end baseline.
+        for (String dt : data.dates) {
+            if (dt.length() != 10 || dt.charAt(4) != '-' || dt.charAt(7) != '-') {
+                continue;
+            }
+            OptionalInt year = parseIntSimple(dt, 0, 4);
+            if (year.isEmpty()) {
+                continue;
+            }
+            OptionalInt month = parseIntSimple(dt, 5, 2);
+            if (month.isEmpty()) {
+                continue;
+            }
+            OptionalInt day = parseIntSimple(dt, 8, 2);
+            if (day.isEmpty()) {
+                continue;
+            }
+            blackhole.consume((int) LocalDate.of(year.getAsInt(), month.getAsInt(), day.getAsInt()).toEpochDay());
+        }
+    }
+
+    private static OptionalInt parseIntSimple(String s, int offset, int length)
+    {
+        int result = 0;
+        for (int i = 0; i < length; i++) {
+            int digit = s.charAt(offset + i) - '0';
+            if (digit < 0 || digit > 9) {
+                return OptionalInt.empty();
+            }
+            result = result * 10 + digit;
+        }
+        return OptionalInt.of(result);
+    }
+
+    // Pre-parsed (year, month, day) triples — isolates the y/m/d → days conversion cost.
+
+    @Benchmark
+    public void daysFromYmdJdk(BenchmarkData data, Blackhole blackhole)
+    {
+        int[] ymd = data.ymd;
+        for (int i = 0; i < ymd.length; i += 3) {
+            blackhole.consume(LocalDate.of(ymd[i], ymd[i + 1], ymd[i + 2]).toEpochDay());
+        }
+    }
+
+    @Benchmark
+    public void daysFromYmdFast(BenchmarkData data, Blackhole blackhole)
+    {
+        int[] ymd = data.ymd;
+        for (int i = 0; i < ymd.length; i += 3) {
+            blackhole.consume(FastDate.daysFromYmd(ymd[i], ymd[i + 1], ymd[i + 2]));
+        }
+    }
+
+    // CAST(date AS varchar) — int days → "YYYY-MM-DD".
+
+    private static final DateTimeFormatter JODA_DATE_FORMATTER = ISODateTimeFormat.date().withZoneUTC();
+
+    @Benchmark
+    public void printDateJoda(BenchmarkData data, Blackhole blackhole)
+    {
+        for (int days : data.dayValues) {
+            blackhole.consume(JODA_DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(days)));
+        }
+    }
+
+    @Benchmark
+    public void printDateFast(BenchmarkData data, Blackhole blackhole)
+    {
+        for (int days : data.dayValues) {
+            blackhole.consume(DateTimeUtils.printDate(days));
+        }
+    }
+
     @State(Thread)
     public static class BenchmarkData
     {
         String[] dates;
+        int[] ymd; // packed year, month, day triples — same dates as above, pre-parsed
+        int[] dayValues; // raw int days for printDate benchmarks
 
         @Setup
         public void setup()
         {
             dates = new String[100];
+            ymd = new int[dates.length * 3];
+            dayValues = new int[dates.length];
             // use the 100 consecutive dates start from 2023-01-01
             String startDate = "2023-01-01";
             int days = DateTimeUtils.parseDate(startDate);
             for (int i = 0; i < dates.length; i++) {
                 dates[i] = DateTimeUtils.printDate(days + i);
+                dayValues[i] = days + i;
+                LocalDate ld = LocalDate.ofEpochDay(days + i);
+                ymd[i * 3] = ld.getYear();
+                ymd[i * 3 + 1] = ld.getMonthValue();
+                ymd[i * 3 + 2] = ld.getDayOfMonth();
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
@@ -13,6 +13,8 @@
  */
 package io.trino.util;
 
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -24,6 +26,8 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.RunnerException;
 
+import java.time.LocalDate;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 
 import static io.trino.jmh.Benchmarks.benchmark;
@@ -47,20 +51,108 @@ public class BenchmarkParseDate
         }
     }
 
+    @Benchmark
+    public void parseDateBaseline(BenchmarkData data, Blackhole blackhole)
+    {
+        // Replicates the pre-PR DateTimeUtils.parseIfIso8601DateFormat structure exactly
+        // (length and separator checks, OptionalInt-style digit parsing) but with the original
+        // LocalDate.of(y, m, d).toEpochDay() conversion. Apples-to-apples end-to-end baseline.
+        for (String dt : data.dates) {
+            if (dt.length() != 10 || dt.charAt(4) != '-' || dt.charAt(7) != '-') {
+                continue;
+            }
+            OptionalInt year = parseIntSimple(dt, 0, 4);
+            if (year.isEmpty()) {
+                continue;
+            }
+            OptionalInt month = parseIntSimple(dt, 5, 2);
+            if (month.isEmpty()) {
+                continue;
+            }
+            OptionalInt day = parseIntSimple(dt, 8, 2);
+            if (day.isEmpty()) {
+                continue;
+            }
+            blackhole.consume((int) LocalDate.of(year.getAsInt(), month.getAsInt(), day.getAsInt()).toEpochDay());
+        }
+    }
+
+    private static OptionalInt parseIntSimple(String s, int offset, int length)
+    {
+        int result = 0;
+        for (int i = 0; i < length; i++) {
+            int digit = s.charAt(offset + i) - '0';
+            if (digit < 0 || digit > 9) {
+                return OptionalInt.empty();
+            }
+            result = result * 10 + digit;
+        }
+        return OptionalInt.of(result);
+    }
+
+    // Pre-parsed (year, month, day) triples — isolates the y/m/d → days conversion cost.
+
+    @Benchmark
+    public void daysFromYmdJdk(BenchmarkData data, Blackhole blackhole)
+    {
+        int[] ymd = data.ymd;
+        for (int i = 0; i < ymd.length; i += 3) {
+            blackhole.consume(LocalDate.of(ymd[i], ymd[i + 1], ymd[i + 2]).toEpochDay());
+        }
+    }
+
+    @Benchmark
+    public void daysFromYmdFast(BenchmarkData data, Blackhole blackhole)
+    {
+        int[] ymd = data.ymd;
+        for (int i = 0; i < ymd.length; i += 3) {
+            blackhole.consume(FastDate.daysFromYmd(ymd[i], ymd[i + 1], ymd[i + 2]));
+        }
+    }
+
+    // CAST(date AS varchar) — int days → "YYYY-MM-DD".
+
+    private static final DateTimeFormatter JODA_DATE_FORMATTER = ISODateTimeFormat.date().withZoneUTC();
+
+    @Benchmark
+    public void printDateJoda(BenchmarkData data, Blackhole blackhole)
+    {
+        for (int days : data.dayValues) {
+            blackhole.consume(JODA_DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(days)));
+        }
+    }
+
+    @Benchmark
+    public void printDateFast(BenchmarkData data, Blackhole blackhole)
+    {
+        for (int days : data.dayValues) {
+            blackhole.consume(DateTimeUtils.printDate(days));
+        }
+    }
+
     @State(Thread)
     public static class BenchmarkData
     {
         String[] dates;
+        int[] ymd; // packed year, month, day triples — same dates as above, pre-parsed
+        int[] dayValues; // raw int days for printDate benchmarks
 
         @Setup
         public void setup()
         {
             dates = new String[100];
+            ymd = new int[dates.length * 3];
+            dayValues = new int[dates.length];
             // use the 100 consecutive dates start from 2023-01-01
             String startDate = "2023-01-01";
             int days = DateTimeUtils.parseDate(startDate);
             for (int i = 0; i < dates.length; i++) {
                 dates[i] = DateTimeUtils.printDate(days + i);
+                dayValues[i] = days + i;
+                LocalDate ld = LocalDate.ofEpochDay(days + i);
+                ymd[i * 3] = ld.getYear();
+                ymd[i * 3 + 1] = ld.getMonthValue();
+                ymd[i * 3 + 2] = ld.getDayOfMonth();
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/util/JdkDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/util/JdkDateTimeFunctions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+import java.time.LocalDate;
+
+/**
+ * JDK {@link java.time.LocalDate}-based implementations of year/month/day, registered under
+ * {@code jdk_*} names for direct A/B comparison against Joda and FastDate paths in
+ * {@link BenchmarkDateProjection}.
+ */
+public final class JdkDateTimeFunctions
+{
+    private JdkDateTimeFunctions() {}
+
+    @Description("Year of the given date (JDK java.time)")
+    @ScalarFunction(value = "jdk_year", neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long yearFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        return LocalDate.ofEpochDay(date).getYear();
+    }
+
+    @Description("Month of the year of the given date (JDK java.time)")
+    @ScalarFunction(value = "jdk_month", neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long monthFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        return LocalDate.ofEpochDay(date).getMonthValue();
+    }
+
+    @Description("Day of the month of the given date (JDK java.time)")
+    @ScalarFunction(value = "jdk_day", neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long dayFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        return LocalDate.ofEpochDay(date).getDayOfMonth();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/LegacyJodaDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/util/LegacyJodaDateTimeFunctions.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.joda.time.DateTimeField;
+import org.joda.time.chrono.ISOChronology;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+
+/**
+ * Pre-optimization Joda-based implementations of year/month/day, registered under
+ * {@code legacy_*} names for direct A/B comparison against the FastDate path in
+ * {@link BenchmarkDateProjection}.
+ */
+public final class LegacyJodaDateTimeFunctions
+{
+    private LegacyJodaDateTimeFunctions() {}
+
+    private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
+    private static final DateTimeField YEAR = UTC_CHRONOLOGY.year();
+    private static final DateTimeField MONTH_OF_YEAR = UTC_CHRONOLOGY.monthOfYear();
+    private static final DateTimeField DAY_OF_MONTH = UTC_CHRONOLOGY.dayOfMonth();
+
+    @Description("Year of the given date (legacy Joda)")
+    @ScalarFunction(value = "legacy_year", neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long yearFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        return YEAR.get(DAYS.toMillis(date));
+    }
+
+    @Description("Month of the year of the given date (legacy Joda)")
+    @ScalarFunction(value = "legacy_month", neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long monthFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        return MONTH_OF_YEAR.get(DAYS.toMillis(date));
+    }
+
+    @Description("Day of the month of the given date (legacy Joda)")
+    @ScalarFunction(value = "legacy_day", neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long dayFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        return DAY_OF_MONTH.get(DAYS.toMillis(date));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/NeriSchneiderDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/NeriSchneiderDate.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+/**
+ * Reference implementation of the Neri-Schneider civil-from-days algorithm
+ * (Cassio Neri & Lorenz Schneider, "Euclidean Affine Functions and Applications to Calendar
+ * Algorithms", 2021, <a href="https://arxiv.org/abs/2102.06959">arXiv:2102.06959</a>).
+ * <p>
+ * Used by {@link BenchmarkDateExtraction} to back the algorithm-choice comparison referenced
+ * in the corresponding PR. Not on any production code path.
+ */
+public final class NeriSchneiderDate
+{
+    private NeriSchneiderDate() {}
+
+    // Shifts sized to keep the algorithm's internal counter non-negative across the full int
+    // days range (matches the era cycle used by FastDate).
+    private static final long K = 146097L * 14704L + 719468L;
+    private static final long L = 400L * 14704L;
+
+    /**
+     * Returns {@code (year << 32) | (month << 8) | day} for the given days-since-1970-01-01.
+     */
+    public static long ymdFromEpochDay(int days)
+    {
+        long n = days + K;
+        long n1 = 4L * n + 3L;
+        long c = n1 / 146097L;
+        long nC = (n1 % 146097L) >>> 2;
+        long n2 = 4L * nC + 3L;
+        long p2 = 2939745L * n2;
+        long z = p2 >>> 32;
+        long nY = ((p2 & 0xFFFFFFFFL) / 2939745L) >>> 2;
+        long y = 100L * c + z;
+        long n3 = 2141L * nY + 197913L;
+        long m = n3 >>> 16;
+        long d = (n3 & 0xFFFFL) / 2141L;
+        long j = nY >= 306L ? 1L : 0L;
+        long year = (y - L) + j;
+        long month = j != 0L ? m - 12L : m;
+        long day = d + 1L;
+        return (year << 32) | (month << 8) | day;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/TestFastDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestFastDate.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFastDate
+{
+    @Test
+    public void testPrintDateRoundTrip()
+    {
+        // Fast path (years 0-9999)
+        assertThat(DateTimeUtils.printDate(0)).isEqualTo("1970-01-01");
+        assertThat(DateTimeUtils.printDate((int) LocalDate.of(2024, 2, 29).toEpochDay())).isEqualTo("2024-02-29");
+        assertThat(DateTimeUtils.printDate((int) LocalDate.of(1, 1, 1).toEpochDay())).isEqualTo("0001-01-01");
+        assertThat(DateTimeUtils.printDate((int) LocalDate.of(9999, 12, 31).toEpochDay())).isEqualTo("9999-12-31");
+        // Joda-fallback path (negative or 5+ digit years) — ISODateTimeFormat formats with sign and width.
+        // Just assert it doesn't blow up and matches Joda's previous behavior, which is what the
+        // existing surrounding code expected.
+        DateTimeUtils.printDate((int) LocalDate.of(-1, 6, 15).toEpochDay());
+        DateTimeUtils.printDate((int) LocalDate.of(12345, 1, 1).toEpochDay());
+    }
+
+    @Test
+    public void testEpoch()
+    {
+        long ymd = FastDate.ymdFromEpochDay(0);
+        assertThat((int) (ymd >> 32)).isEqualTo(1970);
+        assertThat((int) ((ymd >> 8) & 0xFF)).isEqualTo(1);
+        assertThat((int) (ymd & 0xFF)).isEqualTo(1);
+    }
+
+    @Test
+    public void testBoundaryDates()
+    {
+        int[] interestingYears = {-400, -100, -4, -1, 0, 1, 4, 100, 400, 1900, 1969, 1970, 1971, 2000, 2024, 2100, 2400, 9999};
+        for (int year : interestingYears) {
+            assertDate(LocalDate.of(year, 1, 1));
+            assertDate(LocalDate.of(year, 2, 28));
+            if (LocalDate.of(year, 1, 1).isLeapYear()) {
+                assertDate(LocalDate.of(year, 2, 29));
+            }
+            assertDate(LocalDate.of(year, 3, 1));
+            assertDate(LocalDate.of(year, 12, 31));
+        }
+    }
+
+    @Test
+    public void testBoundedSweep()
+    {
+        // ±5_000_000 days ≈ years -11700 .. +15600. Catches every leap-rule edge in Trino's
+        // realistic range and runs in a few seconds.
+        for (int days = -5_000_000; days <= 5_000_000; days++) {
+            check(days);
+        }
+    }
+
+    @Test
+    public void testIntBoundaries()
+    {
+        // The fast algorithm's safe range is [-2_147_476_476, INT_MAX]. Below the lower bound
+        // we fall back to LocalDate, so every int input must round-trip correctly.
+        int[] candidates = {
+                Integer.MIN_VALUE,
+                Integer.MIN_VALUE + 1,
+                -2_147_476_477,   // one below safe boundary — falls back
+                -2_147_476_476,   // safe boundary — fast path
+                -2_000_000_000,
+                -1_000_000_000,
+                -1,
+                0,
+                1,
+                1_000_000_000,
+                2_000_000_000,
+                Integer.MAX_VALUE - 1,
+                Integer.MAX_VALUE,
+        };
+        for (int days : candidates) {
+            check(days);
+        }
+    }
+
+    @Test
+    @Disabled("Manual: parallel sweep over the entire int range; ~1 minute on a workstation.")
+    public void testFullIntSweep()
+    {
+        // Stay within LocalDate.ofEpochDay's supported range to avoid spurious failures.
+        // LocalDate.MIN.toEpochDay() = -365_243_219_162; LocalDate.MAX.toEpochDay() = 365_241_780_471.
+        // int range is well inside that.
+        IntStream.rangeClosed(Integer.MIN_VALUE, Integer.MAX_VALUE)
+                .parallel()
+                .forEach(TestFastDate::check);
+    }
+
+    @Test
+    public void testDaysFromYmdSweep()
+    {
+        // ±5_000_000 days ≈ years -11700..+15600. For each, take (y,m,d) from LocalDate
+        // and assert the round-trip via daysFromYmd matches.
+        for (int days = -5_000_000; days <= 5_000_000; days++) {
+            LocalDate date = LocalDate.ofEpochDay(days);
+            int got = FastDate.daysFromYmd(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+            if (got != days) {
+                throw new AssertionError(String.format(
+                        "daysFromYmd mismatch at %s: expected %d, got %d",
+                        date,
+                        days,
+                        got));
+            }
+        }
+    }
+
+    @Test
+    public void testDaysFromYmdBoundaries()
+    {
+        int[] interestingYears = {-400, -100, -4, -1, 0, 1, 4, 100, 400, 1900, 1969, 1970, 1971, 2000, 2024, 2100, 2400, 9999};
+        for (int year : interestingYears) {
+            assertRoundTrip(LocalDate.of(year, 1, 1));
+            assertRoundTrip(LocalDate.of(year, 2, 28));
+            if (LocalDate.of(year, 1, 1).isLeapYear()) {
+                assertRoundTrip(LocalDate.of(year, 2, 29));
+            }
+            assertRoundTrip(LocalDate.of(year, 3, 1));
+            assertRoundTrip(LocalDate.of(year, 12, 31));
+        }
+    }
+
+    @Test
+    public void testDaysInMonth()
+    {
+        // Jan/Mar/May/Jul/Aug/Oct/Dec = 31; Apr/Jun/Sep/Nov = 30; Feb varies.
+        assertThat(FastDate.daysInMonth(2024, 1)).isEqualTo(31);
+        assertThat(FastDate.daysInMonth(2024, 4)).isEqualTo(30);
+        assertThat(FastDate.daysInMonth(2024, 2)).isEqualTo(29); // leap
+        assertThat(FastDate.daysInMonth(2023, 2)).isEqualTo(28);
+        assertThat(FastDate.daysInMonth(2000, 2)).isEqualTo(29); // /400 leap
+        assertThat(FastDate.daysInMonth(1900, 2)).isEqualTo(28); // /100 non-leap
+        assertThat(FastDate.daysInMonth(2400, 2)).isEqualTo(29);
+    }
+
+    private static void assertRoundTrip(LocalDate date)
+    {
+        int got = FastDate.daysFromYmd(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        long expected = date.toEpochDay();
+        if (got != expected) {
+            throw new AssertionError(String.format(
+                    "daysFromYmd mismatch at %s: expected %d, got %d",
+                    date,
+                    expected,
+                    got));
+        }
+    }
+
+    private static void assertDate(LocalDate date)
+    {
+        check((int) date.toEpochDay());
+    }
+
+    private static void check(int days)
+    {
+        LocalDate expected = LocalDate.ofEpochDay(days);
+        long ymd = FastDate.ymdFromEpochDay(days);
+        int year = (int) (ymd >> 32);
+        int month = (int) ((ymd >> 8) & 0xFF);
+        int day = (int) (ymd & 0xFF);
+        if (year != expected.getYear() || month != expected.getMonthValue() || day != expected.getDayOfMonth()) {
+            throw new AssertionError(String.format(
+                    "Mismatch at days=%d: expected %04d-%02d-%02d, got %d-%d-%d",
+                    days,
+                    expected.getYear(),
+                    expected.getMonthValue(),
+                    expected.getDayOfMonth(),
+                    year,
+                    month,
+                    day));
+        }
+        int doy = FastDate.dayOfYearOf(days);
+        if (doy != expected.getDayOfYear()) {
+            throw new AssertionError(String.format(
+                    "Day-of-year mismatch at days=%d (%s): expected %d, got %d",
+                    days,
+                    expected,
+                    expected.getDayOfYear(),
+                    doy));
+        }
+        int dim = FastDate.daysInMonthOf(days);
+        int expectedDim = expected.lengthOfMonth();
+        if (dim != expectedDim) {
+            throw new AssertionError(String.format(
+                    "Days-in-month mismatch at days=%d (%s): expected %d, got %d",
+                    days,
+                    expected,
+                    expectedDim,
+                    dim));
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/TestFastDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestFastDate.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import io.trino.util.DateTimeUtils.FastDate;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFastDate
+{
+    @Test
+    public void testPrintDateRoundTrip()
+    {
+        // Fast path (years 0-9999)
+        assertThat(DateTimeUtils.printDate(0)).isEqualTo("1970-01-01");
+        assertThat(DateTimeUtils.printDate((int) LocalDate.of(2024, 2, 29).toEpochDay())).isEqualTo("2024-02-29");
+        assertThat(DateTimeUtils.printDate((int) LocalDate.of(1, 1, 1).toEpochDay())).isEqualTo("0001-01-01");
+        assertThat(DateTimeUtils.printDate((int) LocalDate.of(9999, 12, 31).toEpochDay())).isEqualTo("9999-12-31");
+        // Joda-fallback path (negative or 5+ digit years) — ISODateTimeFormat formats with sign and width.
+        // Just assert it doesn't blow up and matches Joda's previous behavior, which is what the
+        // existing surrounding code expected.
+        DateTimeUtils.printDate((int) LocalDate.of(-1, 6, 15).toEpochDay());
+        DateTimeUtils.printDate((int) LocalDate.of(12345, 1, 1).toEpochDay());
+    }
+
+    @Test
+    public void testEpoch()
+    {
+        long ymd = FastDate.ymdFromEpochDay(0);
+        assertThat((int) (ymd >> 32)).isEqualTo(1970);
+        assertThat((int) ((ymd >> 8) & 0xFF)).isEqualTo(1);
+        assertThat((int) (ymd & 0xFF)).isEqualTo(1);
+    }
+
+    @Test
+    public void testBoundaryDates()
+    {
+        int[] interestingYears = {-400, -100, -4, -1, 0, 1, 4, 100, 400, 1900, 1969, 1970, 1971, 2000, 2024, 2100, 2400, 9999};
+        for (int year : interestingYears) {
+            assertDate(LocalDate.of(year, 1, 1));
+            assertDate(LocalDate.of(year, 2, 28));
+            if (LocalDate.of(year, 1, 1).isLeapYear()) {
+                assertDate(LocalDate.of(year, 2, 29));
+            }
+            assertDate(LocalDate.of(year, 3, 1));
+            assertDate(LocalDate.of(year, 12, 31));
+        }
+    }
+
+    @Test
+    public void testBoundedSweep()
+    {
+        // ±5_000_000 days ≈ years -11700 .. +15600. Catches every leap-rule edge in Trino's
+        // realistic range and runs in a few seconds.
+        for (int days = -5_000_000; days <= 5_000_000; days++) {
+            check(days);
+        }
+    }
+
+    @Test
+    public void testIntBoundaries()
+    {
+        // The fast algorithm's safe range is [-2_147_476_476, INT_MAX]. Below the lower bound
+        // we fall back to LocalDate, so every int input must round-trip correctly.
+        int[] candidates = {
+                Integer.MIN_VALUE,
+                Integer.MIN_VALUE + 1,
+                -2_147_476_477,   // one below safe boundary — falls back
+                -2_147_476_476,   // safe boundary — fast path
+                -2_000_000_000,
+                -1_000_000_000,
+                -1,
+                0,
+                1,
+                1_000_000_000,
+                2_000_000_000,
+                Integer.MAX_VALUE - 1,
+                Integer.MAX_VALUE,
+        };
+        for (int days : candidates) {
+            check(days);
+        }
+    }
+
+    @Test
+    @Disabled("Manual: parallel sweep over the entire int range; ~1 minute on a workstation.")
+    public void testFullIntSweep()
+    {
+        // Stay within LocalDate.ofEpochDay's supported range to avoid spurious failures.
+        // LocalDate.MIN.toEpochDay() = -365_243_219_162; LocalDate.MAX.toEpochDay() = 365_241_780_471.
+        // int range is well inside that.
+        IntStream.rangeClosed(Integer.MIN_VALUE, Integer.MAX_VALUE)
+                .parallel()
+                .forEach(TestFastDate::check);
+    }
+
+    @Test
+    public void testDaysFromYmdSweep()
+    {
+        // ±5_000_000 days ≈ years -11700..+15600. For each, take (y,m,d) from LocalDate
+        // and assert the round-trip via daysFromYmd matches.
+        for (int days = -5_000_000; days <= 5_000_000; days++) {
+            LocalDate date = LocalDate.ofEpochDay(days);
+            int got = FastDate.daysFromYmd(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+            if (got != days) {
+                throw new AssertionError(String.format(
+                        "daysFromYmd mismatch at %s: expected %d, got %d",
+                        date, days, got));
+            }
+        }
+    }
+
+    @Test
+    public void testDaysFromYmdBoundaries()
+    {
+        int[] interestingYears = {-400, -100, -4, -1, 0, 1, 4, 100, 400, 1900, 1969, 1970, 1971, 2000, 2024, 2100, 2400, 9999};
+        for (int year : interestingYears) {
+            assertRoundTrip(LocalDate.of(year, 1, 1));
+            assertRoundTrip(LocalDate.of(year, 2, 28));
+            if (LocalDate.of(year, 1, 1).isLeapYear()) {
+                assertRoundTrip(LocalDate.of(year, 2, 29));
+            }
+            assertRoundTrip(LocalDate.of(year, 3, 1));
+            assertRoundTrip(LocalDate.of(year, 12, 31));
+        }
+    }
+
+    @Test
+    public void testDaysInMonth()
+    {
+        // Jan/Mar/May/Jul/Aug/Oct/Dec = 31; Apr/Jun/Sep/Nov = 30; Feb varies.
+        assertThat(FastDate.daysInMonth(2024, 1)).isEqualTo(31);
+        assertThat(FastDate.daysInMonth(2024, 4)).isEqualTo(30);
+        assertThat(FastDate.daysInMonth(2024, 2)).isEqualTo(29); // leap
+        assertThat(FastDate.daysInMonth(2023, 2)).isEqualTo(28);
+        assertThat(FastDate.daysInMonth(2000, 2)).isEqualTo(29); // /400 leap
+        assertThat(FastDate.daysInMonth(1900, 2)).isEqualTo(28); // /100 non-leap
+        assertThat(FastDate.daysInMonth(2400, 2)).isEqualTo(29);
+    }
+
+    private static void assertRoundTrip(LocalDate date)
+    {
+        int got = FastDate.daysFromYmd(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        long expected = date.toEpochDay();
+        if (got != expected) {
+            throw new AssertionError(String.format(
+                    "daysFromYmd mismatch at %s: expected %d, got %d",
+                    date, expected, got));
+        }
+    }
+
+    private static void assertDate(LocalDate date)
+    {
+        check((int) date.toEpochDay());
+    }
+
+    private static void check(int days)
+    {
+        LocalDate expected = LocalDate.ofEpochDay(days);
+        long ymd = FastDate.ymdFromEpochDay(days);
+        int year = (int) (ymd >> 32);
+        int month = (int) ((ymd >> 8) & 0xFF);
+        int day = (int) (ymd & 0xFF);
+        if (year != expected.getYear() || month != expected.getMonthValue() || day != expected.getDayOfMonth()) {
+            throw new AssertionError(String.format(
+                    "Mismatch at days=%d: expected %04d-%02d-%02d, got %d-%d-%d",
+                    days,
+                    expected.getYear(), expected.getMonthValue(), expected.getDayOfMonth(),
+                    year, month, day));
+        }
+        int doy = FastDate.dayOfYearOf(days);
+        if (doy != expected.getDayOfYear()) {
+            throw new AssertionError(String.format(
+                    "Day-of-year mismatch at days=%d (%s): expected %d, got %d",
+                    days, expected, expected.getDayOfYear(), doy));
+        }
+        int dim = FastDate.daysInMonthOf(days);
+        int expectedDim = expected.lengthOfMonth();
+        if (dim != expectedDim) {
+            throw new AssertionError(String.format(
+                    "Days-in-month mismatch at days=%d (%s): expected %d, got %d",
+                    days, expected, expectedDim, dim));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Replaces the Joda-Time-backed implementations of `year`, `month`, `day`, `day_of_year`, `quarter`, `last_day_of_month`, `CAST(date AS varchar)`, and `CAST(varchar AS date)` with a Java port of [Ben Joffe's fast-date-64 algorithm](https://www.benjoffe.com/fast-date-64). SQL semantics are preserved exactly across the full `int` DATE range.

`day_of_week`, `week`, and `year_of_week` stay on Joda - ISO 8601 week semantics are not in the perf-only subset.

## Algorithm choice

Three alternatives to Joda were considered:

- **Joffe** (https://www.benjoffe.com/fast-date-64)
- **JDK `java.time.LocalDate.ofEpochDay`** - the obvious stdlib option. Comparable to fast-date-64 for single-field extraction (HotSpot's escape analysis stack-allocates the `LocalDate` and DCEs unused fields), but **1.78× slower on combined expressions like `year(d)*100 + month(d)`** because each scalar call allocates a fresh `LocalDate`, so the underlying date arithmetic can't be shared across calls. Multi-column and combined projections dominate real analytics queries, so this gap matters.
- **Neri-Schneider (NS)** (https://arxiv.org/abs/2102.06959) - same algorithmic family as Joffe. In Java microbenchmarks on HotSpot, Joffe edges out NS by ~10–15% because its core uses 64-bit-constant `Math.unsignedMultiplyHigh` calls (intrinsified to single `mulq` / `umulh` instructions), while NS uses 32-bit-constant arithmetic with a longer dependency chain. Both deliver Joda-equivalent SQL semantics; the choice between them is small and reasonable to revisit if benchmark results change.

## Benchmarks

### Microbenchmark - `BenchmarkDateExtraction` (ns per date, real / wide)

JDK 25, Temurin. `realistic` = uniform 1970–2100; `wide` = uniform across full int days range.

| Field | Baseline - Joda (realistic / wide) | JDK | NS | This PR - Joffe | Speedup (this PR vs baseline) |
|---|---|---|---|---|---|
| `year(d)` | **4.07** / 10.38 | 4.47 / 5.41 | 5.65 / 5.65 | 5.10 / **5.10** | 0.80× / 2.04× |
| `month(d)` | 6.75 / 13.47 | 6.44 / 7.25 | 5.71 / 5.74 | **5.19 / 5.19** | 1.30× / 2.60× |
| `day(d)` | 10.06 / 16.13 | 7.73 / 8.62 | 5.47 / 5.49 | **4.92 / 4.94** | 2.04× / 3.27× |
| `day_of_year(d)` | **6.10** / 13.24 | 10.94 / 12.51 | 8.35 / 8.33 | 6.84 / **6.89** | 0.89× / 1.92× |
| `quarter(d)` | 11.14 / 17.20 | 7.67 / 8.46 | 7.32 / 7.32 | **6.37 / 6.39** | 1.75× / 2.69× |
| `last_day_of_month(d)` | 31.86 / 36.30 | 21.82 / 23.01 | 8.23 / 8.20 | **7.11 / 7.11** | 4.48× / 5.10× |
| **YMD combined** | 17.61 / 22.89 | 9.41 / 10.30 | 7.01 / 7.01 | **5.87 / 5.85** | 3.00× / 3.91× |

### SQL-level projection - `BenchmarkDateProjection` (ns per row)

`PageProcessor`-driven JMH benchmark with side-by-side scalar functions registered as `legacy_year`/`jdk_year`/`year`. 1024-row pages, no filter.

JDK 25, Temurin. Input: 1024 consecutive days from `SequencePageBuilder.createSequencePage` starting at the epoch (1970-01-01 through 1972-10-21).

| Projection | Baseline - Joda | JDK | This PR - Joffe | Speedup (this PR vs baseline) |
|---|---|---|---|---|
| `d` (identity) | 0.19 | 0.19 | 0.19 | 1x |
| `year(d)` | 11.04 | **8.18** | 9.18 | 1.20× |
| `year(d), month(d), day(d)` | 42.23 | 31.67 | **27.60** | 1.53× |
| `year(d)*10000 + month(d)*100 + day(d)` | 32.25 | 18.85 | **10.56** | 3.05× |

### CAST date ↔ varchar - `BenchmarkParseDate` (ns per record, function call)

JDK 25, Temurin. Input: 100 consecutive dates starting at 2023-01-01.

| Direction | Baseline - Joda | This PR - Joffe | Speedup |
|---|---|---|---|
| `CAST(date AS varchar)` | 163.7 (Joda `DateTimeFormatter.print`) | **47.9** (`FastDate` + hand-built `char[10]`) | 3.4× |
| `CAST(varchar AS date)` | 16.07 (`LocalDate.of(...).toEpochDay()`) | **12.90** (`FastDate.daysFromYmd`) | 1.25× |

## Tests

New `TestFastDate` covers both directions of the algorithm and the two CAST paths:

- **10M-day round-trip sweep** across `[-5_000_000, +5_000_000]` (years -11700 to +15600) against `LocalDate.ofEpochDay` for civil-from-days, and against `LocalDate.of(...).toEpochDay()` for `daysFromYmd`.
- **Leap-rule boundary cases** at years -400/-100/-4/-1/0/1/4/100/400/1900/2000/2100/2400 for both directions.
- **Int-range boundary tests** including the algorithm's safe-range edge (`FAST_MIN_DAYS`) - verifies the fallback to `LocalDate.ofEpochDay` engages and produces correct results for the ~7,172 days at the very bottom of the int range that fall outside the algorithm's safe window.
- **`printDate` round-trip** across both the hand-built buffer fast path (years 0–9999) and the Joda fallback (negative / 5-digit years).
- **`daysInMonth` spot checks** for leap / century-non-leap / 400-leap years.
- **`@Disabled` parallel full-int-range sweep** (~1 minute on a workstation) for manual verification before merging.

Existing suites pass unchanged.

## Additional context and related issues

- Resolves #29288 (the scoped perf issue)
- Step toward #14850 (full Joda → JSR-310 migration). Out of scope here: INTERVAL parsing, ISO weekyear, formatter-based parsing, timezone handling - these have subtle Joda-vs-JSR-310 semantic differences that need their own design conversation.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of DATE component extraction (`year`, `month`, `day`, `day_of_year`, `quarter`, `last_day_of_month`) and `CAST` to/from DATE. Date-heavy projections see 1.2× to 3× speedups, with `CAST(date AS varchar)` 3.4× faster, `last_day_of_month` 4.5× faster, and combined expressions like `year(d) * 100 + month(d)` up to 3× faster. ({issue}`29288`)
```
