### PR TITLE
Use TrinoException for unsupported Iceberg types in TypeConverter

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TypeConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TypeConverter.java
@@ -100,7 +100,7 @@ public final class TypeConverter
             }
             case VARIANT -> VARIANT;
             case GEOMETRY, GEOGRAPHY,
-                 UNKNOWN -> throw new UnsupportedOperationException(format("Cannot convert from Iceberg type '%s' (%s) to Trino type", type, type.typeId()));
+                 UNKNOWN -> throw new TrinoException(NOT_SUPPORTED, format("Cannot convert from Iceberg type '%s' (%s) to Trino type", type, type.typeId()));
         };
     }
 


### PR DESCRIPTION
## Description

Replace `UnsupportedOperationException` with `TrinoException(NOT_SUPPORTED)` for `GEOMETRY`, `GEOGRAPHY`, and `UNKNOWN` Iceberg types in `TypeConverter`, consistent with all other unsupported-type throws in the same class.

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.