### PR TITLE
Add cast operators from char to numeric, boolean, varbinary, temporal types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -187,6 +187,7 @@ import io.trino.operator.scalar.time.TimeOperators;
 import io.trino.operator.scalar.time.TimeToTimeWithTimeZoneCast;
 import io.trino.operator.scalar.time.TimeToTimestampCast;
 import io.trino.operator.scalar.time.TimeToTimestampWithTimeZoneCast;
+import io.trino.operator.scalar.timestamp.CharToTimestampCast;
 import io.trino.operator.scalar.timestamp.DateAdd;
 import io.trino.operator.scalar.timestamp.DateDiff;
 import io.trino.operator.scalar.timestamp.DateFormat;
@@ -224,6 +225,7 @@ import io.trino.operator.scalar.timestamp.VarcharToTimestampCast;
 import io.trino.operator.scalar.timestamp.WithTimeZone;
 import io.trino.operator.scalar.timestamptz.AtTimeZone;
 import io.trino.operator.scalar.timestamptz.AtTimeZoneWithOffset;
+import io.trino.operator.scalar.timestamptz.CharToTimestampWithTimeZoneCast;
 import io.trino.operator.scalar.timestamptz.CurrentTimestamp;
 import io.trino.operator.scalar.timestamptz.DateToTimestampWithTimeZoneCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneOperators;
@@ -664,6 +666,7 @@ public final class SystemFunctionBundle
                 .scalar(TimeWithTimeZoneToTimestampCast.class)
                 .scalar(TimestampWithTimeZoneToTimestampCast.class)
                 .scalar(VarcharToTimestampCast.class)
+                .scalar(CharToTimestampCast.class)
                 .scalar(LocalTimestamp.class)
                 .scalar(DateTrunc.class)
                 .scalar(HumanReadableSeconds.class)
@@ -732,7 +735,8 @@ public final class SystemFunctionBundle
                 .scalar(TimestampWithTimeZoneToVarcharCast.class)
                 .scalar(TimeToTimestampWithTimeZoneCast.class)
                 .scalar(TimeWithTimeZoneToTimestampWithTimeZoneCast.class)
-                .scalar(VarcharToTimestampWithTimeZoneCast.class);
+                .scalar(VarcharToTimestampWithTimeZoneCast.class)
+                .scalar(CharToTimestampWithTimeZoneCast.class);
 
         // time without time zone functions and operators
         builder.scalar(LocalTimeFunction.class)

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -260,6 +260,7 @@ import io.trino.sql.DynamicFilters;
 import io.trino.type.BigintOperators;
 import io.trino.type.BlockTypeOperators;
 import io.trino.type.BooleanOperators;
+import io.trino.type.CharOperators;
 import io.trino.type.DateOperators;
 import io.trino.type.DateTimeOperators;
 import io.trino.type.DecimalOperators;
@@ -497,6 +498,7 @@ public final class SystemFunctionBundle
                 .scalars(DoubleOperators.class)
                 .scalars(RealOperators.class)
                 .scalars(NumberOperators.class)
+                .scalars(CharOperators.class)
                 .scalars(VarcharOperators.class)
                 .scalars(DateOperators.class)
                 .scalars(IntervalDayTimeOperators.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/CharToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/CharToTimestampCast.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamp;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestamp;
+
+import static io.trino.operator.scalar.StringFunctions.trim;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.function.OperatorType.CAST;
+
+@ScalarOperator(CAST)
+public final class CharToTimestampCast
+{
+    private CharToTimestampCast() {}
+
+    @LiteralParameters({"x", "p"})
+    @SqlType("timestamp(p)")
+    public static long castToShort(@LiteralParameter("p") long precision, @SqlType("char(x)") Slice value)
+    {
+        try {
+            return VarcharToTimestampCast.castToShortTimestamp((int) precision, trim(value).toStringUtf8());
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+    }
+
+    @LiteralParameters({"x", "p"})
+    @SqlType("timestamp(p)")
+    public static LongTimestamp castToLong(@LiteralParameter("p") long precision, @SqlType("char(x)") Slice value)
+    {
+        try {
+            return VarcharToTimestampCast.castToLongTimestamp((int) precision, trim(value).toStringUtf8());
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/CharToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/CharToTimestampWithTimeZoneCast.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamptz;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+
+import java.time.ZoneId;
+
+import static io.trino.operator.scalar.StringFunctions.trim;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.function.OperatorType.CAST;
+
+@ScalarOperator(CAST)
+public final class CharToTimestampWithTimeZoneCast
+{
+    private CharToTimestampWithTimeZoneCast() {}
+
+    @LiteralParameters({"x", "p"})
+    @SqlType("timestamp(p) with time zone")
+    public static long castToShort(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("char(x)") Slice value)
+    {
+        try {
+            return VarcharToTimestampWithTimeZoneCast.toShort((int) precision, trim(value).toStringUtf8(), timezone -> {
+                if (timezone == null) {
+                    return session.getTimeZoneKey().getZoneId();
+                }
+                return ZoneId.of(timezone);
+            });
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+    }
+
+    @LiteralParameters({"x", "p"})
+    @SqlType("timestamp(p) with time zone")
+    public static LongTimestampWithTimeZone castToLong(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("char(x)") Slice value)
+    {
+        try {
+            return VarcharToTimestampWithTimeZoneCast.toLong((int) precision, trim(value).toStringUtf8(), timezone -> {
+                if (timezone == null) {
+                    return session.getTimeZoneKey().getZoneId();
+                }
+                return ZoneId.of(timezone);
+            });
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/type/CharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/CharOperators.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+import java.math.BigDecimal;
+
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.type.Reals.toReal;
+import static java.lang.String.format;
+
+public final class CharOperators
+{
+    private CharOperators() {}
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean castToBoolean(@SqlType("char(x)") Slice value)
+    {
+        return VarcharOperators.castToBoolean(value);
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double castToDouble(@SqlType("char(x)") Slice slice)
+    {
+        try {
+            return Double.parseDouble(slice.toStringUtf8().trim());
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to DOUBLE", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.REAL)
+    public static long castToFloat(@SqlType("char(x)") Slice slice)
+    {
+        try {
+            return toReal(Float.parseFloat(slice.toStringUtf8().trim()));
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to REAL", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.BIGINT)
+    public static long castToBigint(@SqlType("char(x)") Slice slice)
+    {
+        try {
+            return Long.parseLong(slice.toStringUtf8().trim());
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.INTEGER)
+    public static long castToInteger(@SqlType("char(x)") Slice slice)
+    {
+        try {
+            return Integer.parseInt(slice.toStringUtf8().trim());
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.SMALLINT)
+    public static long castToSmallint(@SqlType("char(x)") Slice slice)
+    {
+        try {
+            return Short.parseShort(slice.toStringUtf8().trim());
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.TINYINT)
+    public static long castToTinyint(@SqlType("char(x)") Slice slice)
+    {
+        try {
+            return Byte.parseByte(slice.toStringUtf8().trim());
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber castToNumber(@SqlType("char(x)") Slice slice)
+    {
+        String value = slice.toStringUtf8();
+        try {
+            return TrinoNumber.from(switch (value.trim()) {
+                case "NaN" -> new TrinoNumber.NotANumber();
+                case "+Infinity", "Infinity" -> new TrinoNumber.Infinity(false);
+                case "-Infinity" -> new TrinoNumber.Infinity(true);
+                case String trimmed -> new TrinoNumber.BigDecimalValue(new BigDecimal(trimmed));
+            });
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to NUMBER", value), e);
+        }
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice castToBinary(@SqlType("char(x)") Slice slice)
+    {
+        return slice;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/type/DateOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateOperators.java
@@ -66,4 +66,17 @@ public final class DateOperators
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);
         }
     }
+
+    @ScalarOperator(CAST)
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.DATE)
+    public static long castFromChar(@SqlType("char(x)") Slice value)
+    {
+        try {
+            return parseDate(trim(value).toStringUtf8());
+        }
+        catch (IllegalArgumentException | ArithmeticException | DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);
+        }
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -1767,6 +1767,224 @@ public class TestTimestamp
     }
 
     @Test
+    public void testCastFromChar()
+    {
+        // round down
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '2020-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '2020-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '2020-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '2020-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '2020-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '2020-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '2020-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '2020-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '2020-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '2020-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '2020-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '2020-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '2020-05-01 12:34:56.111111111111'");
+
+        // round up
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(0))")).matches("TIMESTAMP '2020-05-01 12:34:57'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(1))")).matches("TIMESTAMP '2020-05-01 12:34:56.6'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(2))")).matches("TIMESTAMP '2020-05-01 12:34:56.56'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(3))")).matches("TIMESTAMP '2020-05-01 12:34:56.556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(4))")).matches("TIMESTAMP '2020-05-01 12:34:56.5556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(5))")).matches("TIMESTAMP '2020-05-01 12:34:56.55556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(6))")).matches("TIMESTAMP '2020-05-01 12:34:56.555556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(7))")).matches("TIMESTAMP '2020-05-01 12:34:56.5555556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(8))")).matches("TIMESTAMP '2020-05-01 12:34:56.55555556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(9))")).matches("TIMESTAMP '2020-05-01 12:34:56.555555556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(10))")).matches("TIMESTAMP '2020-05-01 12:34:56.5555555556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(11))")).matches("TIMESTAMP '2020-05-01 12:34:56.55555555556'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(12))")).matches("TIMESTAMP '2020-05-01 12:34:56.555555555555'");
+
+        // negative epoch, round down
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '2020-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '2020-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '2020-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '2020-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '2020-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '2020-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '2020-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '2020-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '2020-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '2020-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '2020-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '2020-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '2020-05-01 12:34:56.111111111111'");
+
+        // negative epoch, round up
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(0))")).matches("TIMESTAMP '1500-05-01 12:34:57'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(1))")).matches("TIMESTAMP '1500-05-01 12:34:56.6'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(2))")).matches("TIMESTAMP '1500-05-01 12:34:56.56'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(3))")).matches("TIMESTAMP '1500-05-01 12:34:56.556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(4))")).matches("TIMESTAMP '1500-05-01 12:34:56.5556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(5))")).matches("TIMESTAMP '1500-05-01 12:34:56.55556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(6))")).matches("TIMESTAMP '1500-05-01 12:34:56.555556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(7))")).matches("TIMESTAMP '1500-05-01 12:34:56.5555556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(8))")).matches("TIMESTAMP '1500-05-01 12:34:56.55555556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(9))")).matches("TIMESTAMP '1500-05-01 12:34:56.555555556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(10))")).matches("TIMESTAMP '1500-05-01 12:34:56.5555555556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(11))")).matches("TIMESTAMP '1500-05-01 12:34:56.55555555556'");
+        assertThat(assertions.expression("CAST(CHAR '1500-05-01 12:34:56.555555555555' AS TIMESTAMP(12))")).matches("TIMESTAMP '1500-05-01 12:34:56.555555555555'");
+
+        // 6-digit year
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '123001-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '123001-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '123001-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '123001-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST(CHAR '123001-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111111'");
+
+        // 6-digit year with + sign
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '123001-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '123001-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '123001-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '123001-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '123001-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '123001-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST(CHAR '+123001-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '123001-05-01 12:34:56.111111111111'");
+
+        // 6-digit year with - sign
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(0))")).matches("TIMESTAMP '-123001-05-01 12:34:56'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(1))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(2))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(3))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(4))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(5))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(6))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(7))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(8))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(9))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(10))")).matches("TIMESTAMP '-123001-05-01 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(11))")).matches("TIMESTAMP '-123001-05-01 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST(CHAR '-123001-05-01 12:34:56.111111111111' AS TIMESTAMP(12))")).matches("TIMESTAMP '-123001-05-01 12:34:56.111111111111'");
+
+        // values w/ time zone
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56 +01:23' AS TIMESTAMP(0))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.1 +01:23' AS TIMESTAMP(1))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.1'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.11 +01:23' AS TIMESTAMP(2))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.11'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111 +01:23' AS TIMESTAMP(3))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.1111 +01:23' AS TIMESTAMP(4))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.1111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.11111 +01:23' AS TIMESTAMP(5))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.11111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111 +01:23' AS TIMESTAMP(6))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.1111111 +01:23' AS TIMESTAMP(7))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.1111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.11111111 +01:23' AS TIMESTAMP(8))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.11111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111 +01:23' AS TIMESTAMP(9))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.1111111111 +01:23' AS TIMESTAMP(10))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.1111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.11111111111 +01:23' AS TIMESTAMP(11))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.11111111111'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 +01:23' AS TIMESTAMP(12))"))
+                .matches("TIMESTAMP '2020-05-10 12:34:56.111111111111'");
+
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(0))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(1))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(2))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(3))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(4))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(5))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(6))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(7))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(8))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(9))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(10))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(11))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(12))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
+
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(0))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(1))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(2))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(3))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(4))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(5))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(6))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(7))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(8))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(9))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(10))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(11))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10 xxx' AS TIMESTAMP(12))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
+
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(0))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(1))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(2))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(3))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(4))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(5))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(6))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(7))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(8))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(9))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(10))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(11))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+        assertThatThrownBy(assertions.expression("CAST(CHAR '2020-05-10T12:34:56' AS TIMESTAMP(12))")::evaluate)
+                .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
+    }
+
+    @Test
     public void testLowerDigitsZeroed()
     {
         // round down

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -1878,6 +1878,85 @@ public class TestTimestampWithTimeZone
     }
 
     @Test
+    public void testCastFromChar()
+    {
+        // round down
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(1) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.1 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(2) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.11 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(4) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.1111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(5) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.11111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(6) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(7) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.1111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(8) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.11111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(10) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.1111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(11) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.11111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(12) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.111111111111 Asia/Kathmandu'");
+
+        // round up
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:57 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(1) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.6 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(2) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.56 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(4) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.5556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(5) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.55556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(6) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.555556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(7) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.5555556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(8) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.55555556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.555555556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(10) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.5555555556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(11) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.55555555556 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '2020-05-01 12:34:56.555555555555 Asia/Kathmandu' AS TIMESTAMP(12) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.555555555555 Asia/Kathmandu'");
+
+        // 5-digit year
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(1) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(2) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(4) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(5) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(6) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(7) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(8) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(10) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(11) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(12) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111111111111 Asia/Kathmandu'");
+
+        // 5-digit year with + sign
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(1) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(2) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(4) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(5) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(6) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(7) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(8) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(10) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.1111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(11) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.11111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '+12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(12) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56.111111111111 Asia/Kathmandu'");
+
+        // 5-digit year with - sign
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(1) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.1 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(2) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.11 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(4) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.1111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(5) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.11111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(6) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(7) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.1111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(8) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.11111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(10) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.1111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(11) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.11111111111 Asia/Kathmandu'");
+        assertThat(assertions.expression("CAST(CHAR '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu' AS TIMESTAMP(12) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56.111111111111 Asia/Kathmandu'");
+    }
+
+    @Test
     public void testLowerDigitsZeroed()
     {
         // round down

--- a/core/trino-main/src/test/java/io/trino/type/TestCharOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestCharOperators.java
@@ -13,6 +13,8 @@
  */
 package io.trino.type;
 
+import io.trino.spi.type.SqlNumber;
+import io.trino.spi.type.TrinoNumber;
 import io.trino.sql.query.QueryAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,11 +22,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.NumberType.NUMBER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -576,5 +589,108 @@ public class TestCharOperators
 
         assertThat(assertions.operator(INDETERMINATE, "CHAR '123'"))
                 .isEqualTo(false);
+    }
+
+    @Test
+    public void testCharCast()
+    {
+        assertThat(assertions.expression("CAST(CHAR '1337' AS BIGINT)"))
+                .hasType(BIGINT)
+                .isEqualTo(1337L);
+
+        assertThat(assertions.expression("CAST(CHAR ' 1337 ' AS BIGINT)"))
+                .hasType(BIGINT)
+                .isEqualTo(1337L);
+
+        assertThat(assertions.expression("CAST(CHAR '1337' AS INTEGER)"))
+                .hasType(INTEGER)
+                .isEqualTo(1337);
+
+        assertThat(assertions.expression("CAST(CHAR ' 1337 ' AS INTEGER)"))
+                .hasType(INTEGER)
+                .isEqualTo(1337);
+
+        assertThat(assertions.expression("CAST(CHAR '1337' AS SMALLINT)"))
+                .hasType(SMALLINT)
+                .isEqualTo((short) 1337);
+
+        assertThat(assertions.expression("CAST(CHAR ' 1337 ' AS SMALLINT)"))
+                .hasType(SMALLINT)
+                .isEqualTo((short) 1337);
+
+        assertThat(assertions.expression("CAST(CHAR '21' AS TINYINT)"))
+                .hasType(TINYINT)
+                .isEqualTo((byte) 21);
+
+        assertThat(assertions.expression("CAST(CHAR ' 21 ' AS TINYINT)"))
+                .hasType(TINYINT)
+                .isEqualTo((byte) 21);
+
+        assertThat(assertions.expression("CAST(CHAR '1.0' AS DOUBLE)"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0d);
+
+        assertThat(assertions.expression("CAST(CHAR ' 1.0 ' AS DOUBLE)"))
+                .hasType(DOUBLE)
+                .isEqualTo(1.0d);
+
+        assertThat(assertions.expression("CAST(CHAR '13.37' AS REAL)"))
+                .hasType(REAL)
+                .isEqualTo(13.37f);
+
+        assertThat(assertions.expression("CAST(CHAR ' 13.37 ' AS REAL)"))
+                .hasType(REAL)
+                .isEqualTo(13.37f);
+
+        // cast to boolean
+        assertThat(assertions.expression("CAST(CHAR 'true' AS BOOLEAN)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("CAST(CHAR 'false' AS BOOLEAN)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("CAST(CHAR '1' AS BOOLEAN)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("CAST(CHAR '0' AS BOOLEAN)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("CAST(CHAR 'abc' AS VARBINARY)"))
+                .hasType(VARBINARY)
+                .matches("X'616263'");
+
+        // cast to number
+        assertThat(assertions.expression("CAST(CHAR '13.37' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber("13.37"));
+
+        assertThat(assertions.expression("CAST(CHAR ' 13.37 ' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber("13.37"));
+
+        assertThat(assertions.expression("CAST(CHAR 'NaN' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber(new TrinoNumber.NotANumber()));
+
+        assertThat(assertions.expression("CAST(CHAR 'Infinity' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber(new TrinoNumber.Infinity(false)));
+
+        assertThat(assertions.expression("CAST(CHAR '-Infinity' AS NUMBER)"))
+                .hasType(NUMBER)
+                .isEqualTo(new SqlNumber(new TrinoNumber.Infinity(true)));
+
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(CHAR 'abc' AS BIGINT)")::evaluate)
+                .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(CHAR 'abc' AS DOUBLE)")::evaluate)
+                .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(CHAR 'abc' AS NUMBER)")::evaluate)
+                .hasErrorCode(INVALID_CAST_ARGUMENT);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestDate.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDate.java
@@ -498,6 +498,135 @@ public class TestDate
     }
 
     @Test
+    public void testCastFromChar()
+    {
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2001-1-22'"))
+                .matches("DATE '2001-01-22'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '\n\t 2001-1-22'"))
+                .matches("DATE '2001-01-22'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2001-1-22 \t\n'"))
+                .matches("DATE '2001-01-22'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '\n\t 2001-1-22 \t\n'"))
+                .matches("DATE '2001-01-22'");
+
+        // Note: update DomainTranslator.Visitor.createVarcharCastToDateComparisonExtractionResult whenever CAST behavior changes.
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013-02-02'"))
+                .matches("DATE '2013-02-02'");
+
+        // one digit for month or day
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013-2-02'"))
+                .matches("DATE '2013-02-02'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013-02-2'"))
+                .matches("DATE '2013-02-02'");
+
+        // three digit for month or day
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013-02-002'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 2013-02-002");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013-002-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 2013-002-02");
+
+        // zero-padded year
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '02013-02-02'"))
+                .matches("DATE '2013-02-02'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '0013-02-02'"))
+                .matches("DATE '13-02-02'");
+
+        // invalid date
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013-02-29'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 2013-02-29");
+
+        // surrounding whitespace
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '  2013-02-02  '"))
+                .matches("DATE '2013-02-02'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR ' \t\n\u000B\f\r\u001C\u001D\u001E\u001F 2013-02-02 \t\n\u000B\f\n\u001C\u001D\u001E\u001F '"))
+                .matches("DATE '2013-02-02'");
+
+        // intra whitespace
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013 -02-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 2013 -02-02");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '2013- 2-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 2013- 2-02");
+
+        // large year
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '5881580-07-12'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 5881580-07-12");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '392251590-07-12'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: 392251590-07-12");
+
+        // signed
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '+2013-02-02'"))
+                .matches("DATE '2013-02-02'");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '-2013-02-02'"))
+                .matches("DATE '-2013-02-02'");
+
+        // signed with whitespace
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR ' +2013-02-02'"))
+                .matches("DATE '2013-02-02'");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '+ 2013-02-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: + 2013-02-02");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR ' + 2013-02-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date:  + 2013-02-02");
+
+        assertThat(assertions.expression("cast(a as date)")
+                .binding("a", "CHAR ' -2013-02-02'"))
+                .matches("DATE '-2013-02-02'");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR '- 2013-02-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date: - 2013-02-02");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as date)")
+                .binding("a", "CHAR ' - 2013-02-02'").evaluate())
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value cannot be cast to date:  - 2013-02-02");
+    }
+
+    @Test
     public void testGreatest()
     {
         assertThat(assertions.function("greatest", "DATE '2013-03-30'", "DATE '2012-05-23'"))

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCastPushdown.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCastPushdown.java
@@ -467,7 +467,6 @@ final class TestPostgreSqlCastPushdown
                 .add(new InvalidCastTestCase("c_varchar_decimal", "integer"))
                 .add(new InvalidCastTestCase("c_varchar_decimal_sign", "integer"))
                 .add(new InvalidCastTestCase("c_varchar_alpha_numeric", "integer"))
-                .add(new InvalidCastTestCase("c_char_numeric", "integer"))
                 .add(new InvalidCastTestCase("c_nan_real", "integer"))
                 .add(new InvalidCastTestCase("c_nan_double", "integer"))
 

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftCastPushdown.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftCastPushdown.java
@@ -566,9 +566,6 @@ final class TestRedshiftCastPushdown
                 .add(new InvalidCastTestCase("c_varchar_decimal", "integer"))
                 .add(new InvalidCastTestCase("c_varchar_decimal_sign", "integer"))
                 .add(new InvalidCastTestCase("c_varchar_alpha_numeric", "integer"))
-                .add(new InvalidCastTestCase("c_char_50", "integer"))
-                .add(new InvalidCastTestCase("c_char_numeric", "integer"))
-                .add(new InvalidCastTestCase("c_bpchar_numeric", "integer"))
                 .add(new InvalidCastTestCase("c_nan_real", "integer"))
                 .add(new InvalidCastTestCase("c_nan_double", "integer"))
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

 Trino had no registered CAST operators from char(x) to `BIGINT`, `INTEGER`, `SMALLINT`, `TINYINT`, `DOUBLE`, `REAL`, `BOOLEAN`, `NUMBER`,  `VARBINARY`, `TIMESTAMP`, `TIMESTAMP WITH TIMEZONE`, `DATE`

**Before**
```
trino> select CAST(CHAR '1337' AS BIGINT);
Query 20260508_073648_00030_srvy6 failed: line 1:8: Cannot cast char(4) to bigint
io.trino.spi.TrinoException: line 1:8: Cannot cast char(4) to bigint
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:58)
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:52)
	at io.trino.sql.analyzer.ExpressionAnalyzer$Visitor.visitCast(ExpressionAnalyzer.java:2396)
	at io.trino.sql.analyzer.ExpressionAnalyzer$Visitor.visitCast(ExpressionAnalyzer.java:666)
	at io.trino.sql.tree.Cast.accept(Cast.java:84)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.ExpressionAnalyzer$Visitor.process(ExpressionAnalyzer.java:696)
	at io.trino.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:517)
	at io.trino.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:3698)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeExpression(StatementAnalyzer.java:5436)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeSelectSingleColumn(StatementAnalyzer.java:5239)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeSelect(StatementAnalyzer.java:5017)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:3269)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:539)
	at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:558)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:566)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1626)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:539)
	at io.trino.sql.tree.Query.accept(Query.java:130)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:558)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:518)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:507)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:98)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:87)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:302)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:235)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:939)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:163)
	at io.trino.$gen.Trino_testversion____20260508_065737_1.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
select CAST(CHAR '1337' AS BIGINT)
```

After
```
trino> select CAST(CHAR '1337' AS BIGINT);
 _col0 
-------
  1337 
(1 row)
```



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

ANSI SQL SPEC 2016   treats casts between character (whether fixed or variable-length) casts the same
**6.13 cast specification**

<img width="1414" height="1204" alt="image" src="https://github.com/user-attachments/assets/11924ede-76b4-4845-ae9e-0847f8ccdee8" />

For additional context / proof of concept, reviewers can consult  [VarcharOperators.java](https://github.com/trinodb/trino/blob/c5451571e9a3a6c8cd9529a6b0dab508a611dfb0/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java)


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add cast operators from char to numeric, boolean, varbinary types. ({issue}`issuenumber`)
```
