### PR TITLE
Add Histogram and HistogramBucket types to ColumnStatistics SPI

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/ColumnStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/ColumnStatistics.java
@@ -21,12 +21,13 @@ import static java.util.Objects.requireNonNull;
 
 public final class ColumnStatistics
 {
-    private static final ColumnStatistics EMPTY = new ColumnStatistics(Estimate.unknown(), Estimate.unknown(), Estimate.unknown(), Optional.empty());
+    private static final ColumnStatistics EMPTY = new ColumnStatistics(Estimate.unknown(), Estimate.unknown(), Estimate.unknown(), Optional.empty(), Optional.empty());
 
     private final Estimate nullsFraction;
     private final Estimate distinctValuesCount;
     private final Estimate dataSize;
     private final Optional<DoubleRange> range;
+    private final Optional<Histogram> histogram;
 
     public static ColumnStatistics empty()
     {
@@ -38,6 +39,16 @@ public final class ColumnStatistics
             Estimate distinctValuesCount,
             Estimate dataSize,
             Optional<DoubleRange> range)
+    {
+        this(nullsFraction, distinctValuesCount, dataSize, range, Optional.empty());
+    }
+
+    public ColumnStatistics(
+            Estimate nullsFraction,
+            Estimate distinctValuesCount,
+            Estimate dataSize,
+            Optional<DoubleRange> range,
+            Optional<Histogram> histogram)
     {
         this.nullsFraction = requireNonNull(nullsFraction, "nullsFraction is null");
         if (!nullsFraction.isUnknown()) {
@@ -54,6 +65,7 @@ public final class ColumnStatistics
             throw new IllegalArgumentException(format("dataSize must be greater than or equal to 0: %s", dataSize.getValue()));
         }
         this.range = requireNonNull(range, "range is null");
+        this.histogram = requireNonNull(histogram, "histogram is null");
     }
 
     public Estimate getNullsFraction()
@@ -76,6 +88,11 @@ public final class ColumnStatistics
         return range;
     }
 
+    public Optional<Histogram> getHistogram()
+    {
+        return histogram;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -89,13 +106,14 @@ public final class ColumnStatistics
         return Objects.equals(nullsFraction, that.nullsFraction) &&
                 Objects.equals(distinctValuesCount, that.distinctValuesCount) &&
                 Objects.equals(dataSize, that.dataSize) &&
-                Objects.equals(range, that.range);
+                Objects.equals(range, that.range) &&
+                Objects.equals(histogram, that.histogram);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(nullsFraction, distinctValuesCount, dataSize, range);
+        return Objects.hash(nullsFraction, distinctValuesCount, dataSize, range, histogram);
     }
 
     @Override
@@ -106,6 +124,7 @@ public final class ColumnStatistics
                 ", distinctValuesCount=" + distinctValuesCount +
                 ", dataSize=" + dataSize +
                 ", range=" + range +
+                ", histogram=" + histogram +
                 '}';
     }
 
@@ -125,6 +144,7 @@ public final class ColumnStatistics
         private Estimate distinctValuesCount = Estimate.unknown();
         private Estimate dataSize = Estimate.unknown();
         private Optional<DoubleRange> range = Optional.empty();
+        private Optional<Histogram> histogram = Optional.empty();
 
         public Builder setNullsFraction(Estimate nullsFraction)
         {
@@ -156,9 +176,21 @@ public final class ColumnStatistics
             return this;
         }
 
+        public Builder setHistogram(Histogram histogram)
+        {
+            this.histogram = Optional.of(requireNonNull(histogram, "histogram is null"));
+            return this;
+        }
+
+        public Builder setHistogram(Optional<Histogram> histogram)
+        {
+            this.histogram = requireNonNull(histogram, "histogram is null");
+            return this;
+        }
+
         public ColumnStatistics build()
         {
-            return new ColumnStatistics(nullsFraction, distinctValuesCount, dataSize, range);
+            return new ColumnStatistics(nullsFraction, distinctValuesCount, dataSize, range, histogram);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/Histogram.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/Histogram.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.statistics;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.lang.Double.isNaN;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An equi-height histogram for a column, where each bucket covers a value range
+ * and contains a roughly equal number of rows. Buckets must be non-overlapping
+ * and ordered by lower bound.
+ * <p>
+ * The histogram provides an {@link #estimateFraction(double, double)} method
+ * that can be used by the query optimizer to estimate the selectivity of range
+ * and equality predicates more accurately than the uniform-distribution assumption.
+ */
+public final class Histogram
+{
+    private final List<HistogramBucket> buckets;
+
+    /**
+     * Creates a histogram from the given list of buckets.
+     *
+     * @param buckets a non-null list of buckets that must be sorted by lower bound
+     *                and must not overlap (each bucket's high must be less than or
+     *                equal to the next bucket's low)
+     */
+    public Histogram(List<HistogramBucket> buckets)
+    {
+        requireNonNull(buckets, "buckets is null");
+        this.buckets = List.copyOf(buckets);
+        for (int i = 1; i < this.buckets.size(); i++) {
+            HistogramBucket previous = this.buckets.get(i - 1);
+            HistogramBucket current = this.buckets.get(i);
+            if (previous.getHigh() > current.getLow()) {
+                throw new IllegalArgumentException(format(
+                        "Histogram buckets must be non-overlapping and sorted by lower bound. " +
+                                "Bucket %d [%s, %s] overlaps bucket %d [%s, %s]",
+                        i - 1, previous.getLow(), previous.getHigh(),
+                        i, current.getLow(), current.getHigh()));
+            }
+        }
+    }
+
+    public List<HistogramBucket> getBuckets()
+    {
+        return buckets;
+    }
+
+    /**
+     * Estimates the fraction of non-null rows whose values fall within [low, high].
+     * Uses linear interpolation within each bucket (uniform distribution assumption
+     * within a single bucket).
+     *
+     * @return a value in [0.0, 1.0], or {@link Double#NaN} if the histogram is empty
+     *         or total row count is zero
+     */
+    public double estimateFraction(double low, double high)
+    {
+        if (isNaN(low) || isNaN(high) || low > high) {
+            return Double.NaN;
+        }
+        if (buckets.isEmpty()) {
+            return Double.NaN;
+        }
+
+        double totalRowCount = 0;
+        for (HistogramBucket bucket : buckets) {
+            totalRowCount += bucket.getRowCount();
+        }
+        if (totalRowCount == 0) {
+            return 0.0;
+        }
+
+        double matchingRowCount = 0;
+        for (HistogramBucket bucket : buckets) {
+            matchingRowCount += rowsInRange(bucket, low, high);
+        }
+        return matchingRowCount / totalRowCount;
+    }
+
+    private static double rowsInRange(HistogramBucket bucket, double low, double high)
+    {
+        double bucketLow = bucket.getLow();
+        double bucketHigh = bucket.getHigh();
+
+        // No overlap
+        if (low > bucketHigh || high < bucketLow) {
+            return 0.0;
+        }
+        // Bucket fully covered by the queried range
+        if (low <= bucketLow && high >= bucketHigh) {
+            return bucket.getRowCount();
+        }
+        // Point bucket (single value): included if the value falls within [low, high]
+        if (bucketLow == bucketHigh) {
+            return bucket.getRowCount();
+        }
+        // Partial overlap: interpolate assuming uniform distribution within the bucket
+        double overlapFraction = (min(high, bucketHigh) - max(low, bucketLow)) / (bucketHigh - bucketLow);
+        return bucket.getRowCount() * overlapFraction;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Histogram that = (Histogram) o;
+        return Objects.equals(buckets, that.buckets);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(buckets);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Histogram{buckets=" + buckets + '}';
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/HistogramBucket.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/HistogramBucket.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.statistics;
+
+import java.util.Objects;
+
+import static java.lang.Double.isNaN;
+import static java.lang.String.format;
+
+/**
+ * Represents a single bucket in an equi-height histogram.
+ * Each bucket covers a contiguous value range [low, high] and stores
+ * an estimated row count and distinct values count for that range.
+ */
+public final class HistogramBucket
+{
+    private final double low;
+    private final double high;
+    private final double rowCount;
+    private final double distinctValuesCount;
+
+    public HistogramBucket(double low, double high, double rowCount, double distinctValuesCount)
+    {
+        if (isNaN(low)) {
+            throw new IllegalArgumentException("low must not be NaN");
+        }
+        if (isNaN(high)) {
+            throw new IllegalArgumentException("high must not be NaN");
+        }
+        if (low > high) {
+            throw new IllegalArgumentException(format("high must be greater than or equal to low. low: %s. high: %s.", low, high));
+        }
+        if (isNaN(rowCount) || rowCount < 0) {
+            throw new IllegalArgumentException(format("rowCount must be a non-negative finite number: %s", rowCount));
+        }
+        if (isNaN(distinctValuesCount) || distinctValuesCount < 0) {
+            throw new IllegalArgumentException(format("distinctValuesCount must be a non-negative finite number: %s", distinctValuesCount));
+        }
+        this.low = low;
+        this.high = high;
+        this.rowCount = rowCount;
+        this.distinctValuesCount = distinctValuesCount;
+    }
+
+    public double getLow()
+    {
+        return low;
+    }
+
+    public double getHigh()
+    {
+        return high;
+    }
+
+    public double getRowCount()
+    {
+        return rowCount;
+    }
+
+    public double getDistinctValuesCount()
+    {
+        return distinctValuesCount;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HistogramBucket that = (HistogramBucket) o;
+        return Double.compare(low, that.low) == 0 &&
+                Double.compare(high, that.high) == 0 &&
+                Double.compare(rowCount, that.rowCount) == 0 &&
+                Double.compare(distinctValuesCount, that.distinctValuesCount) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(low, high, rowCount, distinctValuesCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "HistogramBucket{" +
+                "low=" + low +
+                ", high=" + high +
+                ", rowCount=" + rowCount +
+                ", distinctValuesCount=" + distinctValuesCount +
+                '}';
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/statistics/TestHistogram.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/statistics/TestHistogram.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.statistics;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+class TestHistogram
+{
+    @Test
+    public void testEmptyHistogram()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of());
+        assertThat(histogram.getBuckets()).isEmpty();
+        assertThat(histogram.estimateFraction(0, 100)).isNaN();
+    }
+
+    @Test
+    public void testSingleBucketFullRange()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 100.0, 1000.0, 100.0)));
+        assertThat(histogram.estimateFraction(0.0, 100.0)).isCloseTo(1.0, within(1e-9));
+    }
+
+    @Test
+    public void testSingleBucketHalfRange()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 100.0, 1000.0, 100.0)));
+        assertThat(histogram.estimateFraction(0.0, 50.0)).isCloseTo(0.5, within(1e-9));
+    }
+
+    @Test
+    public void testMultipleBucketsExactMatch()
+    {
+        // Three equal buckets: [0,10], [10,20], [20,30], each with 300 rows
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 10.0, 300.0, 10.0),
+                new HistogramBucket(10.0, 20.0, 300.0, 10.0),
+                new HistogramBucket(20.0, 30.0, 300.0, 10.0)));
+
+        // Query the entire range
+        assertThat(histogram.estimateFraction(0.0, 30.0)).isCloseTo(1.0, within(1e-9));
+
+        // Query one bucket exactly
+        assertThat(histogram.estimateFraction(0.0, 10.0)).isCloseTo(1.0 / 3, within(1e-9));
+
+        // Query two buckets exactly
+        assertThat(histogram.estimateFraction(0.0, 20.0)).isCloseTo(2.0 / 3, within(1e-9));
+    }
+
+    @Test
+    public void testRangeOutsideHistogram()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(10.0, 20.0, 1000.0, 50.0)));
+
+        // Query entirely below the histogram
+        assertThat(histogram.estimateFraction(0.0, 5.0)).isCloseTo(0.0, within(1e-9));
+
+        // Query entirely above the histogram
+        assertThat(histogram.estimateFraction(30.0, 40.0)).isCloseTo(0.0, within(1e-9));
+    }
+
+    @Test
+    public void testPartialOverlapWithBucket()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 100.0, 1000.0, 100.0)));
+
+        // Query overlaps the first quarter of the bucket
+        assertThat(histogram.estimateFraction(0.0, 25.0)).isCloseTo(0.25, within(1e-9));
+
+        // Query overlaps the last quarter of the bucket
+        assertThat(histogram.estimateFraction(75.0, 100.0)).isCloseTo(0.25, within(1e-9));
+    }
+
+    @Test
+    public void testPointBucket()
+    {
+        // A single-value bucket at x=5
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(5.0, 5.0, 200.0, 1.0)));
+
+        // The point is within the queried range
+        assertThat(histogram.estimateFraction(0.0, 10.0)).isCloseTo(1.0, within(1e-9));
+
+        // The point is outside the queried range
+        assertThat(histogram.estimateFraction(6.0, 10.0)).isCloseTo(0.0, within(1e-9));
+    }
+
+    @Test
+    public void testNaNInputReturnedAsNaN()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 100.0, 1000.0, 100.0)));
+
+        assertThat(histogram.estimateFraction(Double.NaN, 50.0)).isNaN();
+        assertThat(histogram.estimateFraction(0.0, Double.NaN)).isNaN();
+    }
+
+    @Test
+    public void testInvertedRangeReturnedAsNaN()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 100.0, 1000.0, 100.0)));
+
+        assertThat(histogram.estimateFraction(50.0, 0.0)).isNaN();
+    }
+
+    @Test
+    public void testZeroTotalRowCountReturnsZero()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 100.0, 0.0, 0.0)));
+        assertThat(histogram.estimateFraction(0.0, 100.0)).isCloseTo(0.0, within(1e-9));
+    }
+
+    @Test
+    public void testUnequalBucketWeights()
+    {
+        // Skewed distribution: bucket [0,50] has 900 rows, bucket [50,100] has 100 rows
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 50.0, 900.0, 50.0),
+                new HistogramBucket(50.0, 100.0, 100.0, 50.0)));
+
+        // The first bucket represents 90% of rows
+        assertThat(histogram.estimateFraction(0.0, 50.0)).isCloseTo(0.9, within(1e-9));
+
+        // The second bucket represents 10% of rows
+        assertThat(histogram.estimateFraction(50.0, 100.0)).isCloseTo(0.1, within(1e-9));
+    }
+
+    @Test
+    public void testOverlappingBucketsRejected()
+    {
+        List<HistogramBucket> overlapping = ImmutableList.of(
+                new HistogramBucket(0.0, 10.0, 100.0, 5.0),
+                new HistogramBucket(5.0, 20.0, 100.0, 5.0));
+
+        assertThatThrownBy(() -> new Histogram(overlapping))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-overlapping");
+    }
+
+    @Test
+    public void testUnsortedBucketsRejected()
+    {
+        List<HistogramBucket> unsorted = ImmutableList.of(
+                new HistogramBucket(10.0, 20.0, 100.0, 5.0),
+                new HistogramBucket(0.0, 5.0, 100.0, 5.0));
+
+        assertThatThrownBy(() -> new Histogram(unsorted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-overlapping");
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        Histogram histogram1 = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 10.0, 100.0, 5.0)));
+        Histogram histogram2 = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 10.0, 100.0, 5.0)));
+        Histogram histogram3 = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 20.0, 100.0, 5.0)));
+
+        assertThat(histogram1).isEqualTo(histogram2);
+        assertThat(histogram1.hashCode()).isEqualTo(histogram2.hashCode());
+        assertThat(histogram1).isNotEqualTo(histogram3);
+    }
+
+    @Test
+    public void testToString()
+    {
+        Histogram histogram = new Histogram(ImmutableList.of(
+                new HistogramBucket(0.0, 10.0, 100.0, 5.0)));
+        assertThat(histogram.toString()).contains("Histogram{buckets=");
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/statistics/TestHistogramBucket.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/statistics/TestHistogramBucket.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.statistics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestHistogramBucket
+{
+    @Test
+    public void testValidBucket()
+    {
+        HistogramBucket bucket = new HistogramBucket(1.0, 5.0, 100.0, 10.0);
+        assertThat(bucket.getLow()).isEqualTo(1.0);
+        assertThat(bucket.getHigh()).isEqualTo(5.0);
+        assertThat(bucket.getRowCount()).isEqualTo(100.0);
+        assertThat(bucket.getDistinctValuesCount()).isEqualTo(10.0);
+    }
+
+    @Test
+    public void testPointBucket()
+    {
+        HistogramBucket bucket = new HistogramBucket(3.0, 3.0, 50.0, 1.0);
+        assertThat(bucket.getLow()).isEqualTo(3.0);
+        assertThat(bucket.getHigh()).isEqualTo(3.0);
+    }
+
+    @Test
+    public void testZeroRowCountAllowed()
+    {
+        HistogramBucket bucket = new HistogramBucket(0.0, 10.0, 0.0, 0.0);
+        assertThat(bucket.getRowCount()).isEqualTo(0.0);
+    }
+
+    @Test
+    public void testNaNLowRejected()
+    {
+        assertThatThrownBy(() -> new HistogramBucket(Double.NaN, 5.0, 100.0, 10.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("low must not be NaN");
+    }
+
+    @Test
+    public void testNaNHighRejected()
+    {
+        assertThatThrownBy(() -> new HistogramBucket(1.0, Double.NaN, 100.0, 10.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("high must not be NaN");
+    }
+
+    @Test
+    public void testLowGreaterThanHighRejected()
+    {
+        assertThatThrownBy(() -> new HistogramBucket(5.0, 1.0, 100.0, 10.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("high must be greater than or equal to low");
+    }
+
+    @Test
+    public void testNegativeRowCountRejected()
+    {
+        assertThatThrownBy(() -> new HistogramBucket(1.0, 5.0, -1.0, 10.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rowCount must be a non-negative finite number");
+    }
+
+    @Test
+    public void testNaNRowCountRejected()
+    {
+        assertThatThrownBy(() -> new HistogramBucket(1.0, 5.0, Double.NaN, 10.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rowCount must be a non-negative finite number");
+    }
+
+    @Test
+    public void testNegativeDistinctValuesCountRejected()
+    {
+        assertThatThrownBy(() -> new HistogramBucket(1.0, 5.0, 100.0, -1.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("distinctValuesCount must be a non-negative finite number");
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        HistogramBucket bucket1 = new HistogramBucket(1.0, 5.0, 100.0, 10.0);
+        HistogramBucket bucket2 = new HistogramBucket(1.0, 5.0, 100.0, 10.0);
+        HistogramBucket bucket3 = new HistogramBucket(2.0, 5.0, 100.0, 10.0);
+
+        assertThat(bucket1).isEqualTo(bucket2);
+        assertThat(bucket1.hashCode()).isEqualTo(bucket2.hashCode());
+        assertThat(bucket1).isNotEqualTo(bucket3);
+    }
+
+    @Test
+    public void testToString()
+    {
+        HistogramBucket bucket = new HistogramBucket(1.0, 5.0, 100.0, 10.0);
+        assertThat(bucket.toString())
+                .contains("low=1.0")
+                .contains("high=5.0")
+                .contains("rowCount=100.0")
+                .contains("distinctValuesCount=10.0");
+    }
+}


### PR DESCRIPTION
Adds Phase 1 of equi-height histogram support (issue #29396):
- HistogramBucket: a value range [low, high] with rowCount and distinctValuesCount for that range
- Histogram: an ordered, non-overlapping list of HistogramBucket values with an estimateFraction(low, high) method for selectivity estimation using linear interpolation within each bucket
- ColumnStatistics: extended with an Optional<Histogram> field; the existing 4-arg constructor is preserved for backward compatibility