### PR TITLE
Consolidate iterative optimizers in PlanOptimizers (bisect branch B - novstkpv)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -665,6 +665,8 @@ public class PlanOptimizers
                 .add(new PushLimitIntoTableScan(metadata))
                 .add(new PushPredicateIntoTableScan(plannerContext, false))
                 .add(new PushSampleIntoTableScan(metadata))
+                // Disjoint with PushSampleIntoTableScan (matches BERNOULLI, while PushSampleIntoTableScan matches SYSTEM).
+                .add(new ImplementBernoulliSampleAsFilter(metadata))
                 .add(new PushAggregationIntoTableScan(plannerContext))
                 .add(new PushDistinctLimitIntoTableScan(plannerContext))
                 .add(new PushTopNIntoTableScan(metadata))
@@ -696,17 +698,6 @@ public class PlanOptimizers
                         .build());
 
         builder.add(
-                new IterativeOptimizer(
-                        "ImplementBernoulliSample",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        // Temporary hack: separate optimizer step to avoid the sample node being replaced by filter before pushing
-                        // it to table scan node
-                        ImmutableSet.of(new ImplementBernoulliSampleAsFilter(metadata))),
-                columnPruningOptimizer
-                        .withName("PruneOutputsAfterSamplePushdown"),
                 new IterativeOptimizer(
                         "OptimizeDistinctAggregations",
                         plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -746,7 +746,7 @@ public class PlanOptimizers
                                 new ReplaceJoinOverConstantWithProject(),
                                 new ReplaceWindowWithRowNumber())),
                 new IterativeOptimizer(
-                        "MergeWindows",
+                        "MergeWindowsAndPatternRecognition",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
@@ -754,24 +754,14 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 // add UnaliasSymbolReferences when it's ported
                                 .add(new RemoveRedundantIdentityProjections())
+                                .add(new InlineProjections())
+                                .addAll(columnPruningRules)
                                 .addAll(GatherAndMergeWindows.rules())
                                 .addAll(MergePatternRecognitionNodes.rules())
                                 .add(new PushPredicateThroughProjectIntoRowNumber(plannerContext))
                                 .add(new PushPredicateThroughProjectIntoWindow(plannerContext))
+                                .add(new PushDownProjectionsFromPatternRecognition())
                                 .build()),
-                inlineProjections
-                        .withName("InlineProjectionsAfterWindowMerging"),
-                columnPruningOptimizer // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point
-                        .withName("PruneOutputsAfterWindowMerging"),
-                new IterativeOptimizer(
-                        "PushPatternRecognitionProjections",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(
-                                new RemoveRedundantIdentityProjections(),
-                                new PushDownProjectionsFromPatternRecognition())),
                 new MetadataQueryOptimizer(plannerContext),
                 new IterativeOptimizer(
                         "EliminateCrossJoins",

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -991,9 +991,6 @@ public class PlanOptimizers
         builder.add(inlineProjections
                 .withName("InlineProjectionsAfterDynamicFilterCleanup"));
         builder.add(new UnaliasSymbolReferences()); // Run unalias after merging projections to simplify projections more efficiently
-        builder.add(columnPruningOptimizer
-                .withName("PruneOutputsAfterFinalUnalias"));
-
         builder.add(new IterativeOptimizer(
                 "PushRemoteExchangeThroughAssignUniqueId",
                 plannerContext,
@@ -1001,6 +998,7 @@ public class PlanOptimizers
                 statsCalculator,
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
+                        .addAll(columnPruningRules)
                         .add(new RemoveRedundantIdentityProjections())
                         .add(new PushRemoteExchangeThroughAssignUniqueId())
                         .add(new InlineProjections())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -792,7 +792,7 @@ public class PlanOptimizers
                 // to leverage predicate pushdown on projected columns.
                 new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(plannerContext, true, false)),
                 new IterativeOptimizer(
-                        "SimplifyAfterProjectionPushdown",
+                        "CleanupBeforeJoinReordering",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
@@ -800,16 +800,9 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
                                 .add(new PushPredicateIntoTableScan(plannerContext, false))
+                                .addAll(columnPruningRules)
+                                .add(new RemoveRedundantIdentityProjections())
                                 .build()),
-                columnPruningOptimizer
-                        .withName("PruneOutputsBeforeJoinReordering"),
-                new IterativeOptimizer(
-                        "CleanupBeforeJoinReordering",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 // Because ReorderJoins runs only once,
                 // PredicatePushDown, columnPruningOptimizer and RemoveRedundantIdentityProjections
                 // need to run beforehand in order to produce an optimal join order

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -499,19 +499,13 @@ public class PlanOptimizers
                         .withName("SimplifyExpressionsBeforeUnalias"),
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
-                        "RemoveIdentityProjections",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
-                new IterativeOptimizer(
                         "MergeSetOperations",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
                         costCalculator,
                         ImmutableSet.of(
+                                new RemoveRedundantIdentityProjections(),
                                 new MergeUnion(),
                                 new MergeIntersect(),
                                 new MergeExcept(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -410,16 +410,6 @@ public class PlanOptimizers
                                 .addAll(new DesugarLambdaExpression().rules())
                                 .build()),
                 new IterativeOptimizer(
-                        "CanonicalizeRowPattern",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.<Rule<?>>builder()
-                                .addAll(new CanonicalizeExpressions(plannerContext).rules())
-                                .add(new OptimizeRowPattern())
-                                .build()),
-                new IterativeOptimizer(
                         "InitialPlanCleanup",
                         plannerContext,
                         ruleStats,
@@ -431,6 +421,7 @@ public class PlanOptimizers
                                 .addAll(simplifyOptimizerRules)
                                 .addAll(new UnwrapRowSubscript(plannerContext).rules())
                                 .addAll(new PushCastIntoRow().rules())
+                                .add(new OptimizeRowPattern())
                                 .addAll(ImmutableSet.of(
                                         new ImplementTableFunctionSource(metadata),
                                         new UnwrapSingleColumnRowInApply(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -825,24 +825,17 @@ public class PlanOptimizers
                 new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(plannerContext, true, false)));
 
         builder.add(new IterativeOptimizer(
-                "PushTopN",
-                plannerContext,
-                ruleStats,
-                statsCalculator,
-                costCalculator,
-                ImmutableSet.of(
-                        new CreatePartialTopN(),
-                        new PushTopNThroughProject(),
-                        new PushTopNThroughOuterJoin(),
-                        new PushTopNThroughUnion(),
-                        new PushTopNIntoTableScan(metadata))));
-        builder.add(new IterativeOptimizer(
-                "ExtractSpatialJoins",
+                "PushTopNAndExtractSpatialJoins",
                 plannerContext,
                 ruleStats,
                 statsCalculator,
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
+                        .add(new CreatePartialTopN())
+                        .add(new PushTopNThroughProject())
+                        .add(new PushTopNThroughOuterJoin())
+                        .add(new PushTopNThroughUnion())
+                        .add(new PushTopNIntoTableScan(metadata))
                         .add(new RemoveRedundantIdentityProjections())
                         .addAll(new ExtractSpatialJoins(plannerContext, splitManager, pageSourceManager).rules())
                         .add(new InlineProjections())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -537,24 +537,18 @@ public class PlanOptimizers
                                 new ImplementIntersectAll(metadata),
                                 new ImplementExceptAll(metadata))),
                 new LimitPushDown(), // Run the LimitPushDown after flattening set operators to make it easier to do the set flattening
-                columnPruningOptimizer
-                        .withName("PruneOutputsAfterSetOperationRewrite"),
-                inlineProjections
-                        .withName("InlineProjectionsAfterSetRewrite"),
                 new IterativeOptimizer(
-                        "PruneAfterSetFlattening",
+                        "CleanupAfterSetFlattening",
                         plannerContext,
                         ruleStats,
                         statsCalculator,
                         costCalculator,
-                        columnPruningRules),
-                new IterativeOptimizer(
-                        "RewriteExistsApply",
-                        plannerContext,
-                        ruleStats,
-                        statsCalculator,
-                        costCalculator,
-                        ImmutableSet.of(new TransformExistsApplyToCorrelatedJoin(plannerContext))),
+                        ImmutableSet.<Rule<?>>builder()
+                                .addAll(columnPruningRules)
+                                .add(new InlineProjections())
+                                .add(new RemoveRedundantIdentityProjections())
+                                .add(new TransformExistsApplyToCorrelatedJoin(plannerContext))
+                                .build()),
                 new TransformQuantifiedComparisonApplyToCorrelatedJoin(metadata),
                 new IterativeOptimizer(
                         "DecorrelateSubqueries",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/TestMergeUnionAndPushLimitInteraction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/TestMergeUnionAndPushLimitInteraction.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.cost.CachingTableStatsProvider;
+import io.trino.cost.RuntimeInfoProvider;
+import io.trino.cost.StatsAndCosts;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.RuleStatsRecorder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.sql.planner.assertions.PlanAssert;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.iterative.rule.MergeUnion;
+import io.trino.sql.planner.iterative.rule.PushLimitThroughUnion;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.optimizations.PlanOptimizer;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.testing.PlanTester;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.union;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+/**
+ * Demonstrates that `MergeUnion` and `PushLimitThroughUnion` interact badly when placed in the
+ * same `IterativeOptimizer`: `PushLimitThroughUnion` fires first (top-down traversal visits the
+ * `LimitNode` before its `UnionNode` children), inserts intermediate `LimitNode`s between the
+ * outer and inner unions, and `MergeUnion` can no longer flatten them.
+ *
+ * <p>This corroborates the comment in `PlanOptimizers.java` ("MergeUnion ... must run before
+ * limit pushdown rules"), and shows that the actual safeguard today is `InitialPlanCleanup`
+ * running `MergeUnion` to fixpoint before any limit-pushdown rules are introduced.
+ */
+public class TestMergeUnionAndPushLimitInteraction
+        extends BasePlanTest
+{
+    /**
+     * Baseline: `MergeUnion` alone successfully flattens nested unions wrapped in a limit.
+     */
+    @Test
+    public void mergeUnionAloneFlattensNestedUnionsUnderLimit()
+    {
+        assertOptimizedPlan(
+                ImmutableSet.of(new MergeUnion()),
+                builder -> nestedUnionUnderLimit(builder, 10),
+                limit(10,
+                        union(values("a1"), values("a2"), values("a3"), values("a4"))));
+    }
+
+    /**
+     * Baseline: `PushLimitThroughUnion` alone pushes the limit through the outer union.
+     */
+    @Test
+    public void pushLimitThroughUnionAloneInsertsInnerLimits()
+    {
+        assertOptimizedPlan(
+                ImmutableSet.of(new PushLimitThroughUnion()),
+                builder -> nestedUnionUnderLimit(builder, 10),
+                limit(10,
+                        union(
+                                limit(10, ImmutableList.of(), true, union(values("a1"), values("a2"))),
+                                limit(10, ImmutableList.of(), true, union(values("a3"), values("a4"))))));
+    }
+
+    /**
+     * Conflict: when both rules co-exist in one IterativeOptimizer, `PushLimitThroughUnion` fires
+     * first (top-down) and blocks `MergeUnion`. The result keeps the nested-union shape with
+     * inserted intermediate limits — `MergeUnion` never gets to flatten.
+     */
+    @Test
+    public void bothRulesTogetherFailToFlatten()
+    {
+        assertOptimizedPlan(
+                ImmutableSet.of(new MergeUnion(), new PushLimitThroughUnion()),
+                builder -> nestedUnionUnderLimit(builder, 10),
+                limit(10,
+                        union(
+                                limit(10, ImmutableList.of(), true, union(values("a1"), values("a2"))),
+                                limit(10, ImmutableList.of(), true, union(values("a3"), values("a4"))))));
+    }
+
+    /**
+     * Builds the plan:
+     * <pre>
+     *   Limit(N)
+     *     Union(outer)
+     *       Union(inner1)
+     *         Values("a1")
+     *         Values("a2")
+     *       Union(inner2)
+     *         Values("a3")
+     *         Values("a4")
+     * </pre>
+     */
+    private static PlanNode nestedUnionUnderLimit(PlanBuilder p, long limit)
+    {
+        Symbol a1 = p.symbol("a1", BIGINT);
+        Symbol a2 = p.symbol("a2", BIGINT);
+        Symbol a3 = p.symbol("a3", BIGINT);
+        Symbol a4 = p.symbol("a4", BIGINT);
+        Symbol inner1Out = p.symbol("inner1", BIGINT);
+        Symbol inner2Out = p.symbol("inner2", BIGINT);
+        Symbol outerOut = p.symbol("outer", BIGINT);
+
+        PlanNode inner1 = p.union(
+                ImmutableListMultimap.<Symbol, Symbol>builder()
+                        .put(inner1Out, a1)
+                        .put(inner1Out, a2)
+                        .build(),
+                ImmutableList.of(p.values(1, a1), p.values(1, a2)));
+        PlanNode inner2 = p.union(
+                ImmutableListMultimap.<Symbol, Symbol>builder()
+                        .put(inner2Out, a3)
+                        .put(inner2Out, a4)
+                        .build(),
+                ImmutableList.of(p.values(1, a3), p.values(1, a4)));
+        PlanNode outer = p.union(
+                ImmutableListMultimap.<Symbol, Symbol>builder()
+                        .put(outerOut, inner1Out)
+                        .put(outerOut, inner2Out)
+                        .build(),
+                ImmutableList.of(inner1, inner2));
+        return p.limit(limit, outer);
+    }
+
+    private void assertOptimizedPlan(ImmutableSet<Rule<?>> rules, PlanCreator planCreator, PlanMatchPattern pattern)
+    {
+        PlanTester planTester = getPlanTester();
+        planTester.inTransaction(session -> {
+            session.getCatalog().ifPresent(catalog -> planTester.getPlannerContext().getMetadata().getCatalogHandle(session, catalog));
+            PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+            PlanBuilder planBuilder = new PlanBuilder(idAllocator, planTester.getPlannerContext(), session);
+            PlanNode plan = planCreator.create(planBuilder);
+
+            PlanOptimizer optimizer = new IterativeOptimizer(
+                    "Test",
+                    planTester.getPlannerContext(),
+                    new RuleStatsRecorder(),
+                    planTester.getStatsCalculator(),
+                    planTester.getCostCalculator(),
+                    rules);
+
+            SymbolAllocator symbolAllocator = new SymbolAllocator();
+
+            PlanNode optimized = optimizer.optimize(
+                    plan,
+                    new PlanOptimizer.Context(
+                            session,
+                            symbolAllocator,
+                            idAllocator,
+                            WarningCollector.NOOP,
+                            createPlanOptimizersStatsCollector(),
+                            new CachingTableStatsProvider(planTester.getPlannerContext().getMetadata(), session, () -> false),
+                            RuntimeInfoProvider.noImplementation()));
+
+            Plan actual = new Plan(optimized, StatsAndCosts.empty());
+            PlanAssert.assertPlan(
+                    session,
+                    planTester.getPlannerContext().getMetadata(),
+                    planTester.getPlannerContext().getFunctionManager(),
+                    planTester.getStatsCalculator(),
+                    actual,
+                    pattern);
+            return null;
+        });
+    }
+
+    @FunctionalInterface
+    private interface PlanCreator
+    {
+        PlanNode create(PlanBuilder planBuilder);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "80",
+                        "72",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "86",
+                        "80",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "72",
+                        "70",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -102,7 +102,7 @@ public class TestJsonRepresentation
                 ImmutableList.of("_col0 := field"),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(1, 5, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "90",
+                        "86",
                         "Limit",
                         ImmutableMap.of("count", "1", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(new Symbol(INTEGER, "field")),

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1542,14 +1542,14 @@ public class TestEventListenerBasic
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                         ImmutableList.of(new JsonRenderedNode(
-                                "100",
+                                "82",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 90., 0., 0.)),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "173",
+                                        "143",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "[connectorHandleType = SystemPartitioningHandle, partitioning = SINGLE, function = SINGLE]",
@@ -1559,7 +1559,7 @@ public class TestEventListenerBasic
                                         ImmutableList.of(),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10., 90., 0., 0., 0.)),
                                         ImmutableList.of(new JsonRenderedNode(
-                                                "140",
+                                                "114",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
                                                 ImmutableList.of(new Symbol(DOUBLE, "symbol_1")),
@@ -1567,7 +1567,7 @@ public class TestEventListenerBasic
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
                 "1", new JsonRenderedNode(
-                        "139",
+                        "113",
                         "LimitPartial",
                         ImmutableMap.of(
                                 "count", "10",


### PR DESCRIPTION
**Draft for CI bisection — not for review yet.**

Branch B of parallel bisect: adds back `novstkpv` (CleanupBeforeJoinReordering merge) to the confirmed-clean 8-commit base. Branch A in https://github.com/martint/trino/pull/13 tests `stxvlskt` + `olzkywxq`.

Previously abandoned during bisect, this branch checks whether novstkpv triggers TPC-H/TPC-DS plan-shape regressions.