### PR TITLE
Update Parquet to 1.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dep.okhttp.version>5.3.2</dep.okhttp.version>
         <dep.okio.version>3.17.0</dep.okio.version>
         <dep.netty.version>4.2.12.Final</dep.netty.version>
-        <dep.parquet.version>1.17.0</dep.parquet.version>
+        <dep.parquet.version>1.17.1</dep.parquet.version>
         <dep.protobuf.version>4.34.1</dep.protobuf.version>
         <dep.swagger.version>2.2.49</dep.swagger.version>
         <dep.takari.version>2.3.3</dep.takari.version>
@@ -2364,6 +2364,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>parquet-release-candidate</id>
+            <name>Parquet Release Candidate</name>
+            <url>https://repository.apache.org/content/groups/staging/</url>
+        </repository>
+    </repositories>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
