### PR TITLE
Fix non-deterministic query in testAggregationUsingOuterTableSymbols

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -117,8 +117,8 @@ public abstract class AbstractTestAggregations
     public void testAggregationUsingOuterTableSymbols()
     {
         assertQuery(
-                "SELECT max_by(n.nationkey, r.regionkey) FROM (SELECT DISTINCT regionkey FROM region) r LEFT JOIN nation n ON n.regionkey = r.regionkey GROUP BY r.regionkey",
-                "VALUES 16, 20, 21, 23, 24");
+                "SELECT max_by(r.regionkey, n.nationkey) FROM (SELECT DISTINCT regionkey FROM region) r LEFT JOIN nation n ON n.regionkey = r.regionkey GROUP BY r.regionkey",
+                "VALUES 0, 1, 2, 3, 4");
     }
 
     /**


### PR DESCRIPTION
max_by(n.nationkey, r.regionkey) grouped by r.regionkey compared a constant value within each group, making the result arbitrary when multiple nations share the same regionkey. Swapping the arguments to max_by(r.regionkey, n.nationkey) makes the ordering unique (nationkey is unique in TPC-H) while still referencing the outer table symbol that prevents incorrect aggregation pushdown into the join's inner source.
