### PR TITLE
Reduce Redshift flakes

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcCastPushdownTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcCastPushdownTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc;
 import io.trino.Session;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedResult;
 import io.trino.testing.sql.SqlExecutor;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertThatTrinoException;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -83,19 +85,61 @@ public abstract class BaseJdbcCastPushdownTest
 
         for (InvalidCastTestCase testCase : invalidCastTestCases) {
             if (testCase.pushdownErrorMessage().isPresent()) {
-                assertThat(query("SELECT CAST(%s AS %s) FROM %s".formatted(testCase.sourceColumn(), testCase.castType(), tableName)))
-                        .failure()
-                        .hasMessageMatching(testCase.pushdownErrorMessage().get());
-                assertThat(query(withoutPushdown, "SELECT CAST(%s AS %s) FROM %s".formatted(testCase.sourceColumn(), testCase.castType(), tableName)))
-                        .failure()
-                        .hasMessageMatching(testCase.errorMessage());
+                assertInvalidCastFailure(getSession(), tableName, testCase, testCase.pushdownErrorMessage().get());
+                assertInvalidCastFailure(withoutPushdown, tableName, testCase, testCase.errorMessage());
             }
             else {
-                assertThat(query("SELECT CAST(%s AS %s) FROM %s".formatted(testCase.sourceColumn(), testCase.castType(), tableName)))
-                        .failure()
-                        .hasMessageMatching(testCase.errorMessage());
+                assertInvalidCastFailure(getSession(), tableName, testCase, testCase.errorMessage());
             }
         }
+    }
+
+    private void assertInvalidCastFailure(Session session, String tableName, InvalidCastTestCase testCase, String expectedMessage)
+    {
+        String sql = "SELECT CAST(%s AS %s) FROM %s".formatted(testCase.sourceColumn(), testCase.castType(), tableName);
+        MaterializedResult result;
+        try {
+            result = getQueryRunner().execute(session, sql).toTestTypes();
+        }
+        catch (Throwable throwable) {
+            try {
+                assertThatTrinoException(throwable)
+                        .hasMessageMatching(expectedMessage);
+            }
+            catch (AssertionError e) {
+                throw invalidCastAssertionError(tableName, testCase, sql, e);
+            }
+            return;
+        }
+
+        throw invalidCastAssertionError(
+                tableName,
+                testCase,
+                sql,
+                new AssertionError("Expected invalid cast query to fail, but it returned " + describeResult(result)));
+    }
+
+    private static AssertionError invalidCastAssertionError(String tableName, InvalidCastTestCase testCase, String sql, AssertionError cause)
+    {
+        return new AssertionError(
+                "Invalid cast assertion failed for table '%s', source column '%s', cast type '%s', query: %s"
+                        .formatted(tableName, testCase.sourceColumn(), testCase.castType(), sql),
+                cause);
+    }
+
+    private static String describeResult(MaterializedResult result)
+    {
+        if (result.getRowCount() == 0) {
+            return "0 rows";
+        }
+
+        List<?> sampleRows = result.getMaterializedRows().stream()
+                .limit(10)
+                .toList();
+        if (result.getRowCount() > sampleRows.size()) {
+            return "%s rows, first %s: %s".formatted(result.getRowCount(), sampleRows.size(), sampleRows);
+        }
+        return "%s rows: %s".formatted(result.getRowCount(), sampleRows);
     }
 
     public record CastTestCase(String sourceColumn, String castType, String targetColumn)

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -38,7 +38,6 @@ import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_URL;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_USER;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_DATABASE;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
-import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshift;
 import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshiftWithRetry;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
@@ -140,7 +139,7 @@ public final class RedshiftQueryRunner
     private static void createUserIfNotExists(String user, String password)
     {
         try {
-            executeInRedshift("CREATE USER " + user + " PASSWORD " + "'" + password + "'");
+            executeInRedshiftWithRetry("CREATE USER " + user + " PASSWORD " + "'" + password + "'");
         }
         catch (Exception e) {
             // if user already exists, swallow the exception

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftAutomaticJoinPushdown.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftAutomaticJoinPushdown.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
-import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshift;
+import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshiftWithRetry;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
@@ -51,7 +51,7 @@ public class TestRedshiftAutomaticJoinPushdown
     @Override
     protected void gatherStats(String tableName)
     {
-        executeInRedshift(handle -> {
+        executeInRedshiftWithRetry(handle -> {
             handle.execute(format("ANALYZE VERBOSE %s.%s", TEST_SCHEMA, tableName));
             for (int i = 0; i < 5; i++) {
                 long actualCount = handle.createQuery(format("SELECT count(*) FROM %s.%s", TEST_SCHEMA, tableName))

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftCastPushdown.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftCastPushdown.java
@@ -15,6 +15,7 @@ package io.trino.plugin.redshift;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcCastPushdownTest;
 import io.trino.plugin.jdbc.CastDataTypeTestTable;
@@ -28,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestRedshiftCastPushdown
@@ -53,7 +56,7 @@ final class TestRedshiftCastPushdown
     @Override
     protected SqlExecutor onRemoteDatabase()
     {
-        return TestingRedshiftServer::executeInRedshift;
+        return TestingRedshiftServer::executeInRedshiftWithRetry;
     }
 
     @Override
@@ -136,6 +139,7 @@ final class TestRedshiftCastPushdown
                 .addColumn("c_timetz", "timetz", asList("TIME '00:13:42.000000+05:30'", "TIME '10:01:17.100000+05:30'", null))
                 .addColumn("c_super", "super", asList(1, 2, null))
                 .execute(onRemoteDatabase(), TEST_SCHEMA + "." + "left_table_"));
+        assertTableLoaded(left.getName(), 3);
 
         // 2nd row value is different in right than left
         right = closeAfterClass(CastDataTypeTestTable.create(3)
@@ -209,6 +213,17 @@ final class TestRedshiftCastPushdown
                 .addColumn("c_timetz", "timetz", asList("TIME '00:13:42.000000+05:30'", "TIME '11:01:17.100000+05:30'", null))
                 .addColumn("c_super", "super", asList(1, 22, null))
                 .execute(onRemoteDatabase(), TEST_SCHEMA + "." + "right_table_"));
+        assertTableLoaded(right.getName(), 3);
+    }
+
+    private void assertTableLoaded(String tableName, long rowCount)
+    {
+        assertEventually(
+                new Duration(30, SECONDS),
+                new Duration(1, SECONDS),
+                () -> assertThat(computeScalar("SELECT count(*) FROM " + tableName))
+                        .describedAs("row count for " + tableName)
+                        .isEqualTo(rowCount));
     }
 
     @Override

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -59,7 +59,8 @@ import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_USER;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_DATABASE;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
 import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshift;
-import static io.trino.plugin.redshift.TestingRedshiftServer.executeWithRedshift;
+import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshiftWithRetry;
+import static io.trino.plugin.redshift.TestingRedshiftServer.executeWithRedshiftWithRetry;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -422,7 +423,7 @@ public class TestRedshiftConnectorTest
 
     private static void gatherStats(String tableName)
     {
-        executeInRedshift(handle -> {
+        executeInRedshiftWithRetry(handle -> {
             handle.execute("ANALYZE VERBOSE " + TEST_SCHEMA + "." + tableName);
             for (int i = 0; i < 5; i++) {
                 long actualCount = handle.createQuery("SELECT count(*) FROM " + TEST_SCHEMA + "." + tableName)
@@ -575,8 +576,8 @@ public class TestRedshiftConnectorTest
             assertThat(query("SELECT count(name) FROM " + nation + " WHERE name = 'ARGENTINA'")).isFullyPushedDown();
         }
         finally {
-            executeInRedshift("DROP TABLE IF EXISTS " + nation);
-            executeInRedshift("DROP TABLE IF EXISTS " + customer);
+            executeInRedshiftWithRetry("DROP TABLE IF EXISTS " + nation);
+            executeInRedshiftWithRetry("DROP TABLE IF EXISTS " + customer);
         }
     }
 
@@ -637,7 +638,7 @@ public class TestRedshiftConnectorTest
             // NOTE: Redshift doesn't support setting diststyle AUTO in CTAS statements
             executeInRedshift("CREATE TABLE " + destTableName + " AS SELECT * FROM " + sourceTableName);
             // Redshift doesn't allow ALTER DISTSTYLE if original and new style are same, so we need to check current diststyle of table
-            boolean isDistStyleAuto = executeWithRedshift(handle -> {
+            boolean isDistStyleAuto = executeWithRedshiftWithRetry(handle -> {
                 Optional<Long> currentDistStyle = handle.createQuery("" +
                                 "SELECT releffectivediststyle " +
                                 "FROM pg_class_info AS a LEFT JOIN pg_namespace AS b ON a.relnamespace = b.oid " +

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTableStatisticsReader.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTableStatisticsReader.java
@@ -45,6 +45,7 @@ import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_URL;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_USER;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
 import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshift;
+import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshiftWithRetry;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.testing.TestingConnectorSession.SESSION;
@@ -115,9 +116,9 @@ public class TestRedshiftTableStatisticsReader
         String tableName = "testallnulls_" + randomNameSuffix();
         String schemaAndTable = TEST_SCHEMA + "." + tableName;
         try {
-            executeInRedshift("CREATE TABLE " + schemaAndTable + " (i BIGINT)");
+            executeInRedshiftWithRetry("CREATE TABLE IF NOT EXISTS " + schemaAndTable + " (i BIGINT)");
             executeInRedshift("INSERT INTO " + schemaAndTable + " (i) VALUES (NULL)");
-            executeInRedshift("ANALYZE VERBOSE " + schemaAndTable);
+            executeInRedshiftWithRetry("ANALYZE VERBOSE " + schemaAndTable);
 
             TableStatistics stats = statsReader.readTableStatistics(
                     SESSION,
@@ -131,7 +132,7 @@ public class TestRedshiftTableStatisticsReader
                     .returns(emptyMap(), from(TableStatistics::getColumnStatistics));
         }
         finally {
-            executeInRedshift("DROP TABLE IF EXISTS " + schemaAndTable);
+            executeInRedshiftWithRetry("DROP TABLE IF EXISTS " + schemaAndTable);
         }
     }
 
@@ -198,7 +199,7 @@ public class TestRedshiftTableStatisticsReader
                 createVarcharJdbcColumnHandle("comment", 117));
 
         try {
-            executeInRedshift("CREATE OR REPLACE VIEW " + schemaAndTable + " AS SELECT custkey, mktsegment, comment FROM " + TEST_SCHEMA + ".customer");
+            executeInRedshiftWithRetry("CREATE OR REPLACE VIEW " + schemaAndTable + " AS SELECT custkey, mktsegment, comment FROM " + TEST_SCHEMA + ".customer");
             TableStatistics tableStatistics = statsReader.readTableStatistics(
                     SESSION,
                     new JdbcTableHandle(
@@ -209,7 +210,7 @@ public class TestRedshiftTableStatisticsReader
             assertThat(tableStatistics).isEqualTo(TableStatistics.empty());
         }
         finally {
-            executeInRedshift("DROP VIEW IF EXISTS " + schemaAndTable);
+            executeInRedshiftWithRetry("DROP VIEW IF EXISTS " + schemaAndTable);
         }
     }
 
@@ -227,7 +228,7 @@ public class TestRedshiftTableStatisticsReader
         try {
             executeInRedshift("CREATE MATERIALIZED VIEW " + schemaAndTable +
                     " AS SELECT custkey, mktsegment, comment FROM " + TEST_SCHEMA + ".customer");
-            executeInRedshift("REFRESH MATERIALIZED VIEW " + schemaAndTable);
+            executeInRedshiftWithRetry("REFRESH MATERIALIZED VIEW " + schemaAndTable);
             TableStatistics tableStatistics = statsReader.readTableStatistics(
                     SESSION,
                     new JdbcTableHandle(
@@ -238,7 +239,7 @@ public class TestRedshiftTableStatisticsReader
             assertThat(tableStatistics).isEqualTo(TableStatistics.empty());
         }
         finally {
-            executeInRedshift("DROP MATERIALIZED VIEW " + schemaAndTable);
+            executeInRedshiftWithRetry("DROP MATERIALIZED VIEW IF EXISTS " + schemaAndTable);
         }
     }
 
@@ -263,7 +264,7 @@ public class TestRedshiftTableStatisticsReader
                         .put("long_decimals_big_integral decimal(38,1)", List.of("-1234567890123456789012345678901234567.8", "1234567890123456789012345678901234567.8"))
                         .buildOrThrow(),
                 "null")) {
-            executeInRedshift("ANALYZE VERBOSE " + TEST_SCHEMA + "." + table.getName());
+            executeInRedshiftWithRetry("ANALYZE VERBOSE " + TEST_SCHEMA + "." + table.getName());
             assertQuery(
                     "SHOW STATS FOR " + table.getName(),
                     "VALUES " +
@@ -312,7 +313,7 @@ public class TestRedshiftTableStatisticsReader
         String schemaAndTable = TEST_SCHEMA + "." + tableName;
         try {
             executeInRedshift("CREATE TABLE " + schemaAndTable + " AS " + values);
-            executeInRedshift("ANALYZE VERBOSE " + schemaAndTable);
+            executeInRedshiftWithRetry("ANALYZE VERBOSE " + schemaAndTable);
             return statsReader.readTableStatistics(
                     SESSION,
                     new JdbcTableHandle(
@@ -322,7 +323,7 @@ public class TestRedshiftTableStatisticsReader
                     () -> columnHandles);
         }
         finally {
-            executeInRedshift("DROP TABLE IF EXISTS " + schemaAndTable);
+            executeInRedshiftWithRetry("DROP TABLE IF EXISTS " + schemaAndTable);
         }
     }
 

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTypeMapping.java
@@ -42,7 +42,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.plugin.redshift.RedshiftClient.REDSHIFT_MAX_VARCHAR;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
-import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshift;
+import static io.trino.plugin.redshift.TestingRedshiftServer.executeInRedshiftWithRetry;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.CharType.createCharType;
@@ -983,13 +983,13 @@ public class TestRedshiftTypeMapping
         TestView(String namePrefix, String definition)
         {
             name = requireNonNull(namePrefix) + "_" + randomNameSuffix();
-            executeInRedshift(format("CREATE VIEW %s.%s AS %s", TEST_SCHEMA, name, definition));
+            executeInRedshiftWithRetry(format("CREATE OR REPLACE VIEW %s.%s AS %s", TEST_SCHEMA, name, definition));
         }
 
         @Override
         public void close()
         {
-            executeInRedshift(format("DROP VIEW IF EXISTS %s.%s", TEST_SCHEMA, name));
+            executeInRedshiftWithRetry(format("DROP VIEW IF EXISTS %s.%s", TEST_SCHEMA, name));
         }
     }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
@@ -40,14 +40,22 @@ public final class TestingRedshiftServer
 
     public static final String JDBC_URL = "jdbc:redshift://" + JDBC_ENDPOINT + TEST_DATABASE + "?connectTimeout=0";
 
-    public static void executeInRedshiftWithRetry(String sql)
+    public static void executeInRedshiftWithRetry(String sql, Object... parameters)
     {
-        Failsafe.with(RetryPolicy.builder()
-                        .handleIf(TestingRedshiftServer::isExceptionRecoverable)
-                        .withDelay(Duration.ofSeconds(10))
-                        .withMaxRetries(3)
-                        .build())
-                .run(() -> executeInRedshift(sql));
+        executeInRedshiftWithRetry(handle -> handle.execute(sql, parameters));
+    }
+
+    public static <E extends Exception> void executeInRedshiftWithRetry(HandleConsumer<E> consumer)
+            throws E
+    {
+        executeWithRedshiftWithRetry(consumer.asCallback());
+    }
+
+    public static <T, E extends Exception> T executeWithRedshiftWithRetry(HandleCallback<T, E> callback)
+            throws E
+    {
+        return Failsafe.with(retryPolicy())
+                .get(() -> executeWithRedshift(callback));
     }
 
     public static void executeInRedshift(String sql, Object... parameters)
@@ -81,5 +89,14 @@ public final class TestingRedshiftServer
                 || message.matches(".*Connection to .* refused.*")
                 || getCausalChain(exception).stream()
                 .anyMatch(e -> e instanceof ConnectException || e instanceof SocketTimeoutException);
+    }
+
+    private static RetryPolicy<Object> retryPolicy()
+    {
+        return RetryPolicy.builder()
+                .handleIf(TestingRedshiftServer::isExceptionRecoverable)
+                .withDelay(Duration.ofSeconds(10))
+                .withMaxRetries(3)
+                .build();
     }
 }


### PR DESCRIPTION
- For invalid cast pushdown assertions, add a bunch more details so we can figure out why the test is failing
- Harden Redshift cast pushdown test setup
- Apply Redshift retries to test setup SQL

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
