### PR TITLE
Resolve @StaticMethod calls on parametric type bases

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -236,6 +236,12 @@ public final class TypeRegistry
         return instantiatedType;
     }
 
+    public boolean isTypeRegistered(String name)
+    {
+        String key = name.toLowerCase(Locale.ENGLISH);
+        return types.containsKey(new TypeSignature(key)) || parametricTypes.containsKey(key);
+    }
+
     public Collection<Type> getTypes()
     {
         return ImmutableList.copyOf(types.values());
@@ -456,6 +462,12 @@ public final class TypeRegistry
         public Type getType(TypeId id)
         {
             return typeRegistry.getType(id);
+        }
+
+        @Override
+        public boolean isTypeRegistered(String name)
+        {
+            return typeRegistry.isTypeRegistered(name);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1596,17 +1596,10 @@ public class ExpressionAnalyzer
         protected Type visitStaticMethodCall(StaticMethodCall node, Context context)
         {
             QualifiedName receiver = node.getType();
-            if (receiver.getParts().size() != 1) {
+            if (receiver.getParts().size() != 1 || !plannerContext.getTypeManager().isTypeRegistered(receiver.getSuffix())) {
                 throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", receiver);
             }
             TypeSignature receiverSignature = new TypeSignature(receiver.getSuffix());
-            Type receiverType;
-            try {
-                receiverType = plannerContext.getTypeManager().getType(receiverSignature);
-            }
-            catch (TypeNotFoundException e) {
-                throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", receiver);
-            }
 
             List<TypeSignatureProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);
 
@@ -1614,7 +1607,7 @@ public class ExpressionAnalyzer
             try {
                 function = functionResolver.resolveStaticMethod(
                         session,
-                        receiverType.getTypeSignature(),
+                        receiverSignature,
                         QualifiedName.of(node.getMethod().getValue()),
                         argumentTypes,
                         accessControl);

--- a/core/trino-main/src/main/java/io/trino/type/InternalTypeManager.java
+++ b/core/trino-main/src/main/java/io/trino/type/InternalTypeManager.java
@@ -54,6 +54,12 @@ public final class InternalTypeManager
     }
 
     @Override
+    public boolean isTypeRegistered(String name)
+    {
+        return typeRegistry.isTypeRegistered(name);
+    }
+
+    @Override
     public TypeOperators getTypeOperators()
     {
         return typeRegistry.getTypeOperators();

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
@@ -95,6 +95,30 @@ public class TestStaticMethodCall
         return 3L;
     }
 
+    @ScalarFunction("token")
+    @StaticMethod(StandardTypes.ARRAY)
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayToken()
+    {
+        return 10L;
+    }
+
+    @ScalarFunction("token")
+    @StaticMethod(StandardTypes.ROW)
+    @SqlType(StandardTypes.BIGINT)
+    public static long rowToken()
+    {
+        return 20L;
+    }
+
+    @ScalarFunction("token")
+    @StaticMethod(StandardTypes.MAP)
+    @SqlType(StandardTypes.BIGINT)
+    public static long mapToken()
+    {
+        return 30L;
+    }
+
     @Test
     public void testBasic()
     {
@@ -143,6 +167,16 @@ public class TestStaticMethodCall
         assertThat(assertions.expression("array::array_method()")).matches("BIGINT '1'");
         assertThat(assertions.expression("row::row_method()")).matches("BIGINT '2'");
         assertThat(assertions.expression("map::map_method()")).matches("BIGINT '3'");
+    }
+
+    @Test
+    public void testSameMethodNameOnDifferentReceivers()
+    {
+        // Three identically-signed static methods registered on distinct receiver
+        // types must coexist in the same function bundle and dispatch by receiver.
+        assertThat(assertions.expression("array::token()")).matches("BIGINT '10'");
+        assertThat(assertions.expression("row::token()")).matches("BIGINT '20'");
+        assertThat(assertions.expression("map::token()")).matches("BIGINT '30'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
@@ -71,6 +71,30 @@ public class TestStaticMethodCall
         }
     }
 
+    @ScalarFunction("array_method")
+    @StaticMethod(StandardTypes.ARRAY)
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayMethod()
+    {
+        return 1L;
+    }
+
+    @ScalarFunction("row_method")
+    @StaticMethod(StandardTypes.ROW)
+    @SqlType(StandardTypes.BIGINT)
+    public static long rowMethod()
+    {
+        return 2L;
+    }
+
+    @ScalarFunction("map_method")
+    @StaticMethod(StandardTypes.MAP)
+    @SqlType(StandardTypes.BIGINT)
+    public static long mapMethod()
+    {
+        return 3L;
+    }
+
     @Test
     public void testBasic()
     {
@@ -109,6 +133,16 @@ public class TestStaticMethodCall
         // The plain `parse('42')` form must NOT resolve to bigint::parse.
         assertTrinoExceptionThrownBy(() -> assertions.expression("parse('42')").evaluate())
                 .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    @Test
+    public void testParametricBaseReceiver()
+    {
+        // Parametric base types (array, row, map) that have no default instantiation
+        // must still resolve as static method receivers — only the base name matters.
+        assertThat(assertions.expression("array::array_method()")).matches("BIGINT '1'");
+        assertThat(assertions.expression("row::row_method()")).matches("BIGINT '2'");
+        assertThat(assertions.expression("map::map_method()")).matches("BIGINT '3'");
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -286,6 +286,11 @@
                                     <new>method io.trino.spi.function.FunctionMetadata io.trino.spi.function.FunctionMetadata::fromJson(io.trino.spi.function.FunctionId, io.trino.spi.function.Signature, java.lang.String, java.util.Set&lt;java.lang.String&gt;, io.trino.spi.function.FunctionNullability, boolean, boolean, boolean, java.lang.String, io.trino.spi.function.FunctionKind, boolean, java.util.Optional&lt;io.trino.spi.type.TypeSignature&gt;, boolean)</new>
                                     <justification>Add receiverType and instanceMethod to support SQL:2023 method invocation</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method boolean io.trino.spi.type.TypeManager::isTypeRegistered(java.lang.String)</new>
+                                    <justification>Required for resolving static method calls on parametric type bases (array, row, map). Cannot be a default that calls getType because parametric bases require parameters and would force exception-driven control flow.</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionId.java
@@ -15,8 +15,10 @@ package io.trino.spi.function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.trino.spi.type.TypeSignature;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -68,6 +70,12 @@ public class FunctionId
 
     public static FunctionId toFunctionId(String canonicalName, Signature signature)
     {
-        return new FunctionId((canonicalName + signature).toLowerCase(Locale.US));
+        return toFunctionId(canonicalName, signature, Optional.empty());
+    }
+
+    public static FunctionId toFunctionId(String canonicalName, Signature signature, Optional<TypeSignature> receiverType)
+    {
+        String prefix = receiverType.map(type -> type + "::").orElse("");
+        return new FunctionId((prefix + canonicalName + signature).toLowerCase(Locale.US));
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
@@ -395,7 +395,7 @@ public class FunctionMetadata
         {
             FunctionId functionId = this.functionId;
             if (functionId == null) {
-                functionId = FunctionId.toFunctionId(canonicalName, signature);
+                functionId = FunctionId.toFunctionId(canonicalName, signature, receiverType);
             }
             if (argumentNullability == null) {
                 argumentNullability = Collections.nCopies(signature.getArgumentTypes().size(), kind == WINDOW);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeManager.java
@@ -45,6 +45,14 @@ public interface TypeManager
     }
 
     /**
+     * Returns whether `name` is a known type base.
+     *
+     * Unlike `getType`, this returns true for parametric bases (e.g. `array`, `row`,
+     * `map`) that cannot be instantiated without parameters.
+     */
+    boolean isTypeRegistered(String name);
+
+    /**
      * Gets the cache for type operators.
      */
     TypeOperators getTypeOperators();

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestingTypeManager.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestingTypeManager.java
@@ -14,8 +14,10 @@
 package io.trino.spi.type;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -37,6 +39,7 @@ public final class TestingTypeManager
         implements TypeManager
 {
     private static final List<Type> TYPES = ImmutableList.of(BOOLEAN, BIGINT, DOUBLE, INTEGER, VARCHAR, VARBINARY, TIMESTAMP_MILLIS, TIMESTAMP_TZ_MILLIS, DATE, ID, HYPER_LOG_LOG);
+    private static final Set<String> PARAMETRIC_TYPES = ImmutableSet.of(StandardTypes.ARRAY, StandardTypes.ROW, StandardTypes.MAP);
 
     private final TypeOperators typeOperators = new TypeOperators();
 
@@ -81,6 +84,17 @@ public final class TestingTypeManager
             }
         }
         throw new IllegalArgumentException("Type not found: " + id);
+    }
+
+    @Override
+    public boolean isTypeRegistered(String name)
+    {
+        for (Type type : TYPES) {
+            if (type.getBaseName().equals(name)) {
+                return true;
+            }
+        }
+        return PARAMETRIC_TYPES.contains(name);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Two-commit series fixing two related issues with `@StaticMethod` function support.

### 1. Allow parametric type bases as static method receivers

`array::m()`, `row::m()`, `map::m()` previously failed analysis with `Unknown type: array` (etc.). The receiver existence check in `ExpressionAnalyzer.visitStaticMethodCall` called `TypeManager.getType(new TypeSignature(base))`; for parametric types that require parameters this throws `TypeNotFoundException` before resolution can run, even though the downstream resolver only matches candidates by receiver base name.

`TypeManager` now exposes `isTypeRegistered(String name)` which validates by base-name membership in the registry. The fully instantiated `Type` is no longer needed by the analyzer — the bare `TypeSignature` flows straight to `resolveStaticMethod`.

### 2. Include receiver type in default `FunctionId`

Two `@StaticMethod` functions with the same canonical name + signature on different receiver types (e.g. `array::token()` and `row::token()`) collided when added to the same `InternalFunctionBundle`, because `FunctionId` was derived from `(canonicalName + signature)` alone.

`FunctionId.toFunctionId` gains an `Optional<TypeSignature> receiverType` overload that prefixes `receiver::` when set; `FunctionMetadata.Builder.build()` passes the configured receiver. The two-arg overload is kept as a delegate. Identically-signed methods on different receivers now coexist.

## Scope notes

- Parametric *instantiations* as receivers (`array(int)::m()`, `varchar(10)::m()`, multi-word types like `timestamp with time zone::m()`) remain unreachable — those need grammar + AST changes and are out of scope for this PR.
- The existing `@StaticMethod` registration constraint forbidding parametric specs (`@StaticMethod("varchar(5)")`) stays in place: the resolver matches by base alone, so a parametric spec would only confuse overload selection.

## Test plan

- [x] `TestStaticMethodCall` adds `testParametricBaseReceiver` (commit 1) and `testSameMethodNameOnDifferentReceivers` (commit 2)
- [x] `TestStaticMethodCall`, `TestMethodCall`, `TestExpressionCompiler`, `TestSignatureBinder`, `TestScalarFunctionAdapter` all pass locally