### PR TITLE
Recommend airstyle-maven-plugin for formatting in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,6 @@ Trino is developed in IntelliJ. If you run Claude Code with the JetBrains MCP se
 the assistant can drive the IDE directly. Install: https://github.com/JetBrains/mcp-jetbrains.
 
 When available, Claude should prefer these over shell equivalents:
-- `mcp__idea__reformat_file` after Java edits — applies the Airlift formatter; Claude cannot
-  reproduce it by hand.
 - `mcp__idea__get_file_problems` before committing — surfaces IntelliJ inspection results
   (error-prone, unused imports, nullability) without a full Maven build.
 - `mcp__idea__search_symbol` / `mcp__idea__get_symbol_info` for symbol navigation in a codebase
@@ -27,8 +25,10 @@ When available, Claude should prefer these over shell equivalents:
 
 ## Java formatting
 
-Run `mcp__idea__reformat_file` after every Java edit — it applies the Airlift scheme imported into
-IntelliJ. Rules not covered by the formatter:
+Run `mvnd airstyle:format` after Java edits — the `airstyle-maven-plugin` (`io.airlift:airstyle-maven-plugin`)
+applies the canonical Airstyle scheme, which is what CI checks. Scope a single file with
+`mvnd -pl <module> airstyle:format -Dincludes=**/FileName.java`, and use `airstyle:check` to verify
+without rewriting. Rules not covered by the formatter:
 
 - No wildcard imports (e.g. `import io.trino.spi.*`) — checkstyle catches these on build; easier
   to avoid writing them.


### PR DESCRIPTION
## Description

Updates `CLAUDE.md` so Claude Code reaches for `mvnd airstyle:format` (the
`io.airlift:airstyle-maven-plugin`) after Java edits, instead of
`mcp__idea__reformat_file`. The airstyle plugin produces the canonical
formatting that CI checks and works without the JetBrains MCP server
running, so it's the right default for any contributor environment.
Includes pointers to `airstyle:check` and `-Dincludes=` for single-file
scoping. Drops the corresponding MCP-formatter bullet from the JetBrains
section.

## Additional context and related issues

Doc-only change to assistant guidance; no production code or tests affected.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose release notes that summarize the change for end users: