### PR TITLE
iceberg: push TupleDomain constraint into iceberg scan + heap-budget guardrail for unfiltered scans

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsTable.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.system;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.IcebergStatistics;
 import io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
@@ -25,14 +26,19 @@ import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.NestedField;
@@ -53,6 +59,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
+import static io.trino.plugin.iceberg.IcebergTypes.convertTrinoValueToIceberg;
 import static io.trino.plugin.iceberg.IcebergUtil.getIdentityPartitions;
 import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
 import static io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex.createStructLikeWrapper;
@@ -60,15 +67,26 @@ import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.plugin.iceberg.util.SystemTableUtil.getAllPartitionFields;
 import static io.trino.plugin.iceberg.util.SystemTableUtil.getPartitionColumnType;
 import static io.trino.plugin.iceberg.util.SystemTableUtil.partitionTypes;
+import static io.trino.spi.StandardErrorCode.QUERY_REJECTED;
 import static io.trino.spi.block.RowValueBuilder.buildRowValue;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 public class PartitionsTable
         implements SystemTable
 {
+    // TODO: compute() upon feedback
+    //  current logic is
+    //  knob-1: estimated-data-file-object-size = 5 kb
+    //  knob-2: allowed-budget = 5% of -xmX (e.g. 500 gb = 25 gb )
+    //  Formula:
+    //                       ( allowed budget ) x 1024 x 1024
+    //    - allowed-files = ----------------------------------
+    //                           estimated-file-size-in-kb
+    private static final long MAX_FILES_PER_PARTITIONS_SCAN = 100L;
     private final TypeManager typeManager;
     private final Table icebergTable;
     private final OptionalLong snapshotId;
@@ -97,6 +115,15 @@ public class PartitionsTable
         this.partitionColumnType = getPartitionColumnType(typeManager, partitionFields, icebergTable.schema());
         partitionColumnType.ifPresent(icebergPartitionColumn ->
                 columnMetadataBuilder.add(new ColumnMetadata("partition", icebergPartitionColumn.rowType())));
+        // expose each identity-transform partitoin field as a top-level column so predicate on those value can be
+        // pushed to iceberg scan api
+        Schema schema = icebergTable.schema();
+        for (PartitionField field : partitionFields) {
+            if (field.transform().isIdentity()) {
+                Type sourceType = schema.findType(field.sourceId());
+                columnMetadataBuilder.add(new ColumnMetadata(field.name(), toTrinoType(sourceType, typeManager)));
+            }
+        }
 
         Stream.of("record_count", "file_count", "total_size")
                 .forEach(metric -> columnMetadataBuilder.add(new ColumnMetadata(metric, BIGINT)));
@@ -161,29 +188,143 @@ public class PartitionsTable
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        if (snapshotId.isEmpty()) {
+        var icebergFilter = convertToIcebergFilter(constraint);
+        if (snapshotId.isEmpty() || icebergFilter == Expressions.alwaysFalse()) {
             return new InMemoryRecordSet(resultTypes, ImmutableList.of()).cursor();
         }
+
+        // Pre-flight guard:
+        if (icebergFilter == Expressions.alwaysTrue()) {
+            var totalDatafiles = Long.parseLong(
+                    icebergTable.snapshot(snapshotId.getAsLong())
+                            .summary()
+                            .getOrDefault("total-data-files", "0"));
+            if (totalDatafiles > MAX_FILES_PER_PARTITIONS_SCAN) {
+                throw new TrinoException(QUERY_REJECTED,
+                        format("Scan on %s would visit %d of data files unfiltered, exceeding threshold(%d). Add a predicate " +
+                                        "on top-level partition column to prune the manifest",
+                                icebergTable.name(), totalDatafiles, MAX_FILES_PER_PARTITIONS_SCAN));
+            }
+        }
+
         TableScan tableScan = icebergTable.newScan()
                 .useSnapshot(snapshotId.getAsLong())
+                .filter(icebergFilter)
                 .includeColumnStats()
                 .planWith(executor);
         // TODO make the cursor lazy
         return buildRecordCursor(getStatisticsByPartition(tableScan));
     }
 
+    private Expression convertToIcebergFilter(TupleDomain<Integer> constraint)
+    {
+        if (constraint.isAll()) {
+            return Expressions.alwaysTrue();
+        }
+        else if (constraint.isNone()) {
+            return Expressions.alwaysFalse();
+        }
+
+        Map<Integer, Domain> domains = constraint.getDomains().orElseThrow();
+        Schema schema = icebergTable.schema();
+        int startIdx = partitionColumnType.isPresent() ? 1 : 0;
+
+        Expression result = Expressions.alwaysTrue();
+        for (int i = 0; i < partitionFields.size(); i++) {
+            var colDomain = domains.get(startIdx + i);
+            if (colDomain == null || colDomain.isAll()) {
+                continue;
+            }
+            PartitionField field = partitionFields.get(i);
+            var sourceName = schema.findColumnName(field.sourceId());
+            var trinoType = toTrinoType(schema.findType(field.sourceId()), typeManager);
+            var exp = domainToExpression(sourceName, trinoType, colDomain);
+            if (exp.isPresent()) {
+                result = Expressions.and(result, exp.get());
+            }
+        }
+        return result;
+    }
+
+    private static Optional<Expression> domainToExpression(String fieldName,
+            io.trino.spi.type.Type trinoType,
+            Domain domain)
+    {
+        if (domain.isAll()) {
+            return Optional.empty();
+        }
+        else if (domain.isNone()) {
+            return Optional.of(Expressions.alwaysFalse());
+        }
+        else if (domain.isOnlyNull()) {
+            return Optional.of(Expressions.isNull(fieldName));
+        }
+        else if (domain.getValues().isAll() && !domain.isNullAllowed()) {
+            return Optional.of(Expressions.notNull(fieldName));
+        }
+        else {
+            var rangeExp = domain.getValues()
+                    .getRanges()
+                    .getOrderedRanges()
+                    .stream()
+                    .map(range -> rangeToExpression(fieldName, trinoType, range))
+                    .toList();
+            var valExp = rangeExp.stream()
+                    .reduce(Expressions::or)
+                    .orElse(Expressions.alwaysFalse());
+
+            return Optional.of(domain.isNullAllowed()
+                    ? Expressions.or(valExp, Expressions.isNull(fieldName))
+                    : valExp);
+        }
+    }
+
+    private static Expression rangeToExpression(String fieldName,
+            io.trino.spi.type.Type trinoType,
+            Range range)
+    {
+        if (range.isSingleValue()) {
+            var icebergValue = convertTrinoValueToIceberg(trinoType, range.getSingleValue());
+            return Expressions.equal(fieldName, icebergValue);
+        }
+
+        Expression exp = Expressions.alwaysTrue();
+        if (!range.isLowUnbounded()) {
+            var low = convertTrinoValueToIceberg(trinoType, range.getLowBoundedValue());
+            exp = Expressions.and(exp, range.isLowInclusive()
+                    ? Expressions.greaterThanOrEqual(fieldName, low)
+                    : Expressions.greaterThan(fieldName, low));
+        }
+
+        if (!range.isHighUnbounded()) {
+            var high = convertTrinoValueToIceberg(trinoType, range.getHighBoundedValue());
+            exp = Expressions.and(exp, range.isHighInclusive()
+                    ? Expressions.greaterThanOrEqual(fieldName, high)
+                    : Expressions.greaterThan(fieldName, high));
+        }
+        return exp;
+    }
+
     private Map<StructLikeWrapperWithFieldIdToIndex, IcebergStatistics> getStatisticsByPartition(TableScan tableScan)
     {
         try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
             Map<StructLikeWrapperWithFieldIdToIndex, IcebergStatistics.Builder> partitions = new HashMap<>();
+            long fileCount = 0;
             for (FileScanTask fileScanTask : fileScanTasks) {
+                if (fileCount > MAX_FILES_PER_PARTITIONS_SCAN) {
+                    throw new TrinoException(QUERY_REJECTED,
+                            format("Scan on %s exceeded threshold %d. Add a more selective predicate " +
+                                            "on top-level partition column to prune the manifest",
+                                    icebergTable.name(), MAX_FILES_PER_PARTITIONS_SCAN));
+                }
                 DataFile dataFile = fileScanTask.file();
                 StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = createStructLikeWrapper(fileScanTask);
 
                 partitions.computeIfAbsent(
-                        structLikeWrapperWithFieldIdToIndex,
-                        _ -> new IcebergStatistics.Builder(icebergTable.schema().columns(), typeManager))
+                                structLikeWrapperWithFieldIdToIndex,
+                                _ -> new IcebergStatistics.Builder(icebergTable.schema().columns(), typeManager))
                         .acceptDataFile(dataFile, fileScanTask.spec());
+                fileCount++;
             }
 
             return partitions.entrySet().stream()
@@ -227,6 +368,25 @@ public class PartitionsTable
                     }
                 }));
             });
+
+            // add top level partition columns
+            for (PartitionField field : partitionFields) {
+                if (field.transform().isIdentity()) {
+                    Type sourceType = icebergTable.schema().findType(field.sourceId());
+                    Integer fieldId = field.fieldId();
+                    if (partitionStruct.getFieldIdToIndex().containsKey(fieldId)) {
+                        row.add(convertIcebergValueToTrino(
+                                sourceType,
+                                partitionStruct.getStructLikeWrapper()
+                                        .get()
+                                        .get(partitionStruct.getFieldIdToIndex().get(fieldId),
+                                                sourceType.typeId().javaClass())));
+                    }
+                    else {
+                        row.add(null);
+                    }
+                }
+            }
 
             // add the top level metrics.
             row.add(icebergStatistics.recordCount());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionTablePredicatePushdown.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionTablePredicatePushdown.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import io.trino.Session;
+import io.trino.connector.system.SystemTableHandle;
+import io.trino.metastore.Database;
+import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.HiveMetastoreFactory;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.SystemColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.PrincipalType;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.assertions.BasePushdownPlanTest;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.testing.PlanTester;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPartitionTablePredicatePushdown
+        extends BasePushdownPlanTest
+{
+    private static final String CATALOG = "iceberg";
+    private static final String SCHEMA = "schema";
+    private File metastoreDir;
+
+    @Override
+    protected PlanTester createPlanTester()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema(SCHEMA)
+                .build();
+
+        try {
+            metastoreDir = Files.createTempDirectory(null).toFile();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        PlanTester planTester = PlanTester.create(session);
+        planTester.installPlugin(new TestingIcebergPlugin(metastoreDir.toPath()));
+        planTester.createCatalog(CATALOG, "iceberg", ImmutableMap.of());
+
+        HiveMetastore metastore = ((IcebergConnector) planTester.getConnector(CATALOG)).getInjector()
+                .getInstance(HiveMetastoreFactory.class)
+                .createMetastore(Optional.empty());
+
+        Database database = Database.builder()
+                .setDatabaseName(SCHEMA)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
+        metastore.createDatabase(database);
+
+        return planTester;
+    }
+
+    @AfterAll
+    public void cleanup()
+            throws Exception
+    {
+        if (metastoreDir != null) {
+            deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+        }
+    }
+
+    @Test
+    public void testTopLevelColumn()
+    {
+        getPlanTester().executeStatement(
+                "CREATE TABLE my_table(a, b) WITH (partitioning = ARRAY['b']) AS VALUES (1, 11)");
+
+        assertPlan(
+                "SELECT column_name FROM information_schema.columns " +
+                        "WHERE table_name = 'my_table$partitions' " +
+                        " AND column_name = 'b'",
+                anyTree(tableScan("columns")));
+    }
+
+    @Test
+    public void testPredicatePushdownOnPartitionColumn()
+    {
+        getPlanTester().executeStatement(
+                "CREATE TABLE my_table_filter_pushdown (id, part) " +
+                        "WITH (partitioning = ARRAY['part']) " +
+                        "AS VALUES (1, '2026-05-07'), (2, '2026-05-08') ");
+        Domain expectedDomain = Domain.create(
+                SortedRangeSet.copyOf(VarcharType.VARCHAR,
+                        List.of(Range.range(VarcharType.VARCHAR,
+                                utf8Slice("2026-05-07"),
+                                true,
+                                utf8Slice("2026-05-08"),
+                                true))),
+                false
+        );
+
+        String sql = "SELECT count(*) " +
+                "FROM \"my_table_filter_pushdown$partitions\" " +
+                "WHERE part >= '2026-05-07' AND part <= '2026-05-08'";
+        SystemTableHandle scanHandle = (SystemTableHandle) getPlanTester().inTransaction(session -> {
+            Plan plan = getPlanTester().createPlan(session, sql);
+            TableScanNode sc = (TableScanNode) Iterables.getOnlyElement(PlanNodeSearcher.searchFrom(plan.getRoot())
+                    .where(node -> node instanceof TableScanNode tsn
+                            && tsn.getTable().connectorHandle() instanceof SystemTableHandle)
+                    .findAll());
+            return sc.getTable().connectorHandle();
+        });
+
+        TupleDomain<ColumnHandle> constraint = scanHandle.constraint();
+        assertThat(constraint.isAll()).isFalse();
+        ColumnHandle partCol = constraint.getDomains().orElseThrow().keySet().stream()
+                .filter(c -> ((SystemColumnHandle) c).columnName().equals("part"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(constraint.getDomains().orElseThrow().get(partCol))
+                .isEqualTo(expectedDomain);
+    }
+}


### PR DESCRIPTION
## Description
[PartitionTable.cursor](https://github.com/trinodb/trino/blob/master/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsTable.java#L167-L170) ignores its TupleDomain<Integer> argument and scans every file in the snapshot via
planFiles().includeColumnStats(). The scan runs on the coordinator (Distribution.SINGLE_COORDINATOR) and buffers results in a HashMap and ImmutableList<List<Object>> before returning. On a large partitioned table one user query can pin a coordinator core at 100% for few minutes, and OOM the JVM.

Same pattern in $files, $entries, $manifests. Scoping the fix to $partitions for now; the helpers are reusable.


## Additional context and related issues
- https://github.com/trinodb/trino/issues/29390

## Release notes
 -- Pending -- will be adusted based on feedback
( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({https://github.com/trinodb/trino/issues/29390} `29390 `)
```
