### PR TITLE
Remove unused equality methods from PagesHashStrategy

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesHashStrategy.java
@@ -47,24 +47,9 @@ public interface PagesHashStrategy
     /**
      * Compares the values in the specified pages. The values are compared positionally, so {@code leftPage}
      * and {@code rightPage} must have the same number of entries as the hashed columns and each entry
-     * is expected to be the same type.
-     */
-    boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage);
-
-    /**
-     * Compares the values in the specified pages. The values are compared positionally, so {@code leftPage}
-     * and {@code rightPage} must have the same number of entries as the hashed columns and each entry
      * is expected to be the same type. The values are compared under "not distinct from" semantics.
      */
     boolean rowIdenticalToRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage);
-
-    /**
-     * Compares the hashed columns in this PagesHashStrategy to the values in the specified page. The
-     * values are compared positionally, so {@code rightPage} must have the same number of entries as
-     * the hashed columns and each entry is expected to be the same type.
-     * {@code rightPage} is used if join uses filter function and must contain all columns from probe side of join.
-     */
-    boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage);
 
     /**
      * Compares the hashed columns in this PagesHashStrategy to the values in the specified page. The
@@ -92,11 +77,6 @@ public interface PagesHashStrategy
      * and each entry is expected to be the same type.
      */
     boolean positionIdenticalToRow(int leftBlockIndex, int leftPosition, int rightPosition, Page page, int[] rightChannels);
-
-    /**
-     * Compares the hashed columns in this PagesHashStrategy at the specified positions.
-     */
-    boolean positionEqualsPosition(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition);
 
     /**
      * Compares the hashed columns in this PagesHashStrategy at the specified positions.

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
@@ -139,38 +139,12 @@ public class SimplePagesHashStrategy
     }
 
     @Override
-    public boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
-    {
-        for (int i = 0; i < hashChannels.length; i++) {
-            Block leftBlock = leftPage.getBlock(i);
-            Block rightBlock = rightPage.getBlock(i);
-            if (!equalOperators[i].equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
     public boolean rowIdenticalToRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
     {
         for (int i = 0; i < hashChannels.length; i++) {
             Block leftBlock = leftPage.getBlock(i);
             Block rightBlock = rightPage.getBlock(i);
             if (!identicalOperators[i].isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage)
-    {
-        for (int i = 0; i < hashChannels.length; i++) {
-            Block leftBlock = channels.get(hashChannels[i]).get(leftBlockIndex);
-            Block rightBlock = rightPage.getBlock(i);
-            if (!equalOperators[i].equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
         }
@@ -213,20 +187,6 @@ public class SimplePagesHashStrategy
             Block rightBlock = page.getBlock(rightChannels[i]);
             BlockPositionIsIdentical identical = identicalOperators[i];
             if (!identical.isIdentical(leftBlock, leftPosition, rightBlock, rightPosition)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean positionEqualsPosition(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition)
-    {
-        for (int i = 0; i < hashChannels.length; i++) {
-            List<Block> channel = channels.get(hashChannels[i]);
-            Block leftBlock = channel.get(leftBlockIndex);
-            Block rightBlock = channel.get(rightBlockIndex);
-            if (!equalOperators[i].equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
         }
@@ -301,16 +261,5 @@ public class SimplePagesHashStrategy
     private int getSortChannel()
     {
         return sortChannel.getAsInt();
-    }
-
-    private static Type[] toTypesArray(List<Type> types)
-    {
-        Type[] array = types.toArray(Type[]::new);
-        for (Type type : array) {
-            if (type == null) {
-                throw new IllegalArgumentException("types contains null element");
-            }
-        }
-        return array;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -241,14 +241,11 @@ public class JoinCompiler
         generateAppendToMethod(classDefinition, outputChannels, channelFields);
         generateHashPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generateHashRowMethod(classDefinition, callSiteBinder, joinChannelTypes);
-        generateRowEqualsRowMethod(classDefinition, callSiteBinder, joinChannelTypes);
         generateRowIdenticalToRowMethod(classDefinition, callSiteBinder, joinChannelTypes);
         generatePositionEqualsRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields, true);
-        generatePositionEqualsRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields, false);
         generatePositionIdenticalRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionIdenticalToRowWithPageMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionEqualsPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields, true);
-        generatePositionEqualsPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields, false);
         generatePositionIdenticalToPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generateIsPositionNull(classDefinition, joinChannelFields);
         generateCompareSortChannelPositionsMethod(classDefinition, callSiteBinder, types, channelFields, sortChannel);
@@ -464,53 +461,6 @@ public class JoinCompiler
                 .condition(blockRef.invoke("isNull", boolean.class, blockPosition))
                 .ifTrue(constantLong(0L))
                 .ifFalse(invokeDynamic(BOOTSTRAP_METHOD, ImmutableList.of(callSiteBinder.bind(hashCodeOperator).getBindingId()), "hash", hashCodeOperator.type(), blockRef, blockPosition));
-    }
-
-    private void generateRowEqualsRowMethod(
-            ClassDefinition classDefinition,
-            CallSiteBinder callSiteBinder,
-            List<Type> joinChannelTypes)
-    {
-        Parameter leftPosition = arg("leftPosition", int.class);
-        Parameter leftPage = arg("leftPage", Page.class);
-        Parameter rightPosition = arg("rightPosition", int.class);
-        Parameter rightPage = arg("rightPage", Page.class);
-        MethodDefinition rowEqualsRowMethod = classDefinition.declareMethod(
-                a(PUBLIC),
-                "rowEqualsRow",
-                type(boolean.class),
-                leftPosition,
-                leftPage,
-                rightPosition,
-                rightPage);
-
-        for (int index = 0; index < joinChannelTypes.size(); index++) {
-            Type type = joinChannelTypes.get(index);
-
-            BytecodeExpression leftBlock = leftPage.invoke("getBlock", Block.class, constantInt(index));
-
-            BytecodeExpression rightBlock = rightPage.invoke("getBlock", Block.class, constantInt(index));
-
-            LabelNode checkNextField = new LabelNode("checkNextField");
-            rowEqualsRowMethod
-                    .getBody()
-                    .append(typeEquals(
-                            callSiteBinder,
-                            type,
-                            leftBlock,
-                            leftPosition,
-                            rightBlock,
-                            rightPosition))
-                    .ifTrueGoto(checkNextField)
-                    .push(false)
-                    .retBoolean()
-                    .visitLabel(checkNextField);
-        }
-
-        rowEqualsRowMethod
-                .getBody()
-                .push(true)
-                .retInt();
     }
 
     private void generateRowIdenticalToRowMethod(

--- a/core/trino-main/src/test/java/io/trino/operator/TestSimplePagesHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestSimplePagesHashStrategy.java
@@ -62,49 +62,6 @@ public class TestSimplePagesHashStrategy
     }
 
     @Test
-    public void testRowEqualsRowWithIntegerType()
-    {
-        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(INTEGER, ImmutableList.of());
-
-        Page leftPage = new Page(new IntArrayBlock(1, Optional.empty(), new int[] {1234}));
-        Page rightPage1 = new Page(new IntArrayBlock(1, Optional.empty(), new int[] {1234}));
-        Page rightPage2 = new Page(new IntArrayBlock(1, Optional.empty(), new int[] {5678}));
-
-        // This works because IntegerType is comparable.
-        assertThat(strategy.rowEqualsRow(0, leftPage, 0, rightPage1)).isTrue();
-        assertThat(strategy.rowEqualsRow(0, leftPage, 0, rightPage2)).isFalse();
-    }
-
-    @Test
-    public void testRowEqualsRowWithMapType()
-    {
-        MapType mapType = new MapType(INTEGER, INTEGER, new TypeOperators());
-        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(mapType, ImmutableList.of());
-
-        Page leftPage = new Page(mapType.createBlockFromKeyValue(
-                Optional.empty(),
-                new int[] {0, 1},
-                new IntArrayBlock(1, Optional.empty(), new int[] {1234}),
-                new IntArrayBlock(1, Optional.empty(), new int[] {5678})));
-
-        Page rightPage1 = new Page(mapType.createBlockFromKeyValue(
-                Optional.empty(),
-                new int[] {0, 1},
-                new IntArrayBlock(1, Optional.empty(), new int[] {1234}),
-                new IntArrayBlock(1, Optional.empty(), new int[] {5678})));
-
-        Page rightPage2 = new Page(mapType.createBlockFromKeyValue(
-                Optional.empty(),
-                new int[] {0, 1},
-                new IntArrayBlock(1, Optional.empty(), new int[] {1234}),
-                new IntArrayBlock(1, Optional.empty(), new int[] {1234})));
-
-        // This works because MapType is comparable.
-        assertThat(strategy.rowEqualsRow(0, leftPage, 0, rightPage1)).isTrue();
-        assertThat(strategy.rowEqualsRow(0, leftPage, 0, rightPage2)).isFalse();
-    }
-
-    @Test
     public void testCompareSortChannelPositionsWithIntegerType()
     {
         Block block = new IntArrayBlock(3, Optional.empty(), new int[] {1234, 5678, 1234});

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
@@ -70,11 +70,8 @@ public class TestJoinCompiler
         assertThat(hashStrategy.hashRow(0, new Page(channel.get(0)))).isEqualTo(0L);
         assertThat(hashStrategy.hashPosition(0, 5)).isEqualTo(0L);
         assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(0, 5, 0, 5)).isTrue();
-        assertThat(hashStrategy.positionEqualsPosition(0, 5, 0, 5)).isTrue();
         assertThat(hashStrategy.positionIdenticalToPosition(0, 5, 0, 5)).isTrue();
-        assertThat(hashStrategy.positionEqualsRow(0, 5, 5, new Page(channel.get(0)))).isTrue();
         assertThat(hashStrategy.positionIdenticalToRow(0, 5, 5, new Page(channel.get(0)))).isTrue();
-        assertThat(hashStrategy.rowEqualsRow(5, new Page(channel.get(0)), 5, new Page(channel.get(0)))).isTrue();
         assertThat(hashStrategy.rowIdenticalToRow(5, new Page(channel.get(0)), 5, new Page(channel.get(0)))).isTrue();
         assertThat(hashStrategy.positionEqualsRowIgnoreNulls(0, 5, 5, new Page(channel.get(0)))).isTrue();
         assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(0, 5, 0, 5)).isTrue();
@@ -125,13 +122,10 @@ public class TestJoinCompiler
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         boolean expected = equalOperator.equalNullSafe(leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
                         boolean expectedIdentical = identicalOperator.isIdentical(leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-                        assertThat(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock))).isEqualTo(expected);
                         assertThat(hashStrategy.positionIdenticalToRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock))).isEqualTo(expectedIdentical);
-                        assertThat(hashStrategy.rowEqualsRow(leftBlockPosition, new Page(leftBlock), rightBlockPosition, new Page(rightBlock))).isEqualTo(expected);
                         assertThat(hashStrategy.rowIdenticalToRow(leftBlockPosition, new Page(leftBlock), rightBlockPosition, new Page(rightBlock))).isEqualTo(expectedIdentical);
                         assertThat(hashStrategy.positionEqualsRowIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock))).isEqualTo(expected);
                         assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expected);
-                        assertThat(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expected);
                         assertThat(hashStrategy.positionIdenticalToPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expectedIdentical);
                     }
                 }
@@ -142,13 +136,10 @@ public class TestJoinCompiler
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         boolean expected = equalOperator.equalNullSafe(leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
                         boolean expectedIdentical = identicalOperator.isIdentical(leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-                        assertThat(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock))).isEqualTo(expected);
                         assertThat(hashStrategy.positionIdenticalToRow(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock))).isEqualTo(expectedIdentical);
-                        assertThat(hashStrategy.rowEqualsRow(leftBlockPosition, new Page(leftBlock), rightBlockPosition, new Page(rightBlock))).isEqualTo(expected);
                         assertThat(hashStrategy.rowIdenticalToRow(leftBlockPosition, new Page(leftBlock), rightBlockPosition, new Page(rightBlock))).isEqualTo(expectedIdentical);
                         assertThat(hashStrategy.positionEqualsRowIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockPosition, new Page(rightBlock))).isEqualTo(expected);
                         assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expected);
-                        assertThat(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expected);
                         assertThat(hashStrategy.positionIdenticalToPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expectedIdentical);
                     }
                 }
@@ -233,7 +224,6 @@ public class TestJoinCompiler
 
                 // position must be equal to itself
                 assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(leftBlockIndex, leftBlockPosition, leftBlockIndex, leftBlockPosition)).isTrue();
-                assertThat(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, leftBlockIndex, leftBlockPosition)).isTrue();
                 assertThat(hashStrategy.positionIdenticalToPosition(leftBlockIndex, leftBlockPosition, leftBlockIndex, leftBlockPosition)).isTrue();
 
                 // check equality of every position against every other position in the block
@@ -241,7 +231,6 @@ public class TestJoinCompiler
                     Block rightBlock = varcharChannel.get(rightBlockIndex);
                     for (int rightBlockPosition = 0; rightBlockPosition < rightBlock.getPositionCount(); rightBlockPosition++) {
                         assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expectedHashStrategy.positionEqualsPositionIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition));
-                        assertThat(hashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expectedHashStrategy.positionEqualsPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition));
                         assertThat(hashStrategy.positionIdenticalToPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition)).isEqualTo(expectedHashStrategy.positionIdenticalToPosition(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition));
                     }
                 }
@@ -256,12 +245,10 @@ public class TestJoinCompiler
 
                     int rightPositionCount = varcharChannel.get(rightBlockIndex).getPositionCount();
                     for (int rightPosition = 0; rightPosition < rightPositionCount; rightPosition++) {
-                        boolean expected = expectedHashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks));
+                        boolean expected = expectedHashStrategy.positionEqualsRowIgnoreNulls(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks));
                         boolean expectedIdentical = expectedHashStrategy.positionIdenticalToRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks));
 
-                        assertThat(hashStrategy.positionEqualsRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks))).isEqualTo(expected);
                         assertThat(hashStrategy.positionIdenticalToRow(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks))).isEqualTo(expectedIdentical);
-                        assertThat(hashStrategy.rowEqualsRow(leftBlockPosition, new Page(leftBlocks), rightPosition, new Page(rightBlocks))).isEqualTo(expected);
                         assertThat(hashStrategy.rowIdenticalToRow(leftBlockPosition, new Page(leftBlocks), rightPosition, new Page(rightBlocks))).isEqualTo(expectedIdentical);
                         assertThat(hashStrategy.positionEqualsRowIgnoreNulls(leftBlockIndex, leftBlockPosition, rightPosition, new Page(rightBlocks))).isEqualTo(expected);
                     }


### PR DESCRIPTION
## Description

Removes `rowEqualsRow`, `positionEqualsRow`, and `positionEqualsPosition` from `PagesHashStrategy`. These null-safe equality methods are never called in production — joins use only the `IgnoreNulls` variants. Also removes the unreachable `toTypesArray` helper in `SimplePagesHashStrategy`.

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```