### PR TITLE
Fix ClassCastException for decimal statistics encoded as JSON numbers in Delta Lake checkpoint

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeParquetStatisticsUtils.java
@@ -132,7 +132,9 @@ public final class DeltaLakeParquetStatisticsUtils
             return (double) jsonValue;
         }
         if (type instanceof DecimalType decimalType) {
-            BigDecimal decimal = new BigDecimal((String) jsonValue);
+            // Spark may serialize decimal statistics as JSON numbers (Double) rather than strings
+            String decimalString = jsonValue instanceof String stringValue ? stringValue : String.valueOf(jsonValue);
+            BigDecimal decimal = new BigDecimal(decimalString);
 
             if (decimalType.isShort()) {
                 return Decimals.encodeShortScaledValue(decimal, decimalType.getScale());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeParquetStatisticsUtils.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.transactionlog;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.IntegerType;
 import org.apache.parquet.column.statistics.Statistics;
@@ -117,6 +118,28 @@ public class TestDeltaLakeParquetStatisticsUtils
 
         assertThat(DeltaLakeParquetStatisticsUtils.jsonEncodeMin(ImmutableMap.of(columnName, Optional.of(stats)), ImmutableMap.of(columnName, DATE))).isEqualTo(ImmutableMap.of(columnName, "2020-08-26"));
         assertThat(DeltaLakeParquetStatisticsUtils.jsonEncodeMax(ImmutableMap.of(columnName, Optional.of(stats)), ImmutableMap.of(columnName, DATE))).isEqualTo(ImmutableMap.of(columnName, "2020-09-17"));
+    }
+
+    @Test
+    public void testDecimalJsonValueAsString()
+    {
+        // Decimal statistics encoded as JSON strings (standard Trino format)
+        DecimalType shortDecimal = DecimalType.createDecimalType(10, 2);
+        assertThat(jsonValueToTrinoValue(shortDecimal, "36.17")).isNotNull();
+        assertThat(jsonValueToTrinoValue(shortDecimal, "-100.50")).isNotNull();
+
+        DecimalType longDecimal = DecimalType.createDecimalType(38, 10);
+        assertThat(jsonValueToTrinoValue(longDecimal, "12345678901234567890.1234567890")).isNotNull();
+    }
+
+    @Test
+    public void testDecimalJsonValueAsNumber()
+    {
+        // Decimal statistics encoded as JSON numbers (Spark format) — must not throw ClassCastException
+        DecimalType shortDecimal = DecimalType.createDecimalType(10, 2);
+        assertThat(jsonValueToTrinoValue(shortDecimal, 36.17)).isNotNull();
+        assertThat(jsonValueToTrinoValue(shortDecimal, -100.50)).isNotNull();
+        assertThat(jsonValueToTrinoValue(shortDecimal, 36.17d)).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## Description

Spark serializes decimal column min/max statistics as JSON numbers (e.g. `Double`) rather than as JSON strings. The Delta Lake checkpoint reader in `DeltaLakeParquetStatisticsUtils.jsonValueToTrinoValue()` was unconditionally casting the Jackson-parsed value to `String`, causing:

```
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.String
```

when reading checkpoints for tables with DECIMAL columns written by Spark.

## Fix

Accept both `String` and numeric JSON values by converting to `String` before constructing `BigDecimal`:

```java
String decimalString = jsonValue instanceof String stringValue ? stringValue : String.valueOf(jsonValue);
BigDecimal decimal = new BigDecimal(decimalString);
```

## Testing

Added two unit tests to `TestDeltaLakeParquetStatisticsUtils`:
- `testDecimalJsonValueAsString` — existing string format (regression guard)
- `testDecimalJsonValueAsNumber` — numeric JSON value from Spark (was ClassCastException)

Fixes #28532
