### PR TITLE
Fix double-rounding when casting DECIMAL to REAL

### DIFF
--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -1322,6 +1322,30 @@ public class TestDecimalCasts
     }
 
     @Test
+    public void testShortDecimalToRealDoubleRounding()
+    {
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "DECIMAL '999999.00'"))
+                .isEqualTo(999999.0f);
+
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "DECIMAL '-999999.00'"))
+                .isEqualTo(-999999.0f);
+
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "CAST(1000001.00 AS DECIMAL(13,2))"))
+                .isEqualTo(1000001.0f);
+
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "CAST(16777217.0 AS DECIMAL(13,1))"))
+                .isEqualTo(16777217.0f);
+
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "CAST(-16777217.0 AS DECIMAL(13,1))"))
+                .isEqualTo(-16777217.0f);
+    }
+
+    @Test
     public void testNumberToShortDecimalCasts()
     {
         assertThat(assertions.expression("cast(a as DECIMAL(4,1))")

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
@@ -70,7 +70,11 @@ public final class DecimalConversions
 
     public static long shortDecimalToReal(long decimal, long tenToScale)
     {
-        return floatToRawIntBits(((float) decimal) / tenToScale);
+        // Divide in double to avoid double-rounding: ((float) decimal) / tenToScale first
+        // rounds the unscaled value to float (losing precision for |decimal| > 2^24),
+        // then divides — the composition can land on a different float than the correctly
+        // rounded mathematical result.
+        return floatToRawIntBits((float) ((double) decimal / tenToScale));
     }
 
     public static long longDecimalToReal(Int128 decimal, long scale)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`shortDecimalToReal` computed `((float) unscaled) / tenToScale` for the `DECIMAL` -> `REAL` cast. The intermediate (`float`) cast rounds the unscaled integer to float's 24-bit significand before the division, and the two successive roundings can land on a different float than the correctly rounded mathematical result.

For example, `DECIMAL(13,2)` value 999999.00 (unscaled 99999900):
- (float) 99999900 rounds to 99999904.0f (nearest float, error +4)
- 99999904.0f / 100.0f = 999999.0625f (nearest float to 999999.04)
- Correct answer: 999999.0f (99999900 / 100 = 999999 exactly)

Fix: divide in double precision first, then round to float once. Double's 53-bit significand preserves all short decimal unscaled values up to 2^53, so the division result is correctly rounded before the single final narrowing to float.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix double-rounding when casting DECIMAL to REAL. ({issue}`issuenumber`)
```
