### PR TITLE
Fix Ignite connector to support mixed-case identifiers

### DIFF
--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -163,7 +163,7 @@ public class IgniteClient
             IdentifierMapping identifierMapping,
             RemoteQueryModifier queryModifier)
     {
-        super("`", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, false);
+        super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, false);
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
@@ -96,19 +96,19 @@ public class TestIgniteClient
         testImplementAggregation(
                 new AggregateFunction("count", BIGINT, List.of(bigintVariable), List.of(), false, Optional.empty()),
                 Map.of(bigintVariable.getName(), BIGINT_COLUMN),
-                Optional.of("count(`c_bigint`)"));
+                Optional.of("count(\"c_bigint\")"));
 
         // count(double)
         testImplementAggregation(
                 new AggregateFunction("count", BIGINT, List.of(doubleVariable), List.of(), false, Optional.empty()),
                 Map.of(doubleVariable.getName(), DOUBLE_COLUMN),
-                Optional.of("count(`c_double`)"));
+                Optional.of("count(\"c_double\")"));
 
         // count(DISTINCT bigint)
         testImplementAggregation(
                 new AggregateFunction("count", BIGINT, List.of(bigintVariable), List.of(), true, Optional.empty()),
                 Map.of(bigintVariable.getName(), BIGINT_COLUMN),
-                Optional.of("count(DISTINCT `c_bigint`)"));
+                Optional.of("count(DISTINCT \"c_bigint\")"));
 
         // count() FILTER (WHERE ...)
         testImplementAggregation(
@@ -134,25 +134,25 @@ public class TestIgniteClient
         testImplementAggregation(
                 new AggregateFunction("sum", BIGINT, List.of(bigintVariable), List.of(), false, Optional.empty()),
                 Map.of(bigintVariable.getName(), BIGINT_COLUMN),
-                Optional.of("sum(`c_bigint`)"));
+                Optional.of("sum(\"c_bigint\")"));
 
         // sum(double)
         testImplementAggregation(
                 new AggregateFunction("sum", DOUBLE, List.of(doubleVariable), List.of(), false, Optional.empty()),
                 Map.of(doubleVariable.getName(), DOUBLE_COLUMN),
-                Optional.of("sum(`c_double`)"));
+                Optional.of("sum(\"c_double\")"));
 
         // sum(DISTINCT bigint)
         testImplementAggregation(
                 new AggregateFunction("sum", BIGINT, List.of(bigintVariable), List.of(), true, Optional.empty()),
                 Map.of(bigintVariable.getName(), BIGINT_COLUMN),
-                Optional.of("sum(DISTINCT `c_bigint`)"));
+                Optional.of("sum(DISTINCT \"c_bigint\")"));
 
         // sum(DISTINCT double)
         testImplementAggregation(
                 new AggregateFunction("sum", DOUBLE, List.of(doubleVariable), List.of(), true, Optional.empty()),
                 Map.of(doubleVariable.getName(), DOUBLE_COLUMN),
-                Optional.of("sum(DISTINCT `c_double`)"));
+                Optional.of("sum(DISTINCT \"c_double\")"));
 
         // sum(bigint) FILTER (WHERE ...)
         testImplementAggregation(
@@ -171,7 +171,7 @@ public class TestIgniteClient
                                         new Reference(VARCHAR, "c_varchar_symbol"))),
                         Map.of("c_varchar_symbol", VARCHAR_COLUMN))
                 .orElseThrow();
-        assertThat(converted.expression()).isEqualTo("(`c_varchar`) IS NULL");
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IS NULL");
         assertThat(converted.parameters()).isEmpty();
     }
 
@@ -184,7 +184,7 @@ public class TestIgniteClient
                                 not(PLANNER_CONTEXT.getMetadata(), new IsNull(new Reference(VARCHAR, "c_varchar_symbol")))),
                         Map.of("c_varchar_symbol", VARCHAR_COLUMN))
                 .orElseThrow();
-        assertThat(converted.expression()).isEqualTo("(`c_varchar`) IS NOT NULL");
+        assertThat(converted.expression()).isEqualTo("(\"c_varchar\") IS NOT NULL");
         assertThat(converted.parameters()).isEmpty();
     }
 
@@ -199,7 +199,7 @@ public class TestIgniteClient
                                         not(PLANNER_CONTEXT.getMetadata(), new IsNull(new Reference(VARCHAR, "c_varchar_symbol"))))),
                         Map.of("c_varchar_symbol", VARCHAR_COLUMN))
                 .orElseThrow();
-        assertThat(converted.expression()).isEqualTo("NOT ((`c_varchar`) IS NOT NULL)");
+        assertThat(converted.expression()).isEqualTo("NOT ((\"c_varchar\") IS NOT NULL)");
         assertThat(converted.parameters()).isEmpty();
     }
 


### PR DESCRIPTION
## Description

Fixes #29303.

The Ignite connector used backtick as the identifier quote character, which caused all
identifiers (tables and columns) to be created in uppercase. Apache Ignite uses
double-quote for case-sensitive quoting per the SQL standard.

Changed the quote character from backtick to double-quote in `IgniteClient` and the
corresponding test helper in `TestIgniteCaseInsensitiveMapping`.

## Non-technical explanation

Tables created through the Ignite connector can now preserve mixed-case names instead
of being silently uppercased.