### PR TITLE
Test and document Ignite negative-scale decimal type mapping

### DIFF
--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -236,7 +236,9 @@ public class IgniteClient
                     int scale = min(decimalDigits, getDecimalDefaultScale(session));
                     yield Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
                 }
-                precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
+                // Ignite may expose negative scale for some column types via JDBC metadata.
+                // Map decimal(p, -s) to decimal(p+s, 0) to preserve all significant digits.
+                precision = precision + max(-decimalDigits, 0);
                 if (precision > Decimals.MAX_PRECISION) {
                     yield Optional.empty();
                 }

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
@@ -204,6 +205,36 @@ public class TestIgniteClient
                 .orElseThrow();
         assertThat(converted.expression()).isEqualTo("NOT ((`c_varchar`) IS NOT NULL)");
         assertThat(converted.parameters()).isEmpty();
+    }
+
+    @Test
+    public void testDecimalNegativeScaleTypeMapping()
+    {
+        // Positive scale: decimal(5, 2) maps to decimal(5, 2)
+        assertDecimalMapping(5, 2, createDecimalType(5, 2));
+
+        // Zero scale: decimal(5, 0) maps to decimal(5, 0)
+        assertDecimalMapping(5, 0, createDecimalType(5, 0));
+
+        // Negative scale: decimal(p, -s) maps to decimal(p+s, 0) to preserve all significant digits.
+        // e.g. decimal(5, -1) represents values like 123450, mapped to decimal(6, 0)
+        assertDecimalMapping(5, -1, createDecimalType(6, 0));
+        assertDecimalMapping(5, -3, createDecimalType(8, 0));
+        assertDecimalMapping(9, -7, createDecimalType(16, 0));
+    }
+
+    private static void assertDecimalMapping(int columnSize, int decimalDigits, io.trino.spi.type.Type expectedType)
+    {
+        JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                Types.DECIMAL,
+                Optional.of("decimal"),
+                Optional.of(columnSize),
+                Optional.of(decimalDigits),
+                Optional.empty(),
+                Optional.empty());
+        Optional<ColumnMapping> mapping = JDBC_CLIENT.toColumnMapping(SESSION, null, typeHandle);
+        assertThat(mapping).isPresent();
+        assertThat(mapping.get().getType()).isEqualTo(expectedType);
     }
 
     private ConnectorExpression translateToConnectorExpression(Expression expression)


### PR DESCRIPTION
## Description

`IgniteClient.java` line 239 contained an untested code path that maps `decimal(p, -s)` (negative-scale decimal) to `decimal(p+s, 0)`. No tests covered this branch.

The mapping is correct — widening the precision by the absolute scale preserves all significant digits for values like `decimal(5, -1)` (which represents multiples of 10) — but the intent was undocumented and the behaviour unverified.

## Changes

- Replaced the inline comment on the negative-scale mapping with a descriptive comment explaining when this code path activates and why the mapping is correct.
- Added `testDecimalNegativeScaleTypeMapping()` in `TestIgniteClient` covering positive, zero, and negative decimal scale cases via `JDBC_CLIENT.toColumnMapping()`. No Ignite instance required.

## Testing

| columnSize | decimalDigits | Expected Trino type |
|---|---|---|
| 5 | 2 | `decimal(5, 2)` |
| 5 | 0 | `decimal(5, 0)` |
| 5 | -1 | `decimal(6, 0)` |
| 5 | -3 | `decimal(8, 0)` |
| 9 | -7 | `decimal(16, 0)` |

Fixes #28416
