### PR TITLE
Collect deleted bytes during orphan file removal in Iceberg connector

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -985,6 +985,7 @@ ALTER TABLE test_table EXECUTE remove_orphan_files(retention_threshold => '7d');
  active_files_count         |           98
  scanned_files_count        |           97
  deleted_files_count        |            0
+ deleted_bytes              |            0
 ```
 
 The value for `retention_threshold` must be higher than or equal to
@@ -1009,6 +1010,8 @@ The output of the query has the following metrics:
   - The count of files scanned from the file system.
 * - `deleted_files_count`
   - The count of files deleted by remove_orphan_files.
+* - `deleted_bytes`
+  - The total size in bytes of files deleted by remove_orphan_files.
 :::
 
 (drop-extended-stats)=

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFiles.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFiles.java
@@ -129,17 +129,19 @@ public final class RemoveOrphanFiles
             manifestScanFutures.forEach(future -> future.cancel(true));
         }
         ScanAndDeleteResult result = scanAndDeleteInvalidFiles(table, fileSystem, icebergFileDeleteExecutor, schemaTableName, expiration, validFileNames);
-        log.info("remove_orphan_files for table %s processed %d manifest files, found %d active files, scanned %d files, deleted %d files",
+        log.info("remove_orphan_files for table %s processed %d manifest files, found %d active files, scanned %d files, deleted %d files (%d bytes)",
                 schemaTableName,
                 processedManifestFilePaths.size(),
                 validFileNames.size() - 1, // excluding version-hint.text
                 result.scannedFilesCount(),
-                result.deletedFilesCount());
+                result.deletedFilesCount(),
+                result.deletedBytes());
         return ImmutableMap.of(
                 "processed_manifests_count", (long) processedManifestFilePaths.size(),
                 "active_files_count", (long) validFileNames.size() - 1, // excluding version-hint.text
                 "scanned_files_count", result.scannedFilesCount(),
-                "deleted_files_count", result.deletedFilesCount());
+                "deleted_files_count", result.deletedFilesCount(),
+                "deleted_bytes", result.deletedBytes());
     }
 
     private static ScanAndDeleteResult scanAndDeleteInvalidFiles(
@@ -153,6 +155,7 @@ public final class RemoveOrphanFiles
         List<Future<?>> deleteFutures = new ArrayList<>();
         long scannedFilesCount = 0;
         long deletedFilesCount = 0;
+        long deletedBytes = 0;
         try {
             List<Location> filesToDelete = new ArrayList<>(DELETE_BATCH_SIZE);
             FileIterator allFiles = fileSystem.listFiles(Location.of(table.location()));
@@ -162,6 +165,7 @@ public final class RemoveOrphanFiles
                 if (entry.lastModified().isBefore(expiration) && !validFiles.contains(entry.location().fileName())) {
                     filesToDelete.add(entry.location());
                     deletedFilesCount++;
+                    deletedBytes += entry.length();
                     if (filesToDelete.size() >= DELETE_BATCH_SIZE) {
                         List<Location> finalFilesToDelete = filesToDelete;
                         deleteFutures.add(icebergFileDeleteExecutor.submit(() -> deleteFiles(finalFilesToDelete, schemaTableName, fileSystem)));
@@ -188,7 +192,7 @@ public final class RemoveOrphanFiles
             // Ensure any futures still running are canceled in case of failure
             deleteFutures.forEach(future -> future.cancel(true));
         }
-        return new ScanAndDeleteResult(scannedFilesCount, deletedFilesCount);
+        return new ScanAndDeleteResult(scannedFilesCount, deletedFilesCount, deletedBytes);
     }
 
     private static void deleteFiles(List<Location> files, SchemaTableName schemaTableName, TrinoFileSystem fileSystem)
@@ -202,5 +206,5 @@ public final class RemoveOrphanFiles
         }
     }
 
-    private record ScanAndDeleteResult(long scannedFilesCount, long deletedFilesCount) {}
+    private record ScanAndDeleteResult(long scannedFilesCount, long deletedFilesCount, long deletedBytes) {}
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7053,20 +7053,25 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2), ('three', 3)", 2);
         assertUpdate("DELETE FROM " + tableName + " WHERE key = 'two'", 1);
         String location = getTableLocation(tableName);
-        String orphanFile = getIcebergTableDataPath(location) + "/invalidData." + format;
-        createFile(orphanFile);
+        String orphanFile1 = getIcebergTableDataPath(location) + "/invalidData1." + format;
+        String orphanFile2 = getIcebergTableDataPath(location) + "/invalidData2." + format;
+        int orphanFile1Bytes = 123;
+        int orphanFile2Bytes = 456;
+        int totalOrphanBytes = orphanFile1Bytes + orphanFile2Bytes;
+        createFile(orphanFile1, new byte[orphanFile1Bytes]);
+        createFile(orphanFile2, new byte[orphanFile2Bytes]);
         List<String> initialDataFiles = getAllDataFilesFromTableDirectory(tableName);
-        assertThat(initialDataFiles).contains(orphanFile);
+        assertThat(initialDataFiles).contains(orphanFile1, orphanFile2);
 
         assertUpdate(
                 sessionWithShortRetentionUnlocked,
                 "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')",
-                "VALUES ('processed_manifests_count', 3), ('active_files_count', 16), ('scanned_files_count', 17), ('deleted_files_count', 1)");
+                "VALUES ('processed_manifests_count', 3), ('active_files_count', 16), ('scanned_files_count', 18), ('deleted_files_count', 2), ('deleted_bytes', " + totalOrphanBytes + ")");
         assertQuery("SELECT * FROM " + tableName, "VALUES ('one', 1), ('three', 3)");
 
         List<String> updatedDataFiles = getAllDataFilesFromTableDirectory(tableName);
         assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
-        assertThat(updatedDataFiles).doesNotContain(orphanFile);
+        assertThat(updatedDataFiles).doesNotContain(orphanFile1, orphanFile2);
     }
 
     @Test
@@ -10018,6 +10023,12 @@ public abstract class BaseIcebergConnectorTest
             throws IOException
     {
         fileSystem.newOutputFile(Location.of(location)).create().close();
+    }
+
+    protected void createFile(String location, byte[] content)
+            throws IOException
+    {
+        fileSystem.newOutputFile(Location.of(location)).createOrOverwrite(content);
     }
 
     private List<Long> getSnapshotIds(String tableName)


### PR DESCRIPTION
## Description
Orphan file removal collects the current number of files removed, but it would be useful to know how much storage was freed up.

## Additional context and related issues
After snapshots are expired, an iceberg table may have files that are not referenced by any snapshot. Orphan file removal garbage collects those now unreferenced files

## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add `deleted_bytes` column to the output of `remove_orphan_files` procedure. ({issue}`29386`)
```
