### PR TITLE
Skip redundant non_null mask when decorrelating aggregations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AggregationDecorrelation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AggregationDecorrelation.java
@@ -15,6 +15,9 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
@@ -26,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
 
 final class AggregationDecorrelation
 {
@@ -37,6 +41,63 @@ final class AggregationDecorrelation
                 aggregationNode.getAggregations().isEmpty() &&
                 aggregationNode.getGroupingSetCount() == 1 &&
                 aggregationNode.hasNonEmptyGroupingSet();
+    }
+
+    /**
+     * Returns true if every aggregation function "ignores null input values" or more
+     * precisely that result of Aggregation over relation {@code R′ = R ∪ N} is guaranteed
+     * to be the same as result of Aggregation over relation {@code R}, provided that each
+     * tuple of {@code N}:
+     * <ul>
+     *    <li>has the same grouping keys as one of the tuples of {@code R},
+     *    <li>has NULL value for each argument of the aggregation function.
+     * </ul>
+     */
+    public static boolean isNullRowInsensitiveAggregation(AggregationNode node)
+    {
+        for (Aggregation aggregation : node.getAggregations().values()) {
+            // TODO pre-existing (moved), but probably redundant check
+            if (aggregation.getFilter().isPresent() || aggregation.getMask().isPresent()) {
+                return false;
+            }
+            CatalogSchemaFunctionName name = aggregation.getResolvedFunction().name();
+            if (!isBuiltinFunctionName(name)) {
+                // Unrecognized
+                return false;
+            }
+            switch (name.functionName()) {
+                // TODO this should be determined from aggregation function metadata
+                case "min", "max", "sum", "avg", "bool_and", "bool_or" -> {
+                    if (!aggregation.getArguments().stream().allMatch(AggregationDecorrelation::isNullOnNullInput)) {
+                        return false;
+                    }
+                }
+                case "count" -> {
+                    if (aggregation.getArguments().isEmpty()) {
+                        // count(*)
+                        return false;
+                    }
+                    // count(a...)
+                    if (!aggregation.getArguments().stream().allMatch(AggregationDecorrelation::isNullOnNullInput)) {
+                        return false;
+                    }
+                }
+                default -> {
+                    // Unrecognized
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true when expression is guaranteed to return NULL when all references in the expression are NULL.
+     */
+    private static boolean isNullOnNullInput(Expression expression)
+    {
+        // TODO expand to more expression shapes
+        return expression instanceof Reference;
     }
 
     public static Map<Symbol, Aggregation> rewriteWithMasks(Map<Symbol, Aggregation> aggregations, Map<Symbol, Symbol> masks)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithProjection.java
@@ -18,10 +18,8 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Expression;
-import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.optimizations.PlanNodeDecorrelator;
@@ -45,16 +43,15 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.matching.Pattern.empty;
 import static io.trino.matching.Pattern.nonEmpty;
-import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.IrUtils.and;
 import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.isDistinctOperator;
+import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.isNullRowInsensitiveAggregation;
 import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.restoreDistinctAggregation;
 import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.rewriteWithMasks;
 import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
@@ -126,7 +123,6 @@ import static java.util.Objects.requireNonNull;
 public class TransformCorrelatedGlobalAggregationWithProjection
         implements Rule<CorrelatedJoinNode>
 {
-    private static final CatalogSchemaFunctionName BOOL_OR = builtinFunctionName("bool_or");
     private static final Capture<ProjectNode> PROJECTION = newCapture();
     private static final Capture<AggregationNode> AGGREGATION = newCapture();
     private static final Capture<PlanNode> SOURCE = newCapture();
@@ -184,10 +180,11 @@ public class TransformCorrelatedGlobalAggregationWithProjection
         Optional<Symbol> nonNull = Optional.empty();
 
         AggregationNode globalAggregation = captures.get(AGGREGATION);
-        // Null-insensitive aggregations don't distinguish empty input from null input, so they don't need a special mask true symbol
-        // to distinguish between these two cases after decorrelation. For example, count(*) needs a mask symbol because it returns 0
-        // for an empty set but 1 for a set with a single null row, but boolean_or returns null for both an empty set and a set with a single null row.
-        if (!isNullInsensitiveAggregation(globalAggregation)) {
+        // Some aggregations don't need a mask symbol. This is when result of aggregation function over empty input is the same as result of aggregating
+        // single row with all input arguments being null.
+        // For example, count(*) needs a mask as otherwise it would return 0 for an empty input before decorrelation and 1 after decorrelation.
+        // On the other hand, min, max, bool_or, and few others do not need a mask symbol.
+        if (!isNullRowInsensitiveAggregation(globalAggregation)) {
             nonNull = Optional.of(context.getSymbolAllocator().newSymbol("non_null", BOOLEAN));
             source = new ProjectNode(
                     context.getIdAllocator().getNextId(),
@@ -300,19 +297,5 @@ public class TransformCorrelatedGlobalAggregationWithProjection
                 context.getIdAllocator().getNextId(),
                 globalAggregation,
                 assignments));
-    }
-
-    private static boolean isNullInsensitiveAggregation(AggregationNode node)
-    {
-        if (node.getAggregations().size() != 1) {
-            return false;
-        }
-
-        Aggregation aggregation = getOnlyElement(node.getAggregations().values());
-        if (aggregation.getFilter().isPresent() || aggregation.getMask().isPresent()) {
-            return false;
-        }
-
-        return aggregation.getResolvedFunction().name().equals(BOOL_OR) && aggregation.getArguments().getFirst() instanceof Reference;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithoutProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithoutProjection.java
@@ -35,6 +35,7 @@ import io.trino.sql.planner.plan.Patterns;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
@@ -47,6 +48,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.IrUtils.and;
 import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.isDistinctOperator;
+import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.isNullRowInsensitiveAggregation;
 import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.restoreDistinctAggregation;
 import static io.trino.sql.planner.iterative.rule.AggregationDecorrelation.rewriteWithMasks;
 import static io.trino.sql.planner.iterative.rule.Util.restrictOutputs;
@@ -167,16 +169,23 @@ public class TransformCorrelatedGlobalAggregationWithoutProjection
         }
 
         source = decorrelatedSource.get().getNode();
+        AggregationNode globalAggregation = captures.get(AGGREGATION);
+        Optional<Symbol> nonNull = Optional.empty();
 
-        // append non-null symbol on nested plan. It will be used to restore semantics of null-sensitive aggregations after LEFT join
-        Symbol nonNull = context.getSymbolAllocator().newSymbol("non_null", BOOLEAN);
-        source = new ProjectNode(
-                context.getIdAllocator().getNextId(),
-                source,
-                Assignments.builder()
-                        .putIdentities(source.getOutputSymbols())
-                        .put(nonNull, TRUE)
-                        .build());
+        // Some aggregations don't need a mask symbol. This is when result of aggregation function over empty input is the same as result of aggregating
+        // single row with all input arguments being null.
+        // For example, count(*) needs a mask as otherwise it would return 0 for an empty input before decorrelation and 1 after decorrelation.
+        // On the other hand, min, max, bool_or, and few others do not need a mask symbol.
+        if (!isNullRowInsensitiveAggregation(globalAggregation)) {
+            nonNull = Optional.of(context.getSymbolAllocator().newSymbol("non_null", BOOLEAN));
+            source = new ProjectNode(
+                    context.getIdAllocator().getNextId(),
+                    source,
+                    Assignments.builder()
+                            .putIdentities(source.getOutputSymbols())
+                            .put(nonNull.get(), TRUE)
+                            .build());
+        }
 
         // assign unique id on correlated join's input. It will be used to distinguish between original input rows after join
         PlanNode inputWithUniqueId = new AssignUniqueId(
@@ -203,55 +212,54 @@ public class TransformCorrelatedGlobalAggregationWithoutProjection
 
         // restore distinct aggregation
         if (distinct != null) {
+            ImmutableList.Builder<Symbol> distinctSymbols = ImmutableList.<Symbol>builder()
+                    .addAll(join.getLeftOutputSymbols());
+            nonNull.ifPresent(distinctSymbols::add);
+            distinctSymbols.addAll(distinct.getGroupingKeys());
+
             root = restoreDistinctAggregation(
                     distinct,
                     join,
-                    ImmutableList.<Symbol>builder()
-                            .addAll(join.getLeftOutputSymbols())
-                            .add(nonNull)
-                            .addAll(distinct.getGroupingKeys())
-                            .build());
+                    distinctSymbols.build());
         }
 
-        // prepare mask symbols for aggregations
-        // Every original aggregation agg() will be rewritten to agg() mask(non_null). If the aggregation
-        // already has a mask, it will be replaced with conjunction of the existing mask and non_null.
-        // This is necessary to restore the original aggregation result in case when:
-        // - the nested lateral subquery returned empty result for some input row,
-        // - aggregation is null-sensitive, which means that its result over a single null row is different
-        //   than result for empty input (with global grouping)
-        // It applies to the following aggregate functions: count(*), checksum(), array_agg().
-        AggregationNode globalAggregation = captures.get(AGGREGATION);
-        ImmutableMap.Builder<Symbol, Symbol> masks = ImmutableMap.builder();
-        Assignments.Builder assignmentsBuilder = Assignments.builder();
-        for (Entry<Symbol, Aggregation> entry : globalAggregation.getAggregations().entrySet()) {
-            Aggregation aggregation = entry.getValue();
-            if (aggregation.getMask().isPresent()) {
-                Symbol newMask = context.getSymbolAllocator().newSymbol("mask", BOOLEAN);
-                Expression expression = and(aggregation.getMask().get().toSymbolReference(), nonNull.toSymbolReference());
-                assignmentsBuilder.put(newMask, expression);
-                masks.put(entry.getKey(), newMask);
+        Map<Symbol, Aggregation> aggregations = globalAggregation.getAggregations();
+        if (nonNull.isPresent()) {
+            // prepare mask symbols for aggregations
+            // Every original aggregation agg() will be rewritten to agg() mask(non_null). If the aggregation
+            // already has a mask, it will be replaced with conjunction of the existing mask and non_null.
+            ImmutableMap.Builder<Symbol, Symbol> masks = ImmutableMap.builder();
+            Assignments.Builder assignmentsBuilder = Assignments.builder();
+            for (Entry<Symbol, Aggregation> entry : globalAggregation.getAggregations().entrySet()) {
+                Aggregation aggregation = entry.getValue();
+                if (aggregation.getMask().isPresent()) {
+                    Symbol newMask = context.getSymbolAllocator().newSymbol("mask", BOOLEAN);
+                    Expression expression = and(aggregation.getMask().get().toSymbolReference(), nonNull.get().toSymbolReference());
+                    assignmentsBuilder.put(newMask, expression);
+                    masks.put(entry.getKey(), newMask);
+                }
+                else {
+                    masks.put(entry.getKey(), nonNull.get());
+                }
             }
-            else {
-                masks.put(entry.getKey(), nonNull);
+            Assignments maskAssignments = assignmentsBuilder.build();
+            if (!maskAssignments.isEmpty()) {
+                root = new ProjectNode(
+                        context.getIdAllocator().getNextId(),
+                        root,
+                        Assignments.builder()
+                                .putIdentities(root.getOutputSymbols())
+                                .putAll(maskAssignments)
+                                .build());
             }
-        }
-        Assignments maskAssignments = assignmentsBuilder.build();
-        if (!maskAssignments.isEmpty()) {
-            root = new ProjectNode(
-                    context.getIdAllocator().getNextId(),
-                    root,
-                    Assignments.builder()
-                            .putIdentities(root.getOutputSymbols())
-                            .putAll(maskAssignments)
-                            .build());
+            aggregations = rewriteWithMasks(globalAggregation.getAggregations(), masks.buildOrThrow());
         }
 
         // restore global aggregation
         globalAggregation = new AggregationNode(
                 globalAggregation.getId(),
                 root,
-                rewriteWithMasks(globalAggregation.getAggregations(), masks.buildOrThrow()),
+                aggregations,
                 singleGroupingSet(ImmutableList.<Symbol>builder()
                         .addAll(join.getLeftOutputSymbols())
                         .addAll(globalAggregation.getGroupingKeys())

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -1123,7 +1123,7 @@ public class TestLogicalPlanner
                                 singleGroupingSet("n_name", "n_regionkey", "unique"),
                                 ImmutableMap.of(Optional.of("max"), aggregationFunction("max", ImmutableList.of("r_name"))),
                                 ImmutableList.of("n_name", "n_regionkey", "unique"),
-                                ImmutableList.of("non_null"),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 SINGLE,
                                 node(JoinNode.class,
@@ -1132,9 +1132,7 @@ public class TestLogicalPlanner
                                                         REPARTITION,
                                                         tableScan("nation", ImmutableMap.of("n_name", "name", "n_regionkey", "regionkey")))),
                                         anyTree(
-                                                project(
-                                                        ImmutableMap.of("non_null", expression(TRUE)),
-                                                        tableScan("region", ImmutableMap.of("r_name", "name"))))))));
+                                                tableScan("region", ImmutableMap.of("r_name", "name")))))));
 
         // Don't use equi-clauses to trigger replicated join
         assertDistributedPlan(
@@ -1144,7 +1142,7 @@ public class TestLogicalPlanner
                                 singleGroupingSet("n_name", "n_regionkey", "unique"),
                                 ImmutableMap.of(Optional.of("max"), aggregationFunction("max", ImmutableList.of("r_name"))),
                                 ImmutableList.of("n_name", "n_regionkey", "unique"),
-                                ImmutableList.of("non_null"),
+                                ImmutableList.of(),
                                 Optional.empty(),
                                 SINGLE,
                                 node(JoinNode.class,
@@ -1152,9 +1150,7 @@ public class TestLogicalPlanner
                                                 "unique",
                                                 tableScan("nation", ImmutableMap.of("n_name", "name", "n_regionkey", "regionkey"))),
                                         anyTree(
-                                                project(
-                                                        ImmutableMap.of("non_null", expression(TRUE)),
-                                                        tableScan("region", ImmutableMap.of("r_name", "name"))))))));
+                                                tableScan("region", ImmutableMap.of("r_name", "name")))))));
     }
 
     @Test
@@ -1368,16 +1364,15 @@ public class TestLogicalPlanner
                                                                 singleGroupingSet("o_custkey"),
                                                                 ImmutableMap.of(Optional.of("count"), aggregationFunction("count", ImmutableList.of("o_orderkey"))),
                                                                 ImmutableList.of(),
-                                                                ImmutableList.of("non_null"),
+                                                                ImmutableList.of(),
                                                                 Optional.empty(),
                                                                 SINGLE,
-                                                                project(ImmutableMap.of("non_null", expression(TRUE)),
-                                                                        aggregation(
-                                                                                singleGroupingSet("o_orderkey", "o_custkey"),
-                                                                                ImmutableMap.of(),
-                                                                                Optional.empty(),
-                                                                                FINAL,
-                                                                                anyTree(tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey", "o_custkey", "custkey")))))))))
+                                                                aggregation(
+                                                                        singleGroupingSet("o_orderkey", "o_custkey"),
+                                                                        ImmutableMap.of(),
+                                                                        Optional.empty(),
+                                                                        FINAL,
+                                                                        anyTree(tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey", "o_custkey", "custkey"))))))))
                                         .right(anyTree(node(ValuesNode.class)))))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
@@ -153,8 +153,7 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
                                                 .left(assignUniqueId(
                                                         "unique",
                                                         values(ImmutableMap.of("corr", 0))))
-                                                .right(project(ImmutableMap.of("non_null", expression(TRUE)),
-                                                        values(ImmutableMap.of("a", 0, "b", 1))))))));
+                                                .right(values(ImmutableMap.of("a", 0, "b", 1)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithoutProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithoutProjection.java
@@ -136,8 +136,7 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                                 .left(assignUniqueId(
                                                         "unique",
                                                         values(ImmutableMap.of("corr", 0))))
-                                                .right(project(ImmutableMap.of("non_null", expression(TRUE)),
-                                                        values(ImmutableMap.of("a", 0, "b", 1))))))));
+                                                .right(values(ImmutableMap.of("a", 0, "b", 1)))))));
     }
 
     @Test
@@ -153,6 +152,55 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                         .addAggregation(p.symbol("sum"), PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(BIGINT, "a"))), ImmutableList.of(BIGINT))
                                         .globalGrouping()))))
                 .doesNotFire();
+    }
+
+    @Test
+    public void skipsMaskForNullInsensitiveMin()
+    {
+        // min({}) == min({NULL}) == NULL, so the synthetic non_null mask added to compensate for LEFT-join NULL rows
+        // is redundant. This is the TPC-H Q02 case.
+        tester().assertThat(new TransformCorrelatedGlobalAggregationWithoutProjection(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                .addAggregation(p.symbol("min"), PlanBuilder.aggregation("min", ImmutableList.of(new Reference(BIGINT, "a"))), ImmutableList.of(BIGINT))
+                                .globalGrouping())))
+                .matches(
+                        project(ImmutableMap.of("min_1", expression(new Reference(BIGINT, "min_1")), "corr", expression(new Reference(BIGINT, "corr"))),
+                                aggregation(ImmutableMap.of("min_1", aggregationFunction("min", ImmutableList.of("a"))),
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+
+    @Test
+    public void skipsMaskForMultipleNullInsensitiveAggregations()
+    {
+        // When all aggregations in the node are null-insensitive (e.g. min and max together), no synthetic mask is needed.
+        tester().assertThat(new TransformCorrelatedGlobalAggregationWithoutProjection(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                .addAggregation(p.symbol("min"), PlanBuilder.aggregation("min", ImmutableList.of(new Reference(BIGINT, "a"))), ImmutableList.of(BIGINT))
+                                .addAggregation(p.symbol("max"), PlanBuilder.aggregation("max", ImmutableList.of(new Reference(BIGINT, "b"))), ImmutableList.of(BIGINT))
+                                .globalGrouping())))
+                .matches(
+                        project(
+                                aggregation(
+                                        ImmutableMap.of(
+                                                "min_1", aggregationFunction("min", ImmutableList.of("a")),
+                                                "max_1", aggregationFunction("max", ImmutableList.of("b"))),
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(values(ImmutableMap.of("a", 0, "b", 1)))))));
     }
 
     @Test


### PR DESCRIPTION
When decorrelating a correlated subquery into a LEFT join, rules in TransformCorrelatedGlobalAggregation* synthesize a `non_null := TRUE` projection and apply it as a mask so null-sensitive aggregations like count(*) or array_agg can distinguish "no matching rows" from "one all-NULL row" injected by the LEFT join.

The gate guarding this only short-circuited for a single bool_or(reference). Every other aggregation, including two bool_or's or other null-rejecting ones like min/max/sum/avg/count(x) received a redundant mask. The without-projection variant lacked the gate entirely and always added the mask.

Move the predicate to AggregationDecorrelation as a shared helper, broaden it to recognize min, max, sum, avg, count (with at least one argument), bool_and, bool_or and require all aggregations in the node to qualify (so e.g. min(x), max(y) together is also covered). Apply the gate in both with- and without-projection rules.
