### PR TITLE
Set LANG in Docker image to fix rendering in Trino CLI

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -53,6 +53,7 @@ ARG JDK_VERSION
 ARG ARCH
 ENV JAVA_HOME="/usr/lib/jvm/${JDK_VERSION}"
 ENV PATH=$PATH:$JAVA_HOME/bin
+ENV LANG=C.UTF-8
 ENV CATALOG_MANAGEMENT=static
 COPY --from=jdk-download $JAVA_HOME $JAVA_HOME
 COPY --from=packages /tmp/overlay /

--- a/core/docker/container-test.sh
+++ b/core/docker/container-test.sh
@@ -55,11 +55,21 @@ function test_javahome {
     [[ $? == "0" ]]
 }
 
+function test_less_utf8 {
+    local CONTAINER_NAME=$1
+    local PLATFORM=$2
+    local result
+    result=$(docker run --rm --platform "${PLATFORM}" "${CONTAINER_NAME}" \
+        /bin/bash -c 'printf "│\n" | LESS=-FX less')
+    [[ "${result}" == "│" ]]
+}
+
 function test_container {
     local CONTAINER_NAME=$1
     local PLATFORM=$2
     echo "🐢 Validating ${CONTAINER_NAME} on platform ${PLATFORM}..."
     test_javahome "${CONTAINER_NAME}" "${PLATFORM}"
+    test_less_utf8 "${CONTAINER_NAME}" "${PLATFORM}"
     test_trino_starts "${CONTAINER_NAME}" "${PLATFORM}"
     echo "🎉 Validated ${CONTAINER_NAME} on platform ${PLATFORM}"
 }


### PR DESCRIPTION
Without a locale, `less` (the CLI's interactive pager) defaulted to ASCII and escaped every non-ASCII byte as <HH>, mangling the box-drawing characters in EXPLAIN output.

- fixes https://github.com/trinodb/trino/issues/29345
- probably also fixes https://github.com/trinodb/trino/issues/20407