### PR TITLE
Use IrVisitor in PageFieldsToInputParametersRewriter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageFieldsToInputParametersRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageFieldsToInputParametersRewriter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.project;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -21,6 +22,7 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
@@ -28,7 +30,6 @@ import io.trino.sql.ir.Switch;
 import io.trino.sql.ir.WhenClause;
 import io.trino.sql.planner.Symbol;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -53,15 +54,14 @@ public final class PageFieldsToInputParametersRewriter
     {
         // Collect all unique channel indices referenced by the expression,
         // and track which are unconditionally evaluated
-        Set<Integer> referencedChannels = new LinkedHashSet<>();
-        Set<Integer> eagerlyLoadedChannels = new HashSet<>();
-        collectReferencedChannels(expression, layout, true, referencedChannels, eagerlyLoadedChannels);
+        Visitor visitor = new Visitor(layout);
+        visitor.process(expression, true);
 
         // Create compact mapping: original channel index → parameter index (0, 1, 2, ...)
-        List<Integer> inputChannelsList = new ArrayList<>(referencedChannels);
+        List<Integer> inputChannels = visitor.getInputChannels();
         Map<Integer, Integer> channelToParameter = new HashMap<>();
-        for (int i = 0; i < inputChannelsList.size(); i++) {
-            channelToParameter.put(inputChannelsList.get(i), i);
+        for (int i = 0; i < inputChannels.size(); i++) {
+            channelToParameter.put(inputChannels.get(i), i);
         }
 
         // Create compact layout: symbol → compact parameter index
@@ -73,92 +73,143 @@ public final class PageFieldsToInputParametersRewriter
             }
         }
 
-        InputChannels inputChannels = new InputChannels(inputChannelsList, ImmutableSet.copyOf(eagerlyLoadedChannels));
-        return new Result(compactLayout.buildOrThrow(), inputChannels);
+        return new Result(compactLayout.buildOrThrow(), new InputChannels(inputChannels, visitor.getEagerlyLoadedChannels()));
     }
 
-    private static void collectReferencedChannels(
-            Expression expression,
-            Map<Symbol, Integer> layout,
-            boolean unconditionallyEvaluated,
-            Set<Integer> channels,
-            Set<Integer> eagerlyLoadedChannels)
+    private static final class Visitor
+            extends IrVisitor<Void, Boolean>
     {
-        if (expression instanceof Reference reference) {
-            Integer channel = layout.get(Symbol.from(reference));
+        private final Set<Integer> inputChannels = new LinkedHashSet<>();
+        private final Set<Integer> eagerlyLoadedChannels = new HashSet<>();
+        private Map<Symbol, Integer> layout;
+
+        private Visitor(Map<Symbol, Integer> layout)
+        {
+            this.layout = layout;
+        }
+
+        public List<Integer> getInputChannels()
+        {
+            return ImmutableList.copyOf(inputChannels);
+        }
+
+        public Set<Integer> getEagerlyLoadedChannels()
+        {
+            return ImmutableSet.copyOf(eagerlyLoadedChannels);
+        }
+
+        @Override
+        protected Void visitReference(Reference node, Boolean unconditionallyEvaluated)
+        {
+            Integer channel = layout.get(Symbol.from(node));
             if (channel != null) {
-                channels.add(channel);
+                inputChannels.add(channel);
                 if (unconditionallyEvaluated) {
                     eagerlyLoadedChannels.add(channel);
                 }
             }
-            return;
+            return null;
         }
 
-        switch (expression) {
-            // Short-circuit expressions: only the first operand is unconditionally evaluated
-            case Logical logical -> {
-                List<Expression> terms = logical.terms();
-                for (int i = 0; i < terms.size(); i++) {
-                    collectReferencedChannels(terms.get(i), layout, i == 0 && unconditionallyEvaluated, channels, eagerlyLoadedChannels);
+        @Override
+        protected Void visitLogical(Logical node, Boolean unconditionallyEvaluated)
+        {
+            // Short-circuit: only the first term is unconditionally evaluated
+            List<Expression> terms = node.terms();
+            for (int i = 0; i < terms.size(); i++) {
+                process(terms.get(i), i == 0 && unconditionallyEvaluated);
+            }
+            return null;
+        }
+
+        @Override
+        protected Void visitCoalesce(Coalesce node, Boolean unconditionallyEvaluated)
+        {
+            List<Expression> operands = node.operands();
+            for (int i = 0; i < operands.size(); i++) {
+                process(operands.get(i), i == 0 && unconditionallyEvaluated);
+            }
+            return null;
+        }
+
+        @Override
+        protected Void visitCase(Case node, Boolean unconditionallyEvaluated)
+        {
+            // First condition is unconditional; everything else is conditional
+            List<WhenClause> whenClauses = node.whenClauses();
+            if (!whenClauses.isEmpty()) {
+                process(whenClauses.getFirst().getOperand(), unconditionallyEvaluated);
+                process(whenClauses.getFirst().getResult(), false);
+                for (int i = 1; i < whenClauses.size(); i++) {
+                    process(whenClauses.get(i).getOperand(), false);
+                    process(whenClauses.get(i).getResult(), false);
                 }
             }
-            case Coalesce coalesce -> {
-                List<Expression> operands = coalesce.operands();
-                for (int i = 0; i < operands.size(); i++) {
-                    collectReferencedChannels(operands.get(i), layout, i == 0 && unconditionallyEvaluated, channels, eagerlyLoadedChannels);
+            process(node.defaultValue(), false);
+            return null;
+        }
+
+        @Override
+        protected Void visitSwitch(Switch node, Boolean unconditionallyEvaluated)
+        {
+            // Operand and first when-clause operand are unconditional; remaining clauses and default are conditional
+            process(node.operand(), unconditionallyEvaluated);
+            List<WhenClause> whenClauses = node.whenClauses();
+            if (!whenClauses.isEmpty()) {
+                process(whenClauses.getFirst().getOperand(), unconditionallyEvaluated);
+                process(whenClauses.getFirst().getResult(), false);
+                for (int i = 1; i < whenClauses.size(); i++) {
+                    process(whenClauses.get(i).getOperand(), false);
+                    process(whenClauses.get(i).getResult(), false);
                 }
             }
-            case Case caseExpr -> {
-                List<WhenClause> whenClauses = caseExpr.whenClauses();
-                // First condition is unconditional; everything else is conditional
-                if (!whenClauses.isEmpty()) {
-                    collectReferencedChannels(whenClauses.getFirst().getOperand(), layout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-                    collectReferencedChannels(whenClauses.getFirst().getResult(), layout, false, channels, eagerlyLoadedChannels);
-                    for (int i = 1; i < whenClauses.size(); i++) {
-                        collectReferencedChannels(whenClauses.get(i).getOperand(), layout, false, channels, eagerlyLoadedChannels);
-                        collectReferencedChannels(whenClauses.get(i).getResult(), layout, false, channels, eagerlyLoadedChannels);
-                    }
-                }
-                collectReferencedChannels(caseExpr.defaultValue(), layout, false, channels, eagerlyLoadedChannels);
+            process(node.defaultValue(), false);
+            return null;
+        }
+
+        @Override
+        protected Void visitBetween(Between node, Boolean unconditionallyEvaluated)
+        {
+            // Value and min are unconditional; max is conditional on the second comparison
+            process(node.value(), unconditionallyEvaluated);
+            process(node.min(), unconditionallyEvaluated);
+            process(node.max(), false);
+            return null;
+        }
+
+        @Override
+        protected Void visitLambda(Lambda node, Boolean unconditionallyEvaluated)
+        {
+            // Lambda parameters are locally bound — exclude them from the layout so they are not
+            // mistaken for input channel references when traversing the body
+            Map<Symbol, Integer> previousLayout = layout;
+            layout = Maps.filterKeys(layout, key -> !node.arguments().contains(key));
+            try {
+                process(node.body(), unconditionallyEvaluated);
             }
-            case Switch switchExpr -> {
-                // Operand and first when-clause operand are unconditional; remaining clauses and default are conditional
-                collectReferencedChannels(switchExpr.operand(), layout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-                List<WhenClause> whenClauses = switchExpr.whenClauses();
-                if (!whenClauses.isEmpty()) {
-                    collectReferencedChannels(whenClauses.getFirst().getOperand(), layout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-                    collectReferencedChannels(whenClauses.getFirst().getResult(), layout, false, channels, eagerlyLoadedChannels);
-                    for (int i = 1; i < whenClauses.size(); i++) {
-                        collectReferencedChannels(whenClauses.get(i).getOperand(), layout, false, channels, eagerlyLoadedChannels);
-                        collectReferencedChannels(whenClauses.get(i).getResult(), layout, false, channels, eagerlyLoadedChannels);
-                    }
-                }
-                collectReferencedChannels(switchExpr.defaultValue(), layout, false, channels, eagerlyLoadedChannels);
+            finally {
+                layout = previousLayout;
             }
-            case Between between -> {
-                // Value and min are unconditional; max is conditional on the second comparison
-                collectReferencedChannels(between.value(), layout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-                collectReferencedChannels(between.min(), layout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-                collectReferencedChannels(between.max(), layout, false, channels, eagerlyLoadedChannels);
+            return null;
+        }
+
+        @Override
+        protected Void visitCall(Call node, Boolean unconditionallyEvaluated)
+        {
+            for (Expression argument : node.arguments()) {
+                process(argument, unconditionallyEvaluated && !(argument instanceof Lambda));
             }
-            case Lambda lambda -> {
-                // Lambda parameters are locally bound — exclude them from the layout so they are not
-                // mistaken for input channel references when traversing the body
-                Map<Symbol, Integer> bodyLayout = Maps.filterKeys(layout, key -> !lambda.arguments().contains(key));
-                collectReferencedChannels(lambda.body(), bodyLayout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-            }
-            case Call call -> {
-                for (Expression argument : call.arguments()) {
-                    collectReferencedChannels(argument, layout, unconditionallyEvaluated && !(argument instanceof Lambda), channels, eagerlyLoadedChannels);
-                }
-            }
+            return null;
+        }
+
+        @Override
+        protected Void visitExpression(Expression node, Boolean unconditionallyEvaluated)
+        {
             // All other expressions: children inherit the parent's unconditional context
-            default -> {
-                for (Expression child : expression.children()) {
-                    collectReferencedChannels(child, layout, unconditionallyEvaluated, channels, eagerlyLoadedChannels);
-                }
+            for (Expression child : node.children()) {
+                process(child, unconditionallyEvaluated);
             }
+            return null;
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
@@ -52,6 +52,7 @@ import io.trino.spi.type.Type;
 import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.gen.columnar.FilterEvaluator;
 import io.trino.sql.ir.Between;
+import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.In;
@@ -76,9 +77,6 @@ import java.util.stream.Stream;
 import static io.trino.block.BlockAssertions.assertBlockEquals;
 import static io.trino.block.BlockAssertions.createLongSequenceBlock;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
-import static io.trino.spi.function.OperatorType.EQUAL;
-import static io.trino.spi.function.OperatorType.IDENTICAL;
-import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -87,6 +85,12 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.gen.columnar.FilterEvaluator.createColumnarFilterEvaluator;
+import static io.trino.sql.ir.Comparison.Operator.EQUAL;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
+import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.ir.Comparison.Operator.IDENTICAL;
+import static io.trino.sql.ir.Comparison.Operator.LESS_THAN;
+import static io.trino.sql.ir.Comparison.Operator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.IrExpressions.call;
 import static io.trino.sql.ir.IrExpressions.constantNull;
 import static io.trino.testing.DataProviders.cartesianProduct;
@@ -142,48 +146,21 @@ public class TestColumnarFilters
     private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution(FUNCTION_BUNDLE);
     private static final ColumnarFilterCompiler COMPILER = FUNCTION_RESOLUTION.getColumnarFilterCompiler();
 
-    @ParameterizedTest
-    @MethodSource("inputProviders")
-    public void testIsNotDistinctFrom(NullsProvider nullsProvider, boolean dictionaryEncoded)
-    {
-        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
-        // col IS NOT DISTINCT FROM constant
-        Expression isNotDistinctFromFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
-                new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsSupported(isNotDistinctFromFilter);
-        verifyFilter(inputPages, isNotDistinctFromFilter);
-
-        // colA IS NOT DISTINCT FROM NULL
-        isNotDistinctFromFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
-                constantNull(INTEGER), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsNotSupported(isNotDistinctFromFilter);
-        verifyFilter(inputPages, isNotDistinctFromFilter);
-
-        // colA IS NOT DISTINCT FROM colB
-        isNotDistinctFromFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
-                new Reference(INTEGER, COL_INT_C), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsSupported(isNotDistinctFromFilter);
-        verifyFilter(inputPages, isNotDistinctFromFilter);
-    }
-
     @Test
     public void testIsDistinctFrom()
     {
         List<Page> inputPages = createInputPages(NullsProvider.RANDOM_NULLS, false);
         // col IS DISTINCT FROM constant
-        Expression isDistinctFromFilter = createNotExpression(call(
-                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+        Expression isDistinctFromFilter = createNotExpression(new Comparison(
+                Comparison.Operator.IDENTICAL,
                 new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A)));
         // IS DISTINCT is not supported in columnar evaluation yet
         assertThatColumnarFilterEvaluationIsNotSupported(isDistinctFromFilter);
         verifyFilter(inputPages, isDistinctFromFilter);
 
         // colA IS DISTINCT FROM colB
-        isDistinctFromFilter = createNotExpression(call(
-                FUNCTION_RESOLUTION.resolveOperator(IDENTICAL, ImmutableList.of(INTEGER, INTEGER)),
+        isDistinctFromFilter = createNotExpression(new Comparison(
+                Comparison.Operator.IDENTICAL,
                 new Reference(INTEGER, COL_INT_B), new Reference(INTEGER, COL_INT_A)));
         // IS DISTINCT is not supported in columnar evaluation yet
         assertThatColumnarFilterEvaluationIsNotSupported(isDistinctFromFilter);
@@ -272,15 +249,15 @@ public class TestColumnarFilters
     }
 
     @Test
-    public void testNot()
+    public void testNotEqual()
     {
         List<Page> inputPages = createInputPages(NullsProvider.RANDOM_NULLS, false);
-        Expression notNullFilter = createNotExpression(call(
-                FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(INTEGER, INTEGER)),
-                new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A)));
-        // NOT is not supported in columnar evaluation yet
-        assertThatColumnarFilterEvaluationIsNotSupported(notNullFilter);
-        verifyFilter(inputPages, notNullFilter);
+        Expression notEqualFilter = new Comparison(
+                Comparison.Operator.NOT_EQUAL,
+                new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A));
+        // NOT_EQUAL is not supported in columnar evaluation yet
+        assertThatColumnarFilterEvaluationIsNotSupported(notEqualFilter);
+        verifyFilter(inputPages, notEqualFilter);
     }
 
     @ParameterizedTest
@@ -297,56 +274,36 @@ public class TestColumnarFilters
 
     @ParameterizedTest
     @MethodSource("inputProviders")
-    public void testLessThan(NullsProvider nullsProvider, boolean dictionaryEncoded)
+    public void testComparison(NullsProvider nullsProvider, boolean dictionaryEncoded)
     {
         List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
-        // constant < col
-        Expression lessThanFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(INTEGER, INTEGER)),
-                new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
-        verifyFilter(inputPages, lessThanFilter);
+        for (Comparison.Operator operator : List.of(
+                EQUAL,
+                LESS_THAN,
+                LESS_THAN_OR_EQUAL,
+                GREATER_THAN,
+                GREATER_THAN_OR_EQUAL,
+                IDENTICAL)) {
+            // constant OP col
+            Expression filter = new Comparison(operator, new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A));
+            assertThatColumnarFilterEvaluationIsSupported(filter);
+            verifyFilter(inputPages, filter);
 
-        // col < constant
-        lessThanFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(DOUBLE, DOUBLE)),
-                new Reference(DOUBLE, COL_DOUBLE), new Constant(DOUBLE, (double) CONSTANT));
-        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
-        verifyFilter(inputPages, lessThanFilter);
+            // col OP constant
+            filter = new Comparison(operator, new Reference(DOUBLE, COL_DOUBLE), new Constant(DOUBLE, (double) CONSTANT));
+            assertThatColumnarFilterEvaluationIsSupported(filter);
+            verifyFilter(inputPages, filter);
 
-        // colA < colB
-        lessThanFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(LESS_THAN, ImmutableList.of(INTEGER, INTEGER)),
-                new Reference(INTEGER, COL_INT_C), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
-        verifyFilter(inputPages, lessThanFilter);
-    }
+            // colA OP colB
+            filter = new Comparison(operator, new Reference(INTEGER, COL_INT_C), new Reference(INTEGER, COL_INT_A));
+            assertThatColumnarFilterEvaluationIsSupported(filter);
+            verifyFilter(inputPages, filter);
+        }
 
-    @ParameterizedTest
-    @MethodSource("inputProviders")
-    public void testEq(NullsProvider nullsProvider, boolean dictionaryEncoded)
-    {
-        List<Page> inputPages = createInputPages(nullsProvider, dictionaryEncoded);
-        // constant = col
-        Expression lessThanFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(INTEGER, INTEGER)),
-                new Constant(INTEGER, CONSTANT), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
-        verifyFilter(inputPages, lessThanFilter);
-
-        // col = constant
-        lessThanFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(DOUBLE, DOUBLE)),
-                new Reference(DOUBLE, COL_DOUBLE), new Constant(DOUBLE, (double) CONSTANT));
-        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
-        verifyFilter(inputPages, lessThanFilter);
-
-        // colA = colB
-        lessThanFilter = call(
-                FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(INTEGER, INTEGER)),
-                new Reference(INTEGER, COL_INT_C), new Reference(INTEGER, COL_INT_A));
-        assertThatColumnarFilterEvaluationIsSupported(lessThanFilter);
-        verifyFilter(inputPages, lessThanFilter);
+        // colA IS NOT DISTINCT FROM NULL — only IDENTICAL meaningfully compares against NULL
+        Expression identicalNullFilter = new Comparison(IDENTICAL, constantNull(INTEGER), new Reference(INTEGER, COL_INT_A));
+        assertThatColumnarFilterEvaluationIsNotSupported(identicalNullFilter);
+        verifyFilter(inputPages, identicalNullFilter);
     }
 
     @ParameterizedTest
@@ -437,7 +394,7 @@ public class TestColumnarFilters
 
         Expression andFilter = new Logical(Logical.Operator.AND, ImmutableList.of(
                 new Constant(BOOLEAN, false),
-                call(FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(BIGINT, BIGINT)),
+                new Comparison(EQUAL,
                         new Reference(BIGINT, colB), new Constant(BIGINT, CONSTANT))));
 
         TestingSourcePage testingPage = new TestingSourcePage(100,
@@ -462,9 +419,9 @@ public class TestColumnarFilters
                 new Symbol(BIGINT, colB), 1);
 
         Expression orFilter = new Logical(Logical.Operator.OR, ImmutableList.of(
-                call(FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(BIGINT, BIGINT)),
+                new Comparison(EQUAL,
                         new Reference(BIGINT, colA), new Reference(BIGINT, colA)),
-                call(FUNCTION_RESOLUTION.resolveOperator(EQUAL, ImmutableList.of(BIGINT, BIGINT)),
+                new Comparison(EQUAL,
                         new Reference(BIGINT, colB), new Constant(BIGINT, CONSTANT))));
 
         TestingSourcePage testingPage = new TestingSourcePage(100,


### PR DESCRIPTION
## Description

- Refactor `PageFieldsToInputParametersRewriter` to use an `IrVisitor` instead of a recursive helper that threaded five parameters through every call. Per-expression handling moves into dedicated `visitX` methods, making short-circuit and lambda-scoping rules easier to read.
- Switch comparison filters in `TestColumnarFilters` to direct `Comparison` IR nodes (previously built via `Call` to `resolveOperator`), and merge `testEq`, `testLessThan`, and `testIsNotDistinctFrom` into a single `testComparison` loop covering `EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, and `IDENTICAL`. `testNot` becomes `testNotEqual`.

## Additional context and related issues

The `Comparison` switch arm in `ColumnarFilterCompiler.generateComparisonFilter` — including its operand-swap for `GREATER_THAN` / `GREATER_THAN_OR_EQUAL` — was previously not exercised by `TestColumnarFilters`, because the tests built filters as `Call` to operator functions and hit the `Call` arm of `generateFilterInternal` instead. The test changes close that gap without expanding type coverage, since the `Comparison` arm itself is type-agnostic.

Minor cleanups left over from https://github.com/trinodb/trino/pull/29088

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
