### PR TITLE
Run join swaps and pushdowns in tests too

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -920,35 +920,35 @@ public class PlanOptimizers
                         new RemoveEmptyExceptBranches(),
                         new TransformFilteringSemiJoinToInnerJoin())));
 
+        builder.add(new IterativeOptimizer(
+                "DetermineJoinDistributions",
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(
+                        new DetermineJoinDistributionType(costComparator, taskCountEstimator), // Must run before AddExchanges
+                        // Must run before AddExchanges and after ReplicateSemiJoinInDelete
+                        // to avoid temporarily having an invalid plan
+                        new DetermineSemiJoinDistributionType(costComparator, taskCountEstimator))));
+
+        builder.add(new IterativeOptimizer(
+                "PushJoinIntoTableScan",
+                plannerContext,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.<Rule<?>>builder()
+                        .addAll(pushIntoTableScanRulesExceptJoins)
+                        // PushJoinIntoTableScan must run after ReorderJoins (and DetermineJoinDistributionType)
+                        // otherwise too early pushdown could prevent optimal plan from being selected.
+                        .add(new PushJoinIntoTableScan(plannerContext))
+                        // DetermineTableScanNodePartitioning is needed to needs to ensure all table handles have proper partitioning determined
+                        // Must run before AddExchanges
+                        .add(new DetermineTableScanNodePartitioning(metadata, nodePartitioningManager, taskCountEstimator))
+                        .build()));
+
         if (!forceSingleNode) {
-            builder.add(new IterativeOptimizer(
-                    "DetermineJoinDistributions",
-                    plannerContext,
-                    ruleStats,
-                    statsCalculator,
-                    costCalculator,
-                    ImmutableSet.of(
-                            new DetermineJoinDistributionType(costComparator, taskCountEstimator), // Must run before AddExchanges
-                            // Must run before AddExchanges and after ReplicateSemiJoinInDelete
-                            // to avoid temporarily having an invalid plan
-                            new DetermineSemiJoinDistributionType(costComparator, taskCountEstimator))));
-
-            builder.add(new IterativeOptimizer(
-                    "PushJoinIntoTableScan",
-                    plannerContext,
-                    ruleStats,
-                    statsCalculator,
-                    costCalculator,
-                    ImmutableSet.<Rule<?>>builder()
-                            .addAll(pushIntoTableScanRulesExceptJoins)
-                            // PushJoinIntoTableScan must run after ReorderJoins (and DetermineJoinDistributionType)
-                            // otherwise too early pushdown could prevent optimal plan from being selected.
-                            .add(new PushJoinIntoTableScan(plannerContext))
-                            // DetermineTableScanNodePartitioning is needed to needs to ensure all table handles have proper partitioning determined
-                            // Must run before AddExchanges
-                            .add(new DetermineTableScanNodePartitioning(metadata, nodePartitioningManager, taskCountEstimator))
-                            .build()));
-
             builder.add(
                     new IterativeOptimizer(
                             "PushTableWriteThroughUnion",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -648,13 +648,13 @@ public abstract class AbstractPredicatePushdownTest
                                 .equiCriteria(ImmutableList.of())
                                 .left(
                                         filter(
-                                                new Logical(AND, ImmutableList.of(new Comparison(EQUAL, new Reference(BIGINT, "L_NATIONKEY"), new Reference(BIGINT, "L_REGIONKEY")), new Comparison(EQUAL, new Reference(BIGINT, "L_REGIONKEY"), new Constant(BIGINT, 5L)))),
-                                                tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey", "L_REGIONKEY", "regionkey"))))
+                                                new Comparison(EQUAL, new Reference(BIGINT, "R_NATIONKEY"), new Constant(BIGINT, 5L)),
+                                                tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey"))))
                                 .right(
                                         anyTree(
                                                 filter(
-                                                        new Comparison(EQUAL, new Reference(BIGINT, "R_NATIONKEY"), new Constant(BIGINT, 5L)),
-                                                        tableScan("nation", ImmutableMap.of("R_NATIONKEY", "nationkey"))))))));
+                                                        new Logical(AND, ImmutableList.of(new Comparison(EQUAL, new Reference(BIGINT, "L_NATIONKEY"), new Reference(BIGINT, "L_REGIONKEY")), new Comparison(EQUAL, new Reference(BIGINT, "L_REGIONKEY"), new Constant(BIGINT, 5L)))),
+                                                        tableScan("nation", ImmutableMap.of("L_NATIONKEY", "nationkey", "L_REGIONKEY", "regionkey"))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDereferencePushDown.java
@@ -112,14 +112,14 @@ public class TestDereferencePushDown
                         join(INNER, builder -> builder
                                 .left(
                                         project(filter(
-                                                new Comparison(EQUAL, new Reference(DOUBLE, "a_y"), new Constant(DOUBLE, 2.0)),
-                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0)))))))
-                                .right(
-                                        project(filter(
                                                 new Comparison(EQUAL, new Reference(DOUBLE, "b_y"), new Constant(DOUBLE, 2.0)),
                                                 values(
                                                         ImmutableList.of("b_y", "b_x"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))))))));
+                                                        ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L)))))))
+                                .right(
+                                        project(filter(
+                                                new Comparison(EQUAL, new Reference(DOUBLE, "a_y"), new Constant(DOUBLE, 2.0)),
+                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0))))))))));
     }
 
     @Test
@@ -265,14 +265,14 @@ public class TestDereferencePushDown
                         join(INNER, builder -> builder
                                 .left(
                                         project(filter(
-                                                new Comparison(EQUAL, new Reference(DOUBLE, "a_y"), new Constant(DOUBLE, 2.0)),
-                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0)))))))
-                                .right(
-                                        project(filter(
                                                 new Comparison(EQUAL, new Reference(DOUBLE, "b_y"), new Constant(DOUBLE, 2.0)),
                                                 values(
                                                         ImmutableList.of("b_y", "b_x"),
-                                                        ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L))))))))));
+                                                        ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2.0), new Constant(BIGINT, 1L)))))))
+                                .right(
+                                        project(filter(
+                                                new Comparison(EQUAL, new Reference(DOUBLE, "a_y"), new Constant(DOUBLE, 2.0)),
+                                                values(ImmutableList.of("a_y"), ImmutableList.of(ImmutableList.of(new Constant(DOUBLE, 2e0))))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -382,15 +382,15 @@ public class TestLogicalPlanner
                                         filter(
                                                 new Comparison(LESS_THAN, new Reference(BIGINT, "O_ORDERKEY"), new Reference(BIGINT, "L_ORDERKEY")),
                                                 join(INNER, builder -> builder
-                                                        .addDynamicFilter("DF", "L_ORDERKEY")
+                                                        .addDynamicFilter("DF", "O_ORDERKEY")
                                                         .left(
                                                                 filter(
                                                                         TRUE,
                                                                         dynamicFilters -> dynamicFilters
-                                                                                .addConsumer(consumer -> consumer.alias("DF").expression(BIGINT, "O_ORDERKEY").operator(LESS_THAN)),
-                                                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                                                                .addConsumer(consumer -> consumer.alias("DF").expression(BIGINT, "L_ORDERKEY").operator(GREATER_THAN)),
+                                                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))
                                                         .right(
-                                                                any(tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))
+                                                                any(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey")))))
                                                         .withExactOutputs(ImmutableList.of("O_ORDERKEY", "L_ORDERKEY")))))));
 
         assertPlan(
@@ -532,15 +532,15 @@ public class TestLogicalPlanner
                         filter(
                                 new Comparison(LESS_THAN, new Reference(BIGINT, "O_ORDERKEY"), new Reference(BIGINT, "L_ORDERKEY")),
                                 join(INNER, builder -> builder
-                                        .addDynamicFilter("DF", "L_ORDERKEY")
+                                        .addDynamicFilter("DF", "O_ORDERKEY")
                                         .left(
                                                 filter(
                                                         TRUE,
                                                         dynamicFilters -> dynamicFilters
-                                                                .addConsumer(consumer -> consumer.alias("DF").expression(BIGINT, "O_ORDERKEY").operator(LESS_THAN)),
-                                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                                                .addConsumer(consumer -> consumer.alias("DF").expression(BIGINT, "L_ORDERKEY").operator(GREATER_THAN)),
+                                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))
                                         .right(
-                                                any(tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))))));
+                                                any(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))))));
     }
 
     @Test
@@ -582,13 +582,11 @@ public class TestLogicalPlanner
                                 join(INNER, builder -> builder
                                         .left(
                                                 filter(
-                                                        TRUE,
-                                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "L_ORDERKEY"))),
+                                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"))))
                                         .right(
                                                 any(
-                                                        filter(
-                                                                not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "L_ORDERKEY"))),
-                                                                tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))))));
+                                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))))));
     }
 
     @Test
@@ -1772,8 +1770,8 @@ public class TestLogicalPlanner
                                         singleGroupingSet("region_regionkey", "region_name", "unique"),
                                         ImmutableMap.of(),
                                         Optional.empty(),
-                                        SINGLE,
-                                        project(
+                                        FINAL,
+                                        anyTree(project(
                                                 ImmutableMap.of(
                                                         "region_regionkey", expression(new Reference(BIGINT, "region_regionkey")),
                                                         "region_name", expression(new Reference(VARCHAR, "region_name")),
@@ -1781,27 +1779,27 @@ public class TestLogicalPlanner
                                                 filter(
                                                         new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new IsNull(new Reference(BIGINT, "region_regionkey")), new Comparison(EQUAL, new Reference(BIGINT, "region_regionkey"), new Reference(BIGINT, "nation_regionkey")), new IsNull(new Reference(BIGINT, "nation_regionkey")))), new Comparison(LESS_THAN, new Reference(VARCHAR, "nation_name"), new Reference(VARCHAR, "region_name")))),
                                                         join(INNER, builder -> builder
-                                                                .addDynamicFilter("DF", "nation_name")
+                                                                .addDynamicFilter("DF", "region_name")
                                                                 .left(
-                                                                        assignUniqueId(
-                                                                                "unique",
-                                                                                filter(
-                                                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "region_regionkey"))),
-                                                                                        dynamicFilters -> dynamicFilters
-                                                                                                .addConsumer(consumer -> consumer
-                                                                                                        .alias("DF")
-                                                                                                        .expression(VARCHAR, "region_name")
-                                                                                                        .operator(GREATER_THAN)),
-                                                                                        tableScan("region", ImmutableMap.of(
-                                                                                                "region_regionkey", "regionkey",
-                                                                                                "region_name", "name")))))
+                                                                        filter(
+                                                                                not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "nation_regionkey"))),
+                                                                                dynamicFilters -> dynamicFilters
+                                                                                        .addConsumer(consumer -> consumer
+                                                                                                .alias("DF")
+                                                                                                .expression(VARCHAR, "nation_name")
+                                                                                                .operator(LESS_THAN)),
+                                                                                tableScan("nation", ImmutableMap.of(
+                                                                                        "nation_name", "name",
+                                                                                        "nation_regionkey", "regionkey"))))
                                                                 .right(
                                                                         any(
-                                                                                filter(
-                                                                                        not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "nation_regionkey"))),
-                                                                                        tableScan("nation", ImmutableMap.of(
-                                                                                                "nation_name", "name",
-                                                                                                "nation_regionkey", "regionkey"))))))))))));
+                                                                                assignUniqueId(
+                                                                                        "unique",
+                                                                                        filter(
+                                                                                                not(getPlanTester().getPlannerContext().getMetadata(), new IsNull(new Reference(BIGINT, "region_regionkey"))),
+                                                                                                tableScan("region", ImmutableMap.of(
+                                                                                                        "region_regionkey", "regionkey",
+                                                                                                        "region_name", "name"))))))))))))));
     }
 
     @Test
@@ -1815,28 +1813,28 @@ public class TestLogicalPlanner
                                         singleGroupingSet("region_regionkey", "region_name", "unique"),
                                         ImmutableMap.of(),
                                         Optional.empty(),
-                                        SINGLE,
-                                        project(
+                                        FINAL,
+                                        anyTree(project(
                                                 filter(
                                                         new Comparison(LESS_THAN, new Reference(VARCHAR, "nation_name"), new Reference(VARCHAR, "region_name")),
                                                         join(INNER, builder -> builder
-                                                                .addDynamicFilter("DF", "nation_name")
+                                                                .addDynamicFilter("DF", "region_name")
                                                                 .left(
-                                                                        assignUniqueId(
-                                                                                "unique",
-                                                                                filter(
-                                                                                        TRUE,
-                                                                                        dynamicFilters -> dynamicFilters
-                                                                                                .addConsumer(consumer -> consumer
-                                                                                                        .alias("DF")
-                                                                                                        .expression(VARCHAR, "region_name")
-                                                                                                        .operator(GREATER_THAN)),
-                                                                                        tableScan("region", ImmutableMap.of(
-                                                                                                "region_regionkey", "regionkey",
-                                                                                                "region_name", "name")))))
+                                                                        filter(
+                                                                                TRUE,
+                                                                                dynamicFilters -> dynamicFilters
+                                                                                        .addConsumer(consumer -> consumer
+                                                                                                .alias("DF")
+                                                                                                .expression(VARCHAR, "nation_name")
+                                                                                                .operator(LESS_THAN)),
+                                                                                tableScan("nation", ImmutableMap.of("nation_name", "name"))))
                                                                 .right(
                                                                         any(
-                                                                                tableScan("nation", ImmutableMap.of("nation_name", "name")))))))))));
+                                                                                assignUniqueId(
+                                                                                        "unique",
+                                                                                        tableScan("region", ImmutableMap.of(
+                                                                                                "region_regionkey", "regionkey",
+                                                                                                "region_name", "name")))))))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateCrossJoins.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateCrossJoins.java
@@ -26,17 +26,14 @@ import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.Comparison.Operator.LESS_THAN;
 import static io.trino.sql.ir.Comparison.Operator.NOT_EQUAL;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.strictTableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.plan.JoinType.INNER;
@@ -82,9 +79,9 @@ public class TestEliminateCrossJoins
                                 .equiCriteria("L_ORDERKEY", "O_ORDERKEY")
                                 .left(
                                         join(INNER, leftJoinBuilder -> leftJoinBuilder
-                                                .equiCriteria("P_PARTKEY", "L_PARTKEY")
-                                                .left(anyTree(PART_TABLESCAN))
-                                                .right(anyTree(LINEITEM_TABLESCAN))))
+                                                .equiCriteria("L_PARTKEY", "P_PARTKEY")
+                                                .left(anyTree(LINEITEM_TABLESCAN))
+                                                .right(anyTree(PART_TABLESCAN))))
                                 .right(anyTree(ORDERS_TABLESCAN)))));
     }
 
@@ -96,18 +93,18 @@ public class TestEliminateCrossJoins
                         "JOIN (orders o3 JOIN orders o4 ON o3.orderkey = o4.orderkey) ON o1.orderkey = o3.orderkey",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("O1_ORDERKEY", "O3_ORDERKEY")
+                                .equiCriteria("O4_ORDERKEY", "O2_ORDERKEY")
                                 .left(
                                         join(INNER, leftJoinBuilder -> leftJoinBuilder
-                                                .equiCriteria("O1_ORDERKEY", "O2_ORDERKEY")
-                                                .left(anyTree(strictTableScan("orders", ImmutableMap.of("O1_ORDERKEY", "orderkey"))))
-                                                .right(anyTree(strictTableScan("orders", ImmutableMap.of("O2_ORDERKEY", "orderkey", "O2_CUSTKEY", "custkey"))))))
+                                                .equiCriteria("O4_ORDERKEY", "O3_ORDERKEY")
+                                                .left(anyTree(strictTableScan("orders", ImmutableMap.of("O4_ORDERKEY", "orderkey", "O4_totalprice", "totalprice"))))
+                                                .right(anyTree(strictTableScan("orders", ImmutableMap.of("O3_ORDERKEY", "orderkey", "O3_ORDERSTATUS", "orderstatus"))))))
                                 .right(
                                         anyTree(
                                                 join(INNER, rightJoinBuilder -> rightJoinBuilder
-                                                        .equiCriteria("O3_ORDERKEY", "O4_ORDERKEY")
-                                                        .left(anyTree(strictTableScan("orders", ImmutableMap.of("O3_ORDERKEY", "orderkey", "O3_ORDERSTATUS", "orderstatus"))))
-                                                        .right(anyTree(strictTableScan("orders", ImmutableMap.of("O4_ORDERKEY", "orderkey", "O4_totalprice", "totalprice"))))))))));
+                                                        .equiCriteria("O2_ORDERKEY", "O1_ORDERKEY")
+                                                        .left(anyTree(strictTableScan("orders", ImmutableMap.of("O2_ORDERKEY", "orderkey", "O2_CUSTKEY", "custkey"))))
+                                                        .right(anyTree(strictTableScan("orders", ImmutableMap.of("O1_ORDERKEY", "orderkey"))))))))));
     }
 
     @Test
@@ -119,8 +116,8 @@ public class TestEliminateCrossJoins
                                 .equiCriteria("O_ORDERKEY", "L_ORDERKEY")
                                 .left(
                                         join(INNER, leftJoinBuilder -> leftJoinBuilder
-                                                .left(tableScan("part"))
-                                                .right(anyTree(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))))
+                                                .left(anyTree(tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                                .right(anyTree(tableScan("part")))))
                                 .right(
                                         anyTree(tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
     }
@@ -134,20 +131,17 @@ public class TestEliminateCrossJoins
                         "WHERE p.partkey = l.partkey AND l.orderkey = o.orderkey AND p.partkey <> o.orderkey AND p.name < l.comment",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("L_ORDERKEY", "O_ORDERKEY")
-                                .left(
-                                        join(INNER, leftJoinBuilder -> leftJoinBuilder
-                                                .equiCriteria("P_PARTKEY", "L_PARTKEY")
-                                                .filter(new Comparison(LESS_THAN, new Reference(VARCHAR, "P_NAME"), new Reference(VARCHAR, "expr")))
-                                                .left(anyTree(PART_WITH_NAME_TABLESCAN))
-                                                .right(
-                                                        anyTree(
-                                                                project(
-                                                                        ImmutableMap.of("expr", expression(new Cast(new Reference(VARCHAR, "L_COMMENT"), createVarcharType(55)))),
-                                                                        filter(
-                                                                                new Comparison(NOT_EQUAL, new Reference(BIGINT, "L_PARTKEY"), new Reference(BIGINT, "L_ORDERKEY")),
-                                                                                LINEITEM_WITH_COMMENT_TABLESCAN))))))
-                                .right(anyTree(ORDERS_TABLESCAN)))));
+                                .equiCriteria("O_ORDERKEY", "L_ORDERKEY")
+                                .left(anyTree(ORDERS_TABLESCAN))
+                                .right(
+                                        anyTree(
+                                                join(INNER, leftJoinBuilder -> leftJoinBuilder
+                                                        .equiCriteria("L_PARTKEY", "P_PARTKEY")
+                                                        .filter(new Comparison(LESS_THAN, new Reference(createVarcharType(55), "P_NAME"), new Cast(new Reference(createVarcharType(44), "L_COMMENT"), createVarcharType(55))))
+                                                        .left(filter(
+                                                                new Comparison(NOT_EQUAL, new Reference(BIGINT, "L_PARTKEY"), new Reference(BIGINT, "L_ORDERKEY")),
+                                                                LINEITEM_WITH_COMMENT_TABLESCAN))
+                                                        .right(anyTree(PART_WITH_NAME_TABLESCAN))))))));
     }
 
     @Test
@@ -160,11 +154,11 @@ public class TestEliminateCrossJoins
                                 .equiCriteria("L_ORDERKEY", "O_ORDERKEY")
                                 .left(
                                         join(INNER, leftJoinBuilder -> leftJoinBuilder
-                                                .equiCriteria("P_PARTKEY", "L_PARTKEY")
-                                                .left(anyTree(PART_TABLESCAN))
-                                                .right(anyTree(filter(
+                                                .equiCriteria("L_PARTKEY", "P_PARTKEY")
+                                                .left(anyTree(filter(
                                                         new Comparison(EQUAL, new Reference(createVarcharType(1), "L_RETURNFLAG"), new Constant(createVarcharType(1), Slices.utf8Slice("R"))),
-                                                        LINEITEM_WITH_RETURNFLAG_TABLESCAN)))))
+                                                        LINEITEM_WITH_RETURNFLAG_TABLESCAN)))
+                                                .right(anyTree(PART_TABLESCAN))))
                                 .right(
                                         anyTree(filter(
                                                 new Comparison(GREATER_THAN_OR_EQUAL, new Reference(INTEGER, "O_SHIPPRIORITY"), new Constant(INTEGER, 10L)),

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -338,10 +338,10 @@ public class TestSpatialJoinPlanning
                         filter(
                                 not(FUNCTIONS.getMetadata(), new Call(ST_CONTAINS, ImmutableList.of(new Call(ST_GEOMETRY_FROM_TEXT, ImmutableList.of(new Cast(new Reference(VARCHAR, "wkt"), VARCHAR))), new Call(ST_POINT, ImmutableList.of(new Reference(DOUBLE, "lng"), new Reference(DOUBLE, "lat")))))),
                                 join(INNER, builder -> builder
-                                        .left(tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name")))
+                                        .left(tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name")))
                                         .right(
                                                 anyTree(
-                                                        tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name"))))))));
+                                                        tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name"))))))));
     }
 
     @Test
@@ -382,14 +382,14 @@ public class TestSpatialJoinPlanning
                         "WHERE a.name = b.name AND ST_Contains(ST_GeometryFromText(wkt), ST_Point(lng, lat))",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("name_a", "name_b")
+                                .equiCriteria("name_b", "name_a")
                                 .filter(new Call(ST_CONTAINS, ImmutableList.of(new Call(ST_GEOMETRY_FROM_TEXT, ImmutableList.of(new Cast(new Reference(VARCHAR, "wkt"), VARCHAR))), new Call(ST_POINT, ImmutableList.of(new Reference(DOUBLE, "lng"), new Reference(DOUBLE, "lat"))))))
                                 .left(
                                         anyTree(
-                                                tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name"))))
+                                                tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name"))))
                                 .right(
                                         anyTree(
-                                                tableScan("polygons", ImmutableMap.of("wkt", "wkt", "name_b", "name")))))));
+                                                tableScan("points", ImmutableMap.of("lng", "lng", "lat", "lat", "name_a", "name")))))));
     }
 
     @Test


### PR DESCRIPTION
PlanOptimizers `forceSingleNode` is used for plan tests. From that perspective, doing some join sides and distribution determination (ReorderJoins) and blocking some (DetermineJoinDistributionType) does not seem consequential. Unblock join sides and distribution determination, along with join pushdown into table scan, in plan test mode.
