### PR TITLE
Correct LIKE documentation example to be case-sensitive

### DIFF
--- a/docs/src/main/sphinx/functions/comparison.md
+++ b/docs/src/main/sphinx/functions/comparison.md
@@ -230,7 +230,7 @@ for each character. The following query uses two underscores and produces only
 
 ```sql
 SELECT * FROM (VALUES 'America', 'Asia', 'Africa', 'Europe', 'Australia', 'Antarctica') AS t (continent)
-WHERE continent LIKE 'A__A';
+WHERE continent LIKE 'A__a';
 ```
 
 The wildcard characters `_` and `%` must be escaped to allow you to match


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Trino's LIKE is case-sensitive.
This means if I try the edited example ...

```
docker run --name trino -d -p 8080:8080 trinodb/trino
docker exec -it trino trino
trino> SELECT * FROM (
  VALUES 'America',
  'Asia',
  'Africa',
  'Europe',
  'Australia',
  'Antarctica'
) AS t (continent)
WHERE continent LIKE 'A__A';

 continent
-----------
(0 rows)
```

It produces zero results ...
whereas if I lowercase the last a ...

```
 continent
-----------
 Asia
(1 row)
```

We get a query that "produces only Asia as result".

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

[Trino's LIKE is case-sensitive](https://trino.io/docs/current/functions/comparison.html#pattern-comparison-like):
> Matching characters is case sensitive

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* N.A
```
