### PR TITLE
Strip host suffix from vended Azure SAS token keys

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
@@ -63,7 +63,9 @@ final class AzureVendedCredentialsProvider
             if (entry.getKey().startsWith(ADLS_SAS_TOKEN_PREFIX)) {
                 String host = entry.getKey().substring(ADLS_SAS_TOKEN_PREFIX.length());
                 String account = host.contains(".") ? host.substring(0, host.indexOf('.')) : host;
-                sasTokensBuilder.put(account, entry.getValue());
+                if (!account.isEmpty() && !entry.getValue().isEmpty()) {
+                    sasTokensBuilder.put(account, entry.getValue());
+                }
             }
             if (entry.getKey().startsWith(ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX)) {
                 Instant expiresAt = Instant.ofEpochMilli(Long.parseLong(entry.getValue()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/AzureVendedCredentialsProvider.java
@@ -55,11 +55,14 @@ final class AzureVendedCredentialsProvider
 
     private static AzureVendedCredentials parseAzureVendedCredentials(Iterable<Entry<String, String>> properties)
     {
+        // Vending catalogs may suffix the SAS token key with the full host (e.g. "account.dfs.core.windows.net"),
+        // but AzureFileSystem looks up SAS tokens by the bare storage account name.
         ImmutableMap.Builder<String, String> sasTokensBuilder = ImmutableMap.builder();
         Instant earliest = null;
         for (Entry<String, String> entry : properties) {
             if (entry.getKey().startsWith(ADLS_SAS_TOKEN_PREFIX)) {
-                String account = entry.getKey().substring(ADLS_SAS_TOKEN_PREFIX.length());
+                String host = entry.getKey().substring(ADLS_SAS_TOKEN_PREFIX.length());
+                String account = host.contains(".") ? host.substring(0, host.indexOf('.')) : host;
                 sasTokensBuilder.put(account, entry.getValue());
             }
             if (entry.getKey().startsWith(ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX)) {
@@ -69,6 +72,6 @@ final class AzureVendedCredentialsProvider
                 }
             }
         }
-        return new AzureVendedCredentials(sasTokensBuilder.buildOrThrow(), Optional.ofNullable(earliest));
+        return new AzureVendedCredentials(sasTokensBuilder.buildKeepingLast(), Optional.ofNullable(earliest));
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -29,6 +29,8 @@ import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -167,8 +169,13 @@ final class TestIcebergRestCatalogFileSystemFactory
         assertThat(identity).isSameAs(originalIdentity);
     }
 
-    @Test
-    void testAzureVendedCredentialsWithSingleAccount()
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "mystorageaccount",
+            "mystorageaccount.dfs.core.windows.net",
+            "mystorageaccount.blob.core.windows.net",
+    })
+    void testAzureVendedCredentialsWithSingleAccount(String keySuffix)
     {
         AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
         TrinoFileSystemFactory delegate = identity -> {
@@ -179,7 +186,7 @@ final class TestIcebergRestCatalogFileSystemFactory
         IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
-                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + keySuffix, "sv=2022-test-sas-token");
 
         factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
 
@@ -201,8 +208,8 @@ final class TestIcebergRestCatalogFileSystemFactory
         IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
-                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account1", "sas-token-1",
-                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account2", "sas-token-2");
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account1.dfs.core.windows.net", "sas-token-1",
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account2.dfs.core.windows.net", "sas-token-2");
 
         factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@account1.dfs.core.windows.net/some/path/file"));
 
@@ -211,6 +218,30 @@ final class TestIcebergRestCatalogFileSystemFactory
         assertThat(identity.getExtraCredentials())
                 .containsEntry(EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX + "account1", "sas-token-1")
                 .containsEntry(EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX + "account2", "sas-token-2");
+    }
+
+    @Test
+    void testAzureVendedCredentialsWithBareAndHostKeyedFormsCombined()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount.dfs.core.windows.net", "sv=2022-test-sas-token",
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount.blob.core.windows.net", "sv=2022-test-sas-token",
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
+
+        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_AZURE_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
     }
 
     @Test
@@ -224,7 +255,7 @@ final class TestIcebergRestCatalogFileSystemFactory
 
         IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
-        Map<String, String> fileIoProperties = ImmutableMap.of(AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
+        Map<String, String> fileIoProperties = ImmutableMap.of(AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount.dfs.core.windows.net", "sv=2022-test-sas-token");
 
         factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
 
@@ -246,7 +277,7 @@ final class TestIcebergRestCatalogFileSystemFactory
         IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, false);
 
         Map<String, String> fileIoProperties = ImmutableMap.of(
-                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount.dfs.core.windows.net", "sv=2022-test-sas-token");
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
         factory.create(originalIdentity, fileIoProperties);

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergAzureRestCatalogBackendContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergAzureRestCatalogBackendContainer.java
@@ -40,8 +40,8 @@ public class IcebergAzureRestCatalogBackendContainer
                         .put("CATALOG_ADLS_AUTH_SHARED__KEY_ACCOUNT_NAME", storageAccount)
                         .put("CATALOG_ADLS_AUTH_SHARED__KEY_ACCOUNT_KEY", storageAccountKey)
                         // SAS token for vending to clients
-                        .put("CATALOG_ADLS_SAS__TOKEN_" + storageAccount, sasToken)
-                        .put("CATALOG_ADLS_SAS__TOKEN__EXPIRES__AT__MS_" + storageAccount, Long.toString(sasTokenExpiresAtMs))
+                        .put("CATALOG_ADLS_SAS__TOKEN_" + storageAccount + "_DFS_CORE_WINDOWS_NET", sasToken)
+                        .put("CATALOG_ADLS_SAS__TOKEN__EXPIRES__AT__MS_" + storageAccount + "_DFS_CORE_WINDOWS_NET", Long.toString(sasTokenExpiresAtMs))
                         // Increase the size of the worker pool to achieve a higher parallelism for storage operations
                         .put("ICEBERG_WORKER_NUM_THREADS", "16")
                         .buildOrThrow(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Vending catalogs emit `adls.sas-token.<account>.<host-suffix>` keys, but AzureFileSystem looks up SAS tokens by the bare storage account name, so the host-suffixed form was being dropped and authentication failed.

We now strip host suffix from vended Azure SAS token keys.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Closes https://github.com/trinodb/trino/issues/29526.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
