### PR TITLE
Handle null field references in expression interpreter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
@@ -270,6 +270,9 @@ public class IrExpressionEvaluator
     private Object evaluateInternal(FieldReference expression, Session session, Map<String, Object> bindings)
     {
         SqlRow row = (SqlRow) evaluate(expression.base(), session, bindings);
+        if (row == null) {
+            return null;
+        }
         return readNativeValue(expression.type(), row.getRawFieldBlock(expression.field()), row.getRawIndex());
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -20,6 +20,7 @@ import io.airlift.slice.Slices;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.RowType;
 import io.trino.sql.ir.Between;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Case;
@@ -876,6 +877,9 @@ public class TestExpressionInterpreter
         assertOptimizedEquals(
                 new FieldReference(new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(UNKNOWN, null))), 1),
                 new Constant(UNKNOWN, null));
+        assertEvaluatedEquals(
+                new FieldReference(new Constant(RowType.anonymousRow(INTEGER, VARCHAR), null), 1),
+                new Constant(VARCHAR, null));
         assertOptimizedEquals(
                 new FieldReference(new Row(ImmutableList.of(new Call(DIVIDE_INTEGER, ImmutableList.of(new Constant(INTEGER, 0L), new Constant(INTEGER, 0L))), new Constant(INTEGER, 1L))), 0),
                 new FieldReference(new Row(ImmutableList.of(new Call(DIVIDE_INTEGER, ImmutableList.of(new Constant(INTEGER, 0L), new Constant(INTEGER, 0L))), new Constant(INTEGER, 1L))), 0));


### PR DESCRIPTION
## Description

Fix NPE during optimizer for the following shape:

```sql
SELECT transform(ARRAY[CAST(NULL AS ROW(a INTEGER, b VARCHAR))], x -> x.b)
```

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix planning failure for dereferences of null row values inside constant-folded lambda expressions. ({issue}`29504`)
```
