### PR TITLE
Fix expected error pattern in Iceberg BigLake tests

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -244,8 +244,8 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
         String tableLocationWithTrailingSpace = tableLocationWithoutTrailingSpace + " ";
 
         assertThat(query(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS a, 'INDIA' AS b, true AS c", tableName, tableLocationWithTrailingSpace))).failure()
-                .hasMessageStartingWith("Failed to commit the transaction during insert")
-                .hasMessageContaining("Malformed request: Table location is immutable");
+                .hasMessage("Failed to create transaction")
+                .hasStackTraceContaining("Malformed request: The table `location` property can only point to the default path:");
     }
 
     @Test
@@ -263,7 +263,7 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
     {
         assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)
                 .hasMessageMatching("Expected query .* to succeed: CREATE TABLE.*")
-                .hasStackTraceContaining("Malformed request: Table location is immutable");
+                .hasStackTraceContaining("Malformed request: The table `location` property can only point to the default path:");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

I do not know the root cause, But the error message seems to be same as earlier which was changed in https://github.com/trinodb/trino/commit/96e41545945b76e054e40cc22fb69deef45ccaef

https://github.com/trinodb/trino/actions/runs/25352088169/job/74333840104

```
Error:  Failures: 
Error:    TestIcebergBigLakeMetastoreConnectorSmokeTest.testCreateTableWithTrailingSpaceInLocation:247 
Expecting actual:
  "Failed to create transaction"
to start with:
  "Failed to commit the transaction during insert"

Error:    TestIcebergBigLakeMetastoreConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation:266 
Expecting actual:
  "java.lang.AssertionError: Expected query 20260505_010956_00022_yei47 to succeed: CREATE TABLE test_create_table_with_trailing_space_tadvsy75jg WITH (location = 'gs://trino-ci-test/test_iceberg_biglake_otlhur5si8test_create_table_with_trailing_space_tadvsy75jg ') AS SELECT 1 AS a, 'INDIA' AS b, true AS c
	at io.trino.testing.QueryAssertions.assertQuerySucceeds(QueryAssertions.java:453)
	at io.trino.testing.AbstractTestQueryFramework.assertQuerySucceeds(AbstractTestQueryFramework.java:446)
	at io.trino.testing.AbstractTestQueryFramework.assertQuerySucceeds(AbstractTestQueryFramework.java:441)
	at io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation(BaseIcebergConnectorSmokeTest.java:421)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.lambda$testRegisterTableWithTrailingSpaceInLocation$0(TestIcebergBigLakeMetastoreConnectorSmokeTest.java:264)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation(TestIcebergBigLakeMetastoreConnectorSmokeTest.java:264)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:701)
	at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:502)
	at org.junit.jupiter.engine.support.MethodReflectionUtils.invoke(MethodReflectionUtils.java:45)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:61)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:124)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:163)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:148)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:123)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:99)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:66)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:47)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:39)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:98)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invokeVoid(InterceptingExecutableInvoker.java:71)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$0(TestMethodTestDescriptor.java:219)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:215)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:157)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:176)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.exec(ForkJoinPoolHierarchicalTestExecutorService.java:253)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:666)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.joinConcurrentTasksInReverseOrderToEnableWorkStealing(ForkJoinPoolHierarchicalTestExecutorService.java:175)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:141)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.exec(ForkJoinPoolHierarchicalTestExecutorService.java:253)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: io.trino.testing.QueryFailedException: Failed to create transaction
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:591)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:574)
	at io.trino.testing.QueryAssertions.assertQuerySucceeds(QueryAssertions.java:450)
	at io.trino.testing.AbstractTestQueryFramework.assertQuerySucceeds(AbstractTestQueryFramework.java:446)
	at io.trino.testing.AbstractTestQueryFramework.assertQuerySucceeds(AbstractTestQueryFramework.java:441)
	at io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation(BaseIcebergConnectorSmokeTest.java:421)
	at io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.lambda$testRegisterTableWithTrailingSpaceInLocation$0(TestIcebergBigLakeMetastoreConnectorSmokeTest.java:264)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:66)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:908)
	at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1476)
	at org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1319)
	... 54 more
	Suppressed: java.lang.Exception: SQL: CREATE TABLE test_create_table_with_trailing_space_tadvsy75jg WITH (location = 'gs://trino-ci-test/test_iceberg_biglake_otlhur5si8test_create_table_with_trailing_space_tadvsy75jg ') AS SELECT 1 AS a, 'INDIA' AS b, true AS c
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:598)
		... 64 more
Caused by: io.trino.spi.TrinoException: Failed to create transaction
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.newCreateTableTransaction(TrinoRestCatalog.java:430)
	at io.trino.plugin.iceberg.IcebergUtil.newCreateTableTransaction(IcebergUtil.java:947)
	at io.trino.plugin.iceberg.IcebergMetadata.beginCreateTable(IcebergMetadata.java:1464)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.beginCreateTable(ClassLoaderSafeConnectorMetadata.java:590)
	at io.trino.tracing.TracingConnectorMetadata.beginCreateTable(TracingConnectorMetadata.java:659)
	at io.trino.metadata.MetadataManager.beginCreateTable(MetadataManager.java:1218)
	at io.trino.tracing.TracingMetadata.beginCreateTable(TracingMetadata.java:647)
	at io.trino.sql.planner.optimizations.BeginTableWrite$Rewriter.createWriterTarget(BeginTableWrite.java:234)
	at io.trino.sql.planner.optimizations.BeginTableWrite$Rewriter.visitTableFinish(BeginTableWrite.java:175)
	at io.trino.sql.planner.optimizations.BeginTableWrite$Rewriter.visitTableFinish(BeginTableWrite.java:93)
	at io.trino.sql.planner.plan.TableFinishNode.accept(TableFinishNode.java:100)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.rewrite(SimplePlanRewriter.java:81)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.lambda$defaultRewrite$0(SimplePlanRewriter.java:72)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:421)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.defaultRewrite(SimplePlanRewriter.java:72)
	at io.trino.sql.planner.plan.SimplePlanRewriter.visitPlan(SimplePlanRewriter.java:37)
	at io.trino.sql.planner.plan.SimplePlanRewriter.visitPlan(SimplePlanRewriter.java:21)
	at io.trino.sql.planner.plan.PlanVisitor.visitOutput(PlanVisitor.java:49)
	at io.trino.sql.planner.plan.OutputNode.accept(OutputNode.java:82)
	at io.trino.sql.planner.plan.SimplePlanRewriter.rewriteWith(SimplePlanRewriter.java:31)
	at io.trino.sql.planner.optimizations.BeginTableWrite.optimize(BeginTableWrite.java:78)
	at io.trino.sql.planner.LogicalPlanner.runOptimizer(LogicalPlanner.java:305)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:269)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:241)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:236)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:502)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:482)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:420)
	at io.trino.execution.QueryManager.createQuery(QueryManager.java:317)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:151)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$1(LocalDispatchQuery.java:135)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$0(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1126)
	at io.trino.$gen.Trino_testversion____20260505_010916_2498.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
	Suppressed: java.lang.Exception: Current plan:
                Output[columnNames = [rows]]
                │   Layout: [rows:bigint]
                └─ TableCommit[target = iceberg.test_iceberg_biglake_otlhur5si8.test_create_table_with_trailing_space_tadvsy75jg]
                   │   Layout: [rows:bigint]
                   │   Collected statistics:
                   │   aggregations =>
                   │       $iceberg_theta_stat[a] => [iceberg_theta_stat_a := $iceberg_theta_stat(iceberg_theta_stat)]
                   │       $iceberg_theta_stat[b] => [iceberg_theta_stat_b := $iceberg_theta_stat(iceberg_theta_stat_2)]
                   │       $iceberg_theta_stat[c] => [iceberg_theta_stat_c := $iceberg_theta_stat(iceberg_theta_stat_3)]
                   │       grouped by => []
                   └─ LocalExchange[partitioning = SINGLE]
                      │   Layout: [partialrows:bigint, fragment:varbinary, iceberg_theta_stat:varbinary, iceberg_theta_stat_2:varbinary, iceberg_theta_stat_3:varbinary]
                      └─ RemoteExchange[type = GATHER]
                         │   Layout: [partialrows:bigint, fragment:varbinary, iceberg_theta_stat:varbinary, iceberg_theta_stat_2:varbinary, iceberg_theta_stat_3:varbinary]
                         └─ TableWriter[]
                            │   Layout: [partialrows:bigint, fragment:varbinary, iceberg_theta_stat:varbinary, iceberg_theta_stat_2:varbinary, iceberg_theta_stat_3:varbinary]
                            │   a := a
                            │   b := b
                            │   c := c
                            │   Collected statistics:
                            │   aggregations =>
                            │       $iceberg_theta_stat[a] => [iceberg_theta_stat := $iceberg_theta_stat(a)]
                            │       $iceberg_theta_stat[b] => [iceberg_theta_stat_2 := $iceberg_theta_stat(b)]
                            │       $iceberg_theta_stat[c] => [iceberg_theta_stat_3 := $iceberg_theta_stat(c)]
                            │       grouped by => []
                            └─ LocalExchange[partitioning = ROUND_ROBIN (scale writers)]
                               │   Layout: [a:integer, b:varchar(5), c:boolean]
                               └─ RemoteExchange[partitionCount = 100, scaleWriters = true, type = REPARTITION]
                                  │   Layout: [a:integer, b:varchar(5), c:boolean]
                                  └─ Values[]
                                         Layout: [a:integer, b:varchar(5), c:boolean]
                                         (integer '1', varchar(5) 'INDIA', boolean 'true')

		at io.trino.sql.planner.optimizations.BeginTableWrite.optimize(BeginTableWrite.java:84)
		... 17 more
Caused by: org.apache.iceberg.exceptions.BadRequestException: Malformed request: The table `location` property can only point to the default path: gs://trino-ci-test/test_iceberg_biglake_otlhur5si8/test_create_table_with_trailing_space_tadvsy75jg.
	at org.apache.iceberg.rest.ErrorHandlers$DefaultErrorHandler.accept(ErrorHandlers.java:234)
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:124)
	at org.apache.iceberg.rest.ErrorHandlers$TableErrorHandler.accept(ErrorHandlers.java:108)
	at org.apache.iceberg.rest.HTTPClient.throwFailure(HTTPClient.java:240)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:336)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:297)
	at org.apache.iceberg.rest.BaseHTTPClient.post(BaseHTTPClient.java:100)
	at org.apache.iceberg.rest.RESTSessionCatalog$Builder.stageCreate(RESTSessionCatalog.java:923)
	at org.apache.iceberg.rest.RESTSessionCatalog$Builder.createTransaction(RESTSessionCatalog.java:801)
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.newCreateTableTransaction(TrinoRestCatalog.java:427)
	... 37 more
"
to contain:
  "Malformed request: Table location is immutable" 
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/commit/96e41545945b76e054e40cc22fb69deef45ccaef

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
