### PR TITLE
Fix Worker Parallelism metric showing 0.00 in cluster overview UI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/ClusterStatsResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/ClusterStatsResource.java
@@ -30,9 +30,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import static com.google.common.math.DoubleMath.roundToLong;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
-import static java.math.RoundingMode.HALF_UP;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -75,7 +73,7 @@ public class ClusterStatsResource
 
         long totalInputRows = dispatchManager.getStats().getConsumedInputRows().getTotalCount();
         long totalInputBytes = dispatchManager.getStats().getConsumedInputBytes().getTotalCount();
-        long totalCpuTimeSecs = dispatchManager.getStats().getConsumedCpuTimeSecs().getTotalCount();
+        double totalCpuTimeSecs = dispatchManager.getStats().getConsumedCpuTimeSecs().getTotalCount();
 
         for (BasicQueryInfo query : dispatchManager.getQueries()) {
             if (query.getState() == QueryState.QUEUED) {
@@ -93,7 +91,7 @@ public class ClusterStatsResource
             if (!query.getState().isDone()) {
                 totalInputBytes += query.getQueryStats().getPhysicalInputDataSize().toBytes() + query.getQueryStats().getInternalNetworkInputDataSize().toBytes();
                 totalInputRows += query.getQueryStats().getProcessedInputPositions();
-                totalCpuTimeSecs += roundToLong(query.getQueryStats().getTotalCpuTime().getValue(SECONDS), HALF_UP);
+                totalCpuTimeSecs += query.getQueryStats().getTotalCpuTime().getValue(SECONDS);
 
                 memoryReservation += query.getQueryStats().getUserMemoryReservation().toBytes();
                 runningDrivers += query.getQueryStats().getRunningDrivers();
@@ -130,7 +128,7 @@ public class ClusterStatsResource
 
         private final long totalInputRows;
         private final long totalInputBytes;
-        private final long totalCpuTimeSecs;
+        private final double totalCpuTimeSecs;
 
         @JsonCreator
         public ClusterStats(
@@ -144,7 +142,7 @@ public class ClusterStatsResource
                 @JsonProperty("reservedMemory") double reservedMemory,
                 @JsonProperty("totalInputRows") long totalInputRows,
                 @JsonProperty("totalInputBytes") long totalInputBytes,
-                @JsonProperty("totalCpuTimeSecs") long totalCpuTimeSecs)
+                @JsonProperty("totalCpuTimeSecs") double totalCpuTimeSecs)
         {
             this.runningQueries = runningQueries;
             this.blockedQueries = blockedQueries;
@@ -220,7 +218,7 @@ public class ClusterStatsResource
         }
 
         @JsonProperty
-        public long getTotalCpuTimeSecs()
+        public double getTotalCpuTimeSecs()
         {
             return totalCpuTimeSecs;
         }

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestClusterStatsResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestClusterStatsResource.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.ui;
+
+import io.airlift.json.JsonCodec;
+import io.trino.server.ui.ClusterStatsResource.ClusterStats;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestClusterStatsResource
+{
+    private static final JsonCodec<ClusterStats> CODEC = jsonCodec(ClusterStats.class);
+
+    @Test
+    public void testTotalCpuTimeSecsPreservesSubSecondPrecision()
+    {
+        ClusterStats stats = new ClusterStats(1, 0, 2, 1, 4, 10, 16, 1024.0, 1000, 2048, 3.75);
+
+        String json = CODEC.toJson(stats);
+        assertThat(json).contains("\"totalCpuTimeSecs\" : 3.75");
+
+        ClusterStats decoded = CODEC.fromJson(json);
+        assertThat(decoded.getTotalCpuTimeSecs()).isEqualTo(3.75);
+    }
+}

--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/utils/utils.ts
@@ -87,7 +87,7 @@ export function addExponentiallyWeightedToHistory(value: number, valuesArray: nu
     }
 
     let movingAverage = value * MOVING_AVERAGE_ALPHA + valuesArray[valuesArray.length - 1] * (1 - MOVING_AVERAGE_ALPHA)
-    if (value < 1) {
+    if (value < 0) {
         movingAverage = 0
     }
 

--- a/core/trino-web-ui/src/main/resources/webapp/src/utils.js
+++ b/core/trino-web-ui/src/main/resources/webapp/src/utils.js
@@ -191,7 +191,7 @@ export function addExponentiallyWeightedToHistory(value: number, valuesArray: nu
     }
 
     let movingAverage = value * MOVING_AVERAGE_ALPHA + valuesArray[valuesArray.length - 1] * (1 - MOVING_AVERAGE_ALPHA)
-    if (value < 1) {
+    if (value < 0) {
         movingAverage = 0
     }
 


### PR DESCRIPTION
Fixes #29394.

## Problem

Worker Parallelism displays 0.00 in the cluster overview UI even when queries are actively running with Runnable Drivers > 0.

Two issues:
1. **Backend**: `ClusterStatsResource` rounds `totalCpuTimeSecs` to `long`, losing sub-second precision. For short-lived queries or low parallelism, this rounds to 0.
2. **Frontend**: `addExponentiallyWeightedToHistory` discards values < 1 (`if (value < 1) return`), so any parallelism between 0 and 1 is dropped from the moving average.

## Fix

1. Changed `totalCpuTimeSecs` from `long` to `double` to preserve sub-second CPU time.
2. Changed the frontend threshold from `value < 1` to `value < 0` so valid sub-1.0 parallelism values are included in the history.

## Testing

Added `TestClusterStatsResource` verifying `totalCpuTimeSecs` serializes with sub-second precision.
