### PR TITLE
Fix column lineage for recursive CTEs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -5926,8 +5926,8 @@ class StatementAnalyzer
             RelationType newDescriptor = oldDescriptor.withAlias(tableName.getValue(), columnNames.stream().map(Identifier::getValue).collect(toImmutableList()));
 
             Streams.forEachPair(
-                    oldDescriptor.getAllFields().stream(),
                     newDescriptor.getAllFields().stream(),
+                    oldDescriptor.getAllFields().stream(),
                     (newField, field) -> analysis.addSourceColumns(newField, analysis.getSourceColumns(field)));
             return scope.withRelationType(newDescriptor);
         }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -8278,6 +8278,35 @@ public class TestAnalyzer
                 new ColumnDetail("tpch", "information_schema", "schemata", "schema_name"));
     }
 
+    @Test
+    public void testSelectColumnsLineageInfoWithRecursiveCte()
+    {
+        String sql = """
+                WITH RECURSIVE t(x, y) AS (
+                    SELECT a, b FROM t1
+                    UNION ALL
+                    SELECT x + 1, y + 1 FROM t WHERE x < 5
+                )
+                SELECT * FROM t""";
+
+        Analysis analysis = analyze(sql);
+
+        Optional<List<ColumnLineageInfo>> optionalLineageInfo = analysis.getSelectColumnsLineageInfo();
+        assertThat(optionalLineageInfo).isPresent();
+        List<ColumnLineageInfo> lineageInfo = optionalLineageInfo.get();
+        assertThat(lineageInfo).hasSize(2);
+
+        ColumnLineageInfo colX = lineageInfo.get(0);
+        assertThat(colX.name()).isEqualTo("x");
+        assertThat(colX.sourceColumns()).containsExactlyInAnyOrder(
+                new ColumnDetail("tpch", "s1", "t1", "a"));
+
+        ColumnLineageInfo colY = lineageInfo.get(1);
+        assertThat(colY.name()).isEqualTo("y");
+        assertThat(colY.sourceColumns()).containsExactlyInAnyOrder(
+                new ColumnDetail("tpch", "s1", "t1", "b"));
+    }
+
     @BeforeAll
     public void setup()
     {


### PR DESCRIPTION
## Description

Fixes #29304.

In `StatementAnalyzer.setAliases()`, the two stream arguments to `Streams.forEachPair`
were swapped. The first stream (old descriptor fields) was being paired with the
`newField` lambda parameter, and the second stream (new descriptor fields) with
`field`. This caused `addSourceColumns` to record lineage on the old field instead of
the new aliased field, resulting in absent column lineage for recursive CTEs with
explicit column aliases.

Swapped the stream arguments so `newField` correctly receives from `newDescriptor` and
`field` from `oldDescriptor`.

## Non-technical explanation

Column lineage tracking now correctly reports source columns for recursive CTEs that
use column aliases (e.g., `WITH RECURSIVE t(x, y) AS (...)`).