### PR TITLE
Add azure.max-error-retries configuration property for Azure file system

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-azure.md
+++ b/docs/src/main/sphinx/object-storage/file-system-azure.md
@@ -59,6 +59,9 @@ system support:
     for all requests sent to Azure Storage. Defaults to `Trino`. 
 * - `azure.multipart-write-enabled`
   - Enable multipart writes for large files. Defaults to `false`. 
+* - `azure.max-error-retries`
+  - Maximum [integer](prop-type-integer) number of retries for transient Azure
+    HTTP request failures using exponential backoff. Defaults to `4`. 
 :::
 
 (azure-user-assigned-managed-identity-authentication)=

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -27,6 +27,8 @@ import com.azure.storage.blob.models.UserDelegationKey;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.blob.specialized.BlockBlobClient;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.common.policy.RetryPolicyType;
 import com.azure.storage.common.sas.SasProtocol;
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
@@ -94,6 +96,7 @@ public class AzureFileSystem
     private final int maxWriteConcurrency;
     private final long maxSingleUploadSizeBytes;
     private final boolean multipartWriteEnabled;
+    private final int maxErrorRetries;
 
     public AzureFileSystem(
             HttpClient httpClient,
@@ -106,7 +109,8 @@ public class AzureFileSystem
             DataSize writeBlockSize,
             int maxWriteConcurrency,
             DataSize maxSingleUploadSize,
-            boolean multipartWriteEnabled)
+            boolean multipartWriteEnabled,
+            int maxErrorRetries)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.concurrencyPolicy = requireNonNull(concurrencyPolicy, "concurrencyPolicy is null");
@@ -120,6 +124,7 @@ public class AzureFileSystem
         this.maxWriteConcurrency = maxWriteConcurrency;
         this.maxSingleUploadSizeBytes = maxSingleUploadSize.toBytes();
         this.multipartWriteEnabled = multipartWriteEnabled;
+        this.maxErrorRetries = maxErrorRetries;
     }
 
     @Override
@@ -684,6 +689,7 @@ public class AzureFileSystem
         BlobContainerClientBuilder builder = new BlobContainerClientBuilder()
                 .httpClient(httpClient)
                 .addPolicy(concurrencyPolicy)
+                .retryOptions(new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, maxErrorRetries, (Integer) null, null, null, null))
                 .clientOptions(new ClientOptions().setTracingOptions(tracingOptions))
                 .endpoint("https://%s.blob.%s".formatted(location.account(), validatedEndpoint(location)));
 
@@ -701,6 +707,7 @@ public class AzureFileSystem
         DataLakeServiceClientBuilder builder = new DataLakeServiceClientBuilder()
                 .httpClient(httpClient)
                 .addPolicy(concurrencyPolicy)
+                .retryOptions(new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, maxErrorRetries, (Integer) null, null, null, null))
                 .clientOptions(new ClientOptions().setTracingOptions(tracingOptions))
                 .endpoint("https://%s.dfs.%s".formatted(location.account(), validatedEndpoint(location)));
         key.ifPresent(encryption -> builder.customerProvidedKey(lakeCustomerProvidedKey(encryption)));

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -52,6 +52,7 @@ public class AzureFileSystemConfig
     private Duration httpRequestTimeout = new Duration(10, TimeUnit.MINUTES);
     private String applicationId = "Trino";
     private boolean multipartWriteEnabled;
+    private int maxErrorRetries = 4;
 
     @NotNull
     public AuthType getAuthType()
@@ -212,6 +213,20 @@ public class AzureFileSystemConfig
     public AzureFileSystemConfig setMultipartWriteEnabled(boolean multipartWriteEnabled)
     {
         this.multipartWriteEnabled = multipartWriteEnabled;
+        return this;
+    }
+
+    @Min(0)
+    public int getMaxErrorRetries()
+    {
+        return maxErrorRetries;
+    }
+
+    @Config("azure.max-error-retries")
+    @ConfigDescription("Maximum number of retries for transient Azure HTTP request failures")
+    public AzureFileSystemConfig setMaxErrorRetries(int maxErrorRetries)
+    {
+        this.maxErrorRetries = maxErrorRetries;
         return this;
     }
 }

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -61,6 +61,7 @@ public class AzureFileSystemFactory
     private final EventLoopGroup eventLoopGroup;
     private final boolean multipart;
     private final HttpPipelinePolicy concurrencyPolicy;
+    private final int maxErrorRetries;
 
     @Inject
     public AzureFileSystemFactory(OpenTelemetry openTelemetry, AzureAuth azureAuth, AzureFileSystemConfig config)
@@ -77,7 +78,8 @@ public class AzureFileSystemFactory
                 config.getConnectionPoolMaxIdleTime(),
                 config.getHttpRequestTimeout(),
                 config.getApplicationId(),
-                config.isMultipartWriteEnabled());
+                config.isMultipartWriteEnabled(),
+                config.getMaxErrorRetries());
     }
 
     public AzureFileSystemFactory(
@@ -93,7 +95,8 @@ public class AzureFileSystemFactory
             Duration connectionPoolMaxIdleTime,
             Duration httpRequestTimeout,
             String applicationId,
-            boolean multipart)
+            boolean multipart,
+            int maxErrorRetries)
     {
         this.auth = requireNonNull(azureAuth, "azureAuth is null");
         this.endpoint = requireNonNull(endpoint, "endpoint is null");
@@ -116,6 +119,7 @@ public class AzureFileSystemFactory
         clientOptions.setMaximumConnectionPoolSize(maxHttpConnections);
         httpClient = createAzureHttpClient(connectionProvider, eventLoopGroup, clientOptions);
         this.multipart = multipart;
+        this.maxErrorRetries = maxErrorRetries;
         this.concurrencyPolicy = new ConcurrencyLimitHttpPipelinePolicy(
                 maxHttpRequests,
                 httpRequestTimeout.toJavaTime());
@@ -147,7 +151,7 @@ public class AzureFileSystemFactory
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
         AzureAuth effectiveAuth = getEffectiveAuth(identity);
-        return new AzureFileSystem(httpClient, concurrencyPolicy, uploadExecutor, tracingOptions, effectiveAuth, endpoint, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize, multipart);
+        return new AzureFileSystem(httpClient, concurrencyPolicy, uploadExecutor, tracingOptions, effectiveAuth, endpoint, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize, multipart, maxErrorRetries);
     }
 
     private AzureAuth getEffectiveAuth(ConnectorIdentity identity)

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -45,7 +45,8 @@ class TestAzureFileSystemConfig
                 .setConnectionPoolMaxIdleTime(new Duration(5, MINUTES))
                 .setHttpRequestTimeout(new Duration(10, MINUTES))
                 .setApplicationId("Trino")
-                .setMultipartWriteEnabled(false));
+                .setMultipartWriteEnabled(false)
+                .setMaxErrorRetries(4));
     }
 
     @Test
@@ -64,6 +65,7 @@ class TestAzureFileSystemConfig
                 .put("azure.http-request-timeout", "1m")
                 .put("azure.application-id", "application id")
                 .put("azure.multipart-write-enabled", "true")
+                .put("azure.max-error-retries", "10")
                 .buildOrThrow();
 
         AzureFileSystemConfig expected = new AzureFileSystemConfig()
@@ -78,7 +80,8 @@ class TestAzureFileSystemConfig
                 .setConnectionPoolMaxIdleTime(new Duration(1, MINUTES))
                 .setHttpRequestTimeout(new Duration(1, MINUTES))
                 .setApplicationId("application id")
-                .setMultipartWriteEnabled(true);
+                .setMultipartWriteEnabled(true)
+                .setMaxErrorRetries(10);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Adds `azure.max-error-retries` configuration property to the Azure filesystem connector. Wires `RequestRetryOptions` with exponential backoff into both `BlobContainerClientBuilder` and `DataLakeServiceClientBuilder`. Defaults to `4`, which matches the Azure SDK built-in default - so existing behavior is unchanged unless the property is explicitly set.                      
                                                                                                                                                                                                                 
The exchange filesystem connector (`trino-exchange-filesystem`) already uses this pattern via `ExchangeAzureConfig.getMaxErrorRetries()`; this PR aligns the main filesystem connector with the same approach.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The Azure SDK adds a default `RequestRetryPolicy` to all clients, but it is not configurable through the filesystem connector today. Operators encountering transient Azure errors (connection resets, rate limiting) have no knob to increase retry attempts without patching the connector.

This was observed in production under high ADLS concurrency, where transient connection failures increased. Following the connection pool improvements in #29284, configurable retries provide an additional layer of resilience for operators hitting transient Azure errors under load.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake, Iceberg
* Add `azure.max-error-retries` configuration property to configure the number of retries for Azure HTTP request failures.
```
