### PR TITLE
Include query id to Iceberg SessionContext#sessionId

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -881,7 +881,7 @@ public class TrinoRestCatalog
         return switch (sessionType) {
             case NONE -> new SessionContext(randomUUID().toString(), null, credentials, ImmutableMap.of(), session.getIdentity());
             case USER -> {
-                String sessionId = format("%s-%s", session.getUser(), session.getSource().orElse("default"));
+                String sessionId = format("%s-%s-%s", session.getUser(), session.getQueryId(), session.getSource().orElse("default"));
 
                 Map<String, String> properties = ImmutableMap.of(
                         "user", session.getUser(),


### PR DESCRIPTION
## Description

The `SessionContext#sessionId` can be used for caching state within a session in Iceberg library. 

- Relates to https://github.com/apache/iceberg/pull/14398

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
