### PR TITLE
Add function ROW::fields(data)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -323,6 +323,7 @@ import static io.trino.operator.scalar.MapZipWithFunction.MAP_ZIP_WITH_FUNCTION;
 import static io.trino.operator.scalar.MathFunctions.DECIMAL_MOD_FUNCTION;
 import static io.trino.operator.scalar.Re2JCastToRegexpFunction.castCharToRe2JRegexp;
 import static io.trino.operator.scalar.Re2JCastToRegexpFunction.castVarcharToRe2JRegexp;
+import static io.trino.operator.scalar.RowFieldsFunction.ROW_FIELDS_FUNCTION;
 import static io.trino.operator.scalar.RowToJsonCast.ROW_TO_JSON;
 import static io.trino.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
 import static io.trino.operator.scalar.RowToVariantCast.ROW_TO_VARIANT;
@@ -625,6 +626,7 @@ public final class SystemFunctionBundle
                 .functions(MAP_FILTER_FUNCTION, new MapTransformKeysFunction(blockTypeOperators), MAP_TRANSFORM_VALUES_FUNCTION)
                 .function(FORMAT_FUNCTION)
                 .function(TRY_CAST)
+                .function(ROW_FIELDS_FUNCTION)
                 .function(new GenericReadValueOperator(typeOperators))
                 .function(new GenericEqualOperator(typeOperators))
                 .function(new GenericHashCodeOperator(typeOperators))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowFieldsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowFieldsFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.SqlRow;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.Signature;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.StandardTypes;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.type.TypeTemplates.arrayType;
+import static io.trino.spi.type.TypeTemplates.type;
+import static io.trino.spi.type.TypeTemplates.typeVariable;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.util.Reflection.methodHandle;
+
+public final class RowFieldsFunction
+        extends SqlScalarFunction
+{
+    public static final String NAME = "fields";
+
+    public static final RowFieldsFunction ROW_FIELDS_FUNCTION = new RowFieldsFunction();
+
+    private static final MethodHandle METHOD_HANDLE = methodHandle(RowFieldsFunction.class, "rowFields", RowType.class, SqlRow.class);
+
+    private RowFieldsFunction()
+    {
+        super(FunctionMetadata.scalarBuilder(NAME)
+                .signature(Signature.builder()
+                        .rowTypeParameter("T")
+                        .argumentType(typeVariable("T"))
+                        .returnType(arrayType(type(StandardTypes.VARCHAR)))
+                        .build())
+                .argumentNullability(true)
+                .description("Returns the field names of the row type.")
+                .receiverType(type("row"))
+                .neverFails()
+                .build());
+    }
+
+    @Override
+    public SpecializedSqlScalarFunction specialize(BoundSignature boundSignature, FunctionDependencies functionDependencies)
+    {
+        RowType rowType = (RowType) boundSignature.getArgumentType(0);
+        return new ChoicesSpecializedSqlScalarFunction(
+                boundSignature,
+                FAIL_ON_NULL,
+                ImmutableList.of(BOXED_NULLABLE),
+                METHOD_HANDLE.bindTo(rowType));
+    }
+
+    @UsedByGeneratedCode
+    public static Block rowFields(RowType rowType, SqlRow row)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, fields.size());
+        fields.forEach(field -> field.getName().map(Slices::utf8Slice)
+                .ifPresentOrElse(slice -> VARCHAR.writeSlice(builder, slice), builder::appendNull));
+        return builder.build();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestRowFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestRowFunctions.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.ArrayType;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Arrays;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestRowFunctions
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testFields()
+    {
+        assertThat(assertions.expression("ROW::fields(data)")
+                .binding("data", "CAST(ROW('hello', 'world') AS ROW(greeting VARCHAR, planet VARCHAR))"))
+                .hasType(new ArrayType(VARCHAR))
+                .neverFails()
+                .isEqualTo(ImmutableList.of("greeting", "planet"));
+
+        assertThat(assertions.expression("ROW::fields(data)")
+                .binding("data", "CAST(NULL AS ROW(greeting VARCHAR, planet VARCHAR))"))
+                .hasType(new ArrayType(VARCHAR))
+                .neverFails()
+                .isEqualTo(ImmutableList.of("greeting", "planet"));
+
+        assertThat(assertions.expression("ROW::fields(data)")
+                .binding("data", "ROW('hello', 'world')"))
+                .hasType(new ArrayType(VARCHAR))
+                .neverFails()
+                .isEqualTo(Arrays.asList(null, null));
+
+        assertThat(assertions.expression("ROW::fields(data)")
+                .binding("data", "CAST(NULL AS ROW(greeting VARCHAR, planet ROW(color varchar, size bigint)))"))
+                .hasType(new ArrayType(VARCHAR))
+                .neverFails()
+                .isEqualTo(ImmutableList.of("greeting", "planet"));
+    }
+}

--- a/docs/src/main/sphinx/functions.md
+++ b/docs/src/main/sphinx/functions.md
@@ -53,6 +53,7 @@ Machine learning    <functions/ml>
 Map                 <functions/map>
 Math                <functions/math>
 Quantile digest     <functions/qdigest>
+Row                 <functions/row>
 Regular expression  <functions/regexp>
 Session             <functions/session>
 Set Digest          <functions/setdigest>

--- a/docs/src/main/sphinx/functions/list-by-topic.md
+++ b/docs/src/main/sphinx/functions/list-by-topic.md
@@ -439,6 +439,12 @@ For more details, see {doc}`regexp`
 - {func}`regexp_replace`
 - {func}`regexp_split`
 
+## Row
+
+For more details, see {doc}`row`
+
+- {func}`ROW::fields`
+
 ## Row pattern recognition expressions
 
 - {ref}`classifier <classifier-function>`

--- a/docs/src/main/sphinx/functions/list.md
+++ b/docs/src/main/sphinx/functions/list.md
@@ -363,6 +363,7 @@
 - {func}`reverse`
 - {func}`rgb`
 - {func}`round`
+- {func}`ROW::fields`
 - {func}`row_number`
 - {func}`rpad`
 - {func}`rtrim`

--- a/docs/src/main/sphinx/functions/row.md
+++ b/docs/src/main/sphinx/functions/row.md
@@ -1,0 +1,11 @@
+# Row functions
+Functions for the [ROW](/language/types) data type.
+
+
+:::{function} ROW::fields(data) -> array(varchar)
+Returns all the field names of the `data` ROW.
+```sql
+SELECT ROW::fields(row('hello' as greeting, 'world' as planet));
+-- ['GREETING', 'PLANET']
+```
+:::


### PR DESCRIPTION
## Description
Returns all the keys in the row. In complex nested row structures, it can be very useful to generate the fields for an `UNNEST`:

```sql
SELECT ROW::fields(CAST(NULL AS ROW(greeting VARCHAR, planet ROW(color varchar, size bigint))));
-- ['greeting', 'planet']
```

```sql
SELECT concat_ws(', ', ROW::fields(element_at(data.some.nested.array_with_rows, 1)));
-- field1, field2, field3, field4, field5, field6, field7
```

```sql
SELECT * FROM UNNEST(data.some.nested.array_with_rows)
  AS d(field1, field2, field3, field4, field5, field6, field7);
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
*  Add function ROW::fields(data) to get all field names of the data row
```
