### PR TITLE
Avoid BigDecimal/BigInteger allocations in decimal bucket-hash

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.PartitionField;
 import org.joda.time.DateTimeField;
 import org.joda.time.chrono.ISOChronology;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Function;
@@ -69,6 +71,7 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Integer.parseInt;
 import static java.lang.Math.floorDiv;
+import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.DAYS;
 
@@ -76,6 +79,9 @@ public final class PartitionTransforms
 {
     private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
     private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
+
+    private static final VarHandle LONG_HANDLE_BIG_ENDIAN =
+            MethodHandles.byteArrayViewVarHandle(long[].class, BIG_ENDIAN);
 
     private static final DateTimeField YEAR_FIELD = ISOChronology.getInstanceUTC().year();
     private static final DateTimeField MONTH_FIELD = ISOChronology.getInstanceUTC().monthOfYear();
@@ -653,20 +659,60 @@ public final class PartitionTransforms
 
     private static Hasher hashShortDecimal(DecimalType decimal)
     {
+        // Reused across rows; safe because Hasher is invoked single-threaded per operator/driver
+        byte[] bytes = new byte[8];
         return (block, position) -> {
-            // TODO: write optimized implementation
-            BigDecimal value = readBigDecimal(decimal, block, position);
-            return bucketHash(Slices.wrappedBuffer(value.unscaledValue().toByteArray()));
+            long unscaled = decimal.getLong(block, position);
+            int offset = minimalBigEndianBytes(unscaled, bytes);
+            return bucketHash(Slices.wrappedBuffer(bytes, offset, 8 - offset));
         };
     }
 
     private static Hasher hashLongDecimal(DecimalType decimal)
     {
+        // Reused across rows; safe because Hasher is invoked single-threaded per operator/driver
+        byte[] bytes = new byte[16];
         return (block, position) -> {
-            // TODO: write optimized implementation
-            BigDecimal value = readBigDecimal(decimal, block, position);
-            return bucketHash(Slices.wrappedBuffer(value.unscaledValue().toByteArray()));
+            Int128 unscaled = (Int128) decimal.getObject(block, position);
+            LONG_HANDLE_BIG_ENDIAN.set(bytes, 0, unscaled.getHigh());
+            LONG_HANDLE_BIG_ENDIAN.set(bytes, 8, unscaled.getLow());
+            int offset = minimalBigEndianOffset(bytes);
+            return bucketHash(Slices.wrappedBuffer(bytes, offset, 16 - offset));
         };
+    }
+
+    /**
+     * Writes a long value as big-endian bytes into the buffer and returns the offset
+     * of the first byte of the minimal two's-complement representation (matching
+     * {@link java.math.BigInteger#toByteArray()} output).
+     */
+    private static int minimalBigEndianBytes(long value, byte[] bytes)
+    {
+        LONG_HANDLE_BIG_ENDIAN.set(bytes, 0, value);
+        return minimalBigEndianOffset(bytes);
+    }
+
+    /**
+     * Returns the start offset for the minimal two's-complement representation
+     * within a big-endian byte array (matching {@link java.math.BigInteger#toByteArray()} output).
+     */
+    private static int minimalBigEndianOffset(byte[] bytes)
+    {
+        int length = bytes.length;
+        if (bytes[0] == 0) {
+            // Positive or zero: skip leading 0x00 bytes, but keep one if next byte has high bit set
+            int offset = 0;
+            while (offset < length - 1 && bytes[offset] == 0 && (bytes[offset + 1] & 0x80) == 0) {
+                offset++;
+            }
+            return offset;
+        }
+        // Negative: skip leading 0xFF bytes, but keep one if next byte has high bit clear
+        int offset = 0;
+        while (offset < length - 1 && bytes[offset] == (byte) 0xFF && (bytes[offset + 1] & 0x80) != 0) {
+            offset++;
+        }
+        return offset;
     }
 
     private static int hashDate(Block block, int position)


### PR DESCRIPTION
Fixes #29162.

## Problem

`hashShortDecimal` and `hashLongDecimal` in `PartitionTransforms` allocate per-row: `BigDecimal` -> `BigInteger` -> `byte[]` -> `Slice`. On bucket-partitioned tables with decimal columns, this creates significant GC pressure from short-lived objects on every row.

## Fix

Compute the minimal big-endian two's-complement bytes directly from Trino's internal representation (`long` for short decimals, `Int128` for long decimals) without going through `BigDecimal`/`BigInteger`. The output is byte-for-byte identical to `BigInteger.toByteArray()`, satisfying the Iceberg spec requirement for bucket hashing.

For short decimals: write the `long` as 8 big-endian bytes, trim leading sign-extension bytes to produce the minimal representation, then Murmur3 hash.

For long decimals: write both `Int128` longs as 16 big-endian bytes, trim leading sign-extension, then hash.

## Testing

Existing `TestIcebergBucketing` tests validate correctness with hardcoded expected hash values. All 5 tests pass.
