### PR TITLE
Move in-memory Join from unspilled to nonspilling sub-package

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorFactories.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorFactories.java
@@ -15,10 +15,10 @@ package io.trino.operator;
 
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.LookupSourceFactory;
+import io.trino.operator.join.nonspilling.JoinProbe;
+import io.trino.operator.join.nonspilling.PartitionedLookupSourceFactory;
 import io.trino.operator.join.spilling.JoinProbe.JoinProbeFactory;
 import io.trino.operator.join.spilling.LookupJoinOperatorFactory;
-import io.trino.operator.join.unspilled.JoinProbe;
-import io.trino.operator.join.unspilled.PartitionedLookupSourceFactory;
 import io.trino.spi.type.Type;
 import io.trino.spiller.PartitioningSpillerFactory;
 import io.trino.sql.planner.plan.PlanNodeId;
@@ -50,7 +50,7 @@ public final class OperatorFactories
                 .map(probeTypes::get)
                 .collect(toImmutableList());
 
-        return createAdapterOperatorFactory(new io.trino.operator.join.unspilled.LookupJoinOperatorFactory(
+        return createAdapterOperatorFactory(new io.trino.operator.join.nonspilling.LookupJoinOperatorFactory(
                 operatorId,
                 planNodeId,
                 lookupSourceFactory,

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/HashBuilderOperator.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/JoinProbe.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/JoinProbe.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.primitives.Ints;
 import io.trino.operator.join.LookupSource;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/LookupJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/LookupJoinOperator.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -22,7 +22,7 @@ import io.trino.operator.WorkProcessorOperator;
 import io.trino.operator.join.JoinStatisticsCounter;
 import io.trino.operator.join.JoinType;
 import io.trino.operator.join.LookupSource;
-import io.trino.operator.join.unspilled.JoinProbe.JoinProbeFactory;
+import io.trino.operator.join.nonspilling.JoinProbe.JoinProbeFactory;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/LookupJoinOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/LookupJoinOperatorFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.operator.JoinOperatorType;
@@ -24,7 +24,7 @@ import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.JoinOperatorFactory;
 import io.trino.operator.join.JoinType;
 import io.trino.operator.join.LookupOuterOperator.LookupOuterOperatorFactory;
-import io.trino.operator.join.unspilled.JoinProbe.JoinProbeFactory;
+import io.trino.operator.join.nonspilling.JoinProbe.JoinProbeFactory;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/LookupJoinPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/LookupJoinPageBuilder.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import io.trino.operator.join.LookupSource;
 import io.trino.spi.Page;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PageJoiner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PageJoiner.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -21,7 +21,7 @@ import io.trino.operator.WorkProcessor;
 import io.trino.operator.join.JoinStatisticsCounter;
 import io.trino.operator.join.JoinType;
 import io.trino.operator.join.LookupSource;
-import io.trino.operator.join.unspilled.JoinProbe.JoinProbeFactory;
+import io.trino.operator.join.nonspilling.JoinProbe.JoinProbeFactory;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PartitionedLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PartitionedLookupSource.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.io.Closer;
 import com.google.errorprone.annotations.concurrent.GuardedBy;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PartitionedLookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PartitionedLookupSourceFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -37,7 +37,7 @@ import static com.google.common.util.concurrent.Futures.nonCancellationPropagati
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.operator.join.OuterLookupSource.createOuterLookupSourceSupplier;
-import static io.trino.operator.join.unspilled.PartitionedLookupSource.createPartitionedLookupSourceSupplier;
+import static io.trino.operator.join.nonspilling.PartitionedLookupSource.createPartitionedLookupSourceSupplier;
 import static java.util.Objects.requireNonNull;
 
 public final class PartitionedLookupSourceFactory

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -45,7 +45,7 @@ import io.trino.operator.join.JoinHash;
 import io.trino.operator.join.JoinHashSupplier;
 import io.trino.operator.join.LookupSourceSupplier;
 import io.trino.operator.join.PagesHash;
-import io.trino.operator.join.unspilled.PartitionedLookupSource;
+import io.trino.operator.join.nonspilling.PartitionedLookupSource;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -126,9 +126,9 @@ import io.trino.operator.join.JoinOperatorFactory;
 import io.trino.operator.join.LookupSourceFactory;
 import io.trino.operator.join.NestedLoopJoinBridge;
 import io.trino.operator.join.NestedLoopJoinPagesSupplier;
+import io.trino.operator.join.nonspilling.HashBuilderOperator;
 import io.trino.operator.join.spilling.HashBuilderOperator.HashBuilderOperatorFactory;
 import io.trino.operator.join.spilling.PartitionedLookupSourceFactory;
-import io.trino.operator.join.unspilled.HashBuilderOperator;
 import io.trino.operator.output.PartitionedOutputOperator.PartitionedOutputFactory;
 import io.trino.operator.output.PositionsAppenderFactory;
 import io.trino.operator.output.SkewedPartitionRebalancer;
@@ -3000,9 +3000,9 @@ public class LocalExecutionPlanner
                         hashCompiler);
             }
             else {
-                JoinBridgeManager<io.trino.operator.join.unspilled.PartitionedLookupSourceFactory> lookupSourceFactory = new JoinBridgeManager<>(
+                JoinBridgeManager<io.trino.operator.join.nonspilling.PartitionedLookupSourceFactory> lookupSourceFactory = new JoinBridgeManager<>(
                         buildOuter,
-                        new io.trino.operator.join.unspilled.PartitionedLookupSourceFactory(
+                        new io.trino.operator.join.nonspilling.PartitionedLookupSourceFactory(
                                 buildTypes,
                                 buildOutputTypes,
                                 buildChannels.stream()

--- a/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/BenchmarkHashBuildAndJoinOperators.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
@@ -29,7 +29,7 @@ import io.trino.operator.TaskContext;
 import io.trino.operator.exchange.LocalPartitionGenerator;
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.LookupSource;
-import io.trino.operator.join.unspilled.HashBuilderOperator.HashBuilderOperatorFactory;
+import io.trino.operator.join.nonspilling.HashBuilderOperator.HashBuilderOperatorFactory;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;

--- a/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/JoinTestUtils.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
@@ -31,7 +31,7 @@ import io.trino.operator.join.InternalJoinFilterFunction;
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.LookupSource;
 import io.trino.operator.join.StandardJoinFilterFunction;
-import io.trino.operator.join.unspilled.HashBuilderOperator.HashBuilderOperatorFactory;
+import io.trino.operator.join.nonspilling.HashBuilderOperator.HashBuilderOperatorFactory;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;

--- a/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestHashBuilderOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestHashBuilderOperator.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -44,9 +44,9 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SequencePageBuilder.createSequencePage;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.operator.HashArraySizeSupplier.defaultHashArraySizeSupplier;
-import static io.trino.operator.join.unspilled.HashBuilderOperator.State.CLOSED;
-import static io.trino.operator.join.unspilled.HashBuilderOperator.State.CONSUMING_INPUT;
-import static io.trino.operator.join.unspilled.HashBuilderOperator.State.LOOKUP_SOURCE_BUILT;
+import static io.trino.operator.join.nonspilling.HashBuilderOperator.State.CLOSED;
+import static io.trino.operator.join.nonspilling.HashBuilderOperator.State.CONSUMING_INPUT;
+import static io.trino.operator.join.nonspilling.HashBuilderOperator.State.LOOKUP_SOURCE_BUILT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;

--- a/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestHashJoinOperator.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -31,8 +31,8 @@ import io.trino.operator.TaskContext;
 import io.trino.operator.join.InternalJoinFilterFunction;
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.JoinOperatorInfo;
-import io.trino.operator.join.unspilled.JoinTestUtils.BuildSideSetup;
-import io.trino.operator.join.unspilled.JoinTestUtils.TestInternalJoinFilterFunction;
+import io.trino.operator.join.nonspilling.JoinTestUtils.BuildSideSetup;
+import io.trino.operator.join.nonspilling.JoinTestUtils.TestInternalJoinFilterFunction;
 import io.trino.spi.Page;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
@@ -66,10 +66,10 @@ import static io.trino.operator.OperatorAssertion.assertOperatorEquals;
 import static io.trino.operator.OperatorAssertion.toMaterializedResult;
 import static io.trino.operator.OperatorAssertion.toPages;
 import static io.trino.operator.OperatorFactories.join;
-import static io.trino.operator.join.unspilled.JoinTestUtils.buildLookupSource;
-import static io.trino.operator.join.unspilled.JoinTestUtils.innerJoinOperatorFactory;
-import static io.trino.operator.join.unspilled.JoinTestUtils.instantiateBuildDrivers;
-import static io.trino.operator.join.unspilled.JoinTestUtils.setupBuildSide;
+import static io.trino.operator.join.nonspilling.JoinTestUtils.buildLookupSource;
+import static io.trino.operator.join.nonspilling.JoinTestUtils.innerJoinOperatorFactory;
+import static io.trino.operator.join.nonspilling.JoinTestUtils.instantiateBuildDrivers;
+import static io.trino.operator.join.nonspilling.JoinTestUtils.setupBuildSide;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.concurrent.Executors.newCachedThreadPool;

--- a/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestLookupJoinPageBuilder.java
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator.join.unspilled;
+package io.trino.operator.join.nonspilling;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.operator.join.LookupSource;
-import io.trino.operator.join.unspilled.JoinProbe.JoinProbeFactory;
+import io.trino.operator.join.nonspilling.JoinProbe.JoinProbeFactory;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;


### PR DESCRIPTION
The `unspilled` package is too close to "unspilling, act of reading
spilled data back" not to be confusing as a package name. It remains
confusing even to those familiar with the code. `nonspilling`
sub-package is determined as a somewhat better name.