### PR TITLE
Fix Iceberg REST recursive namespace listing when child namespace disappears

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -204,13 +204,24 @@ public class TrinoRestCatalog
     {
         try {
             return restSessionCatalog.listNamespaces(convert(session), parentNamespace).stream()
-                    .flatMap(childNamespace -> Stream.concat(
-                            Stream.of(childNamespace.toString()),
-                            collectNamespaces(session, childNamespace).stream()))
+                    .flatMap(childNamespace -> collectNamespaceIfExists(session, childNamespace).stream())
                     .collect(toImmutableList());
         }
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list namespaces", e);
+        }
+    }
+
+    private List<String> collectNamespaceIfExists(ConnectorSession session, Namespace namespace)
+    {
+        try {
+            return Stream.concat(
+                            Stream.of(namespace.toString()),
+                            collectNamespaces(session, namespace).stream())
+                    .collect(toImmutableList());
+        }
+        catch (NoSuchNamespaceException e) {
+            return ImmutableList.of();
         }
     }
 
@@ -1056,7 +1067,17 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list namespaces", e);
         }
-        return childNamespaces.stream().flatMap(childNamespace -> Stream.concat(Stream.of(childNamespace), listNamespaces(session, childNamespace).stream())).toList();
+        return childNamespaces.stream().flatMap(childNamespace -> listNamespaceIfExists(session, childNamespace).stream()).toList();
+    }
+
+    private List<Namespace> listNamespaceIfExists(ConnectorSession session, Namespace namespace)
+    {
+        try {
+            return Stream.concat(Stream.of(namespace), listNamespaces(session, namespace).stream()).toList();
+        }
+        catch (NoSuchNamespaceException e) {
+            return ImmutableList.of();
+        }
     }
 
     private static Namespace toTrinoNamespace(Namespace namespace)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -29,6 +29,10 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.junit.jupiter.api.Test;
@@ -36,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -93,6 +98,16 @@ public class TestTrinoRestCatalog
 
         restSessionCatalog.initialize(catalogName, properties);
 
+        return createTrinoRestCatalog(useUniqueTableLocations, restSessionCatalog, false, false);
+    }
+
+    private static TrinoRestCatalog createTrinoRestCatalog(
+            boolean useUniqueTableLocations,
+            RESTSessionCatalog restSessionCatalog,
+            boolean nestedNamespaceEnabled,
+            boolean caseInsensitiveNameMatching)
+    {
+        String catalogName = "iceberg_rest";
         return new TrinoRestCatalog(
                 new DefaultIcebergFileSystemFactory(HDFS_FILE_SYSTEM_FACTORY),
                 restSessionCatalog,
@@ -100,11 +115,11 @@ public class TestTrinoRestCatalog
                 Security.NONE,
                 NONE,
                 ImmutableMap.of(),
-                false,
+                nestedNamespaceEnabled,
                 "test",
                 TESTING_TYPE_MANAGER,
                 useUniqueTableLocations,
-                false,
+                caseInsensitiveNameMatching,
                 EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
                 EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
                 true);
@@ -183,6 +198,79 @@ public class TestTrinoRestCatalog
                 .cause()
                 .as("should fail as the prefix dev is not implemented for the current endpoint")
                 .hasMessageContaining("Malformed request: No route for request: POST v1/dev/namespaces");
+    }
+
+    @Test
+    public void testNestedListNamespacesIgnoresNamespaceDeletedDuringRecursiveListing()
+    {
+        TrinoCatalog catalog = createTrinoRestCatalog(false, new NamespaceDeletedDuringRecursiveListingCatalog(), true, false);
+
+        assertThat(catalog.listNamespaces(SESSION))
+                .containsExactly("ExIsTiNg", "ExIsTiNg.child");
+    }
+
+    @Test
+    public void testCaseInsensitiveNamespaceLookupIgnoresNamespaceDeletedDuringRecursiveListing()
+    {
+        TrinoCatalog catalog = createTrinoRestCatalog(false, new NamespaceDeletedDuringRecursiveListingCatalog(), false, true);
+
+        assertThat(catalog.namespaceExists(SESSION, "existing")).isTrue();
+    }
+
+    @Test
+    public void testNestedListNamespacesPropagatesRecursiveRestFailures()
+    {
+        RESTSessionCatalog restSessionCatalog = new RESTSessionCatalog()
+        {
+            @Override
+            public List<Namespace> listNamespaces(SessionContext context, Namespace namespace)
+            {
+                if (namespace.isEmpty()) {
+                    return List.of(Namespace.of("failing"));
+                }
+                throw new RESTException("catalog failure");
+            }
+        };
+        TrinoCatalog catalog = createTrinoRestCatalog(false, restSessionCatalog, true, false);
+
+        assertThatThrownBy(() -> catalog.listNamespaces(SESSION))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Failed to list namespaces")
+                .cause()
+                .isInstanceOf(RESTException.class)
+                .hasMessage("catalog failure");
+    }
+
+    private static class NamespaceDeletedDuringRecursiveListingCatalog
+            extends RESTSessionCatalog
+    {
+        private static final Namespace EXISTING_NAMESPACE = Namespace.of("ExIsTiNg");
+        private static final Namespace EXISTING_CHILD_NAMESPACE = Namespace.of("ExIsTiNg", "child");
+        private static final Namespace DELETED_NAMESPACE = Namespace.of("deleted");
+
+        @Override
+        public List<Namespace> listNamespaces(SessionContext context, Namespace namespace)
+        {
+            if (namespace.isEmpty()) {
+                return List.of(EXISTING_NAMESPACE, DELETED_NAMESPACE);
+            }
+            if (namespace.equals(EXISTING_NAMESPACE)) {
+                return List.of(EXISTING_CHILD_NAMESPACE);
+            }
+            if (namespace.equals(EXISTING_CHILD_NAMESPACE)) {
+                return List.of();
+            }
+            if (namespace.equals(DELETED_NAMESPACE)) {
+                throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+            }
+            throw new AssertionError("Unexpected namespace: " + namespace);
+        }
+
+        @Override
+        public boolean namespaceExists(SessionContext context, Namespace namespace)
+        {
+            return namespace.equals(EXISTING_NAMESPACE);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Fix a race in Iceberg REST catalog recursive namespace listing.

When nested namespaces are enabled, Trino recursively walks REST catalog namespaces by listing each parent namespace and then listing each returned child namespace. If a child namespace is dropped after it is returned by the parent listing but before Trino recursively lists that child, Iceberg REST throws `NoSuchNamespaceException`.

Previously, that exception escaped the recursive walk and could fail unrelated operations such as `DROP SCHEMA ... CASCADE` on a different schema.

This change treats `NoSuchNamespaceException` during recursive child traversal as a vanished child branch and continues listing the remaining namespaces. Top-level/root listing failures and other REST catalog failures still surface normally.

The same narrow handling is applied to the recursive namespace walk used for case-insensitive namespace lookup.

This behavior was observed as a CI failure in an unrelated PR:

`TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.testDropNestedSchemaCascade`

The dropped schema was unrelated to the missing namespace reported by the REST catalog, which indicates a concurrent namespace-listing race rather than a failure in the schema being dropped.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix failure when listing schemas in an Iceberg REST catalog and a nested namespace is dropped concurrently. ({issue}`issuenumber`)
```
