### PR TITLE
Tighten decimal multiplication result precision

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
@@ -275,8 +275,9 @@ public final class DecimalOperators
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
+            // except that raw_precision is a_precision + b_precision instead of a_precision + b_precision + 1,
             // as follows, with all expressions inlined:
-            //     raw_precision = a_precision + b_precision + 1;
+            //     raw_precision = a_precision + b_precision;
             //     raw_scale = a_scale + b_scale;
             //
             // Adjustment if precision doesn't fit into 38 digits:
@@ -284,8 +285,8 @@ public final class DecimalOperators
             //     precision = min(raw_precision, 38);
             //     scale = min(raw_scale, integral > 32 ? 6 : 38 - integral);
             signature
-                    .longVariable("r_precision", "min(a_precision + b_precision + 1, 38)")
-                    .longVariable("r_scale", "min(a_scale + b_scale, if(a_precision + b_precision + 1 - (a_scale + b_scale) > 32, 6, 38 - (a_precision + b_precision + 1 - (a_scale + b_scale))))");
+                    .longVariable("r_precision", "min(a_precision + b_precision, 38)")
+                    .longVariable("r_scale", "min(a_scale + b_scale, if(a_precision + b_precision - (a_scale + b_scale) > 32, 6, 38 - (a_precision + b_precision - (a_scale + b_scale))))");
         }
 
         return new PolymorphicScalarFunctionBuilder(MULTIPLY, DecimalOperators.class)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -2972,7 +2972,7 @@ public class TestAnalyzer
                 "          )" +
                 "          SELECT * from t")
                 .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:82: recursion step relation output type (decimal(3,1)) is not coercible to recursion base relation output type (decimal(1,0)) at column 1");
+                .hasMessage("line 1:82: recursion step relation output type (decimal(2,1)) is not coercible to recursion base relation output type (decimal(1,0)) at column 1");
 
         assertFails("WITH RECURSIVE t(n) AS (" +
                 "          SELECT * FROM (VALUES('a'), ('b')) AS t(n)" +

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestInlineProjections.java
@@ -111,7 +111,7 @@ public class TestInlineProjections
                         p.project(
                                 Assignments.builder()
                                         // Use the literal-like expression multiple times. Single-use expression may be inlined regardless of whether it's a literal
-                                        .put(p.symbol("decimal_multiplication", createDecimalType(17, 8)), new Call(MULTIPLY_DECIMAL_8_4, ImmutableList.of(new Reference(createDecimalType(8, 4), "decimal_literal"), new Reference(createDecimalType(8, 4), "decimal_literal"))))
+                                        .put(p.symbol("decimal_multiplication", createDecimalType(16, 8)), new Call(MULTIPLY_DECIMAL_8_4, ImmutableList.of(new Reference(createDecimalType(8, 4), "decimal_literal"), new Reference(createDecimalType(8, 4), "decimal_literal"))))
                                         .put(p.symbol("decimal_addition", createDecimalType(9, 4)), new Call(ADD_DECIMAL_8_4, ImmutableList.of(new Reference(createDecimalType(8, 4), "decimal_literal"), new Reference(createDecimalType(8, 4), "decimal_literal"))))
                                         .build(),
                                 p.project(Assignments.builder()

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
@@ -291,59 +291,59 @@ public class TestDecimalOperators
     {
         // short short -> short
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '0'", "DECIMAL '1'"))
-                .isEqualTo(decimal("00", createDecimalType(3)));
+                .isEqualTo(decimal("00", createDecimalType(2)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '0'", "DECIMAL '-1'"))
-                .isEqualTo(decimal("00", createDecimalType(3)));
+                .isEqualTo(decimal("00", createDecimalType(2)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '1'", "DECIMAL '0'"))
-                .isEqualTo(decimal("00", createDecimalType(3)));
+                .isEqualTo(decimal("00", createDecimalType(2)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-1'", "DECIMAL '0'"))
-                .isEqualTo(decimal("00", createDecimalType(3)));
+                .isEqualTo(decimal("00", createDecimalType(2)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '12'", "DECIMAL '3'"))
-                .isEqualTo(decimal("036", createDecimalType(4)));
+                .isEqualTo(decimal("036", createDecimalType(3)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '12'", "DECIMAL '-3'"))
-                .isEqualTo(decimal("-036", createDecimalType(4)));
+                .isEqualTo(decimal("-036", createDecimalType(3)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-12'", "DECIMAL '3'"))
-                .isEqualTo(decimal("-036", createDecimalType(4)));
+                .isEqualTo(decimal("-036", createDecimalType(3)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '1234567890123456'", "DECIMAL '3'"))
-                .isEqualTo(decimal("03703703670370368", createDecimalType(18)));
+                .isEqualTo(decimal("03703703670370368", createDecimalType(17)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1234567890123456'", "DECIMAL '3'"))
-                .isEqualTo(decimal("0.3703703670370368", createDecimalType(18, 16)));
+                .isEqualTo(decimal("0.3703703670370368", createDecimalType(17, 16)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1234567890123456'", "DECIMAL '.3'"))
-                .isEqualTo(decimal(".03703703670370368", createDecimalType(18, 17)));
+                .isEqualTo(decimal(".03703703670370368", createDecimalType(17, 17)));
 
         // short short -> long
         assertThat(assertions.operator(MULTIPLY, "CAST(0 AS DECIMAL(18,0))", "CAST(1 AS DECIMAL(18,0))"))
-                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(37)));
+                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "CAST(0 AS DECIMAL(18,0))", "CAST(-1 AS DECIMAL(18,0))"))
-                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(37)));
+                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "CAST(1 AS DECIMAL(18,0))", "CAST(0 AS DECIMAL(18,0))"))
-                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(37)));
+                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "CAST(-1 AS DECIMAL(18,0))", "CAST(0 AS DECIMAL(18,0))"))
-                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(37)));
+                .isEqualTo(decimal("000000000000000000000000000000000000", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567'", "DECIMAL '123456789012345670'"))
-                .isEqualTo(decimal("01524157875323883455265967556774890", createDecimalType(36)));
+                .isEqualTo(decimal("01524157875323883455265967556774890", createDecimalType(35)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-12345678901234567'", "DECIMAL '123456789012345670'"))
-                .isEqualTo(decimal("-01524157875323883455265967556774890", createDecimalType(36)));
+                .isEqualTo(decimal("-01524157875323883455265967556774890", createDecimalType(35)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-12345678901234567'", "DECIMAL '-123456789012345670'"))
-                .isEqualTo(decimal("01524157875323883455265967556774890", createDecimalType(36)));
+                .isEqualTo(decimal("01524157875323883455265967556774890", createDecimalType(35)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567'", "DECIMAL '.123456789012345670'"))
-                .isEqualTo(decimal(".01524157875323883455265967556774890", createDecimalType(36, 35)));
+                .isEqualTo(decimal(".01524157875323883455265967556774890", createDecimalType(35, 35)));
 
         // long short -> long
         assertThat(assertions.operator(MULTIPLY, "CAST(0 AS DECIMAL(38,0))", "1"))
@@ -362,10 +362,10 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("37037036703703703670370370367037037034", createDecimalType(38)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '1234567890123456789.0123456789012345678'", "DECIMAL '3'"))
-                .isEqualTo(decimal("3703703670370370367.03703703670370370", createDecimalType(38, 17)));
+                .isEqualTo(decimal("3703703670370370367.037037036703703703", createDecimalType(38, 18)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '3'"))
-                .isEqualTo(decimal(".370370367037037036703703703670370370", createDecimalType(38, 36)));
+                .isEqualTo(decimal(".3703703670370370367037037036703703703", createDecimalType(38, 37)));
 
         // short long -> long
         assertThat(assertions.operator(MULTIPLY, "0", "CAST(1 AS DECIMAL(38,0))"))
@@ -384,10 +384,10 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("37037036703703703670370370367037037034", createDecimalType(38)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '3'", "DECIMAL '1234567890123456789.0123456789012345678'"))
-                .isEqualTo(decimal("3703703670370370367.03703703670370370", createDecimalType(38, 17)));
+                .isEqualTo(decimal("3703703670370370367.037037036703703703", createDecimalType(38, 18)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '3'", "DECIMAL '.12345678901234567890123456789012345678'"))
-                .isEqualTo(decimal(".370370367037037036703703703670370370", createDecimalType(38, 36)));
+                .isEqualTo(decimal(".3703703670370370367037037036703703703", createDecimalType(38, 37)));
 
         // long long -> long
         assertThat(assertions.operator(MULTIPLY, "CAST(0 AS DECIMAL(38,0))", "CAST(1 AS DECIMAL(38,0))"))
@@ -409,26 +409,26 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("0000000000000000000000000000000000000.6", createDecimalType(38, 1)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1234567890123456789'", "DECIMAL '.1234567890123456789'"))
-                .isEqualTo(decimal(".0152415787532388367501905199875019052", createDecimalType(38, 37)));
+                .isEqualTo(decimal(".01524157875323883675019051998750190521", createDecimalType(38, 38)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1234567890123456789'", "DECIMAL '.12345678901234567890'"))
-                .isEqualTo(decimal("0.0152415787532388367501905199875019052", createDecimalType(38, 37)));
+                .isEqualTo(decimal("0.01524157875323883675019051998750190521", createDecimalType(38, 38)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1'", "DECIMAL '.12345678901234567890123456789012345678'"))
-                .isEqualTo(decimal("0.0123456789012345678901234567890123457", createDecimalType(38, 37)));
+                .isEqualTo(decimal("0.01234567890123456789012345678901234568", createDecimalType(38, 38)));
 
         // runtime overflow tests
         assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '9'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '9'"))
-                .isEqualTo(decimal("1.111111101111111110111111111011111111", createDecimalType(38, 36)));
+                .isEqualTo(decimal("1.1111111011111111101111111110111111110", createDecimalType(38, 37)));
 
         assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '-9'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '-9'"))
-                .isEqualTo(decimal("-1.111111101111111110111111111011111111", createDecimalType(38, 36)));
+                .isEqualTo(decimal("-1.1111111011111111101111111110111111110", createDecimalType(38, 37)));
     }
 
     @Test
@@ -2135,41 +2135,41 @@ public class TestDecimalOperators
     {
         // decimal bigint
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567'", "12345678901234567"))
-                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(37)));
+                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-12345678901234567'", "12345678901234567"))
-                .isEqualTo(decimal("-000152415787532388345526596755677489", createDecimalType(37)));
+                .isEqualTo(decimal("-000152415787532388345526596755677489", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-12345678901234567'", "-12345678901234567"))
-                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(37)));
+                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1234567890'", "BIGINT '3'"))
-                .isEqualTo(decimal("0000000000000000000.3703703670", createDecimalType(30, 10)));
+                .isEqualTo(decimal("0000000000000000000.3703703670", createDecimalType(29, 10)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '.1234567890'", "BIGINT '0'"))
-                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(30, 10)));
+                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(29, 10)));
 
         assertThat(assertions.operator(MULTIPLY, "DECIMAL '-.1234567890'", "BIGINT '0'"))
-                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(30, 10)));
+                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(29, 10)));
 
         // bigint decimal
         assertThat(assertions.operator(MULTIPLY, "12345678901234567", "DECIMAL '12345678901234567'"))
-                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(37)));
+                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "12345678901234567", "DECIMAL '-12345678901234567'"))
-                .isEqualTo(decimal("-000152415787532388345526596755677489", createDecimalType(37)));
+                .isEqualTo(decimal("-000152415787532388345526596755677489", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "-12345678901234567", "DECIMAL '-12345678901234567'"))
-                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(37)));
+                .isEqualTo(decimal("000152415787532388345526596755677489", createDecimalType(36)));
 
         assertThat(assertions.operator(MULTIPLY, "BIGINT '3'", "DECIMAL '.1234567890'"))
-                .isEqualTo(decimal("0000000000000000000.3703703670", createDecimalType(30, 10)));
+                .isEqualTo(decimal("0000000000000000000.3703703670", createDecimalType(29, 10)));
 
         assertThat(assertions.operator(MULTIPLY, "BIGINT '3'", "DECIMAL '.0000000000'"))
-                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(30, 10)));
+                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(29, 10)));
 
         assertThat(assertions.operator(MULTIPLY, "BIGINT '-3'", "DECIMAL '.0000000000'"))
-                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(30, 10)));
+                .isEqualTo(decimal("0000000000000000000.0000000000", createDecimalType(29, 10)));
     }
 
     @Test


### PR DESCRIPTION
Use a_precision + b_precision instead of a_precision + b_precision + 1 in the modern multiplication result-type formula. The +1, inherited from MSSQL, has no mathematical basis: |A * B| < 10^(a_precision + b_precision), so a_precision + b_precision digits always fit the exact product, and half-up rounding during scale shedding cannot reach 10^38 either, since the gap to 10^(a_precision + b_precision) exceeds half the shed factor for any a_precision, b_precision <= 38.

- fixes https://github.com/trinodb/trino/issues/29381