### PR TITLE
Skip redundant CI on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
   merge_group:
   repository_dispatch:


### PR DESCRIPTION
## Description

The CI is run before merge using a merge queue.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
