### PR TITLE
Fix CREATE OR REPLACE MATERIALIZED VIEW in Iceberg HMS catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -580,6 +580,10 @@ public class TrinoHiveCatalog
         }
 
         if (hideMaterializedViewStorageTable) {
+            if (replace) {
+                existing.ifPresent(existingView -> dropMaterializedViewStorage(session, existingView));
+            }
+
             Location storageMetadataLocation = createMaterializedViewStorage(session, viewName, definition, materializedViewProperties);
 
             Map<String, String> viewProperties = createMaterializedViewProperties(session, storageMetadataLocation);
@@ -620,8 +624,6 @@ public class TrinoHiveCatalog
                 }
                 throw e;
             }
-
-            existing.ifPresent(existingView -> dropMaterializedViewStorage(session, existingView));
         }
         else {
             createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties, existing);
@@ -724,8 +726,46 @@ public class TrinoHiveCatalog
             throw new TrinoException(UNSUPPORTED_TABLE_TYPE, "Not a Materialized View: " + viewName);
         }
 
-        dropMaterializedViewStorage(session, view);
+        String storageTableName = view.getParameters().get(STORAGE_TABLE);
+        if (storageTableName != null) {
+            String storageSchema = Optional.ofNullable(view.getParameters().get(STORAGE_SCHEMA))
+                    .orElse(viewName.getSchemaName());
+            metastore.dropTable(viewName.getSchemaName(), viewName.getTableName(), true);
+            try {
+                dropTable(session, new SchemaTableName(storageSchema, storageTableName));
+            }
+            catch (TrinoException e) {
+                log.warn(e, "Failed to drop storage table '%s.%s' for materialized view '%s'", storageSchema, storageTableName, viewName);
+            }
+            return;
+        }
+
+        // Hidden storage table: the metastore directory may overlap with the Iceberg storage location
+        // (e.g. file metastore stores .trinoSchema in the same directory as Iceberg metadata).
+        // Resolve the storage data location BEFORE dropping the metastore entry so the metadata file is still readable.
+        String storageMetadataLocation = view.getParameters().get(METADATA_LOCATION_PROP);
+        checkState(storageMetadataLocation != null, "Storage location missing in definition of materialized view %s", viewName);
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+        Optional<Location> storageDataLocation = Optional.empty();
+        try {
+            TableMetadata metadata = TableMetadataParser.read(fileIoFactory.create(fileSystem, isUseFileSizeFromMetadata(session)), storageMetadataLocation);
+            storageDataLocation = Optional.of(Location.of(metadata.location()));
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Failed to read storage table metadata '%s' for materialized view '%s'", storageMetadataLocation, viewName);
+        }
+
         metastore.dropTable(viewName.getSchemaName(), viewName.getTableName(), true);
+        invalidateTableCache(viewName);
+
+        if (storageDataLocation.isPresent()) {
+            try {
+                fileSystem.deleteDirectory(storageDataLocation.get());
+            }
+            catch (IOException e) {
+                log.warn(e, "Failed to delete storage data '%s' for materialized view '%s'", storageDataLocation.get(), viewName);
+            }
+        }
     }
 
     private void dropMaterializedViewStorage(ConnectorSession session, Table view)
@@ -751,6 +791,7 @@ public class TrinoHiveCatalog
             catch (IOException e) {
                 log.warn(e, "Failed to delete storage table metadata '%s' for materialized view '%s'", storageMetadataLocation, viewName);
             }
+            invalidateTableCache(viewName);
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -14,9 +14,12 @@
 package io.trino.plugin.iceberg;
 
 import io.trino.Session;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
 import io.trino.metastore.HiveMetastore;
 import io.trino.metastore.Table;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.security.ConnectorIdentity;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -28,6 +31,7 @@ import java.util.Map;
 
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
@@ -156,5 +160,38 @@ public class TestIcebergMaterializedView
         assertUpdate(secondIceberg, "DROP TABLE common_base_table");
         assertUpdate(defaultIceberg, "DROP TABLE common_base_table");
         assertUpdate("DROP MATERIALIZED VIEW mv_on_iceberg2");
+    }
+
+    @Test
+    public void testReplaceAndDropMaterializedView()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE base_table AS SELECT 10 value", 1);
+
+        // Create materialized view using catalog with hidden storage table
+        assertUpdate("CREATE MATERIALIZED VIEW mv_replace AS SELECT sum(value) AS s FROM base_table");
+        assertUpdate("REFRESH MATERIALIZED VIEW mv_replace", 1);
+        assertThat(query("TABLE mv_replace")).matches("VALUES BIGINT '10'");
+
+        // Replace materialized view and verify it still works
+        assertUpdate("INSERT INTO base_table VALUES 7", 1);
+        assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW mv_replace AS SELECT sum(value) AS s FROM base_table");
+        assertUpdate("REFRESH MATERIALIZED VIEW mv_replace", 1);
+        assertThat(query("TABLE mv_replace")).matches("VALUES BIGINT '17'");
+
+        // Store the storage metadata location before drop
+        String storageMetadataLocation = getStorageMetadataLocation("mv_replace");
+        assertThat(storageMetadataLocation).isNotNull();
+        Location storageLocation = Location.of(storageMetadataLocation).parentDirectory();
+
+        // Drop materialized view and verify storage files are cleaned up
+        assertUpdate("DROP MATERIALIZED VIEW mv_replace");
+
+        TrinoFileSystem fileSystem = getFileSystemFactory(getQueryRunner()).create(ConnectorIdentity.ofUser("test"));
+        assertThat(fileSystem.listFiles(storageLocation).hasNext())
+                .describedAs("Storage files should be cleaned up after drop")
+                .isFalse();
+
+        assertUpdate("DROP TABLE base_table");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
@@ -34,7 +34,6 @@ import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -58,7 +57,6 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -122,7 +120,6 @@ public class TestTrinoHiveCatalogWithFileMetastore
     }
 
     @Test
-    @Disabled
     public void testDropMaterializedView()
     {
         testDropMaterializedView(false);
@@ -169,13 +166,5 @@ public class TestTrinoHiveCatalogWithFileMetastore
                 log.warn("Failed to clean up namespace: %s", namespace);
             }
         }
-    }
-
-    @Test
-    @Override
-    public void testListTables()
-    {
-        // the test actually works but when cleanup up the materialized view the error is thrown
-        assertThatThrownBy(super::testListTables).hasMessageMatching("Table 'ns2.*.mv' not found");
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/trinodb/trino/issues/25610

When using `hideMaterializedViewStorageTable=true`, `CREATE OR REPLACE MATERIALIZED VIEW` corrupts the new materialized view because the old storage is dropped **after** the new view is created pointing to the same location, effectively deleting the new view's files.

## Root Cause

In `TrinoHiveCatalog.createMaterializedView()`, for the `hideMaterializedViewStorageTable` path, the sequence was:

1. Create new MV storage (at the same location as old)
2. Register new MV in metastore (`replaceTable`)
3. Drop old MV storage ← **this deletes the new MV's files**

After step 3, querying the MV fails with `Metadata not found in metadata location`.

## Fix

- Drop old storage **before** creating new storage, and **only** when `replace=true` (pure `CREATE` has no existing storage to drop)
- Add `invalidateTableCache()` call after dropping storage metadata files in the `METADATA_LOCATION_PROP` path
- Remove `@Disabled` from `testDropMaterializedView` in `TestTrinoHiveCatalogWithFileMetastore` (now passes)
- Remove `testListTables` override (underlying cleanup error no longer occurs)
- Add `testReplaceAndDropMaterializedView` test that verifies:
  - CREATE OR REPLACE MV works correctly (data is queryable after replace + refresh)
  - DROP MV properly cleans up storage files on the filesystem

## Credit

Based on the approach in #26730 by @codluca, with review feedback from @findinpath addressed.

## Test Plan

- [ ] `TestIcebergMaterializedView#testReplaceAndDropMaterializedView` — verifies replace and drop
- [ ] `TestTrinoHiveCatalogWithFileMetastore#testDropMaterializedView` — previously `@Disabled`, now passes
- [ ] `TestTrinoHiveCatalogWithFileMetastore#testListTables` — no longer needs override