### PR TITLE
Cache namespace listings for Iceberg REST case-insensitive resolution

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.apache.iceberg.CatalogProperties;
 
@@ -66,6 +67,8 @@ public class IcebergRestCatalogConfig
     private boolean caseInsensitiveNameMatching;
     private Map<String, String> httpHeaders = ImmutableMap.of();
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+    private boolean caseInsensitiveNameMatchingNamespaceCacheEnabled = true;
+    private long caseInsensitiveNameMatchingNamespaceCacheMaxSize = 10_000;
 
     @NotNull
     public URI getBaseUri()
@@ -263,6 +266,33 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
     {
         this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
+        return this;
+    }
+
+    public boolean isCaseInsensitiveNameMatchingNamespaceCacheEnabled()
+    {
+        return caseInsensitiveNameMatchingNamespaceCacheEnabled;
+    }
+
+    @Config("iceberg.rest-catalog.case-insensitive-name-matching.namespace-cache.enabled")
+    @ConfigDescription("Cache the full list of tables/views per namespace to avoid repeated listings during case insensitive resolution")
+    public IcebergRestCatalogConfig setCaseInsensitiveNameMatchingNamespaceCacheEnabled(boolean caseInsensitiveNameMatchingNamespaceCacheEnabled)
+    {
+        this.caseInsensitiveNameMatchingNamespaceCacheEnabled = caseInsensitiveNameMatchingNamespaceCacheEnabled;
+        return this;
+    }
+
+    @Min(1)
+    public long getCaseInsensitiveNameMatchingNamespaceCacheMaxSize()
+    {
+        return caseInsensitiveNameMatchingNamespaceCacheMaxSize;
+    }
+
+    @Config("iceberg.rest-catalog.case-insensitive-name-matching.namespace-cache.max-size")
+    @ConfigDescription("Maximum total number of table or view identifiers retained across namespaces in the case insensitive listing cache")
+    public IcebergRestCatalogConfig setCaseInsensitiveNameMatchingNamespaceCacheMaxSize(long caseInsensitiveNameMatchingNamespaceCacheMaxSize)
+    {
+        this.caseInsensitiveNameMatchingNamespaceCacheMaxSize = caseInsensitiveNameMatchingNamespaceCacheMaxSize;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/NamespaceListingKey.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/NamespaceListingKey.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.catalog.Namespace;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+record NamespaceListingKey(Namespace namespace, Optional<String> user, Optional<String> credentialsDigest)
+{
+    NamespaceListingKey
+    {
+        requireNonNull(namespace, "namespace is null");
+        requireNonNull(user, "user is null");
+        requireNonNull(credentialsDigest, "credentialsDigest is null");
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -36,7 +36,9 @@ import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.RESTUtil;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -62,6 +64,8 @@ public class TrinoIcebergRestCatalogFactory
     private final boolean caseInsensitiveNameMatching;
     private final Cache<Namespace, Namespace> remoteNamespaceMappingCache;
     private final Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache;
+    private final Optional<Cache<NamespaceListingKey, List<TableIdentifier>>> namespaceTableListingCache;
+    private final Optional<Cache<NamespaceListingKey, List<TableIdentifier>>> namespaceViewListingCache;
 
     @GuardedBy("this")
     private RESTSessionCatalog icebergCatalog;
@@ -101,6 +105,24 @@ public class TrinoIcebergRestCatalogFactory
                 .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
                 .build();
+        if (caseInsensitiveNameMatching && restConfig.isCaseInsensitiveNameMatchingNamespaceCacheEnabled()) {
+            this.namespaceTableListingCache = Optional.of(EvictableCacheBuilder.newBuilder()
+                    .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
+                    .maximumWeight(restConfig.getCaseInsensitiveNameMatchingNamespaceCacheMaxSize())
+                    .<NamespaceListingKey, List<TableIdentifier>>weigher((_, identifiers) -> identifiers.size())
+                    .shareNothingWhenDisabled()
+                    .build());
+            this.namespaceViewListingCache = Optional.of(EvictableCacheBuilder.newBuilder()
+                    .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
+                    .maximumWeight(restConfig.getCaseInsensitiveNameMatchingNamespaceCacheMaxSize())
+                    .<NamespaceListingKey, List<TableIdentifier>>weigher((_, identifiers) -> identifiers.size())
+                    .shareNothingWhenDisabled()
+                    .build());
+        }
+        else {
+            this.namespaceTableListingCache = Optional.empty();
+            this.namespaceViewListingCache = Optional.empty();
+        }
     }
 
     @Override
@@ -135,7 +157,7 @@ public class TrinoIcebergRestCatalogFactory
                 catalogName,
                 security,
                 sessionType,
-                credentials,
+                                credentials,
                 nestedNamespaceEnabled,
                 trinoVersion,
                 typeManager,
@@ -143,6 +165,8 @@ public class TrinoIcebergRestCatalogFactory
                 caseInsensitiveNameMatching,
                 remoteNamespaceMappingCache,
                 remoteTableMappingCache,
+                namespaceTableListingCache,
+                namespaceViewListingCache,
                 viewEndpointsEnabled);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -19,6 +19,8 @@ import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
 import io.jsonwebtoken.impl.DefaultJwtBuilder;
@@ -102,6 +104,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.quotedTableName;
 import static io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog.ICEBERG_VIEW_RUN_AS_OWNER;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
@@ -129,6 +132,8 @@ public class TrinoRestCatalog
     private final boolean caseInsensitiveNameMatching;
     private final Cache<Namespace, Namespace> remoteNamespaceMappingCache;
     private final Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache;
+    private final Optional<Cache<NamespaceListingKey, List<TableIdentifier>>> namespaceTableListingCache;
+    private final Optional<Cache<NamespaceListingKey, List<TableIdentifier>>> namespaceViewListingCache;
     private final boolean viewEndpointsEnabled;
 
     private final Cache<SchemaTableName, BaseTable> tableCache = EvictableCacheBuilder.newBuilder()
@@ -149,6 +154,8 @@ public class TrinoRestCatalog
             boolean caseInsensitiveNameMatching,
             Cache<Namespace, Namespace> remoteNamespaceMappingCache,
             Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache,
+            Optional<Cache<NamespaceListingKey, List<TableIdentifier>>> namespaceTableListingCache,
+            Optional<Cache<NamespaceListingKey, List<TableIdentifier>>> namespaceViewListingCache,
             boolean viewEndpointsEnabled)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
@@ -164,6 +171,8 @@ public class TrinoRestCatalog
         this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
         this.remoteNamespaceMappingCache = requireNonNull(remoteNamespaceMappingCache, "remoteNamespaceMappingCache is null");
         this.remoteTableMappingCache = requireNonNull(remoteTableMappingCache, "remoteTableMappingCache is null");
+        this.namespaceTableListingCache = requireNonNull(namespaceTableListingCache, "namespaceTableListingCache is null");
+        this.namespaceViewListingCache = requireNonNull(namespaceViewListingCache, "namespaceViewListingCache is null");
         this.viewEndpointsEnabled = viewEndpointsEnabled;
     }
 
@@ -229,6 +238,7 @@ public class TrinoRestCatalog
         if (caseInsensitiveNameMatching) {
             remoteNamespaceMappingCache.invalidate(toNamespace(namespace));
         }
+        invalidateNamespaceListingCaches(namespace);
     }
 
     @Override
@@ -464,6 +474,7 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to register table '%s'".formatted(tableName.getTableName()), e);
         }
+        invalidateNamespaceTableListingCache(tableName);
     }
 
     @Override
@@ -479,6 +490,7 @@ public class TrinoRestCatalog
         }
         invalidateTableCache(tableName);
         invalidateTableMappingCache(tableName);
+        invalidateNamespaceTableListingCache(tableName);
     }
 
     @Override
@@ -492,6 +504,7 @@ public class TrinoRestCatalog
         }
         invalidateTableCache(schemaTableName);
         invalidateTableMappingCache(schemaTableName);
+        invalidateNamespaceTableListingCache(schemaTableName);
     }
 
     private void purgeBigLakeTable(ConnectorSession session, SchemaTableName schemaTableName)
@@ -551,6 +564,8 @@ public class TrinoRestCatalog
         }
         invalidateTableCache(from);
         invalidateTableMappingCache(from);
+        invalidateNamespaceTableListingCache(from);
+        invalidateNamespaceTableListingCache(to);
     }
 
     @Override
@@ -691,6 +706,8 @@ public class TrinoRestCatalog
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to rename view '%s' to '%s'".formatted(source, target), e);
         }
         invalidateTableMappingCache(source);
+        invalidateNamespaceViewListingCache(source);
+        invalidateNamespaceViewListingCache(target);
     }
 
     @Override
@@ -709,6 +726,7 @@ public class TrinoRestCatalog
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to drop view '%s'".formatted(schemaViewName.getTableName()), e);
         }
         invalidateTableMappingCache(schemaViewName);
+        invalidateNamespaceViewListingCache(schemaViewName);
     }
 
     @Override
@@ -923,6 +941,37 @@ public class TrinoRestCatalog
         }
     }
 
+    private void invalidateNamespaceTableListingCache(SchemaTableName schemaTableName)
+    {
+        namespaceTableListingCache.ifPresent(cache -> invalidateNamespaceEntries(cache, toNamespace(schemaTableName.getSchemaName())));
+    }
+
+    private void invalidateNamespaceViewListingCache(SchemaTableName schemaViewName)
+    {
+        namespaceViewListingCache.ifPresent(cache -> invalidateNamespaceEntries(cache, toNamespace(schemaViewName.getSchemaName())));
+    }
+
+    private void invalidateNamespaceListingCaches(String namespace)
+    {
+        Namespace trinoNamespace = toNamespace(namespace);
+        namespaceTableListingCache.ifPresent(cache -> invalidateNamespaceEntries(cache, trinoNamespace));
+        namespaceViewListingCache.ifPresent(cache -> invalidateNamespaceEntries(cache, trinoNamespace));
+    }
+
+    private void invalidateNamespaceEntries(Cache<NamespaceListingKey, List<TableIdentifier>> cache, Namespace namespace)
+    {
+        if (sessionType != SessionType.USER) {
+            cache.invalidate(new NamespaceListingKey(namespace, Optional.empty(), Optional.empty()));
+            return;
+        }
+        // With sessionType=USER the cache holds one entry per (namespace, user, credentials) tuple;
+        // a mutation by any user must evict every matching listing.
+        cache.asMap().keySet().stream()
+                .filter(key -> key.namespace().equals(namespace))
+                .toList()
+                .forEach(cache::invalidate);
+    }
+
     private Namespace toNamespace(String schemaName)
     {
         if (!nestedNamespaceEnabled && schemaName.contains(NAMESPACE_SEPARATOR)) {
@@ -964,24 +1013,14 @@ public class TrinoRestCatalog
     private TableIdentifier findRemoteTable(ConnectorSession session, TableIdentifier tableIdentifier)
     {
         Namespace remoteNamespace = toRemoteNamespace(session, tableIdentifier.namespace());
-        List<TableIdentifier> tableIdentifiers;
-        try {
-            tableIdentifiers = restSessionCatalog.listTables(convert(session), remoteNamespace);
+        Optional<TableIdentifier> match = matchRemoteIdentifier(tableIdentifier, loadNamespaceTableListing(session, remoteNamespace), "table");
+        if (match.isEmpty() && namespaceTableListingCache.isPresent()) {
+            // Cached listing didn't contain the table. Refresh once before declaring it missing,
+            // in case it was created out-of-band since the cache was populated.
+            namespaceTableListingCache.get().invalidate(namespaceListingKey(session, remoteNamespace));
+            match = matchRemoteIdentifier(tableIdentifier, loadNamespaceTableListing(session, remoteNamespace), "table");
         }
-        catch (RESTException e) {
-            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list tables", e);
-        }
-        TableIdentifier matchingTable = null;
-        for (TableIdentifier identifier : tableIdentifiers) {
-            if (identifier.name().equalsIgnoreCase(tableIdentifier.name())) {
-                if (matchingTable != null) {
-                    throw new TrinoException(NOT_SUPPORTED, "Duplicate table names are not supported with Iceberg REST catalog: "
-                            + Joiner.on(", ").join(matchingTable, identifier.name()));
-                }
-                matchingTable = identifier;
-            }
-        }
-        return matchingTable == null ? TableIdentifier.of(remoteNamespace, tableIdentifier.name()) : matchingTable;
+        return match.orElseGet(() -> TableIdentifier.of(remoteNamespace, tableIdentifier.name()));
     }
 
     private TableIdentifier toRemoteView(ConnectorSession session, SchemaTableName schemaViewName, boolean getCached)
@@ -997,24 +1036,93 @@ public class TrinoRestCatalog
         }
 
         Namespace remoteNamespace = toRemoteNamespace(session, tableIdentifier.namespace());
-        List<TableIdentifier> tableIdentifiers;
-        try {
-            tableIdentifiers = restSessionCatalog.listViews(convert(session), remoteNamespace);
+        Optional<TableIdentifier> match = matchRemoteIdentifier(tableIdentifier, loadNamespaceViewListing(session, remoteNamespace), "view");
+        if (match.isEmpty() && namespaceViewListingCache.isPresent()) {
+            // Cached listing didn't contain the view. Refresh once before declaring it missing,
+            // in case it was created out-of-band since the cache was populated.
+            namespaceViewListingCache.get().invalidate(namespaceListingKey(session, remoteNamespace));
+            match = matchRemoteIdentifier(tableIdentifier, loadNamespaceViewListing(session, remoteNamespace), "view");
         }
-        catch (RESTException e) {
-            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list views", e);
+        return match.orElseGet(() -> TableIdentifier.of(remoteNamespace, tableIdentifier.name()));
+    }
+
+    private List<TableIdentifier> loadNamespaceTableListing(ConnectorSession session, Namespace remoteNamespace)
+    {
+        Supplier<List<TableIdentifier>> listing = () -> {
+            try {
+                return ImmutableList.copyOf(restSessionCatalog.listTables(convert(session), remoteNamespace));
+            }
+            catch (RESTException e) {
+                throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list tables", e);
+            }
+        };
+        return namespaceTableListingCache
+                .map(cache -> uncheckedCacheGet(cache, namespaceListingKey(session, remoteNamespace), listing))
+                .orElseGet(listing);
+    }
+
+    private List<TableIdentifier> loadNamespaceViewListing(ConnectorSession session, Namespace remoteNamespace)
+    {
+        Supplier<List<TableIdentifier>> listing = () -> {
+            try {
+                return ImmutableList.copyOf(restSessionCatalog.listViews(convert(session), remoteNamespace));
+            }
+            catch (RESTException e) {
+                throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list views", e);
+            }
+        };
+        return namespaceViewListingCache
+                .map(cache -> uncheckedCacheGet(cache, namespaceListingKey(session, remoteNamespace), listing))
+                .orElseGet(listing);
+    }
+
+    private NamespaceListingKey namespaceListingKey(ConnectorSession session, Namespace namespace)
+    {
+        // With sessionType=USER the REST server may filter listings by the authenticated principal, so
+        // sharing an entry across users would leak metadata. The credentials digest further partitions by
+        // per-user tokens carried in extraCredentials; SHA-256 keeps the credential itself out of the key.
+        if (sessionType != SessionType.USER) {
+            return new NamespaceListingKey(namespace, Optional.empty(), Optional.empty());
         }
-        TableIdentifier matchingView = null;
-        for (TableIdentifier identifier : tableIdentifiers) {
+        return new NamespaceListingKey(
+                namespace,
+                Optional.of(session.getUser()),
+                hashExtraCredentials(session.getIdentity().getExtraCredentials()));
+    }
+
+    private static Optional<String> hashExtraCredentials(Map<String, String> extraCredentials)
+    {
+        if (extraCredentials.isEmpty()) {
+            return Optional.empty();
+        }
+        Hasher hasher = Hashing.sha256().newHasher();
+        extraCredentials.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    hasher.putString(entry.getKey(), UTF_8);
+                    hasher.putByte((byte) 0);
+                    hasher.putString(entry.getValue(), UTF_8);
+                    hasher.putByte((byte) 0);
+                });
+        return Optional.of(hasher.hash().toString());
+    }
+
+    private Optional<TableIdentifier> matchRemoteIdentifier(
+            TableIdentifier tableIdentifier,
+            List<TableIdentifier> remoteIdentifiers,
+            String objectKind)
+    {
+        TableIdentifier matching = null;
+        for (TableIdentifier identifier : remoteIdentifiers) {
             if (identifier.name().equalsIgnoreCase(tableIdentifier.name())) {
-                if (matchingView != null) {
-                    throw new TrinoException(NOT_SUPPORTED, "Duplicate view names are not supported with Iceberg REST catalog: "
-                            + Joiner.on(", ").join(matchingView.name(), identifier.name()));
+                if (matching != null) {
+                    throw new TrinoException(NOT_SUPPORTED, "Duplicate " + objectKind + " names are not supported with Iceberg REST catalog: "
+                            + Joiner.on(", ").join(matching, identifier.name()));
                 }
-                matchingView = identifier;
+                matching = identifier;
             }
         }
-        return matchingView == null ? TableIdentifier.of(remoteNamespace, tableIdentifier.name()) : matchingView;
+        return Optional.ofNullable(matching);
     }
 
     private TableIdentifier toRemoteObject(TableIdentifier tableIdentifier, Supplier<TableIdentifier> remoteObjectProvider, boolean getCached)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -47,6 +47,8 @@ public class TestIcebergRestCatalogConfig
                 .setViewEndpointsEnabled(true)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setCaseInsensitiveNameMatchingNamespaceCacheEnabled(true)
+                .setCaseInsensitiveNameMatchingNamespaceCacheMaxSize(10_000)
                 .setHttpHeaders(List.of()));
     }
 
@@ -67,6 +69,8 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.view-endpoints-enabled", "false")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl", "3m")
+                .put("iceberg.rest-catalog.case-insensitive-name-matching.namespace-cache.enabled", "false")
+                .put("iceberg.rest-catalog.case-insensitive-name-matching.namespace-cache.max-size", "50")
                 .put("iceberg.rest-catalog.http-headers", "Polaris-Realm: default-realm")
                 .buildOrThrow();
 
@@ -84,6 +88,8 @@ public class TestIcebergRestCatalogConfig
                 .setViewEndpointsEnabled(false)
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES))
+                .setCaseInsensitiveNameMatchingNamespaceCacheEnabled(false)
+                .setCaseInsensitiveNameMatchingNamespaceCacheMaxSize(50)
                 .setHttpHeaders(List.of("Polaris-Realm: default-realm"));
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableMap;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.metastore.TableInfo;
@@ -27,17 +28,28 @@ import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
 import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -55,6 +67,7 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -107,6 +120,8 @@ public class TestTrinoRestCatalog
                 false,
                 EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
                 EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
+                Optional.empty(),
+                Optional.empty(),
                 true);
     }
 
@@ -183,6 +198,190 @@ public class TestTrinoRestCatalog
                 .cause()
                 .as("should fail as the prefix dev is not implemented for the current endpoint")
                 .hasMessageContaining("Malformed request: No route for request: POST v1/dev/namespaces");
+    }
+
+    @Test
+    public void testCaseInsensitiveNamespaceListingCacheReusesListing()
+            throws IOException
+    {
+        // Resolving a case-insensitive name normally goes: findRemoteTable -> listTables(namespace) -> scan for equalsIgnoreCase match.
+        // With the namespace listing cache enabled, multiple resolutions against the same namespace should share a single listTables call.
+
+        Path warehouseLocation = Files.createTempDirectory(null);
+        warehouseLocation.toFile().deleteOnExit();
+
+        String catalogName = "iceberg_rest";
+        // Delegating proxy counts listTables(Namespace) calls hitting the backend so we can assert on actual REST-layer traffic.
+        Catalog backend = backendCatalog(warehouseLocation);
+        AtomicInteger listTablesCount = new AtomicInteger();
+        Catalog countingBackend = (Catalog) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {Catalog.class, SupportsNamespaces.class, ViewCatalog.class, Closeable.class},
+                (_, method, args) -> {
+                    if (method.getName().equals("listTables") && args != null && args.length == 1) {
+                        listTablesCount.incrementAndGet();
+                    }
+                    return method.invoke(backend, args);
+                });
+
+        RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog.builder()
+                .delegate(countingBackend)
+                .build();
+        restSessionCatalog.initialize(catalogName, ImmutableMap.of());
+
+        // Real, weight-based listing cache matching the production configuration shape.
+        Cache<NamespaceListingKey, List<TableIdentifier>> listingCache = EvictableCacheBuilder.newBuilder()
+                .expireAfterWrite(1, MINUTES)
+                .maximumWeight(10_000)
+                .<NamespaceListingKey, List<TableIdentifier>>weigher((_, identifiers) -> identifiers.size())
+                .shareNothingWhenDisabled()
+                .build();
+
+        TrinoRestCatalog catalog = new TrinoRestCatalog(
+                new DefaultIcebergFileSystemFactory(HDFS_FILE_SYSTEM_FACTORY),
+                restSessionCatalog,
+                new CatalogName(catalogName),
+                Security.NONE,
+                NONE,
+                ImmutableMap.of(),
+                false,
+                "test",
+                TESTING_TYPE_MANAGER,
+                false,
+                true, // caseInsensitiveNameMatching enabled so findRemoteTable is exercised
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1, MINUTES).shareNothingWhenDisabled().build(),
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1, MINUTES).shareNothingWhenDisabled().build(),
+                Optional.of(listingCache),
+                Optional.empty(), // no view listing cache - this test only asserts on the table path
+                true);
+
+        String schema = "ns_cache_test_" + randomNameSuffix();
+        List<String> tableNames = List.of("table_a", "table_b", "table_c");
+        catalog.createNamespace(SESSION, schema, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+        try {
+            // Create tables directly against the backend so setup doesn't warm Trino-side caches.
+            Schema tableSchema = new Schema(Types.NestedField.required(1, "c", Types.IntegerType.get()));
+            for (String name : tableNames) {
+                backend.buildTable(TableIdentifier.of(schema, name), tableSchema).create();
+            }
+            // Reset the counter so only the assertions below are measured.
+            listTablesCount.set(0);
+
+            // Resolve three distinct tables. Without the listing cache each would trigger its own listTables.
+            for (String name : tableNames) {
+                catalog.loadTable(SESSION, new SchemaTableName(schema, name));
+            }
+
+            // One listTables call serves all three resolutions within the TTL window.
+            assertThat(listTablesCount.get())
+                    .as("listTables invocations during case-insensitive resolution of %d tables", tableNames.size())
+                    .isEqualTo(1);
+        }
+        finally {
+            for (String name : tableNames) {
+                try {
+                    catalog.dropTable(SESSION, new SchemaTableName(schema, name));
+                }
+                catch (RuntimeException ignored) {
+                }
+            }
+            catalog.dropNamespace(SESSION, schema);
+        }
+    }
+
+    @Test
+    public void testCaseInsensitiveNamespaceListingCacheRefreshesOnMiss()
+            throws IOException
+    {
+        // A cached listing can become stale if a table is created out-of-band (e.g. by Spark) after the cache was populated.
+        // On a cache miss (no case-insensitive match in the cached listing), the implementation must invalidate and refetch
+        // once before declaring the table missing, so the out-of-band table becomes visible immediately on next lookup.
+
+        Path warehouseLocation = Files.createTempDirectory(null);
+        warehouseLocation.toFile().deleteOnExit();
+
+        String catalogName = "iceberg_rest";
+        Catalog backend = backendCatalog(warehouseLocation);
+        AtomicInteger listTablesCount = new AtomicInteger();
+        Catalog countingBackend = (Catalog) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {Catalog.class, SupportsNamespaces.class, ViewCatalog.class, Closeable.class},
+                (_, method, args) -> {
+                    if (method.getName().equals("listTables") && args != null && args.length == 1) {
+                        listTablesCount.incrementAndGet();
+                    }
+                    return method.invoke(backend, args);
+                });
+
+        RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog.builder()
+                .delegate(countingBackend)
+                .build();
+        restSessionCatalog.initialize(catalogName, ImmutableMap.of());
+
+        Cache<NamespaceListingKey, List<TableIdentifier>> listingCache = EvictableCacheBuilder.newBuilder()
+                .expireAfterWrite(1, MINUTES)
+                .maximumWeight(10_000)
+                .<NamespaceListingKey, List<TableIdentifier>>weigher((_, identifiers) -> identifiers.size())
+                .shareNothingWhenDisabled()
+                .build();
+
+        TrinoRestCatalog catalog = new TrinoRestCatalog(
+                new DefaultIcebergFileSystemFactory(HDFS_FILE_SYSTEM_FACTORY),
+                restSessionCatalog,
+                new CatalogName(catalogName),
+                Security.NONE,
+                NONE,
+                ImmutableMap.of(),
+                false,
+                "test",
+                TESTING_TYPE_MANAGER,
+                false,
+                true,
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1, MINUTES).shareNothingWhenDisabled().build(),
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1, MINUTES).shareNothingWhenDisabled().build(),
+                Optional.of(listingCache),
+                Optional.empty(),
+                true);
+
+        String schema = "ns_cache_refresh_test_" + randomNameSuffix();
+        catalog.createNamespace(SESSION, schema, ImmutableMap.of(), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+        try {
+            Schema tableSchema = new Schema(Types.NestedField.required(1, "c", Types.IntegerType.get()));
+
+            // Create first table and load it via Trino - populates the cache with [table_a].
+            backend.buildTable(TableIdentifier.of(schema, "table_a"), tableSchema).create();
+            listTablesCount.set(0);
+            catalog.loadTable(SESSION, new SchemaTableName(schema, "table_a"));
+            assertThat(listTablesCount.get())
+                    .as("listTables calls on initial resolve (cold cache)")
+                    .isEqualTo(1);
+
+            // Create a second table out-of-band while the cache still holds the stale [table_a] listing.
+            backend.buildTable(TableIdentifier.of(schema, "table_b"), tableSchema).create();
+
+            // Resolving table_b must find it despite the stale cache - the miss should trigger a refresh.
+            catalog.loadTable(SESSION, new SchemaTableName(schema, "table_b"));
+            assertThat(listTablesCount.get())
+                    .as("listTables calls after miss-triggered refresh picks up the out-of-band table")
+                    .isEqualTo(2);
+
+            // The refresh also repopulated the cache, so table_b lookups are fast on subsequent calls.
+            catalog.loadTable(SESSION, new SchemaTableName(schema, "table_b"));
+            catalog.loadTable(SESSION, new SchemaTableName(schema, "table_a"));
+            assertThat(listTablesCount.get())
+                    .as("subsequent lookups for tables now in the refreshed cache do not trigger more listTables")
+                    .isEqualTo(2);
+        }
+        finally {
+            for (String name : List.of("table_a", "table_b")) {
+                try {
+                    catalog.dropTable(SESSION, new SchemaTableName(schema, name));
+                }
+                catch (RuntimeException ignored) {
+                }
+            }
+            catalog.dropNamespace(SESSION, schema);
+        }
     }
 
     @Override


### PR DESCRIPTION
When iceberg.rest-catalog.case-insensitive-name-matching is enabled, each case-insensitive name lookup calls listTables/listViews against the REST server. Repeated lookups within the same namespace (common when a query references multiple tables) issue one call each, even though every call returns the same full listing.

Add a per-namespace listing cache (tables and views, separate) sharing the existing caseInsensitiveNameMatchingCacheTtl. Entries are weight-bound by identifier count rather than namespace count, so the cap controls total memory regardless of schema size.

When sessionType=USER, cache entries are partitioned per (namespace, user, credentials digest). REST servers may filter listings by the authenticated principal, so sharing an entry across users would leak metadata. The credentials digest (SHA-256 of session.extraCredentials) further distinguishes callers that share the same Trino user but use different per-user tokens. With sessionType=NONE the request identity is fixed catalog-side and a namespace-only key is used.

On a case-insensitive miss against a cached listing, invalidate the namespace entry and refetch once before declaring the object missing. This keeps tables created out-of-band (e.g. by Spark) visible immediately rather than hidden for up to TTL, trading one extra list call per genuine miss for correctness.

New configuration properties (both only consulted when case-insensitive-name-matching is true):
* iceberg.rest-catalog.case-insensitive-name-matching.namespace-cache.enabled (default: true)
* iceberg.rest-catalog.case-insensitive-name-matching.namespace-cache.max-size (default: 10_000 identifiers)

Invalidation is wired into dropTable, unregisterTable, renameTable (both source and target namespaces), registerTable, renameView, dropView, and dropNamespace to avoid serving stale listings after known mutations.


## Release notes

  ( ) This is not user-visible or is docs only, and no release notes are required.
  ( ) Release notes are required. Please propose a release note for me.
  (x) Release notes are required, with the following suggested text:

```
  ## Iceberg connector
  * Improve performance of case-insensitive name matching against REST catalogs. ({issue}`NNNNN`)
```
