### PR TITLE
Reduce Unnecessary Metaspace Growth from ReduceAggregationFunction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ReduceAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ReduceAggregationFunction.java
@@ -27,6 +27,7 @@ import io.trino.operator.aggregation.state.GenericSliceStateSerializer;
 import io.trino.operator.aggregation.state.StateCompiler;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.AggregationFunctionMetadata;
 import io.trino.spi.function.AggregationImplementation;
 import io.trino.spi.function.BoundSignature;
@@ -66,6 +67,11 @@ public class ReduceAggregationFunction
     private static final MethodHandle BOOLEAN_STATE_OUTPUT_FUNCTION = methodHandle(GenericBooleanState.class, "write", Type.class, GenericBooleanState.class, BlockBuilder.class);
     private static final MethodHandle SLICE_STATE_OUTPUT_FUNCTION = methodHandle(GenericSliceState.class, "write", Type.class, GenericSliceState.class, BlockBuilder.class);
 
+    private static final AccumulatorStateFactory<GenericLongState> LONG_STATE_FACTORY = StateCompiler.generateStateFactory(GenericLongState.class);
+    private static final AccumulatorStateFactory<GenericDoubleState> DOUBLE_STATE_FACTORY = StateCompiler.generateStateFactory(GenericDoubleState.class);
+    private static final AccumulatorStateFactory<GenericBooleanState> BOOLEAN_STATE_FACTORY = StateCompiler.generateStateFactory(GenericBooleanState.class);
+    private static final AccumulatorStateFactory<GenericSliceState> SLICE_STATE_FACTORY = StateCompiler.generateStateFactory(GenericSliceState.class);
+
     public ReduceAggregationFunction()
     {
         super(
@@ -100,7 +106,7 @@ public class ReduceAggregationFunction
                     .accumulatorStateDescriptor(
                             GenericLongState.class,
                             new GenericLongStateSerializer(stateType),
-                            StateCompiler.generateStateFactory(GenericLongState.class))
+                            LONG_STATE_FACTORY)
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }
@@ -112,7 +118,7 @@ public class ReduceAggregationFunction
                     .accumulatorStateDescriptor(
                             GenericDoubleState.class,
                             new GenericDoubleStateSerializer(stateType),
-                            StateCompiler.generateStateFactory(GenericDoubleState.class))
+                            DOUBLE_STATE_FACTORY)
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }
@@ -124,7 +130,7 @@ public class ReduceAggregationFunction
                     .accumulatorStateDescriptor(
                             GenericBooleanState.class,
                             new GenericBooleanStateSerializer(stateType),
-                            StateCompiler.generateStateFactory(GenericBooleanState.class))
+                            BOOLEAN_STATE_FACTORY)
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }
@@ -137,7 +143,7 @@ public class ReduceAggregationFunction
                     .accumulatorStateDescriptor(
                             GenericSliceState.class,
                             new GenericSliceStateSerializer(stateType),
-                            StateCompiler.generateStateFactory(GenericSliceState.class))
+                            SLICE_STATE_FACTORY)
                     .lambdaInterfaces(BinaryFunctionInterface.class, BinaryFunctionInterface.class)
                     .build();
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`reduce_agg()` is an aggregation function that takes user-provided lambdas for input and combine logic. Its implementation in `ReduceAggregationFunction.specialize()` needs a state factory for whichever primitive type the aggregation operates on (`long`, `double`, `boolean`, or `slice`). It gets this by calling `StateCompiler.generateStateFactory()`, which performs runtime codegen and loads it with a new `DynamicClassLoader`.

The problem is that `specialize()` runs on every specialization cache miss, and the state classes are always the same four (`GenericLongState`, `GenericDoubleState`, `GenericBooleanState`, `GenericSliceState`). Each call creates a classloader that will never be GC'ed if only young generation GCs are being triggered. 

This change caches the four factories as `static final` fields that are generated once at class load and then reused indefinitely. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is a secondary source of unnecessary Metaspace growth that affects `reduce_agg()` specifically. The primary source we discovered occurs for all annotation-based aggregation functions. A fix is proposed for this in #29523.

Related: #11358 added a cache at the execution layer (`accumulatorFactoryCache` in `LocalExecutionPlanner`), but that doesn't prevent the bytecode from being regenerated at specialization time.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce unnecessary Metaspace growth from repeated state factory generation for `reduce_agg`.