### PR TITLE
Handle processor count with SMT-aware scaling

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/MachineInfo.java
+++ b/core/trino-main/src/main/java/io/trino/util/MachineInfo.java
@@ -13,6 +13,7 @@
  */
 package io.trino.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.StandardSystemProperty;
@@ -20,8 +21,11 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.VMOption;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -32,7 +36,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static java.lang.Math.min;
+import static java.lang.Math.ceilDiv;
 import static java.util.Locale.ENGLISH;
 import static java.util.function.Predicate.not;
 
@@ -66,18 +70,29 @@ public final class MachineInfo
         String osName = StandardSystemProperty.OS_NAME.value();
         // logical core count (including container cpu quota if there is any)
         int availableProcessorCount = Runtime.getRuntime().availableProcessors();
-        int totalPhysicalProcessorCount;
         if ("Linux".equals(osName) && "amd64".equals(osArch)) {
-            totalPhysicalProcessorCount = readLinuxPhysicalProcessorCount()
-                    .orElse(availableProcessorCount);
-        }
-        else {
-            // Fallback to logical processor count when physical core topology is not available.
-            totalPhysicalProcessorCount = availableProcessorCount;
+            return calculateAvailablePhysicalProcessorCount(
+                    availableProcessorCount,
+                    isActiveProcessorCountExplicitlySet(),
+                    MachineInfo::readLinuxThreadsPerCore);
         }
 
-        // cap available processor count to container cpu quota (if there is any).
-        return min(totalPhysicalProcessorCount, availableProcessorCount);
+        return availableProcessorCount;
+    }
+
+    @VisibleForTesting
+    static int calculateAvailablePhysicalProcessorCount(
+            int availableProcessorCount,
+            boolean activeProcessorCountExplicitlySet,
+            Supplier<Optional<Integer>> linuxThreadsPerCore)
+    {
+        if (activeProcessorCountExplicitlySet) {
+            return availableProcessorCount;
+        }
+
+        return linuxThreadsPerCore.get()
+                .map(threadsPerCore -> ceilDiv(availableProcessorCount, threadsPerCore))
+                .orElse(availableProcessorCount);
     }
 
     private static Set<String> readCpuFlagsInternal()
@@ -89,26 +104,47 @@ public final class MachineInfo
         };
     }
 
-    private static Optional<Integer> readLinuxPhysicalProcessorCount()
+    private static Optional<Integer> readLinuxThreadsPerCore()
     {
         return readLines(Path.of("/proc/cpuinfo"))
-                .flatMap(MachineInfo::parseLinuxPhysicalProcessorCount);
+                .flatMap(MachineInfo::parseLinuxThreadsPerCore);
     }
 
-    static Optional<Integer> parseLinuxPhysicalProcessorCount(List<String> cpuInfoLines)
+    private static boolean isActiveProcessorCountExplicitlySet()
     {
-        Set<String> physicalCores = new HashSet<>();
-        String currentPhysicalId = null;
-        String currentCoreId = null;
+        try {
+            HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+            return bean != null && bean.getVMOption("ActiveProcessorCount").getOrigin() == VMOption.Origin.VM_CREATION;
+        }
+        catch (IllegalArgumentException | UnsupportedOperationException e) {
+            return false;
+        }
+    }
+
+    static Optional<Integer> parseLinuxThreadsPerCore(List<String> cpuInfoLines)
+    {
+        Integer threadsPerCore = null;
+        Integer currentSiblings = null;
+        Integer currentCpuCores = null;
 
         // add a synthetic section separator so the final section is flushed
         for (String line : withTrailingBlankLine(cpuInfoLines)) {
             if (line.isBlank()) {
-                if (currentPhysicalId != null && currentCoreId != null) {
-                    physicalCores.add(currentPhysicalId + ":" + currentCoreId);
+                if ((currentSiblings == null) != (currentCpuCores == null)) {
+                    return Optional.empty();
                 }
-                currentPhysicalId = null;
-                currentCoreId = null;
+                if (currentSiblings != null && currentCpuCores != null) {
+                    if (currentSiblings < currentCpuCores || currentSiblings % currentCpuCores != 0) {
+                        return Optional.empty();
+                    }
+                    int currentThreadsPerCore = currentSiblings / currentCpuCores;
+                    if (threadsPerCore != null && !threadsPerCore.equals(currentThreadsPerCore)) {
+                        return Optional.empty();
+                    }
+                    threadsPerCore = currentThreadsPerCore;
+                }
+                currentSiblings = null;
+                currentCpuCores = null;
                 continue;
             }
 
@@ -119,18 +155,23 @@ public final class MachineInfo
 
             String key = keyAndValue.getFirst().toLowerCase(ENGLISH);
             String value = keyAndValue.getLast();
-            if (key.equals("physical id")) {
-                currentPhysicalId = value;
+            if (key.equals("siblings")) {
+                Optional<Integer> parsedValue = parsePositiveInteger(value);
+                if (parsedValue.isEmpty()) {
+                    return Optional.empty();
+                }
+                currentSiblings = parsedValue.get();
             }
-            else if (key.equals("core id")) {
-                currentCoreId = value;
+            else if (key.equals("cpu cores")) {
+                Optional<Integer> parsedValue = parsePositiveInteger(value);
+                if (parsedValue.isEmpty()) {
+                    return Optional.empty();
+                }
+                currentCpuCores = parsedValue.get();
             }
         }
 
-        if (physicalCores.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(physicalCores.size());
+        return Optional.ofNullable(threadsPerCore);
     }
 
     private static Set<String> readLinuxCpuFlags()
@@ -196,6 +237,20 @@ public final class MachineInfo
     private static Iterable<String> withTrailingBlankLine(Iterable<String> lines)
     {
         return Iterables.concat(lines, List.of(""));
+    }
+
+    private static Optional<Integer> parsePositiveInteger(String value)
+    {
+        try {
+            int parsedValue = Integer.parseInt(value);
+            if (parsedValue <= 0) {
+                return Optional.empty();
+            }
+            return Optional.of(parsedValue);
+        }
+        catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 
     private static Set<String> parseCpuFlags(String value)

--- a/core/trino-main/src/main/java/io/trino/util/MachineInfo.java
+++ b/core/trino-main/src/main/java/io/trino/util/MachineInfo.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -43,6 +44,7 @@ public final class MachineInfo
     private static final Splitter KEY_VALUE_SPLITTER = Splitter.on(':')
             .limit(2)
             .trimResults();
+    private static final Pattern ROOT_CGROUP_PATTERN = Pattern.compile("\\d+:[^:]*:/");
 
     // cache physical processor count, so that it's not queried multiple times during tests
     private static final Supplier<Integer> PHYSICAL_PROCESSOR_COUNT = memoize(MachineInfo::readAvailablePhysicalProcessorCount);
@@ -66,18 +68,29 @@ public final class MachineInfo
         String osName = StandardSystemProperty.OS_NAME.value();
         // logical core count (including container cpu quota if there is any)
         int availableProcessorCount = Runtime.getRuntime().availableProcessors();
-        int totalPhysicalProcessorCount;
         if ("Linux".equals(osName) && "amd64".equals(osArch)) {
-            totalPhysicalProcessorCount = readLinuxPhysicalProcessorCount()
-                    .orElse(availableProcessorCount);
+            return calculateAvailablePhysicalProcessorCount(
+                    availableProcessorCount,
+                    hasOnlyRootCgroups(),
+                    readLinuxSmtActive(),
+                    MachineInfo::readLinuxPhysicalProcessorCount);
         }
-        else {
-            // Fallback to logical processor count when physical core topology is not available.
-            totalPhysicalProcessorCount = availableProcessorCount;
+
+        return availableProcessorCount;
+    }
+
+    static int calculateAvailablePhysicalProcessorCount(
+            int availableProcessorCount,
+            boolean linuxHasOnlyRootCgroups,
+            Optional<Boolean> linuxSmtActive,
+            Supplier<Optional<Integer>> linuxPhysicalProcessorCount)
+    {
+        if (!linuxHasOnlyRootCgroups || linuxSmtActive.equals(Optional.of(false))) {
+            return availableProcessorCount;
         }
 
         // cap available processor count to container cpu quota (if there is any).
-        return min(totalPhysicalProcessorCount, availableProcessorCount);
+        return min(linuxPhysicalProcessorCount.get().orElse(availableProcessorCount), availableProcessorCount);
     }
 
     private static Set<String> readCpuFlagsInternal()
@@ -93,6 +106,39 @@ public final class MachineInfo
     {
         return readLines(Path.of("/proc/cpuinfo"))
                 .flatMap(MachineInfo::parseLinuxPhysicalProcessorCount);
+    }
+
+    private static Optional<Boolean> readLinuxSmtActive()
+    {
+        return readLines(Path.of("/sys/devices/system/cpu/smt/active"))
+                .flatMap(lines -> lines.stream()
+                        .findFirst()
+                        .flatMap(MachineInfo::parseLinuxSmtActive));
+    }
+
+    static Optional<Boolean> parseLinuxSmtActive(String value)
+    {
+        return switch (value.trim()) {
+            case "0" -> Optional.of(false);
+            case "1" -> Optional.of(true);
+            default -> Optional.empty();
+        };
+    }
+
+    private static boolean hasOnlyRootCgroups()
+    {
+        return readLines(Path.of("/proc/self/cgroup"))
+                .map(MachineInfo::hasOnlyRootCgroups)
+                .orElse(false);
+    }
+
+    static boolean hasOnlyRootCgroups(List<String> cgroupLines)
+    {
+        List<String> nonBlankLines = cgroupLines.stream()
+                .filter(not(String::isBlank))
+                .toList();
+        return !nonBlankLines.isEmpty() && nonBlankLines.stream()
+                .allMatch(line -> ROOT_CGROUP_PATTERN.matcher(line).matches());
     }
 
     static Optional<Integer> parseLinuxPhysicalProcessorCount(List<String> cpuInfoLines)

--- a/core/trino-main/src/test/java/io/trino/util/TestMachineInfo.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestMachineInfo.java
@@ -18,39 +18,63 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static io.trino.util.MachineInfo.calculateAvailablePhysicalProcessorCount;
+import static io.trino.util.MachineInfo.parseLinuxCpuFlags;
+import static io.trino.util.MachineInfo.parseLinuxThreadsPerCore;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestMachineInfo
 {
     @Test
-    void testParseLinuxPhysicalProcessorCount()
+    void testCalculateAvailablePhysicalProcessorCount()
     {
-        List<String> cpuInfoLines =
-                """
-                processor : 0
-                physical id : 0
-                core id : 0
-
-                processor : 1
-                physical id : 0
-                core id : 0
-
-                processor : 2
-                physical id : 0
-                core id : 1
-
-                processor : 3
-                physical id : 0
-                core id : 1
-                """.lines().toList();
-
-        assertThat(MachineInfo.parseLinuxPhysicalProcessorCount(cpuInfoLines))
-                .isEqualTo(Optional.of(2));
+        assertThat(calculateAvailablePhysicalProcessorCount(16, false, () -> Optional.of(2))).isEqualTo(8);
+        assertThat(calculateAvailablePhysicalProcessorCount(3, false, () -> Optional.of(2))).isEqualTo(2);
+        assertThat(calculateAvailablePhysicalProcessorCount(16, false, () -> Optional.of(1))).isEqualTo(16);
+        assertThat(calculateAvailablePhysicalProcessorCount(16, false, Optional::empty)).isEqualTo(16);
     }
 
     @Test
-    void testParseLinuxPhysicalProcessorCountWithoutCoreIds()
+    void testCalculateAvailablePhysicalProcessorCountWithActiveProcessorCount()
+    {
+        AtomicBoolean threadsPerCoreRead = new AtomicBoolean();
+
+        assertThat(calculateAvailablePhysicalProcessorCount(16, true, () -> {
+            threadsPerCoreRead.set(true);
+            return Optional.of(2);
+        })).isEqualTo(16);
+        assertThat(threadsPerCoreRead).isFalse();
+    }
+
+    @Test
+    void testParseLinuxThreadsPerCore()
+    {
+        List<String> cpuInfoLines =
+                """
+                processor : 0
+                siblings : 4
+                cpu cores : 2
+
+                processor : 1
+                siblings : 4
+                cpu cores : 2
+
+                processor : 2
+                siblings : 4
+                cpu cores : 2
+
+                processor : 3
+                siblings : 4
+                cpu cores : 2
+                """.lines().toList();
+
+        assertThat(parseLinuxThreadsPerCore(cpuInfoLines)).isEqualTo(Optional.of(2));
+    }
+
+    @Test
+    void testParseLinuxThreadsPerCoreWithoutTopology()
     {
         List<String> cpuInfoLines =
                 """
@@ -61,8 +85,24 @@ final class TestMachineInfo
                 flags : avx512f avx512_vbmi2
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxPhysicalProcessorCount(cpuInfoLines))
-                .isEqualTo(Optional.empty());
+        assertThat(parseLinuxThreadsPerCore(cpuInfoLines)).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testParseLinuxThreadsPerCoreWithInvalidTopology()
+    {
+        assertThat(parseLinuxThreadsPerCore(
+                """
+                processor : 0
+                siblings : 3
+                cpu cores : 2
+                """.lines().toList())).isEqualTo(Optional.empty());
+
+        assertThat(parseLinuxThreadsPerCore(
+                """
+                processor : 0
+                siblings : 4
+                """.lines().toList())).isEqualTo(Optional.empty());
     }
 
     @Test
@@ -77,7 +117,7 @@ final class TestMachineInfo
                 flags : avx512f asimd
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxCpuFlags(cpuInfoLines))
+        assertThat(parseLinuxCpuFlags(cpuInfoLines))
                 .isEqualTo(Set.of("avx512f", "neon"));
     }
 
@@ -90,7 +130,7 @@ final class TestMachineInfo
                 flags : avx512f asimd
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxCpuFlags(cpuInfoLines))
+        assertThat(parseLinuxCpuFlags(cpuInfoLines))
                 .isEqualTo(Set.of("avx512f", "neon"));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/util/TestMachineInfo.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestMachineInfo.java
@@ -18,11 +18,70 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static io.trino.util.MachineInfo.calculateAvailablePhysicalProcessorCount;
+import static io.trino.util.MachineInfo.hasOnlyRootCgroups;
+import static io.trino.util.MachineInfo.parseLinuxCpuFlags;
+import static io.trino.util.MachineInfo.parseLinuxPhysicalProcessorCount;
+import static io.trino.util.MachineInfo.parseLinuxSmtActive;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestMachineInfo
 {
+    @Test
+    void testCalculateAvailablePhysicalProcessorCount()
+    {
+        assertThat(calculateAvailablePhysicalProcessorCount(16, true, Optional.of(true), () -> Optional.of(8))).isEqualTo(8);
+        assertThat(calculateAvailablePhysicalProcessorCount(4, true, Optional.of(true), () -> Optional.of(8))).isEqualTo(4);
+        assertThat(calculateAvailablePhysicalProcessorCount(16, true, Optional.empty(), () -> Optional.of(8))).isEqualTo(8);
+        assertThat(calculateAvailablePhysicalProcessorCount(16, true, Optional.of(true), Optional::empty)).isEqualTo(16);
+    }
+
+    @Test
+    void testCalculateAvailablePhysicalProcessorCountInNonRootCgroup()
+    {
+        AtomicBoolean physicalProcessorCountRead = new AtomicBoolean();
+
+        assertThat(calculateAvailablePhysicalProcessorCount(16, false, Optional.of(true), () -> {
+            physicalProcessorCountRead.set(true);
+            return Optional.of(8);
+        })).isEqualTo(16);
+        assertThat(physicalProcessorCountRead).isFalse();
+    }
+
+    @Test
+    void testCalculateAvailablePhysicalProcessorCountWithSmtDisabled()
+    {
+        AtomicBoolean physicalProcessorCountRead = new AtomicBoolean();
+
+        assertThat(calculateAvailablePhysicalProcessorCount(16, true, Optional.of(false), () -> {
+            physicalProcessorCountRead.set(true);
+            return Optional.of(8);
+        })).isEqualTo(16);
+        assertThat(physicalProcessorCountRead).isFalse();
+    }
+
+    @Test
+    void testParseLinuxSmtActive()
+    {
+        assertThat(parseLinuxSmtActive("1")).isEqualTo(Optional.of(true));
+        assertThat(parseLinuxSmtActive("0\n")).isEqualTo(Optional.of(false));
+        assertThat(parseLinuxSmtActive("unknown")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testHasOnlyRootCgroups()
+    {
+        assertThat(hasOnlyRootCgroups(List.of("0::/"))).isTrue();
+        assertThat(hasOnlyRootCgroups(List.of("2:cpu,cpuacct:/", "1:name=systemd:/"))).isTrue();
+        assertThat(hasOnlyRootCgroups(List.of("0::/user.slice/user-1000.slice/session-1.scope"))).isFalse();
+        assertThat(hasOnlyRootCgroups(List.of("0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/cri-containerd-456.scope"))).isFalse();
+        assertThat(hasOnlyRootCgroups(List.of("1:name=systemd:/docker/0123456789abcdef"))).isFalse();
+        assertThat(hasOnlyRootCgroups(List.of("invalid"))).isFalse();
+        assertThat(hasOnlyRootCgroups(List.of())).isFalse();
+    }
+
     @Test
     void testParseLinuxPhysicalProcessorCount()
     {
@@ -45,7 +104,7 @@ final class TestMachineInfo
                 core id : 1
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxPhysicalProcessorCount(cpuInfoLines))
+        assertThat(parseLinuxPhysicalProcessorCount(cpuInfoLines))
                 .isEqualTo(Optional.of(2));
     }
 
@@ -61,7 +120,7 @@ final class TestMachineInfo
                 flags : avx512f avx512_vbmi2
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxPhysicalProcessorCount(cpuInfoLines))
+        assertThat(parseLinuxPhysicalProcessorCount(cpuInfoLines))
                 .isEqualTo(Optional.empty());
     }
 
@@ -77,7 +136,7 @@ final class TestMachineInfo
                 flags : avx512f asimd
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxCpuFlags(cpuInfoLines))
+        assertThat(parseLinuxCpuFlags(cpuInfoLines))
                 .isEqualTo(Set.of("avx512f", "neon"));
     }
 
@@ -90,7 +149,7 @@ final class TestMachineInfo
                 flags : avx512f asimd
                 """.lines().toList();
 
-        assertThat(MachineInfo.parseLinuxCpuFlags(cpuInfoLines))
+        assertThat(parseLinuxCpuFlags(cpuInfoLines))
                 .isEqualTo(Set.of("avx512f", "neon"));
     }
 }


### PR DESCRIPTION
## Description

On Linux systems with SMT, Trino can overestimate available CPU capacity because the JVM reports logical processors. This is especially visible in containers where the JVM count may already reflect CPU limits.

Avoid treating SMT threads as additional physical CPU capacity while preserving explicit `-XX:ActiveProcessorCount` settings.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix overestimating CPU capacity on Linux systems with SMT enabled. ({issue}`29348`)
```
