### PR TITLE
Fix incorrect negated NUMBER pushdowns

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
@@ -104,7 +104,7 @@ public final class TypeUtils
 
     public static boolean typeHasNaN(Type type)
     {
-        return type == REAL || type == DOUBLE;
+        return type == REAL || type == DOUBLE || type == NUMBER;
     }
 
     public static boolean isFloatingPointNaN(Type type, Object value)


### PR DESCRIPTION
Somehow f22a524140e3482de0431355997791745f1abfb8 updated `isFloatingPointNaN` but omitted `typeHasNaN`.
