### PR TITLE
Export JTS geometry packages to parent-first classloader

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -76,6 +76,7 @@ public class PluginManager
             .add("io.airlift.slice.")
             .add("io.opentelemetry.api.")
             .add("io.opentelemetry.context.")
+            .add("org.locationtech.jts.")
             .build();
 
     private static final Logger log = Logger.get(PluginManager.class);


### PR DESCRIPTION
Following the migration from the ESRI geometry library to JTS in PR #27881, the core engine's native Geometry type relies on JTS classes. However, because the `org.locationtech.jts` package is not shared parent-first, plugins like `trino-postgresql` load an isolated duplicate copy of the JTS classes via their respective PluginClassLoader.

This classloader split causes an IllegalArgumentException during JDBC column mapping evaluation:
"Trino type Geometry is not compatible with read function... returning class org.locationtech.jts.geom.Geometry"

Fix this by adding "org.locationtech.jts." to the classloader whitelist in PluginManager, making JTS a globally shared package and resolving the ClassLoader mismatch for downstream JDBC connectors.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

Fixes [issue](https://github.com/trinodb/trino/issues/29505)

