### PR TITLE
Disable testDataMappingSmokeTest in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -384,6 +384,11 @@ public abstract class BaseBigQueryConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @Test
+    @Disabled // Type mapping is tested by BaseBigQueryTypeMapping. Disable this test to avoid the API rate limit.
+    @Override
+    public void testDataMappingSmokeTest() {}
+
     @Override
     protected boolean isColumnNameRejected(Exception exception, String columnName, boolean delimited)
     {


### PR DESCRIPTION
## Description

Mitigates API rate limit: 
https://github.com/trinodb/trino/actions/runs/25780369400/job/75721567550
```
Error:    TestBigQueryAvroConnectorTest>BaseConnectorTest.testDataMappingSmokeTest:6565->BaseConnectorTest.testDataMapping:6595->BaseConnectorTest.lambda$testDataMapping$0:6588->AbstractTestQueryFramework.assertUpdate:421->AbstractTestQueryFramework.assertUpdate:426 » QueryFailed io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: Exceeds 'CreateWriteStream requests' quota, user_id: project0000007599659589_us (status: INSUFFICIENT_TOKENS), you can issue a raise quota request through Google Cloud Console. Be sure to include this full error message in the request description. Before requesting an increase, please ensure your existing streams have enough utilization in terms of write traffic. For guidelines see https://cloud.google.com/bigquery/docs/write-api-best-practices#limit_the_rate_of_stream_creation. Entity: projects/sep-bq-cicd/datasets/tpch/tables/tmp_trino_a30113b9_77aeb179
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
