### PR TITLE
Reduce flakiness of Kafka Tests 

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
@@ -30,9 +30,12 @@ import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_PRODUCER_ERROR;
+import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -70,34 +73,35 @@ public class KafkaPageSink
     private static class ProducerCallback
             implements Callback
     {
-        private long errorCount;
-        private long writtenBytes;
-
-        public ProducerCallback()
-        {
-            this.errorCount = 0;
-            this.writtenBytes = 0;
-        }
+        private final AtomicLong errorCount = new AtomicLong();
+        private final AtomicLong writtenBytes = new AtomicLong();
+        private final AtomicReference<Exception> firstException = new AtomicReference<>();
 
         @Override
         public void onCompletion(RecordMetadata recordMetadata, Exception e)
         {
             if (e != null) {
-                errorCount++;
+                errorCount.incrementAndGet();
+                firstException.compareAndSet(null, e);
             }
             else {
-                writtenBytes += recordMetadata.serializedValueSize() + recordMetadata.serializedKeySize();
+                writtenBytes.addAndGet(max(recordMetadata.serializedValueSize(), 0) + max(recordMetadata.serializedKeySize(), 0));
             }
         }
 
         public long getErrorCount()
         {
-            return errorCount;
+            return errorCount.get();
         }
 
         public long getWrittenBytes()
         {
-            return writtenBytes;
+            return writtenBytes.get();
+        }
+
+        public Exception getFirstException()
+        {
+            return firstException.get();
         }
     }
 
@@ -146,15 +150,15 @@ public class KafkaPageSink
             throw new UncheckedIOException("Failed to close row encoders", e);
         }
 
+        if (producerCallback.getErrorCount() > 0) {
+            throw new TrinoException(KAFKA_PRODUCER_ERROR, format("%d producer record(s) failed to send", producerCallback.getErrorCount()), producerCallback.getFirstException());
+        }
+
         checkArgument(
                 producerCallback.getWrittenBytes() == expectedWrittenBytes,
                 "Actual written bytes: '%s' not equal to expected written bytes: '%s'",
                 producerCallback.getWrittenBytes(),
                 expectedWrittenBytes);
-
-        if (producerCallback.getErrorCount() > 0) {
-            throw new TrinoException(KAFKA_PRODUCER_ERROR, format("%d producer record(s) failed to send", producerCallback.getErrorCount()));
-        }
 
         return completedFuture(ImmutableList.of());
     }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -72,7 +72,7 @@ public final class KafkaQueryRunner
 
     public static Builder builder(TestingKafka testingKafka)
     {
-        return new Builder(TPCH_SCHEMA, false)
+        return new Builder(testingKafka, TPCH_SCHEMA, false)
                 .addConnectorProperties(Map.of(
                         "kafka.nodes", testingKafka.getConnectString(),
                         "kafka.messages-per-split", "1000",
@@ -81,7 +81,7 @@ public final class KafkaQueryRunner
 
     public static Builder builderForConfluentSchemaRegistry(TestingKafka testingKafka)
     {
-        return new Builder("default", true)
+        return new Builder(testingKafka, "default", true)
                 .addConnectorProperties(Map.of(
                         "kafka.nodes", testingKafka.getConnectString(),
                         "kafka.messages-per-split", "1000",
@@ -94,16 +94,18 @@ public final class KafkaQueryRunner
             extends DistributedQueryRunner.Builder<Builder>
     {
         private final Map<String, String> connectorProperties = new HashMap<>();
+        private final TestingKafka testingKafka;
         private List<TpchTable<?>> tables = ImmutableList.of();
         private Map<SchemaTableName, KafkaTopicDescription> extraTopicDescription = ImmutableMap.of();
         private final boolean schemaRegistryEnabled;
 
-        private Builder(String schemaName, boolean schemaRegistryEnabled)
+        private Builder(TestingKafka testingKafka, String schemaName, boolean schemaRegistryEnabled)
         {
             super(testSessionBuilder()
                     .setCatalog("kafka")
                     .setSchema(schemaName)
                     .build());
+            this.testingKafka = requireNonNull(testingKafka, "testingKafka is null");
             this.schemaRegistryEnabled = schemaRegistryEnabled;
         }
 
@@ -143,9 +145,10 @@ public final class KafkaQueryRunner
                     extensions = () -> _ -> {};
                 }
                 else {
+                    Map<SchemaTableName, KafkaTopicDescription> tpchTopicDescriptions = createTpchTopicDescriptions(queryRunner.getPlannerContext().getTypeManager(), tables);
                     ImmutableMap.Builder<SchemaTableName, KafkaTopicDescription> topicDescriptions = ImmutableMap.<SchemaTableName, KafkaTopicDescription>builder()
                             .putAll(extraTopicDescription)
-                            .putAll(createTpchTopicDescriptions(queryRunner.getPlannerContext().getTypeManager(), tables));
+                            .putAll(tpchTopicDescriptions);
 
                     List<SchemaTableName> tableNames = new ArrayList<>();
                     tableNames.add(new SchemaTableName("read_test", "all_datatypes_json"));
@@ -157,6 +160,11 @@ public final class KafkaQueryRunner
                     for (SchemaTableName tableName : tableNames) {
                         topicDescriptions.put(tableName, createTable(tableName, topicDescriptionJsonCodec));
                     }
+                    Map<SchemaTableName, KafkaTopicDescription> topicDescriptionMap = topicDescriptions.buildOrThrow();
+                    tpchTopicDescriptions.values().stream()
+                            .map(KafkaTopicDescription::topicName)
+                            .distinct()
+                            .forEach(testingKafka::createTopic);
 
                     extensions = () -> new AbstractConfigurationAwareModule()
                     {
@@ -164,7 +172,7 @@ public final class KafkaQueryRunner
                         protected void setup(Binder binder)
                         {
                             if (buildConfigObject(KafkaConfig.class).getTableDescriptionSupplier().equalsIgnoreCase(TEST)) {
-                                binder.bind(TableDescriptionSupplier.class).toInstance(new MapBasedTableDescriptionSupplier(topicDescriptions.buildOrThrow()));
+                                binder.bind(TableDescriptionSupplier.class).toInstance(new MapBasedTableDescriptionSupplier(topicDescriptionMap));
                             }
                             binder.bind(ContentSchemaProvider.class).to(FileReadContentSchemaProvider.class).in(Scopes.SINGLETON);
                             install(new DecoderModule());

--- a/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
+++ b/testing/trino-testing-kafka/src/main/java/io/trino/testing/kafka/TestingKafka.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.LongSerializer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.kafka.ConfluentKafkaContainer;
@@ -157,21 +158,7 @@ public final class TestingKafka
 
     private void createTopic(int partitions, int replication, String topic)
     {
-        try {
-            List<String> command = new ArrayList<>();
-            command.add("kafka-topics");
-            command.add("--partitions");
-            command.add(Integer.toString(partitions));
-            command.add("--replication-factor");
-            command.add(Integer.toString(replication));
-            command.add("--topic");
-            command.add(topic);
-
-            kafka.execInContainer(command.toArray(new String[0]));
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        createTopicWithConfig(partitions, replication, topic, false);
     }
 
     public void createTopicWithConfig(int partitions, int replication, String topic, boolean enableLogAppendTime)
@@ -180,6 +167,7 @@ public final class TestingKafka
             List<String> command = new ArrayList<>();
             command.add("kafka-topics");
             command.add("--create");
+            command.add("--if-not-exists");
             command.add("--topic");
             command.add(topic);
             command.add("--partitions");
@@ -193,11 +181,40 @@ public final class TestingKafka
                 command.add("message.timestamp.type=LogAppendTime");
             }
 
-            kafka.execInContainer(command.toArray(new String[0]));
+            executeKafkaTopicsCommand(topic, command);
+
+            executeKafkaTopicsCommand(topic, List.of(
+                    "kafka-topics",
+                    "--describe",
+                    "--topic",
+                    topic,
+                    "--bootstrap-server",
+                    "localhost:9093"));
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void executeKafkaTopicsCommand(String topic, List<String> command)
+    {
+        Failsafe.with(
+                        RetryPolicy.builder()
+                                .onRetry(event -> log.warn(event.getLastException(), "Retrying Kafka topic setup for %s", topic))
+                                .withMaxAttempts(10)
+                                .withBackoff(100, 10_000, MILLIS)
+                                .build())
+                .get(() -> {
+                    Container.ExecResult result = kafka.execInContainer(command.toArray(new String[0]));
+                    checkState(
+                            result.getExitCode() == 0,
+                            "Failed to execute Kafka topic command %s: exitCode=%s, stdout=%s, stderr=%s",
+                            command,
+                            result.getExitCode(),
+                            result.getStdout(),
+                            result.getStderr());
+                    return result;
+                });
     }
 
     public <K, V> RecordMetadata sendMessages(Stream<ProducerRecord<K, V>> recordStream)


### PR DESCRIPTION
## Description

Root cause: the Kafka tests were writing TPCH preload data into topics that the fixture had not explicitly created yet. That meant the first `INSERT INTO nation ...` could depend on Kafka auto-topic creation and metadata propagation. Under CI timing/load, the producer could start writing before the topic was fully ready/visible, causing some sends to fail or not be acknowledged. The sink then surfaced that as a confusing “actual written bytes != expected written bytes” error.

The fix makes the fixture deterministic before any data write happens:

1. The Kafka query runner now gathers all topic descriptions and explicitly creates those topics before populating TPCH tables.
2. `TestingKafka.createTopic` now uses the proper `kafka-topics --create --if-not-exists --bootstrap-server ...` command.
3. Topic setup is retried, and after creation the fixture runs `kafka-topics --describe` with retries to verify the topic is visible before inserts begin.
4. The sink’s producer callback accounting is thread-safe, and producer errors are reported before the byte-count sanity check, so any remaining failure points at the real Kafka exception.

Why it works: we retry only idempotent setup operations before any rows are written. We do not retry the `INSERT`, because Kafka writes are non-transactional and retrying a partial insert could hide bugs by duplicating messages. By making topic creation complete and observable first, the initial preload insert no longer races Kafka topic creation.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
