### PR TITLE
Avoid recreating storage table on CREATE OR REPLACE MATERIALIZED VIEW

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -90,6 +90,7 @@ public abstract class AbstractIcebergTableOperations
     protected String currentMetadataLocation;
     protected boolean shouldRefresh = true;
     protected OptionalInt version = OptionalInt.empty();
+    protected Optional<MaterializedViewCommitData> materializedViewCommitData = Optional.empty();
 
     protected AbstractIcebergTableOperations(
             FileIO fileIo,
@@ -158,7 +159,7 @@ public abstract class AbstractIcebergTableOperations
         }
 
         if (isMaterializedViewStorage(tableName)) {
-            commitMaterializedViewRefresh(base, metadata);
+            commitMaterializedView(base, metadata);
             return;
         }
 
@@ -187,7 +188,12 @@ public abstract class AbstractIcebergTableOperations
 
     protected abstract void commitToExistingTable(TableMetadata base, TableMetadata metadata);
 
-    protected abstract void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata);
+    protected abstract void commitMaterializedView(TableMetadata base, TableMetadata metadata);
+
+    public void applyMaterializedViewCommitData(Optional<MaterializedViewCommitData> materializedViewCommitData)
+    {
+        this.materializedViewCommitData = requireNonNull(materializedViewCommitData, "materializedViewCommitData is null");
+    }
 
     @Override
     public FileIO io()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 
 import java.io.IOException;
@@ -64,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -76,9 +78,12 @@ import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.decodeMaterializedViewData;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.encodeMaterializedViewData;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.fromConnectorMaterializedViewDefinition;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewProperties.STORAGE_SCHEMA;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewProperties.getStorageSchema;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
+import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameWithType;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getSortOrder;
@@ -93,6 +98,7 @@ import static io.trino.plugin.iceberg.PartitionTransforms.getColumnTransform;
 import static io.trino.plugin.iceberg.SortFieldUtils.parseSortFields;
 import static io.trino.plugin.iceberg.TableType.MATERIALIZED_VIEW_STORAGE;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
+import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -112,6 +118,7 @@ import static org.apache.iceberg.TableMetadataParser.getFileExtension;
 import static org.apache.iceberg.TableProperties.METADATA_COMPRESSION_DEFAULT;
 import static org.apache.iceberg.Transactions.createOrReplaceTableTransaction;
 import static org.apache.iceberg.Transactions.createTableTransaction;
+import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
 
 public abstract class AbstractTrinoCatalog
         implements TrinoCatalog
@@ -359,7 +366,7 @@ public abstract class AbstractTrinoCatalog
         return storageTable;
     }
 
-    private List<ColumnMetadata> columnsForMaterializedView(ConnectorMaterializedViewDefinition definition, Map<String, Object> materializedViewProperties)
+    protected List<ColumnMetadata> columnsForMaterializedView(ConnectorMaterializedViewDefinition definition, Map<String, Object> materializedViewProperties)
     {
         Schema schemaWithTimestampTzPreserved = schemaFromMetadata(definition.getColumns().stream()
                 .map(column -> {
@@ -505,6 +512,52 @@ public abstract class AbstractTrinoCatalog
                 .put(TRINO_CREATED_BY, TRINO_CREATED_BY_VALUE)
                 .put(TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT)
                 .buildOrThrow();
+    }
+
+    protected void replaceMaterializedViewStorageTable(
+            ConnectorSession session,
+            SchemaTableName storageTableName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
+            ExecutorService icebergScanExecutor)
+    {
+        BaseTable icebergTable = loadTable(session, storageTableName);
+        AbstractIcebergTableOperations tableOperations = (AbstractIcebergTableOperations) icebergTable.operations();
+        if (isMaterializedViewStorage(storageTableName.getTableName())) {
+            // Update the view definition while performing the commit operation on the iceberg table
+            Map<String, String> viewProperties = createMaterializedViewProperties(session, Location.of(tableOperations.current().metadataFileLocation()));
+            tableOperations.applyMaterializedViewCommitData(Optional.of(new MaterializedViewCommitData(
+                    encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition)),
+                    viewProperties)));
+        }
+
+        Optional<String> providedTableLocation = getTableLocation(materializedViewProperties);
+        if (providedTableLocation.isPresent() && !stripTrailingSlash(providedTableLocation.get()).equals(icebergTable.location())) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, format("The provided location '%s' does not match the existing storage table location '%s'", providedTableLocation.get(), icebergTable.location()));
+        }
+
+        List<ColumnMetadata> columns = columnsForMaterializedView(definition, materializedViewProperties);
+        Schema schema = IcebergUtil.schemaFromMetadata(columns);
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(materializedViewProperties));
+        SortOrder sortOrder = parseSortFields(schema, getSortOrder(materializedViewProperties));
+        Map<String, String> properties = createTableProperties(new ConnectorTableMetadata(storageTableName, columns, materializedViewProperties, Optional.empty()), _ -> false);
+        TableMetadata newTableMetadata = icebergTable.operations().current()
+                // don't inherit table properties from earlier snapshots
+                .replaceProperties(properties)
+                .buildReplacement(schema, partitionSpec, sortOrder, icebergTable.location(), properties);
+        Transaction transaction = createOrReplaceTableTransaction(storageTableName.getTableName(), icebergTable.operations(), newTableMetadata);
+        transaction.newDelete()
+                .deleteFromRowFilter(Expressions.alwaysTrue())
+                .scanManifestsWith(icebergScanExecutor)
+                .commit();
+        try {
+            transaction.commitTransaction();
+        }
+        finally {
+            if (isMaterializedViewStorage(storageTableName.getTableName())) {
+                tableOperations.applyMaterializedViewCommitData(Optional.empty());
+            }
+        }
     }
 
     protected abstract void invalidateTableCache(SchemaTableName schemaTableName);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/MaterializedViewCommitData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/MaterializedViewCommitData.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record MaterializedViewCommitData(String viewOriginalText, Map<String, String> parameters)
+{
+    public MaterializedViewCommitData
+    {
+        requireNonNull(viewOriginalText, "viewOriginalText is null");
+        parameters = ImmutableMap.copyOf(parameters);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
@@ -63,12 +63,22 @@ public class FileMetastoreTableOperations
     }
 
     @Override
-    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    protected void commitMaterializedView(TableMetadata base, TableMetadata metadata)
     {
         Table materializedView = getTable(database, tableNameFrom(tableName));
-        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> Table.builder(table)
-                .apply(builder -> builder.setParameter(METADATA_LOCATION_PROP, newMetadataLocation).setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation))
-                .build());
+        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> {
+            if (materializedViewCommitData.isPresent()) {
+                table = Table.builder(table)
+                        .setParameters(materializedViewCommitData.get().parameters())
+                        .setViewOriginalText(Optional.of(materializedViewCommitData.get().viewOriginalText()))
+                        .build();
+            }
+            return Table.builder(table)
+                    .apply(builder -> builder
+                            .setParameter(METADATA_LOCATION_PROP, newMetadataLocation)
+                            .setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation))
+                    .build();
+        });
     }
 
     private void commitTableUpdate(Table table, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -162,12 +162,19 @@ public class GlueIcebergTableOperations
     }
 
     @Override
-    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    protected void commitMaterializedView(TableMetadata base, TableMetadata metadata)
     {
         commitTableUpdate(
                 getTable(database, tableNameFrom(tableName), false),
                 metadata,
                 (table, newMetadataLocation) -> {
+                    if (materializedViewCommitData.isPresent()) {
+                        table = table.toBuilder()
+                                .viewOriginalText(materializedViewCommitData.get().viewOriginalText())
+                                .parameters(materializedViewCommitData.get().parameters())
+                                .build();
+                    }
+
                     Map<String, String> parameters = new HashMap<>(table.parameters());
                     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);
                     parameters.put(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -91,6 +91,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -130,6 +131,7 @@ import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.fromConn
 import static io.trino.plugin.iceberg.IcebergMaterializedViewProperties.STORAGE_SCHEMA;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
+import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameWithType;
 import static io.trino.plugin.iceberg.IcebergUtil.COLUMN_TRINO_NOT_NULL_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.COLUMN_TRINO_TYPE_ID_PROPERTY;
@@ -173,6 +175,7 @@ public class TrinoGlueCatalog
     private final boolean hideMaterializedViewStorageTable;
     private final boolean isUsingSystemSecurity;
     private final Executor metadataFetchingExecutor;
+    private final ExecutorService icebergScanExecutor;
 
     private final Cache<SchemaTableName, Table> glueTableCache = EvictableCacheBuilder.newBuilder()
             // Even though this is query-scoped, this still needs to be bounded. information_schema queries can access large number of tables.
@@ -202,7 +205,8 @@ public class TrinoGlueCatalog
             Optional<String> defaultSchemaLocation,
             boolean useUniqueTableLocation,
             boolean hideMaterializedViewStorageTable,
-            Executor metadataFetchingExecutor)
+            Executor metadataFetchingExecutor,
+            ExecutorService icebergScanExecutor)
     {
         super(catalogName, useUniqueTableLocation, typeManager, tableOperationsProvider, fileSystemFactory, fileIoFactory);
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
@@ -212,6 +216,7 @@ public class TrinoGlueCatalog
         this.defaultSchemaLocation = requireNonNull(defaultSchemaLocation, "defaultSchemaLocation is null");
         this.hideMaterializedViewStorageTable = hideMaterializedViewStorageTable;
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
+        this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
     }
 
     @Override
@@ -1125,6 +1130,9 @@ public class TrinoGlueCatalog
                 }
                 throw new TrinoException(ALREADY_EXISTS, "Materialized view already exists: " + viewName);
             }
+
+            replaceMaterializedView(session, viewName, definition, materializedViewProperties);
+            return;
         }
 
         if (hideMaterializedViewStorageTable) {
@@ -1135,12 +1143,7 @@ public class TrinoGlueCatalog
                     isUsingSystemSecurity ? null : session.getUser(),
                     createMaterializedViewProperties(session, storageMetadataLocation));
             try {
-                if (existing.isPresent()) {
-                    updateTable(viewName.getSchemaName(), materializedViewTableInput);
-                }
-                else {
-                    createTable(viewName.getSchemaName(), materializedViewTableInput);
-                }
+                createTable(viewName.getSchemaName(), materializedViewTableInput);
             }
             catch (RuntimeException e) {
                 try {
@@ -1154,11 +1157,34 @@ public class TrinoGlueCatalog
                 }
                 throw e;
             }
-
-            existing.ifPresent(existingView -> dropMaterializedViewStorage(session, existingView));
         }
         else {
-            createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties, existing);
+            createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties);
+        }
+    }
+
+    private void replaceMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties)
+    {
+        ConnectorMaterializedViewDefinition existingDefinition = getMaterializedView(session, viewName)
+                .orElseThrow(() -> new TrinoException(ICEBERG_BAD_DATA, "Materialized view definition missing: " + viewName));
+        SchemaTableName storageTableName = existingDefinition.getStorageTable()
+                .map(CatalogSchemaTableName::getSchemaTableName)
+                .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + viewName));
+
+        replaceMaterializedViewStorageTable(session, storageTableName, definition, materializedViewProperties, icebergScanExecutor);
+
+        if (!isMaterializedViewStorage(storageTableName.getTableName())) {
+            // Replace the existing view definition
+            TableInput materializedViewTableInput = getMaterializedViewTableInput(
+                    viewName.getTableName(),
+                    encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition)),
+                    isUsingSystemSecurity ? null : session.getUser(),
+                    createMaterializedViewProperties(session, storageTableName));
+            updateTable(viewName.getSchemaName(), materializedViewTableInput);
         }
     }
 
@@ -1166,8 +1192,7 @@ public class TrinoGlueCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
-            Map<String, Object> materializedViewProperties,
-            Optional<Table> existing)
+            Map<String, Object> materializedViewProperties)
     {
         // Create the storage table
         SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition, materializedViewProperties);
@@ -1178,27 +1203,7 @@ public class TrinoGlueCatalog
                 isUsingSystemSecurity ? null : session.getUser(),
                 createMaterializedViewProperties(session, storageTable));
 
-        if (existing.isPresent()) {
-            try {
-                updateTable(viewName.getSchemaName(), materializedViewTableInput);
-            }
-            catch (RuntimeException e) {
-                try {
-                    // Update failed, clean up new storage table
-                    dropTable(session, storageTable);
-                }
-                catch (RuntimeException suppressed) {
-                    LOG.warn(suppressed, "Failed to drop new storage table '%s' for materialized view '%s'", storageTable, viewName);
-                    if (e != suppressed) {
-                        e.addSuppressed(suppressed);
-                    }
-                }
-            }
-            dropMaterializedViewStorage(session, existing.get());
-        }
-        else {
-            createTable(viewName.getSchemaName(), materializedViewTableInput);
-        }
+        createTable(viewName.getSchemaName(), materializedViewTableInput);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -20,6 +20,7 @@ import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.hive.security.UsingSystemSecurity;
 import io.trino.plugin.iceberg.ForIcebergMetadata;
+import io.trino.plugin.iceberg.ForIcebergSplitManager;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
@@ -57,6 +58,7 @@ public class TrinoGlueCatalogFactory
     private final GlueMetastoreStats stats;
     private final boolean isUsingSystemSecurity;
     private final Executor metadataFetchingExecutor;
+    private final ExecutorService icebergScanExecutor;
 
     @Inject
     public TrinoGlueCatalogFactory(
@@ -72,7 +74,8 @@ public class TrinoGlueCatalogFactory
             @UsingSystemSecurity boolean usingSystemSecurity,
             GlueMetastoreStats stats,
             GlueClient glueClient,
-            @ForIcebergMetadata ExecutorService metadataExecutorService)
+            @ForIcebergMetadata ExecutorService metadataExecutorService,
+            @ForIcebergSplitManager ExecutorService icebergScanExecutor)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
@@ -93,6 +96,7 @@ public class TrinoGlueCatalogFactory
         else {
             this.metadataFetchingExecutor = new BoundedExecutor(metadataExecutorService, icebergConfig.getMetadataParallelism());
         }
+        this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
     }
 
     @Managed
@@ -118,6 +122,7 @@ public class TrinoGlueCatalogFactory
                 defaultSchemaLocation,
                 isUniqueTableLocation,
                 hideMaterializedViewStorageTable,
-                metadataFetchingExecutor);
+                metadataFetchingExecutor,
+                icebergScanExecutor);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
@@ -80,16 +80,24 @@ public class HiveMetastoreTableOperations
     }
 
     @Override
-    protected final void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    protected final void commitMaterializedView(TableMetadata base, TableMetadata metadata)
     {
         Table materializedView = getTable(database, tableNameFrom(tableName));
-        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> Table.builder(table)
-                .apply(builder -> builder
-                        .setParameter(METADATA_LOCATION_PROP, newMetadataLocation)
-                        .setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation)
-                        .setParameter(CURRENT_SNAPSHOT_ID, String.valueOf(metadata.currentSnapshot().snapshotId()))
-                        .setParameter(CURRENT_SNAPSHOT_TIMESTAMP, String.valueOf(metadata.currentSnapshot().timestampMillis())))
-                .build());
+        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> {
+            if (materializedViewCommitData.isPresent()) {
+                table = Table.builder(table)
+                        .setParameters(materializedViewCommitData.get().parameters())
+                        .setViewOriginalText(Optional.of(materializedViewCommitData.get().viewOriginalText()))
+                        .build();
+            }
+            return Table.builder(table)
+                    .apply(builder -> builder
+                            .setParameter(METADATA_LOCATION_PROP, newMetadataLocation)
+                            .setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation)
+                            .setParameter(CURRENT_SNAPSHOT_ID, String.valueOf(metadata.currentSnapshot().snapshotId()))
+                            .setParameter(CURRENT_SNAPSHOT_TIMESTAMP, String.valueOf(metadata.currentSnapshot().timestampMillis())))
+                    .build();
+        });
     }
 
     private void commitTableUpdate(Table table, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -77,6 +77,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -108,6 +109,7 @@ import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.fromConn
 import static io.trino.plugin.iceberg.IcebergMaterializedViewProperties.STORAGE_SCHEMA;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
+import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.plugin.iceberg.IcebergUtil.quotedTableName;
@@ -141,6 +143,7 @@ public class TrinoHiveCatalog
     private final boolean deleteSchemaLocationsFallback;
     private final boolean hideMaterializedViewStorageTable;
     private final Executor metadataFetchingExecutor;
+    private final ExecutorService icebergScanExecutor;
 
     private final Cache<SchemaTableName, TableMetadata> tableMetadataCache = EvictableCacheBuilder.newBuilder()
             .maximumSize(PER_QUERY_CACHE_SIZE)
@@ -158,7 +161,8 @@ public class TrinoHiveCatalog
             boolean isUsingSystemSecurity,
             boolean deleteSchemaLocationsFallback,
             boolean hideMaterializedViewStorageTable,
-            Executor metadataFetchingExecutor)
+            Executor metadataFetchingExecutor,
+            ExecutorService icebergScanExecutor)
     {
         super(catalogName, useUniqueTableLocation, typeManager, tableOperationsProvider, fileSystemFactory, fileIoFactory);
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -167,6 +171,7 @@ public class TrinoHiveCatalog
         this.deleteSchemaLocationsFallback = deleteSchemaLocationsFallback;
         this.hideMaterializedViewStorageTable = hideMaterializedViewStorageTable;
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
+        this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
     }
 
     public CachingHiveMetastore getMetastore()
@@ -578,11 +583,13 @@ public class TrinoHiveCatalog
                 }
                 throw new TrinoException(ALREADY_EXISTS, "Materialized view already exists: " + viewName);
             }
+
+            replaceMaterializedView(session, viewName, definition, materializedViewProperties, existing.get());
+            return;
         }
 
         if (hideMaterializedViewStorageTable) {
             Location storageMetadataLocation = createMaterializedViewStorage(session, viewName, definition, materializedViewProperties);
-
             Map<String, String> viewProperties = createMaterializedViewProperties(session, storageMetadataLocation);
             Column dummyColumn = new Column("dummy", HIVE_STRING, Optional.empty(), ImmutableMap.of());
             Table.Builder tableBuilder = Table.builder()
@@ -600,14 +607,8 @@ public class TrinoHiveCatalog
                     .setViewExpandedText(Optional.of("/* " + ICEBERG_MATERIALIZED_VIEW_COMMENT + " */"));
             Table table = tableBuilder.build();
             PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
-
             try {
-                if (existing.isPresent()) {
-                    metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges, ImmutableMap.of());
-                }
-                else {
-                    metastore.createTable(table, principalPrivileges);
-                }
+                metastore.createTable(table, principalPrivileges);
             }
             catch (RuntimeException e) {
                 try {
@@ -621,11 +622,38 @@ public class TrinoHiveCatalog
                 }
                 throw e;
             }
-
-            existing.ifPresent(existingView -> dropMaterializedViewStorage(session, existingView));
         }
         else {
-            createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties, existing);
+            createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties);
+        }
+    }
+
+    private void replaceMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
+            Table existingMetastoreTable)
+    {
+        ConnectorMaterializedViewDefinition existingDefinition = getMaterializedView(session, viewName)
+                .orElseThrow(() -> new TrinoException(ICEBERG_BAD_DATA, "Materialized view definition missing: " + viewName));
+        SchemaTableName storageTableName = existingDefinition.getStorageTable()
+                .map(CatalogSchemaTableName::getSchemaTableName)
+                .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + viewName));
+
+        replaceMaterializedViewStorageTable(session, storageTableName, definition, materializedViewProperties, icebergScanExecutor);
+
+        if (!isMaterializedViewStorage(storageTableName.getTableName())) {
+            // Replace the existing view definition
+            Map<String, String> viewProperties = createMaterializedViewProperties(session, storageTableName);
+            Table table = Table.builder(existingMetastoreTable)
+                    .setOwner(isUsingSystemSecurity ? Optional.empty() : Optional.of(session.getUser()))
+                    .setViewOriginalText(Optional.of(
+                            encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition))))
+                    .setParameters(viewProperties)
+                    .build();
+            PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
+            metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges, ImmutableMap.of());
         }
     }
 
@@ -633,8 +661,7 @@ public class TrinoHiveCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
-            Map<String, Object> materializedViewProperties,
-            Optional<Table> existing)
+            Map<String, Object> materializedViewProperties)
     {
         SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition, materializedViewProperties);
 
@@ -657,19 +684,6 @@ public class TrinoHiveCatalog
                 .setViewExpandedText(Optional.of("/* " + ICEBERG_MATERIALIZED_VIEW_COMMENT + " */"));
         Table table = tableBuilder.build();
         PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
-        if (existing.isPresent()) {
-            // drop the current storage table
-            String oldStorageTable = existing.get().getParameters().get(STORAGE_TABLE);
-            if (oldStorageTable != null) {
-                String storageSchema = Optional.ofNullable(existing.get().getParameters().get(STORAGE_SCHEMA))
-                        .orElse(viewName.getSchemaName());
-                metastore.dropTable(storageSchema, oldStorageTable, true);
-            }
-            // Replace the existing view definition
-            metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges, ImmutableMap.of());
-            return;
-        }
-        // create the view definition
         metastore.createTable(table, principalPrivileges);
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalogFactory.java
@@ -21,6 +21,7 @@ import io.trino.metastore.cache.CachingHiveMetastore;
 import io.trino.plugin.hive.TrinoViewHiveMetastore;
 import io.trino.plugin.hive.security.UsingSystemSecurity;
 import io.trino.plugin.iceberg.ForIcebergMetadata;
+import io.trino.plugin.iceberg.ForIcebergSplitManager;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
@@ -55,6 +56,7 @@ public class TrinoHiveCatalogFactory
     private final boolean deleteSchemaLocationsFallback;
     private final boolean hideMaterializedViewStorageTable;
     private final Executor metadataFetchingExecutor;
+    private final ExecutorService icebergScanExecutor;
 
     @Inject
     public TrinoHiveCatalogFactory(
@@ -67,7 +69,8 @@ public class TrinoHiveCatalogFactory
             IcebergTableOperationsProvider tableOperationsProvider,
             NodeVersion nodeVersion,
             @UsingSystemSecurity boolean isUsingSystemSecurity,
-            @ForIcebergMetadata ExecutorService metadataExecutorService)
+            @ForIcebergMetadata ExecutorService metadataExecutorService,
+            @ForIcebergSplitManager ExecutorService icebergScanExecutor)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
@@ -86,6 +89,7 @@ public class TrinoHiveCatalogFactory
         else {
             this.metadataFetchingExecutor = new BoundedExecutor(metadataExecutorService, config.getMetadataParallelism());
         }
+        this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
     }
 
     @Override
@@ -104,6 +108,7 @@ public class TrinoHiveCatalogFactory
                 isUsingSystemSecurity,
                 deleteSchemaLocationsFallback,
                 hideMaterializedViewStorageTable,
-                metadataFetchingExecutor);
+                metadataFetchingExecutor,
+                icebergScanExecutor);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcTableOperations.java
@@ -69,7 +69,7 @@ public class IcebergJdbcTableOperations
     }
 
     @Override
-    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    protected void commitMaterializedView(TableMetadata base, TableMetadata metadata)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
@@ -156,7 +156,7 @@ public class IcebergNessieTableOperations
     }
 
     @Override
-    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    protected void commitMaterializedView(TableMetadata base, TableMetadata metadata)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-iceberg/src/main/java/org/apache/iceberg/snowflake/SnowflakeIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/org/apache/iceberg/snowflake/SnowflakeIcebergTableOperations.java
@@ -89,7 +89,7 @@ public class SnowflakeIcebergTableOperations
     }
 
     @Override
-    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    protected void commitMaterializedView(TableMetadata base, TableMetadata metadata)
     {
         throw new TrinoException(NOT_SUPPORTED, "Snowflake managed Iceberg tables do not support modifications");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -48,8 +48,10 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -82,6 +84,7 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -570,18 +573,188 @@ public abstract class BaseIcebergMaterializedViewTest
     public void testReplace()
     {
         // Materialized view to test 'replace' feature
-        assertUpdate("CREATE MATERIALIZED VIEW materialized_view_replace WITH (partitioning = ARRAY['_date']) as select _date, count(_date) as num_dates from base_table1 group by 1");
-        assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_replace", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW materialized_view_replace WITH (partitioning = ARRAY['_date']) AS SELECT _date, count(_date) AS num_dates FROM base_table1 GROUP BY 1");
 
-        assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace as select sum(1) as num_rows from base_table2");
+        assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_replace", 3);
+        TableMetadata storageMetadata = getStorageTableMetadata("materialized_view_replace");
+        List<Snapshot> storageSnapshots = storageMetadata.snapshots();
+        String storageTableUuid = storageMetadata.uuid();
+        String storageTableLocation = storageMetadata.location();
+        assertThat(storageSnapshots).hasSize(2);
+
+        assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace WITH (format='AVRO') AS SELECT sum(1) AS num_rows FROM base_table2");
+        storageMetadata = getStorageTableMetadata("materialized_view_replace");
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "AVRO"));
+        assertThat(storageMetadata.snapshots()).hasSize(3).containsAll(storageSnapshots);
+        storageSnapshots = storageMetadata.snapshots();
+
         assertThat(getExplainPlan("SELECT * FROM materialized_view_replace", ExplainType.Type.IO))
                 .contains("base_table2");
+
         assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_replace", 1);
+        storageMetadata = getStorageTableMetadata("materialized_view_replace");
+        assertThat(storageMetadata.snapshots()).hasSize(5).containsAll(storageSnapshots);
+
         computeScalar("SELECT * FROM materialized_view_replace");
         assertThat(query("SELECT * FROM materialized_view_replace"))
                 .matches("VALUES BIGINT '3'");
 
+        assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace WITH (format='PARQUET', location ='" + storageTableLocation + "') AS SELECT * FROM base_table1");
+        assertThat(getExplainPlan("SELECT * FROM materialized_view_replace", ExplainType.Type.IO))
+                .contains("base_table1");
+        storageMetadata = getStorageTableMetadata("materialized_view_replace");
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "PARQUET"));
+        assertThat(storageMetadata.snapshots()).hasSize(6).containsAll(storageSnapshots);
+
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_replace");
+    }
+
+    @Test
+    public void testReplaceWithLegacyMetastoreStorage()
+    {
+        String schemaName = getSession().getSchema().orElseThrow();
+        String materializedViewName = "test_materialized_view_replace_legacy" + randomNameSuffix();
+        // Materialized view to test 'replace' feature
+        assertUpdate(format("CREATE MATERIALIZED VIEW iceberg_legacy_mv.%1$s.%2$s WITH (partitioning = ARRAY['_date']) AS SELECT _date, count(_date) AS num_dates FROM iceberg.%1$s.base_table1 GROUP BY 1", schemaName, materializedViewName));
+        String storageTableName = (String) computeScalar("SELECT storage_table FROM system.metadata.materialized_views WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + materializedViewName + "'");
+
+        assertUpdate(format("REFRESH MATERIALIZED VIEW iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), 3);
+        TableMetadata storageMetadata = getStorageTableMetadata(storageTableName);
+        String storageTableUuid = storageMetadata.uuid();
+        List<Snapshot> storageSnapshots = storageMetadata.snapshots();
+        assertThat(storageSnapshots).hasSize(3);
+
+        assertUpdate(format("CREATE OR REPLACE MATERIALIZED VIEW iceberg_legacy_mv.%1$s.%2$s WITH (format='AVRO') AS SELECT sum(1) AS num_rows FROM iceberg.%1$s.base_table2", schemaName, materializedViewName));
+        storageMetadata = getStorageTableMetadata(storageTableName);
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "AVRO"));
+        assertThat(storageMetadata.snapshots()).hasSize(4).containsAll(storageSnapshots);
+        storageSnapshots = storageMetadata.snapshots();
+
+        assertThat(getExplainPlan(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), ExplainType.Type.IO))
+                .contains("base_table2");
+
+        assertUpdate(format("REFRESH MATERIALIZED VIEW iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), 1);
+        storageMetadata = getStorageTableMetadata(storageTableName);
+        // REFRESH performs "delete" and new data "append"
+        assertThat(storageMetadata.snapshots()).hasSize(6).containsAll(storageSnapshots);
+
+        computeScalar(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName));
+        assertThat(query(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName)))
+                .matches("VALUES BIGINT '3'");
+
+        // CREATE OR REPLACE without specifying location
+        assertUpdate(format("CREATE OR REPLACE MATERIALIZED VIEW iceberg_legacy_mv.%s.%s WITH (format='PARQUET') AS SELECT * FROM base_table1", schemaName, materializedViewName));
+        assertThat(getExplainPlan(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), ExplainType.Type.IO))
+                .contains("base_table1");
+        storageMetadata = getStorageTableMetadata(storageTableName);
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "PARQUET"));
+        assertThat(storageMetadata.snapshots()).hasSize(7).containsAll(storageSnapshots);
+
+        assertUpdate(format("DROP MATERIALIZED VIEW iceberg_legacy_mv.%s.%s", schemaName, materializedViewName));
+    }
+
+    @Test
+    public void testReplaceWithLocation()
+    {
+        // Avoid location conflicts with the file metastore
+        String materializedViewLocation = getSchemaDirectory() + "/materialized_view_replace_location" + randomNameSuffix();
+        // Materialized view to test 'replace' feature
+        assertUpdate("CREATE MATERIALIZED VIEW materialized_view_replace_location WITH (location='" + materializedViewLocation + "', partitioning = ARRAY['_date']) AS SELECT _date, count(_date) AS num_dates FROM base_table1 GROUP BY 1");
+
+        assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_replace_location", 3);
+        TableMetadata storageMetadata = getStorageTableMetadata("materialized_view_replace_location");
+        String storageTableUuid = storageMetadata.uuid();
+        List<Snapshot> storageSnapshots = storageMetadata.snapshots();
+        assertThat(storageSnapshots).hasSize(2);
+
+        assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace_location WITH (location='" + materializedViewLocation + "', format='AVRO') AS SELECT sum(1) AS num_rows FROM base_table2");
+        storageMetadata = getStorageTableMetadata("materialized_view_replace_location");
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "AVRO"));
+        assertThat(storageMetadata.snapshots()).hasSize(3).containsAll(storageSnapshots);
+        storageSnapshots = storageMetadata.snapshots();
+
+        assertThat(getExplainPlan("SELECT * FROM materialized_view_replace_location", ExplainType.Type.IO))
+                .contains("base_table2");
+
+        assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_replace_location", 1);
+        storageMetadata = getStorageTableMetadata("materialized_view_replace_location");
+        // REFRESH performs "delete" and new data "append"
+        assertThat(storageMetadata.snapshots()).hasSize(5).containsAll(storageSnapshots);
+
+        computeScalar("SELECT * FROM materialized_view_replace_location");
+        assertThat(query("SELECT * FROM materialized_view_replace_location"))
+                .matches("VALUES BIGINT '3'");
+
+        assertUpdate("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace_location WITH (format = 'PARQUET') AS SELECT * FROM base_table1");
+        assertThat(getExplainPlan("SELECT * FROM materialized_view_replace_location", ExplainType.Type.IO))
+                .contains("base_table1");
+        storageMetadata = getStorageTableMetadata("materialized_view_replace_location");
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "PARQUET"));
+        assertThat(storageMetadata.snapshots()).hasSize(6).containsAll(storageSnapshots);
+
+        String newMaterializedViewLocation = getSchemaDirectory() + "/new_materialized_view_replace_location" + randomNameSuffix();
+        assertThatThrownBy(() -> computeActual("CREATE OR REPLACE MATERIALIZED VIEW materialized_view_replace_location WITH (location='" + newMaterializedViewLocation + "') as select 1 as data"))
+                .hasMessage("The provided location '%s' does not match the existing storage table location '%s'".formatted(newMaterializedViewLocation, materializedViewLocation));
+        assertUpdate("DROP MATERIALIZED VIEW materialized_view_replace_location");
+    }
+
+    @Test
+    public void testReplaceWithLegacyMetastoreStorageWithLocation()
+    {
+        String schemaName = getSession().getSchema().orElseThrow();
+        String materializedViewName = "test_materialized_view_replace_legacy" + randomNameSuffix();
+        // Avoid location conflicts with the file metastore
+        String storageTableLocation = getSchemaDirectory() + "/" + materializedViewName + "location";
+
+        // Materialized view to test 'replace' feature
+        assertUpdate(format("CREATE MATERIALIZED VIEW iceberg_legacy_mv.%1$s.%2$s WITH (partitioning = ARRAY['_date'], location='%3$s') AS SELECT _date, count(_date) AS num_dates FROM iceberg.%1$s.base_table1 GROUP BY 1", schemaName, materializedViewName, storageTableLocation));
+        String storageTableName = (String) computeScalar("SELECT storage_table FROM system.metadata.materialized_views WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + materializedViewName + "'");
+
+        assertUpdate(format("REFRESH MATERIALIZED VIEW iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), 3);
+        TableMetadata storageMetadata = getStorageTableMetadata(storageTableName);
+        String storageTableUuid = storageMetadata.uuid();
+        List<Snapshot> storageSnapshots = storageMetadata.snapshots();
+        assertThat(storageSnapshots).hasSize(3);
+
+        assertUpdate(format("CREATE OR REPLACE MATERIALIZED VIEW iceberg_legacy_mv.%1$s.%2$s WITH (location='%3$s', format='AVRO') AS SELECT sum(1) AS num_rows FROM iceberg.%1$s.base_table2", schemaName, materializedViewName, storageTableLocation));
+        storageMetadata = getStorageTableMetadata(storageTableName);
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "AVRO"));
+        assertThat(storageMetadata.snapshots()).hasSize(4).containsAll(storageSnapshots);
+        storageSnapshots = storageMetadata.snapshots();
+
+        assertThat(getExplainPlan(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), ExplainType.Type.IO))
+                .contains("base_table2");
+
+        assertUpdate(format("REFRESH MATERIALIZED VIEW iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), 1);
+        storageMetadata = getStorageTableMetadata(storageTableName);
+        // REFRESH performs "delete" and new data "append"
+        assertThat(storageMetadata.snapshots()).hasSize(6).containsAll(storageSnapshots);
+
+        computeScalar(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName));
+        assertThat(query(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName)))
+                .matches("VALUES BIGINT '3'");
+
+        // CREATE OR REPLACE without specifying location
+        assertUpdate(format("CREATE OR REPLACE MATERIALIZED VIEW iceberg_legacy_mv.%s.%s WITH (format='PARQUET') AS SELECT * FROM base_table1", schemaName, materializedViewName));
+        assertThat(getExplainPlan(format("SELECT * FROM iceberg_legacy_mv.%s.%s", schemaName, materializedViewName), ExplainType.Type.IO))
+                .contains("base_table1");
+        storageMetadata = getStorageTableMetadata(storageTableName);
+        assertThat(storageMetadata.uuid()).isEqualTo(storageTableUuid);
+        assertThat(storageMetadata.properties()).contains(entry(TableProperties.DEFAULT_FILE_FORMAT, "PARQUET"));
+        assertThat(storageMetadata.snapshots()).hasSize(7).containsAll(storageSnapshots);
+
+        String newStorageTableLocation = getSchemaDirectory() + "/" + materializedViewName + "newlocation";
+        assertThatThrownBy(() -> computeActual(format("CREATE OR REPLACE MATERIALIZED VIEW iceberg_legacy_mv.%s.%s WITH (location='%s') AS SELECT 1 AS data", schemaName, materializedViewName, newStorageTableLocation)))
+                .hasMessage("The provided location '%s' does not match the existing storage table location '%s'".formatted(newStorageTableLocation, storageTableLocation));
+
+        assertUpdate(format("DROP MATERIALIZED VIEW iceberg_legacy_mv.%s.%s", schemaName, materializedViewName));
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -1183,8 +1183,8 @@ public abstract class BaseIcebergMaterializedViewTest
 
         String matViewDef =
                 """
-                SELECT a, b FROM %s a WHERE a.a < 3 UNION ALL
-                SELECT * FROM %s b WHERE b.a > 5""".formatted(sourceTableName, sourceTableName);
+                        SELECT a, b FROM %s a WHERE a.a < 3 UNION ALL
+                        SELECT * FROM %s b WHERE b.a > 5""".formatted(sourceTableName, sourceTableName);
 
         // create source table and two identical MVs
         assertUpdate("CREATE TABLE %s (a int, b varchar)".formatted(sourceTableName));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -255,7 +255,8 @@ public final class IcebergTestUtils
                 false,
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
     }
 
     public static Map<String, Long> getMetadataFileAndUpdatedMillis(TrinoFileSystem trinoFileSystem, String tableLocation)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMergeAppend.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMergeAppend.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Table;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.trino.metastore.cache.CachingHiveMetastore.createPerTransactionCache;
 import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
@@ -64,7 +65,8 @@ public class TestIcebergMergeAppend
                 false,
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
 
         return queryRunner;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.trino.SystemSessionProperties.INITIAL_SPLITS_PER_NODE;
 import static io.trino.SystemSessionProperties.MAX_DRIVERS_PER_TASK;
 import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
@@ -104,7 +105,8 @@ public class TestIcebergOrcMetricsCollection
                 false,
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
 
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -132,7 +132,8 @@ public class TestIcebergSplitSource
                 false,
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
 
         return queryRunner;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.trino.metastore.cache.CachingHiveMetastore.createPerTransactionCache;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
@@ -118,7 +119,8 @@ public class TestTrinoHiveCatalogWithFileMetastore
                 false,
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -112,7 +112,8 @@ public class TestTrinoGlueCatalog
                 Optional.empty(),
                 useUniqueTableLocations,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
     }
 
     private static GlueClient createGlueClient()
@@ -269,7 +270,8 @@ public class TestTrinoGlueCatalog
                 Optional.of(tmpDirectory.toAbsolutePath().toString()),
                 false,
                 new IcebergConfig().isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
 
         String namespace = "test_default_location_" + randomNameSuffix();
         String table = "tableName";

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -63,6 +63,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.trino.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.metastore.cache.CachingHiveMetastore.createPerTransactionCache;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
@@ -186,7 +187,8 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                 false,
                 false,
                 isHideMaterializedViewStorageTable(),
-                directExecutor());
+                directExecutor(),
+                newDirectExecutorService());
     }
 
     protected boolean isHideMaterializedViewStorageTable()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Update the Hive metastore and Glue catalog implementations to retain the existing Iceberg
storage table when replacing a materialized view,rather than creating it and dropping the old
storage table.

Previously, replacing a materialized view with a fixed storage location would drop at the end of
the operation the storage table, destroying all existing data.

## Issue addressed by the current PR

```
trino> create or replace materialized view iceberg.tpch.mv10 WITH (location= 's3://test-bucket/mvtest/') as select * from iceberg.tpch.orders limit 10;
CREATE MATERIALIZED VIEW
trino> refresh materialized view iceberg.tpch.mv10;
REFRESH MATERIALIZED VIEW: 10 rows
trino> select * from iceberg.tpch.mv10;
 orderkey | custkey | orderstatus | totalprice | orderdate  |  orderpriority  |      clerk      | shippriority |        >
----------+---------+-------------+------------+------------+-----------------+-----------------+--------------+-------->
     3745 |    1118 | F           |   23657.43 | 1993-09-29 | 5-LOW           | Clerk#000000181 |            0 | ckages >
     3746 |     731 | F           |  109530.26 | 1994-09-11 | 4-NOT SPECIFIED | Clerk#000000188 |            0 | . expre>
...
(10 rows)
trino> create or replace materialized view iceberg.tpch.mv10 WITH (location= 's3://test-bucket/mvtest/') as select * from iceberg.tpch.orders limit 20;
CREATE MATERIALIZED VIEW
trino> select * from iceberg.tpch.mv10;
Query 20260414_111159_00030_4ep65 failed: Metadata not found in metadata location for table tpch.mv10$materialized_view_storage
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

While testing the current PR, I've stumbled on an unrelated issue https://github.com/trinodb/trino/issues/29479 - which will be addressed when upgrading to Iceberg 1.11.0

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Avoid recreating storage table on CREATE OR REPLACE MATERIALIZED VIEW ({issue}`issuenumber`)
```
