### PR TITLE
feat: Add auto-analyze background service for stale table statistics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/AutoAnalyzeConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/AutoAnalyzeConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class AutoAnalyzeConfig
+{
+    private boolean enabled;
+    private Duration checkInterval = new Duration(10, TimeUnit.MINUTES);
+    private long smallTableThreshold = 100_000;
+    private Duration smallTableInterval = new Duration(1, TimeUnit.HOURS);
+    private Duration largeTableInterval = new Duration(24, TimeUnit.HOURS);
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("auto-analyze.enabled")
+    @ConfigDescription("Enable automatic background ANALYZE for all tables")
+    public AutoAnalyzeConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @NotNull
+    public Duration getCheckInterval()
+    {
+        return checkInterval;
+    }
+
+    @Config("auto-analyze.check-interval")
+    @ConfigDescription("How often to scan tables and submit ANALYZE for stale ones")
+    public AutoAnalyzeConfig setCheckInterval(Duration checkInterval)
+    {
+        this.checkInterval = checkInterval;
+        return this;
+    }
+
+    @Min(0)
+    public long getSmallTableThreshold()
+    {
+        return smallTableThreshold;
+    }
+
+    @Config("auto-analyze.small-table-threshold")
+    @ConfigDescription("Tables with fewer rows than this threshold are considered small tables")
+    public AutoAnalyzeConfig setSmallTableThreshold(long smallTableThreshold)
+    {
+        this.smallTableThreshold = smallTableThreshold;
+        return this;
+    }
+
+    @NotNull
+    public Duration getSmallTableInterval()
+    {
+        return smallTableInterval;
+    }
+
+    @Config("auto-analyze.small-table-interval")
+    @ConfigDescription("Minimum time between ANALYZE runs for small tables (fewer than small-table-threshold rows)")
+    public AutoAnalyzeConfig setSmallTableInterval(Duration smallTableInterval)
+    {
+        this.smallTableInterval = smallTableInterval;
+        return this;
+    }
+
+    @NotNull
+    public Duration getLargeTableInterval()
+    {
+        return largeTableInterval;
+    }
+
+    @Config("auto-analyze.large-table-interval")
+    @ConfigDescription("Minimum time between ANALYZE runs for large tables (at least small-table-threshold rows)")
+    public AutoAnalyzeConfig setLargeTableInterval(Duration largeTableInterval)
+    {
+        this.largeTableInterval = largeTableInterval;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/AutoAnalyzeService.java
+++ b/core/trino-main/src/main/java/io/trino/server/AutoAnalyzeService.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.opentelemetry.api.trace.Span;
+import io.trino.Session;
+import io.trino.dispatcher.DispatchManager;
+import io.trino.execution.QueryIdGenerator;
+import io.trino.metadata.CatalogInfo;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.QualifiedTablePrefix;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.metadata.TableHandle;
+import io.trino.security.AccessControl;
+import io.trino.server.protocol.Slug;
+import io.trino.spi.QueryId;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.SelectedRole;
+import io.trino.spi.session.ResourceEstimates;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.sql.SqlPath;
+import io.trino.transaction.TransactionId;
+import io.trino.transaction.TransactionManager;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class AutoAnalyzeService
+{
+    private static final Logger log = Logger.get(AutoAnalyzeService.class);
+
+    // Internal username for ANALYZE query sessions. Cluster operators may need to allow
+    // this user in their access control configuration.
+    private static final String AUTO_ANALYZE_USER = "$auto-analyze";
+    private static final String INFORMATION_SCHEMA = "information_schema";
+
+    private final AutoAnalyzeConfig config;
+    private final Metadata metadata;
+    private final TransactionManager transactionManager;
+    private final AccessControl accessControl;
+    private final SessionPropertyManager sessionPropertyManager;
+    private final DispatchManager dispatchManager;
+    private final QueryIdGenerator queryIdGenerator;
+
+    private final ConcurrentHashMap<QualifiedObjectName, Instant> lastAnalyzed = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("auto-analyze-%s"));
+
+    private ScheduledFuture<?> scheduledFuture;
+
+    @Inject
+    public AutoAnalyzeService(
+            AutoAnalyzeConfig config,
+            Metadata metadata,
+            TransactionManager transactionManager,
+            AccessControl accessControl,
+            SessionPropertyManager sessionPropertyManager,
+            DispatchManager dispatchManager,
+            QueryIdGenerator queryIdGenerator)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+        this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
+        this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        if (!config.isEnabled()) {
+            return;
+        }
+        long intervalMillis = config.getCheckInterval().toMillis();
+        scheduledFuture = executor.scheduleWithFixedDelay(() -> {
+            try {
+                checkAndAnalyze();
+            }
+            catch (Throwable e) {
+                log.error(e, "Error during auto-analyze check");
+            }
+        }, intervalMillis, intervalMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+            scheduledFuture = null;
+        }
+        executor.shutdownNow();
+    }
+
+    private void checkAndAnalyze()
+    {
+        List<QualifiedObjectName> tablesToAnalyze = collectStaleTables();
+        for (QualifiedObjectName table : tablesToAnalyze) {
+            submitAnalyze(table);
+        }
+    }
+
+    private List<QualifiedObjectName> collectStaleTables()
+    {
+        // Run catalog/table listing and statistics reads inside a single auto-commit transaction.
+        TransactionId transactionId = transactionManager.beginTransaction(true);
+        try {
+            Session browseSession = createBrowseSession(transactionId);
+            List<QualifiedObjectName> stale = findStaleTables(browseSession);
+            transactionManager.asyncCommit(transactionId);
+            return stale;
+        }
+        catch (Throwable e) {
+            log.error(e, "Failed to collect tables for auto-analyze");
+            transactionManager.asyncAbort(transactionId);
+            return ImmutableList.of();
+        }
+    }
+
+    private List<QualifiedObjectName> findStaleTables(Session browseSession)
+    {
+        List<QualifiedObjectName> stale = new ArrayList<>();
+        for (CatalogInfo catalogInfo : metadata.listCatalogs(browseSession)) {
+            String catalogName = catalogInfo.catalogName();
+            List<QualifiedObjectName> tables;
+            try {
+                tables = metadata.listTables(browseSession, new QualifiedTablePrefix(catalogName));
+            }
+            catch (Throwable e) {
+                log.warn(e, "Failed to list tables in catalog %s", catalogName);
+                continue;
+            }
+            for (QualifiedObjectName table : tables) {
+                if (table.schemaName().equalsIgnoreCase(INFORMATION_SCHEMA)) {
+                    continue;
+                }
+                if (isStale(browseSession, table)) {
+                    stale.add(table);
+                }
+            }
+        }
+        return stale;
+    }
+
+    private boolean isStale(Session browseSession, QualifiedObjectName table)
+    {
+        Instant lastTime = lastAnalyzed.get(table);
+        if (lastTime == null) {
+            // Never analyzed — treat as stale immediately
+            return true;
+        }
+
+        long elapsedMillis = Instant.now().toEpochMilli() - lastTime.toEpochMilli();
+        long intervalMillis = resolveIntervalMillis(browseSession, table);
+        return elapsedMillis >= intervalMillis;
+    }
+
+    private long resolveIntervalMillis(Session browseSession, QualifiedObjectName table)
+    {
+        try {
+            Optional<TableHandle> tableHandle = metadata.getTableHandle(browseSession, table);
+            if (tableHandle.isPresent()) {
+                TableStatistics stats = metadata.getTableStatistics(browseSession, tableHandle.get());
+                Estimate rowCount = stats.getRowCount();
+                if (!rowCount.isUnknown() && rowCount.getValue() >= config.getSmallTableThreshold()) {
+                    return config.getLargeTableInterval().toMillis();
+                }
+            }
+        }
+        catch (Throwable e) {
+            log.debug(e, "Could not fetch statistics for %s; defaulting to small-table interval", table);
+        }
+        return config.getSmallTableInterval().toMillis();
+    }
+
+    private void submitAnalyze(QualifiedObjectName table)
+    {
+        // Record submission time before dispatching so that a slow ANALYZE does not
+        // cause repeated re-submission on subsequent check cycles.
+        lastAnalyzed.put(table, Instant.now());
+
+        QueryId queryId = dispatchManager.createQueryId();
+        String analyzeQuery = format(
+                "ANALYZE \"%s\".\"%s\".\"%s\"",
+                table.catalogName().replace("\"", "\"\""),
+                table.schemaName().replace("\"", "\"\""),
+                table.objectName().replace("\"", "\"\""));
+
+        try {
+            dispatchManager.createQuery(queryId, Span.getInvalid(), Slug.createNew(), createAnalyzeSessionContext(), analyzeQuery);
+            log.debug("Submitted auto-analyze for %s (queryId=%s)", table, queryId);
+        }
+        catch (Throwable e) {
+            log.warn(e, "Failed to submit auto-analyze for %s", table);
+        }
+    }
+
+    private Session createBrowseSession(TransactionId transactionId)
+    {
+        Identity identity = Identity.ofUser(AUTO_ANALYZE_USER);
+        QueryId queryId = queryIdGenerator.createNextQueryId();
+        Session session = Session.builder(sessionPropertyManager)
+                .setQueryId(queryId)
+                .setQuerySpan(Span.getInvalid())
+                .setIdentity(identity)
+                .setOriginalIdentity(identity)
+                .setSource("auto-analyze")
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLocale(Locale.ENGLISH)
+                .setPath(SqlPath.EMPTY_PATH)
+                .build();
+        return session.beginTransactionId(transactionId, transactionManager, accessControl);
+    }
+
+    private SessionContext createAnalyzeSessionContext()
+    {
+        Identity identity = Identity.ofUser(AUTO_ANALYZE_USER);
+        return new SessionContext(
+                TRINO_HEADERS,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                identity,
+                identity,
+                new SelectedRole(SelectedRole.Type.NONE, Optional.empty()),
+                Optional.of("auto-analyze"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty()),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                Optional.empty());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -332,6 +332,10 @@ public class CoordinatorModule
         // dynamic filtering service
         binder.bind(DynamicFilterService.class).in(Scopes.SINGLETON);
 
+        // auto-analyze service
+        configBinder(binder).bindConfig(AutoAnalyzeConfig.class);
+        binder.bind(AutoAnalyzeService.class).in(Scopes.SINGLETON);
+
         // language functions
         binder.bind(LanguageFunctionManager.class).in(Scopes.SINGLETON);
         binder.bind(InitializeLanguageFunctionManager.class).asEagerSingleton();

--- a/core/trino-main/src/test/java/io/trino/server/TestAutoAnalyzeConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestAutoAnalyzeConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestAutoAnalyzeConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AutoAnalyzeConfig.class)
+                .setEnabled(false)
+                .setCheckInterval(new Duration(10, TimeUnit.MINUTES))
+                .setSmallTableThreshold(100_000)
+                .setSmallTableInterval(new Duration(1, TimeUnit.HOURS))
+                .setLargeTableInterval(new Duration(24, TimeUnit.HOURS)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("auto-analyze.enabled", "true")
+                .put("auto-analyze.check-interval", "5m")
+                .put("auto-analyze.small-table-threshold", "50000")
+                .put("auto-analyze.small-table-interval", "30m")
+                .put("auto-analyze.large-table-interval", "12h")
+                .buildOrThrow();
+
+        AutoAnalyzeConfig expected = new AutoAnalyzeConfig()
+                .setEnabled(true)
+                .setCheckInterval(new Duration(5, TimeUnit.MINUTES))
+                .setSmallTableThreshold(50_000)
+                .setSmallTableInterval(new Duration(30, TimeUnit.MINUTES))
+                .setLargeTableInterval(new Duration(12, TimeUnit.HOURS));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
Add a coordinator-side background service that automatically triggers ANALYZE on tables whose statistics have become stale. This is Phase 1 of the auto-analyze feature described in issue #29395: no SPI changes, purely coordinator-side implementation.

The service:
- Is disabled by default (auto-analyze.enabled=false)
- Periodically scans all catalogs and tables via Metadata APIs
- Tracks the last ANALYZE submission time per table in memory
- Uses configurable intervals based on estimated table size:
  - Small tables (< small-table-threshold rows): analyzed every 1h
  - Large tables (>= small-table-threshold rows): analyzed every 24h
- Submits ANALYZE queries via DispatchManager under the internal user $auto-analyze (operators may need to allow this in AC config)
- Skips information_schema tables
- Fails gracefully: errors in one table do not block others

Configuration properties:
- auto-analyze.enabled (default: false)
- auto-analyze.check-interval (default: 10m)
- auto-analyze.small-table-threshold (default: 100000)
- auto-analyze.small-table-interval (default: 1h)
- auto-analyze.large-table-interval (default: 24h)

Closes #29395
