### PR TITLE
Test and document SQL Server negative-scale decimal type mapping

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -638,8 +638,10 @@ public class SqlServerClient
             case Types.NUMERIC, Types.DECIMAL -> {
                 int columnSize = typeHandle.requiredColumnSize();
                 int decimalDigits = typeHandle.requiredDecimalDigits();
-                // TODO does sql server support negative scale?
-                int precision = columnSize + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
+                // SQL Server does not support negative-scale decimal in DDL, but the JDBC driver
+                // may expose negative decimalDigits for computed or linked-server columns.
+                // Map decimal(p, -s) (negative scale) to decimal(p+s, 0) to avoid losing digits.
+                int precision = columnSize + max(-decimalDigits, 0);
                 if (precision > Decimals.MAX_PRECISION) {
                     yield getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR ? mapToUnboundedVarchar(typeHandle) : Optional.empty();
                 }

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
@@ -149,6 +150,36 @@ public class TestSqlServerClient
                 new AggregateFunction("sum", BIGINT, List.of(bigintVariable), List.of(), false, filter),
                 Map.of(bigintVariable.getName(), BIGINT_COLUMN),
                 Optional.empty()); // filter not supported
+    }
+
+    @Test
+    public void testDecimalNegativeScaleTypeMapping()
+    {
+        // Positive scale: decimal(5, 2) maps to decimal(5, 2)
+        assertDecimalMapping(5, 2, createDecimalType(5, 2));
+
+        // Zero scale: decimal(5, 0) maps to decimal(5, 0)
+        assertDecimalMapping(5, 0, createDecimalType(5, 0));
+
+        // Negative scale: decimal(p, -s) maps to decimal(p+s, 0) to preserve all significant digits.
+        // e.g. decimal(5, -1) represents values like 123450, mapped to decimal(6, 0)
+        assertDecimalMapping(5, -1, createDecimalType(6, 0));
+        assertDecimalMapping(5, -3, createDecimalType(8, 0));
+        assertDecimalMapping(9, -7, createDecimalType(16, 0));
+    }
+
+    private static void assertDecimalMapping(int columnSize, int decimalDigits, io.trino.spi.type.Type expectedType)
+    {
+        JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                Types.DECIMAL,
+                Optional.of("decimal"),
+                Optional.of(columnSize),
+                Optional.of(decimalDigits),
+                Optional.empty(),
+                Optional.empty());
+        Optional<ColumnMapping> mapping = JDBC_CLIENT.toColumnMapping(SESSION, null, typeHandle);
+        assertThat(mapping).isPresent();
+        assertThat(mapping.get().getType()).isEqualTo(expectedType);
     }
 
     private static void testImplementAggregation(AggregateFunction aggregateFunction, Map<String, ColumnHandle> assignments, Optional<String> expectedExpression)


### PR DESCRIPTION
## Description

`SqlServerClient.java` (lines 641–642) contained an untested code path that maps `decimal(p, -s)` (negative-scale decimal) to `decimal(p+s, 0)`, guarded only by a TODO comment asking whether SQL Server supports negative scale at all.

SQL Server does not expose negative-scale decimal columns through DDL, but the JDBC driver may report negative `decimalDigits` for computed or linked-server columns. The mapping logic is correct — it widens the precision by the absolute scale to avoid losing integer digits — but was completely unexercised.

## Changes

- Replaced the TODO comment with a descriptive comment explaining when this code path activates and why the mapping makes sense.
- Added `testDecimalNegativeScaleTypeMapping()` in `TestSqlServerClient` covering positive, zero, and negative decimal scale cases via `JDBC_CLIENT.toColumnMapping()`. No database connection required.

## Testing

The new test is a pure unit test that exercises `SqlServerClient.toColumnMapping()` directly with a synthetic `JdbcTypeHandle`:

| columnSize | decimalDigits | Expected Trino type |
|---|---|---|
| 5 | 2 | `decimal(5, 2)` |
| 5 | 0 | `decimal(5, 0)` |
| 5 | -1 | `decimal(6, 0)` |
| 5 | -3 | `decimal(8, 0)` |
| 9 | -7 | `decimal(16, 0)` |

- Fixes #28418
