### PR TITLE
Reduce Unnecessary Metaspace Growth from AggregationFromAnnotationsParser

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -406,7 +406,9 @@ public final class AggregationFromAnnotationsParser
             allDependencies.addAll(dependencies);
         }
         else {
-            serializerGenerator = (_, _) -> generateStateSerializer(stateClass);
+            // Eagerly generate to avoid creating a new DynamicClassLoader on every invocation
+            AccumulatorStateSerializer<T> serializer = generateStateSerializer(stateClass);
+            serializerGenerator = (_, _) -> serializer;
         }
 
         TypeSignature serializedType;
@@ -431,7 +433,9 @@ public final class AggregationFromAnnotationsParser
             allDependencies.addAll(dependencies);
         }
         else {
-            factoryGenerator = (_, _) -> generateStateFactory(stateClass);
+            // Eagerly generate to avoid creating a new DynamicClassLoader on every invocation
+            AccumulatorStateFactory<T> factory = generateStateFactory(stateClass);
+            factoryGenerator = (_, _) -> factory;
         }
 
         return new AccumulatorStateDetails<>(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Aggregation functions in Trino are registered generically (e.g. `sum` works on `bigint`, `double`, `decimal`, etc.) and then specialized at query time for the concrete types they're called with. Specialization produces type-specific helpers, such as a state serializer and a state factory, that know how to read/write the accumulator state for that particular type. These specialized helpers are cached, but on a cache miss they need to be regenerated.

If the aggregation doesn't declare custom serializer/factory classes, `AggregationFromAnnotationsParser` generates them at runtime using `StateCompiler`, which performs runtime codegen and loads it with a new `DynamicClassLoader`. The problem is that this generation happens inside a lambda that runs on every cache miss, causing each call to produce a new classloader. 

In some execution environments, we observe that this causes unnecessary Metaspace growth when mixed GC does not occur, even though these DynamicClassLoaders are GC-eligible. 

In order to fix this, we generate the serializer and factory once, then return that same instance from the lambda on subsequent calls. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
In production we observed Metaspace grow from ~250MB to 480MB+ over 9 days of uptime. This was on a Trino instance running with JDK 17. 

This affects every annotation-based aggregation function: `count`, `sum`, `avg`, `min`, `max`, `approx_distinct`, etc.

Related: #11358 added a cache at the execution layer (`accumulatorFactoryCache` in `LocalExecutionPlanner`), but that doesn't prevent the bytecode from being regenerated at specialization time.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce unnecessary Metaspace growth from classloader accumulation in aggregation function specialization. 
```
