### PR TITLE
Add the PIVOT relation operator

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -385,9 +385,34 @@ joinCriteria
     ;
 
 sampledRelation
-    : patternRecognition (
+    : pivot (
         TABLESAMPLE sampleType '(' percentage=expression ')'
       )?
+    ;
+
+pivot
+    : patternRecognition (
+        PIVOT '('
+          pivotAggregation (',' pivotAggregation)*
+          FOR pivotColumns IN '(' pivotValueGroup (',' pivotValueGroup)* ')'
+          (GROUP BY groupBy)?
+        ')'
+        (AS? identifier columnAliases?)?
+      )?
+    ;
+
+pivotAggregation
+    : expression (AS? identifier)?
+    ;
+
+pivotColumns
+    : qualifiedName
+    | '(' qualifiedName (',' qualifiedName)* ')'
+    ;
+
+pivotValueGroup
+    : '(' expression (',' expression)+ ')' (AS? identifier)?
+    | expression (AS? identifier)?
     ;
 
 sampleType
@@ -1059,7 +1084,7 @@ nonReserved
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEAREST | NESTED | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
     | OBJECT | OF | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW
-    | PARTITION | PARTITIONS | PASSING | PAST | PATH | PATTERN | PER | PERIOD | PERMUTE | PLAN | POSITION | PRECEDING | PRECISION | PRIVILEGES | PROPERTIES | PRUNE
+    | PARTITION | PARTITIONS | PASSING | PAST | PATH | PATTERN | PER | PERIOD | PERMUTE | PIVOT | PLAN | POSITION | PRECEDING | PRECISION | PRIVILEGES | PROPERTIES | PRUNE
     | QUOTES
     | RANGE | READ | REFRESH | RENAME | REPEAT  | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | RETURN | RETURNING | RETURNS | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS | RUNNING
     | SCALAR | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
@@ -1273,6 +1298,7 @@ PATTERN: 'PATTERN';
 PER: 'PER';
 PERIOD: 'PERIOD';
 PERMUTE: 'PERMUTE';
+PIVOT: 'PIVOT';
 PLAN : 'PLAN';
 POSITION: 'POSITION';
 PRECEDING: 'PRECEDING';

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -80,6 +80,7 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Offset;
 import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.Parameter;
+import io.trino.sql.tree.Pivot;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.Query;
@@ -145,6 +146,8 @@ public class Analysis
     private Optional<Boolean> tableExecuteReadsData;
 
     private final Map<NodeRef<Table>, Query> namedQueries = new LinkedHashMap<>();
+
+    private final Map<NodeRef<Pivot>, Query> pivotRewrites = new LinkedHashMap<>();
 
     // map expandable query to the node being the inner recursive reference
     private final Map<NodeRef<Query>, Node> expandableNamedQueries = new LinkedHashMap<>();
@@ -893,6 +896,21 @@ public class Analysis
         requireNonNull(query, "query is null");
 
         namedQueries.put(NodeRef.of(tableReference), query);
+    }
+
+    public void registerPivotRewrite(Pivot pivot, Query query)
+    {
+        requireNonNull(pivot, "pivot is null");
+        requireNonNull(query, "query is null");
+
+        pivotRewrites.put(NodeRef.of(pivot), query);
+    }
+
+    public Query getPivotRewrite(Pivot pivot)
+    {
+        Query query = pivotRewrites.get(NodeRef.of(pivot));
+        checkArgument(query != null, "pivot has no rewriting registered: %s", pivot);
+        return query;
     }
 
     public void registerExpandableQuery(Query query, Node recursiveReference)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -104,8 +104,10 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeNotFoundException;
 import io.trino.spi.type.VarcharType;
+import io.trino.sql.ExpressionFormatter;
 import io.trino.sql.InterpretedFunctionInvoker;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.QueryUtil;
 import io.trino.sql.analyzer.Analysis.CorrespondingAnalysis;
 import io.trino.sql.analyzer.Analysis.GroupingSetAnalysis;
 import io.trino.sql.analyzer.Analysis.JsonTableAnalysis;
@@ -192,6 +194,7 @@ import io.trino.sql.tree.JsonTableSpecificPlan;
 import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.Literal;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
@@ -210,6 +213,9 @@ import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.OrdinalityColumn;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.PatternRecognitionRelation;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -292,6 +298,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -3221,6 +3228,151 @@ class StatementAnalyzer
             validateNoNestedTableFunction(relation.getRelation(), "sample");
 
             return createAndAssignScope(relation, scope, relationScope.getRelationType());
+        }
+
+        @Override
+        protected Scope visitPivot(Pivot relation, Optional<Scope> scope)
+        {
+            validatePivotShape(relation);
+            Query rewritten = buildPivotRewrite(relation);
+            analysis.registerPivotRewrite(relation, rewritten);
+
+            StatementAnalyzer analyzer = statementAnalyzerFactory.createStatementAnalyzer(analysis, session, warningCollector, CorrelationSupport.ALLOWED);
+            Scope queryScope = analyzer.analyze(rewritten, scope.orElseThrow());
+            return createAndAssignScope(relation, scope, queryScope.getRelationType());
+        }
+
+        private void validatePivotShape(Pivot relation)
+        {
+            int pivotColumnArity = relation.getPivotColumns().size();
+            for (PivotValueGroup valueGroup : relation.getValueGroups()) {
+                if (valueGroup.getValues().size() != pivotColumnArity) {
+                    throw semanticException(
+                            INVALID_ARGUMENTS,
+                            valueGroup,
+                            "Number of pivot values (%s) does not match number of pivot columns (%s)",
+                            valueGroup.getValues().size(),
+                            pivotColumnArity);
+                }
+            }
+
+            if (relation.getAggregations().size() > 1) {
+                for (PivotAggregation aggregation : relation.getAggregations()) {
+                    if (aggregation.getAlias().isEmpty()) {
+                        throw semanticException(
+                                MISSING_COLUMN_ALIASES,
+                                aggregation,
+                                "PIVOT with multiple aggregations requires an alias on each aggregation");
+                    }
+                }
+            }
+        }
+
+        private Query buildPivotRewrite(Pivot relation)
+        {
+            boolean multipleAggregations = relation.getAggregations().size() > 1;
+            ImmutableList.Builder<SelectItem> selectItems = ImmutableList.builder();
+
+            // Forward GROUP BY expressions to the SELECT list so they remain in the output.
+            // Deduplicate across grouping elements so GROUP BY GROUPING SETS / CUBE / ROLLUP
+            // emits each unique grouping expression exactly once.
+            relation.getGroupBy().ifPresent(groupBy -> {
+                Set<Expression> projected = new LinkedHashSet<>();
+                for (GroupingElement element : groupBy.getGroupingElements()) {
+                    projected.addAll(element.getExpressions());
+                }
+                for (Expression expression : projected) {
+                    selectItems.add(new SingleColumn(cloneNode(expression)));
+                }
+            });
+
+            Set<String> seenNames = new HashSet<>();
+            for (PivotValueGroup valueGroup : relation.getValueGroups()) {
+                for (PivotAggregation aggregation : relation.getAggregations()) {
+                    Identifier columnName = pivotColumnName(valueGroup, aggregation, multipleAggregations);
+                    if (!seenNames.add(columnName.getValue().toLowerCase(ENGLISH))) {
+                        throw semanticException(
+                                DUPLICATE_COLUMN_NAME,
+                                valueGroup,
+                                "PIVOT produces duplicate output column name: %s",
+                                columnName.getValue());
+                    }
+                    Expression predicate = buildPivotPredicate(relation.getPivotColumns(), valueGroup.getValues());
+                    Expression filtered = injectFilter(aggregation.getExpression(), predicate);
+                    selectItems.add(new SingleColumn(filtered, columnName));
+                }
+            }
+
+            return QueryUtil.query(new QuerySpecification(
+                    new Select(false, selectItems.build()),
+                    Optional.of(relation.getInput()),
+                    Optional.empty(),
+                    relation.getGroupBy(),
+                    Optional.empty(),
+                    ImmutableList.of(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()));
+        }
+
+        private Identifier pivotColumnName(PivotValueGroup valueGroup, PivotAggregation aggregation, boolean multipleAggregations)
+        {
+            String valuePart = valueGroup.getAlias()
+                    .map(Identifier::getValue)
+                    .orElseGet(() -> valueGroup.getValues().stream()
+                            .map(ExpressionFormatter::formatExpression)
+                            .collect(Collectors.joining("_")));
+            String aggPart = aggregation.getAlias().map(Identifier::getValue).orElse("");
+            String columnName = aggPart.isEmpty() ? valuePart : valuePart + "_" + aggPart;
+            return new Identifier(columnName);
+        }
+
+        private Expression buildPivotPredicate(List<Expression> pivotColumns, List<Expression> values)
+        {
+            Expression result = null;
+            for (int i = 0; i < pivotColumns.size(); i++) {
+                Expression equality = new ComparisonExpression(
+                        ComparisonExpression.Operator.EQUAL,
+                        cloneNode(pivotColumns.get(i)),
+                        cloneNode(values.get(i)));
+                result = (result == null) ? equality : LogicalExpression.and(result, equality);
+            }
+            return result;
+        }
+
+        private Expression injectFilter(Expression expression, Expression predicate)
+        {
+            return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+            {
+                @Override
+                public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+                {
+                    if (functionResolver.isAggregationFunction(session, node.getName(), accessControl)) {
+                        Optional<Expression> existingFilter = node.getFilter();
+                        Expression freshPredicate = cloneNode(predicate);
+                        Expression mergedFilter = existingFilter
+                                .map(existing -> (Expression) LogicalExpression.and(existing, freshPredicate))
+                                .orElse(freshPredicate);
+                        return new FunctionCall(
+                                node.getLocation(),
+                                node.getName(),
+                                node.getWindow(),
+                                Optional.of(mergedFilter),
+                                node.getOrderBy(),
+                                node.isDistinct(),
+                                node.getNullTreatment(),
+                                node.getProcessingMode(),
+                                node.getArguments());
+                    }
+                    return treeRewriter.defaultRewrite(node, context);
+                }
+            }, expression);
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <T extends Expression> T cloneNode(T expression)
+        {
+            return (T) ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<>() {}, expression);
         }
 
         // this method should run after the `base` relation is processed, so that it is

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -135,6 +135,7 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.OrdinalityColumn;
 import io.trino.sql.tree.PatternRecognitionRelation;
 import io.trino.sql.tree.PatternSearchMode;
+import io.trino.sql.tree.Pivot;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -1861,6 +1862,13 @@ class RelationPlanner
     protected RelationPlan visitTableSubquery(TableSubquery node, Void context)
     {
         RelationPlan plan = process(node.getQuery(), context);
+        return new RelationPlan(plan.getRoot(), analysis.getScope(node), plan.getFieldMappings(), outerContext);
+    }
+
+    @Override
+    protected RelationPlan visitPivot(Pivot node, Void context)
+    {
+        RelationPlan plan = process(analysis.getPivotRewrite(node), context);
         return new RelationPlan(plan.getRoot(), analysis.getScope(node), plan.getFieldMappings(), outerContext);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestPivot.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestPivot.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.spi.StandardErrorCode.DUPLICATE_COLUMN_NAME;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static io.trino.spi.StandardErrorCode.MISSING_COLUMN_ALIASES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestPivot
+{
+    private static final String SALES = """
+            (VALUES
+              ('NA', 1, BIGINT '100'),
+              ('NA', 1, BIGINT '50'),
+              ('NA', 2, BIGINT '70'),
+              ('EU', 1, BIGINT '40'),
+              ('EU', 3, BIGINT '20')
+            ) AS sales(region, month, amount)
+            """;
+
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testSingleAggregationNoGroupBy()
+    {
+        // No implicit grouping: collapses to a single row.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS feb, 3 AS mar))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '190', BIGINT '70', BIGINT '20')");
+    }
+
+    @Test
+    public void testSingleAggregationWithGroupBy()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS feb) GROUP BY region)
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches("""
+                        VALUES
+                            ('EU', BIGINT '40', CAST(NULL AS BIGINT)),
+                            ('NA', BIGINT '150', BIGINT '70')
+                        """);
+    }
+
+    @Test
+    public void testMultipleAggregations()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total,
+                    count(amount) AS cnt
+                    FOR month IN (1 AS jan, 2 AS feb)
+                    GROUP BY region
+                )
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches("""
+                        VALUES
+                            ('EU', BIGINT '40', BIGINT '1', CAST(NULL AS BIGINT), BIGINT '0'),
+                            ('NA', BIGINT '150', BIGINT '2', BIGINT '70', BIGINT '1')
+                        """);
+    }
+
+    @Test
+    public void testMultiplePivotColumns()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount)
+                    FOR (region, month) IN (
+                        ('NA', 1) AS na_jan,
+                        ('NA', 2) AS na_feb,
+                        ('EU', 1) AS eu_jan
+                    )
+                )
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '150', BIGINT '70', BIGINT '40')");
+    }
+
+    @Test
+    public void testAggregationExpression()
+    {
+        // Aggregation slot is a general expression containing aggregates;
+        // FILTER is attached to each aggregate inside.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) - max(amount) AS minor
+                    FOR month IN (1 AS jan)
+                    GROUP BY region
+                )
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches("""
+                        VALUES
+                            ('EU', BIGINT '0'),
+                            ('NA', BIGINT '50')
+                        """);
+    }
+
+    @Test
+    public void testValueWithoutAlias()
+    {
+        // Unaliased values use literal SQL text as the column name, so 1 and '1'
+        // produce distinct columns (both nominally compare to month though only one
+        // matches month's bigint type).
+        assertThat(assertions.query("""
+                SELECT "1"
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testNullValue()
+    {
+        // NULL value uses Trino's standard '=' semantics: never matches, so the
+        // synthesized column is the empty-input aggregation result (0 for count).
+        // Single-agg with both value-alias and agg-alias produces "valueAlias_aggAlias".
+        assertThat(assertions.query("""
+                SELECT cnt_null_cnt
+                FROM %s
+                PIVOT (count(amount) AS cnt FOR month IN (NULL AS cnt_null))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testRelationAlias()
+    {
+        assertThat(assertions.query("""
+                SELECT p.r, p.jan
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan) GROUP BY region) AS p (r, jan)
+                ORDER BY p.r
+                """.formatted(SALES)))
+                .ordered()
+                .matches("""
+                        VALUES
+                            ('EU', BIGINT '40'),
+                            ('NA', BIGINT '150')
+                        """);
+    }
+
+    @Test
+    public void testPivotOfPivot()
+    {
+        // PIVOT output is a relation; another PIVOT can apply to it. The first PIVOT
+        // is wrapped in a subquery so the second one can attach.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM (
+                    SELECT *
+                    FROM %s
+                    PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS feb) GROUP BY region)
+                ) PIVOT (sum(jan) FOR region IN ('NA' AS na_total))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '150')");
+    }
+
+    @Test
+    public void testCoercion()
+    {
+        // Pivot column is BIGINT; integer literal in IN coerces.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testMultiplePivotColumnsTupleArityMismatch()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR (region, month) IN (('NA', 1), ('EU')))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessageContaining("Number of pivot values");
+    }
+
+    @Test
+    public void testMultipleAggregationsRequireAlias()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount), count(amount) FOR month IN (1))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(MISSING_COLUMN_ALIASES)
+                .hasMessageContaining("PIVOT with multiple aggregations requires an alias");
+    }
+
+    @Test
+    public void testDuplicateOutputColumnName()
+    {
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(DUPLICATE_COLUMN_NAME)
+                .hasMessageContaining("PIVOT produces duplicate output column name");
+    }
+
+    @Test
+    public void testGroupingSetsInsidePivot()
+    {
+        // GROUP BY GROUPING SETS within PIVOT — emits a row per grouping set, with NULL
+        // for missing dimensions.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total
+                    FOR month IN (1 AS jan)
+                    GROUP BY GROUPING SETS ((region), ())
+                )
+                ORDER BY region NULLS FIRST
+                """.formatted(SALES)))
+                .ordered()
+                .matches("""
+                        VALUES
+                            (CAST(NULL AS varchar(2)), BIGINT '190'),
+                            ('EU', BIGINT '40'),
+                            ('NA', BIGINT '150')
+                        """);
+    }
+
+    @Test
+    public void testValueIsExpression()
+    {
+        // IN values can be arbitrary constant expressions; coercion follows the
+        // pivot column's type.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 + 0 AS jan, 2 * 1 AS feb))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '190', BIGINT '70')");
+    }
+
+    @Test
+    public void testAggregationSlotMustBeAggregating()
+    {
+        // No aggregate function in the slot — caught by AggregationAnalyzer in the
+        // rewritten query.
+        assertThat(assertions.query("""
+                SELECT *
+                FROM %s
+                PIVOT (amount FOR month IN (1 AS jan) GROUP BY region)
+                """.formatted(SALES)))
+                .failure()
+                .hasMessageContaining("must be an aggregate expression or appear in GROUP BY clause");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -111,6 +111,9 @@ import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.OrdinalityColumn;
 import io.trino.sql.tree.ParameterDeclaration;
 import io.trino.sql.tree.PatternRecognitionRelation;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -1007,7 +1010,7 @@ public final class SqlFormatter
 
         private void processRelationSuffix(Relation relation, Integer indent)
         {
-            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation) || (relation instanceof PatternRecognitionRelation)) {
+            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation) || (relation instanceof PatternRecognitionRelation) || (relation instanceof Pivot)) {
                 builder.append("( ");
                 process(relation, indent + 1);
                 append(indent, ")");
@@ -1015,6 +1018,64 @@ public final class SqlFormatter
             else {
                 process(relation, indent);
             }
+        }
+
+        @Override
+        protected Void visitPivot(Pivot node, Integer indent)
+        {
+            processRelationSuffix(node.getInput(), indent);
+
+            builder.append(" PIVOT (\n");
+            append(indent + 1, node.getAggregations().stream()
+                    .map(this::formatPivotAggregation)
+                    .collect(joining(", ")))
+                    .append("\n");
+            append(indent + 1, "FOR ")
+                    .append(formatPivotColumns(node.getPivotColumns()))
+                    .append(" IN (")
+                    .append(node.getValueGroups().stream()
+                            .map(this::formatPivotValueGroup)
+                            .collect(joining(", ")))
+                    .append(")\n");
+            node.getGroupBy().ifPresent(groupBy ->
+                    append(indent + 1, "GROUP BY " + (groupBy.isDistinct() ? "DISTINCT " : "") + formatGroupBy(groupBy.getGroupingElements()))
+                            .append("\n"));
+            append(indent, ")");
+            return null;
+        }
+
+        private String formatPivotAggregation(PivotAggregation aggregation)
+        {
+            String result = formatExpression(aggregation.getExpression());
+            if (aggregation.getAlias().isPresent()) {
+                result += " AS " + formatName(aggregation.getAlias().get());
+            }
+            return result;
+        }
+
+        private String formatPivotColumns(List<Expression> pivotColumns)
+        {
+            String formatted = pivotColumns.stream()
+                    .map(SqlFormatter::formatExpression)
+                    .collect(joining(", "));
+            if (pivotColumns.size() == 1) {
+                return formatted;
+            }
+            return "(" + formatted + ")";
+        }
+
+        private String formatPivotValueGroup(PivotValueGroup valueGroup)
+        {
+            String formatted = valueGroup.getValues().stream()
+                    .map(SqlFormatter::formatExpression)
+                    .collect(joining(", "));
+            if (valueGroup.getValues().size() != 1) {
+                formatted = "(" + formatted + ")";
+            }
+            if (valueGroup.getAlias().isPresent()) {
+                formatted += " AS " + formatName(valueGroup.getAlias().get());
+            }
+            return formatted;
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -211,6 +211,9 @@ import io.trino.sql.tree.PatternRecognitionRelation;
 import io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch;
 import io.trino.sql.tree.PatternSearchMode;
 import io.trino.sql.tree.PatternVariable;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -2001,7 +2004,7 @@ class AstBuilder
     @Override
     public Node visitSampledRelation(SqlBaseParser.SampledRelationContext context)
     {
-        Relation child = (Relation) visit(context.patternRecognition());
+        Relation child = (Relation) visit(context.pivot());
 
         if (context.TABLESAMPLE() == null) {
             return child;
@@ -2062,6 +2065,70 @@ class AstBuilder
     public Node visitMeasureDefinition(SqlBaseParser.MeasureDefinitionContext context)
     {
         return new MeasureDefinition(getLocation(context), (Expression) visit(context.expression()), (Identifier) visit(context.identifier()));
+    }
+
+    @Override
+    public Node visitPivot(SqlBaseParser.PivotContext context)
+    {
+        Relation child = (Relation) visit(context.patternRecognition());
+
+        if (context.PIVOT() == null) {
+            return child;
+        }
+
+        List<PivotAggregation> aggregations = visit(context.pivotAggregation(), PivotAggregation.class);
+        List<Expression> pivotColumns = buildPivotColumns(context.pivotColumns());
+        List<PivotValueGroup> valueGroups = visit(context.pivotValueGroup(), PivotValueGroup.class);
+
+        Optional<GroupBy> groupBy = Optional.empty();
+        if (context.GROUP() != null) {
+            groupBy = Optional.of((GroupBy) visit(context.groupBy()));
+        }
+
+        Pivot pivot = new Pivot(getLocation(context), child, aggregations, pivotColumns, valueGroups, groupBy);
+
+        if (context.identifier() == null) {
+            return pivot;
+        }
+
+        List<Identifier> aliases = null;
+        if (context.columnAliases() != null) {
+            aliases = visit(context.columnAliases().identifier(), Identifier.class);
+        }
+
+        return new AliasedRelation(getLocation(context), pivot, (Identifier) visit(context.identifier()), aliases);
+    }
+
+    @Override
+    public Node visitPivotAggregation(SqlBaseParser.PivotAggregationContext context)
+    {
+        Optional<Identifier> alias = Optional.empty();
+        if (context.identifier() != null) {
+            alias = Optional.of((Identifier) visit(context.identifier()));
+        }
+        return new PivotAggregation(getLocation(context), (Expression) visit(context.expression()), alias);
+    }
+
+    @Override
+    public Node visitPivotValueGroup(SqlBaseParser.PivotValueGroupContext context)
+    {
+        Optional<Identifier> alias = Optional.empty();
+        if (context.identifier() != null) {
+            alias = Optional.of((Identifier) visit(context.identifier()));
+        }
+        return new PivotValueGroup(
+                getLocation(context),
+                visit(context.expression(), Expression.class),
+                alias);
+    }
+
+    private List<Expression> buildPivotColumns(SqlBaseParser.PivotColumnsContext context)
+    {
+        ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+        for (SqlBaseParser.QualifiedNameContext qualifiedNameContext : context.qualifiedName()) {
+            builder.add(DereferenceExpression.from(getQualifiedName(qualifiedNameContext)));
+        }
+        return builder.build();
     }
 
     private static Optional<RowsPerMatch> getRowsPerMatch(SqlBaseParser.RowsPerMatchContext context)

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -537,6 +537,21 @@ public abstract class AstVisitor<R, C>
         return visitRelation(node, context);
     }
 
+    protected R visitPivot(Pivot node, C context)
+    {
+        return visitRelation(node, context);
+    }
+
+    protected R visitPivotAggregation(PivotAggregation node, C context)
+    {
+        return visitNode(node, context);
+    }
+
+    protected R visitPivotValueGroup(PivotValueGroup node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitJoin(Join node, C context)
     {
         return visitRelation(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Pivot.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Pivot.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class Pivot
+        extends Relation
+{
+    private final Relation input;
+    private final List<PivotAggregation> aggregations;
+    private final List<Expression> pivotColumns;
+    private final List<PivotValueGroup> valueGroups;
+    private final Optional<GroupBy> groupBy;
+
+    public Pivot(
+            NodeLocation location,
+            Relation input,
+            List<PivotAggregation> aggregations,
+            List<Expression> pivotColumns,
+            List<PivotValueGroup> valueGroups,
+            Optional<GroupBy> groupBy)
+    {
+        super(Optional.of(location));
+        this.input = requireNonNull(input, "input is null");
+        requireNonNull(aggregations, "aggregations is null");
+        checkArgument(!aggregations.isEmpty(), "aggregations is empty");
+        this.aggregations = ImmutableList.copyOf(aggregations);
+        requireNonNull(pivotColumns, "pivotColumns is null");
+        checkArgument(!pivotColumns.isEmpty(), "pivotColumns is empty");
+        this.pivotColumns = ImmutableList.copyOf(pivotColumns);
+        requireNonNull(valueGroups, "valueGroups is null");
+        checkArgument(!valueGroups.isEmpty(), "valueGroups is empty");
+        this.valueGroups = ImmutableList.copyOf(valueGroups);
+        this.groupBy = requireNonNull(groupBy, "groupBy is null");
+    }
+
+    public Relation getInput()
+    {
+        return input;
+    }
+
+    public List<PivotAggregation> getAggregations()
+    {
+        return aggregations;
+    }
+
+    public List<Expression> getPivotColumns()
+    {
+        return pivotColumns;
+    }
+
+    public List<PivotValueGroup> getValueGroups()
+    {
+        return valueGroups;
+    }
+
+    public Optional<GroupBy> getGroupBy()
+    {
+        return groupBy;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPivot(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        builder.add(input);
+        builder.addAll(aggregations);
+        builder.addAll(pivotColumns);
+        builder.addAll(valueGroups);
+        groupBy.ifPresent(builder::add);
+        return builder.build();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("input", input)
+                .add("aggregations", aggregations)
+                .add("pivotColumns", pivotColumns)
+                .add("valueGroups", valueGroups)
+                .add("groupBy", groupBy.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Pivot pivot = (Pivot) o;
+        return Objects.equals(input, pivot.input) &&
+                Objects.equals(aggregations, pivot.aggregations) &&
+                Objects.equals(pivotColumns, pivot.pivotColumns) &&
+                Objects.equals(valueGroups, pivot.valueGroups) &&
+                Objects.equals(groupBy, pivot.groupBy);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(input, aggregations, pivotColumns, valueGroups, groupBy);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/PivotAggregation.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/PivotAggregation.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PivotAggregation
+        extends Node
+{
+    private final Expression expression;
+    private final Optional<Identifier> alias;
+
+    public PivotAggregation(NodeLocation location, Expression expression, Optional<Identifier> alias)
+    {
+        super(location);
+        this.expression = requireNonNull(expression, "expression is null");
+        this.alias = requireNonNull(alias, "alias is null");
+    }
+
+    public Expression getExpression()
+    {
+        return expression;
+    }
+
+    public Optional<Identifier> getAlias()
+    {
+        return alias;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPivotAggregation(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        builder.add(expression);
+        alias.ifPresent(builder::add);
+        return builder.build();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("expression", expression)
+                .add("alias", alias.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PivotAggregation that = (PivotAggregation) o;
+        return Objects.equals(expression, that.expression) &&
+                Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression, alias);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+        return Objects.equals(alias, ((PivotAggregation) other).alias);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/PivotValueGroup.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/PivotValueGroup.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class PivotValueGroup
+        extends Node
+{
+    private final List<Expression> values;
+    private final Optional<Identifier> alias;
+
+    public PivotValueGroup(NodeLocation location, List<Expression> values, Optional<Identifier> alias)
+    {
+        super(location);
+        requireNonNull(values, "values is null");
+        checkArgument(!values.isEmpty(), "values is empty");
+        this.values = ImmutableList.copyOf(values);
+        this.alias = requireNonNull(alias, "alias is null");
+    }
+
+    public List<Expression> getValues()
+    {
+        return values;
+    }
+
+    public Optional<Identifier> getAlias()
+    {
+        return alias;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPivotValueGroup(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        builder.addAll(values);
+        alias.ifPresent(builder::add);
+        return builder.build();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("values", values)
+                .add("alias", alias.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PivotValueGroup that = (PivotValueGroup) o;
+        return Objects.equals(values, that.values) &&
+                Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(values, alias);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+        return Objects.equals(alias, ((PivotValueGroup) other).alias);
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -7860,6 +7860,24 @@ public class TestSqlParser
     }
 
     @Test
+    public void testPivot()
+    {
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) FOR month IN (1, 2))");
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) AS total FOR month IN (1 AS jan, 2 AS feb))");
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) AS total, avg(amount) AS mean FOR month IN (1 AS jan, 2 AS feb))");
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) FOR (region, month) IN (('NA', 1), ('EU', 1), ('NA', 2) AS na_feb))");
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) FOR month IN (1) GROUP BY region)");
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) FOR month IN (1)) AS p");
+        assertRoundtrip("SELECT * FROM t PIVOT (sum(amount) FOR month IN (1)) AS p (r, jan)");
+        assertRoundtrip("SELECT pivot AS x FROM (SELECT 1 AS pivot)");
+    }
+
+    private static void assertRoundtrip(@Language("SQL") String sql)
+    {
+        assertFormattedSql(SQL_PARSER, SQL_PARSER.createStatement(sql));
+    }
+
+    @Test
     public void testResetSessionAuthorization()
     {
         assertThat(statement("RESET SESSION AUTHORIZATION"))

--- a/docs/src/main/sphinx/language/sql-support.md
+++ b/docs/src/main/sphinx/language/sql-support.md
@@ -61,7 +61,7 @@ catalogs](/admin/properties-catalog):
 The following statements provide read access to data and metadata exposed by a
 connector accessing a data source. They are supported by all connectors:
 
-- {doc}`/sql/select` including {doc}`/sql/match-recognize`
+- {doc}`/sql/select` including {doc}`/sql/match-recognize` and {doc}`/sql/pivot`
 - {doc}`/sql/describe`
 - {doc}`/sql/show-catalogs`
 - {doc}`/sql/show-columns`

--- a/docs/src/main/sphinx/sql.md
+++ b/docs/src/main/sphinx/sql.md
@@ -52,6 +52,7 @@ sql/grant-roles
 sql/insert
 sql/match-recognize
 sql/merge
+sql/pivot
 sql/prepare
 sql/refresh-materialized-view
 sql/reset-session

--- a/docs/src/main/sphinx/sql/pivot.md
+++ b/docs/src/main/sphinx/sql/pivot.md
@@ -1,0 +1,185 @@
+# PIVOT
+
+## Synopsis
+
+```text
+PIVOT (
+  aggregation [ [ AS ] aggregation_alias ] [, ...]
+  FOR pivot_column [, (pivot_column [, ...]) ] IN ( pivot_value_group [, ...] )
+  [ GROUP BY grouping_element [, ...] ]
+  )
+```
+
+where `pivot_value_group` is one of
+
+```text
+expression [ [ AS ] value_alias ]
+( expression, expression [, ...] ) [ [ AS ] value_alias ]
+```
+
+## Description
+
+The `PIVOT` clause is an optional subclause of the `FROM` clause. It rotates
+rows of an input relation into output columns by partitioning the rows on
+one or more *pivot columns* and computing one or more *aggregations* for
+each *pivot value*. The input to a pivot is a table, a view, or a subquery.
+The output of a pivot is a relation, so it can itself appear in a `FROM`
+clause, be aliased, or be the input to another `PIVOT`.
+
+`PIVOT` is useful when each row in the input represents one observation
+along a categorical dimension (such as a month, region, or status), and the
+report should display one column per category. Common use cases include:
+
+- summarizing measurements by time bucket,
+- producing a column per status or category,
+- comparing aggregated metrics side by side without writing repetitive
+  `CASE` or `FILTER` expressions.
+
+## Example
+
+In the following example, `sales` records one row per region/month, and
+`PIVOT` produces one column per month within each region:
+
+```sql
+SELECT *
+FROM sales PIVOT (
+    sum(amount) AS total
+    FOR month IN (1 AS jan, 2 AS feb, 3 AS mar)
+    GROUP BY region
+    )
+```
+
+The output has columns `region`, `jan_total`, `feb_total`, `mar_total`.
+
+In the following sections, all subclauses of the `PIVOT` clause are
+explained.
+
+## Aggregations
+
+```sql
+sum(amount) AS total
+```
+
+Each aggregation is an expression that contains one or more aggregate
+function calls. The expression is evaluated once per pivot value, with each
+aggregate scoped to the rows that match that pivot value.
+
+The aggregation alias becomes part of the output column names (see
+[](pivot-output)). Aliases are optional in the single-aggregation case but
+required when a `PIVOT` declares more than one aggregation. Without
+aliases, every output column for the multi-aggregation case would collide.
+
+`PIVOT` accepts any expression Trino accepts as an aggregating select
+item. For example, the following all work:
+
+```sql
+sum(amount)                                    -- single aggregate
+avg(amount) * 100 AS pct                       -- expression over an aggregate
+sum(amount) - sum(refund) AS net               -- multiple aggregates in one slot
+```
+
+When the slot expression contains multiple aggregate calls, the pivot
+filter is applied to each aggregate individually, so `sum(amount) -
+sum(refund)` filters both `sum`s to the rows for the current pivot value.
+
+## Pivot column and IN list
+
+```sql
+FOR month IN (1 AS jan, 2 AS feb, 3 AS mar)
+```
+
+The `FOR` clause names the pivot column (or, for compound keys, a
+parenthesised list of pivot columns) and the `IN` clause supplies the
+values that become output columns. Each value is a constant expression and
+is coerced to the pivot column's type using the standard implicit
+coercion rules.
+
+For multiple pivot columns, supply tuple values in matching order:
+
+```sql
+FOR (region, month) IN (('NA', 1) AS na_jan, ('EU', 1) AS eu_jan)
+```
+
+Each tuple must have the same arity as the pivot column list.
+
+The value alias controls the output column name for that value. It is
+strongly recommended in practice — without it, the column name is
+derived from the SQL text of the value expression (so `1` and `'1'`
+become distinct columns named `1` and `'1'`).
+
+`NULL` is a permitted value, but it is treated using Trino's standard
+`=` semantics: the predicate `pivot_column = NULL` is `UNKNOWN`, so the
+corresponding output column always carries the empty-input aggregation
+result (`NULL` for `sum`, `0` for `count`, and so on). To produce a
+column for rows where the pivot column is `NULL`, supply that bucket
+explicitly in the source relation rather than relying on a `NULL` IN
+value.
+
+## GROUP BY
+
+```sql
+GROUP BY region
+```
+
+The optional `GROUP BY` clause inside `PIVOT` controls which dimensions
+are preserved as additional output columns. It accepts the same forms as
+a top-level `GROUP BY`, including simple expressions, `()`, `GROUPING
+SETS`, `CUBE`, and `ROLLUP`. Each grouping expression is projected as an
+output column (with grouping-set semantics applied as usual).
+
+When `GROUP BY` is omitted, no implicit grouping is performed: the result
+is a single row whose only columns are the pivot output columns. To
+preserve a dimension, name it explicitly in `GROUP BY`. This matches
+Trino's general rule that aggregating queries collapse to a single row
+unless `GROUP BY` says otherwise.
+
+(pivot-output)=
+## Output columns
+
+The output column list is, in order:
+
+1. The columns introduced by `GROUP BY` (in declaration order), if any.
+2. One block per pivot value group (in declaration order).
+
+Within each block, columns appear once per aggregation slot in the order
+the aggregations were declared. The column name is determined by the
+value alias and aggregation alias:
+
+| Form | Output column name |
+|---|---|
+| Single aggregation, value alias provided | `valueAlias` |
+| Single aggregation, no value alias | SQL text of the value |
+| Multiple aggregations | `valueAlias_aggAlias` |
+| Tuple value with tuple alias | `tupleAlias` |
+| Tuple value without alias | components joined by `_` |
+
+If two output columns would collide, an error is reported at analysis
+time pointing at the colliding values.
+
+## Pivot relation alias
+
+A `PIVOT` clause may itself be aliased, with optional column aliases:
+
+```sql
+SELECT p.r, p.jan, p.feb
+FROM sales PIVOT (
+    sum(amount) FOR month IN (1 AS jan, 2 AS feb)
+    GROUP BY region
+    ) AS p (r, jan, feb)
+```
+
+The column-alias list, when present, must match the number of output
+columns. This is the same form supported for subquery aliases.
+
+## Restrictions
+
+- `PIVOT` and {doc}`MATCH_RECOGNIZE</sql/match-recognize>` cannot apply to
+  the same input relation. Wrap one in a subquery to combine them.
+- The `IN` list does not support `ANY` or a subquery — values must be
+  enumerated explicitly.
+- `UNPIVOT` is not currently supported.
+
+## See also
+
+- {doc}`select`
+- {doc}`match-recognize`

--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -40,6 +40,13 @@ For detailed description of `MATCH_RECOGNIZE` clause, see {doc}`pattern
 recognition in FROM clause</sql/match-recognize>`.
 
 ```text
+table_name PIVOT pivot_specification
+  [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+```
+
+For detailed description of `PIVOT` clause, see {doc}`pivot</sql/pivot>`.
+
+```text
 TABLE (table_function_invocation) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
 ```
 


### PR DESCRIPTION
## Summary

Adds first-class `PIVOT` syntax to Trino, eliminating the need to hand-write `FILTER` aggregation SQL to rotate row values into columns.

```sql
SELECT *
FROM sales PIVOT (
    sum(amount) AS total
    FOR month IN (1 AS jan, 2 AS feb, 3 AS mar)
    GROUP BY region
)
```

`PIVOT` attaches to the relation tree at the same level as `MATCH_RECOGNIZE` and supports:

- multiple aggregations per slot, requiring an alias on each;
- single or multi-column pivot keys, with tuple values for the multi-column form;
- arbitrary aggregating expressions in the aggregation slot (e.g. `sum(x) - sum(y)`), validated by the existing `AggregationAnalyzer`;
- explicit `GROUP BY` including `GROUPING SETS`, `CUBE`, and `ROLLUP`;
- alias and column-alias on the `PIVOT` output (`PIVOT (...) AS p (c1, c2)`).

Two semantic choices align `PIVOT` with the rest of Trino rather than with other engines' shortcuts:

- **No implicit grouping.** When `GROUP BY` is omitted the result is a single row, matching Trino's existing rule that aggregating queries collapse unless `GROUP BY` says otherwise. Other engines silently group by all unmentioned columns.
- **Standard NULL semantics.** `IN (NULL)` produces a column whose `=` predicate is `UNKNOWN` — never matches — so the column always carries the empty-input aggregation result. Other engines special-case this to mean `IS NULL`.

`PIVOT` is desugared at analysis time. `StatementAnalyzer.visitPivot` rewrites the node into an equivalent `Query` of `FILTER` aggregations and stores the rewriting in `Analysis`; `RelationPlanner.visitPivot` looks the rewriting up and plans it through the existing `QueryPlanner`. `PIVOT` therefore inherits all existing aggregate, GROUP BY, FILTER, and coercion plan-time rules without new operators.

`PIVOT` is added as a non-reserved keyword.

Out of scope (deliberate, can come later):

- `UNPIVOT`
- `IN (ANY)` / `IN (<subquery>)`
- `DEFAULT ON NULL`

## Test plan

- [x] New `TestPivot` (16 cases): no/with `GROUP BY`, multi-aggregation, multi-column keys, expression aggregations, expression IN values, `GROUPING SETS`, NULL semantics, `pivot`-of-`pivot`, relation alias with column aliases, plus four error paths (arity mismatch, missing alias, duplicate output column, non-aggregating slot).
- [x] New `TestSqlParser` cases (8) covering each grammar shape including `pivot` used as an identifier.
- [x] `TestSqlParser` and `TestAnalyzer` continue to pass (173 + 288 tests).
- [x] `MATCH_RECOGNIZE` tests continue to pass — verified there's no grammar regression in the relation-tree slot.
- [x] `mvnd verify` for `core/trino-grammar`, `core/trino-parser`, and `core/trino-main` passes (compile, checkstyle, modernizer).

## Documentation

- New `docs/src/main/sphinx/sql/pivot.md` reference page modelled after `match-recognize.md`.
- Toctree entry, cross-reference from `select.md`, and listing in `language/sql-support.md`.