### PR TITLE
Test IR expression visitors completeness

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionBytecodeCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionBytecodeCompiler.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.gen;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.BytecodeBlock;
@@ -134,9 +135,16 @@ public class ExpressionBytecodeCompiler
         return new Reference(type, TEMP_PREFIX + variable.getName());
     }
 
-    private class Visitor
+    @VisibleForTesting
+    class Visitor
             extends IrVisitor<BytecodeNode, Context>
     {
+        @Override
+        public BytecodeNode process(Expression node)
+        {
+            throw new UnsupportedOperationException("Process without context should not be called");
+        }
+
         @Override
         protected BytecodeNode visitExpression(Expression node, Context context)
         {
@@ -360,5 +368,6 @@ public class ExpressionBytecodeCompiler
         }
     }
 
-    private record Context(Scope scope, Optional<Class<?>> lambdaInterface) {}
+    @VisibleForTesting
+    record Context(Scope scope, Optional<Class<?>> lambdaInterface) {}
 }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/DefaultTraversalVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/DefaultTraversalVisitor.java
@@ -17,6 +17,12 @@ public abstract class DefaultTraversalVisitor<C>
         extends IrVisitor<Void, C>
 {
     @Override
+    protected Void visitExpression(Expression node, C context)
+    {
+        throw new UnsupportedOperationException("Should not be called");
+    }
+
+    @Override
     protected Void visitArray(Array node, C context)
     {
         for (Expression element : node.elements()) {
@@ -30,6 +36,13 @@ public abstract class DefaultTraversalVisitor<C>
     protected Void visitCast(Cast node, C context)
     {
         process(node.expression(), context);
+        return null;
+    }
+
+    @Override
+    protected Void visitReference(Reference node, C context)
+    {
+        // No sub-expressions
         return null;
     }
 
@@ -67,6 +80,13 @@ public abstract class DefaultTraversalVisitor<C>
         process(node.left(), context);
         process(node.right(), context);
 
+        return null;
+    }
+
+    @Override
+    protected Void visitConstant(Constant node, C context)
+    {
+        // No sub-expressions
         return null;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.ir;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
@@ -67,7 +68,8 @@ public final class ExpressionTreeRewriter<C>
         return (T) visitor.process(node, new Context<>(context, true));
     }
 
-    private class RewritingVisitor
+    @VisibleForTesting
+    class RewritingVisitor
             extends IrVisitor<Expression, Context<C>>
     {
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrVisitor.java
@@ -27,9 +27,14 @@ public abstract class IrVisitor<R, C>
         return node.accept(this, context);
     }
 
-    protected R visitExpression(Expression node, C context)
+    protected R visitConstant(Constant node, C context)
     {
-        return null;
+        return visitExpression(node, context);
+    }
+
+    protected R visitReference(Reference node, C context)
+    {
+        return visitExpression(node, context);
     }
 
     protected R visitArray(Array node, C context)
@@ -37,27 +42,17 @@ public abstract class IrVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitBetween(Between node, C context)
+    protected R visitRow(Row node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitCoalesce(Coalesce node, C context)
+    protected R visitFieldReference(FieldReference node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitComparison(Comparison node, C context)
-    {
-        return visitExpression(node, context);
-    }
-
-    protected R visitConstant(Constant node, C context)
-    {
-        return visitExpression(node, context);
-    }
-
-    protected R visitIn(In node, C context)
+    protected R visitCast(Cast node, C context)
     {
         return visitExpression(node, context);
     }
@@ -72,17 +67,22 @@ public abstract class IrVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitSwitch(Switch node, C context)
+    protected R visitBind(Bind node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitNullIf(NullIf node, C context)
+    protected R visitComparison(Comparison node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitCase(Case node, C context)
+    protected R visitBetween(Between node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
+    protected R visitIn(In node, C context)
     {
         return visitExpression(node, context);
     }
@@ -92,33 +92,33 @@ public abstract class IrVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitFieldReference(FieldReference node, C context)
-    {
-        return visitExpression(node, context);
-    }
-
     protected R visitLogical(Logical node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitRow(Row node, C context)
+    protected R visitCase(Case node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitCast(Cast node, C context)
+    protected R visitSwitch(Switch node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitReference(Reference node, C context)
+    protected R visitCoalesce(Coalesce node, C context)
     {
         return visitExpression(node, context);
     }
 
-    protected R visitBind(Bind node, C context)
+    protected R visitNullIf(NullIf node, C context)
     {
         return visitExpression(node, context);
+    }
+
+    protected R visitExpression(Expression node, C context)
+    {
+        return null;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionBytecodeCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionBytecodeCompiler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrVisitor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+class TestExpressionBytecodeCompiler
+{
+    @Test
+    void testEveryExpressionConsidered()
+            throws Exception
+    {
+        assertAllMethodsOverridden(IrVisitor.class, ExpressionBytecodeCompiler.Visitor.class, Set.of(
+                // process(expression, context) has a good default
+                IrVisitor.class.getMethod("process", Expression.class, Object.class /*context*/)));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/TestDefaultTraversalVisitor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/TestDefaultTraversalVisitor.java
@@ -17,39 +17,17 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
-import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestExpressionFormatter
+class TestDefaultTraversalVisitor
 {
     @Test
-    public void testReference()
-    {
-        assertFormattedExpression(
-                new Reference(BIGINT, "abc"),
-                "abc");
-        assertFormattedExpression(
-                new Reference(BIGINT, "with a space"),
-                "\"with a space\"");
-        assertFormattedExpression(
-                new Reference(BIGINT, "with \" quote, $ dollar and ' apostrophe"),
-                "\"with \"\" quote, $ dollar and ' apostrophe\"");
-    }
-
-    @Test
-    public void testEveryExpressionConsidered()
+    void testEverythingImplemented()
             throws Exception
     {
-        assertAllMethodsOverridden(IrVisitor.class, ExpressionFormatter.Formatter.class, Set.of(
+        assertAllMethodsOverridden(IrVisitor.class, DefaultTraversalVisitor.class, Set.of(
                 // process(..) have reasonable defaults
                 IrVisitor.class.getMethod("process", Expression.class),
                 IrVisitor.class.getMethod("process", Expression.class, Object.class /*context*/)));
-    }
-
-    private void assertFormattedExpression(Expression expression, String expected)
-    {
-        assertThat(ExpressionFormatter.formatExpression(expression)).as("formatted expression")
-                .isEqualTo(expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/ir/TestExpressionTreeRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/TestExpressionTreeRewriter.java
@@ -17,39 +17,17 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
-import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestExpressionFormatter
+class TestExpressionTreeRewriter
 {
     @Test
-    public void testReference()
-    {
-        assertFormattedExpression(
-                new Reference(BIGINT, "abc"),
-                "abc");
-        assertFormattedExpression(
-                new Reference(BIGINT, "with a space"),
-                "\"with a space\"");
-        assertFormattedExpression(
-                new Reference(BIGINT, "with \" quote, $ dollar and ' apostrophe"),
-                "\"with \"\" quote, $ dollar and ' apostrophe\"");
-    }
-
-    @Test
-    public void testEveryExpressionConsidered()
+    void testEveryExpressionConsidered()
             throws Exception
     {
-        assertAllMethodsOverridden(IrVisitor.class, ExpressionFormatter.Formatter.class, Set.of(
+        assertAllMethodsOverridden(IrVisitor.class, ExpressionTreeRewriter.RewritingVisitor.class, Set.of(
                 // process(..) have reasonable defaults
                 IrVisitor.class.getMethod("process", Expression.class),
                 IrVisitor.class.getMethod("process", Expression.class, Object.class /*context*/)));
-    }
-
-    private void assertFormattedExpression(Expression expression, String expected)
-    {
-        assertThat(ExpressionFormatter.formatExpression(expression)).as("formatted expression")
-                .isEqualTo(expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
@@ -73,6 +73,12 @@ public final class ExpressionVerifier
     }
 
     @Override
+    protected Boolean visitExpression(Expression node, Expression context)
+    {
+        throw new UnsupportedOperationException("visit not implemented for " + node.getClass().getSimpleName());
+    }
+
+    @Override
     protected Boolean visitArray(Array actual, Expression expectedExpression)
     {
         if (!(expectedExpression instanceof Array expected)) {

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/InterfaceTestUtils.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/InterfaceTestUtils.java
@@ -18,7 +18,6 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Fail;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -28,39 +27,47 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.reflect.Reflection.newProxy;
 import static java.lang.String.format;
+import static java.lang.reflect.Modifier.isProtected;
+import static java.lang.reflect.Modifier.isPublic;
+import static java.lang.reflect.Modifier.isStatic;
 
 public final class InterfaceTestUtils
 {
     private InterfaceTestUtils() {}
 
-    public static <I, C extends I> void assertAllMethodsOverridden(Class<I> iface, Class<C> clazz)
+    public static <I, C extends I> void assertAllMethodsOverridden(Class<I> superType, Class<C> clazz)
     {
-        assertAllMethodsOverridden(iface, clazz, ImmutableSet.of());
+        assertAllMethodsOverridden(superType, clazz, ImmutableSet.of());
     }
 
-    public static <I, C extends I> void assertAllMethodsOverridden(Class<I> iface, Class<C> clazz, Set<Method> exclusions)
+    public static <I, C extends I> void assertAllMethodsOverridden(Class<I> superType, Class<C> clazz, Set<Method> exclusions)
     {
-        checkArgument(iface.isAssignableFrom(clazz), "%s is not supertype of %s", iface, clazz);
+        checkArgument(superType.isAssignableFrom(clazz), "%s is not supertype of %s", superType, clazz);
         exclusions = new HashSet<>(exclusions);
-        for (Method method : iface.getMethods()) {
-            if (Modifier.isStatic(method.getModifiers())) {
-                continue;
-            }
-            if (method.getDeclaringClass() == Object.class) {
-                continue;
-            }
-            try {
-                Method override = clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
-                if (!method.getReturnType().isAssignableFrom(override.getReturnType())) {
-                    Fail.fail(format("%s is not assignable from %s for method %s", method.getReturnType(), override.getReturnType(), method));
+        for (Class<?> parent = superType; parent != null; parent = parent.getSuperclass()) {
+            for (Method method : parent.getDeclaredMethods()) {
+                if (isStatic(method.getModifiers())) {
+                    continue;
                 }
-            }
-            catch (NoSuchMethodException e) {
-                if (exclusions.remove(method)) {
-                    // ignored
+                if (!(isPublic(method.getModifiers()) || isProtected(method.getModifiers()))) {
+                    continue;
                 }
-                else {
-                    Fail.fail(format("%s does not override [%s]", clazz.getName(), method));
+                if (method.getDeclaringClass() == Object.class) {
+                    continue;
+                }
+                try {
+                    Method override = clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
+                    if (!method.getReturnType().isAssignableFrom(override.getReturnType())) {
+                        Fail.fail(format("%s is not assignable from %s for method %s", method.getReturnType(), override.getReturnType(), method));
+                    }
+                }
+                catch (NoSuchMethodException e) {
+                    if (exclusions.remove(method)) {
+                        // ignored
+                    }
+                    else {
+                        Fail.fail(format("%s does not override [%s]", clazz.getName(), method));
+                    }
                 }
             }
         }

--- a/testing/trino-testing-services/src/test/java/io/trino/testing/TestInterfaceTestUtils.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testing/TestInterfaceTestUtils.java
@@ -77,6 +77,20 @@ class TestInterfaceTestUtils
         InterfaceTestUtils.assertAllMethodsOverridden(AbstractClass.class, ImplementationOfAbstractClass.class);
     }
 
+    @Test
+    public void testReportNotOverriddenAbstractClassMethods()
+    {
+        // public methods
+        assertThatThrownBy(() -> InterfaceTestUtils.assertAllMethodsOverridden(AbstractClass.class, ImplementationOfAbstractClassNotOverridingAPublicMethod.class))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("io.trino.testing.TestInterfaceTestUtils$ImplementationOfAbstractClassNotOverridingAPublicMethod does not override [public void io.trino.testing.TestInterfaceTestUtils$AbstractClass.foo(java.lang.String)]");
+
+        // protected methods such as in a visitor
+        assertThatThrownBy(() -> InterfaceTestUtils.assertAllMethodsOverridden(AbstractClassWithProtectedMethod.class, ImplementationOfAbstractClassNotOverridingAProtectedMethod.class))
+                .isInstanceOf(AssertionError.class)
+                .hasMessage("io.trino.testing.TestInterfaceTestUtils$ImplementationOfAbstractClassNotOverridingAProtectedMethod does not override [protected void io.trino.testing.TestInterfaceTestUtils$AbstractClassWithProtectedMethod.foo(java.lang.String)]");
+    }
+
     private abstract static class AbstractClass
     {
         public void foo(String unused) {}
@@ -88,6 +102,17 @@ class TestInterfaceTestUtils
         @Override
         public void foo(String unused) {}
     }
+
+    private static class ImplementationOfAbstractClassNotOverridingAPublicMethod
+            extends AbstractClass {}
+
+    private abstract static class AbstractClassWithProtectedMethod
+    {
+        protected void foo(String unused) {}
+    }
+
+    private static class ImplementationOfAbstractClassNotOverridingAProtectedMethod
+            extends AbstractClassWithProtectedMethod {}
 
     @Test
     public void testAssertProperForwardingMethodsAreCalledWithPrivateMethods()


### PR DESCRIPTION
We use visitors rather than a long switch for readability. The downside of this is that we don't verify completeness of coverage when 100% coverage is intended. Test existing visitor implementations for completeness.
