### PR TITLE
Fix DESCRIBE on PostgreSQL geometry columns by sharing JTS classloader across plugins

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -76,6 +76,10 @@ public class PluginManager
             .add("io.airlift.slice.")
             .add("io.opentelemetry.api.")
             .add("io.opentelemetry.context.")
+            // JTS is used as the Java stack type for Trino's Geometry type, so it must be
+            // shared across all plugin classloaders to prevent ClassCastException when the
+            // geospatial and JDBC plugins exchange Geometry values.
+            .add("org.locationtech.jts.")
             .build();
 
     private static final Logger log = Logger.get(PluginManager.class);


### PR DESCRIPTION
## Description

After the JTS migration (commit `0ace6d237b` "Use JTS Geometry as native stack type"), `GeometryType` declares `org.locationtech.jts.geom.Geometry` as its Java stack type. The PostgreSQL JDBC connector references the same `Geometry` class inside `geometryColumnMapping()`.

However, each Trino plugin is loaded in its own isolated classloader (see `PluginManager.SPI_PACKAGES`). Both `trino-geospatial` and `trino-postgresql` bundle `jts-core` as a compile-scope dependency, so each plugin loads its own copy. The `ColumnMapping` constructor validates compatibility with reference equality (`==`):

```java
checkArgument(type.getJavaType() == readFunction.getJavaType(), ...)
```

Because `Geometry.class` from the geospatial plugin's classloader ≠ `Geometry.class` from the postgresql plugin's classloader, this throws:

```
IllegalArgumentException: Trino type Geometry is not compatible with read function
  returning class org.locationtech.jts.geom.Geometry
```

whenever `DESCRIBE` or `SHOW COLUMNS` is run against a PostgreSQL table containing a PostGIS geometry column.

## Fix

Add `org.locationtech.jts.` to `SPI_PACKAGES` in `PluginManager`, making all plugin classloaders delegate JTS class loading to the shared server classloader. `jts-core` is already a dependency of `trino-main`, so the classes are present on the parent classpath.

## Testing

- Existing PostgreSQL geometry tests cover the happy path.
- To manually verify: create a PostgreSQL table with a `geometry` column and run `DESCRIBE <table>` against it in a Trino cluster with the geospatial plugin enabled.

Fixes #29505
