### PR TITLE
Add whitelisted extra credentials to OPA identity context

### DIFF
--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -92,7 +92,7 @@ public sealed class OpaAccessControl
     private final OpaHighLevelClient opaHighLevelClient;
     private final boolean allowPermissionManagementOperations;
     private final OpaPluginContext pluginContext;
-    final Set<String> extraCredentialsKeys;
+    private final Set<String> extraCredentialsKeys;
 
     @Inject
     public OpaAccessControl(LifeCycleManager lifeCycleManager, OpaHighLevelClient opaHighLevelClient, OpaConfig config, OpaPluginContext pluginContext)

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaAccessControl.java
@@ -92,6 +92,7 @@ public sealed class OpaAccessControl
     private final OpaHighLevelClient opaHighLevelClient;
     private final boolean allowPermissionManagementOperations;
     private final OpaPluginContext pluginContext;
+    final Set<String> extraCredentialsKeys;
 
     @Inject
     public OpaAccessControl(LifeCycleManager lifeCycleManager, OpaHighLevelClient opaHighLevelClient, OpaConfig config, OpaPluginContext pluginContext)
@@ -100,6 +101,7 @@ public sealed class OpaAccessControl
         this.opaHighLevelClient = requireNonNull(opaHighLevelClient, "opaHighLevelClient is null");
         this.allowPermissionManagementOperations = config.getAllowPermissionManagementOperations();
         this.pluginContext = requireNonNull(pluginContext, "pluginContext is null");
+        this.extraCredentialsKeys = ImmutableSet.copyOf(config.getExtraCredentialsKeys());
     }
 
     @Override
@@ -124,7 +126,7 @@ public sealed class OpaAccessControl
     @Override
     public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
-        opaHighLevelClient.queryAndEnforce(buildQueryContext(identity), "ViewQueryOwnedBy", AccessDeniedException::denyViewQuery, OpaQueryInputResource.builder().user(new TrinoUser(queryOwner)).build());
+        opaHighLevelClient.queryAndEnforce(buildQueryContext(identity), "ViewQueryOwnedBy", AccessDeniedException::denyViewQuery, OpaQueryInputResource.builder().user(new TrinoUser(queryOwner, extraCredentialsKeys)).build());
     }
 
     @Override
@@ -135,13 +137,13 @@ public sealed class OpaAccessControl
                 queryOwner -> buildQueryInputForSimpleResource(
                         buildQueryContext(identity),
                         "FilterViewQueryOwnedBy",
-                        OpaQueryInputResource.builder().user(new TrinoUser(queryOwner)).build()));
+                        OpaQueryInputResource.builder().user(new TrinoUser(queryOwner, extraCredentialsKeys)).build()));
     }
 
     @Override
     public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
-        opaHighLevelClient.queryAndEnforce(buildQueryContext(identity), "KillQueryOwnedBy", AccessDeniedException::denyKillQuery, OpaQueryInputResource.builder().user(new TrinoUser(queryOwner)).build());
+        opaHighLevelClient.queryAndEnforce(buildQueryContext(identity), "KillQueryOwnedBy", AccessDeniedException::denyKillQuery, OpaQueryInputResource.builder().user(new TrinoUser(queryOwner, extraCredentialsKeys)).build());
     }
 
     @Override
@@ -802,11 +804,11 @@ public sealed class OpaAccessControl
 
     OpaQueryContext buildQueryContext(Identity trinoIdentity)
     {
-        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(trinoIdentity), pluginContext, opaHighLevelClient.getAdditionalContext(), Optional.empty());
+        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(trinoIdentity, extraCredentialsKeys), pluginContext, opaHighLevelClient.getAdditionalContext(), Optional.empty());
     }
 
     OpaQueryContext buildQueryContext(SystemSecurityContext securityContext)
     {
-        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(securityContext.getIdentity()), pluginContext, opaHighLevelClient.getAdditionalContext(), Optional.of(securityContext.getQueryId()));
+        return new OpaQueryContext(TrinoIdentity.fromTrinoIdentity(securityContext.getIdentity(), extraCredentialsKeys), pluginContext, opaHighLevelClient.getAdditionalContext(), Optional.of(securityContext.getQueryId()));
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaBatchAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaBatchAccessControl.java
@@ -50,6 +50,7 @@ public final class OpaBatchAccessControl
     private final JsonCodec<OpaBatchQueryResult> batchResultCodec;
     private final URI opaBatchedPolicyUri;
     private final OpaHttpClient opaHttpClient;
+    private final Set<String> extraCredentialsKeys;
 
     @Inject
     public OpaBatchAccessControl(
@@ -64,6 +65,7 @@ public final class OpaBatchAccessControl
         this.opaBatchedPolicyUri = config.getOpaBatchUri().orElseThrow();
         this.batchResultCodec = requireNonNull(batchResultCodec, "batchResultCodec is null");
         this.opaHttpClient = requireNonNull(opaHttpClient, "opaHttpClient is null");
+        this.extraCredentialsKeys = ImmutableSet.copyOf(config.getExtraCredentialsKeys());
     }
 
     @Override

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaBatchAccessControl.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaBatchAccessControl.java
@@ -74,7 +74,7 @@ public final class OpaBatchAccessControl
                 "FilterViewQueryOwnedBy",
                 queryOwners,
                 queryOwner -> OpaQueryInputResource.builder()
-                        .user(new TrinoUser(queryOwner))
+                        .user(new TrinoUser(queryOwner, extraCredentialsKeys))
                         .build());
     }
 

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.opa;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -168,10 +167,9 @@ public class OpaConfig
 
     @Config("opa.identity.extra-credentials-keys")
     @ConfigDescription("Comma-separated list of extra credential keys from client connections to forward to OPA in the identity context")
-    public OpaConfig setExtraCredentialsKeys(String extraCredentialsKeys)
+    public OpaConfig setExtraCredentialsKeys(Set<String> extraCredentialsKeys)
     {
-        this.extraCredentialsKeys = extraCredentialsKeys == null ? ImmutableSet.of() :
-                ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(extraCredentialsKeys));
+        this.extraCredentialsKeys = ImmutableSet.copyOf(extraCredentialsKeys);
         return this;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/OpaConfig.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.opa;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
@@ -21,6 +23,7 @@ import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 
 public class OpaConfig
 {
@@ -34,6 +37,7 @@ public class OpaConfig
     private Optional<URI> opaColumnMaskingUri = Optional.empty();
     private Optional<URI> opaBatchColumnMaskingUri = Optional.empty();
     private Optional<Path> additionalContextFile = Optional.empty();
+    private Set<String> extraCredentialsKeys = ImmutableSet.of();
 
     @NotNull
     public URI getOpaUri()
@@ -154,6 +158,20 @@ public class OpaConfig
     public OpaConfig setAdditionalContextFile(Path additionalContextFile)
     {
         this.additionalContextFile = Optional.ofNullable(additionalContextFile);
+        return this;
+    }
+
+    public Set<String> getExtraCredentialsKeys()
+    {
+        return extraCredentialsKeys;
+    }
+
+    @Config("opa.identity.extra-credentials-keys")
+    @ConfigDescription("Comma-separated list of extra credential keys from client connections to forward to OPA in the identity context")
+    public OpaConfig setExtraCredentialsKeys(String extraCredentialsKeys)
+    {
+        this.extraCredentialsKeys = extraCredentialsKeys == null ? ImmutableSet.of() :
+                ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(extraCredentialsKeys));
         return this;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
@@ -21,33 +21,31 @@ import io.trino.spi.security.Identity;
 import java.util.Map;
 import java.util.Set;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
-@JsonInclude(NON_NULL)
 public record TrinoIdentity(
         String user,
         Set<String> groups,
-        Map<String, String> extraCredentials)
+        @JsonInclude(NON_EMPTY) Map<String, String> extraCredentials)
 {
     public static TrinoIdentity fromTrinoIdentity(Identity identity, Set<String> allowedExtraCredentialsKeys)
     {
         Map<String, String> allCredentials = identity.getExtraCredentials();
-        Map<String, String> filteredCredentials = allowedExtraCredentialsKeys.isEmpty() ? null :
-                allowedExtraCredentialsKeys.stream()
+        Map<String, String> filteredCredentials = allowedExtraCredentialsKeys.stream()
                 .filter(allCredentials::containsKey)
                 .collect(toImmutableMap(key -> key, allCredentials::get));
         return new TrinoIdentity(
                 identity.getUser(),
                 identity.getGroups(),
-                filteredCredentials == null || filteredCredentials.isEmpty() ? null : filteredCredentials);
+                filteredCredentials);
     }
 
     public TrinoIdentity
     {
         requireNonNull(user, "user is null");
         groups = ImmutableSet.copyOf(requireNonNull(groups, "groups is null"));
-        extraCredentials = extraCredentials != null ? ImmutableMap.copyOf(extraCredentials) : null;
+        extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
@@ -33,13 +33,13 @@ public record TrinoIdentity(
     public static TrinoIdentity fromTrinoIdentity(Identity identity, Set<String> allowedExtraCredentialsKeys)
     {
         Map<String, String> allCredentials = identity.getExtraCredentials();
-        Map<String, String> filteredCredentials = allowedExtraCredentialsKeys.stream()
+        Map<String, String> allowedExtraCredentials = allowedExtraCredentialsKeys.stream()
                 .filter(allCredentials::containsKey)
                 .collect(toImmutableMap(key -> key, allCredentials::get));
         return new TrinoIdentity(
                 identity.getUser(),
                 identity.getGroups(),
-                filteredCredentials);
+                allowedExtraCredentials);
     }
 
     public TrinoIdentity

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
@@ -13,27 +13,41 @@
  */
 package io.trino.plugin.opa.schema;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.security.Identity;
 
+import java.util.Map;
 import java.util.Set;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
+@JsonInclude(NON_NULL)
 public record TrinoIdentity(
         String user,
-        Set<String> groups)
+        Set<String> groups,
+        Map<String, String> extraCredentials)
 {
-    public static TrinoIdentity fromTrinoIdentity(Identity identity)
+    public static TrinoIdentity fromTrinoIdentity(Identity identity, Set<String> allowedExtraCredentialsKeys)
     {
+        Map<String, String> allCredentials = identity.getExtraCredentials();
+        Map<String, String> filteredCredentials = allowedExtraCredentialsKeys.isEmpty() ? null :
+                allowedExtraCredentialsKeys.stream()
+                .filter(allCredentials::containsKey)
+                .collect(toImmutableMap(key -> key, allCredentials::get));
         return new TrinoIdentity(
                 identity.getUser(),
-                identity.getGroups());
+                identity.getGroups(),
+                filteredCredentials == null || filteredCredentials.isEmpty() ? null : filteredCredentials);
     }
 
     public TrinoIdentity
     {
         requireNonNull(user, "user is null");
         groups = ImmutableSet.copyOf(requireNonNull(groups, "groups is null"));
+        extraCredentials = extraCredentials != null ? ImmutableMap.copyOf(extraCredentials) : null;
     }
 }

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoUser.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoUser.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.trino.spi.security.Identity;
 
+import java.util.Set;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.util.Objects.requireNonNull;
 
@@ -38,8 +40,8 @@ public record TrinoUser(String user, @JsonUnwrapped TrinoIdentity identity)
         this(name, null);
     }
 
-    public TrinoUser(Identity identity)
+    public TrinoUser(Identity identity, Set<String> allowedExtraCredentialsKeys)
     {
-        this(null, TrinoIdentity.fromTrinoIdentity(identity));
+        this(null, TrinoIdentity.fromTrinoIdentity(identity, allowedExtraCredentialsKeys));
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestHelpers.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestHelpers.java
@@ -93,6 +93,9 @@ public final class TestHelpers
         config.getOpaColumnMaskingUri().ifPresent(columnMaskingUri -> configBuilder.put("opa.policy.column-masking-uri", columnMaskingUri.toString()));
         config.getOpaBatchColumnMaskingUri().ifPresent(batchColumnMaskingUri -> configBuilder.put("opa.policy.batch-column-masking-uri", batchColumnMaskingUri.toString()));
         config.getAdditionalContextFile().ifPresent(additionalContextFile -> configBuilder.put("opa.context-file", additionalContextFile.toString()));
+        if (!config.getExtraCredentialsKeys().isEmpty()) {
+            configBuilder.put("opa.identity.extra-credentials-keys", String.join(",", config.getExtraCredentialsKeys()));
+        }
         return configBuilder.buildOrThrow();
     }
 

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -1062,7 +1062,7 @@ final class TestOpaAccessControl
                 .withAdditionalExtraCredentials(ImmutableMap.of("ai-service", "my-ai-app", "ai-scope", "read-only", "otherKey", "other-value"))
                 .build();
 
-        OpaConfig configWithWhitelist = simpleOpaConfig().setExtraCredentialsKeys("ai-service,ai-scope");
+        OpaConfig configWithWhitelist = simpleOpaConfig().setExtraCredentialsKeys(ImmutableSet.of("ai-service", "ai-scope"));
         InstrumentedHttpClient mockClient = createMockHttpClient(OPA_SERVER_URI, _ -> OK_RESPONSE);
         OpaAccessControl authorizer = createOpaAuthorizer(configWithWhitelist, mockClient);
         authorizer.checkCanExecuteQuery(identityWithCredentials, TEST_QUERY_ID);

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -1054,6 +1054,41 @@ final class TestOpaAccessControl
         assertStringRequestsEqual(ImmutableSet.of(expectedActionRequest), mockClient.getRequests(), "/input/action");
     }
 
+    @Test
+    public void testExtraCredentialsPropagation()
+    {
+        Identity identityWithCredentials = Identity.forUser("source-user")
+                .withGroups(ImmutableSet.of("some-group"))
+                .withAdditionalExtraCredentials(ImmutableMap.of("ai-service", "my-ai-app", "ai-scope", "read-only", "otherKey", "other-value"))
+                .build();
+
+        OpaConfig configWithWhitelist = simpleOpaConfig().setExtraCredentialsKeys("ai-service,ai-scope");
+        InstrumentedHttpClient mockClient = createMockHttpClient(OPA_SERVER_URI, _ -> OK_RESPONSE);
+        OpaAccessControl authorizer = createOpaAuthorizer(configWithWhitelist, mockClient);
+        authorizer.checkCanExecuteQuery(identityWithCredentials, TEST_QUERY_ID);
+
+        JsonNode extraCredentials = mockClient.getRequests().get(0).path("input").path("context").path("identity").path("extraCredentials");
+        assertThat(extraCredentials.path("ai-service").asText()).isEqualTo("my-ai-app");
+        assertThat(extraCredentials.path("ai-scope").asText()).isEqualTo("read-only");
+        assertThat(extraCredentials.has("otherKey")).isFalse();
+    }
+
+    @Test
+    public void testExtraCredentialsNotForwardedByDefault()
+    {
+        Identity identityWithCredentials = Identity.forUser("source-user")
+                .withGroups(ImmutableSet.of("some-group"))
+                .withAdditionalExtraCredentials(ImmutableMap.of("ai-service", "my-ai-app"))
+                .build();
+
+        InstrumentedHttpClient mockClient = createMockHttpClient(OPA_SERVER_URI, _ -> OK_RESPONSE);
+        OpaAccessControl authorizer = createOpaAuthorizer(simpleOpaConfig(), mockClient);
+        authorizer.checkCanExecuteQuery(identityWithCredentials, TEST_QUERY_ID);
+
+        JsonNode identityNode = mockClient.getRequests().get(0).path("input").path("context").path("identity");
+        assertThat(identityNode.has("extraCredentials")).isFalse();
+    }
+
     private void testGetColumnMasks(Map<ColumnSchema, String> columnResponseContent, Map<ColumnSchema, OpaViewExpression> expectedResult)
     {
         InstrumentedHttpClient httpClient = createMockHttpClient(

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -1089,6 +1089,35 @@ final class TestOpaAccessControl
         assertThat(identityNode.has("extraCredentials")).isFalse();
     }
 
+    @Test
+    public void testQueryOwnerExtraCredentialsPropagation()
+    {
+        Identity executor = Identity.forUser("executor-user")
+                .withAdditionalExtraCredentials(ImmutableMap.of("ai-service", "executor-ai-app", "otherKey", "executor-other-value"))
+                .build();
+        Identity queryOwner = Identity.forUser("query-owner")
+                .withGroups(ImmutableSet.of("owner-group"))
+                .withAdditionalExtraCredentials(ImmutableMap.of("ai-service", "owner-ai-app", "otherKey", "owner-other-value"))
+                .build();
+
+        OpaConfig configWithWhitelist = simpleOpaConfig().setExtraCredentialsKeys(ImmutableSet.of("ai-service"));
+        InstrumentedHttpClient mockClient = createMockHttpClient(OPA_SERVER_URI, _ -> OK_RESPONSE);
+        OpaAccessControl authorizer = createOpaAuthorizer(configWithWhitelist, mockClient);
+        authorizer.checkCanKillQueryOwnedBy(executor, queryOwner);
+
+        JsonNode request = mockClient.getRequests().get(0);
+        // The executor's own extra credentials are propagated in the identity context
+        JsonNode executorNode = request.path("input").path("context").path("identity");
+        assertThat(executorNode.path("user").asText()).isEqualTo("executor-user");
+        assertThat(executorNode.path("extraCredentials").path("ai-service").asText()).isEqualTo("executor-ai-app");
+        assertThat(executorNode.path("extraCredentials").has("otherKey")).isFalse();
+        // The query owner's extra credentials are propagated separately in the resource
+        JsonNode ownerNode = request.path("input").path("action").path("resource").path("user");
+        assertThat(ownerNode.path("user").asText()).isEqualTo("query-owner");
+        assertThat(ownerNode.path("extraCredentials").path("ai-service").asText()).isEqualTo("owner-ai-app");
+        assertThat(ownerNode.path("extraCredentials").has("otherKey")).isFalse();
+    }
+
     private void testGetColumnMasks(Map<ColumnSchema, String> columnResponseContent, Map<ColumnSchema, OpaViewExpression> expectedResult)
     {
         InstrumentedHttpClient httpClient = createMockHttpClient(

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.opa;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -39,7 +40,7 @@ final class TestOpaConfig
                 .setLogResponses(false)
                 .setAllowPermissionManagementOperations(false)
                 .setAdditionalContextFile(null)
-                .setExtraCredentialsKeys(null));
+                .setExtraCredentialsKeys(ImmutableSet.of()));
     }
 
     @Test
@@ -68,7 +69,7 @@ final class TestOpaConfig
                 .setLogResponses(true)
                 .setAllowPermissionManagementOperations(true)
                 .setAdditionalContextFile(Path.of("src/test/resources/additional-context.properties"))
-                .setExtraCredentialsKeys("ai-service,ai-scope");
+                .setExtraCredentialsKeys(ImmutableSet.of("ai-service", "ai-scope"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaConfig.java
@@ -38,7 +38,8 @@ final class TestOpaConfig
                 .setLogRequests(false)
                 .setLogResponses(false)
                 .setAllowPermissionManagementOperations(false)
-                .setAdditionalContextFile(null));
+                .setAdditionalContextFile(null)
+                .setExtraCredentialsKeys(null));
     }
 
     @Test
@@ -54,6 +55,7 @@ final class TestOpaConfig
                 .put("opa.log-responses", "true")
                 .put("opa.allow-permission-management-operations", "true")
                 .put("opa.context-file", "src/test/resources/additional-context.properties")
+                .put("opa.identity.extra-credentials-keys", "ai-service,ai-scope")
                 .buildOrThrow();
 
         OpaConfig expected = new OpaConfig()
@@ -65,7 +67,8 @@ final class TestOpaConfig
                 .setLogRequests(true)
                 .setLogResponses(true)
                 .setAllowPermissionManagementOperations(true)
-                .setAdditionalContextFile(Path.of("src/test/resources/additional-context.properties"));
+                .setAdditionalContextFile(Path.of("src/test/resources/additional-context.properties"))
+                .setExtraCredentialsKeys("ai-service,ai-scope");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Introduces a new config property `opa.identity.extra-credentials-keys` (comma-separated list) that controls which keys from a client connection's extra credentials are forwarded to OPA as `input.context.identity.extraCredentials`.

This is opt-in: when the property is not set, `extraCredentials` is absent from the OPA request — no behaviour change for existing deployments.

Example: with `opa.identity.extra-credentials-keys=ai-service,ai-scope` and a JDBC connection string `?extraCredentials=ai-service:my-ai-app;ai-scope:read-only`, an OPA policy can enforce rules like:

```rego
allow if input.context.identity.extraCredentials["ai-service"] == "my-ai-app"
```

Only the whitelisted keys are forwarded; all other extra credentials are dropped. If none of the whitelisted keys are present in the connection's credentials, `extraCredentials` is omitted from the request.

## Additional context and related issues

Extra credentials are set on the client side via the `X-Trino-Extra-Credential` HTTP header or the `extraCredentials` JDBC connection property. They flow into `Identity.getExtraCredentials()`, which the OPA plugin now exposes selectively. The whitelist prevents accidental leakage of sensitive credential values to OPA.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## OPA
* Add `opa.identity.extra-credentials-keys` config property to forward selected extra credential keys from client connections to OPA as `input.context.identity.extraCredentials`.
```