### PR TITLE
Reject varbinary partition columns in Delta Lake connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1743,10 +1743,13 @@ public class DeltaLakeMetadata
                 .filter(partitionColumnName -> !columnNames.contains(partitionColumnName))
                 .collect(toImmutableList());
 
-        if (columns.stream().filter(column -> partitionColumnNames.contains(column.getName()))
-                .anyMatch(column -> column.getType() instanceof ArrayType || column.getType() instanceof MapType || column.getType() instanceof RowType)) {
-            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Using array, map or row type on partitioned columns is unsupported");
-        }
+        columns.stream()
+                .filter(column -> partitionColumnNames.contains(column.getName()))
+                .filter(column -> column.getType() instanceof ArrayType || column.getType() instanceof MapType || column.getType() instanceof RowType || column.getType().equals(VARBINARY))
+                .findFirst()
+                .ifPresent(column -> {
+                    throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Unsupported partition column type: " + column.getType().getDisplayName());
+                });
 
         if (!invalidPartitionNames.isEmpty()) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Table property 'partitioned_by' contained column names which do not exist: " + invalidPartitionNames);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -548,7 +548,6 @@ public class TestDeltaLakeBasic
                     ImmutableList.of("0.12", "3.45"),
                     ImmutableList.of(decimal("0.12", createDecimalType(3, 2)), decimal("3.45", createDecimalType(3, 2))));
             testPartitionValuesParsedCheckpoint(mode, "varchar", ImmutableList.of("'alice'", "'bob'"), ImmutableList.of("alice", "bob"));
-            // TODO https://github.com/trinodb/trino/issues/24155 Cannot insert varbinary values into partitioned columns
             testPartitionValuesParsedCheckpoint(
                     mode,
                     "date",
@@ -566,7 +565,7 @@ public class TestDeltaLakeBasic
                     "timestamp with time zone",
                     ImmutableList.of("TIMESTAMP '1970-01-01 00:00:00 +00:00'", "TIMESTAMP '1970-01-02 00:00:00 +00:00'"),
                     ImmutableList.of(SqlTimestamp.newInstance(3, 0, 0), SqlTimestamp.newInstance(3, epochPlus1DayMillis, 0)));
-            // array, map, row types are unsupported as partition column type. This is tested in TestDeltaLakeConnectorTest.testCreateTableWithUnsupportedPartitionType.
+            // array, map, row, varbinary types are unsupported as partition column type. This is tested in TestDeltaLakeConnectorTest.testCreateTableWithUnsupportedPartitionType.
         }
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -451,25 +451,16 @@ public class TestDeltaLakeConnectorTest
         String tableName = "test_create_table_unsupported_partition_types_" + randomNameSuffix();
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(a INT, part ARRAY(INT)) WITH (partitioned_by = ARRAY['part'])",
-                "Using array, map or row type on partitioned columns is unsupported");
+                "Unsupported partition column type: array\\(integer\\)");
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(a INT, part MAP(INT,INT)) WITH (partitioned_by = ARRAY['part'])",
-                "Using array, map or row type on partitioned columns is unsupported");
+                "Unsupported partition column type: map\\(integer, integer\\)");
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(a INT, part ROW(field INT)) WITH (partitioned_by = ARRAY['part'])",
-                "Using array, map or row type on partitioned columns is unsupported");
-    }
-
-    @Test
-    public void testInsertIntoUnsupportedVarbinaryPartitionType()
-    {
-        // TODO https://github.com/trinodb/trino/issues/24155 Cannot insert varbinary values into partitioned columns
-        // Update TestDeltaLakeBasic.testPartitionValuesParsedCheckpoint() when fixing this issue
-        try (TestTable table = newTrinoTable(
-                "test_varbinary_partition",
-                "(x int, part varbinary) WITH (partitioned_by = ARRAY['part'])")) {
-            assertQueryFails("INSERT INTO " + table.getName() + " VALUES (1, X'01')", "Unsupported type for partition: varbinary");
-        }
+                "Unsupported partition column type: row\\(\"field\" integer\\)");
+        assertQueryFails(
+                "CREATE TABLE " + tableName + "(a INT, part VARBINARY) WITH (partitioned_by = ARRAY['part'])",
+                "Unsupported partition column type: varbinary");
     }
 
     @Test
@@ -478,13 +469,16 @@ public class TestDeltaLakeConnectorTest
         String tableName = "test_ctas_unsupported_partition_types_" + randomNameSuffix();
         assertQueryFails(
                 "CREATE TABLE " + tableName + " WITH (partitioned_by = ARRAY['part']) AS SELECT 1 a, array[1] part",
-                "Using array, map or row type on partitioned columns is unsupported");
+                "Unsupported partition column type: array\\(integer\\)");
         assertQueryFails(
                 "CREATE TABLE " + tableName + " WITH (partitioned_by = ARRAY['part']) AS SELECT 1 a, map() part",
-                "Using array, map or row type on partitioned columns is unsupported");
+                "Unsupported partition column type: map\\(unknown, unknown\\)");
         assertQueryFails(
                 "CREATE TABLE " + tableName + " WITH (partitioned_by = ARRAY['part']) AS SELECT 1 a, row(1) part",
-                "Using array, map or row type on partitioned columns is unsupported");
+                "Unsupported partition column type: row\\(integer\\)");
+        assertQueryFails(
+                "CREATE TABLE " + tableName + " WITH (partitioned_by = ARRAY['part']) AS SELECT 1 a, X'01' part",
+                "Unsupported partition column type: varbinary");
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateTableAsSelectCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateTableAsSelectCompatibility.java
@@ -136,13 +136,13 @@ public class TestDeltaLakeCreateTableAsSelectCompatibility
         try {
             assertThatThrownBy(() -> onTrino().executeQuery("" +
                     "CREATE TABLE delta.default." + tableName + " WITH (partitioned_by = ARRAY['part'], location = '" + tableLocation + "') AS SELECT 1 a, array[1] part"))
-                    .hasMessageContaining("Using array, map or row type on partitioned columns is unsupported");
+                    .hasMessageContaining("Unsupported partition column type: array");
             assertThatThrownBy(() -> onTrino().executeQuery("" +
                     "CREATE TABLE delta.default." + tableName + " WITH (partitioned_by = ARRAY['part'], location = '" + tableLocation + "') AS SELECT 1 a, map() part"))
-                    .hasMessageContaining("Using array, map or row type on partitioned columns is unsupported");
+                    .hasMessageContaining("Unsupported partition column type: map");
             assertThatThrownBy(() -> onTrino().executeQuery("" +
                     "CREATE TABLE delta.default." + tableName + " WITH (partitioned_by = ARRAY['part'], location = '" + tableLocation + "') AS SELECT 1 a, row(1) part"))
-                    .hasMessageContaining("Using array, map or row type on partitioned columns is unsupported");
+                    .hasMessageContaining("Unsupported partition column type: row");
 
             assertThatThrownBy(() -> onDelta().executeQuery(
                     "CREATE TABLE default." + tableName + " USING DELTA PARTITIONED BY (part) LOCATION '" + tableLocation + "' AS SELECT 1 a, array(1) part"))

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
@@ -288,13 +288,13 @@ public class TestDeltaLakeDatabricksCreateTableCompatibility
         try {
             assertThatThrownBy(() -> onTrino().executeQuery("" +
                     "CREATE TABLE delta.default." + tableName + "(a INT, part ARRAY(INT)) WITH (partitioned_by = ARRAY['part'], location = '" + tableLocation + "')"))
-                    .hasMessageContaining("Using array, map or row type on partitioned columns is unsupported");
+                    .hasMessageContaining("Unsupported partition column type: array");
             assertThatThrownBy(() -> onTrino().executeQuery("" +
                     "CREATE TABLE delta.default." + tableName + "(a INT, part MAP(INT,INT)) WITH (partitioned_by = ARRAY['part'], location = '" + tableLocation + "')"))
-                    .hasMessageContaining("Using array, map or row type on partitioned columns is unsupported");
+                    .hasMessageContaining("Unsupported partition column type: map");
             assertThatThrownBy(() -> onTrino().executeQuery("" +
                     "CREATE TABLE delta.default." + tableName + "(a INT, part ROW(field INT)) WITH (partitioned_by = ARRAY['part'], location = '" + tableLocation + "')"))
-                    .hasMessageContaining("Using array, map or row type on partitioned columns is unsupported");
+                    .hasMessageContaining("Unsupported partition column type: row");
 
             assertThatThrownBy(() -> onDelta().executeQuery(
                     "CREATE TABLE default." + tableName + "(a INT, part ARRAY<INT>) USING DELTA PARTITIONED BY (part) LOCATION '" + tableLocation + "'"))


### PR DESCRIPTION
## Description

Creating a Delta Lake table with a `VARBINARY` partition column succeeded, but the table was unusable after that: every `INSERT` blew up deep in the write path with `Unsupported type for partition: varbinary` from `DeltaLakeWriteUtils.toPartitionValue`, and even reading a Spark-written varbinary-partitioned table surfaced `Unable to parse value [...] from column part with type varbinary` from `TransactionLogParser.deserializeColumnValue`. The Delta protocol's binary partition-value encoding is unimplemented on both sides.

`DeltaLakeMetadata.checkPartitionColumns` already rejects `array`, `map`, and `row` for partition columns. Adding `varbinary` to the same condition fires at CREATE / CTAS / `getNewTableLayout` time, before the table is registered, so users get a clear error instead of a half-broken table. Hive's `isValidPartitionType` already excludes `varbinary` for the same reasons — this brings Delta Lake to parity, matching the comment in the file noting that the surrounding util was copied from `HiveWriteUtils`.

## Additional context and related issues

Closes #24155.

Existing `TestDeltaLakeConnectorTest#testCreateTableWithUnsupportedPartitionType` and `testCreateTableAsSelectWithUnsupportedPartitionType` are extended to cover `varbinary` alongside the existing `array/map/row` cases. The obsolete `testInsertIntoUnsupportedVarbinaryPartitionType` (which carried a `TODO: see #24155` since the issue was filed) is removed — the CREATE-side reject makes it unreachable.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
