### PR TITLE
Disable broken tests in Sheets connector

### DIFF
--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheets.java
@@ -31,6 +31,7 @@ import io.airlift.units.Duration;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
@@ -45,6 +46,7 @@ import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Disabled // TODO https://github.com/trinodb/trino/issues/29407 Fix 'Invalid JWT Signature' failure
 public class TestGoogleSheets
         extends AbstractTestQueryFramework
 {

--- a/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheetsWithoutMetadataSheetId.java
+++ b/plugin/trino-google-sheets/src/test/java/io/trino/plugin/google/sheets/TestGoogleSheetsWithoutMetadataSheetId.java
@@ -15,6 +15,7 @@ package io.trino.plugin.google.sheets;
 
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.google.sheets.TestSheetsPlugin.DATA_SHEET_ID;
@@ -32,6 +33,7 @@ public class TestGoogleSheetsWithoutMetadataSheetId
     }
 
     @Test
+    @Disabled // TODO https://github.com/trinodb/trino/issues/29407 Fix 'Invalid JWT Signature' failure
     public void testSheetQuerySimple()
     {
         assertQuery(


### PR DESCRIPTION
## Description

These two tests are consistently failing now:

- https://github.com/trinodb/trino/issues/29407

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
