### PR TITLE
Add retry logic for transient BigQuery 503 errors in getDestinationTable

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -41,6 +41,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.cache.EvictableCacheBuilder;
@@ -50,6 +52,7 @@ import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -94,6 +97,12 @@ import static java.util.stream.Collectors.joining;
 public class BigQueryClient
 {
     private static final Logger log = Logger.get(BigQueryClient.class);
+    private static final RetryPolicy<Object> GET_DESTINATION_TABLE_RETRY_POLICY = RetryPolicy.builder()
+            .withMaxRetries(3)
+            .withBackoff(100, 2000, ChronoUnit.MILLIS)
+            .onRetry(event -> log.debug("Getting destination table failed, retrying: %s", event.getLastException()))
+            .handleIf(BigQueryUtil::isRetryable)
+            .build();
 
     // BigQuery has different table_type in `INFORMATION_SCHEMA` than API responses that returns TableDefinition.Type
     // see https://cloud.google.com/bigquery/docs/information-schema-tables#schema
@@ -551,7 +560,8 @@ public class BigQueryClient
 
         JobConfiguration jobConfiguration;
         try {
-            jobConfiguration = bigQuery.create(jobInfo).getConfiguration();
+            jobConfiguration = Failsafe.with(GET_DESTINATION_TABLE_RETRY_POLICY)
+                    .get(() -> bigQuery.create(jobInfo).getConfiguration());
         }
         catch (BigQueryException e) {
             throw new TrinoException(

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryUtil.java
@@ -58,6 +58,10 @@ public final class BigQueryUtil
                     // https://docs.cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/Code
                     statusRuntimeException.getStatus().getCode() == Status.Code.UNAVAILABLE;
         }
+        // Handle HTTP-level retryable errors (e.g. 503 Service Unavailable) from BigQuery REST API
+        if (t instanceof BigQueryException bigQueryException) {
+            return bigQueryException.isRetryable();
+        }
         return false;
     }
 


### PR DESCRIPTION
## Description

There was a flaky issue we can retry: 
```
Error:  io.trino.plugin.bigquery.TestBigQueryAvroConnectorTest.testLimitPushdownWithMaterializedView -- Time elapsed: 24.90 s <<< ERROR!
io.trino.spi.TrinoException: Failed to get destination table for query. code: 503, reason: backendError, retryable: true, debug: null, message: Error encountered during execution. Retrying may solve the problem.
	at io.trino.plugin.bigquery.BigQueryClient.getDestinationTable(BigQueryClient.java:559)
	at io.trino.plugin.bigquery.ptf.Query$QueryFunction.analyze(Query.java:117)
	at io.trino.spi.function.table.ConnectorTableFunction.analyze(ConnectorTableFunction.java:54)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction.analyze(ClassLoaderSafeConnectorTableFunction.java:96)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTableFunctionInvocation(StatementAnalyzer.java:1737)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTableFunctionInvocation(StatementAnalyzer.java:536)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
