### PR TITLE
Increase Databricks retry attempts to 60 in onDelta()

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryExecutors.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryExecutors.java
@@ -135,7 +135,7 @@ public final class QueryExecutors
                     return stackTrace.contains("HTTP Response code: 502") || stackTrace.contains("The current cluster state is Pending") || stackTrace.contains("The current cluster state is Terminated");
                 })
                 .withDelay(Duration.of(30, ChronoUnit.SECONDS))
-                .withMaxRetries(40)
+                .withMaxRetries(60)
                 .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))
                 .build();
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The onDelta() retry policy retries Databricks queries every 30 seconds when the cluster is unavailable (e.g. cold-starting, state is Pending or Terminated). With the previous limit of 40 retries (20 minutes total), tests occasionally fail when a cluster takes longer than 20 minutes to become available.                                                                    
                                                                                                                                                                                                                                                                                                                                                                                     
  Observed failure — test ran for exactly 20 minutes before all retry attempts were exhausted:                                                                                                                                                                                                                                                                                       
                  
```
  java.lang.RuntimeException: java.sql.SQLException: Preparatory statement failed: USE default                                                                                                                                                                                                                                                                                       
      ...                                                                                                                                                                                                                                                                                                                                                                            
  Caused by: com.databricks.jdbc.exception.DatabricksHttpException: HTTP request failed by code: 503,
      status line: HTTP/1.1 503 Service Unavailable.                                                                                                                                                                                                                                                                                                                                 
      Thrift Header: TEMPORARILY_UNAVAILABLE: Cluster 5711-083124-7nybcy05 is temporarily unavailable.                                                                                                                                                                                                                                                                               
      The current cluster state is Pending. Please retry your request after 30 seconds.                                                                                                                                                                                                                                                                                              
      at com.databricks.jdbc.common.util.ValidationUtil.checkHTTPError(ValidationUtil.java:140)                                                                                                                                                                                                                                                                                      
      at com.databricks.jdbc.dbclient.impl.thrift.DatabricksHttpTTransport.flush(DatabricksHttpTTransport.java:130)                                                                                                                                                                                                                                                                  
      at com.databricks.internal.apache.thrift.TServiceClient.sendBase(TServiceClient.java:75)                                                                                                                                                                                                                                                                                       
      at com.databricks.jdbc.model.client.thrift.generated.TCLIService$Client.OpenSession(TCLIService.java:206)                                                                                                                                                                                                                                                                      
      at com.databricks.jdbc.dbclient.impl.thrift.DatabricksThriftServiceClient.createSession(DatabricksThriftServiceClient.java:108)                                                                                                                                                                                                                                                
      at com.databricks.jdbc.api.impl.DatabricksSession.open(DatabricksSession.java:157)                                                                                                                                                                                                                                                                                             
      at com.databricks.jdbc.api.impl.DatabricksConnection.open(DatabricksConnection.java:67)                                                                                                                                                                                                                                                                                        
      at com.databricks.client.jdbc.Driver.connect(Driver.java:63)   

  2026-05-07 22:24:23 WARNING: Query failed on attempt 1, will retry.                                                                                                                                                                                                                                                                                                                
  2026-05-07 22:24:53 WARNING: Query failed on attempt 2, will retry.
  ...                                                                                                                                                                                                                                                                                                                                                                                
  2026-05-07 22:43:37 WARNING: Query failed on attempt 39, will retry.
  2026-05-07 22:44:08 WARNING: Query failed on attempt 40, will retry.                                                                                                                                                                                                                                                                                                               
                  
  Immediately after attempt 40 the test was recorded as failed (20 minutes 16 seconds elapsed):                                                                                                                                                                                                                                                                                      
                  
  2026-05-07 22:44:08 FAILURE                                                                                                                                                                                                                                                                                                                                                        
    TestDeltaLakeDatabricksUnityCompatibility.testReadWriteCatalogManagedTable took 20 minutes and 16 seconds
```                          



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
