### PR TITLE
Fix data loss on INSERT OVERWRITE when partition stats update fails

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1483,6 +1483,7 @@ public class SemiTransactionalHiveMetastore
         AcidTransaction transaction = getOptionalAcidTransaction();
 
         Committer committer = new Committer(transaction);
+        boolean commitSucceeded = false;
         try {
             for (Entry<SchemaTableName, Action<TableAndMore>> entry : tableActions.entrySet()) {
                 SchemaTableName schemaTableName = entry.getKey();
@@ -1521,7 +1522,7 @@ public class SemiTransactionalHiveMetastore
             committer.executeAlterTableOperations();
             committer.executeAlterPartitionOperations();
             committer.executeAddPartitionOperations(transaction);
-            committer.executeUpdateStatisticsOperations(transaction);
+            commitSucceeded = true;
         }
         catch (Throwable t) {
             log.warn("Rolling back due to metastore commit failure: %s", t.getMessage());
@@ -1553,6 +1554,15 @@ public class SemiTransactionalHiveMetastore
         }
         finally {
             committer.executeTableInvalidationCallback();
+        }
+
+        if (commitSucceeded) {
+            try {
+                committer.executeUpdateStatisticsOperations(transaction);
+            }
+            catch (Throwable t) {
+                log.warn("Failed to update statistics; continuing without rollback: %s", t.getMessage());
+            }
         }
 
         try {
@@ -1750,9 +1760,9 @@ public class SemiTransactionalHiveMetastore
             Location targetPath = Location.of(table.getStorage().getLocation());
             tablesToInvalidate.add(table);
             Location currentPath = tableAndMore.getCurrentLocation().orElseThrow();
-            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(identity, targetPath, false));
 
             if (!targetPath.equals(currentPath)) {
+                cleanUpTasksForAbort.add(new DirectoryCleanUpTask(identity, targetPath, false));
                 // if staging directory is used, we cherry-pick files to be moved
                 TrinoFileSystem fileSystem = fileSystemFactory.create(identity);
                 asyncRename(fileSystem, fileSystemExecutor, fileSystemOperationsCancelled, fileSystemOperationFutures, currentPath, targetPath, tableAndMore.getFileNames().orElseThrow());
@@ -1971,9 +1981,9 @@ public class SemiTransactionalHiveMetastore
             partitionsToInvalidate.add(partition);
             Location targetPath = Location.of(partition.getStorage().getLocation());
             Location currentPath = partitionAndMore.currentLocation();
-            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(identity, targetPath, false));
 
             if (!targetPath.equals(currentPath)) {
+                cleanUpTasksForAbort.add(new DirectoryCleanUpTask(identity, targetPath, false));
                 // if staging directory is used, we cherry-pick files to be moved
                 TrinoFileSystem fileSystem = fileSystemFactory.create(identity);
                 asyncRename(fileSystem, fileSystemExecutor, fileSystemOperationsCancelled, fileSystemOperationFutures, currentPath, targetPath, partitionAndMore.getFileNames());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestInsertOverwriteWithStatsFailure.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestInsertOverwriteWithStatsFailure.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.local.LocalFileSystemFactory;
+import io.trino.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore;
+import io.trino.spi.TrinoException;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/trinodb/trino/issues/29428
+ * Verifies that INSERT does not lose data when updateStatistics fails during commit.
+ * The fix moves executeUpdateStatisticsOperations outside the try-catch that triggers rollback,
+ * so statistics failures no longer cause data loss.
+ */
+public class TestInsertOverwriteWithStatsFailure
+        extends AbstractTestQueryFramework
+{
+    private final AtomicBoolean failUpdateStatistics = new AtomicBoolean(false);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setMetastore(queryRunner -> {
+                    Path dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data");
+                    dataDir.toFile().mkdirs();
+                    HiveMetastore delegate = TestingFileHiveMetastore.createTestingFileHiveMetastore(
+                            new LocalFileSystemFactory(dataDir),
+                            Location.of("local:///hive"));
+                    return createFailingStatsMetastore(delegate);
+                })
+                // Disable staging to use DIRECT_TO_TARGET_EXISTING_DIRECTORY mode,
+                // which triggers updateTableStatistics during commit
+                .addHiveProperty("hive.temporary-staging-directory-enabled", "false")
+                .build();
+    }
+
+    private HiveMetastore createFailingStatsMetastore(HiveMetastore delegate)
+    {
+        return (HiveMetastore) Proxy.newProxyInstance(
+                HiveMetastore.class.getClassLoader(),
+                new Class<?>[] {HiveMetastore.class},
+                (_, method, args) -> {
+                    if (method.getName().equals("updateTableStatistics") && failUpdateStatistics.get()) {
+                        throw new TrinoException(GENERIC_INTERNAL_ERROR, "Simulated failure in updateTableStatistics");
+                    }
+                    try {
+                        return method.invoke(delegate, args);
+                    }
+                    catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
+    }
+
+    @Test
+    public void testInsertPreservesDataOnStatsUpdateFailure()
+    {
+        String tableName = "test_stats_failure_" + randomNameSuffix();
+
+        // Create an unpartitioned table with initial data
+        assertUpdate("CREATE TABLE " + tableName + " (name VARCHAR, id BIGINT)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('initial', 1)", 1);
+
+        // Verify initial data
+        assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '1'");
+
+        // Enable stats failure and perform INSERT
+        // Without the fix: updateTableStatistics failure triggers rollback → INSERT fails
+        // With the fix: failure is caught and logged → INSERT succeeds, data preserved
+        failUpdateStatistics.set(true);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('second', 2)", 1);
+        failUpdateStatistics.set(false);
+
+        // Verify all data is preserved
+        assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '2'");
+        assertThat(query("SELECT name FROM " + tableName + " WHERE id = 2")).matches("VALUES VARCHAR 'second'");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+}


### PR DESCRIPTION
Mitigates #29428.

## Problem

When `insert_existing_partitions_behavior=OVERWRITE` is set and `updatePartitionStatistics` throws a timeout exception during `SemiTransactionalHiveMetastore.commitShared()`, the transaction rollback incorrectly removes the newly written partition data. The partition overwrite has already succeeded at the metastore level, but the rollback triggered by the stats failure deletes the new files, leaving the partition empty.

## Fix

1. Move `executeUpdateStatisticsOperations` outside the rollback try-catch in `commitShared()`, guarded by a `commitSucceeded` flag. Stats updates only run if all metastore operations succeeded. A stats failure at this point should not trigger a full rollback that deletes committed data.

2. In DIRECT_TO_TARGET_EXISTING_DIRECTORY mode (where `targetPath == currentPath`), do not register `cleanUpTasksForAbort` for the target directory. In this mode, old files have already been removed by the overwrite -- registering an abort cleanup would delete the new files too, causing data loss.

Stats update failures are now logged as warnings. Stale stats can be corrected with `ANALYZE TABLE`.

Note: this mitigates the stats-update-triggered data loss scenario. If the metastore times out during the actual partition operations (add/alter), data loss may still occur -- that is a broader problem requiring transactional guarantees.

## Testing

Added `TestInsertOverwriteWithStatsFailure` -- injects a failure in `updateTableStatistics` via a proxy metastore and verifies data is preserved after the stats failure. Test fails without the fix (data lost due to rollback), passes with it.
