### PR TITLE
Expose location as a table property in delta lake.

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePropertiesTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePropertiesTable.java
@@ -100,6 +100,11 @@ public class DeltaLakePropertiesTable
     {
         PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
 
+        pagesBuilder.beginRow();
+        pagesBuilder.appendVarchar("location");
+        pagesBuilder.appendVarchar(table.location());
+        pagesBuilder.endRow();
+
         metadataEntry.getConfiguration().forEach((key, value) -> {
             pagesBuilder.beginRow();
             pagesBuilder.appendVarchar(key);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -59,9 +59,12 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -1668,7 +1671,8 @@ public class TestDeltaLakeConnectorTest
                             "('delta.enableChangeDataFeed', 'true')," +
                             "('delta.enableDeletionVectors', 'false')," +
                             "('delta.minReaderVersion', '1')," +
-                            "('delta.minWriterVersion', '4')");
+                            "('delta.minWriterVersion', '4')," +
+                            "('location', '" + getTableLocation(table.getName()) + "')");
         }
 
         // timestamp type requires reader version 3 and writer version 7
@@ -1681,7 +1685,8 @@ public class TestDeltaLakeConnectorTest
                             "('delta.minReaderVersion', '3')," +
                             "('delta.minWriterVersion', '7')," +
                             "('delta.feature.timestampNtz', 'supported')," +
-                            "('delta.feature.changeDataFeed', 'supported')");
+                            "('delta.feature.changeDataFeed', 'supported')," +
+                            "('location', '" + getTableLocation(table.getName()) + "')");
         }
     }
 
@@ -1858,7 +1863,8 @@ public class TestDeltaLakeConnectorTest
                             "('delta.columnMapping.mode', 'name')," +
                             "('delta.columnMapping.maxColumnId', '1')," +
                             "('delta.minReaderVersion', '2')," +
-                            "('delta.minWriterVersion', '5')");
+                            "('delta.minWriterVersion', '5')," +
+                            "('location', '" + getTableLocation(table.getName()) + "')");
         }
 
         // timestamp type requires reader version 3 and writer version 7
@@ -1872,7 +1878,8 @@ public class TestDeltaLakeConnectorTest
                             "('delta.minReaderVersion', '3')," +
                             "('delta.minWriterVersion', '7')," +
                             "('delta.feature.columnMapping', 'supported')," +
-                            "('delta.feature.timestampNtz', 'supported')");
+                            "('delta.feature.timestampNtz', 'supported')," +
+                            "('location', '" + getTableLocation(table.getName()) + "')");
         }
     }
 
@@ -4482,6 +4489,7 @@ public class TestDeltaLakeConnectorTest
                             .put("delta.enableDeletionVectors", "false")
                             .put("delta.minReaderVersion", "1")
                             .put("delta.minWriterVersion", "4")
+                            .put("location", getTableLocation(table.getName()))
                             .buildOrThrow());
 
             assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN ts TIMESTAMP");
@@ -4495,6 +4503,7 @@ public class TestDeltaLakeConnectorTest
                             .put("delta.feature.timestampNtz", "supported")
                             .put("delta.minReaderVersion", "3")
                             .put("delta.minWriterVersion", "7")
+                            .put("location", getTableLocation(table.getName()))
                             .buildOrThrow());
         }
     }
@@ -4503,6 +4512,18 @@ public class TestDeltaLakeConnectorTest
     {
         return computeActual("SELECT key, value FROM \"" + tableName + "$properties\"").getMaterializedRows().stream()
                 .collect(toImmutableMap(row -> (String) row.getField(0), row -> (String) row.getField(1)));
+    }
+
+    private String getTableLocation(String tableName)
+    {
+        Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
+        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        if (m.find()) {
+            String location = m.group(1);
+            verify(!m.find(), "Unexpected second match");
+            return location;
+        }
+        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
@@ -134,12 +134,14 @@ public class TestDeltaLakeSystemTables
         String tableName = "test_simple_properties_table";
         try {
             assertUpdate("CREATE TABLE " + tableName + " (_bigint BIGINT) WITH (change_data_feed_enabled = true, checkpoint_interval = 5)");
-            assertQuery("SELECT * FROM \"" + tableName + "$properties\"", "VALUES " +
+            assertQuery("SELECT * FROM \"" + tableName + "$properties\" WHERE key LIKE 'delta%'", "VALUES " +
                     "('delta.enableChangeDataFeed', 'true')," +
                     "('delta.enableDeletionVectors', 'false')," +
                     "('delta.checkpointInterval', '5')," +
                     "('delta.minReaderVersion', '1')," +
                     "('delta.minWriterVersion', '4')");
+            assertThat((String) computeScalar("SELECT value FROM \"" + tableName + "$properties\" WHERE key = 'location'"))
+                    .matches("local:///delta/tpch/test_simple_properties_table.*");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + tableName);

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseDeltaConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseDeltaConnectorSmokeTest.java
@@ -71,7 +71,7 @@ public class TestLakehouseDeltaConnectorSmokeTest
     {
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$history\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$transactions\"")).matches("VALUES (CAST(1 AS BIGINT))");
-        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(3 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(4 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$partitions\"")).matches("VALUES (CAST(0 AS BIGINT))");
 
         // This test should get updated if a new system table is added

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeSystemTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeSystemTableCompatibility.java
@@ -49,7 +49,7 @@ public class TestDeltaLakeSystemTableCompatibility
                 row("Test_Key", "Test_Mixed_Case"));
         try {
             QueryResult deltaResult = onDelta().executeQuery("SHOW TBLPROPERTIES default." + tableName);
-            QueryResult trinoResult = onTrino().executeQuery("SELECT * FROM default.\"" + tableName + "$properties\"");
+            QueryResult trinoResult = onTrino().executeQuery("SELECT * FROM default.\"" + tableName + "$properties\" WHERE key != 'location'");
             assertThat(deltaResult).contains(expectedRows);
             assertThat(trinoResult).contains(expectedRows);
             assertThat(trinoResult.rows()).containsExactlyInAnyOrderElementsOf(deltaResult.rows());
@@ -79,7 +79,7 @@ public class TestDeltaLakeSystemTableCompatibility
                 row("delta.minWriterVersion", "7"));
         try {
             QueryResult deltaResult = onDelta().executeQuery("SHOW TBLPROPERTIES default." + tableName);
-            QueryResult trinoResult = onTrino().executeQuery("SELECT * FROM default.\"" + tableName + "$properties\"");
+            QueryResult trinoResult = onTrino().executeQuery("SELECT * FROM default.\"" + tableName + "$properties\" WHERE key LIKE 'delta%'");
             assertThat(deltaResult).contains(expectedRows);
             assertThat(trinoResult).contains(expectedRows);
             assertThat(trinoResult.rows()).containsExactlyInAnyOrderElementsOf(deltaResult.rows());

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestHiveAndDeltaLakeRedirect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestHiveAndDeltaLakeRedirect.java
@@ -836,7 +836,8 @@ public class TestHiveAndDeltaLakeRedirect
 
         List<Row> expected = List.of(
                 row("delta.minReaderVersion", "1"),
-                row("delta.minWriterVersion", "2"));
+                row("delta.minWriterVersion", "2"),
+                row("location", locationForTable(tableName)));
 
         try {
             assertThat(onTrino().executeQuery(format("SELECT * FROM delta.default.\"%s$properties\"", tableName))).containsOnly(expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Expose location as a table property in delta lake.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Both iceberg and hudi expose "location" in $properties table.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
