### PR TITLE
Fix infinite loop in RemoveRedundantPredicateAboveTableScan

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
@@ -126,8 +126,11 @@ public class RemoveRedundantPredicateAboveTableScan
             return predicateColumnDomain.intersect(enforcedColumnDomain);
         });
 
-        if (unenforcedDomain.equals(predicateDomain)) {
-            // no change in filter predicate
+        if (isEquivalent(unenforcedDomain, predicateDomain)) {
+            // no change in filter predicate. Use value-based equivalence rather than equals because
+            // SortedRangeSet represents `[3,4]` and `{[3], [4]}` differently for discrete types
+            // even though they accept the same values, and a structural compare would trigger
+            // an infinite rule loop (see issue #23147).
             return Result.empty();
         }
 
@@ -160,5 +163,18 @@ public class RemoveRedundantPredicateAboveTableScan
                         extractedPredicates.getOrDefault(FALSE, ImmutableList.of()).stream()
                                 .map(ExtractionResult::getRemainingExpression)
                                 .collect(toImmutableList())));
+    }
+
+    /**
+     * Value-based equivalence of two TupleDomains: true if they accept the same set of tuples.
+     * Equivalent to {@code a.contains(b) && b.contains(a)}. Cheaper to check than the bidirectional
+     * containment when both sides are structurally equal, hence the {@code equals} fast-path.
+     */
+    private static boolean isEquivalent(TupleDomain<ColumnHandle> a, TupleDomain<ColumnHandle> b)
+    {
+        if (a.equals(b)) {
+            return true;
+        }
+        return a.contains(b) && b.contains(a);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantPredicateAboveTableScan.java
@@ -203,6 +203,28 @@ public class TestRemoveRedundantPredicateAboveTableScan
     }
 
     @Test
+    public void doesNotFireWhenUnenforcedDomainIsEquivalentToPredicateDomain()
+    {
+        // Predicate is `nationkey BETWEEN 0 AND 2` (one range [0,2]). The connector enforces a
+        // strict superset {0, 1, 2, 3}. The intersect of predicate ∩ enforced is {0, 1, 2}, which
+        // is structurally different from the predicate range [0, 2] but accepts the same bigint
+        // values. The rule must recognize the equivalence and bail; otherwise rewriting the filter
+        // back to discrete values would let SimplifyContinuousInValues rewrite it to BETWEEN
+        // again, looping indefinitely (issue #23147).
+        ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
+        tester().assertThat(removeRedundantPredicateAboveTableScan)
+                .on(p -> p.filter(
+                        new Between(new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 0L), new Constant(BIGINT, 2L)),
+                        p.tableScan(
+                                nationTableHandle,
+                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                ImmutableMap.of(p.symbol("nationkey", BIGINT), columnHandle),
+                                TupleDomain.withColumnDomains(ImmutableMap.of(
+                                        columnHandle, Domain.multipleValues(BIGINT, ImmutableList.of(0L, 1L, 2L, 3L)))))))
+                .doesNotFire();
+    }
+
+    @Test
     public void doesNotFireOnNonDeterministicPredicate()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -1170,6 +1170,25 @@ public final class SortedRangeSet
                 }
                 thisRangeView = this.getRangeView(thisRangeIndex);
             }
+            if (thisRangeView.contains(thatRangeView)) {
+                continue;
+            }
+            // For discrete types (e.g. bigint, date), `{[3,3], [4,4]}` semantically equals `[3,4]`
+            // even though SortedRangeSet keeps them as separate ranges. Try to coalesce consecutive
+            // value-adjacent ranges in `this` to cover `thatRangeView`. Only entered when the cheap
+            // structural check fails, so the common case pays no extra cost.
+            while (thisRangeIndex + 1 < thisRangeCount) {
+                RangeView next = this.getRangeView(thisRangeIndex + 1);
+                Optional<RangeView> coalesced = thisRangeView.tryCoalesceValueAdjacent(next);
+                if (coalesced.isEmpty()) {
+                    return false;
+                }
+                thisRangeView = coalesced.get();
+                thisRangeIndex++;
+                if (thisRangeView.contains(thatRangeView)) {
+                    break;
+                }
+            }
             if (!thisRangeView.contains(thatRangeView)) {
                 // thisRange partially overlaps with thatRange, or it's fully after thatRange
                 return false;
@@ -1662,6 +1681,47 @@ public final class SortedRangeSet
             }
 
             return Optional.empty();
+        }
+
+        /**
+         * Returns a merged range covering {@code this} and {@code next} when they are adjacent in
+         * the type's value space (i.e. {@code Type#getNextValue(this.high) == next.low}). For
+         * example, on {@code bigint} ranges {@code [3,3]} and {@code [4,4]} are value-adjacent and
+         * coalesce to {@code [3,4]}, even though their bounds do not touch structurally.
+         *
+         * <p>Only handles the case where {@code this.high} and {@code next.low} are inclusive: that
+         * matches the canonical representation used for discrete value sets (e.g. {@code IN} lists
+         * extracted to a domain) which are the practically relevant inputs.
+         */
+        private Optional<RangeView> tryCoalesceValueAdjacent(RangeView next)
+        {
+            if (!this.highInclusive || !next.lowInclusive) {
+                return Optional.empty();
+            }
+            if (this.isHighUnbounded() || next.isLowUnbounded()) {
+                return Optional.empty();
+            }
+            Object highValue = readNativeValue(type, this.highValueBlock, this.highValuePosition);
+            Optional<Object> nextOfHigh = type.getNextValue(highValue);
+            if (nextOfHigh.isEmpty()) {
+                return Optional.empty();
+            }
+            BlockBuilder builder = type.createBlockBuilder(null, 1);
+            writeNativeValue(type, builder, nextOfHigh.get());
+            Block nextOfHighBlock = builder.build();
+            if (compareValues(comparisonOperator, nextOfHighBlock, 0, next.lowValueBlock, next.lowValuePosition) != 0) {
+                return Optional.empty();
+            }
+            return Optional.of(new RangeView(
+                    this.type,
+                    this.comparisonOperator,
+                    this.rangeComparisonOperator,
+                    this.lowInclusive,
+                    this.lowValueBlock,
+                    this.lowValuePosition,
+                    next.highInclusive,
+                    next.highValueBlock,
+                    next.highValuePosition));
         }
 
         public boolean isLowUnbounded()

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -386,6 +386,39 @@ class TestSortedRangeSet
                 SortedRangeSet.of(Range.equal(BIGINT, 4L), Range.equal(BIGINT, 6L), Range.equal(BIGINT, 9L)))).isTrue();
         assertThat(SortedRangeSet.of(rangeA, rangeB, rangeC).contains(
                 SortedRangeSet.of(Range.equal(BIGINT, 1L), Range.range(BIGINT, 6L, true, 10L, true)))).isFalse();
+
+        // Discrete value-adjacent ranges should compare equivalent to the spanning range for
+        // discrete types (i.e. types with Type.getNextValue defined).
+        // {[3], [4]} contains [3, 4] over bigint because the two singletons together cover the
+        // whole integer range [3, 4].
+        assertThat(SortedRangeSet.of(Range.equal(BIGINT, 3L), Range.equal(BIGINT, 4L))
+                .contains(SortedRangeSet.of(Range.range(BIGINT, 3L, true, 4L, true)))).isTrue();
+        // Three-singleton coalescing: {[3], [4], [5]} contains [3, 5]
+        assertThat(SortedRangeSet.of(Range.equal(BIGINT, 3L), Range.equal(BIGINT, 4L), Range.equal(BIGINT, 5L))
+                .contains(SortedRangeSet.of(Range.range(BIGINT, 3L, true, 5L, true)))).isTrue();
+        // Gap breaks coalescing: {[3], [5]} does not contain [3, 5] (4 is missing)
+        assertThat(SortedRangeSet.of(Range.equal(BIGINT, 3L), Range.equal(BIGINT, 5L))
+                .contains(SortedRangeSet.of(Range.range(BIGINT, 3L, true, 5L, true)))).isFalse();
+        // Partial cover: {[3], [4]} does not contain [3, 5]
+        assertThat(SortedRangeSet.of(Range.equal(BIGINT, 3L), Range.equal(BIGINT, 4L))
+                .contains(SortedRangeSet.of(Range.range(BIGINT, 3L, true, 5L, true)))).isFalse();
+        // Continuous types have no nextValue: {[3.0], [4.0]} does NOT contain [3.0, 4.0] over double
+        assertThat(SortedRangeSet.of(Range.equal(DOUBLE, 3.0), Range.equal(DOUBLE, 4.0))
+                .contains(SortedRangeSet.of(Range.range(DOUBLE, 3.0, true, 4.0, true)))).isFalse();
+        // Coalescing must not change reverse direction: [3, 4] still contains {[3], [4]}.
+        assertThat(SortedRangeSet.of(Range.range(BIGINT, 3L, true, 4L, true))
+                .contains(SortedRangeSet.of(Range.equal(BIGINT, 3L), Range.equal(BIGINT, 4L)))).isTrue();
+        // Coalescing combined with span: {[3], [4], [10]} contains {[3, 4], [10]}
+        assertThat(SortedRangeSet.of(Range.equal(BIGINT, 3L), Range.equal(BIGINT, 4L), Range.equal(BIGINT, 10L))
+                .contains(SortedRangeSet.of(Range.range(BIGINT, 3L, true, 4L, true), Range.equal(BIGINT, 10L)))).isTrue();
+        // Edge of representable range: getNextValue near MAX_VALUE
+        assertThat(SortedRangeSet.of(Range.equal(BIGINT, Long.MAX_VALUE - 1), Range.equal(BIGINT, Long.MAX_VALUE))
+                .contains(SortedRangeSet.of(Range.range(BIGINT, Long.MAX_VALUE - 1, true, Long.MAX_VALUE, true)))).isTrue();
+        // Across types: tinyint and integer behave the same
+        assertThat(SortedRangeSet.of(Range.equal(INTEGER, 3L), Range.equal(INTEGER, 4L))
+                .contains(SortedRangeSet.of(Range.range(INTEGER, 3L, true, 4L, true)))).isTrue();
+        assertThat(SortedRangeSet.of(Range.equal(TINYINT, 3L), Range.equal(TINYINT, 4L))
+                .contains(SortedRangeSet.of(Range.range(TINYINT, 3L, true, 4L, true)))).isTrue();
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIssue23147.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIssue23147.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static io.trino.SystemSessionProperties.OPTIMIZE_METADATA_QUERIES;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestIssue23147
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder().build();
+    }
+
+    @Test
+    @Timeout(30)
+    public void testCastInOverPartitionedTable()
+    {
+        String tableName = "test_issue_23147_cast_in";
+        assertUpdate("CREATE TABLE %s(id int, part_key bigint) WITH (partitioning = ARRAY ['part_key'])".formatted(tableName));
+        try {
+            assertUpdate("""
+                    INSERT INTO %s
+                         VALUES
+                                 (1, 1),
+                                 (2, 3),
+                                 (3, 4),
+                                 (4, 5)
+                    """.formatted(tableName), 4);
+
+            Session session = testSessionBuilder(getSession())
+                    .setSystemProperty(OPTIMIZE_METADATA_QUERIES, "true")
+                    .build();
+            @Language("SQL") String query = """
+                    SELECT t0.*
+                    FROM (
+                            SELECT cast(part_key as varchar) part FROM %s
+                            WHERE part_key IN (SELECT part_key FROM %s)
+                    ) t0
+                    WHERE t0.part IN ('3', '4')
+                    """.formatted(tableName, tableName);
+            assertQuery(session, query, "VALUES ('3'), ('4')");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testInOverContinuousPartitionValues()
+    {
+        // Mirrors the SQL from issue #23147 as originally reported: an IN expression that
+        // SimplifyContinuousInValues rewrites to a BETWEEN, layered with partition pruning that
+        // enforces the partition keys as discrete singletons. Without value-aware domain
+        // equivalence in RemoveRedundantPredicateAboveTableScan, the planner loops forever.
+        String tableA = "test_issue_23147_a";
+        String tableB = "test_issue_23147_b";
+        assertUpdate("CREATE TABLE %s(stat_month bigint) WITH (partitioning = ARRAY ['stat_month'])".formatted(tableA));
+        assertUpdate("CREATE TABLE %s(stat_month bigint) WITH (partitioning = ARRAY ['stat_month'])".formatted(tableB));
+        try {
+            assertUpdate("INSERT INTO %s VALUES 202403, 202404".formatted(tableA), 2);
+            assertUpdate("INSERT INTO %s VALUES 202403, 202404, 202405".formatted(tableB), 3);
+
+            Session session = testSessionBuilder(getSession())
+                    .setSystemProperty(OPTIMIZE_METADATA_QUERIES, "true")
+                    .build();
+            @Language("SQL") String query = """
+                    SELECT t0.*
+                    FROM (
+                            SELECT stat_month
+                            FROM %s
+                            WHERE stat_month IN (SELECT stat_month FROM %s)
+                            UNION ALL
+                            SELECT stat_month FROM %s
+                    ) t0
+                    WHERE t0.stat_month IN (202403, 202404)
+                    """.formatted(tableA, tableA, tableB);
+            assertQuery(session, query, "VALUES (202403), (202404), (202403), (202404)");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableA);
+            assertUpdate("DROP TABLE " + tableB);
+        }
+    }
+}


### PR DESCRIPTION
## Description

`SimplifyContinuousInValues` rewrites `IN` over consecutive integers
into `BETWEEN`. The connector still enforces partition keys as discrete
singletons, so `unenforcedDomain` in `RemoveRedundantPredicateAboveTableScan`
ended up structurally different from the predicate domain even when the
two accept the same values. The previous `equals` check then emitted a
new `FilterNode` that `SimplifyContinuousInValues` rewrote back to
`BETWEEN`, looping until the optimizer time limit.

Fix in two parts:

1. `SortedRangeSet.contains` coalesces value-adjacent ranges via
   `Type.getNextValue` when the structural check fails. Fast path
   unchanged.
2. `RemoveRedundantPredicateAboveTableScan` replaces `equals` with
   bidirectional containment.

## Additional context and related issues

Fixes #23147. Replaces #23235, which worked around one reproduction
via an IR-level `UnwrapInCast` rule but did not address the underlying
domain-comparison issue.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix infinite loop in query planning on partitioned tables. ({issue}`23147`)
```