### PR TITLE
Add support for PIVOT

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -392,9 +392,34 @@ joinCriteria
     ;
 
 sampledRelation
-    : patternRecognition (
+    : pivot (
         TABLESAMPLE sampleType '(' percentage=expression ')'
       )?
+    ;
+
+pivot
+    : patternRecognition (
+        PIVOT '('
+          pivotAggregation (',' pivotAggregation)*
+          FOR pivotColumns IN '(' pivotValueGroup (',' pivotValueGroup)* ')'
+          (GROUP BY groupBy)?
+        ')'
+        (AS? identifier columnAliases?)?
+      )?
+    ;
+
+pivotAggregation
+    : expression (AS? identifier)?
+    ;
+
+pivotColumns
+    : qualifiedName
+    | '(' qualifiedName (',' qualifiedName)* ')'
+    ;
+
+pivotValueGroup
+    : '(' expression (',' expression)+ ')' (AS? identifier)?
+    | expression (AS? identifier)?
     ;
 
 sampleType
@@ -1087,7 +1112,7 @@ nonReserved
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEAREST | NESTED | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
     | OBJECT | OF | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW | OVERLAY
-    | PARTIAL | PARTITION | PARTITIONS | PASSING | PAST | PATH | PATTERN | PER | PERIOD | PERMUTE | PLACING | PLAN | POSITION | PRECEDING | PRECISION | PRIVILEGES | PROPERTIES | PRUNE
+    | PARTIAL | PARTITION | PARTITIONS | PASSING | PAST | PATH | PATTERN | PER | PERIOD | PERMUTE | PIVOT | PLACING | PLAN | POSITION | PRECEDING | PRECISION | PRIVILEGES | PROPERTIES | PRUNE
     | QUOTES
     | RANGE | READ | REFRESH | RENAME | REPEAT  | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | RETURN | RETURNING | RETURNS | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS | RUNNING
     | SCALAR | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
@@ -1305,6 +1330,7 @@ PATTERN: 'PATTERN';
 PER: 'PER';
 PERIOD: 'PERIOD';
 PERMUTE: 'PERMUTE';
+PIVOT: 'PIVOT';
 PLACING: 'PLACING';
 PLAN : 'PLAN';
 POSITION: 'POSITION';

--- a/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
+++ b/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
@@ -231,6 +231,7 @@ public class TestSqlKeywords
                         "PER",
                         "PERIOD",
                         "PERMUTE",
+                        "PIVOT",
                         "PLACING",
                         "PLAN",
                         "POSITION",

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -188,7 +188,7 @@ public class Analysis
 
     private final Map<NodeRef<QuerySpecification>, List<FunctionCall>> aggregates = new LinkedHashMap<>();
     private final Map<NodeRef<OrderBy>, List<Expression>> orderByAggregates = new LinkedHashMap<>();
-    private final Map<NodeRef<QuerySpecification>, GroupingSetAnalysis> groupingSets = new LinkedHashMap<>();
+    private final Map<NodeRef<Node>, GroupingSetAnalysis> groupingSets = new LinkedHashMap<>();
 
     private final Map<NodeRef<Node>, Expression> where = new LinkedHashMap<>();
     private final Map<NodeRef<QuerySpecification>, Expression> having = new LinkedHashMap<>();
@@ -438,7 +438,7 @@ public class Analysis
         return unmodifiableMap(lambdaArgumentReferences);
     }
 
-    public void setGroupingSets(QuerySpecification node, GroupingSetAnalysis groupingSets)
+    public void setGroupingSets(Node node, GroupingSetAnalysis groupingSets)
     {
         this.groupingSets.put(NodeRef.of(node), groupingSets);
     }
@@ -448,7 +448,7 @@ public class Analysis
         return groupingSets.containsKey(NodeRef.of(node));
     }
 
-    public GroupingSetAnalysis getGroupingSets(QuerySpecification node)
+    public GroupingSetAnalysis getGroupingSets(Node node)
     {
         return groupingSets.get(NodeRef.of(node));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -80,6 +80,7 @@ import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.Offset;
 import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.Parameter;
+import io.trino.sql.tree.Pivot;
 import io.trino.sql.tree.Predicate;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
@@ -146,6 +147,8 @@ public class Analysis
     private Optional<Boolean> tableExecuteReadsData;
 
     private final Map<NodeRef<Table>, Query> namedQueries = new LinkedHashMap<>();
+
+    private final Map<NodeRef<Pivot>, PivotAnalysis> pivotAnalyses = new LinkedHashMap<>();
 
     // map expandable query to the node being the inner recursive reference
     private final Map<NodeRef<Query>, Node> expandableNamedQueries = new LinkedHashMap<>();
@@ -946,6 +949,21 @@ public class Analysis
         requireNonNull(query, "query is null");
 
         namedQueries.put(NodeRef.of(tableReference), query);
+    }
+
+    public void registerPivotAnalysis(Pivot pivot, PivotAnalysis analysis)
+    {
+        requireNonNull(pivot, "pivot is null");
+        requireNonNull(analysis, "analysis is null");
+
+        pivotAnalyses.put(NodeRef.of(pivot), analysis);
+    }
+
+    public PivotAnalysis getPivotAnalysis(Pivot pivot)
+    {
+        PivotAnalysis analysis = pivotAnalyses.get(NodeRef.of(pivot));
+        checkArgument(analysis != null, "pivot has no analysis registered: %s", pivot);
+        return analysis;
     }
 
     public void registerExpandableQuery(Query query, Node recursiveReference)
@@ -1849,6 +1867,29 @@ public class Analysis
                                     .flatMap(Collection::stream)
                                     .flatMap(Collection::stream))
                     .collect(toImmutableSet());
+        }
+    }
+
+    public record PivotAnalysis(
+            GroupingSetAnalysis groupingSetAnalysis,
+            boolean distinctGroupingSets,
+            List<PivotOutputColumn> outputColumns,
+            List<FunctionCall> aggregates)
+    {
+        public PivotAnalysis
+        {
+            requireNonNull(groupingSetAnalysis, "groupingSetAnalysis is null");
+            outputColumns = ImmutableList.copyOf(outputColumns);
+            aggregates = ImmutableList.copyOf(aggregates);
+        }
+    }
+
+    public record PivotOutputColumn(String name, Type type)
+    {
+        public PivotOutputColumn
+        {
+            requireNonNull(name, "name is null");
+            requireNonNull(type, "type is null");
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -190,7 +190,7 @@ public class Analysis
 
     private final Map<NodeRef<QuerySpecification>, List<FunctionCall>> aggregates = new LinkedHashMap<>();
     private final Map<NodeRef<OrderBy>, List<Expression>> orderByAggregates = new LinkedHashMap<>();
-    private final Map<NodeRef<QuerySpecification>, GroupingSetAnalysis> groupingSets = new LinkedHashMap<>();
+    private final Map<NodeRef<Node>, GroupingSetAnalysis> groupingSets = new LinkedHashMap<>();
 
     private final Map<NodeRef<Node>, Expression> where = new LinkedHashMap<>();
     private final Map<NodeRef<QuerySpecification>, Expression> having = new LinkedHashMap<>();
@@ -444,7 +444,7 @@ public class Analysis
         return unmodifiableMap(lambdaArgumentReferences);
     }
 
-    public void setGroupingSets(QuerySpecification node, GroupingSetAnalysis groupingSets)
+    public void setGroupingSets(Node node, GroupingSetAnalysis groupingSets)
     {
         this.groupingSets.put(NodeRef.of(node), groupingSets);
     }
@@ -454,7 +454,7 @@ public class Analysis
         return groupingSets.containsKey(NodeRef.of(node));
     }
 
-    public GroupingSetAnalysis getGroupingSets(QuerySpecification node)
+    public GroupingSetAnalysis getGroupingSets(Node node)
     {
         return groupingSets.get(NodeRef.of(node));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -103,6 +103,7 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeNotFoundException;
+import io.trino.sql.ExpressionFormatter;
 import io.trino.sql.InterpretedFunctionInvoker;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis.CorrespondingAnalysis;
@@ -110,6 +111,8 @@ import io.trino.sql.analyzer.Analysis.GroupingSetAnalysis;
 import io.trino.sql.analyzer.Analysis.JsonTableAnalysis;
 import io.trino.sql.analyzer.Analysis.MergeAnalysis;
 import io.trino.sql.analyzer.Analysis.NearestAnalysis;
+import io.trino.sql.analyzer.Analysis.PivotAnalysis;
+import io.trino.sql.analyzer.Analysis.PivotOutputColumn;
 import io.trino.sql.analyzer.Analysis.ResolvedWindow;
 import io.trino.sql.analyzer.Analysis.SelectExpression;
 import io.trino.sql.analyzer.Analysis.SourceColumn;
@@ -209,6 +212,9 @@ import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.OrdinalityColumn;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.PatternRecognitionRelation;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -329,6 +335,7 @@ import static io.trino.spi.StandardErrorCode.DUPLICATE_NAMED_QUERY;
 import static io.trino.spi.StandardErrorCode.DUPLICATE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.DUPLICATE_RANGE_VARIABLE;
 import static io.trino.spi.StandardErrorCode.DUPLICATE_WINDOW_NAME;
+import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_AGGREGATE;
 import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_CONSTANT;
 import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_IN_DISTINCT;
 import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
@@ -3192,6 +3199,250 @@ class StatementAnalyzer
             return createAndAssignScope(relation, scope, relationScope.getRelationType());
         }
 
+        @Override
+        protected Scope visitPivot(Pivot relation, Optional<Scope> scope)
+        {
+            validatePivotShape(relation);
+
+            // Analyze the input relation in the surrounding scope.
+            Scope inputScope = process(relation.getInput(), scope);
+
+            // Resolve pivot columns against the input scope. The grammar restricts the FOR
+            // clause to qualifiedName, so a pivot column is a plain column reference: no
+            // aggregates, window functions, or subqueries can appear here.
+            for (Expression pivotColumn : relation.getPivotColumns()) {
+                analyzeExpression(pivotColumn, inputScope);
+            }
+
+            // Resolve and validate IN values. A value identifies one output column, so it must be
+            // constant: it cannot vary from input row to input row. The value must also be
+            // comparable with the corresponding pivot column, i.e. the two types must share a
+            // common supertype that itself supports equality. The comparison is built at planning
+            // time at that supertype, matching plain '=' semantics.
+            for (PivotValueGroup valueGroup : relation.getValueGroups()) {
+                for (int i = 0; i < relation.getPivotColumns().size(); i++) {
+                    Expression value = valueGroup.getValues().get(i);
+                    analyzePivotValue(value, inputScope);
+                    Type pivotColumnType = analysis.getType(relation.getPivotColumns().get(i));
+                    Type valueType = analysis.getType(value);
+                    Optional<Type> commonSuperType = typeCoercion.getCommonSuperType(valueType, pivotColumnType);
+                    if (commonSuperType.isEmpty() || !commonSuperType.get().isComparable()) {
+                        throw semanticException(
+                                TYPE_MISMATCH,
+                                value,
+                                "Pivot value of type %s is not comparable with pivot column type %s",
+                                valueType,
+                                pivotColumnType);
+                    }
+                }
+            }
+
+            // Resolve GROUP BY expressions against the input scope. PIVOT does not have a SELECT
+            // list, so ordinal references and AUTO grouping are not meaningful here.
+            GroupingSetAnalysis groupingSetAnalysis;
+            boolean distinctGroupingSets;
+            if (relation.getGroupBy().isPresent()) {
+                groupingSetAnalysis = analyzeGroupingElements(relation, relation.getGroupBy().get(), inputScope, ImmutableList.of());
+                distinctGroupingSets = relation.getGroupBy().get().isDistinct();
+            }
+            else {
+                groupingSetAnalysis = new GroupingSetAnalysis(ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
+                analysis.setGroupingSets(relation, groupingSetAnalysis);
+                distinctGroupingSets = false;
+            }
+            List<Expression> groupingExpressions = groupingSetAnalysis.getOriginalExpressions();
+
+            // Analyze each aggregation slot expression (as written by the user) in the input scope.
+            // A slot is an expression over aggregates: it must contain at least one aggregate, since
+            // it is the aggregate that the pivot value scoping applies to. Window functions and
+            // grouping operations are not aggregates and have no meaning in a slot.
+            ImmutableList.Builder<Expression> slotExpressionsBuilder = ImmutableList.builder();
+            for (PivotAggregation aggregation : relation.getAggregations()) {
+                Expression slotExpression = aggregation.getExpression();
+                verifyPivotSlotShape(slotExpression);
+                analysis.recordSubqueries(relation, analyzeExpression(slotExpression, inputScope));
+                slotExpressionsBuilder.add(slotExpression);
+            }
+            List<Expression> slotExpressions = slotExpressionsBuilder.build();
+
+            // Verify that non-aggregate parts of slot expressions only reference grouping columns.
+            AggregationAnalyzer.verifySourceAggregations(
+                    groupingExpressions,
+                    inputScope,
+                    slotExpressions,
+                    session,
+                    plannerContext,
+                    accessControl,
+                    analysis);
+
+            // Collect the aggregate function calls inside the slot expressions for the planner.
+            List<FunctionCall> aggregates = extractAggregateFunctions(slotExpressions, session, functionResolver, accessControl);
+
+            // Compute output column metadata. The order matches the planner's iteration:
+            // for each value group, for each aggregation slot.
+            // Output column names need not be unique, matching a SELECT list: two value groups or
+            // aggregations may produce the same name. Referencing such a name later is ambiguous,
+            // but selecting all columns is not.
+            ImmutableList.Builder<PivotOutputColumn> outputColumns = ImmutableList.builder();
+            for (PivotValueGroup valueGroup : relation.getValueGroups()) {
+                for (PivotAggregation aggregation : relation.getAggregations()) {
+                    String columnName = pivotColumnName(valueGroup, aggregation);
+                    outputColumns.add(new PivotOutputColumn(columnName, analysis.getType(aggregation.getExpression())));
+                }
+            }
+            List<PivotOutputColumn> pivotOutputColumns = outputColumns.build();
+
+            // Build output Field list: grouping expressions, then pivot output columns.
+            ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+            for (Expression groupingExpression : groupingExpressions) {
+                outputFields.add(Field.newUnqualified(deriveColumnName(groupingExpression), analysis.getType(groupingExpression)));
+            }
+            for (PivotOutputColumn column : pivotOutputColumns) {
+                outputFields.add(Field.newUnqualified(column.name(), column.type()));
+            }
+
+            analysis.registerPivotAnalysis(
+                    relation,
+                    new PivotAnalysis(groupingSetAnalysis, distinctGroupingSets, pivotOutputColumns, aggregates));
+
+            return createAndAssignScope(relation, scope, outputFields.build());
+        }
+
+        private void validatePivotShape(Pivot relation)
+        {
+            int pivotColumnArity = relation.getPivotColumns().size();
+            for (PivotValueGroup valueGroup : relation.getValueGroups()) {
+                if (valueGroup.getValues().size() != pivotColumnArity) {
+                    throw semanticException(
+                            INVALID_ARGUMENTS,
+                            valueGroup,
+                            "Number of pivot values (%s) does not match number of pivot columns (%s)",
+                            valueGroup.getValues().size(),
+                            pivotColumnArity);
+                }
+            }
+
+            if (relation.getAggregations().size() > 1) {
+                for (PivotAggregation aggregation : relation.getAggregations()) {
+                    if (aggregation.getAlias().isEmpty()) {
+                        throw semanticException(
+                                MISSING_COLUMN_ALIASES,
+                                aggregation,
+                                "PIVOT with multiple aggregations requires an alias on each aggregation");
+                    }
+                }
+            }
+        }
+
+        private void analyzePivotValue(Expression value, Scope inputScope)
+        {
+            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, value, "PIVOT IN clause");
+
+            // An IN value names one output column, so it must be constant: the same value for every
+            // input row. As ExpressionAnalyzer.createConstantAnalyzer defines constant, that rules
+            // out subqueries, column references, and non-deterministic functions.
+            List<SubqueryExpression> subqueries = extractExpressions(ImmutableList.of(value), SubqueryExpression.class);
+            if (!subqueries.isEmpty()) {
+                throw semanticException(
+                        EXPRESSION_NOT_CONSTANT,
+                        subqueries.getFirst(),
+                        "PIVOT IN clause must be constant and cannot contain a subquery");
+            }
+
+            analyzeExpression(value, inputScope);
+
+            // Reject genuine column references, which analysis marks with lambda and dereference
+            // scoping applied — so a lambda argument that shadows an input column is not one.
+            List<Expression> columnReferences = extractExpressions(ImmutableList.of(value), Expression.class).stream()
+                    .filter(analysis::isColumnReference)
+                    .collect(toImmutableList());
+            if (!columnReferences.isEmpty()) {
+                throw semanticException(
+                        EXPRESSION_NOT_CONSTANT,
+                        columnReferences.getFirst(),
+                        "PIVOT IN clause must be constant and cannot reference a column: %s",
+                        columnReferences.getFirst());
+            }
+
+            if (!isDeterministic(value, this::getResolvedFunction)) {
+                throw semanticException(
+                        EXPRESSION_NOT_CONSTANT,
+                        value,
+                        "PIVOT IN clause must be constant and cannot be non-deterministic: %s",
+                        value);
+            }
+        }
+
+        private void verifyPivotSlotShape(Expression slotExpression)
+        {
+            List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(slotExpression), session, functionResolver, accessControl);
+            if (!windowExpressions.isEmpty()) {
+                throw semanticException(
+                        NESTED_WINDOW,
+                        windowExpressions.getFirst(),
+                        "PIVOT expression cannot contain window functions or row pattern measures: %s",
+                        windowExpressions.getFirst());
+            }
+
+            List<GroupingOperation> groupingOperations = extractExpressions(ImmutableList.of(slotExpression), GroupingOperation.class);
+            if (!groupingOperations.isEmpty()) {
+                throw semanticException(
+                        NOT_SUPPORTED,
+                        groupingOperations.getFirst(),
+                        "PIVOT expression cannot contain grouping operations: %s",
+                        groupingOperations.getFirst());
+            }
+
+            List<FunctionCall> aggregates = extractAggregateFunctions(ImmutableList.of(slotExpression), session, functionResolver, accessControl);
+            if (aggregates.isEmpty()) {
+                throw semanticException(
+                        EXPRESSION_NOT_AGGREGATE,
+                        slotExpression,
+                        "PIVOT expression must contain an aggregate function: %s",
+                        slotExpression);
+            }
+
+            // A subquery outside the aggregate calls would have to be planned per value group,
+            // which PIVOT does not do yet. A subquery anywhere inside an aggregate call — its
+            // arguments, FILTER, or ORDER BY — is fine: it is planned once, with the other
+            // aggregation inputs.
+            Set<NodeRef<SubqueryExpression>> aggregateSubqueries = extractExpressions(aggregates, SubqueryExpression.class).stream()
+                    .map(NodeRef::of)
+                    .collect(toImmutableSet());
+            extractExpressions(ImmutableList.of(slotExpression), SubqueryExpression.class).stream()
+                    .filter(subquery -> !aggregateSubqueries.contains(NodeRef.of(subquery)))
+                    .findFirst()
+                    .ifPresent(subquery -> {
+                        throw semanticException(
+                                NOT_SUPPORTED,
+                                subquery,
+                                "PIVOT expression cannot contain a subquery outside an aggregate function: %s",
+                                subquery);
+                    });
+        }
+
+        private static String pivotColumnName(PivotValueGroup valueGroup, PivotAggregation aggregation)
+        {
+            String valueName = valueGroup.getAlias()
+                    .map(Identifier::getCanonicalValue)
+                    .orElseGet(() -> valueGroup.getValues().stream()
+                            .map(ExpressionFormatter::formatExpression)
+                            .collect(Collectors.joining("_")));
+            String aggregationName = aggregation.getAlias().map(Identifier::getCanonicalValue).orElse("");
+            return aggregationName.isEmpty() ? valueName : valueName + "_" + aggregationName;
+        }
+
+        private static Optional<String> deriveColumnName(Expression expression)
+        {
+            if (expression instanceof Identifier identifier) {
+                return Optional.of(identifier.getCanonicalValue());
+            }
+            if (expression instanceof DereferenceExpression dereference) {
+                return Optional.of(dereference.getField().orElseThrow().getCanonicalValue());
+            }
+            return Optional.empty();
+        }
+
         // this method should run after the `base` relation is processed, so that it is
         // determined whether the table function is polymorphic
         private void validateNoNestedTableFunction(Relation base, String context)
@@ -4842,7 +5093,7 @@ class StatementAnalyzer
                     // AUTO derives its grouping columns from the SELECT list. Callers without
                     // one (e.g. PIVOT) must not silently degrade to GROUP BY ().
                     if (outputExpressions.isEmpty()) {
-                        throw semanticException(NOT_SUPPORTED, groupingElement, "GROUP BY AUTO requires a SELECT list to derive grouping columns from");
+                        throw semanticException(NOT_SUPPORTED, groupingElement, "GROUP BY AUTO is not supported in %s", node instanceof Pivot ? "PIVOT" : "this context");
                     }
                     // Analyze non-aggregation outputs
                     for (Expression column : outputExpressions) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4783,102 +4783,7 @@ class StatementAnalyzer
         private GroupingSetAnalysis analyzeGroupBy(QuerySpecification node, Scope scope, List<Expression> outputExpressions)
         {
             if (node.getGroupBy().isPresent()) {
-                ImmutableList.Builder<List<Set<FieldId>>> cubes = ImmutableList.builder();
-                ImmutableList.Builder<List<Set<FieldId>>> rollups = ImmutableList.builder();
-                ImmutableList.Builder<List<Set<FieldId>>> sets = ImmutableList.builder();
-                ImmutableList.Builder<Expression> complexExpressions = ImmutableList.builder();
-                ImmutableList.Builder<Expression> groupingExpressions = ImmutableList.builder();
-
-                checkGroupingSetsCount(node.getGroupBy().get());
-                for (GroupingElement groupingElement : node.getGroupBy().get().getGroupingElements()) {
-                    if (groupingElement instanceof SimpleGroupBy) {
-                        for (Expression column : groupingElement.getExpressions()) {
-                            // simple GROUP BY expressions allow ordinals or arbitrary expressions
-                            if (column instanceof LongLiteral) {
-                                long ordinal = ((LongLiteral) column).getParsedValue();
-                                if (ordinal < 1 || ordinal > outputExpressions.size()) {
-                                    throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY position %s is not in select list", ordinal);
-                                }
-
-                                column = outputExpressions.get(toIntExact(ordinal - 1));
-                                verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
-                            }
-                            else {
-                                verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
-                                analyzeExpression(column, scope);
-                            }
-
-                            ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
-                            if (field != null) {
-                                sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
-                            }
-                            else {
-                                analysis.recordSubqueries(node, analyzeExpression(column, scope));
-                                complexExpressions.add(column);
-                            }
-
-                            groupingExpressions.add(column);
-                        }
-                    }
-                    else if (groupingElement instanceof AutoGroupBy) {
-                        // Analyze non-aggregation outputs
-                        for (Expression column : outputExpressions) {
-                            if (containsAggregation(column, this::getResolvedFunction)) {
-                                continue;
-                            }
-                            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
-                            analyzeExpression(column, scope);
-
-                            ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
-                            if (field != null) {
-                                sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
-                            }
-                            else {
-                                analysis.recordSubqueries(node, analyzeExpression(column, scope));
-                                complexExpressions.add(column);
-                            }
-
-                            groupingExpressions.add(column);
-                        }
-                    }
-                    else if (groupingElement instanceof GroupingSets element) {
-                        for (Expression column : groupingElement.getExpressions()) {
-                            analyzeExpression(column, scope);
-                            if (!analysis.getColumnReferences().contains(NodeRef.of(column))) {
-                                throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY expression must be a column reference: %s", column);
-                            }
-
-                            groupingExpressions.add(column);
-                        }
-
-                        List<Set<FieldId>> groupingSets = element.getSets().stream()
-                                .map(set -> set.stream()
-                                        .map(NodeRef::of)
-                                        .map(analysis.getColumnReferenceFields()::get)
-                                        .map(ResolvedField::getFieldId)
-                                        .collect(toImmutableSet()))
-                                .collect(toImmutableList());
-
-                        switch (element.getType()) {
-                            case CUBE -> cubes.add(groupingSets);
-                            case ROLLUP -> rollups.add(groupingSets);
-                            case EXPLICIT -> sets.add(groupingSets);
-                        }
-                    }
-                }
-
-                List<Expression> expressions = groupingExpressions.build();
-                for (Expression expression : expressions) {
-                    Type type = analysis.getType(expression);
-                    if (!type.isComparable()) {
-                        throw semanticException(TYPE_MISMATCH, node, "%s is not comparable, and therefore cannot be used in GROUP BY", type);
-                    }
-                }
-
-                GroupingSetAnalysis groupingSets = new GroupingSetAnalysis(expressions, cubes.build(), rollups.build(), sets.build(), complexExpressions.build());
-                analysis.setGroupingSets(node, groupingSets);
-
-                return groupingSets;
+                return analyzeGroupingElements(node, node.getGroupBy().get(), scope, outputExpressions);
             }
 
             GroupingSetAnalysis result = new GroupingSetAnalysis(ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
@@ -4888,6 +4793,115 @@ class StatementAnalyzer
             }
 
             return result;
+        }
+
+        // Analyzes the elements of a GROUP BY clause and registers a GroupingSetAnalysis
+        // keyed by `node`. The `outputExpressions` list is used only for resolving ordinal
+        // references and for the AUTO grouping element; callers without a SELECT list pass
+        // an empty list, in which case those forms are not allowed.
+        private GroupingSetAnalysis analyzeGroupingElements(Node node, GroupBy groupBy, Scope scope, List<Expression> outputExpressions)
+        {
+            ImmutableList.Builder<List<Set<FieldId>>> cubes = ImmutableList.builder();
+            ImmutableList.Builder<List<Set<FieldId>>> rollups = ImmutableList.builder();
+            ImmutableList.Builder<List<Set<FieldId>>> sets = ImmutableList.builder();
+            ImmutableList.Builder<Expression> complexExpressions = ImmutableList.builder();
+            ImmutableList.Builder<Expression> groupingExpressions = ImmutableList.builder();
+
+            checkGroupingSetsCount(groupBy);
+            for (GroupingElement groupingElement : groupBy.getGroupingElements()) {
+                if (groupingElement instanceof SimpleGroupBy) {
+                    for (Expression column : groupingElement.getExpressions()) {
+                        // simple GROUP BY expressions allow ordinals or arbitrary expressions
+                        if (column instanceof LongLiteral) {
+                            long ordinal = ((LongLiteral) column).getParsedValue();
+                            if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                                throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY position %s is not in select list", ordinal);
+                            }
+
+                            column = outputExpressions.get(toIntExact(ordinal - 1));
+                            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
+                        }
+                        else {
+                            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
+                            analyzeExpression(column, scope);
+                        }
+
+                        ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
+                        if (field != null) {
+                            sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
+                        }
+                        else {
+                            analysis.recordSubqueries(node, analyzeExpression(column, scope));
+                            complexExpressions.add(column);
+                        }
+
+                        groupingExpressions.add(column);
+                    }
+                }
+                else if (groupingElement instanceof AutoGroupBy) {
+                    // AUTO derives its grouping columns from the SELECT list. Callers without
+                    // one (e.g. PIVOT) must not silently degrade to GROUP BY ().
+                    if (outputExpressions.isEmpty()) {
+                        throw semanticException(NOT_SUPPORTED, groupingElement, "GROUP BY AUTO requires a SELECT list to derive grouping columns from");
+                    }
+                    // Analyze non-aggregation outputs
+                    for (Expression column : outputExpressions) {
+                        if (containsAggregation(column, this::getResolvedFunction)) {
+                            continue;
+                        }
+                        verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
+                        analyzeExpression(column, scope);
+
+                        ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
+                        if (field != null) {
+                            sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
+                        }
+                        else {
+                            analysis.recordSubqueries(node, analyzeExpression(column, scope));
+                            complexExpressions.add(column);
+                        }
+
+                        groupingExpressions.add(column);
+                    }
+                }
+                else if (groupingElement instanceof GroupingSets element) {
+                    for (Expression column : groupingElement.getExpressions()) {
+                        analyzeExpression(column, scope);
+                        if (!analysis.getColumnReferences().contains(NodeRef.of(column))) {
+                            throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY expression must be a column reference: %s", column);
+                        }
+
+                        groupingExpressions.add(column);
+                    }
+
+                    List<Set<FieldId>> groupingSets = element.getSets().stream()
+                            .map(set -> set.stream()
+                                    .map(NodeRef::of)
+                                    .map(analysis.getColumnReferenceFields()::get)
+                                    .map(ResolvedField::getFieldId)
+                                    .collect(toImmutableSet()))
+                            .collect(toImmutableList());
+
+                    switch (element.getType()) {
+                        case CUBE -> cubes.add(groupingSets);
+                        case ROLLUP -> rollups.add(groupingSets);
+                        case EXPLICIT -> sets.add(groupingSets);
+                    }
+                }
+            }
+
+            List<Expression> expressions = groupingExpressions.build();
+            for (Expression expression : expressions) {
+                Type type = analysis.getType(expression);
+                if (!type.isComparable()) {
+                    throw semanticException(TYPE_MISMATCH, node, "%s is not comparable, and therefore cannot be used in GROUP BY", type);
+                }
+            }
+
+            GroupingSetAnalysis groupingSets = new GroupingSetAnalysis(expressions, cubes.build(), rollups.build(), sets.build(), complexExpressions.build());
+            analysis.setGroupingSets(node, groupingSets);
+
+            return groupingSets;
         }
 
         private boolean hasAggregates(QuerySpecification node)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4813,102 +4813,7 @@ class StatementAnalyzer
         private GroupingSetAnalysis analyzeGroupBy(QuerySpecification node, Scope scope, List<Expression> outputExpressions)
         {
             if (node.getGroupBy().isPresent()) {
-                ImmutableList.Builder<List<Set<FieldId>>> cubes = ImmutableList.builder();
-                ImmutableList.Builder<List<Set<FieldId>>> rollups = ImmutableList.builder();
-                ImmutableList.Builder<List<Set<FieldId>>> sets = ImmutableList.builder();
-                ImmutableList.Builder<Expression> complexExpressions = ImmutableList.builder();
-                ImmutableList.Builder<Expression> groupingExpressions = ImmutableList.builder();
-
-                checkGroupingSetsCount(node.getGroupBy().get());
-                for (GroupingElement groupingElement : node.getGroupBy().get().getGroupingElements()) {
-                    if (groupingElement instanceof SimpleGroupBy) {
-                        for (Expression column : groupingElement.getExpressions()) {
-                            // simple GROUP BY expressions allow ordinals or arbitrary expressions
-                            if (column instanceof LongLiteral) {
-                                long ordinal = ((LongLiteral) column).getParsedValue();
-                                if (ordinal < 1 || ordinal > outputExpressions.size()) {
-                                    throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY position %s is not in select list", ordinal);
-                                }
-
-                                column = outputExpressions.get(toIntExact(ordinal - 1));
-                                verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
-                            }
-                            else {
-                                verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
-                                analyzeExpression(column, scope);
-                            }
-
-                            ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
-                            if (field != null) {
-                                sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
-                            }
-                            else {
-                                analysis.recordSubqueries(node, analyzeExpression(column, scope));
-                                complexExpressions.add(column);
-                            }
-
-                            groupingExpressions.add(column);
-                        }
-                    }
-                    else if (groupingElement instanceof AutoGroupBy) {
-                        // Analyze non-aggregation outputs
-                        for (Expression column : outputExpressions) {
-                            if (containsAggregation(column, this::getResolvedFunction)) {
-                                continue;
-                            }
-                            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
-                            analyzeExpression(column, scope);
-
-                            ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
-                            if (field != null) {
-                                sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
-                            }
-                            else {
-                                analysis.recordSubqueries(node, analyzeExpression(column, scope));
-                                complexExpressions.add(column);
-                            }
-
-                            groupingExpressions.add(column);
-                        }
-                    }
-                    else if (groupingElement instanceof GroupingSets element) {
-                        for (Expression column : groupingElement.getExpressions()) {
-                            analyzeExpression(column, scope);
-                            if (!analysis.getColumnReferences().contains(NodeRef.of(column))) {
-                                throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY expression must be a column reference: %s", column);
-                            }
-
-                            groupingExpressions.add(column);
-                        }
-
-                        List<Set<FieldId>> groupingSets = element.getSets().stream()
-                                .map(set -> set.stream()
-                                        .map(NodeRef::of)
-                                        .map(analysis.getColumnReferenceFields()::get)
-                                        .map(ResolvedField::getFieldId)
-                                        .collect(toImmutableSet()))
-                                .collect(toImmutableList());
-
-                        switch (element.getType()) {
-                            case CUBE -> cubes.add(groupingSets);
-                            case ROLLUP -> rollups.add(groupingSets);
-                            case EXPLICIT -> sets.add(groupingSets);
-                        }
-                    }
-                }
-
-                List<Expression> expressions = groupingExpressions.build();
-                for (Expression expression : expressions) {
-                    Type type = analysis.getType(expression);
-                    if (!type.isComparable()) {
-                        throw semanticException(TYPE_MISMATCH, node, "%s is not comparable, and therefore cannot be used in GROUP BY", type);
-                    }
-                }
-
-                GroupingSetAnalysis groupingSets = new GroupingSetAnalysis(expressions, cubes.build(), rollups.build(), sets.build(), complexExpressions.build());
-                analysis.setGroupingSets(node, groupingSets);
-
-                return groupingSets;
+                return analyzeGroupingElements(node, node.getGroupBy().get(), scope, outputExpressions);
             }
 
             GroupingSetAnalysis result = new GroupingSetAnalysis(ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
@@ -4918,6 +4823,110 @@ class StatementAnalyzer
             }
 
             return result;
+        }
+
+        // Analyzes the elements of a GROUP BY clause and registers a GroupingSetAnalysis
+        // keyed by `node`. The `outputExpressions` list is used only for resolving ordinal
+        // references and for the AUTO grouping element; callers without a SELECT list pass
+        // an empty list, in which case those forms are not allowed.
+        private GroupingSetAnalysis analyzeGroupingElements(Node node, GroupBy groupBy, Scope scope, List<Expression> outputExpressions)
+        {
+            ImmutableList.Builder<List<Set<FieldId>>> cubes = ImmutableList.builder();
+            ImmutableList.Builder<List<Set<FieldId>>> rollups = ImmutableList.builder();
+            ImmutableList.Builder<List<Set<FieldId>>> sets = ImmutableList.builder();
+            ImmutableList.Builder<Expression> complexExpressions = ImmutableList.builder();
+            ImmutableList.Builder<Expression> groupingExpressions = ImmutableList.builder();
+
+            checkGroupingSetsCount(groupBy);
+            for (GroupingElement groupingElement : groupBy.getGroupingElements()) {
+                if (groupingElement instanceof SimpleGroupBy) {
+                    for (Expression column : groupingElement.getExpressions()) {
+                        // simple GROUP BY expressions allow ordinals or arbitrary expressions
+                        if (column instanceof LongLiteral) {
+                            long ordinal = ((LongLiteral) column).getParsedValue();
+                            if (ordinal < 1 || ordinal > outputExpressions.size()) {
+                                throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY position %s is not in select list", ordinal);
+                            }
+
+                            column = outputExpressions.get(toIntExact(ordinal - 1));
+                            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
+                        }
+                        else {
+                            verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
+                            analyzeExpression(column, scope);
+                        }
+
+                        ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
+                        if (field != null) {
+                            sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
+                        }
+                        else {
+                            analysis.recordSubqueries(node, analyzeExpression(column, scope));
+                            complexExpressions.add(column);
+                        }
+
+                        groupingExpressions.add(column);
+                    }
+                }
+                else if (groupingElement instanceof AutoGroupBy) {
+                    // Analyze non-aggregation outputs
+                    for (Expression column : outputExpressions) {
+                        if (containsAggregation(column, this::getResolvedFunction)) {
+                            continue;
+                        }
+                        verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, column, "GROUP BY clause");
+                        analyzeExpression(column, scope);
+
+                        ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(column));
+                        if (field != null) {
+                            sets.add(ImmutableList.of(ImmutableSet.of(field.getFieldId())));
+                        }
+                        else {
+                            analysis.recordSubqueries(node, analyzeExpression(column, scope));
+                            complexExpressions.add(column);
+                        }
+
+                        groupingExpressions.add(column);
+                    }
+                }
+                else if (groupingElement instanceof GroupingSets element) {
+                    for (Expression column : groupingElement.getExpressions()) {
+                        analyzeExpression(column, scope);
+                        if (!analysis.getColumnReferences().contains(NodeRef.of(column))) {
+                            throw semanticException(INVALID_COLUMN_REFERENCE, column, "GROUP BY expression must be a column reference: %s", column);
+                        }
+
+                        groupingExpressions.add(column);
+                    }
+
+                    List<Set<FieldId>> groupingSets = element.getSets().stream()
+                            .map(set -> set.stream()
+                                    .map(NodeRef::of)
+                                    .map(analysis.getColumnReferenceFields()::get)
+                                    .map(ResolvedField::getFieldId)
+                                    .collect(toImmutableSet()))
+                            .collect(toImmutableList());
+
+                    switch (element.getType()) {
+                        case CUBE -> cubes.add(groupingSets);
+                        case ROLLUP -> rollups.add(groupingSets);
+                        case EXPLICIT -> sets.add(groupingSets);
+                    }
+                }
+            }
+
+            List<Expression> expressions = groupingExpressions.build();
+            for (Expression expression : expressions) {
+                Type type = analysis.getType(expression);
+                if (!type.isComparable()) {
+                    throw semanticException(TYPE_MISMATCH, node, "%s is not comparable, and therefore cannot be used in GROUP BY", type);
+                }
+            }
+
+            GroupingSetAnalysis groupingSets = new GroupingSetAnalysis(expressions, cubes.build(), rollups.build(), sets.build(), complexExpressions.build());
+            analysis.setGroupingSets(node, groupingSets);
+
+            return groupingSets;
         }
 
         private boolean hasAggregates(QuerySpecification node)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -39,6 +39,8 @@ import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis;
 import io.trino.sql.analyzer.Analysis.GroupingSetAnalysis;
 import io.trino.sql.analyzer.Analysis.MergeAnalysis;
+import io.trino.sql.analyzer.Analysis.PivotAnalysis;
+import io.trino.sql.analyzer.Analysis.PivotOutputColumn;
 import io.trino.sql.analyzer.Analysis.ResolvedWindow;
 import io.trino.sql.analyzer.Analysis.SelectExpression;
 import io.trino.sql.analyzer.FieldId;
@@ -99,6 +101,9 @@ import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Offset;
 import io.trino.sql.tree.OrderBy;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.QuerySpecification;
 import io.trino.sql.tree.Relation;
@@ -110,6 +115,7 @@ import io.trino.sql.tree.VariableDefinition;
 import io.trino.sql.tree.WindowFrame;
 import io.trino.sql.tree.WindowOperation;
 import io.trino.type.Reals;
+import io.trino.type.TypeCoercion;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -153,6 +159,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.sql.NodeUtils.getSortItemsFromOrderBy;
 import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.IrExpressions.cast;
@@ -485,6 +492,193 @@ class QueryPlanner
                 analysis.getScope(node),
                 computeOutputs(builder, outputs),
                 outerContext);
+    }
+
+    public RelationPlan planPivot(Pivot node, RelationPlan inputPlan)
+    {
+        PivotAnalysis pivotAnalysis = analysis.getPivotAnalysis(node);
+        GroupingSetAnalysis groupingSetAnalysis = pivotAnalysis.groupingSetAnalysis();
+        List<FunctionCall> aggregateCalls = pivotAnalysis.aggregates();
+
+        PlanBuilder subPlan = newPlanBuilder(inputPlan, analysis, lambdaDeclarationToSymbolMap, session, plannerContext, symbolAllocator);
+
+        // Project everything the aggregation predicate and arguments need: aggregate
+        // arguments, aggregate ORDER BY sort keys, aggregate FILTER expressions, complex
+        // grouping expressions, pivot column references, and pivot value expressions.
+        ImmutableList.Builder<io.trino.sql.tree.Expression> inputBuilder = ImmutableList.builder();
+        for (FunctionCall aggregate : aggregateCalls) {
+            argumentsInSignatureOrder(aggregate).stream()
+                    .filter(argument -> !(argument instanceof LambdaExpression))
+                    .forEach(inputBuilder::add);
+            getSortItemsFromOrderBy(aggregate.getOrderBy()).stream()
+                    .map(SortItem::getSortKey)
+                    .forEach(inputBuilder::add);
+            aggregate.getFilter().ifPresent(inputBuilder::add);
+        }
+        inputBuilder.addAll(groupingSetAnalysis.getComplexExpressions());
+        inputBuilder.addAll(node.getPivotColumns());
+        for (PivotValueGroup valueGroup : node.getValueGroups()) {
+            inputBuilder.addAll(valueGroup.getValues());
+        }
+        List<io.trino.sql.tree.Expression> inputs = inputBuilder.build();
+
+        subPlan = subqueryPlanner.handleSubqueries(subPlan, inputs, analysis.getSubqueries(node));
+        subPlan = subPlan.appendProjections(inputs, symbolAllocator, idAllocator);
+
+        PlanAndMappings coercions = coerce(plannerContext.getTypeManager(), subPlan, inputs, analysis, idAllocator, symbolAllocator);
+        subPlan = coercions.getSubPlan();
+
+        // Build a boolean predicate symbol per (value group, aggregate): the value group's
+        // match pivot_col_1 = value_1 AND ... combined with that aggregate's FILTER, if any.
+        // Each comparison runs at the common supertype of the column and value types, so a
+        // Cast is inserted on whichever side is narrower (this also covers the unknown-typed
+        // NULL literal). Aggregates without a FILTER share the value group's match symbol.
+        TypeCoercion typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
+        boolean hasUnfilteredAggregate = aggregateCalls.stream().anyMatch(function -> function.getFilter().isEmpty());
+        Map<NodeRef<PivotValueGroup>, Map<NodeRef<FunctionCall>, Symbol>> predicateSymbols = new LinkedHashMap<>();
+        Assignments.Builder predicateAssignments = Assignments.builder();
+        predicateAssignments.putIdentities(subPlan.getRoot().getOutputSymbols());
+        for (PivotValueGroup valueGroup : node.getValueGroups()) {
+            ImmutableList.Builder<Expression> matchConjuncts = ImmutableList.builder();
+            for (int i = 0; i < node.getPivotColumns().size(); i++) {
+                Symbol columnSymbol = coercions.get(node.getPivotColumns().get(i));
+                Symbol valueSymbol = coercions.get(valueGroup.getValues().get(i));
+                Type commonType = typeCoercion.getCommonSuperType(columnSymbol.type(), valueSymbol.type()).orElseThrow();
+                Expression columnExpression = columnSymbol.toSymbolReference();
+                if (!columnSymbol.type().equals(commonType)) {
+                    columnExpression = cast(plannerContext.getTypeManager(), columnExpression, commonType);
+                }
+                Expression valueExpression = valueSymbol.toSymbolReference();
+                if (!valueSymbol.type().equals(commonType)) {
+                    valueExpression = cast(plannerContext.getTypeManager(), valueExpression, commonType);
+                }
+                matchConjuncts.add(comparison(plannerContext.getMetadata(), EQUAL, columnExpression, valueExpression));
+            }
+            List<Expression> valueGroupMatch = matchConjuncts.build();
+
+            Optional<Symbol> valueGroupSymbol = Optional.empty();
+            if (hasUnfilteredAggregate) {
+                Symbol symbol = symbolAllocator.newSymbol("pivot_match", BOOLEAN);
+                predicateAssignments.put(symbol, and(valueGroupMatch));
+                valueGroupSymbol = Optional.of(symbol);
+            }
+
+            Map<NodeRef<FunctionCall>, Symbol> aggregatePredicates = new LinkedHashMap<>();
+            for (FunctionCall function : aggregateCalls) {
+                if (function.getFilter().isEmpty()) {
+                    aggregatePredicates.put(NodeRef.of(function), valueGroupSymbol.orElseThrow());
+                    continue;
+                }
+                // AND the user-written FILTER into this aggregate's value-group match.
+                Symbol filteredSymbol = symbolAllocator.newSymbol("pivot_match", BOOLEAN);
+                predicateAssignments.put(filteredSymbol, and(ImmutableList.<Expression>builder()
+                        .addAll(valueGroupMatch)
+                        .add(coercions.get(function.getFilter().get()).toSymbolReference())
+                        .build()));
+                aggregatePredicates.put(NodeRef.of(function), filteredSymbol);
+            }
+            predicateSymbols.put(NodeRef.of(valueGroup), aggregatePredicates);
+        }
+        subPlan = subPlan.withNewRoot(new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), predicateAssignments.build()));
+
+        GroupingSetsPlan groupingSets = planGroupingSets(subPlan, pivotAnalysis.distinctGroupingSets(), groupingSetAnalysis);
+        subPlan = groupingSets.getSubPlan();
+
+        // Build one Aggregation per (value group, aggregate call) with FILTER set to that
+        // aggregate's value-group predicate symbol. Each (value group, call) pair gets its
+        // own output Symbol so the slot expressions can be projected per group.
+        Map<PivotValueGroup, Map<NodeRef<FunctionCall>, Symbol>> aggregateSymbolsByGroup = new LinkedHashMap<>();
+        ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
+        PlanBuilder finalSubPlan = subPlan;
+        for (PivotValueGroup valueGroup : node.getValueGroups()) {
+            Map<NodeRef<FunctionCall>, Symbol> perGroup = new LinkedHashMap<>();
+            Map<NodeRef<FunctionCall>, Symbol> groupPredicates = predicateSymbols.get(NodeRef.of(valueGroup));
+            for (FunctionCall function : aggregateCalls) {
+                Symbol output = symbolAllocator.newSymbol(function.getName().toString(), analysis.getType(function));
+                Aggregation aggregation = new Aggregation(
+                        analysis.getResolvedFunction(function).orElseThrow(),
+                        argumentsInSignatureOrder(function).stream()
+                                .map(argument -> {
+                                    if (argument instanceof LambdaExpression) {
+                                        return finalSubPlan.rewrite(argument);
+                                    }
+                                    return coercions.get(argument).toSymbolReference();
+                                })
+                                .collect(toImmutableList()),
+                        function.isDistinct(),
+                        Optional.of(groupPredicates.get(NodeRef.of(function))),
+                        function.getOrderBy().map(orderBy -> translateOrderingScheme(orderBy.getSortItems(), coercions::get)),
+                        Optional.empty());
+                aggregations.put(output, aggregation);
+                perGroup.put(NodeRef.of(function), output);
+            }
+            aggregateSymbolsByGroup.put(valueGroup, perGroup);
+        }
+
+        ImmutableSet.Builder<Integer> globalGroupingSets = ImmutableSet.builder();
+        for (int i = 0; i < groupingSets.getGroupingSets().size(); i++) {
+            if (groupingSets.getGroupingSets().get(i).isEmpty()) {
+                globalGroupingSets.add(i);
+            }
+        }
+        ImmutableSet.Builder<Symbol> groupingKeys = ImmutableSet.builder();
+        groupingSets.getGroupingSets().stream()
+                .flatMap(List::stream)
+                .distinct()
+                .forEach(groupingKeys::add);
+        groupingSets.getGroupIdSymbol().ifPresent(groupingKeys::add);
+
+        AggregationNode aggregationNode = new AggregationNode(
+                idAllocator.getNextId(),
+                subPlan.getRoot(),
+                aggregations.buildOrThrow(),
+                groupingSets(
+                        groupingKeys.build(),
+                        groupingSets.getGroupingSets().size(),
+                        globalGroupingSets.build()),
+                ImmutableList.of(),
+                AggregationNode.Step.SINGLE,
+                groupingSets.getGroupIdSymbol());
+        subPlan = new PlanBuilder(subPlan.getTranslations(), aggregationNode);
+
+        // Subqueries in the non-aggregate part of a slot are rejected during analysis, and the ones
+        // inside aggregate calls were planned with the inputs; nothing more to plan here.
+
+        // Final projection: grouping expressions identity-projected, then for each
+        // (value group, slot) translate the user's slot expression with a per-group
+        // aggregate-call -> aggregation-symbol mapping, producing the synthesized output
+        // column.
+        Assignments.Builder outputAssignments = Assignments.builder();
+        ImmutableList.Builder<Symbol> outputSymbols = ImmutableList.builder();
+
+        for (io.trino.sql.tree.Expression groupingExpression : groupingSetAnalysis.getOriginalExpressions()) {
+            Symbol symbol = subPlan.translate(groupingExpression);
+            outputAssignments.putIdentity(symbol);
+            outputSymbols.add(symbol);
+        }
+
+        int outputColumnIndex = 0;
+        List<PivotOutputColumn> outputColumnMetadata = pivotAnalysis.outputColumns();
+        for (PivotValueGroup valueGroup : node.getValueGroups()) {
+            Map<NodeRef<FunctionCall>, Symbol> perGroupSymbols = aggregateSymbolsByGroup.get(valueGroup);
+            ImmutableMap.Builder<ScopeAware<io.trino.sql.tree.Expression>, Symbol> mappings = ImmutableMap.builder();
+            for (FunctionCall function : aggregateCalls) {
+                mappings.put(scopeAwareKey(function, analysis, subPlan.getScope()), perGroupSymbols.get(NodeRef.of(function)));
+            }
+            TranslationMap groupTranslations = subPlan.getTranslations().withAdditionalMappings(mappings.buildKeepingLast());
+
+            for (PivotAggregation aggregation : node.getAggregations()) {
+                Expression slotIr = groupTranslations.rewrite(aggregation.getExpression());
+                PivotOutputColumn column = outputColumnMetadata.get(outputColumnIndex++);
+                Symbol output = symbolAllocator.newSymbol(column.name(), column.type());
+                outputAssignments.put(output, slotIr);
+                outputSymbols.add(output);
+            }
+        }
+
+        ProjectNode outputProject = new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), outputAssignments.build());
+
+        return new RelationPlan(outputProject, analysis.getScope(node), outputSymbols.build(), outerContext);
     }
 
     private static boolean hasExpressionsToUnfold(List<SelectExpression> selectExpressions)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1202,14 +1202,15 @@ class QueryPlanner
         PlanAndMappings coercions = coerce(plannerContext.getTypeManager(), subPlan, inputs, analysis, idAllocator, symbolAllocator);
         subPlan = coercions.getSubPlan();
 
-        GroupingSetsPlan groupingSets = planGroupingSets(subPlan, node, groupingSetAnalysis);
+        boolean distinctGroupingSets = node.getGroupBy().isPresent() && node.getGroupBy().get().isDistinct();
+        GroupingSetsPlan groupingSets = planGroupingSets(subPlan, distinctGroupingSets, groupingSetAnalysis);
 
         subPlan = planAggregation(groupingSets.getSubPlan(), groupingSets.getGroupingSets(), groupingSets.getGroupIdSymbol(), analysis.getAggregates(node), coercions::get);
 
         return planGroupingOperations(subPlan, node, groupingSets.getGroupIdSymbol(), groupingSets.getColumnOnlyGroupingSets());
     }
 
-    private GroupingSetsPlan planGroupingSets(PlanBuilder subPlan, QuerySpecification node, GroupingSetAnalysis groupingSetAnalysis)
+    private GroupingSetsPlan planGroupingSets(PlanBuilder subPlan, boolean distinctGroupingSets, GroupingSetAnalysis groupingSetAnalysis)
     {
         Map<Symbol, Symbol> groupingSetMappings = new LinkedHashMap<>();
 
@@ -1245,7 +1246,7 @@ class QueryPlanner
         // This tracks the grouping sets before complex expressions are considered.
         // It's also used to compute the descriptors needed to implement grouping()
         List<Set<FieldId>> columnOnlyGroupingSets = enumerateGroupingSets(groupingSetAnalysis);
-        if (node.getGroupBy().isPresent() && node.getGroupBy().get().isDistinct()) {
+        if (distinctGroupingSets) {
             columnOnlyGroupingSets = columnOnlyGroupingSets.stream()
                     .distinct()
                     .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1186,14 +1186,15 @@ class QueryPlanner
         PlanAndMappings coercions = coerce(subPlan, inputs, analysis, idAllocator, symbolAllocator);
         subPlan = coercions.getSubPlan();
 
-        GroupingSetsPlan groupingSets = planGroupingSets(subPlan, node, groupingSetAnalysis);
+        boolean distinctGroupingSets = node.getGroupBy().isPresent() && node.getGroupBy().get().isDistinct();
+        GroupingSetsPlan groupingSets = planGroupingSets(subPlan, distinctGroupingSets, groupingSetAnalysis);
 
         subPlan = planAggregation(groupingSets.getSubPlan(), groupingSets.getGroupingSets(), groupingSets.getGroupIdSymbol(), analysis.getAggregates(node), coercions::get);
 
         return planGroupingOperations(subPlan, node, groupingSets.getGroupIdSymbol(), groupingSets.getColumnOnlyGroupingSets());
     }
 
-    private GroupingSetsPlan planGroupingSets(PlanBuilder subPlan, QuerySpecification node, GroupingSetAnalysis groupingSetAnalysis)
+    private GroupingSetsPlan planGroupingSets(PlanBuilder subPlan, boolean distinctGroupingSets, GroupingSetAnalysis groupingSetAnalysis)
     {
         Map<Symbol, Symbol> groupingSetMappings = new LinkedHashMap<>();
 
@@ -1229,7 +1230,7 @@ class QueryPlanner
         // This tracks the grouping sets before complex expressions are considered.
         // It's also used to compute the descriptors needed to implement grouping()
         List<Set<FieldId>> columnOnlyGroupingSets = enumerateGroupingSets(groupingSetAnalysis);
-        if (node.getGroupBy().isPresent() && node.getGroupBy().get().isDistinct()) {
+        if (distinctGroupingSets) {
             columnOnlyGroupingSets = columnOnlyGroupingSets.stream()
                     .distinct()
                     .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -134,6 +134,7 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.OrdinalityColumn;
 import io.trino.sql.tree.PatternRecognitionRelation;
 import io.trino.sql.tree.PatternSearchMode;
+import io.trino.sql.tree.Pivot;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -1876,6 +1877,14 @@ class RelationPlanner
     {
         RelationPlan plan = process(node.getQuery(), context);
         return new RelationPlan(plan.getRoot(), analysis.getScope(node), plan.getFieldMappings(), outerContext);
+    }
+
+    @Override
+    protected RelationPlan visitPivot(Pivot node, Void context)
+    {
+        RelationPlan inputPlan = process(node.getInput(), context);
+        return new QueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries)
+                .planPivot(node, inputPlan);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -4782,6 +4782,65 @@ public class TestAnalyzer
         analyze("VALUES 'a', ('a'), ROW('a'), CAST(ROW('a') AS row(char(5)))");
     }
 
+    @Test
+    public void testPivot()
+    {
+        // t1 has columns a, b, c, d, all BIGINT.
+        analyze("SELECT * FROM t1 PIVOT (sum(a) FOR b IN (1 AS one))");
+
+        // An expression must contain an aggregate.
+        assertFails("SELECT * FROM t1 PIVOT (a FOR b IN (1 AS one))")
+                .hasErrorCode(EXPRESSION_NOT_AGGREGATE)
+                .hasMessageContaining("PIVOT expression must contain an aggregate function");
+        assertFails("SELECT * FROM t1 PIVOT (1 FOR b IN (1 AS one))")
+                .hasErrorCode(EXPRESSION_NOT_AGGREGATE);
+
+        // Window functions and grouping operations are not aggregates.
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) OVER () FOR b IN (1 AS one))")
+                .hasErrorCode(NESTED_WINDOW)
+                .hasMessageContaining("PIVOT expression cannot contain window functions");
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) + grouping(c) FOR b IN (1 AS one) GROUP BY ROLLUP (c))")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("PIVOT expression cannot contain grouping operations");
+
+        // A subquery outside the aggregate calls is not supported; one inside an aggregate call is fine.
+        assertFails("SELECT * FROM t1 PIVOT ((sum(a) + (SELECT 1)) AS x FOR b IN (1 AS one))")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("PIVOT expression cannot contain a subquery outside an aggregate function");
+        analyze("SELECT * FROM t1 PIVOT (sum((SELECT a)) AS x FOR b IN (1 AS one))");
+
+        // An IN value must be a constant: no aggregate, subquery, input-column reference, or
+        // non-deterministic function.
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR b IN (max(a)))")
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessageContaining("PIVOT IN clause cannot contain aggregations");
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR b IN ((SELECT 1)))")
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("cannot contain a subquery");
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR b IN (a))")
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("cannot reference a column: a");
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR b IN (CAST(random(3) AS bigint)))")
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("cannot be non-deterministic");
+
+        // A value must share a comparable supertype with the pivot column.
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR b IN (VARCHAR 'x'))")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("not comparable");
+
+        // Shape constraints.
+        assertFails("SELECT * FROM t1 PIVOT (sum(a), count(a) FOR b IN (1))")
+                .hasErrorCode(MISSING_COLUMN_ALIASES)
+                .hasMessageContaining("requires an alias");
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR (b, c) IN ((1)))")
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessageContaining("Number of pivot values");
+        assertFails("SELECT * FROM t1 PIVOT (sum(a) FOR b IN (1) GROUP BY AUTO)")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("GROUP BY AUTO is not supported in PIVOT");
+    }
+
     // TEST ROW PATTERN RECOGNITION: MATCH_RECOGNIZE CLAUSE
     @Test
     public void testInputColumnNames()

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestPivot.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestPivot.java
@@ -1,0 +1,895 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.Session;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_AGGREGATE;
+import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_CONSTANT;
+import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_SCALAR;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static io.trino.spi.StandardErrorCode.MISSING_COLUMN_ALIASES;
+import static io.trino.spi.StandardErrorCode.NESTED_WINDOW;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestPivot
+{
+    private static final String SALES =
+            """
+            (VALUES
+              ('NA', 1, BIGINT '100'),
+              ('NA', 1, BIGINT '50'),
+              ('NA', 2, BIGINT '70'),
+              ('EU', 1, BIGINT '40'),
+              ('EU', 3, BIGINT '20')
+            ) AS sales(region, month, amount)
+            """;
+
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testSingleAggregationNoGroupBy()
+    {
+        // No implicit grouping: collapses to a single row.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS feb, 3 AS mar))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '190', BIGINT '70', BIGINT '20')");
+    }
+
+    @Test
+    public void testSingleAggregationWithGroupBy()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS feb) GROUP BY region)
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ('EU', BIGINT '40', CAST(NULL AS BIGINT)),
+                            ('NA', BIGINT '150', BIGINT '70')
+                        """);
+    }
+
+    @Test
+    public void testMultipleAggregations()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total,
+                    count(amount) AS cnt
+                    FOR month IN (1 AS jan, 2 AS feb)
+                    GROUP BY region
+                )
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ('EU', BIGINT '40', BIGINT '1', CAST(NULL AS BIGINT), BIGINT '0'),
+                            ('NA', BIGINT '150', BIGINT '2', BIGINT '70', BIGINT '1')
+                        """);
+    }
+
+    @Test
+    public void testMultiplePivotColumns()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount)
+                    FOR (region, month) IN (
+                        ('NA', 1) AS na_jan,
+                        ('NA', 2) AS na_feb,
+                        ('EU', 1) AS eu_jan
+                    )
+                )
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '150', BIGINT '70', BIGINT '40')");
+    }
+
+    @Test
+    public void testAggregationExpression()
+    {
+        // Aggregation slot is a general expression containing multiple aggregates.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) - max(amount) AS minor
+                    FOR month IN (1 AS jan)
+                    GROUP BY region
+                )
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ('EU', BIGINT '0'),
+                            ('NA', BIGINT '50')
+                        """);
+    }
+
+    @Test
+    public void testSlotSubqueryInsideAggregate()
+    {
+        // A subquery anywhere inside an aggregate call — its arguments, FILTER, or ORDER BY — is
+        // planned before the aggregation, with the other inputs.
+
+        // In an argument: returns each row's amount, so the sum for month 1 is 190.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum((SELECT amount)) AS total FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+
+        // In a FILTER: EXISTS (SELECT 1) is always true, so every row for month 1 is summed.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FILTER (WHERE EXISTS (SELECT 1)) AS total FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+
+        // In an ORDER BY sort key: orders EU's amounts (40, 20) by (SELECT amount) ascending.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (array_agg(amount ORDER BY (SELECT amount)) AS amounts FOR region IN ('EU' AS eu))
+                """.formatted(SALES)))
+                .matches("VALUES ARRAY[BIGINT '20', BIGINT '40']");
+    }
+
+    @Test
+    public void testSlotRejectsSubqueryOutsideAggregate()
+    {
+        // A subquery outside the aggregate calls would have to be planned per value group, which
+        // PIVOT does not support yet. This covers the scalar, EXISTS, and IN forms.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT ((sum(amount) + (SELECT BIGINT '1')) AS total FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("PIVOT expression cannot contain a subquery outside an aggregate function");
+
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT ((sum(amount) + (CASE WHEN EXISTS (SELECT 1) THEN 1 ELSE 0 END)) AS total FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("PIVOT expression cannot contain a subquery outside an aggregate function");
+
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT ((sum(amount) + (CASE WHEN 1 IN (SELECT 1) THEN 1 ELSE 0 END)) AS total FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("PIVOT expression cannot contain a subquery outside an aggregate function");
+    }
+
+    @Test
+    public void testAggregateFilterInSlot()
+    {
+        // A FILTER on a pivot-slot aggregate is ANDed into that aggregate's value-group
+        // predicate. The unfiltered total alongside it is unaffected: NA's filtered sum is
+        // 100 (only amount > 50 qualifies), while its total stays 150.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total,
+                    sum(amount) FILTER (WHERE amount > 50) AS big
+                    FOR month IN (1 AS jan)
+                    GROUP BY region
+                )
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ('EU', BIGINT '40', CAST(NULL AS BIGINT)),
+                            ('NA', BIGINT '150', BIGINT '100')
+                        """);
+    }
+
+    @Test
+    public void testValueWithoutAlias()
+    {
+        // Unaliased values use literal SQL text as the column name, so 1 and '1'
+        // produce distinct columns (both nominally compare to month though only one
+        // matches month's bigint type).
+        assertThat(assertions.query(
+                """
+                SELECT "1"
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testNullValue()
+    {
+        // NULL value uses Trino's standard '=' semantics: never matches, so the
+        // synthesized column is the empty-input aggregation result (0 for count).
+        // Single-agg with both value-alias and agg-alias produces "valueAlias_aggAlias".
+        assertThat(assertions.query(
+                """
+                SELECT cnt_null_cnt
+                FROM %s
+                PIVOT (count(amount) AS cnt FOR month IN (NULL AS cnt_null))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
+    public void testRelationAlias()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT p.r, p.jan
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan) GROUP BY region) AS p (r, jan)
+                ORDER BY p.r
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ('EU', BIGINT '40'),
+                            ('NA', BIGINT '150')
+                        """);
+    }
+
+    @Test
+    public void testPivotOfPivot()
+    {
+        // PIVOT output is a relation; another PIVOT can apply to it. The first PIVOT
+        // is wrapped in a subquery so the second one can attach.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (
+                    SELECT *
+                    FROM %s
+                    PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS feb) GROUP BY region)
+                ) PIVOT (sum(jan) FOR region IN ('NA' AS na_total))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '150')");
+    }
+
+    @Test
+    public void testCoercion()
+    {
+        // Pivot column is BIGINT; integer literal in IN coerces.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testValueWiderThanColumn()
+    {
+        // The IN value's type need not coerce *to* the pivot column's type; it is enough
+        // that the two share a common supertype, matching plain '=' semantics. Here month
+        // is INTEGER and the value is BIGINT, so the comparison happens at BIGINT.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (count(amount) AS cnt FOR month IN (1 AS jan, 9999999999 AS huge))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '3', BIGINT '0')");
+    }
+
+    @Test
+    public void testValueNotComparableWithColumn()
+    {
+        // No common supertype between the value and the pivot column: rejected, just as a
+        // plain 'month = ...' comparison of the same types would be.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (VARCHAR 'x'))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("not comparable");
+    }
+
+    @Test
+    public void testAggregateOrderByInSlot()
+    {
+        // The aggregate's ORDER BY sort key is projected before pivot coercion, so
+        // array_agg(... ORDER BY ...) plans correctly even when the sort key is not
+        // one of the aggregate's arguments.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    array_agg(amount ORDER BY month) AS amounts
+                    FOR region IN ('EU' AS eu)
+                )
+                """.formatted(SALES)))
+                .matches("VALUES (ARRAY[BIGINT '40', BIGINT '20'])");
+    }
+
+    @Test
+    public void testInValueRejectsAggregate()
+    {
+        // An IN value names one output column, so it must be a constant expression; an
+        // aggregate, which summarizes rows rather than yielding a fixed value, is rejected.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (max(month)))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessageContaining("PIVOT IN clause cannot contain aggregations");
+    }
+
+    @Test
+    public void testGroupByAutoRejected()
+    {
+        // PIVOT has no SELECT list to derive AUTO grouping columns from, so AUTO is
+        // explicitly rejected rather than silently degrading to GROUP BY ().
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1) GROUP BY AUTO)
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("GROUP BY AUTO is not supported in PIVOT");
+    }
+
+    @Test
+    public void testMultiplePivotColumnsTupleArityMismatch()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR (region, month) IN (('NA', 1), ('EU')))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(INVALID_ARGUMENTS)
+                .hasMessageContaining("Number of pivot values");
+    }
+
+    @Test
+    public void testMultipleAggregationsRequireAlias()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount), count(amount) FOR month IN (1))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(MISSING_COLUMN_ALIASES)
+                .hasMessageContaining("PIVOT with multiple aggregations requires an alias");
+    }
+
+    @Test
+    public void testDuplicateOutputColumnName()
+    {
+        // Duplicate output column names are allowed, as in a SELECT list: SELECT * returns both.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '190', BIGINT '70')");
+
+        // Referencing the ambiguous name, however, fails.
+        assertThat(assertions.query(
+                """
+                SELECT jan
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan, 2 AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasMessageContaining("Column 'jan' is ambiguous");
+    }
+
+    @Test
+    public void testGroupingSetsInsidePivot()
+    {
+        // GROUP BY GROUPING SETS within PIVOT — emits a row per grouping set with NULL for
+        // the missing dimensions.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total
+                    FOR month IN (1 AS jan)
+                    GROUP BY GROUPING SETS ((region), ())
+                )
+                ORDER BY region NULLS FIRST
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            (CAST(NULL AS varchar(2)), BIGINT '190'),
+                            ('EU', BIGINT '40'),
+                            ('NA', BIGINT '150')
+                        """);
+    }
+
+    @Test
+    public void testCubeInsidePivot()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total
+                    FOR month IN (1 AS jan)
+                    GROUP BY CUBE (region)
+                )
+                ORDER BY region NULLS FIRST
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            (CAST(NULL AS varchar(2)), BIGINT '190'),
+                            ('EU', BIGINT '40'),
+                            ('NA', BIGINT '150')
+                        """);
+    }
+
+    @Test
+    public void testRollupInsidePivot()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total
+                    FOR month IN (1 AS jan)
+                    GROUP BY ROLLUP (region)
+                )
+                ORDER BY region NULLS FIRST
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            (CAST(NULL AS varchar(2)), BIGINT '190'),
+                            ('EU', BIGINT '40'),
+                            ('NA', BIGINT '150')
+                        """);
+    }
+
+    @Test
+    public void testEmptyGroupBy()
+    {
+        // GROUP BY () inside PIVOT — equivalent to no GROUP BY: collapses to a single row.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total
+                    FOR month IN (1 AS jan)
+                    GROUP BY ()
+                )
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '190')");
+    }
+
+    @Test
+    public void testValueIsExpression()
+    {
+        // IN values can be arbitrary constant expressions.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 + 0 AS jan, 2 * 1 AS feb))
+                """.formatted(SALES)))
+                .matches("VALUES (BIGINT '190', BIGINT '70')");
+    }
+
+    @Test
+    public void testValueIsQueryConstant()
+    {
+        // The rule is that a value is the same for every input row of the query, not that it is
+        // the same across queries: current_date is fixed for the query, so it is a valid value.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES (current_date, BIGINT '7')) AS t(day, amount)
+                PIVOT (sum(amount) FOR day IN (current_date AS today))
+                """))
+                .matches("VALUES BIGINT '7'");
+    }
+
+    @Test
+    public void testValueRejectsSubquery()
+    {
+        // A value is a constant expression in the sense the analyzer uses everywhere else, which
+        // excludes a subquery: the query it runs is opaque to the value's own checks, so what the
+        // value stands for could not be constrained.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN ((SELECT 1) AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("PIVOT IN clause must be constant and cannot contain a subquery");
+
+        // Including one that reads a WITH query, which is how a non-deterministic value would
+        // otherwise sneak in.
+        assertThat(assertions.query(
+                """
+                WITH pivot_value(v) AS (SELECT CAST(random(3) AS integer))
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN ((SELECT v FROM pivot_value) AS lucky))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("PIVOT IN clause must be constant and cannot contain a subquery");
+    }
+
+    @Test
+    public void testValueRejectsColumnReference()
+    {
+        // An IN value identifies one output column, so it must not vary per input row.
+        // Without this, 'month' would match every row against its own value.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (month AS same))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("PIVOT IN clause must be constant and cannot reference a column: month");
+    }
+
+    @Test
+    public void testValueWithShadowedColumnName()
+    {
+        // The lambda argument 'month' shadows the pivot column of the same name, so the value is
+        // constant despite mentioning that name. It evaluates to 1 and matches month = 1.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (transform(ARRAY[1], month -> month)[1] AS one))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testValueRejectsNonDeterministicExpression()
+    {
+        // A non-deterministic value is evaluated per input row, so it would scatter rows across
+        // the output column it is supposed to name.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (count(*) FOR month IN (CAST(random(3) AS integer) AS lucky))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("PIVOT IN clause must be constant and cannot be non-deterministic");
+    }
+
+    @Test
+    public void testAggregationSlotMustContainAggregate()
+    {
+        // The pivot value scoping applies to the aggregates in the slot, so a slot without
+        // one is meaningless: the column reference case would need the pivot filter it never
+        // gets, and the constant case would ignore the pivot value entirely.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (amount FOR month IN (1 AS jan) GROUP BY region)
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_AGGREGATE)
+                .hasMessageContaining("PIVOT expression must contain an aggregate function: amount");
+
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (1 FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_AGGREGATE)
+                .hasMessageContaining("PIVOT expression must contain an aggregate function: 1");
+    }
+
+    @Test
+    public void testAggregationSlotRejectsWindowFunction()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(sum(amount)) OVER () AS total FOR month IN (1 AS jan) GROUP BY region)
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(NESTED_WINDOW)
+                .hasMessageContaining("PIVOT expression cannot contain window functions or row pattern measures");
+    }
+
+    @Test
+    public void testAggregationSlotRejectsGroupingOperation()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (
+                    sum(amount) + grouping(region) AS total
+                    FOR month IN (1 AS jan)
+                    GROUP BY ROLLUP (region)
+                )
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("PIVOT expression cannot contain grouping operations");
+    }
+
+    @Test
+    public void testOutputColumnNames()
+    {
+        // Output columns are, in order: the GROUP BY columns, then one column per (value group,
+        // aggregation). A column's name is the value's name (alias, or SQL text of the value)
+        // with the aggregation alias appended when the aggregation has one.
+        assertThat(assertions.query(
+                """
+                SELECT region, jan_total, jan_cnt, feb_total, feb_cnt
+                FROM %s
+                PIVOT (
+                    sum(amount) AS total,
+                    count(amount) AS cnt
+                    FOR month IN (1 AS jan, 2 AS feb)
+                    GROUP BY region
+                )
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ('EU', BIGINT '40', BIGINT '1', CAST(NULL AS BIGINT), BIGINT '0'),
+                            ('NA', BIGINT '150', BIGINT '2', BIGINT '70', BIGINT '1')
+                        """);
+
+        // Single aggregation without an alias: the column is named for the value alone.
+        assertThat(assertions.query(
+                """
+                SELECT jan
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+
+        // Value without an alias: the column is named for the SQL text of the value.
+        assertThat(assertions.query(
+                """
+                SELECT "1_total"
+                FROM %s
+                PIVOT (sum(amount) AS total FOR month IN (1))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testOutputColumnNamesAreCanonicalized()
+    {
+        // An unquoted alias is canonicalized to lower case, so the output column is "jan_total".
+        assertThat(assertions.query(
+                """
+                SELECT jan_total
+                FROM %s
+                PIVOT (sum(amount) AS Total FOR month IN (1 AS Jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+
+        // A quoted alias keeps its case, so the output column is "Jan".
+        assertThat(assertions.query(
+                """
+                SELECT "Jan"
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS "Jan"))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '190'");
+
+        // A canonicalized GROUP BY column name behaves the same way.
+        assertThat(assertions.query(
+                """
+                SELECT region
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan) GROUP BY Region)
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches("VALUES 'EU', 'NA'");
+    }
+
+    @Test
+    public void testGroupByOutputColumnNames()
+    {
+        // A simple GROUP BY expression is named for the column; a complex one has no derived name
+        // and is addressed positionally.
+        assertThat(assertions.query(
+                """
+                SELECT region, jan
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan) GROUP BY region)
+                ORDER BY region
+                """.formatted(SALES)))
+                .ordered()
+                .matches("VALUES ('EU', BIGINT '40'), ('NA', BIGINT '150')");
+
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (sum(amount) FOR month IN (1 AS jan) GROUP BY region || '!')
+                ORDER BY 1
+                """.formatted(SALES)))
+                .ordered()
+                .matches("VALUES (CAST('EU!' AS varchar), BIGINT '40'), (CAST('NA!' AS varchar), BIGINT '150')");
+    }
+
+    @Test
+    public void testValueAndColumnCoerceToCommonSupertype()
+    {
+        // Neither side is the common supertype: the INTEGER column and the DECIMAL value are both
+        // coerced to decimal, and the comparison runs there.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES (INTEGER '1', BIGINT '10'), (INTEGER '2', BIGINT '20')) AS t(k, v)
+                PIVOT (sum(v) FOR k IN (DECIMAL '1' AS one, DECIMAL '2' AS two))
+                """))
+                .matches("VALUES (BIGINT '10', BIGINT '20')");
+    }
+
+    @Test
+    public void testColumnTakesDifferentCoercionsPerValueGroup()
+    {
+        // The same pivot column is compared at a different supertype in each value group: at BIGINT
+        // against the BIGINT value, and at INTEGER against the SMALLINT value.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES (INTEGER '1', BIGINT '10'), (INTEGER '2', BIGINT '20')) AS t(k, v)
+                PIVOT (sum(v) FOR k IN (BIGINT '1' AS a, SMALLINT '2' AS b))
+                """))
+                .matches("VALUES (BIGINT '10', BIGINT '20')");
+    }
+
+    @Test
+    public void testDistinctAggregation()
+    {
+        // A DISTINCT aggregate in a slot is planned like any other aggregate. For month 1 the
+        // regions are NA, NA, EU, so two distinct values.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM %s
+                PIVOT (count(DISTINCT region) AS regions FOR month IN (1 AS jan))
+                """.formatted(SALES)))
+                .matches("VALUES BIGINT '2'");
+    }
+
+    @Test
+    public void testValueIsParameter()
+    {
+        // A parameter is constant for the execution, so it is a valid value.
+        Session session = Session.builder(assertions.getDefaultSession())
+                .addPreparedStatement(
+                        "my_query",
+                        """
+                        SELECT *
+                        FROM %s
+                        PIVOT (sum(amount) FOR month IN (? AS chosen))
+                        """.formatted(SALES))
+                .build();
+        assertThat(assertions.query(session, "EXECUTE my_query USING 1"))
+                .matches("VALUES BIGINT '190'");
+    }
+
+    @Test
+    public void testValueRejectsCorrelatedColumn()
+    {
+        // A value cannot reference a column of an enclosing query any more than one of the pivot
+        // input: it must be constant.
+        assertThat(assertions.query(
+                """
+                SELECT (
+                    SELECT total
+                    FROM %s
+                    PIVOT (sum(amount) AS total FOR month IN (o.month))
+                )
+                FROM (VALUES 1) AS o(month)
+                """.formatted(SALES)))
+                .failure()
+                .hasErrorCode(EXPRESSION_NOT_CONSTANT)
+                .hasMessageContaining("PIVOT IN clause must be constant");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -111,6 +111,9 @@ import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.OrdinalityColumn;
 import io.trino.sql.tree.ParameterDeclaration;
 import io.trino.sql.tree.PatternRecognitionRelation;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -1007,7 +1010,7 @@ public final class SqlFormatter
 
         private void processRelationSuffix(Relation relation, Integer indent)
         {
-            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation) || (relation instanceof PatternRecognitionRelation)) {
+            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation) || (relation instanceof PatternRecognitionRelation) || (relation instanceof Pivot)) {
                 builder.append("( ");
                 process(relation, indent + 1);
                 append(indent, ")");
@@ -1015,6 +1018,64 @@ public final class SqlFormatter
             else {
                 process(relation, indent);
             }
+        }
+
+        @Override
+        protected Void visitPivot(Pivot node, Integer indent)
+        {
+            processRelationSuffix(node.getInput(), indent);
+
+            builder.append(" PIVOT (\n");
+            append(indent + 1, node.getAggregations().stream()
+                    .map(this::formatPivotAggregation)
+                    .collect(joining(", ")))
+                    .append("\n");
+            append(indent + 1, "FOR ")
+                    .append(formatPivotColumns(node.getPivotColumns()))
+                    .append(" IN ")
+                    .append(node.getValueGroups().stream()
+                            .map(this::formatPivotValueGroup)
+                            .collect(joining(", ", "(", ")")))
+                    .append("\n");
+            node.getGroupBy().ifPresent(groupBy ->
+                    append(indent + 1, "GROUP BY " + (groupBy.isDistinct() ? "DISTINCT " : "") + formatGroupBy(groupBy.getGroupingElements()))
+                            .append("\n"));
+            append(indent, ")");
+            return null;
+        }
+
+        private String formatPivotAggregation(PivotAggregation aggregation)
+        {
+            String result = formatExpression(aggregation.getExpression());
+            if (aggregation.getAlias().isPresent()) {
+                result += " AS " + formatName(aggregation.getAlias().get());
+            }
+            return result;
+        }
+
+        private static String formatPivotColumns(List<Expression> pivotColumns)
+        {
+            return formatPivotTuple(pivotColumns);
+        }
+
+        private String formatPivotValueGroup(PivotValueGroup valueGroup)
+        {
+            String formatted = formatPivotTuple(valueGroup.getValues());
+            if (valueGroup.getAlias().isPresent()) {
+                formatted += " AS " + formatName(valueGroup.getAlias().get());
+            }
+            return formatted;
+        }
+
+        // A single element is bare; two or more are wrapped in parentheses, matching the grammar.
+        private static String formatPivotTuple(List<Expression> expressions)
+        {
+            if (expressions.size() == 1) {
+                return formatExpression(expressions.getFirst());
+            }
+            return expressions.stream()
+                    .map(SqlFormatter::formatExpression)
+                    .collect(joining(", ", "(", ")"));
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -220,6 +220,9 @@ import io.trino.sql.tree.PatternRecognitionRelation;
 import io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch;
 import io.trino.sql.tree.PatternSearchMode;
 import io.trino.sql.tree.PatternVariable;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -2017,7 +2020,7 @@ class AstBuilder
     @Override
     public Node visitSampledRelation(SqlBaseParser.SampledRelationContext context)
     {
-        Relation child = (Relation) visit(context.patternRecognition());
+        Relation child = (Relation) visit(context.pivot());
 
         if (context.TABLESAMPLE() == null) {
             return child;
@@ -2078,6 +2081,81 @@ class AstBuilder
     public Node visitMeasureDefinition(SqlBaseParser.MeasureDefinitionContext context)
     {
         return new MeasureDefinition(getLocation(context), (Expression) visit(context.expression()), (Identifier) visit(context.identifier()));
+    }
+
+    @Override
+    public Node visitPivot(SqlBaseParser.PivotContext context)
+    {
+        Relation child = (Relation) visit(context.patternRecognition());
+
+        if (context.PIVOT() == null) {
+            return child;
+        }
+
+        List<PivotAggregation> aggregations = visit(context.pivotAggregation(), PivotAggregation.class);
+        List<Expression> pivotColumns = buildPivotColumns(context.pivotColumns());
+        List<PivotValueGroup> valueGroups = visit(context.pivotValueGroup(), PivotValueGroup.class);
+
+        Optional<GroupBy> groupBy = Optional.empty();
+        if (context.GROUP() != null) {
+            groupBy = Optional.of((GroupBy) visit(context.groupBy()));
+        }
+
+        Pivot pivot = new Pivot(getLocation(context), child, aggregations, pivotColumns, valueGroups, groupBy);
+
+        if (context.identifier() == null) {
+            return pivot;
+        }
+
+        List<Identifier> aliases = null;
+        if (context.columnAliases() != null) {
+            aliases = visit(context.columnAliases().identifier(), Identifier.class);
+        }
+
+        return new AliasedRelation(getLocation(context), pivot, (Identifier) visit(context.identifier()), aliases);
+    }
+
+    @Override
+    public Node visitPivotAggregation(SqlBaseParser.PivotAggregationContext context)
+    {
+        Optional<Identifier> alias = Optional.empty();
+        if (context.identifier() != null) {
+            alias = Optional.of((Identifier) visit(context.identifier()));
+        }
+        return new PivotAggregation(getLocation(context), (Expression) visit(context.expression()), alias);
+    }
+
+    @Override
+    public Node visitPivotValueGroup(SqlBaseParser.PivotValueGroupContext context)
+    {
+        Optional<Identifier> alias = Optional.empty();
+        if (context.identifier() != null) {
+            alias = Optional.of((Identifier) visit(context.identifier()));
+        }
+        return new PivotValueGroup(
+                getLocation(context),
+                visit(context.expression(), Expression.class),
+                alias);
+    }
+
+    private List<Expression> buildPivotColumns(SqlBaseParser.PivotColumnsContext context)
+    {
+        // A pivot column is a qualifiedName. The usual way to turn one into an Expression,
+        // DereferenceExpression.from(QualifiedName), builds the nodes from a QualifiedName, which
+        // carries no source locations; the resulting expression would have none either, so an
+        // analyzer error on a pivot column (an unknown name, a type mismatch) would have no
+        // position to point at. Build the column from the located identifiers instead, chaining
+        // them into a DereferenceExpression for a compound name such as t.a.
+        ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+        for (SqlBaseParser.QualifiedNameContext qualifiedNameContext : context.qualifiedName()) {
+            List<Identifier> parts = visit(qualifiedNameContext.identifier(), Identifier.class);
+            Expression column = parts.getFirst();
+            for (Identifier part : parts.subList(1, parts.size())) {
+                column = new DereferenceExpression(getLocation(qualifiedNameContext), column, part);
+            }
+            builder.add(column);
+        }
+        return builder.build();
     }
 
     private static Optional<RowsPerMatch> getRowsPerMatch(SqlBaseParser.RowsPerMatchContext context)

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -587,6 +587,21 @@ public abstract class AstVisitor<R, C>
         return visitRelation(node, context);
     }
 
+    protected R visitPivot(Pivot node, C context)
+    {
+        return visitRelation(node, context);
+    }
+
+    protected R visitPivotAggregation(PivotAggregation node, C context)
+    {
+        return visitNode(node, context);
+    }
+
+    protected R visitPivotValueGroup(PivotValueGroup node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitJoin(Join node, C context)
     {
         return visitRelation(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -1107,4 +1107,40 @@ public abstract class DefaultTraversalVisitor<C>
 
         return null;
     }
+
+    @Override
+    protected Void visitPivot(Pivot node, C context)
+    {
+        process(node.getInput(), context);
+        for (PivotAggregation aggregation : node.getAggregations()) {
+            process(aggregation, context);
+        }
+        for (Expression pivotColumn : node.getPivotColumns()) {
+            process(pivotColumn, context);
+        }
+        for (PivotValueGroup valueGroup : node.getValueGroups()) {
+            process(valueGroup, context);
+        }
+        node.getGroupBy().ifPresent(groupBy -> process(groupBy, context));
+
+        return null;
+    }
+
+    @Override
+    protected Void visitPivotAggregation(PivotAggregation node, C context)
+    {
+        process(node.getExpression(), context);
+
+        return null;
+    }
+
+    @Override
+    protected Void visitPivotValueGroup(PivotValueGroup node, C context)
+    {
+        for (Expression value : node.getValues()) {
+            process(value, context);
+        }
+
+        return null;
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Pivot.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Pivot.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class Pivot
+        extends Relation
+{
+    private final Relation input;
+    private final List<PivotAggregation> aggregations;
+    private final List<Expression> pivotColumns;
+    private final List<PivotValueGroup> valueGroups;
+    private final Optional<GroupBy> groupBy;
+
+    public Pivot(
+            NodeLocation location,
+            Relation input,
+            List<PivotAggregation> aggregations,
+            List<Expression> pivotColumns,
+            List<PivotValueGroup> valueGroups,
+            Optional<GroupBy> groupBy)
+    {
+        super(Optional.of(location));
+        this.input = requireNonNull(input, "input is null");
+        this.aggregations = ImmutableList.copyOf(aggregations);
+        checkArgument(!this.aggregations.isEmpty(), "aggregations is empty");
+        this.pivotColumns = ImmutableList.copyOf(pivotColumns);
+        checkArgument(!this.pivotColumns.isEmpty(), "pivotColumns is empty");
+        this.valueGroups = ImmutableList.copyOf(valueGroups);
+        checkArgument(!this.valueGroups.isEmpty(), "valueGroups is empty");
+        this.groupBy = requireNonNull(groupBy, "groupBy is null");
+    }
+
+    public Relation getInput()
+    {
+        return input;
+    }
+
+    public List<PivotAggregation> getAggregations()
+    {
+        return aggregations;
+    }
+
+    public List<Expression> getPivotColumns()
+    {
+        return pivotColumns;
+    }
+
+    public List<PivotValueGroup> getValueGroups()
+    {
+        return valueGroups;
+    }
+
+    public Optional<GroupBy> getGroupBy()
+    {
+        return groupBy;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPivot(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.<Node>builder()
+                .add(input)
+                .addAll(aggregations)
+                .addAll(pivotColumns)
+                .addAll(valueGroups)
+                .addAll(groupBy.stream().toList())
+                .build();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("input", input)
+                .add("aggregations", aggregations)
+                .add("pivotColumns", pivotColumns)
+                .add("valueGroups", valueGroups)
+                .add("groupBy", groupBy.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Pivot pivot = (Pivot) o;
+        return Objects.equals(input, pivot.input) &&
+                Objects.equals(aggregations, pivot.aggregations) &&
+                Objects.equals(pivotColumns, pivot.pivotColumns) &&
+                Objects.equals(valueGroups, pivot.valueGroups) &&
+                Objects.equals(groupBy, pivot.groupBy);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(input, aggregations, pivotColumns, valueGroups, groupBy);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/PivotAggregation.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/PivotAggregation.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PivotAggregation
+        extends Node
+{
+    private final Expression expression;
+    private final Optional<Identifier> alias;
+
+    public PivotAggregation(NodeLocation location, Expression expression, Optional<Identifier> alias)
+    {
+        super(location);
+        this.expression = requireNonNull(expression, "expression is null");
+        this.alias = requireNonNull(alias, "alias is null");
+    }
+
+    public Expression getExpression()
+    {
+        return expression;
+    }
+
+    public Optional<Identifier> getAlias()
+    {
+        return alias;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPivotAggregation(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        // alias is a scalar attribute, not a child: it is compared in shallowEquals instead.
+        return ImmutableList.of(expression);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("expression", expression)
+                .add("alias", alias.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PivotAggregation that = (PivotAggregation) o;
+        return Objects.equals(expression, that.expression) &&
+                Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression, alias);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+        return Objects.equals(alias, ((PivotAggregation) other).alias);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/PivotValueGroup.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/PivotValueGroup.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class PivotValueGroup
+        extends Node
+{
+    private final List<Expression> values;
+    private final Optional<Identifier> alias;
+
+    public PivotValueGroup(NodeLocation location, List<Expression> values, Optional<Identifier> alias)
+    {
+        super(location);
+        requireNonNull(values, "values is null");
+        checkArgument(!values.isEmpty(), "values is empty");
+        this.values = ImmutableList.copyOf(values);
+        this.alias = requireNonNull(alias, "alias is null");
+    }
+
+    public List<Expression> getValues()
+    {
+        return values;
+    }
+
+    public Optional<Identifier> getAlias()
+    {
+        return alias;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPivotValueGroup(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        // alias is a scalar attribute, not a child: it is compared in shallowEquals instead.
+        return values;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("values", values)
+                .add("alias", alias.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PivotValueGroup that = (PivotValueGroup) o;
+        return Objects.equals(values, that.values) &&
+                Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(values, alias);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+        return Objects.equals(alias, ((PivotValueGroup) other).alias);
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -163,6 +163,9 @@ import io.trino.sql.tree.PatternAlternation;
 import io.trino.sql.tree.PatternConcatenation;
 import io.trino.sql.tree.PatternSearchMode;
 import io.trino.sql.tree.PatternVariable;
+import io.trino.sql.tree.Pivot;
+import io.trino.sql.tree.PivotAggregation;
+import io.trino.sql.tree.PivotValueGroup;
 import io.trino.sql.tree.PlanLeaf;
 import io.trino.sql.tree.PlanParentChild;
 import io.trino.sql.tree.PlanSiblings;
@@ -9582,6 +9585,106 @@ public class TestSqlParser
                 .isEqualTo(new SetSessionAuthorization(location(1, 1), new Identifier(location(1, 27), "null", true)));
         assertThat(statement("SET SESSION AUTHORIZATION 'null'"))
                 .isEqualTo(new SetSessionAuthorization(location(1, 1), new StringLiteral(location(1, 27), "null")));
+    }
+
+    @Test
+    public void testPivot()
+    {
+        assertThat(statement("SELECT * FROM t PIVOT (sum(amount) FOR month IN (1, 2))"))
+                .isEqualTo(selectAllFrom(new Pivot(
+                        location(1, 15),
+                        new Table(location(1, 15), qualifiedName(location(1, 15), "t")),
+                        ImmutableList.of(new PivotAggregation(
+                                location(1, 24),
+                                new FunctionCall(location(1, 24), qualifiedName(location(1, 24), "sum"), ImmutableList.of(new Identifier(location(1, 28), "amount", false))),
+                                Optional.empty())),
+                        ImmutableList.of(new Identifier(location(1, 40), "month", false)),
+                        ImmutableList.of(
+                                new PivotValueGroup(location(1, 50), ImmutableList.of(new LongLiteral(location(1, 50), "1")), Optional.empty()),
+                                new PivotValueGroup(location(1, 53), ImmutableList.of(new LongLiteral(location(1, 53), "2")), Optional.empty())),
+                        Optional.empty())));
+
+        assertThat(statement("SELECT * FROM t PIVOT (sum(amount) AS total, avg(amount) AS mean FOR month IN (1 AS jan))"))
+                .isEqualTo(selectAllFrom(new Pivot(
+                        location(1, 15),
+                        new Table(location(1, 15), qualifiedName(location(1, 15), "t")),
+                        ImmutableList.of(
+                                new PivotAggregation(
+                                        location(1, 24),
+                                        new FunctionCall(location(1, 24), qualifiedName(location(1, 24), "sum"), ImmutableList.of(new Identifier(location(1, 28), "amount", false))),
+                                        Optional.of(new Identifier(location(1, 39), "total", false))),
+                                new PivotAggregation(
+                                        location(1, 46),
+                                        new FunctionCall(location(1, 46), qualifiedName(location(1, 46), "avg"), ImmutableList.of(new Identifier(location(1, 50), "amount", false))),
+                                        Optional.of(new Identifier(location(1, 61), "mean", false)))),
+                        ImmutableList.of(new Identifier(location(1, 70), "month", false)),
+                        ImmutableList.of(new PivotValueGroup(
+                                location(1, 80),
+                                ImmutableList.of(new LongLiteral(location(1, 80), "1")),
+                                Optional.of(new Identifier(location(1, 85), "jan", false)))),
+                        Optional.empty())));
+
+        assertThat(statement("SELECT * FROM t PIVOT (sum(amount) FOR (region, month) IN (('NA', 1) AS na_jan) GROUP BY region)"))
+                .isEqualTo(selectAllFrom(new Pivot(
+                        location(1, 15),
+                        new Table(location(1, 15), qualifiedName(location(1, 15), "t")),
+                        ImmutableList.of(new PivotAggregation(
+                                location(1, 24),
+                                new FunctionCall(location(1, 24), qualifiedName(location(1, 24), "sum"), ImmutableList.of(new Identifier(location(1, 28), "amount", false))),
+                                Optional.empty())),
+                        ImmutableList.of(
+                                new Identifier(location(1, 41), "region", false),
+                                new Identifier(location(1, 49), "month", false)),
+                        ImmutableList.of(new PivotValueGroup(
+                                location(1, 60),
+                                ImmutableList.of(
+                                        new StringLiteral(location(1, 61), "NA"),
+                                        new LongLiteral(location(1, 67), "1")),
+                                Optional.of(new Identifier(location(1, 73), "na_jan", false)))),
+                        Optional.of(new GroupBy(
+                                location(1, 90),
+                                false,
+                                ImmutableList.of(new SimpleGroupBy(
+                                        location(1, 90),
+                                        ImmutableList.of(new Identifier(location(1, 90), "region", false)))))))));
+
+        assertThat(statement("SELECT * FROM t PIVOT (sum(amount) FOR month IN (1)) AS p (r, jan)"))
+                .isEqualTo(selectAllFrom(new AliasedRelation(
+                        location(1, 15),
+                        new Pivot(
+                                location(1, 15),
+                                new Table(location(1, 15), qualifiedName(location(1, 15), "t")),
+                                ImmutableList.of(new PivotAggregation(
+                                        location(1, 24),
+                                        new FunctionCall(location(1, 24), qualifiedName(location(1, 24), "sum"), ImmutableList.of(new Identifier(location(1, 28), "amount", false))),
+                                        Optional.empty())),
+                                ImmutableList.of(new Identifier(location(1, 40), "month", false)),
+                                ImmutableList.of(new PivotValueGroup(location(1, 50), ImmutableList.of(new LongLiteral(location(1, 50), "1")), Optional.empty())),
+                                Optional.empty()),
+                        new Identifier(location(1, 57), "p", false),
+                        ImmutableList.of(
+                                new Identifier(location(1, 60), "r", false),
+                                new Identifier(location(1, 63), "jan", false)))));
+
+        // PIVOT is not a reserved keyword
+        assertThat(statement("SELECT pivot FROM t"))
+                .isEqualTo(createQuery(new QuerySpecification(
+                        location(1, 1),
+                        new Select(
+                                location(1, 1),
+                                false,
+                                ImmutableList.of(new SingleColumn(
+                                        location(1, 8),
+                                        new Identifier(location(1, 8), "pivot", false),
+                                        Optional.empty()))),
+                        Optional.of(new Table(location(1, 19), qualifiedName(location(1, 19), "t"))),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty())));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -53,7 +53,7 @@ public class TestSqlParserErrorHandling
                         "line 1:15: mismatched input '''. Expecting: '(', 'JSON_TABLE', 'LATERAL', 'NEAREST', 'TABLE', 'UNNEST', <identifier>"),
                 Arguments.of("select *\nfrom x\nfrom",
                         "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'CROSS', 'EXCEPT', 'FETCH', 'FOR', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', " +
-                                "'LIMIT', 'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>, <identifier>"),
+                                "'LIMIT', 'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'PIVOT', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>, <identifier>"),
                 Arguments.of(
                         "select *\nfrom x\nwhere from",
                         "line 3:7: mismatched input 'from'. Expecting: <expression>"),
@@ -158,7 +158,7 @@ public class TestSqlParserErrorHandling
                         "line 1:23: mismatched input '<EOF>'. Expecting: 'WHERE'"),
                 Arguments.of("SELECT * FROM t t x",
                         "line 1:19: mismatched input 'x'. Expecting: '(', ',', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', 'LIMIT', " +
-                                "'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>"),
+                                "'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'PIVOT', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>"),
                 Arguments.of(
                         "SELECT * FROM t WHERE EXISTS (",
                         "line 1:31: mismatched input '<EOF>'. Expecting: <query>"),

--- a/docs/src/main/sphinx/language/sql-support.md
+++ b/docs/src/main/sphinx/language/sql-support.md
@@ -61,7 +61,7 @@ catalogs](/admin/properties-catalog):
 The following statements provide read access to data and metadata exposed by a
 connector accessing a data source. They are supported by all connectors:
 
-- {doc}`/sql/select` including {doc}`/sql/match-recognize`
+- {doc}`/sql/select` including {doc}`/sql/match-recognize` and {doc}`/sql/pivot`
 - {doc}`/sql/describe`
 - {doc}`/sql/show-catalogs`
 - {doc}`/sql/show-columns`

--- a/docs/src/main/sphinx/sql.md
+++ b/docs/src/main/sphinx/sql.md
@@ -52,6 +52,7 @@ sql/grant-roles
 sql/insert
 sql/match-recognize
 sql/merge
+sql/pivot
 sql/prepare
 sql/refresh-materialized-view
 sql/reset-session

--- a/docs/src/main/sphinx/sql/pivot.md
+++ b/docs/src/main/sphinx/sql/pivot.md
@@ -1,0 +1,205 @@
+# PIVOT
+
+## Synopsis
+
+```text
+PIVOT (
+  aggregation [ [ AS ] aggregation_alias ] [, ...]
+  FOR { pivot_column | ( pivot_column, pivot_column [, ...] ) } IN ( pivot_value_group [, ...] )
+  [ GROUP BY grouping_element [, ...] ]
+  )
+```
+
+where `pivot_value_group` is one of
+
+```text
+expression [ [ AS ] value_alias ]
+( expression, expression [, ...] ) [ [ AS ] value_alias ]
+```
+
+## Description
+
+The `PIVOT` clause is an optional subclause of the `FROM` clause. It rotates
+rows of an input relation into output columns by partitioning the rows on
+one or more *pivot columns* and computing one or more *aggregations* for
+each *pivot value*. The input to a pivot is a table, a view, or a subquery.
+The output of a pivot is a relation, so it can itself appear in a `FROM`
+clause, be aliased, or be the input to another `PIVOT`.
+
+`PIVOT` is useful when each row in the input represents one observation
+along a categorical dimension (such as a month, region, or status), and the
+report should display one column per category. Common use cases include:
+
+- summarizing measurements by time bucket,
+- producing a column per status or category,
+- comparing aggregated metrics side by side without writing repetitive
+  `CASE` or `FILTER` expressions.
+
+## Example
+
+In the following example, `sales` records one row per region/month, and
+`PIVOT` produces one column per month within each region:
+
+```sql
+SELECT *
+FROM sales PIVOT (
+    sum(amount) AS total
+    FOR month IN (1 AS jan, 2 AS feb, 3 AS mar)
+    GROUP BY region
+    )
+```
+
+The output has columns `region`, `jan_total`, `feb_total`, `mar_total`.
+
+In the following sections, all subclauses of the `PIVOT` clause are
+explained.
+
+## Aggregations
+
+```sql
+sum(amount) AS total
+```
+
+Each aggregation is an expression that contains one or more aggregate
+function calls. The expression is evaluated once per pivot value, with each
+aggregate scoped to the rows that match that pivot value. It is the
+aggregate that the pivot value scoping applies to, so an expression without
+one is rejected. Window functions and grouping operations are not
+aggregates, and are not allowed in an aggregation.
+
+The aggregation alias becomes part of the output column names (see
+[](pivot-output)). Aliases are optional in the single-aggregation case but
+required when a `PIVOT` declares more than one aggregation, so that each
+aggregation contributes a distinguishable suffix to its output columns.
+
+Beyond that, `PIVOT` accepts any expression Trino accepts as an
+aggregating select item. For example, the following all work:
+
+```sql
+sum(amount)                                    -- single aggregate
+avg(amount) * 100 AS pct                       -- expression over an aggregate
+sum(amount) - sum(refund) AS net               -- multiple aggregates in one slot
+sum(amount) FILTER (WHERE amount > 0) AS gains  -- explicit FILTER on an aggregate
+```
+
+When the slot expression contains multiple aggregate calls, the pivot
+filter is applied to each aggregate individually, so `sum(amount) -
+sum(refund)` filters both `sum`s to the rows for the current pivot value.
+
+An aggregate may also carry its own `FILTER (WHERE ...)` clause. It composes
+with the pivot value scoping: the aggregate sees only the rows that match
+both the current pivot value and the explicit filter condition.
+
+A subquery may appear anywhere inside an aggregate call — its arguments,
+`FILTER`, or `ORDER BY` — but not elsewhere in the aggregation expression.
+
+## Pivot column and IN list
+
+```sql
+FOR month IN (1 AS jan, 2 AS feb, 3 AS mar)
+```
+
+The `FOR` clause names the pivot column (or, for compound keys, a
+parenthesised list of pivot columns) and the `IN` clause supplies the
+values that become output columns. Each value is a constant expression: it
+names one output column, so it must have the same value for every input
+row of the query. It can therefore not reference a column of the input
+relation, contain a subquery, or call a non-deterministic function such as
+{func}`random`. A value that is fixed for the query but not across queries,
+such as {func}`current_date` or a query parameter, is allowed.
+
+A row matches a value when `pivot_column = value` holds, with the usual `=`
+semantics: the column and the value are coerced to a common comparable
+supertype, which may be wider than the column's own type. So an `INTEGER`
+pivot column can be matched against a `BIGINT` value, and both sides are
+compared as `BIGINT`.
+
+For multiple pivot columns, supply tuple values in matching order:
+
+```sql
+FOR (region, month) IN (('NA', 1) AS na_jan, ('EU', 1) AS eu_jan)
+```
+
+Each tuple must have the same arity as the pivot column list.
+
+The value alias controls the output column name for that value. It is
+strongly recommended in practice — without it, the column name is
+derived from the SQL text of the value expression (so `1` and `'1'`
+become distinct columns named `1` and `'1'`).
+
+`NULL` is a permitted value, but it is treated using Trino's standard
+`=` semantics: the predicate `pivot_column = NULL` is `UNKNOWN`, so the
+corresponding output column always carries the empty-input aggregation
+result (`NULL` for `sum`, `0` for `count`, and so on). To produce a
+column for rows where the pivot column is `NULL`, supply that bucket
+explicitly in the source relation rather than relying on a `NULL` IN
+value.
+
+## GROUP BY
+
+```sql
+GROUP BY region
+```
+
+The optional `GROUP BY` clause inside `PIVOT` controls which dimensions
+are preserved as additional output columns. It accepts the same forms as
+a top-level {doc}`GROUP BY <select>`: simple expressions, `GROUP BY ()`,
+`GROUPING SETS`, `CUBE`, and `ROLLUP`. Each grouping expression is
+projected as an output column. `GROUP BY AUTO` is not allowed, because a
+`PIVOT` has no select list to derive the grouping columns from.
+
+When `GROUP BY` is omitted, the behaviour is the same as `GROUP BY ()`:
+the result is a single row whose only columns are the pivot output
+columns.
+
+(pivot-output)=
+## Output columns
+
+The output column list is, in order:
+
+1. The columns introduced by `GROUP BY` (in declaration order), if any.
+2. One block per pivot value group (in declaration order).
+
+Within each block, columns appear once per aggregation slot in the order
+the aggregations were declared. The column name is the name of the value,
+with the aggregation alias appended when the aggregation has one:
+
+| Value form | Name of the value |
+|---|---|
+| Value with alias | `valueAlias` |
+| Value without alias | SQL text of the value |
+| Tuple value with alias | `tupleAlias` |
+| Tuple value without alias | SQL text of the components joined by `_` |
+
+So `sum(amount) FOR month IN (1 AS jan)` produces `jan`, while
+`sum(amount) AS total FOR month IN (1 AS jan)` produces `jan_total`. Since
+a `PIVOT` with multiple aggregations requires an alias on each of them, its
+column names always take the second form.
+
+An alias that comes from an identifier is canonicalized like any other:
+an unquoted alias is lower-cased, while a quoted alias keeps its case. So
+`AS Jan` names the column `jan`, and `AS "Jan"` names it `Jan`.
+
+Two output columns may share a name, as in a `SELECT` list. A query that
+selects all columns returns each of them; one that references the shared
+name by name fails as ambiguous.
+
+## Pivot relation alias
+
+A `PIVOT` clause may itself be aliased, with optional column aliases:
+
+```sql
+SELECT p.r, p.jan, p.feb
+FROM sales PIVOT (
+    sum(amount) FOR month IN (1 AS jan, 2 AS feb)
+    GROUP BY region
+    ) AS p (r, jan, feb)
+```
+
+The column-alias list, when present, must match the number of output
+columns. This is the same form supported for subquery aliases.
+
+## See also
+
+- {doc}`select`
+- {doc}`match-recognize`

--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -40,6 +40,13 @@ For detailed description of `MATCH_RECOGNIZE` clause, see {doc}`pattern
 recognition in FROM clause</sql/match-recognize>`.
 
 ```text
+from_item PIVOT pivot_specification
+  [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+```
+
+For detailed description of `PIVOT` clause, see {doc}`pivot</sql/pivot>`.
+
+```text
 TABLE (table_function_invocation) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
 ```
 


### PR DESCRIPTION
## Summary

Adds first-class `PIVOT` syntax to Trino, eliminating the need to hand-write `FILTER` aggregation SQL to rotate row values into columns.

```sql
SELECT *
FROM sales PIVOT (
    sum(amount) AS total
    FOR month IN (1 AS jan, 2 AS feb, 3 AS mar)
    GROUP BY region
)
```

`PIVOT` attaches to the relation tree at the same level as `MATCH_RECOGNIZE` and supports:

- multiple aggregations per pivot, requiring an alias on each;
- single or multi-column pivot keys, with tuple values for the multi-column form;
- arbitrary expressions over aggregates in an aggregation slot (e.g. `sum(x) - sum(y)`, `avg(x) * 100`), including an aggregate carrying its own `FILTER (WHERE ...)`, which composes with the pivot value scoping;
- explicit `GROUP BY` including `GROUPING SETS`, `CUBE`, `ROLLUP`, and `GROUP BY ()`;
- alias and column-alias on the `PIVOT` output (`PIVOT (...) AS p (c1, c2)`).

`PIVOT` is added as a non-reserved keyword.

## Semantics

- **Missing `GROUP BY` implies `GROUP BY ()`**: the result is a single row whose only columns are the pivot output columns. To preserve a dimension, name it explicitly in `GROUP BY`.
- **An aggregation slot is an expression over aggregates**: it must contain at least one aggregate function, since the aggregate is what the pivot value scoping applies to. Window functions and grouping operations are not aggregates and are rejected.
- **`IN` values follow standard `=` semantics**: a value is accepted when it shares a common comparable supertype with the pivot column — not only when it coerces directly to the column's type — and the comparison is made at that supertype. `IN (NULL)` therefore never matches, and its column always carries the empty-input aggregation result.
- **`IN` values are constant expressions**, in the sense the analyzer already uses elsewhere (`ExpressionAnalyzer.createConstantAnalyzer`): a value names one output column, so it must have the same value for every input row of the query. It can therefore not reference a column of the input relation, contain a subquery, or call a non-deterministic function. A value that is fixed for the query but not across queries, such as `current_date` or a query parameter, is allowed.

## Architecture

- The analyzer reads the user-written `Pivot` AST and synthesizes none of its own. It calls `analyzeExpression` on the pivot columns, `GROUP BY` expressions and slot expressions in the input scope, and on the `IN` values in an empty scope (which is what makes an input-column reference in a value unresolvable). `AggregationAnalyzer.verifySourceAggregations` enforces that non-aggregate parts of a slot reference only grouping columns. It records `Analysis.PivotAnalysis`: the `GroupingSetAnalysis`, the `GROUP BY DISTINCT` flag, the per-output-column descriptors (name + type), and the aggregate `FunctionCall`s (collected via the existing `ExpressionTreeUtils.extractAggregateFunctions`).
- The planner builds the desugared plan in `QueryPlanner.planPivot`. It projects the aggregation inputs (aggregate arguments, aggregate `ORDER BY` sort keys, aggregate `FILTER` expressions, complex grouping expressions, pivot column references, pivot value expressions), coerces, then constructs a boolean predicate symbol per `(value group, aggregate)` as IR — the value group's `column = value` match (each comparison at the common supertype, with a `Cast` on whichever side is narrower), AND-ed with that aggregate's own `FILTER` when it has one. After `planGroupingSets`, it builds one `AggregationNode.Aggregation` per `(value group, aggregate call)` with `filter` set to the matching predicate symbol, all inside a single `AggregationNode`. The output projection translates each user-written slot expression through a per-group `TranslationMap` overlay, so the same `sum(x)` resolves to N different output symbols for N value groups.

`PIVOT` reuses every existing aggregation, `GROUP BY`, `FILTER`, and coercion plan-time rule without introducing a new operator.

The first two commits are pure refactors that decouple `analyzeGroupBy` and `planGroupingSets` from `QuerySpecification` so `PIVOT` can reuse them. Neither changes behavior for the `QuerySpecification` path.

## Test plan

- [x] New `TestPivot` (31 cases): with and without `GROUP BY`, multi-aggregation, multi-column keys, expression aggregations, aggregate `FILTER` and `ORDER BY` in a slot, expression and query-constant (`current_date`) `IN` values, value wider than the pivot column, `GROUPING SETS` / `CUBE` / `ROLLUP` / `GROUP BY ()`, `NULL` semantics, `pivot`-of-`pivot`, relation alias with column aliases — plus the error paths: tuple arity mismatch, missing aggregation alias, duplicate output column, slot without an aggregate, window function or grouping operation in a slot, `GROUP BY AUTO`, and an `IN` value that is an aggregate, references an input column, contains a subquery, or is non-deterministic.
- [x] New `TestSqlParser` case asserting the parsed AST for each grammar shape, plus `pivot` used as an identifier.
- [x] `TestSqlKeywords` and `TestSqlParserErrorHandling` updated for the new `PIVOT` keyword.
- [x] Existing `TestSqlFormatter`, `TestStatementBuilder`, `MATCH_RECOGNIZE` and aggregation tests continue to pass.
- [x] `mvnd verify` for the touched modules passes (compile, checkstyle, modernizer, error-prone).

## Documentation

- New `docs/src/main/sphinx/sql/pivot.md` reference page modelled after `match-recognize.md`.
- Toctree entry in `sql.md`, cross-reference from `select.md`, and listing in `language/sql-support.md`.
