### PR TITLE
Add multi-column joint statistics for GROUP BY cardinality estimation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/AggregationStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/AggregationStatsRule.java
@@ -14,6 +14,7 @@
 package io.trino.cost;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.cost.StatsCalculator.Context;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.Symbol;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.trino.sql.planner.plan.AggregationNode.Step.INTERMEDIATE;
 import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
@@ -91,6 +93,13 @@ public class AggregationStatsRule
 
     public static double getRowsCount(PlanNodeStatsEstimate sourceStats, Collection<Symbol> groupBySymbols)
     {
+        // Use joint NDV from connector statistics when available — avoids the independence assumption.
+        Set<Symbol> groupBySet = ImmutableSet.copyOf(groupBySymbols);
+        double jointNdv = sourceStats.getColumnGroupNdv(groupBySet);
+        if (!Double.isNaN(jointNdv)) {
+            return jointNdv;
+        }
+
         double rowsCount = 1;
         for (Symbol groupBySymbol : groupBySymbols) {
             SymbolStatsEstimate symbolStatistics = sourceStats.getSymbolStatistics(groupBySymbol);

--- a/core/trino-main/src/main/java/io/trino/cost/PlanNodeStatsEstimate.java
+++ b/core/trino-main/src/main/java/io/trino/cost/PlanNodeStatsEstimate.java
@@ -38,10 +38,14 @@ import static java.util.Objects.requireNonNull;
 public class PlanNodeStatsEstimate
 {
     private static final double DEFAULT_DATA_SIZE_PER_COLUMN = 50;
-    private static final PlanNodeStatsEstimate UNKNOWN = new PlanNodeStatsEstimate(NaN, ImmutableMap.of());
+    private static final PlanNodeStatsEstimate UNKNOWN = new PlanNodeStatsEstimate(NaN, HashTreePMap.empty(), ImmutableMap.of());
 
     private final double outputRowCount;
     private final PMap<Symbol, SymbolStatsEstimate> symbolStatistics;
+    // Joint NDV for groups of symbols; not included in JSON serialization since Set<Symbol>
+    // cannot be a JSON object key. This is an in-memory optimization hint that is populated
+    // by TableScanStatsRule when the connector supplies ColumnGroupStatistics.
+    private final ImmutableMap<Set<Symbol>, Double> columnGroupNdv;
 
     public static PlanNodeStatsEstimate unknown()
     {
@@ -53,14 +57,15 @@ public class PlanNodeStatsEstimate
             @JsonProperty("outputRowCount") double outputRowCount,
             @JsonProperty("symbolStatistics") Map<Symbol, SymbolStatsEstimate> symbolStatistics)
     {
-        this(outputRowCount, HashTreePMap.from(requireNonNull(symbolStatistics, "symbolStatistics is null")));
+        this(outputRowCount, HashTreePMap.from(requireNonNull(symbolStatistics, "symbolStatistics is null")), ImmutableMap.of());
     }
 
-    private PlanNodeStatsEstimate(double outputRowCount, PMap<Symbol, SymbolStatsEstimate> symbolStatistics)
+    private PlanNodeStatsEstimate(double outputRowCount, PMap<Symbol, SymbolStatsEstimate> symbolStatistics, ImmutableMap<Set<Symbol>, Double> columnGroupNdv)
     {
         checkArgument(isNaN(outputRowCount) || outputRowCount >= 0, "outputRowCount cannot be negative");
         this.outputRowCount = outputRowCount;
         this.symbolStatistics = symbolStatistics;
+        this.columnGroupNdv = requireNonNull(columnGroupNdv, "columnGroupNdv is null");
     }
 
     /**
@@ -141,6 +146,16 @@ public class PlanNodeStatsEstimate
         return symbolStatistics.keySet();
     }
 
+    /**
+     * Returns the joint NDV for the given symbol group, or {@link Double#NaN} if no joint
+     * statistics are available for that group.
+     */
+    public double getColumnGroupNdv(Set<Symbol> symbolGroup)
+    {
+        Double value = columnGroupNdv.get(symbolGroup);
+        return value != null ? value : NaN;
+    }
+
     public boolean isOutputRowCountUnknown()
     {
         return isNaN(outputRowCount);
@@ -152,6 +167,7 @@ public class PlanNodeStatsEstimate
         return toStringHelper(this)
                 .add("outputRowCount", outputRowCount)
                 .add("symbolStatistics", symbolStatistics)
+                .add("columnGroupNdv", columnGroupNdv)
                 .toString();
     }
 
@@ -166,13 +182,14 @@ public class PlanNodeStatsEstimate
         }
         PlanNodeStatsEstimate that = (PlanNodeStatsEstimate) o;
         return Double.compare(outputRowCount, that.outputRowCount) == 0 &&
-                Objects.equals(symbolStatistics, that.symbolStatistics);
+                Objects.equals(symbolStatistics, that.symbolStatistics) &&
+                Objects.equals(columnGroupNdv, that.columnGroupNdv);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(outputRowCount, symbolStatistics);
+        return Objects.hash(outputRowCount, symbolStatistics, columnGroupNdv);
     }
 
     public static Builder builder()
@@ -182,23 +199,25 @@ public class PlanNodeStatsEstimate
 
     public static Builder buildFrom(PlanNodeStatsEstimate other)
     {
-        return new Builder(other.getOutputRowCount(), other.symbolStatistics);
+        return new Builder(other.getOutputRowCount(), other.symbolStatistics, other.columnGroupNdv);
     }
 
     public static final class Builder
     {
         private double outputRowCount;
         private PMap<Symbol, SymbolStatsEstimate> symbolStatistics;
+        private ImmutableMap.Builder<Set<Symbol>, Double> columnGroupNdv;
 
         public Builder()
         {
-            this(NaN, HashTreePMap.empty());
+            this(NaN, HashTreePMap.empty(), ImmutableMap.of());
         }
 
-        private Builder(double outputRowCount, PMap<Symbol, SymbolStatsEstimate> symbolStatistics)
+        private Builder(double outputRowCount, PMap<Symbol, SymbolStatsEstimate> symbolStatistics, ImmutableMap<Set<Symbol>, Double> columnGroupNdv)
         {
             this.outputRowCount = outputRowCount;
             this.symbolStatistics = symbolStatistics;
+            this.columnGroupNdv = ImmutableMap.<Set<Symbol>, Double>builder().putAll(columnGroupNdv);
         }
 
         public Builder setOutputRowCount(double outputRowCount)
@@ -225,9 +244,15 @@ public class PlanNodeStatsEstimate
             return this;
         }
 
+        public Builder addColumnGroupNdv(Set<Symbol> symbolGroup, double ndv)
+        {
+            columnGroupNdv.put(symbolGroup, ndv);
+            return this;
+        }
+
         public PlanNodeStatsEstimate build()
         {
-            return new PlanNodeStatsEstimate(outputRowCount, symbolStatistics);
+            return new PlanNodeStatsEstimate(outputRowCount, symbolStatistics, columnGroupNdv.buildOrThrow());
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TableScanStatsRule.java
@@ -16,6 +16,7 @@ package io.trino.cost;
 import io.trino.cost.StatsCalculator.Context;
 import io.trino.matching.Pattern;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.statistics.ColumnGroupStatistics;
 import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
@@ -28,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.trino.SystemSessionProperties.isStatisticsPrecalculationForPushdownEnabled;
 import static io.trino.sql.planner.plan.Patterns.tableScan;
@@ -61,6 +64,7 @@ public class TableScanStatsRule
         TableStatistics tableStatistics = context.tableStatsProvider().getTableStatistics(node.getTable());
 
         Map<Symbol, SymbolStatsEstimate> outputSymbolStats = new HashMap<>();
+        Map<ColumnHandle, Symbol> reverseAssignments = new HashMap<>();
 
         for (Entry<Symbol, ColumnHandle> entry : node.getAssignments().entrySet()) {
             Symbol symbol = entry.getKey();
@@ -69,12 +73,26 @@ public class TableScanStatsRule
                     .map(statistics -> toSymbolStatistics(tableStatistics, statistics, symbol.type()))
                     .orElse(SymbolStatsEstimate.unknown());
             outputSymbolStats.put(symbol, symbolStatistics);
+            reverseAssignments.put(entry.getValue(), symbol);
         }
 
-        return Optional.of(PlanNodeStatsEstimate.builder()
+        PlanNodeStatsEstimate.Builder builder = PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(tableStatistics.getRowCount().getValue())
-                .addSymbolStatistics(outputSymbolStats)
-                .build());
+                .addSymbolStatistics(outputSymbolStats);
+
+        for (Entry<Set<ColumnHandle>, ColumnGroupStatistics> entry : tableStatistics.getColumnGroupStatistics().entrySet()) {
+            if (entry.getValue().getDistinctValuesCount().isUnknown()) {
+                continue;
+            }
+            Set<Symbol> symbolGroup = entry.getKey().stream()
+                    .map(reverseAssignments::get)
+                    .collect(Collectors.toSet());
+            if (!symbolGroup.contains(null)) {
+                builder.addColumnGroupNdv(symbolGroup, entry.getValue().getDistinctValuesCount().getValue());
+            }
+        }
+
+        return Optional.of(builder.build());
     }
 
     private static SymbolStatsEstimate toSymbolStatistics(TableStatistics tableStatistics, ColumnStatistics columnStatistics, Type type)

--- a/core/trino-main/src/test/java/io/trino/cost/TestAggregationStatsRule.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestAggregationStatsRule.java
@@ -187,6 +187,30 @@ public class TestAggregationStatsRule
     }
 
     @Test
+    public void testAggregationWithJointNdvFromConnector()
+    {
+        // country has 50 NDV, state has 500 NDV; independence assumption yields 25000 groups.
+        // With joint NDV of 500, the estimate should be 500 instead.
+        tester().assertStatsFor(pb -> pb
+                        .aggregation(ab -> ab
+                                .singleGroupingSet(pb.symbol("country", BIGINT), pb.symbol("state", BIGINT))
+                                .source(pb.values(pb.symbol("country", BIGINT), pb.symbol("state", BIGINT)))))
+                .withSourceStats(PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(1_000_000)
+                        .addSymbolStatistics(new Symbol(BIGINT, "country"), SymbolStatsEstimate.builder()
+                                .setDistinctValuesCount(50)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol(BIGINT, "state"), SymbolStatsEstimate.builder()
+                                .setDistinctValuesCount(500)
+                                .setNullsFraction(0)
+                                .build())
+                        .addColumnGroupNdv(ImmutableSet.of(new Symbol(BIGINT, "country"), new Symbol(BIGINT, "state")), 500)
+                        .build())
+                .check(check -> check.outputRowsCount(500));
+    }
+
+    @Test
     void testAggregationStep()
     {
         testAggregationStep(AggregationNode.Step.PARTIAL);

--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/ColumnGroupStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/ColumnGroupStatistics.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.statistics;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Statistics for a group of columns, capturing correlations between them.
+ * The primary metric is the joint number of distinct value combinations,
+ * which corrects the optimizer's independence assumption when estimating
+ * GROUP BY cardinality and multi-predicate selectivity.
+ */
+public final class ColumnGroupStatistics
+{
+    private static final ColumnGroupStatistics EMPTY = new ColumnGroupStatistics(Estimate.unknown());
+
+    private final Estimate distinctValuesCount;
+
+    public static ColumnGroupStatistics empty()
+    {
+        return EMPTY;
+    }
+
+    public ColumnGroupStatistics(Estimate distinctValuesCount)
+    {
+        this.distinctValuesCount = requireNonNull(distinctValuesCount, "distinctValuesCount is null");
+        if (!distinctValuesCount.isUnknown() && distinctValuesCount.getValue() < 0) {
+            throw new IllegalArgumentException(format("distinctValuesCount must be greater than or equal to 0: %s", distinctValuesCount.getValue()));
+        }
+    }
+
+    /**
+     * Returns the estimated number of distinct value combinations for this column group.
+     * This is the joint NDV — it accounts for correlations between columns rather than
+     * assuming statistical independence.
+     */
+    public Estimate getDistinctValuesCount()
+    {
+        return distinctValuesCount;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnGroupStatistics that = (ColumnGroupStatistics) o;
+        return Objects.equals(distinctValuesCount, that.distinctValuesCount);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(distinctValuesCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ColumnGroupStatistics{" +
+                "distinctValuesCount=" + distinctValuesCount +
+                '}';
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Estimate distinctValuesCount = Estimate.unknown();
+
+        public Builder setDistinctValuesCount(Estimate distinctValuesCount)
+        {
+            this.distinctValuesCount = requireNonNull(distinctValuesCount, "distinctValuesCount is null");
+            return this;
+        }
+
+        public ColumnGroupStatistics build()
+        {
+            return new ColumnGroupStatistics(distinctValuesCount);
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/TableStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/TableStatistics.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ColumnHandle;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableMap;
@@ -30,6 +31,7 @@ public final class TableStatistics
 
     private final Estimate rowCount;
     private final Map<ColumnHandle, ColumnStatistics> columnStatistics;
+    private final Map<Set<ColumnHandle>, ColumnGroupStatistics> columnGroupStatistics;
 
     public static TableStatistics empty()
     {
@@ -38,11 +40,17 @@ public final class TableStatistics
 
     public TableStatistics(Estimate rowCount, Map<ColumnHandle, ColumnStatistics> columnStatistics)
     {
+        this(rowCount, columnStatistics, Map.of());
+    }
+
+    public TableStatistics(Estimate rowCount, Map<ColumnHandle, ColumnStatistics> columnStatistics, Map<Set<ColumnHandle>, ColumnGroupStatistics> columnGroupStatistics)
+    {
         this.rowCount = requireNonNull(rowCount, "rowCount cannot be null");
         if (!rowCount.isUnknown() && rowCount.getValue() < 0) {
             throw new IllegalArgumentException(format("rowCount must be greater than or equal to 0: %s", rowCount.getValue()));
         }
         this.columnStatistics = unmodifiableMap(requireNonNull(columnStatistics, "columnStatistics cannot be null"));
+        this.columnGroupStatistics = unmodifiableMap(requireNonNull(columnGroupStatistics, "columnGroupStatistics cannot be null"));
     }
 
     public Estimate getRowCount()
@@ -53,6 +61,16 @@ public final class TableStatistics
     public Map<ColumnHandle, ColumnStatistics> getColumnStatistics()
     {
         return columnStatistics;
+    }
+
+    /**
+     * Returns joint statistics for groups of columns. The key is an unordered set of column
+     * handles; the value holds the joint number of distinct value combinations for that group.
+     * Connectors that do not collect joint statistics may return an empty map.
+     */
+    public Map<Set<ColumnHandle>, ColumnGroupStatistics> getColumnGroupStatistics()
+    {
+        return columnGroupStatistics;
     }
 
     public boolean isEmpty()
@@ -71,13 +89,14 @@ public final class TableStatistics
         }
         TableStatistics that = (TableStatistics) o;
         return Objects.equals(rowCount, that.rowCount) &&
-                Objects.equals(columnStatistics, that.columnStatistics);
+                Objects.equals(columnStatistics, that.columnStatistics) &&
+                Objects.equals(columnGroupStatistics, that.columnGroupStatistics);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(rowCount, columnStatistics);
+        return Objects.hash(rowCount, columnStatistics, columnGroupStatistics);
     }
 
     @Override
@@ -86,6 +105,7 @@ public final class TableStatistics
         return "TableStatistics{" +
                 "rowCount=" + rowCount +
                 ", columnStatistics=" + columnStatistics +
+                ", columnGroupStatistics=" + columnGroupStatistics +
                 '}';
     }
 
@@ -97,6 +117,7 @@ public final class TableStatistics
     public static final class Builder
     {
         private final Map<ColumnHandle, ColumnStatistics> columnStatisticsMap = new LinkedHashMap<>();
+        private final Map<Set<ColumnHandle>, ColumnGroupStatistics> columnGroupStatisticsMap = new LinkedHashMap<>();
         private Estimate rowCount = Estimate.unknown();
 
         public Builder setRowCount(Estimate rowCount)
@@ -113,9 +134,20 @@ public final class TableStatistics
             return this;
         }
 
+        public Builder setColumnGroupStatistics(Set<ColumnHandle> columnGroup, ColumnGroupStatistics columnGroupStatistics)
+        {
+            requireNonNull(columnGroup, "columnGroup cannot be null");
+            requireNonNull(columnGroupStatistics, "columnGroupStatistics cannot be null");
+            if (columnGroup.isEmpty()) {
+                throw new IllegalArgumentException("columnGroup cannot be empty");
+            }
+            this.columnGroupStatisticsMap.put(columnGroup, columnGroupStatistics);
+            return this;
+        }
+
         public TableStatistics build()
         {
-            return new TableStatistics(rowCount, columnStatisticsMap);
+            return new TableStatistics(rowCount, columnStatisticsMap, columnGroupStatisticsMap);
         }
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/statistics/TestColumnGroupStatistics.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/statistics/TestColumnGroupStatistics.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.statistics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestColumnGroupStatistics
+{
+    @Test
+    public void testEmpty()
+    {
+        ColumnGroupStatistics empty = ColumnGroupStatistics.empty();
+        assertThat(empty.getDistinctValuesCount().isUnknown()).isTrue();
+    }
+
+    @Test
+    public void testBuilderWithKnownNdv()
+    {
+        ColumnGroupStatistics stats = ColumnGroupStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(42))
+                .build();
+        assertThat(stats.getDistinctValuesCount().getValue()).isEqualTo(42.0);
+    }
+
+    @Test
+    public void testBuilderRejectsNegativeNdv()
+    {
+        assertThatThrownBy(() -> ColumnGroupStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(-1))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("distinctValuesCount must be greater than or equal to 0");
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        ColumnGroupStatistics a = ColumnGroupStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(100))
+                .build();
+        ColumnGroupStatistics b = ColumnGroupStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(100))
+                .build();
+        ColumnGroupStatistics c = ColumnGroupStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(200))
+                .build();
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).isNotEqualTo(c);
+    }
+
+    @Test
+    public void testToString()
+    {
+        ColumnGroupStatistics stats = ColumnGroupStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(77))
+                .build();
+        assertThat(stats.toString()).contains("77");
+    }
+}


### PR DESCRIPTION
Implements Phase 1 (SPI extension) and Phase 3 (GROUP BY integration) from issue #29397. The optimizer's independence assumption can significantly overestimate GROUP BY cardinality when correlated columns are grouped together.

Changes:
- Add ColumnGroupStatistics to SPI: holds the joint NDV (distinct value combinations) for a set of correlated columns. Connectors can populate this via TableStatistics.Builder.setColumnGroupStatistics().
- Extend TableStatistics with Map<Set<ColumnHandle>, ColumnGroupStatistics> (backward-compatible; existing 2-arg constructor delegates to the new 3-arg constructor with an empty map).
- Extend PlanNodeStatsEstimate with an in-memory ImmutableMap<Set<Symbol>, Double> columnGroupNdv field. Not included in JSON serialization since Set<Symbol> is not a valid JSON object key; populated fresh from each table scan.
- Update TableScanStatsRule to translate ColumnGroupStatistics from the connector into symbol-level joint NDV entries on PlanNodeStatsEstimate.
- Update AggregationStatsRule.getRowsCount() to use the joint NDV directly when available, falling back to the independence assumption otherwise.

Fixes #29397
