### PR TITLE
Update org.apache.thrift/libthrift to 0.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2114,7 +2114,7 @@
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.22.0</version>
+                <version>0.23.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

- 0.23.0 fixed https://github.com/advisories/GHSA-7pwc-h2j2-rjgj

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
