### PR TITLE
Add partition_projection_enforce_directory table property for prefix-based S3 listing

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -244,6 +244,13 @@ final class S3FileSystem
     }
 
     @Override
+    public FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        return listObjects(location, false, "", false);
+    }
+
+    @Override
     public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {
@@ -361,8 +368,14 @@ final class S3FileSystem
     private FileIterator listObjects(Location location, boolean includeDirectoryObjects, String startingFrom)
             throws IOException
     {
+        return listObjects(location, includeDirectoryObjects, startingFrom, true);
+    }
+
+    private FileIterator listObjects(Location location, boolean includeDirectoryObjects, String startingFrom, boolean enforceDirectory)
+            throws IOException
+    {
         S3Location s3Location = new S3Location(location);
-        String keyPrefix = directoryKey(s3Location.key());
+        String keyPrefix = enforceDirectory ? directoryKey(s3Location.key()) : s3Location.key();
         ListObjectsV2Request.Builder request = listObjectsRequest(s3Location, keyPrefix);
 
         try {

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -80,6 +80,12 @@ public abstract class AbstractTestS3FileSystem
     }
 
     @Override
+    protected boolean supportsPrefixListing()
+    {
+        return true;
+    }
+
+    @Override
     protected final TrinoFileSystem getFileSystem()
     {
         if (useServerSideEncryptionWithCustomerKey()) {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
@@ -231,6 +231,29 @@ public interface TrinoFileSystem
             throws IOException;
 
     /**
+     * Lists all files whose path starts with the specified location prefix. Unlike
+     * {@link #listFiles(Location)}, this method does not assume the location is a directory
+     * and does not append a trailing slash. The location is used as a raw prefix for matching.
+     * <p>
+     * This is useful for blob file systems where data is organized with non-directory key
+     * prefixes (e.g., partition projection with partial S3 prefixes like "foo-bar-" that
+     * match keys "foo-bar-baz/file.csv", "foo-bar-qux/file.csv", etc.).
+     * <p>
+     * For hierarchical file systems, this method falls back to directory listing behavior
+     * by appending a slash and delegating to {@link #listFiles(Location)}.
+     * <p>
+     * The returned FileEntry locations will start with the specified location exactly.
+     *
+     * @param location the prefix to match against file paths
+     * @throws IllegalArgumentException if location is not valid for this file system
+     */
+    default FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        return listFiles(location);
+    }
+
+    /**
      * Lists files within the specified directory recursively, including only files where the
      * remainder of the path after the location is lexicographically greater than or equal to
      * {@code startingFrom}. The location can be empty, listing all files in the file system where

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
@@ -141,6 +141,13 @@ public final class CacheFileSystem
     }
 
     @Override
+    public FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        return delegate.listFilesByPrefix(location);
+    }
+
+    @Override
     public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionEnforcingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionEnforcingFileSystem.java
@@ -133,6 +133,13 @@ public class EncryptionEnforcingFileSystem
     }
 
     @Override
+    public FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        return delegate.listFilesByPrefix(location);
+    }
+
+    @Override
     public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/switching/SwitchingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/switching/SwitchingFileSystem.java
@@ -117,6 +117,13 @@ final class SwitchingFileSystem
     }
 
     @Override
+    public FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        return fileSystem(location).listFilesByPrefix(location);
+    }
+
+    @Override
     public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
@@ -120,6 +120,16 @@ final class TracingFileSystem
     }
 
     @Override
+    public FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.listFilesByPrefix")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location.toString())
+                .startSpan();
+        return withTracing(span, () -> delegate.listFilesByPrefix(location));
+    }
+
+    @Override
     public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracking/TrackingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracking/TrackingFileSystem.java
@@ -96,6 +96,13 @@ public class TrackingFileSystem
     }
 
     @Override
+    public FileIterator listFilesByPrefix(Location location)
+            throws IOException
+    {
+        return delegate.listFilesByPrefix(location);
+    }
+
+    @Override
     public FileIterator listFilesStartingFrom(Location location, String startingFrom)
             throws IOException
     {

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -138,6 +138,11 @@ public abstract class AbstractTestTrinoFileSystem
         return true;
     }
 
+    protected boolean supportsPrefixListing()
+    {
+        return false;
+    }
+
     protected Location createLocation(String path)
     {
         if (path.isEmpty()) {
@@ -1336,6 +1341,48 @@ public abstract class AbstractTestTrinoFileSystem
     }
 
     @Test
+    public void testListFilesByPrefix()
+            throws IOException
+    {
+        try (Closer closer = Closer.create()) {
+            createBlob(closer, "data/bfc-adx-rtb-i-aaa/file1.csv");
+            createBlob(closer, "data/bfc-adx-rtb-i-bbb/file2.csv");
+            createBlob(closer, "data/bfc-nyc-rtb-i-ccc/file3.csv");
+            createBlob(closer, "data/other/file4.csv");
+
+            // directory-style prefix (trailing slash) works on all file system types
+            assertThat(listByPrefix("data/bfc-adx-rtb-i-aaa/")).containsExactly(
+                    createLocation("data/bfc-adx-rtb-i-aaa/file1.csv"));
+
+            assertThat(listByPrefix("data/other/")).containsExactly(
+                    createLocation("data/other/file4.csv"));
+
+            // equivalence with listFiles for slash-ending paths
+            assertThat(listByPrefix("data/")).containsExactlyInAnyOrderElementsOf(listPath("data/"));
+
+            // partial prefix (no trailing slash)
+            if (supportsPrefixListing()) {
+                assertThat(listByPrefix("data/bfc-adx-")).containsExactlyInAnyOrder(
+                        createLocation("data/bfc-adx-rtb-i-aaa/file1.csv"),
+                        createLocation("data/bfc-adx-rtb-i-bbb/file2.csv"));
+
+                assertThat(listByPrefix("data/bfc-nyc-")).containsExactly(
+                        createLocation("data/bfc-nyc-rtb-i-ccc/file3.csv"));
+
+                // non-matching prefix
+                assertThat(listByPrefix("data/xyz-")).isEmpty();
+            }
+            else {
+                // default fallback appends '/' so partial prefixes return empty
+                assertThat(listByPrefix("data/bfc-adx-")).isEmpty();
+            }
+
+            // empty prefix lists all files, same as listFiles with empty path
+            assertThat(listByPrefix("")).containsExactlyInAnyOrderElementsOf(listPath(""));
+        }
+    }
+
+    @Test
     public void testDirectoryExists()
             throws IOException
     {
@@ -1607,6 +1654,17 @@ public abstract class AbstractTestTrinoFileSystem
             Location location = fileEntry.location();
             assertThat(fileEntry.length()).isEqualTo(TEST_BLOB_CONTENT_PREFIX.length() + location.toString().length());
             locations.add(location);
+        }
+        return locations;
+    }
+
+    private List<Location> listByPrefix(String path)
+            throws IOException
+    {
+        List<Location> locations = new ArrayList<>();
+        FileIterator fileIterator = getFileSystem().listFilesByPrefix(createLocation(path));
+        while (fileIterator.hasNext()) {
+            locations.add(fileIterator.next().location());
         }
         return locations;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -89,6 +89,7 @@ import static io.trino.plugin.hive.HiveStorageFormat.getHiveStorageFormat;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.getProtectMode;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.makePartitionName;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.verifyOnline;
+import static io.trino.plugin.hive.projection.PartitionProjectionProperties.shouldEnforceDirectory;
 import static io.trino.plugin.hive.util.HiveCoercionPolicy.canCoerce;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -273,7 +274,7 @@ public class HiveSplitManager
                 transactionalMetadata.getDirectoryLister(),
                 executor,
                 splitLoaderConcurrency,
-                recursiveDfsWalkerEnabled,
+                recursiveDfsWalkerEnabled || !shouldEnforceDirectory(table.getParameters()),
                 !hiveTable.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session),
                 metastore.getValidWriteIds(session, hiveTable)
                         .map(value -> value.getTableValidWriteIdList(table.getDatabaseName() + "." + table.getTableName())),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.PARTITION_PROJECTION_ENABLED;
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.PARTITION_PROJECTION_IGNORE;
+import static io.trino.plugin.hive.projection.PartitionProjectionProperties.PARTITION_PROJECTION_LOCATION_ENFORCE_DIRECTORY;
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.PARTITION_PROJECTION_LOCATION_TEMPLATE;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V2;
@@ -189,6 +190,11 @@ public class HiveTableProperties
                 stringProperty(
                         PARTITION_PROJECTION_LOCATION_TEMPLATE,
                         "Partition projection location template",
+                        null,
+                        false),
+                booleanProperty(
+                        PARTITION_PROJECTION_LOCATION_ENFORCE_DIRECTORY,
+                        "Require the location to have a trailing slash",
                         null,
                         false),
                 new PropertyMetadata<>(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -45,6 +45,7 @@ import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
+import static io.trino.plugin.hive.projection.PartitionProjectionProperties.shouldEnforceDirectory;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
@@ -119,14 +120,20 @@ public class CachingDirectoryLister
     public RemoteIterator<TrinoFileStatus> listFilesRecursively(TrinoFileSystem fs, Table table, Location location)
             throws IOException
     {
+        boolean shouldEnforceDirectory = shouldEnforceDirectory(table.getParameters());
         if (!isCacheEnabledFor(table.getSchemaTableName())) {
-            return new TrinoFileStatusRemoteIterator(fs.listFiles(location), filterPredicate);
+            if (shouldEnforceDirectory) {
+                return new TrinoFileStatusRemoteIterator(fs.listFiles(location), filterPredicate);
+            }
+            else {
+                return new TrinoFileStatusRemoteIterator(fs.listFilesByPrefix(location), filterPredicate);
+            }
         }
 
-        return listInternal(fs, location, table.getSchemaTableName());
+        return listInternal(fs, location, table.getSchemaTableName(), shouldEnforceDirectory);
     }
 
-    private RemoteIterator<TrinoFileStatus> listInternal(TrinoFileSystem fs, Location location, SchemaTableName schemaTableName)
+    private RemoteIterator<TrinoFileStatus> listInternal(TrinoFileSystem fs, Location location, SchemaTableName schemaTableName, boolean shouldEnforceDirectory)
             throws IOException
     {
         CacheKey cacheKey = new CacheKey(location, schemaTableName);
@@ -135,13 +142,18 @@ public class CachingDirectoryLister
             return new SimpleRemoteIterator(cachedValueHolder.getFiles().get().iterator());
         }
 
-        return cachingRemoteIterator(cachedValueHolder, createListingRemoteIterator(fs, location, filterPredicate), cacheKey);
+        return cachingRemoteIterator(cachedValueHolder, createListingRemoteIterator(fs, location, filterPredicate, shouldEnforceDirectory), cacheKey);
     }
 
-    private static RemoteIterator<TrinoFileStatus> createListingRemoteIterator(TrinoFileSystem fs, Location location, Predicate<FileEntry> filterPredicate)
+    private static RemoteIterator<TrinoFileStatus> createListingRemoteIterator(TrinoFileSystem fs, Location location, Predicate<FileEntry> filterPredicate, boolean shouldEnforceDirectory)
             throws IOException
     {
-        return new TrinoFileStatusRemoteIterator(fs.listFiles(location), filterPredicate);
+        if (shouldEnforceDirectory) {
+            return new TrinoFileStatusRemoteIterator(fs.listFiles(location), filterPredicate);
+        }
+        else {
+            return new TrinoFileStatusRemoteIterator(fs.listFilesByPrefix(location), filterPredicate);
+        }
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjectionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjectionProperties.java
@@ -52,6 +52,7 @@ public final class PartitionProjectionProperties
     private static final String METASTORE_PROPERTY_PROJECTION_INTERVAL_UNIT_SUFFIX = "interval.unit";
     private static final String METASTORE_PROPERTY_PROJECTION_ENABLED = "projection.enabled";
     private static final String METASTORE_PROPERTY_PROJECTION_LOCATION_TEMPLATE = "storage.location.template";
+    private static final String METASTORE_PROPERTY_PROJECTION_LOCATION_ENFORCE_DIRECTORY = "storage.location.enforce_directory";
     private static final String METASTORE_PROPERTY_PROJECTION_IGNORE = "trino.partition_projection.ignore";
     private static final String PROPERTY_KEY_PREFIX = "partition_projection_";
 
@@ -64,9 +65,19 @@ public final class PartitionProjectionProperties
     public static final String COLUMN_PROJECTION_TYPE = PROPERTY_KEY_PREFIX + COLUMN_PROJECTION_TYPE_SUFFIX;
     public static final String PARTITION_PROJECTION_IGNORE = PROPERTY_KEY_PREFIX + "ignore";
     public static final String PARTITION_PROJECTION_LOCATION_TEMPLATE = PROPERTY_KEY_PREFIX + "location_template";
+    public static final String PARTITION_PROJECTION_LOCATION_ENFORCE_DIRECTORY = PROPERTY_KEY_PREFIX + "enforce_directory";
     public static final String PARTITION_PROJECTION_ENABLED = PROPERTY_KEY_PREFIX + "enabled";
 
     private PartitionProjectionProperties() {}
+
+    public static boolean shouldEnforceDirectory(Map<String, String> tableParameters)
+    {
+        String enforceDirectory = tableParameters.get(METASTORE_PROPERTY_PROJECTION_LOCATION_ENFORCE_DIRECTORY);
+        if (enforceDirectory == null) {
+            return true;
+        }
+        return Boolean.parseBoolean(enforceDirectory);
+    }
 
     public static Map<String, Object> getPartitionProjectionTrinoTableProperties(Table table)
     {
@@ -86,6 +97,11 @@ public final class PartitionProjectionProperties
         String locationTemplate = metastoreTableProperties.get(METASTORE_PROPERTY_PROJECTION_LOCATION_TEMPLATE);
         if (locationTemplate != null) {
             trinoTablePropertiesBuilder.put(PARTITION_PROJECTION_LOCATION_TEMPLATE, locationTemplate);
+        }
+
+        String enforceDirectory = metastoreTableProperties.get(METASTORE_PROPERTY_PROJECTION_LOCATION_ENFORCE_DIRECTORY);
+        if (enforceDirectory != null) {
+            trinoTablePropertiesBuilder.put(PARTITION_PROJECTION_LOCATION_ENFORCE_DIRECTORY, Boolean.valueOf(enforceDirectory));
         }
 
         return trinoTablePropertiesBuilder.buildOrThrow();
@@ -116,6 +132,11 @@ public final class PartitionProjectionProperties
         Object locationTemplate = trinoTableProperties.get(PARTITION_PROJECTION_LOCATION_TEMPLATE);
         if (locationTemplate != null) {
             metastoreTablePropertiesBuilder.put(METASTORE_PROPERTY_PROJECTION_LOCATION_TEMPLATE, locationTemplate.toString());
+        }
+
+        Object enforceDirectory = trinoTableProperties.get(PARTITION_PROJECTION_LOCATION_ENFORCE_DIRECTORY);
+        if (enforceDirectory != null) {
+            metastoreTablePropertiesBuilder.put(METASTORE_PROPERTY_PROJECTION_LOCATION_ENFORCE_DIRECTORY, enforceDirectory.toString().toLowerCase(ROOT));
         }
 
         // Handle Column Properties

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -1178,6 +1178,80 @@ abstract class BaseTestHiveOnDataLake
     }
 
     @Test
+    void testPartitionProjectionWithEnforceDirectoryDisabled()
+    {
+        String tableName = "partition_projection_enforce_directory_disabled_" + randomNameSuffix();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+        String tablePath = format("%s/%s", HIVE_TEST_SCHEMA, tableName);
+
+        computeActual(
+                "CREATE TABLE " + fullyQualifiedTestTableName + " ( " +
+                        "  name varchar(25), " +
+                        "  comment varchar(152), " +
+                        "  dt DATE WITH (" +
+                        "    partition_projection_type='date', " +
+                        "    partition_projection_format='yyyy/MM/dd', " +
+                        "    partition_projection_range=ARRAY['2025/01/01', '2025/12/31'], " +
+                        "    partition_projection_interval=1, " +
+                        "    partition_projection_interval_unit='DAYS'" +
+                        "  ), " +
+                        "  line_type varchar(25) WITH (partition_projection_type='injected'), " +
+                        "  line_exchange varchar(25) WITH (partition_projection_type='injected') " +
+                        ") WITH ( " +
+                        "  partitioned_by=ARRAY['dt', 'line_type', 'line_exchange'], " +
+                        "  partition_projection_enabled=true, " +
+                        "  partition_projection_location_template='s3://" + bucketName + "/" + tablePath + "/${dt}/${line_type}-${line_exchange}-', " +
+                        "  partition_projection_enforce_directory=false, " +
+                        "  format='TEXTFILE')");
+
+        assertThat(
+                hiveMinioDataLake
+                        .runOnHive("SHOW TBLPROPERTIES " + getHiveTestTableName(tableName)))
+                .containsPattern("[ |]+projection\\.enabled[ |]+true[ |]+")
+                .containsPattern("[ |]+storage\\.location\\.template[ |]+.*\\$\\{dt\\}/\\$\\{line_type\\}-\\$\\{line_exchange\\}-[ |]+")
+                .containsPattern("[ |]+storage\\.location\\.enforce_directory[ |]+false[ |]+");
+
+        // Upload data with partial-prefix directory structure:
+        //   .../2025/01/15/bfc-adx-rtb-i-aaa/data.txt  (matches bfc + adx)
+        //   .../2025/01/15/bfc-adx-rtb-i-bbb/data.txt  (matches bfc + adx)
+        //   .../2025/01/15/bfc-apn-rtb-i-ccc/data.txt  (matches bfc + apn)
+        //   .../2025/01/15/bid-adx-rtb-i-ddd/data.txt  (matches bid + adx)
+        byte[] bfcAdxRow1 = "BFC_ADX_1\u0001row1".getBytes(UTF_8);
+        byte[] bfcAdxRow2 = "BFC_ADX_2\u0001row2".getBytes(UTF_8);
+        byte[] bfcApnRow = "BFC_APN_1\u0001row3".getBytes(UTF_8);
+        byte[] bidAdxRow = "BID_ADX_1\u0001row4".getBytes(UTF_8);
+
+        String basePath = tablePath + "/2025/01/15";
+        hiveMinioDataLake.getMinioClient().putObject(bucketName, bfcAdxRow1, basePath + "/bfc-adx-rtb-i-aaa/data.txt");
+        hiveMinioDataLake.getMinioClient().putObject(bucketName, bfcAdxRow2, basePath + "/bfc-adx-rtb-i-bbb/data.txt");
+        hiveMinioDataLake.getMinioClient().putObject(bucketName, bfcApnRow, basePath + "/bfc-apn-rtb-i-ccc/data.txt");
+        hiveMinioDataLake.getMinioClient().putObject(bucketName, bidAdxRow, basePath + "/bid-adx-rtb-i-ddd/data.txt");
+
+        // Prefix "bfc-adx-" should match bfc-adx-rtb-i-aaa and bfc-adx-rtb-i-bbb
+        assertQuery(
+                format("SELECT name FROM %s WHERE dt = DATE '2025-01-15' AND line_type = 'bfc' AND line_exchange = 'adx'", fullyQualifiedTestTableName),
+                "VALUES 'BFC_ADX_1', 'BFC_ADX_2'");
+
+        // Prefix "bfc-apn-" should match only bfc-apn-rtb-i-ccc
+        assertQuery(
+                format("SELECT name FROM %s WHERE dt = DATE '2025-01-15' AND line_type = 'bfc' AND line_exchange = 'apn'", fullyQualifiedTestTableName),
+                "VALUES 'BFC_APN_1'");
+
+        // Prefix "bid-adx-" should match only bid-adx-rtb-i-ddd
+        assertQuery(
+                format("SELECT name FROM %s WHERE dt = DATE '2025-01-15' AND line_type = 'bid' AND line_exchange = 'adx'", fullyQualifiedTestTableName),
+                "VALUES 'BID_ADX_1'");
+
+        // Non-matching prefix should return empty
+        assertQueryReturnsEmptyResult(
+                format("SELECT name FROM %s WHERE dt = DATE '2025-01-15' AND line_type = 'api' AND line_exchange = 'foo'", fullyQualifiedTestTableName));
+
+        // SHOW CREATE TABLE should round-trip the enforce_directory property
+        String showCreate = (String) computeScalar("SHOW CREATE TABLE " + fullyQualifiedTestTableName);
+        assertThat(showCreate).contains("partition_projection_enforce_directory = false");
+    }
+
+    @Test
     void testWriteNotSupportedWithCustomProjection()
     {
         String tableName = "partition_write_not_support_custom_" + randomNameSuffix();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
This is an attempt to add the feature request I opened here https://github.com/trinodb/trino/issues/29349
## Description

Add a new boolean table property `partition_projection_enforce_directory` that enables
partition projection with partial S3 key prefixes instead of directory-based listing.

When set to `false`, Trino uses the partition projection location template as a raw S3 prefix (e.g., `s3://bucket/logs/2026/05/01/bfc-adx-`) instead of treating it as a directory and appending a trailing slash. This allows querying data organized in non-Hive-style paths where the partition values don't correspond to full directory names. The default preserves existing behavior.

## Motivation

Our data is stored in paths like:

```
s3://bucket/logs/YYYY/MM/DD/<type>-<exchange>-<instance_id>-<region>/file.csv.zst
```

We want to query by `type` and `exchange` using partition projection, without enumerating all 18,000+ per-instance prefixes. If we use a location template like 
```
s3://bucket/logs/${date}/${line_type}-${line_exchange}-
``` 
S3's native prefix matching finds all files whose keys start with `bfc-adx-`, matching subdirectories like:
 - `bfc-adx-rtb-i-aaa111-us-west-2/`
 -  `bfc-adx-rtb-i-bbb222-us-east-1/`
 -  etc

This is not possible today because `S3FileSystem.listObjects()` always appends `/` to the prefix via `directoryKey()`. This transforms `bfc-adx-` into `bfc-adx-/` and matches nothing in S3.

## Changes

### How it works
A new `listFilesByPrefix` method was added to the `TrinoFileSystem` interface (with a default that falls back to `listFiles`), and overridden in `S3FileSystem` and the wrapper filesystems in the call chain (`TracingFileSystem`, `SwitchingFileSystem`, `CacheFileSystem`) to ensure correct delegation.

I added a new boolean table property `partition_projection_enforce_directory` that is stored in the Hive metastore as `storage.location.enforce_directory`. When a table has this set to `false`, `CachingDirectoryLister.listFilesRecursively()` calls `fs.listFilesByPrefix(location)` instead of `fs.listFiles(location)`. The prefix variant skips the trailing-slash normalization that S3 listing normally applies, so the location template is used as a raw S3 key prefix.

I also added a bit of a hack to `HiveSplitManager` to override `recursiveDirWalkerEnabled` when `enforce_directory` is set to false. Without this, `HiveFileIterator.FileStatusIterator` wraps the listing results in `DirectoryListingFilter`, which only keeps files that are direct children of the location (i.e., `parent(filePath) == location`). With prefix-based listing, files are in subdirectories relative to the prefix (e.g., `bfc-adx-rtb-i-aaa/data.txt` under prefix `bfc-adx-`), so `DirectoryListingFilter` silently drops everything — resulting in 0 rows. Setting `recursiveDirWalkerEnabled` bypasses this filter.  I am unsure if that is the correct path forward. Another possibility I thought of is to allow setting `recursiveDirWalkerEnabled` at the Hive table level but I wanted to get this PR up with minimal changes to start a discussion.

### Integration test

**File:** `plugin/trino-hive/.../BaseTestHiveOnDataLake.java`

New test `testPartitionProjectionWithEnforceDirectoryDisabled`:
- Creates a table with `partition_projection_enforce_directory=false` and a location
  template ending with `${line_type}-${line_exchange}-`
- Uploads data to MinIO with partial-prefix directory structure
- Asserts correct prefix matching across multiple partition value combinations
- Asserts empty results for non-matching prefixes
- Verifies Hive metastore properties round-trip correctly
- Verifies `SHOW CREATE TABLE` round-trips `partition_projection_enforce_directory = false`

## Example DDL

```sql
CREATE TABLE hive.scratch.log_lines (
    "timestamp" VARCHAR,
    cookie_id VARCHAR,
    url VARCHAR,
    "date" DATE WITH (
        partition_projection_type = 'DATE',
        partition_projection_range = ARRAY['2026/05/01', 'NOW'],
        partition_projection_format = 'yyyy/MM/dd',
        partition_projection_interval = 1,
        partition_projection_interval_unit = 'DAYS'
    ),
    line_type VARCHAR WITH (partition_projection_type = 'INJECTED'),
    line_exchange VARCHAR WITH (partition_projection_type = 'INJECTED')
)
WITH (
    format = 'CSV',
    external_location = 's3://bucket/logs/',
    partition_projection_enabled = true,
    partition_projection_location_template = 's3://bucket/logs/${date}/${line_type}-${line_exchange}-',
    partition_projection_enforce_directory = false,
    partitioned_by = ARRAY['date', 'line_type', 'line_exchange']
);
```

## Backward compatibility

- Default behavior is unchanged: `enforce_directory` defaults to `true` when not set
- No existing tests are modified
- The `listFilesByPrefix` default implementation falls back to `listFiles`, so  non-S3 filesystems work without changes




<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
