### PR TITLE
Add SQL-level tests for sum(decimal) overflow

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -1528,4 +1528,38 @@ public abstract class AbstractTestAggregations
                 GROUP BY id
                 """);
     }
+
+    @Test
+    public void testSumDecimalOverflow()
+    {
+        // max DECIMAL(38,0)
+        assertThat(query("SELECT sum(v) FROM (VALUES (DECIMAL '99999999999999999999999999999999999999'), (DECIMAL '99999999999999999999999999999999999999')) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+        assertThat(query("SELECT sum(v) FROM (VALUES (DECIMAL '-99999999999999999999999999999999999999'), (DECIMAL '-99999999999999999999999999999999999999')) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+        // max DECIMAL(38,10)
+        assertThat(query("SELECT sum(v) FROM (VALUES (DECIMAL '9999999999999999999999999999.9999999999'), (DECIMAL '9999999999999999999999999999.9999999999')) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+        assertThat(query("SELECT sum(v) FROM (VALUES (DECIMAL '-9999999999999999999999999999.9999999999'), (DECIMAL '-9999999999999999999999999999.9999999999')) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+
+        // Overflow after adding couple values
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '45000000000000000000000000000000000000' FROM (VALUES 1, 2) t(x)) t(v)"))
+                .matches("VALUES DECIMAL '90000000000000000000000000000000000000'");
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '45000000000000000000000000000000000000' FROM (VALUES 1, 2, 3, 4) t(x)) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '-45000000000000000000000000000000000000' FROM (VALUES 1, 2) t(x)) t(v)"))
+                .matches("VALUES DECIMAL '-90000000000000000000000000000000000000'");
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '-45000000000000000000000000000000000000' FROM (VALUES 1, 2, 3, 4) t(x)) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+        // same with non-zero scale: DECIMAL(38,10)
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '4500000000000000000000000000.0000000000' FROM (VALUES 1, 2) t(x)) t(v)"))
+                .matches("VALUES DECIMAL '9000000000000000000000000000.0000000000'");
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '4500000000000000000000000000.0000000000' FROM (VALUES 1, 2, 3, 4) t(x)) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '-4500000000000000000000000000.0000000000' FROM (VALUES 1, 2) t(x)) t(v)"))
+                .matches("VALUES DECIMAL '-9000000000000000000000000000.0000000000'");
+        assertThat(query("SELECT sum(v) FROM (SELECT DECIMAL '-4500000000000000000000000000.0000000000' FROM (VALUES 1, 2, 3, 4) t(x)) t(v)"))
+                .failure().hasMessageContaining("Decimal overflow");
+    }
 }


### PR DESCRIPTION
TestDecimalSumAggregation tests the aggregation state machinery in isolation. Add end-to-end coverage in AbstractTestAggregations to verify that summing large decimal values through the full query engine raises an error for both positive and negative overflow, across scales zero and non-zero.
