### PR TITLE
Add SQL:2023 static method invocation

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -605,6 +605,7 @@ primaryExpression
         filter? over?                                                                     #functionCall
     | processingMode? qualifiedName '(' (setQuantifier? expression (',' expression)*)?
         orderBy? ')' filter? (nullTreatment? over)?                                       #functionCall
+    | qualifiedName '::' identifier '(' (expression (',' expression)*)? ')'               #staticMethodCall
     | identifier over                                                                     #measure
     | identifier '->' expression                                                          #lambda
     | '(' (identifier (',' identifier)*)? ')' '->' expression                             #lambda

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -118,7 +119,9 @@ public class FunctionResolver
                 session,
                 name,
                 parameterTypes,
-                catalogSchemaFunctionName -> metadata.getFunctions(session, catalogSchemaFunctionName),
+                catalogSchemaFunctionName -> filterCandidates(
+                        metadata.getFunctions(session, catalogSchemaFunctionName),
+                        candidate -> candidate.functionMetadata().getReceiverType().isEmpty()),
                 accessControl);
 
         FunctionMetadata functionMetadata = catalogFunctionBinding.boundFunctionMetadata();
@@ -127,6 +130,41 @@ public class FunctionResolver
         }
 
         return resolve(session, catalogFunctionBinding, accessControl);
+    }
+
+    public ResolvedFunction resolveStaticMethod(
+            Session session,
+            TypeSignature receiverType,
+            QualifiedName methodName,
+            List<TypeSignatureProvider> parameterTypes,
+            AccessControl accessControl)
+    {
+        String receiver = receiverType.getBase();
+        CatalogFunctionBinding catalogFunctionBinding = bindFunction(
+                session,
+                methodName,
+                parameterTypes,
+                catalogSchemaFunctionName -> filterCandidates(
+                        metadata.getFunctions(session, catalogSchemaFunctionName),
+                        candidate -> candidate.functionMetadata().getReceiverType()
+                                .map(TypeSignature::getBase).equals(Optional.of(receiver))),
+                accessControl);
+
+        FunctionMetadata functionMetadata = catalogFunctionBinding.boundFunctionMetadata();
+        if (functionMetadata.isDeprecated()) {
+            warningCollector.add(new TrinoWarning(DEPRECATED_FUNCTION, "Use of deprecated function: %s::%s: %s".formatted(receiverType, methodName, functionMetadata.getDescription())));
+        }
+
+        return resolve(session, catalogFunctionBinding, accessControl);
+    }
+
+    private static Collection<CatalogFunctionMetadata> filterCandidates(
+            Collection<CatalogFunctionMetadata> candidates,
+            Predicate<CatalogFunctionMetadata> predicate)
+    {
+        return candidates.stream()
+                .filter(predicate)
+                .collect(toImmutableList());
     }
 
     private ResolvedFunction resolve(Session session, CatalogFunctionBinding functionBinding, AccessControl accessControl)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ParametricScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ParametricScalar.java
@@ -81,6 +81,7 @@ public class ParametricScalar
         if (deprecated) {
             functionMetadata.deprecated();
         }
+        details.getReceiverType().ifPresent(functionMetadata::receiverType);
 
         if (functionNullability.isReturnNullable()) {
             functionMetadata.nullable();

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.StaticMethod;
+import io.trino.spi.type.TypeSignature;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -30,6 +32,7 @@ import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
 import static io.trino.operator.annotations.FunctionsParserHelper.parseDescription;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
 import static java.util.Objects.requireNonNull;
 
 public class ScalarHeader
@@ -41,8 +44,14 @@ public class ScalarHeader
     private final boolean hidden;
     private final boolean deterministic;
     private final boolean neverFails;
+    private final Optional<TypeSignature> receiverType;
 
     public ScalarHeader(String name, Set<String> aliases, Optional<String> description, boolean hidden, boolean deterministic, boolean neverFails)
+    {
+        this(name, aliases, description, hidden, deterministic, neverFails, Optional.empty());
+    }
+
+    public ScalarHeader(String name, Set<String> aliases, Optional<String> description, boolean hidden, boolean deterministic, boolean neverFails, Optional<TypeSignature> receiverType)
     {
         this.name = requireNonNull(name, "name is null");
         checkArgument(!name.isEmpty());
@@ -53,6 +62,7 @@ public class ScalarHeader
         this.hidden = hidden;
         this.deterministic = deterministic;
         this.neverFails = neverFails;
+        this.receiverType = requireNonNull(receiverType, "receiverType is null");
     }
 
     public ScalarHeader(OperatorType operatorType, Optional<String> description)
@@ -64,19 +74,30 @@ public class ScalarHeader
         this.hidden = true;
         this.deterministic = true;
         this.neverFails = false;
+        this.receiverType = Optional.empty();
     }
 
     public static List<ScalarHeader> fromAnnotatedElement(AnnotatedElement annotated)
     {
         ScalarFunction scalarFunction = annotated.getAnnotation(ScalarFunction.class);
         ScalarOperator scalarOperator = annotated.getAnnotation(ScalarOperator.class);
+        StaticMethod staticMethod = annotated.getAnnotation(StaticMethod.class);
         Optional<String> description = parseDescription(annotated);
 
         ImmutableList.Builder<ScalarHeader> builder = ImmutableList.builder();
 
         if (scalarFunction != null) {
             String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
-            builder.add(new ScalarHeader(baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic(), scalarFunction.neverFails()));
+            Optional<TypeSignature> receiverType = Optional.empty();
+            if (staticMethod != null) {
+                TypeSignature parsed = parseTypeSignature(staticMethod.value(), ImmutableSet.of());
+                checkArgument(parsed.getParameters().isEmpty(), "@StaticMethod receiver type must not have parameters: %s", staticMethod.value());
+                receiverType = Optional.of(parsed);
+            }
+            builder.add(new ScalarHeader(baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic(), scalarFunction.neverFails(), receiverType));
+        }
+        else if (staticMethod != null) {
+            throw new IllegalArgumentException("@StaticMethod requires @ScalarFunction on " + annotated);
         }
 
         if (scalarOperator != null) {
@@ -138,5 +159,10 @@ public class ScalarHeader
     public boolean neverFails()
     {
         return neverFails;
+    }
+
+    public Optional<TypeSignature> getReceiverType()
+    {
+        return receiverType;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -53,6 +53,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeId;
 import io.trino.spi.type.TypeNotFoundException;
 import io.trino.spi.type.TypeParameter;
+import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis.PredicateCoercions;
@@ -148,6 +149,7 @@ import io.trino.sql.tree.SimpleIntervalQualifier;
 import io.trino.sql.tree.SkipTo;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.SortItem.Ordering;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -1456,6 +1458,61 @@ public class ExpressionAnalyzer
 
             Type type = signature.getReturnType();
             return setExpressionType(node, type);
+        }
+
+        @Override
+        protected Type visitStaticMethodCall(StaticMethodCall node, Context context)
+        {
+            QualifiedName receiver = node.getType();
+            if (receiver.getParts().size() != 1) {
+                throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", receiver);
+            }
+            TypeSignature receiverSignature = new TypeSignature(receiver.getSuffix());
+            Type receiverType;
+            try {
+                receiverType = plannerContext.getTypeManager().getType(receiverSignature);
+            }
+            catch (TypeNotFoundException e) {
+                throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", receiver);
+            }
+
+            List<TypeSignatureProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);
+
+            ResolvedFunction function;
+            try {
+                function = functionResolver.resolveStaticMethod(
+                        session,
+                        receiverType.getTypeSignature(),
+                        QualifiedName.of(node.getMethod().getValue()),
+                        argumentTypes,
+                        accessControl);
+            }
+            catch (TrinoException e) {
+                if (e.getLocation().isPresent()) {
+                    throw e;
+                }
+                throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
+            }
+
+            if (node.getArguments().size() > 127) {
+                throw semanticException(TOO_MANY_ARGUMENTS, node, "Too many arguments for static method call %s::%s()", receiver, node.getMethod().getValue());
+            }
+
+            BoundSignature signature = function.signature();
+            for (int i = 0; i < argumentTypes.size(); i++) {
+                Expression expression = node.getArguments().get(i);
+                Type expectedType = signature.getArgumentTypes().get(i);
+                if (argumentTypes.get(i).hasDependency()) {
+                    FunctionType expectedFunctionType = (FunctionType) expectedType;
+                    process(expression, context.expectingLambda(expectedFunctionType.getArgumentTypes()));
+                }
+                else {
+                    Type actualType = plannerContext.getTypeManager().getType(argumentTypes.get(i).getTypeSignature());
+                    coerceType(expression, actualType, expectedType, format("Static method %s::%s argument %d", receiver, node.getMethod().getValue(), i));
+                }
+            }
+            resolvedFunctions.put(NodeRef.of(node), function);
+            return setExpressionType(node, signature.getReturnType());
         }
 
         private void analyzeWindow(ResolvedWindow window, Context context, Node originalNode)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -113,6 +113,7 @@ import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.SimpleIntervalQualifier;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.Trim;
@@ -320,6 +321,7 @@ public class TranslationMap
                 case io.trino.sql.tree.FieldReference expression -> translate(expression);
                 case Identifier expression -> translate(expression);
                 case FunctionCall expression -> translate(expression);
+                case StaticMethodCall expression -> translate(expression);
                 case DereferenceExpression expression -> translate(expression);
                 case Array expression -> translate(expression);
                 case CurrentCatalog expression -> translate(expression);
@@ -674,6 +676,18 @@ public class TranslationMap
 
         Optional<ResolvedFunction> resolvedFunction = analysis.getResolvedFunction(expression);
         checkArgument(resolvedFunction.isPresent(), "Function has not been analyzed: %s", expression);
+
+        return new Call(
+                resolvedFunction.get(),
+                expression.getArguments().stream()
+                        .map(this::translateExpression)
+                        .collect(toImmutableList()));
+    }
+
+    private io.trino.sql.ir.Expression translate(StaticMethodCall expression)
+    {
+        Optional<ResolvedFunction> resolvedFunction = analysis.getResolvedFunction(expression);
+        checkArgument(resolvedFunction.isPresent(), "Static method has not been analyzed: %s", expression);
 
         return new Call(
                 resolvedFunction.get(),

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.StaticMethod;
+import io.trino.spi.type.StandardTypes;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.TYPE_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestStaticMethodCall
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder()
+                .scalars(getClass())
+                .build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @ScalarFunction("parse")
+    @StaticMethod(StandardTypes.BIGINT)
+    @SqlType(StandardTypes.BIGINT)
+    public static long bigintParse(@SqlType(StandardTypes.VARCHAR) Slice value)
+    {
+        try {
+            return Long.parseLong(value.toStringUtf8());
+        }
+        catch (NumberFormatException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Cannot parse '%s' as bigint".formatted(value.toStringUtf8()));
+        }
+    }
+
+    @Test
+    public void testBasic()
+    {
+        assertThat(assertions.expression("bigint::parse('42')"))
+                .matches("BIGINT '42'");
+
+        assertThat(assertions.expression("bigint::parse('-1234567890')"))
+                .matches("BIGINT '-1234567890'");
+    }
+
+    @Test
+    public void testInvalidArgument()
+    {
+        assertTrinoExceptionThrownBy(assertions.expression("bigint::parse('abc')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+    }
+
+    @Test
+    public void testUnknownReceiverType()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("not_a_type::parse('42')").evaluate())
+                .hasErrorCode(TYPE_NOT_FOUND)
+                .hasMessageContaining("Unknown type: not_a_type");
+    }
+
+    @Test
+    public void testUnknownMethod()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::nope('42')").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    @Test
+    public void testStaticMethodNotResolvableWithoutReceiver()
+    {
+        // The plain `parse('42')` form must NOT resolve to bigint::parse.
+        assertTrinoExceptionThrownBy(() -> assertions.expression("parse('42')").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    @Test
+    public void testParametricReceiverTypeRejected()
+    {
+        assertThatThrownBy(() -> InternalFunctionBundle.builder().scalars(ParametricReceiverFixture.class).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("@StaticMethod receiver type must not have parameters");
+    }
+
+    public static class ParametricReceiverFixture
+    {
+        @ScalarFunction("parse")
+        @StaticMethod("varchar(5)")
+        @SqlType(StandardTypes.BIGINT)
+        public static long parse(@SqlType(StandardTypes.VARCHAR) Slice value)
+        {
+            return 0;
+        }
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -94,6 +94,7 @@ import io.trino.sql.tree.SimpleGroupBy;
 import io.trino.sql.tree.SimpleIntervalQualifier;
 import io.trino.sql.tree.SkipTo;
 import io.trino.sql.tree.SortItem;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -503,6 +504,12 @@ public final class ExpressionFormatter
             }
 
             return builder.toString();
+        }
+
+        @Override
+        protected String visitStaticMethodCall(StaticMethodCall node, Void context)
+        {
+            return formatName(node.getType()) + "::" + formatExpression(node.getMethod()) + "(" + joinExpressions(node.getArguments()) + ")";
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -284,6 +284,7 @@ import io.trino.sql.tree.SkipTo;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -3159,6 +3160,16 @@ class AstBuilder
                 nulls,
                 mode,
                 arguments);
+    }
+
+    @Override
+    public Node visitStaticMethodCall(SqlBaseParser.StaticMethodCallContext context)
+    {
+        return new StaticMethodCall(
+                getLocation(context),
+                getQualifiedName(context.qualifiedName()),
+                (Identifier) visit(context.identifier()),
+                visit(context.expression(), Expression.class));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -337,6 +337,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitStaticMethodCall(StaticMethodCall node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitProcessingMode(ProcessingMode node, C context)
     {
         return visitNode(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -224,6 +224,15 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitStaticMethodCall(StaticMethodCall node, C context)
+    {
+        for (Expression argument : node.getArguments()) {
+            process(argument, context);
+        }
+        return null;
+    }
+
+    @Override
     protected Void visitWindowOperation(WindowOperation node, C context)
     {
         process(node.getName(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -105,6 +105,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteStaticMethodCall(StaticMethodCall node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteWindowOperation(WindowOperation node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -520,6 +520,23 @@ public final class ExpressionTreeRewriter<C>
             return node;
         }
 
+        @Override
+        public Expression visitStaticMethodCall(StaticMethodCall node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteStaticMethodCall(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            List<Expression> arguments = rewrite(node.getArguments(), context);
+            if (!sameElements(node.getArguments(), arguments)) {
+                return new StaticMethodCall(node.getLocation().orElseThrow(), node.getType(), node.getMethod(), arguments);
+            }
+            return node;
+        }
+
         // Since OrderBy contains list of SortItems, we want to process each SortItem's key, which is an expression
         private OrderBy rewriteOrderBy(OrderBy orderBy, Context<C> context)
         {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/StaticMethodCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/StaticMethodCall.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class StaticMethodCall
+        extends Expression
+{
+    private final QualifiedName type;
+    private final Identifier method;
+    private final List<Expression> arguments;
+
+    public StaticMethodCall(NodeLocation location, QualifiedName type, Identifier method, List<Expression> arguments)
+    {
+        super(location);
+        this.type = requireNonNull(type, "type is null");
+        this.method = requireNonNull(method, "method is null");
+        this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
+    }
+
+    public QualifiedName getType()
+    {
+        return type;
+    }
+
+    public Identifier getMethod()
+    {
+        return method;
+    }
+
+    public List<Expression> getArguments()
+    {
+        return arguments;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitStaticMethodCall(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.<Node>builder()
+                .addAll(arguments)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        StaticMethodCall other = (StaticMethodCall) obj;
+        return Objects.equals(type, other.type) &&
+                Objects.equals(method, other.method) &&
+                Objects.equals(arguments, other.arguments);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, method, arguments);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+        StaticMethodCall otherInvocation = (StaticMethodCall) other;
+        return type.equals(otherInvocation.type) &&
+                method.equals(otherInvocation.method);
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -216,6 +216,7 @@ import io.trino.sql.tree.SingleColumn;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
@@ -335,6 +336,39 @@ public class TestSqlParser
                 .isEqualTo(new FunctionCall(location(1, 1), QualifiedName.of("strpos"), ImmutableList.of(
                         new StringLiteral(location(1, 18), "b"),
                         new StringLiteral(location(1, 10), "a"))));
+    }
+
+    @Test
+    public void testStaticMethodCall()
+    {
+        assertThat(expression("bigint::parse('42')"))
+                .isEqualTo(new StaticMethodCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "bigint", false))),
+                        new Identifier(location(1, 9), "parse", false),
+                        ImmutableList.of(new StringLiteral(location(1, 15), "42"))));
+
+        assertThat(expression("cat.sch.t::method()"))
+                .isEqualTo(new StaticMethodCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(
+                                new Identifier(location(1, 1), "cat", false),
+                                new Identifier(location(1, 5), "sch", false),
+                                new Identifier(location(1, 9), "t", false))),
+                        new Identifier(location(1, 12), "method", false),
+                        ImmutableList.of()));
+
+        assertThat(expression("array::contains(x, 1)"))
+                .isEqualTo(new StaticMethodCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "array", false))),
+                        new Identifier(location(1, 8), "contains", false),
+                        ImmutableList.of(
+                                new Identifier(location(1, 17), "x", false),
+                                new LongLiteral(location(1, 20), "1"))));
+
+        // Parametric receiver types are not allowed in the grammar.
+        assertInvalidExpression("varchar(5)::parse('42')", "mismatched input '::'.*");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -125,7 +125,7 @@ public class TestSqlParserErrorHandling
                         "line 1:23: mismatched input 'select'. Expecting: ')', 'BETWEEN', 'CURRENT', 'GROUPS', 'MEASURES', 'ORDER', 'PARTITION', 'RANGE', 'ROWS', 'UNBOUNDED', <expression>"),
                 Arguments.of(
                         "SELECT X() OVER (ROWS UNBOUNDED) FROM T",
-                        "line 1:32: mismatched input ')'. Expecting: '%', '(', '*', '+', '-', '->', '.', '/', 'AND', 'AT', 'FOLLOWING', 'OR', 'OVER', 'PRECEDING', '[', '||', <predicate>, <string>"),
+                        "line 1:32: mismatched input ')'. Expecting: '%', '(', '*', '+', '-', '->', '.', '/', '::', 'AND', 'AT', 'FOLLOWING', 'OR', 'OVER', 'PRECEDING', '[', '||', <predicate>, <string>"),
                 Arguments.of(
                         "SELECT a FROM x ORDER BY (SELECT b FROM t WHERE ",
                         "line 1:49: mismatched input '<EOF>'. Expecting: <expression>"),
@@ -213,10 +213,10 @@ public class TestSqlParserErrorHandling
                         "line 1:50: mismatched input '<EOF>'. Expecting: <expression>"),
                 Arguments.of(
                         "SELECT (DATE '2022-10-10', DOUBLE 12.0)",
-                        "line 1:35: mismatched input '12.0'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', 'AND', 'AT', 'OR', 'OVER', 'PRECISION', '[', '||', <predicate>, <string>"),
+                        "line 1:35: mismatched input '12.0'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'OVER', 'PRECISION', '[', '||', <predicate>, <string>"),
                 Arguments.of(
                         "VALUES(DATE 2)",
-                        "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
+                        "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
                 Arguments.of(
                         "SELECT count(DISTINCT *) FROM (VALUES 1)",
                         "line 1:23: mismatched input '*'. Expecting: <expression>"));

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -280,6 +280,12 @@
                                     <old>method void io.trino.spi.connector.ConnectorMetadata::finishTableExecute(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableExecuteHandle, java.util.Collection&lt;io.airlift.slice.Slice&gt;, java.util.List&lt;java.lang.Object&gt;)</old>
                                     <new>method java.util.Map&lt;java.lang.String, java.lang.Long&gt; io.trino.spi.connector.ConnectorMetadata::finishTableExecute(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableExecuteHandle, java.util.Collection&lt;io.airlift.slice.Slice&gt;, java.util.List&lt;java.lang.Object&gt;)</new>
                                 </item>
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method io.trino.spi.function.FunctionMetadata io.trino.spi.function.FunctionMetadata::fromJson(io.trino.spi.function.FunctionId, io.trino.spi.function.Signature, java.lang.String, java.util.Set&lt;java.lang.String&gt;, io.trino.spi.function.FunctionNullability, boolean, boolean, boolean, java.lang.String, io.trino.spi.function.FunctionKind, boolean)</old>
+                                    <new>method io.trino.spi.function.FunctionMetadata io.trino.spi.function.FunctionMetadata::fromJson(io.trino.spi.function.FunctionId, io.trino.spi.function.Signature, java.lang.String, java.util.Set&lt;java.lang.String&gt;, io.trino.spi.function.FunctionNullability, boolean, boolean, boolean, java.lang.String, io.trino.spi.function.FunctionKind, boolean, java.util.Optional&lt;io.trino.spi.type.TypeSignature&gt;)</new>
+                                    <justification>Add receiverType to support SQL:2023 static method invocation</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
@@ -16,11 +16,13 @@ package io.trino.spi.function;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.DoNotCall;
+import io.trino.spi.type.TypeSignature;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.spi.function.FunctionKind.AGGREGATE;
@@ -45,6 +47,7 @@ public class FunctionMetadata
     private final String description;
     private final FunctionKind kind;
     private final boolean deprecated;
+    private final Optional<TypeSignature> receiverType;
 
     private FunctionMetadata(
             FunctionId functionId,
@@ -57,7 +60,8 @@ public class FunctionMetadata
             boolean neverFails,
             String description,
             FunctionKind kind,
-            boolean deprecated)
+            boolean deprecated,
+            Optional<TypeSignature> receiverType)
     {
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.signature = requireNonNull(signature, "signature is null");
@@ -77,6 +81,7 @@ public class FunctionMetadata
         this.description = requireNonNull(description, "description is null");
         this.kind = requireNonNull(kind, "kind is null");
         this.deprecated = deprecated;
+        this.receiverType = requireNonNull(receiverType, "receiverType is null");
     }
 
     /**
@@ -160,6 +165,17 @@ public class FunctionMetadata
         return deprecated;
     }
 
+    /**
+     * The receiver type when this function is a static method invocable as
+     * {@code T::method(args)}. A non-empty value implies the function is a
+     * static method; an empty value implies a regular function.
+     */
+    @JsonProperty
+    public Optional<TypeSignature> getReceiverType()
+    {
+        return receiverType;
+    }
+
     @JsonCreator
     @DoNotCall // For JSON deserialization only
     public static FunctionMetadata fromJson(
@@ -173,7 +189,8 @@ public class FunctionMetadata
             @JsonProperty boolean neverFails,
             @JsonProperty String description,
             @JsonProperty FunctionKind kind,
-            @JsonProperty boolean deprecated)
+            @JsonProperty boolean deprecated,
+            @JsonProperty Optional<TypeSignature> receiverType)
     {
         return new FunctionMetadata(
                 functionId,
@@ -186,7 +203,8 @@ public class FunctionMetadata
                 neverFails,
                 description,
                 kind,
-                deprecated);
+                deprecated,
+                receiverType == null ? Optional.empty() : receiverType);
     }
 
     @Override
@@ -240,6 +258,7 @@ public class FunctionMetadata
         private String description;
         private FunctionId functionId;
         private boolean deprecated;
+        private Optional<TypeSignature> receiverType = Optional.empty();
 
         private Builder(String canonicalName, FunctionKind kind)
         {
@@ -338,6 +357,12 @@ public class FunctionMetadata
             return this;
         }
 
+        public Builder receiverType(TypeSignature receiverType)
+        {
+            this.receiverType = Optional.of(requireNonNull(receiverType, "receiverType is null"));
+            return this;
+        }
+
         public FunctionMetadata build()
         {
             FunctionId functionId = this.functionId;
@@ -358,7 +383,8 @@ public class FunctionMetadata
                     neverFails,
                     description,
                     kind,
-                    deprecated);
+                    deprecated,
+                    receiverType);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/StaticMethod.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/StaticMethod.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a scalar function as a static method of the named type, invocable
+ * via SQL:2023 {@code <static method invocation>} syntax: {@code T::method(args)}.
+ * The value is a Trino type signature (e.g. {@code "bigint"}, {@code "varchar"}).
+ */
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface StaticMethod
+{
+    String value();
+}


### PR DESCRIPTION
## Description

SQL:2023 specifies `<static method invocation>` — `T::method(args)` — for functions
associated with a type. Trino has no equivalent today: every function lives in a single
global namespace, so the same SQL name cannot be reused across types (e.g. a `parse`
function on `bigint` and a different `parse` on `date`).

This change introduces the syntax and a new `@StaticMethod` SPI annotation. Functions
tagged with `@StaticMethod("<type>")` are registered against a receiver type and become
callable only as `T::method(args)`. The two namespaces are independent:

- `method(args)` cannot resolve to a static method.
- `T::method(args)` cannot resolve to a regular function.

Example:

    @ScalarFunction("parse")
    @StaticMethod(StandardTypes.BIGINT)
    @SqlType(StandardTypes.BIGINT)
    public static long bigintParse(@SqlType(StandardTypes.VARCHAR) Slice value) { ... }

    SELECT bigint::parse('42');  -- 42

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# SPI
* Add `@StaticMethod` annotation to register a scalar function as a static method of a
  named type, invocable via `T::method(args)`. ({issue}`29385`)
```