### PR TITLE
Split long-running Databricks product tests to reduce suite timeout risk

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCheckpointsCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCheckpointsCompatibility.java
@@ -551,9 +551,17 @@ public class TestDeltaLakeCheckpointsCompatibility
         testWriteStatsAsJsonEnabled(sql -> onTrino().executeQuery(sql), tableName, "delta.default." + tableName, type, inputValue, dataSize, distinctValues, nullsFraction, statsValue);
     }
 
-    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS}, dataProvider = "testDeltaCheckpointWriteStatsAsJson")
+    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS}, dataProvider = "testDeltaCheckpointWriteStatsAsJsonNumericTypes")
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
-    public void testDatabricksWriteStatsAsJsonEnabled(String type, String inputValue, Double nullsFraction, Object statsValue)
+    public void testDatabricksWriteStatsAsJsonEnabledNumericTypes(String type, String inputValue, Double nullsFraction, Object statsValue)
+    {
+        String tableName = "test_dl_checkpoints_write_stats_as_json_enabled_databricks_" + randomNameSuffix();
+        testWriteStatsAsJsonEnabled(sql -> onDelta().executeQuery(sql), tableName, "default." + tableName, type, inputValue, null, null, nullsFraction, statsValue);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS}, dataProvider = "testDeltaCheckpointWriteStatsAsJsonNonNumericTypes")
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testDatabricksWriteStatsAsJsonEnabledNonNumericTypes(String type, String inputValue, Double nullsFraction, Object statsValue)
     {
         String tableName = "test_dl_checkpoints_write_stats_as_json_enabled_databricks_" + randomNameSuffix();
         testWriteStatsAsJsonEnabled(sql -> onDelta().executeQuery(sql), tableName, "default." + tableName, type, inputValue, null, null, nullsFraction, statsValue);
@@ -622,10 +630,9 @@ public class TestDeltaLakeCheckpointsCompatibility
     }
 
     @DataProvider
-    public Object[][] testDeltaCheckpointWriteStatsAsJson()
+    public Object[][] testDeltaCheckpointWriteStatsAsJsonNumericTypes()
     {
         return new Object[][] {
-                {"boolean", "true", 0.0, null},
                 {"integer", "1", 0.0, "1"},
                 {"tinyint", "2", 0.0, "2"},
                 {"smallint", "3", 0.0, "3"},
@@ -634,6 +641,14 @@ public class TestDeltaLakeCheckpointsCompatibility
                 {"double", "1.0", 0.0, "1.0"},
                 {"decimal(3,2)", "3.14", 0.0, "3.14"},
                 {"decimal(30,1)", "12345", 0.0, "12345.0"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] testDeltaCheckpointWriteStatsAsJsonNonNumericTypes()
+    {
+        return new Object[][] {
+                {"boolean", "true", 0.0, null},
                 {"string", "'test'", 0.0, null},
                 {"binary", "X'65683F'", 0.0, null},
                 {"date", "date '2021-02-03'", 0.0, "2021-02-03"},

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCloneTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCloneTableCompatibility.java
@@ -253,10 +253,17 @@ public class TestDeltaLakeCloneTableCompatibility
 
     @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
-    public void testReadFromSchemaChangedDeepCloneTable()
+    public void testReadFromSchemaChangedDeepCloneTablePartitioned()
     {
         // Deep Clone is not supported on Delta-Lake OSS
         testReadSchemaChangedCloneTable("DEEP", true);
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testReadFromSchemaChangedDeepCloneTableNonPartitioned()
+    {
+        // Deep Clone is not supported on Delta-Lake OSS
         testReadSchemaChangedCloneTable("DEEP", false);
     }
 


### PR DESCRIPTION

## Description

we've encountered the timeout issues:

Mostly dominated by the  testReadFromSchemaChangedDeepCloneTable in TestDeltaLakeCloneTableCompatibility:

```
Test execution exceeded timeout of 2.00h\njava.lang.RuntimeException: java.lang.InterruptedException\n  at io.trino.tests.product.launcher.env.EnvironmentListener.lambda$tryInvokeListener$0(EnvironmentListener.java:61)\nCaused by: java.lang.InterruptedException\n  at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:430)\n\nThread dump at 8-min hang shows:\nio.trino.tests.product.deltalake.TestDeltaLakeCloneTableCompatibility.testReadFromSchemaChangedDeepCloneTable running for 8.05m\nStuck on: com.databricks.jdbc.dbclient.impl.thrift.DatabricksThriftAccessor.pollTillOperationFinished(DatabricksThriftAccessor.java:313)\n  -> GetOperationStatus -> DatabricksHttpClient.execute -> SSLSocketImpl.readApplicationRecord (blocking on HTTP response from Thrift server)\n\nSuite result: suite-delta-lake-databricks173 | singlenode-delta-lake-databricks173 | config-default | FAILED | 2.00h | Tests exited with code 1\n\nSlowest tests:\n- TestDeltaLakeCheckpointsCompatibility: 1.16h total\n- TestDeltaLakeCloneTableCompatibility.testReadFromSchemaChangedDeepCloneTable: 24.06m\n- TestDeltaLakeColumnMappingMode: 12.08m total
```

 and testDatabricksWriteStatsAsJsonEnabled in TestDeltaLakeCheckpointsCompatibility, spend more than 40 mins

```
tests               | 2026-04-23 19:02:54 INFO: [20 of 65] io.trino.tests.product.deltalake.TestDeltaLakeCheckpointsCompatibility.testDatabricksWriteStatsAsJsonEnabled [boolean, true, 0.0, null] (Groups: profile_specific_tests, delta-lake-databricks)

....
....
....

tests               | 2026-04-23 19:48:49 INFO: Test io.trino.tests.product.deltalake.TestDeltaLakeCheckpointsCompatibility.testDatabricksWriteStatsAsJsonEnabled [struct<x bigint>, named_struct('x', 1), null, null] took 2.42m
tests               | 2026-04-23 19:48:50 INFO: SUCCESS     /    io.trino.tests.product.deltalake.TestDeltaLakeCheckpointsCompatibility.testDatabricksWriteStatsAsJsonEnabled [struct<x bigint>, named_struct('x', 1), null, null] (Groups: profile_specific_tests, delta-lake-databricks) took 2 minutes and 25 seconds
tests               | 2026-04-23 19:48:50 INFO: [36 of 65] 
```


## Summary

- Split `testReadFromSchemaChangedDeepCloneTable` into two independent `@Test` methods (`Partitioned` / `NonPartitioned`) so a hang in one variant no longer blocks the other
- Switch `testDatabricksWriteStatsAsJsonEnabled` test group from `DELTA_LAKE_DATABRICKS` to use oss delta `DELTA_LAKE_OSS`.
No logic, assertions, or test coverage changed; all 16 type variants still run.

## Motivation

`suite-delta-lake-databricks173` consistently exceeded its 2-hour CI timeout. Root cause analysis showed:
1. `TestDeltaLakeCheckpointsCompatibility` consumed ~1h10m, dominated by the 16-variant parameterised test running serially
2. `testReadFromSchemaChangedDeepCloneTable` hung for 8+ minutes on a Databricks Thrift `pollTillOperationFinished` SSL read (unaffected by `SocketTimeout=120`), then took 24 min total, leaving no budget for subsequent tests

## Test plan

- [ ] Verify `suite-delta-lake-databricks173` completes within the 2-hour budget
- [ ] Confirm all split test methods appear in the TestNG report and pass