### PR TITLE
Enable multiple issuers for JWT token validation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
@@ -13,8 +13,12 @@
  */
 package io.trino.server.security.jwt;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.http.client.HttpClient;
+import io.airlift.log.Logger;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.JwtParserBuilder;
 import io.jsonwebtoken.Locator;
@@ -24,12 +28,21 @@ import io.trino.server.security.UserMapping;
 import io.trino.server.security.UserMappingException;
 import io.trino.spi.security.BasicPrincipal;
 import io.trino.spi.security.Identity;
+import jakarta.annotation.PreDestroy;
 import jakarta.ws.rs.container.ContainerRequestContext;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
 import java.security.Key;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static io.jsonwebtoken.Claims.AUDIENCE;
 import static io.trino.server.security.UserMapping.createUserMapping;
 import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
@@ -38,44 +51,102 @@ import static java.lang.String.format;
 public class JwtAuthenticator
         extends AbstractBearerAuthenticator
 {
-    private final JwtParser jwtParser;
-    private final String principalField;
-    private final UserMapping userMapping;
-    private final Optional<String> requiredAudience;
+    private static final Logger log = Logger.get(JwtAuthenticator.class);
+
+    private final List<JwtIssuer> issuers;
+    private final List<JwkService> jwkServices;
 
     @Inject
-    public JwtAuthenticator(JwtAuthenticatorConfig config, @ForJwt Locator<Key> signingKeyLocator)
+    public JwtAuthenticator(JwtAuthenticatorConfig config, @ForJwt HttpClient httpClient)
     {
-        principalField = config.getPrincipalField();
-        requiredAudience = Optional.ofNullable(config.getRequiredAudience());
+        ImmutableList.Builder<JwkService> jwkServicesBuilder = ImmutableList.builder();
 
-        JwtParserBuilder jwtParser = newJwtParserBuilder()
-                .keyLocator(signingKeyLocator);
-
-        if (config.getRequiredIssuer() != null) {
-            jwtParser.requireIssuer(config.getRequiredIssuer());
+        List<File> configFiles = config.getConfigFiles();
+        if (configFiles.isEmpty()) {
+            checkState(config.getKeyFile() != null,
+                    "http-server.authentication.jwt.key-file or http-server.authentication.jwt.config-files must be set");
+            Locator<Key> keyLocator = createKeyLocator(config.getKeyFile(), httpClient, jwkServicesBuilder);
+            JwtParser parser = createJwtParser(keyLocator, config.getRequiredIssuer());
+            issuers = ImmutableList.of(new JwtIssuer(
+                    parser,
+                    config.getPrincipalField(),
+                    Optional.ofNullable(config.getRequiredAudience()),
+                    createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile())));
         }
-        this.jwtParser = jwtParser.build();
-        userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
+        else {
+            ImmutableList.Builder<JwtIssuer> issuersBuilder = ImmutableList.builder();
+            for (File configFile : configFiles) {
+                Map<String, String> properties;
+                try {
+                    properties = loadPropertiesFrom(configFile.getPath());
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(format("Error reading JWT issuer configuration file %s", configFile), e);
+                }
+
+                String keyFile = properties.get("http-server.authentication.jwt.key-file");
+                checkState(keyFile != null,
+                        "http-server.authentication.jwt.key-file must be set in %s", configFile);
+
+                Locator<Key> keyLocator = createKeyLocator(keyFile, httpClient, jwkServicesBuilder);
+                String issuer = properties.get("http-server.authentication.jwt.required-issuer");
+                JwtParser parser = createJwtParser(keyLocator, issuer);
+
+                String principalField = properties.getOrDefault("http-server.authentication.jwt.principal-field", "sub");
+                String audience = properties.get("http-server.authentication.jwt.required-audience");
+                UserMapping userMapping = createUserMapping(
+                        Optional.ofNullable(properties.get("http-server.authentication.jwt.user-mapping.pattern")),
+                        Optional.ofNullable(properties.get("http-server.authentication.jwt.user-mapping.file")).map(File::new));
+
+                issuersBuilder.add(new JwtIssuer(
+                        parser,
+                        principalField,
+                        Optional.ofNullable(audience),
+                        userMapping));
+            }
+            issuers = issuersBuilder.build();
+        }
+
+        jwkServices = jwkServicesBuilder.build();
+        jwkServices.forEach(JwkService::start);
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        jwkServices.forEach(JwkService::stop);
     }
 
     @Override
     protected Optional<Identity> createIdentity(String token)
             throws UserMappingException
     {
-        Claims claims = jwtParser.parseSignedClaims(token).getPayload();
-        validateAudience(claims);
+        JwtException lastException = null;
+        for (JwtIssuer issuer : issuers) {
+            try {
+                Claims claims = issuer.parser().parseSignedClaims(token).getPayload();
+                validateAudience(claims, issuer.requiredAudience());
 
-        Optional<String> principal = Optional.ofNullable(claims.get(principalField, String.class));
-        if (principal.isEmpty()) {
-            return Optional.empty();
+                Optional<String> principal = Optional.ofNullable(claims.get(issuer.principalField(), String.class));
+                if (principal.isEmpty()) {
+                    return Optional.empty();
+                }
+                return Optional.of(Identity.forUser(issuer.userMapping().mapUser(principal.get()))
+                        .withPrincipal(new BasicPrincipal(principal.get()))
+                        .build());
+            }
+            catch (JwtException e) {
+                log.debug(e, "JWT validation failed for issuer, trying next");
+                lastException = e;
+            }
         }
-        return Optional.of(Identity.forUser(userMapping.mapUser(principal.get()))
-                .withPrincipal(new BasicPrincipal(principal.get()))
-                .build());
+        if (lastException != null) {
+            throw lastException;
+        }
+        return Optional.empty();
     }
 
-    private void validateAudience(Claims claims)
+    private static void validateAudience(Claims claims, Optional<String> requiredAudience)
     {
         if (requiredAudience.isEmpty()) {
             return;
@@ -98,9 +169,35 @@ public class JwtAuthenticator
         }
     }
 
+    private static JwtParser createJwtParser(Locator<Key> keyLocator, String requiredIssuer)
+    {
+        JwtParserBuilder builder = newJwtParserBuilder()
+                .keyLocator(keyLocator);
+        if (requiredIssuer != null) {
+            builder.requireIssuer(requiredIssuer);
+        }
+        return builder.build();
+    }
+
+    private static Locator<Key> createKeyLocator(String keyFile, HttpClient httpClient, ImmutableList.Builder<JwkService> jwkServices)
+    {
+        if (keyFile.startsWith("https://") || keyFile.startsWith("http://")) {
+            JwkService jwkService = new JwkService(URI.create(keyFile), httpClient);
+            jwkServices.add(jwkService);
+            return new JwkSigningKeyLocator(jwkService);
+        }
+        return new FileSigningKeyLocator(keyFile);
+    }
+
     @Override
     protected AuthenticationException needAuthentication(ContainerRequestContext request, Optional<String> currentToken, String message)
     {
         return new AuthenticationException(message, "Bearer realm=\"Trino\", token_type=\"JWT\"");
     }
+
+    private record JwtIssuer(
+            JwtParser parser,
+            String principalField,
+            Optional<String> requiredAudience,
+            UserMapping userMapping) {}
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorConfig.java
@@ -13,12 +13,15 @@
  */
 package io.trino.server.security.jwt;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.configuration.validation.FileExists;
 import jakarta.validation.constraints.NotNull;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 
 public class JwtAuthenticatorConfig
@@ -29,8 +32,8 @@ public class JwtAuthenticatorConfig
     private String principalField = "sub";
     private Optional<String> userMappingPattern = Optional.empty();
     private Optional<File> userMappingFile = Optional.empty();
+    private List<File> configFiles = ImmutableList.of();
 
-    @NotNull
     public String getKeyFile()
     {
         return keyFile;
@@ -104,6 +107,19 @@ public class JwtAuthenticatorConfig
     public JwtAuthenticatorConfig setUserMappingFile(File userMappingFile)
     {
         this.userMappingFile = Optional.ofNullable(userMappingFile);
+        return this;
+    }
+
+    public List<@FileExists File> getConfigFiles()
+    {
+        return configFiles;
+    }
+
+    @Config("http-server.authentication.jwt.config-files")
+    @ConfigDescription("Comma-separated list of configuration files for JWT issuers")
+    public JwtAuthenticatorConfig setConfigFiles(List<File> configFiles)
+    {
+        this.configFiles = ImmutableList.copyOf(configFiles);
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -15,16 +15,7 @@ package io.trino.server.security.jwt;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.Provides;
-import com.google.inject.Scopes;
-import com.google.inject.Singleton;
-import com.google.inject.TypeLiteral;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.airlift.http.client.HttpClient;
-import io.jsonwebtoken.Locator;
-
-import java.net.URI;
-import java.security.Key;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -36,21 +27,12 @@ public class JwtAuthenticatorSupportModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(JwtAuthenticatorConfig.class);
-
-        if (isHttp(buildConfigObject(JwtAuthenticatorConfig.class))) {
-            install(new JwkModule());
-        }
-        else {
-            binder.bind(new TypeLiteral<Locator<Key>>() {}).annotatedWith(ForJwt.class).to(FileSigningKeyLocator.class).in(Scopes.SINGLETON);
-        }
+        install(new JwkHttpClientModule());
     }
 
-    private static boolean isHttp(JwtAuthenticatorConfig config)
-    {
-        return config.getKeyFile().startsWith("https://") || config.getKeyFile().startsWith("http://");
-    }
-
-    private static class JwkModule
+    // This module can be installed multiple times, and equals/hashCode
+    // prevent duplicate processing by Guice
+    private static class JwkHttpClientModule
             implements Module
     {
         @Override
@@ -59,33 +41,16 @@ public class JwtAuthenticatorSupportModule
             httpClientBinder(binder).bindHttpClient("jwk", ForJwt.class);
         }
 
-        @Provides
-        @Singleton
-        @ForJwt
-        public static JwkService createJwkService(JwtAuthenticatorConfig config, @ForJwt HttpClient httpClient)
-        {
-            return new JwkService(URI.create(config.getKeyFile()), httpClient);
-        }
-
-        @Provides
-        @Singleton
-        @ForJwt
-        public static Locator<Key> createJwkSigningKeyLocator(@ForJwt JwkService jwkService)
-        {
-            return new JwkSigningKeyLocator(jwkService);
-        }
-
-        // this module can be added multiple times, and this prevents multiple processing by Guice
         @Override
         public int hashCode()
         {
-            return JwkModule.class.hashCode();
+            return JwkHttpClientModule.class.hashCode();
         }
 
         @Override
         public boolean equals(Object obj)
         {
-            return obj instanceof JwkModule;
+            return obj instanceof JwkHttpClientModule;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -77,6 +77,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -618,6 +619,92 @@ public class TestResourceSecurity
                             .build())
                     .build();
             assertAuthenticationAutomatic(httpServerInfo.getHttpsUri(), clientWithJwt);
+        }
+    }
+
+    @Test
+    public void testJwtAuthenticatorWithMultipleIssuers()
+            throws Exception
+    {
+        // Create a second HMAC key
+        byte[] hmac2Bytes = new byte[32];
+        Arrays.fill(hmac2Bytes, (byte) 42);
+        SecretKey hmac2 = hmacShaKeyFor(hmac2Bytes);
+        Path hmacKeyFile2 = Files.createTempFile("hmac2", ".txt");
+        Files.writeString(hmacKeyFile2, Base64.getEncoder().encodeToString(hmac2Bytes));
+
+        // Create issuer config files
+        Path issuerConfig1 = Files.createTempFile("jwt-issuer1", ".properties");
+        Files.writeString(issuerConfig1,
+                "http-server.authentication.jwt.key-file=" + HMAC_KEY + "\n" +
+                "http-server.authentication.jwt.required-issuer=issuer-1\n" +
+                "http-server.authentication.jwt.required-audience=" + TRINO_AUDIENCE + "\n");
+
+        Path issuerConfig2 = Files.createTempFile("jwt-issuer2", ".properties");
+        Files.writeString(issuerConfig2,
+                "http-server.authentication.jwt.key-file=" + hmacKeyFile2 + "\n" +
+                "http-server.authentication.jwt.required-issuer=issuer-2\n" +
+                "http-server.authentication.jwt.required-audience=" + TRINO_AUDIENCE + "\n");
+
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "jwt")
+                        .put("http-server.authentication.jwt.config-files", issuerConfig1 + "," + issuerConfig2)
+                        .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                .build()) {
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+
+            SecretKey hmac1 = hmacShaKeyFor(Base64.getDecoder().decode(Files.readString(Path.of(HMAC_KEY)).trim()));
+
+            // Token from issuer-1 should succeed
+            String token1 = newJwtBuilder()
+                    .signWith(hmac1)
+                    .issuer("issuer-1")
+                    .claim(AUDIENCE, TRINO_AUDIENCE)
+                    .subject(TEST_USER)
+                    .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .compact();
+
+            OkHttpClient clientWithJwt1 = client.newBuilder()
+                    .authenticator((_, response) -> response.request().newBuilder()
+                            .header(AUTHORIZATION, "Bearer " + token1)
+                            .build())
+                    .build();
+            assertAuthenticationAutomatic(httpServerInfo.getHttpsUri(), clientWithJwt1);
+
+            // Token from issuer-2 should also succeed
+            String token2 = newJwtBuilder()
+                    .signWith(hmac2)
+                    .issuer("issuer-2")
+                    .claim(AUDIENCE, TRINO_AUDIENCE)
+                    .subject(TEST_USER)
+                    .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .compact();
+
+            OkHttpClient clientWithJwt2 = client.newBuilder()
+                    .authenticator((_, response) -> response.request().newBuilder()
+                            .header(AUTHORIZATION, "Bearer " + token2)
+                            .build())
+                    .build();
+            assertAuthenticationAutomatic(httpServerInfo.getHttpsUri(), clientWithJwt2);
+
+            // Token with wrong issuer should fail
+            String tokenWrongIssuer = newJwtBuilder()
+                    .signWith(hmac1)
+                    .issuer("wrong-issuer")
+                    .claim(AUDIENCE, TRINO_AUDIENCE)
+                    .subject(TEST_USER)
+                    .expiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                    .compact();
+
+            assertResponseCode(client, getAuthorizedUserLocation(httpServerInfo.getHttpsUri()), SC_UNAUTHORIZED, Headers.of(AUTHORIZATION, "Bearer " + tokenWrongIssuer));
+        }
+        finally {
+            Files.deleteIfExists(hmacKeyFile2);
+            Files.deleteIfExists(issuerConfig1);
+            Files.deleteIfExists(issuerConfig2);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwtAuthenticatorConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwtAuthenticatorConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.security.jwt;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,8 @@ public class TestJwtAuthenticatorConfig
                 .setRequiredIssuer(null)
                 .setPrincipalField("sub")
                 .setUserMappingPattern(null)
-                .setUserMappingFile(null));
+                .setUserMappingFile(null)
+                .setConfigFiles(ImmutableList.of()));
     }
 
     @Test
@@ -45,6 +47,8 @@ public class TestJwtAuthenticatorConfig
     {
         Path jwtKeyFile = Files.createTempFile(null, null);
         Path userMappingFile = Files.createTempFile(null, null);
+        Path configFile1 = Files.createTempFile(null, null);
+        Path configFile2 = Files.createTempFile(null, null);
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("http-server.authentication.jwt.key-file", jwtKeyFile.toString())
@@ -53,6 +57,7 @@ public class TestJwtAuthenticatorConfig
                 .put("http-server.authentication.jwt.principal-field", "some-field")
                 .put("http-server.authentication.jwt.user-mapping.pattern", "(.*)@something")
                 .put("http-server.authentication.jwt.user-mapping.file", userMappingFile.toString())
+                .put("http-server.authentication.jwt.config-files", configFile1 + "," + configFile2)
                 .buildOrThrow();
 
         JwtAuthenticatorConfig expected = new JwtAuthenticatorConfig()
@@ -61,7 +66,8 @@ public class TestJwtAuthenticatorConfig
                 .setRequiredIssuer("some-issuer")
                 .setPrincipalField("some-field")
                 .setUserMappingPattern("(.*)@something")
-                .setUserMappingFile(userMappingFile.toFile());
+                .setUserMappingFile(userMappingFile.toFile())
+                .setConfigFiles(ImmutableList.of(configFile1.toFile(), configFile2.toFile()));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Add support for configuring multiple JWT token issuers, each with their own signing key, required issuer, required audience, principal field, and user mapping. This is useful when tokens are issued by different identity providers and the Trino cluster needs to accept tokens from all of them.

Closes #16949
Based on the concept from #17396 by @aislinnjeske — thank you for the original work.

## Changes

### New configuration

A new property `http-server.authentication.jwt.config-files` accepts a comma-separated list of properties files. Each file defines a complete JWT issuer configuration using the existing property names:

```properties
# issuer1.properties
http-server.authentication.jwt.key-file=https://idp1.example.com/.well-known/jwks.json
http-server.authentication.jwt.required-issuer=https://idp1.example.com
http-server.authentication.jwt.required-audience=trino
http-server.authentication.jwt.principal-field=sub
```

Server config:
```properties
http-server.authentication.type=jwt
http-server.authentication.jwt.config-files=/etc/trino/jwt/issuer1.properties,/etc/trino/jwt/issuer2.properties
```

When `config-files` is set, the authenticator tries each issuer in order until one validates the token. The existing single-issuer configuration via top-level properties continues to work unchanged.

### Implementation

- **JwtAuthenticatorConfig**: Added `configFiles` property (`List<File>`)
- **JwtAuthenticator**: Rewritten to support multiple `JwtIssuer` instances. In legacy mode (no config-files), creates a single issuer from top-level config. In multi-issuer mode, loads each properties file and creates a `JwtIssuer` per file. Token validation iterates over issuers, catching `JwtException` per issuer and re-throwing the last exception if all fail.
- **JwtAuthenticatorSupportModule**: Simplified — removed conditional JWK binding logic since `JwtAuthenticator` now manages `JwkService` lifecycle directly via `@PreDestroy`.
- **Tests**: Updated `TestJwtAuthenticatorConfig` for the new property. Added `testJwtAuthenticatorWithMultipleIssuers()` integration test in `TestResourceSecurity` that validates tokens from two different issuers with different HMAC keys.

## Test plan

- [ ] `TestJwtAuthenticatorConfig` — config defaults and explicit property mappings
- [ ] `TestResourceSecurity#testJwtAuthenticator` — existing single-issuer tests (backward compatibility)
- [ ] `TestResourceSecurity#testJwtWithJwkAuthenticator` — existing JWK tests
- [ ] `TestResourceSecurity#testJwtAuthenticatorWithMultipleIssuers` — new multi-issuer test

Note: `master` currently has pre-existing compilation errors in unrelated files (`QueryStateMachine`, `AccessControlManager`, `InMemoryTransactionManager`, `TestingAccessControlManager`) that prevent running the full test suite. The JWT code compiles cleanly.