### PR TITLE
Add schema-prefix-based catalog redirect to Hive and Iceberg connectors

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -169,6 +169,7 @@ public class HiveConfig
     private Optional<String> deltaLakeCatalogName = Optional.empty();
     private Optional<String> hudiCatalogName = Optional.empty();
     private Map<String, String> schemaPrefixRedirectRules = ImmutableMap.of();
+    private Optional<String> defaultRedirectCatalog = Optional.empty();
 
     private DataSize targetMaxFileSize = DataSize.of(1, GIGABYTE);
     private DataSize idleWriterMinFileSize = DataSize.of(16, MEGABYTE);
@@ -1258,6 +1259,19 @@ public class HiveConfig
                     }
                 })
                 .collect(toImmutableMap(parts -> parts[0], parts -> parts[1]));
+        return this;
+    }
+
+    public Optional<String> getDefaultRedirectCatalog()
+    {
+        return defaultRedirectCatalog;
+    }
+
+    @Config("hive.default-redirect-catalog")
+    @ConfigDescription("Catalog to redirect to when no schema-prefix rule matches; the schema and table name are kept as-is")
+    public HiveConfig setDefaultRedirectCatalog(String defaultRedirectCatalog)
+    {
+        this.defaultRedirectCatalog = Optional.ofNullable(defaultRedirectCatalog);
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -35,11 +36,13 @@ import org.joda.time.DateTimeZone;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
@@ -165,6 +168,7 @@ public class HiveConfig
     private Optional<String> icebergCatalogName = Optional.empty();
     private Optional<String> deltaLakeCatalogName = Optional.empty();
     private Optional<String> hudiCatalogName = Optional.empty();
+    private Map<String, String> schemaPrefixRedirectRules = ImmutableMap.of();
 
     private DataSize targetMaxFileSize = DataSize.of(1, GIGABYTE);
     private DataSize idleWriterMinFileSize = DataSize.of(16, MEGABYTE);
@@ -1234,6 +1238,26 @@ public class HiveConfig
     public HiveConfig setHudiCatalogName(String hudiCatalogName)
     {
         this.hudiCatalogName = Optional.ofNullable(hudiCatalogName);
+        return this;
+    }
+
+    public Map<String, String> getSchemaPrefixRedirectRules()
+    {
+        return schemaPrefixRedirectRules;
+    }
+
+    @Config("hive.schema-prefix-redirect-rules")
+    @ConfigDescription("Comma-separated list of schema-prefix=catalog-name pairs; schemas matching a prefix are redirected to the given catalog (e.g. 'analytics_=iceberg,reporting_=delta')")
+    public HiveConfig setSchemaPrefixRedirectRules(List<String> rules)
+    {
+        this.schemaPrefixRedirectRules = rules.stream()
+                .map(rule -> rule.split("=", 2))
+                .peek(parts -> {
+                    if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                        throw new IllegalArgumentException("Invalid schema-prefix-redirect-rules entry, expected 'prefix=catalog': " + String.join("=", parts));
+                    }
+                })
+                .collect(toImmutableMap(parts -> parts[0], parts -> parts[1]));
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -170,6 +170,7 @@ public class HiveConfig
     private Optional<String> hudiCatalogName = Optional.empty();
     private Map<String, String> schemaPrefixRedirectRules = ImmutableMap.of();
     private Optional<String> defaultRedirectCatalog = Optional.empty();
+    private List<String> defaultRedirectExcludedPrefixes = ImmutableList.of();
 
     private DataSize targetMaxFileSize = DataSize.of(1, GIGABYTE);
     private DataSize idleWriterMinFileSize = DataSize.of(16, MEGABYTE);
@@ -1272,6 +1273,19 @@ public class HiveConfig
     public HiveConfig setDefaultRedirectCatalog(String defaultRedirectCatalog)
     {
         this.defaultRedirectCatalog = Optional.ofNullable(defaultRedirectCatalog);
+        return this;
+    }
+
+    public List<String> getDefaultRedirectExcludedPrefixes()
+    {
+        return defaultRedirectExcludedPrefixes;
+    }
+
+    @Config("hive.default-redirect-excluded-prefixes")
+    @ConfigDescription("Comma-separated list of schema name prefixes that bypass hive.default-redirect-catalog (e.g. 'bexg_,vrbo_')")
+    public HiveConfig setDefaultRedirectExcludedPrefixes(List<String> excludedPrefixes)
+    {
+        this.defaultRedirectExcludedPrefixes = ImmutableList.copyOf(excludedPrefixes);
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -430,6 +430,7 @@ public class HiveMetadata
     private final Executor metadataFetchingExecutor;
     private final Map<String, String> schemaPrefixRedirectRules;
     private final Optional<String> defaultRedirectCatalog;
+    private final List<String> defaultRedirectExcludedPrefixes;
 
     public HiveMetadata(
             CatalogName catalogName,
@@ -459,7 +460,8 @@ public class HiveMetadata
             HiveTimestampPrecision hiveViewsTimestampPrecision,
             Executor metadataFetchingExecutor,
             Map<String, String> schemaPrefixRedirectRules,
-            Optional<String> defaultRedirectCatalog)
+            Optional<String> defaultRedirectCatalog,
+            List<String> defaultRedirectExcludedPrefixes)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -489,6 +491,7 @@ public class HiveMetadata
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
         this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
         this.defaultRedirectCatalog = requireNonNull(defaultRedirectCatalog, "defaultRedirectCatalog is null");
+        this.defaultRedirectExcludedPrefixes = ImmutableList.copyOf(requireNonNull(defaultRedirectExcludedPrefixes, "defaultRedirectExcludedPrefixes is null"));
     }
 
     @Override
@@ -4035,6 +4038,11 @@ public class HiveMetadata
                     continue;
                 }
                 return Optional.of(new CatalogSchemaTableName(targetCatalog, targetSchema, tableName.getTableName()));
+            }
+        }
+        for (String excludedPrefix : defaultRedirectExcludedPrefixes) {
+            if (schemaName.startsWith(excludedPrefix)) {
+                return Optional.empty();
             }
         }
         return defaultRedirectCatalog.map(catalog ->

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -429,6 +429,7 @@ public class HiveMetadata
     private final HiveTimestampPrecision hiveViewsTimestampPrecision;
     private final Executor metadataFetchingExecutor;
     private final Map<String, String> schemaPrefixRedirectRules;
+    private final Optional<String> defaultRedirectCatalog;
 
     public HiveMetadata(
             CatalogName catalogName,
@@ -457,7 +458,8 @@ public class HiveMetadata
             long maxPartitionDropsPerQuery,
             HiveTimestampPrecision hiveViewsTimestampPrecision,
             Executor metadataFetchingExecutor,
-            Map<String, String> schemaPrefixRedirectRules)
+            Map<String, String> schemaPrefixRedirectRules,
+            Optional<String> defaultRedirectCatalog)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -486,6 +488,7 @@ public class HiveMetadata
         this.hiveViewsTimestampPrecision = requireNonNull(hiveViewsTimestampPrecision, "hiveViewsTimestampPrecision is null");
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
         this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
+        this.defaultRedirectCatalog = requireNonNull(defaultRedirectCatalog, "defaultRedirectCatalog is null");
     }
 
     @Override
@@ -4034,7 +4037,8 @@ public class HiveMetadata
                 return Optional.of(new CatalogSchemaTableName(targetCatalog, targetSchema, tableName.getTableName()));
             }
         }
-        return Optional.empty();
+        return defaultRedirectCatalog.map(catalog ->
+                new CatalogSchemaTableName(catalog, schemaName, tableName.getTableName()));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -428,6 +428,7 @@ public class HiveMetadata
     private final long maxPartitionDropsPerQuery;
     private final HiveTimestampPrecision hiveViewsTimestampPrecision;
     private final Executor metadataFetchingExecutor;
+    private final Map<String, String> schemaPrefixRedirectRules;
 
     public HiveMetadata(
             CatalogName catalogName,
@@ -455,7 +456,8 @@ public class HiveMetadata
             boolean allowTableRename,
             long maxPartitionDropsPerQuery,
             HiveTimestampPrecision hiveViewsTimestampPrecision,
-            Executor metadataFetchingExecutor)
+            Executor metadataFetchingExecutor,
+            Map<String, String> schemaPrefixRedirectRules)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -483,6 +485,7 @@ public class HiveMetadata
         this.maxPartitionDropsPerQuery = maxPartitionDropsPerQuery;
         this.hiveViewsTimestampPrecision = requireNonNull(hiveViewsTimestampPrecision, "hiveViewsTimestampPrecision is null");
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
+        this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
     }
 
     @Override
@@ -3948,6 +3951,11 @@ public class HiveMetadata
         requireNonNull(session, "session is null");
         requireNonNull(tableName, "tableName is null");
 
+        Optional<CatalogSchemaTableName> prefixRedirect = redirectTableBySchemaPrefix(tableName);
+        if (prefixRedirect.isPresent()) {
+            return prefixRedirect;
+        }
+
         Optional<String> icebergCatalogName = getIcebergCatalogName(session);
         Optional<String> deltaLakeCatalogName = getDeltaLakeCatalogName(session);
         Optional<String> hudiCatalogName = getHudiCatalogName(session);
@@ -4008,6 +4016,23 @@ public class HiveMetadata
         }
         if (isHudiTable(table)) {
             return targetCatalogName.map(catalog -> new CatalogSchemaTableName(catalog, table.getSchemaTableName()));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<CatalogSchemaTableName> redirectTableBySchemaPrefix(SchemaTableName tableName)
+    {
+        String schemaName = tableName.getSchemaName();
+        for (Map.Entry<String, String> rule : schemaPrefixRedirectRules.entrySet()) {
+            String prefix = rule.getKey();
+            String targetCatalog = rule.getValue();
+            if (schemaName.startsWith(prefix)) {
+                String targetSchema = schemaName.substring(prefix.length());
+                if (targetSchema.isEmpty()) {
+                    continue;
+                }
+                return Optional.of(new CatalogSchemaTableName(targetCatalog, targetSchema, tableName.getTableName()));
+            }
         }
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.concurrent.BoundedExecutor;
@@ -33,6 +34,7 @@ import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -80,6 +82,7 @@ public class HiveMetadataFactory
     private final boolean allowTableRename;
     private final HiveTimestampPrecision hiveViewsTimestampPrecision;
     private final Executor metadataFetchingExecutor;
+    private final Map<String, String> schemaPrefixRedirectRules;
 
     @Inject
     public HiveMetadataFactory(
@@ -138,7 +141,8 @@ public class HiveMetadataFactory
                 hiveConfig.isPartitionProjectionEnabled(),
                 allowTableRename,
                 hiveConfig.getTimestampPrecision(),
-                hiveConfig.getMetadataParallelism());
+                hiveConfig.getMetadataParallelism(),
+                hiveConfig.getSchemaPrefixRedirectRules());
     }
 
     public HiveMetadataFactory(
@@ -176,7 +180,8 @@ public class HiveMetadataFactory
             boolean partitionProjectionEnabled,
             boolean allowTableRename,
             HiveTimestampPrecision hiveViewsTimestampPrecision,
-            int metadataParallelism)
+            int metadataParallelism,
+            Map<String, String> schemaPrefixRedirectRules)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -219,6 +224,7 @@ public class HiveMetadataFactory
         this.partitionProjectionEnabled = partitionProjectionEnabled;
         this.allowTableRename = allowTableRename;
         this.hiveViewsTimestampPrecision = requireNonNull(hiveViewsTimestampPrecision, "hiveViewsTimestampPrecision is null");
+        this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
         if (metadataParallelism == 1) {
             this.metadataFetchingExecutor = directExecutor();
         }
@@ -274,6 +280,7 @@ public class HiveMetadataFactory
                 allowTableRename,
                 maxPartitionDropsPerQuery,
                 hiveViewsTimestampPrecision,
-                metadataFetchingExecutor);
+                metadataFetchingExecutor,
+                schemaPrefixRedirectRules);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -34,6 +35,7 @@ import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -84,6 +86,7 @@ public class HiveMetadataFactory
     private final Executor metadataFetchingExecutor;
     private final Map<String, String> schemaPrefixRedirectRules;
     private final Optional<String> defaultRedirectCatalog;
+    private final List<String> defaultRedirectExcludedPrefixes;
 
     @Inject
     public HiveMetadataFactory(
@@ -144,7 +147,8 @@ public class HiveMetadataFactory
                 hiveConfig.getTimestampPrecision(),
                 hiveConfig.getMetadataParallelism(),
                 hiveConfig.getSchemaPrefixRedirectRules(),
-                hiveConfig.getDefaultRedirectCatalog());
+                hiveConfig.getDefaultRedirectCatalog(),
+                hiveConfig.getDefaultRedirectExcludedPrefixes());
     }
 
     public HiveMetadataFactory(
@@ -184,7 +188,8 @@ public class HiveMetadataFactory
             HiveTimestampPrecision hiveViewsTimestampPrecision,
             int metadataParallelism,
             Map<String, String> schemaPrefixRedirectRules,
-            Optional<String> defaultRedirectCatalog)
+            Optional<String> defaultRedirectCatalog,
+            List<String> defaultRedirectExcludedPrefixes)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -229,6 +234,7 @@ public class HiveMetadataFactory
         this.hiveViewsTimestampPrecision = requireNonNull(hiveViewsTimestampPrecision, "hiveViewsTimestampPrecision is null");
         this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
         this.defaultRedirectCatalog = requireNonNull(defaultRedirectCatalog, "defaultRedirectCatalog is null");
+        this.defaultRedirectExcludedPrefixes = ImmutableList.copyOf(requireNonNull(defaultRedirectExcludedPrefixes, "defaultRedirectExcludedPrefixes is null"));
         if (metadataParallelism == 1) {
             this.metadataFetchingExecutor = directExecutor();
         }
@@ -286,6 +292,7 @@ public class HiveMetadataFactory
                 hiveViewsTimestampPrecision,
                 metadataFetchingExecutor,
                 schemaPrefixRedirectRules,
-                defaultRedirectCatalog);
+                defaultRedirectCatalog,
+                defaultRedirectExcludedPrefixes);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -83,6 +83,7 @@ public class HiveMetadataFactory
     private final HiveTimestampPrecision hiveViewsTimestampPrecision;
     private final Executor metadataFetchingExecutor;
     private final Map<String, String> schemaPrefixRedirectRules;
+    private final Optional<String> defaultRedirectCatalog;
 
     @Inject
     public HiveMetadataFactory(
@@ -142,7 +143,8 @@ public class HiveMetadataFactory
                 allowTableRename,
                 hiveConfig.getTimestampPrecision(),
                 hiveConfig.getMetadataParallelism(),
-                hiveConfig.getSchemaPrefixRedirectRules());
+                hiveConfig.getSchemaPrefixRedirectRules(),
+                hiveConfig.getDefaultRedirectCatalog());
     }
 
     public HiveMetadataFactory(
@@ -181,7 +183,8 @@ public class HiveMetadataFactory
             boolean allowTableRename,
             HiveTimestampPrecision hiveViewsTimestampPrecision,
             int metadataParallelism,
-            Map<String, String> schemaPrefixRedirectRules)
+            Map<String, String> schemaPrefixRedirectRules,
+            Optional<String> defaultRedirectCatalog)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -225,6 +228,7 @@ public class HiveMetadataFactory
         this.allowTableRename = allowTableRename;
         this.hiveViewsTimestampPrecision = requireNonNull(hiveViewsTimestampPrecision, "hiveViewsTimestampPrecision is null");
         this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
+        this.defaultRedirectCatalog = requireNonNull(defaultRedirectCatalog, "defaultRedirectCatalog is null");
         if (metadataParallelism == 1) {
             this.metadataFetchingExecutor = directExecutor();
         }
@@ -281,6 +285,7 @@ public class HiveMetadataFactory
                 maxPartitionDropsPerQuery,
                 hiveViewsTimestampPrecision,
                 metadataFetchingExecutor,
-                schemaPrefixRedirectRules);
+                schemaPrefixRedirectRules,
+                defaultRedirectCatalog);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -123,7 +123,8 @@ public class TestHiveConfig
                 .setMetadataParallelism(8)
                 .setProtobufDescriptorsLocation(null)
                 .setProtobufDescriptorsCacheRefreshInterval(new Duration(1, TimeUnit.DAYS))
-                .setProtobufDescriptorsCacheMaxSize(64));
+                .setProtobufDescriptorsCacheMaxSize(64)
+                .setSchemaPrefixRedirectRules(ImmutableList.of()));
     }
 
     @Test
@@ -214,6 +215,7 @@ public class TestHiveConfig
                 .put("hive.protobuf.descriptors.location", "/tmp")
                 .put("hive.protobuf.descriptors.cache.max-size", "8")
                 .put("hive.protobuf.descriptors.cache.refresh-interval", "10s")
+                .put("hive.schema-prefix-redirect-rules", "analytics_=iceberg")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -299,7 +301,8 @@ public class TestHiveConfig
                 .setMetadataParallelism(10)
                 .setProtobufDescriptorsLocation(Path.of("/tmp"))
                 .setProtobufDescriptorsCacheMaxSize(8)
-                .setProtobufDescriptorsCacheRefreshInterval(new Duration(10, TimeUnit.SECONDS));
+                .setProtobufDescriptorsCacheRefreshInterval(new Duration(10, TimeUnit.SECONDS))
+                .setSchemaPrefixRedirectRules(ImmutableList.of("analytics_=iceberg"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -124,7 +124,8 @@ public class TestHiveConfig
                 .setProtobufDescriptorsLocation(null)
                 .setProtobufDescriptorsCacheRefreshInterval(new Duration(1, TimeUnit.DAYS))
                 .setProtobufDescriptorsCacheMaxSize(64)
-                .setSchemaPrefixRedirectRules(ImmutableList.of()));
+                .setSchemaPrefixRedirectRules(ImmutableList.of())
+                .setDefaultRedirectCatalog(null));
     }
 
     @Test
@@ -216,6 +217,7 @@ public class TestHiveConfig
                 .put("hive.protobuf.descriptors.cache.max-size", "8")
                 .put("hive.protobuf.descriptors.cache.refresh-interval", "10s")
                 .put("hive.schema-prefix-redirect-rules", "analytics_=iceberg")
+                .put("hive.default-redirect-catalog", "iceberg")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -302,7 +304,8 @@ public class TestHiveConfig
                 .setProtobufDescriptorsLocation(Path.of("/tmp"))
                 .setProtobufDescriptorsCacheMaxSize(8)
                 .setProtobufDescriptorsCacheRefreshInterval(new Duration(10, TimeUnit.SECONDS))
-                .setSchemaPrefixRedirectRules(ImmutableList.of("analytics_=iceberg"));
+                .setSchemaPrefixRedirectRules(ImmutableList.of("analytics_=iceberg"))
+                .setDefaultRedirectCatalog("iceberg");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -125,7 +125,8 @@ public class TestHiveConfig
                 .setProtobufDescriptorsCacheRefreshInterval(new Duration(1, TimeUnit.DAYS))
                 .setProtobufDescriptorsCacheMaxSize(64)
                 .setSchemaPrefixRedirectRules(ImmutableList.of())
-                .setDefaultRedirectCatalog(null));
+                .setDefaultRedirectCatalog(null)
+                .setDefaultRedirectExcludedPrefixes(ImmutableList.of()));
     }
 
     @Test
@@ -218,6 +219,7 @@ public class TestHiveConfig
                 .put("hive.protobuf.descriptors.cache.refresh-interval", "10s")
                 .put("hive.schema-prefix-redirect-rules", "analytics_=iceberg")
                 .put("hive.default-redirect-catalog", "iceberg")
+                .put("hive.default-redirect-excluded-prefixes", "staging_,dev_")
                 .buildOrThrow();
 
         HiveConfig expected = new HiveConfig()
@@ -305,7 +307,8 @@ public class TestHiveConfig
                 .setProtobufDescriptorsCacheMaxSize(8)
                 .setProtobufDescriptorsCacheRefreshInterval(new Duration(10, TimeUnit.SECONDS))
                 .setSchemaPrefixRedirectRules(ImmutableList.of("analytics_=iceberg"))
-                .setDefaultRedirectCatalog("iceberg");
+                .setDefaultRedirectCatalog("iceberg")
+                .setDefaultRedirectExcludedPrefixes(ImmutableList.of("staging_", "dev_"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -33,10 +34,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -77,6 +80,9 @@ public class IcebergConfig
     private boolean registerTableProcedureEnabled;
     private boolean addFilesProcedureEnabled;
     private Optional<String> hiveCatalogName = Optional.empty();
+    private Map<String, String> schemaPrefixRedirectRules = ImmutableMap.of();
+    private Optional<String> defaultRedirectCatalog = Optional.empty();
+    private List<String> defaultRedirectExcludedPrefixes = ImmutableList.of();
     private int formatVersion = 2;
     private Duration expireSnapshotsMinRetention = new Duration(7, DAYS);
     private Duration removeOrphanFilesMinRetention = new Duration(7, DAYS);
@@ -323,6 +329,52 @@ public class IcebergConfig
     public IcebergConfig setHiveCatalogName(String hiveCatalogName)
     {
         this.hiveCatalogName = Optional.ofNullable(hiveCatalogName);
+        return this;
+    }
+
+    public Map<String, String> getSchemaPrefixRedirectRules()
+    {
+        return schemaPrefixRedirectRules;
+    }
+
+    @Config("iceberg.schema-prefix-redirect-rules")
+    @ConfigDescription("Comma-separated list of schema-prefix=catalog-name pairs; schemas matching a prefix are redirected to the given catalog (e.g. 'egdp_prod_=egdp_prod,egdp_test_=egdp_test')")
+    public IcebergConfig setSchemaPrefixRedirectRules(List<String> rules)
+    {
+        this.schemaPrefixRedirectRules = rules.stream()
+                .map(rule -> rule.split("=", 2))
+                .peek(parts -> {
+                    if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                        throw new IllegalArgumentException("Invalid schema-prefix-redirect-rules entry, expected 'prefix=catalog': " + String.join("=", parts));
+                    }
+                })
+                .collect(toImmutableMap(parts -> parts[0], parts -> parts[1]));
+        return this;
+    }
+
+    public Optional<String> getDefaultRedirectCatalog()
+    {
+        return defaultRedirectCatalog;
+    }
+
+    @Config("iceberg.default-redirect-catalog")
+    @ConfigDescription("Catalog to redirect to when no schema-prefix rule matches; the schema and table name are kept as-is")
+    public IcebergConfig setDefaultRedirectCatalog(String defaultRedirectCatalog)
+    {
+        this.defaultRedirectCatalog = Optional.ofNullable(defaultRedirectCatalog);
+        return this;
+    }
+
+    public List<String> getDefaultRedirectExcludedPrefixes()
+    {
+        return defaultRedirectExcludedPrefixes;
+    }
+
+    @Config("iceberg.default-redirect-excluded-prefixes")
+    @ConfigDescription("Comma-separated list of schema name prefixes that bypass iceberg.default-redirect-catalog (e.g. 'bexg_,vrbo_')")
+    public IcebergConfig setDefaultRedirectExcludedPrefixes(List<String> excludedPrefixes)
+    {
+        this.defaultRedirectExcludedPrefixes = ImmutableList.copyOf(excludedPrefixes);
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -506,6 +506,9 @@ public class IcebergMetadata
     private final ExecutorService icebergFileDeleteExecutor;
     private final int materializedViewRefreshMaxSnapshotsToExpire;
     private final Duration materializedViewRefreshSnapshotRetentionPeriod;
+    private final Map<String, String> schemaPrefixRedirectRules;
+    private final Optional<String> defaultRedirectCatalog;
+    private final List<String> defaultRedirectExcludedPrefixes;
     private final Map<IcebergTableHandle, AtomicReference<TableStatistics>> tableStatisticsCache = new ConcurrentHashMap<>();
     private final IcebergTableCredentialsProvider tableCredentialsProvider;
     private final DeletionVectorWriter deletionVectorWriter;
@@ -529,7 +532,10 @@ public class IcebergMetadata
             ExecutorService icebergPlanningExecutor,
             ExecutorService icebergFileDeleteExecutor,
             int materializedViewRefreshMaxSnapshotsToExpire,
-            Duration materializedViewRefreshSnapshotRetentionPeriod)
+            Duration materializedViewRefreshSnapshotRetentionPeriod,
+            Map<String, String> schemaPrefixRedirectRules,
+            Optional<String> defaultRedirectCatalog,
+            List<String> defaultRedirectExcludedPrefixes)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
@@ -548,6 +554,9 @@ public class IcebergMetadata
         this.materializedViewRefreshMaxSnapshotsToExpire = materializedViewRefreshMaxSnapshotsToExpire;
         this.materializedViewRefreshSnapshotRetentionPeriod = materializedViewRefreshSnapshotRetentionPeriod;
         this.tableCredentialsProvider = new IcebergTableCredentialsProvider(catalog);
+        this.schemaPrefixRedirectRules = ImmutableMap.copyOf(requireNonNull(schemaPrefixRedirectRules, "schemaPrefixRedirectRules is null"));
+        this.defaultRedirectCatalog = requireNonNull(defaultRedirectCatalog, "defaultRedirectCatalog is null");
+        this.defaultRedirectExcludedPrefixes = ImmutableList.copyOf(requireNonNull(defaultRedirectExcludedPrefixes, "defaultRedirectExcludedPrefixes is null"));
     }
 
     @Override
@@ -4250,11 +4259,39 @@ public class IcebergMetadata
     @Override
     public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName)
     {
+        Optional<CatalogSchemaTableName> prefixRedirect = redirectTableBySchemaPrefix(tableName);
+        if (prefixRedirect.isPresent()) {
+            return prefixRedirect;
+        }
+
         Optional<String> targetCatalogName = getHiveCatalogName(session);
         if (targetCatalogName.isEmpty()) {
             return Optional.empty();
         }
         return catalog.redirectTable(session, tableName, targetCatalogName.get());
+    }
+
+    private Optional<CatalogSchemaTableName> redirectTableBySchemaPrefix(SchemaTableName tableName)
+    {
+        String schemaName = tableName.getSchemaName();
+        for (Map.Entry<String, String> rule : schemaPrefixRedirectRules.entrySet()) {
+            String prefix = rule.getKey();
+            String targetCatalog = rule.getValue();
+            if (schemaName.startsWith(prefix)) {
+                String targetSchema = schemaName.substring(prefix.length());
+                if (targetSchema.isEmpty()) {
+                    continue;
+                }
+                return Optional.of(new CatalogSchemaTableName(targetCatalog, targetSchema, tableName.getTableName()));
+            }
+        }
+        for (String excludedPrefix : defaultRedirectExcludedPrefixes) {
+            if (schemaName.startsWith(excludedPrefix)) {
+                return Optional.empty();
+            }
+        }
+        return defaultRedirectCatalog.map(catalog ->
+                new CatalogSchemaTableName(catalog, schemaName, tableName.getTableName()));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -26,6 +26,8 @@ import io.trino.plugin.iceberg.delete.DeletionVectorWriter;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -52,6 +54,9 @@ public class IcebergMetadataFactory
     private final DeletionVectorWriter deletionVectorWriter;
     private final int materializedViewRefreshMaxSnapshotsToExpire;
     private final Duration materializedViewRefreshSnapshotRetentionPeriod;
+    private final Map<String, String> schemaPrefixRedirectRules;
+    private final Optional<String> defaultRedirectCatalog;
+    private final List<String> defaultRedirectExcludedPrefixes;
 
     @Inject
     public IcebergMetadataFactory(
@@ -96,6 +101,9 @@ public class IcebergMetadataFactory
         this.icebergFileDeleteExecutor = requireNonNull(icebergFileDeleteExecutor, "icebergFileDeleteExecutor is null");
         this.materializedViewRefreshMaxSnapshotsToExpire = config.getMaterializedViewRefreshMaxSnapshotsToExpire();
         this.materializedViewRefreshSnapshotRetentionPeriod = config.getMaterializedViewRefreshSnapshotRetentionPeriod();
+        this.schemaPrefixRedirectRules = config.getSchemaPrefixRedirectRules();
+        this.defaultRedirectCatalog = config.getDefaultRedirectCatalog();
+        this.defaultRedirectExcludedPrefixes = config.getDefaultRedirectExcludedPrefixes();
     }
 
     public IcebergMetadata create(ConnectorIdentity identity)
@@ -116,6 +124,9 @@ public class IcebergMetadataFactory
                 icebergPlanningExecutor,
                 icebergFileDeleteExecutor,
                 materializedViewRefreshMaxSnapshotsToExpire,
-                materializedViewRefreshSnapshotRetentionPeriod);
+                materializedViewRefreshSnapshotRetentionPeriod,
+                schemaPrefixRedirectRules,
+                defaultRedirectCatalog,
+                defaultRedirectExcludedPrefixes);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -86,7 +86,10 @@ public class TestIcebergConfig
                 .setMaterializedViewRefreshSnapshotRetentionPeriod(new Duration(4, HOURS))
                 .setObjectStoreLayoutEnabled(false)
                 .setMetadataParallelism(8)
-                .setBucketExecutionEnabled(true));
+                .setBucketExecutionEnabled(true)
+                .setSchemaPrefixRedirectRules(ImmutableList.of())
+                .setDefaultRedirectCatalog(null)
+                .setDefaultRedirectExcludedPrefixes(ImmutableList.of()));
     }
 
     @Test
@@ -133,6 +136,9 @@ public class TestIcebergConfig
                 .put("iceberg.object-store-layout.enabled", "true")
                 .put("iceberg.metadata.parallelism", "10")
                 .put("iceberg.bucket-execution", "false")
+                .put("iceberg.schema-prefix-redirect-rules", "egdp_prod_=egdp_prod,egdp_test_=egdp_test")
+                .put("iceberg.default-redirect-catalog", "default_catalog")
+                .put("iceberg.default-redirect-excluded-prefixes", "bexg_,vrbo_")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -176,7 +182,10 @@ public class TestIcebergConfig
                 .setMaterializedViewRefreshSnapshotRetentionPeriod(new Duration(1, HOURS))
                 .setObjectStoreLayoutEnabled(true)
                 .setMetadataParallelism(10)
-                .setBucketExecutionEnabled(false);
+                .setBucketExecutionEnabled(false)
+                .setSchemaPrefixRedirectRules(ImmutableList.of("egdp_prod_=egdp_prod", "egdp_test_=egdp_test"))
+                .setDefaultRedirectCatalog("default_catalog")
+                .setDefaultRedirectExcludedPrefixes(ImmutableList.of("bexg_", "vrbo_"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -158,7 +158,10 @@ public abstract class BaseTrinoCatalogTest
                     newDirectExecutorService(),
                     newDirectExecutorService(),
                     0,
-                    ZERO);
+                    ZERO,
+                    ImmutableMap.of(),
+                    Optional.empty(),
+                    ImmutableList.of());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isFalse();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")
@@ -199,7 +202,10 @@ public abstract class BaseTrinoCatalogTest
                     newDirectExecutorService(),
                     newDirectExecutorService(),
                     0,
-                    ZERO);
+                    ZERO,
+                    ImmutableMap.of(),
+                    Optional.empty(),
+                    ImmutableList.of());
 
             assertThat(icebergMetadata.getSchemaProperties(SESSION, namespace))
                     .doesNotContainKey("invalid_property");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -172,7 +172,10 @@ public class TestTrinoGlueCatalog
                     newDirectExecutorService(),
                     newDirectExecutorService(),
                     0,
-                    ZERO);
+                    ZERO,
+                    ImmutableMap.of(),
+                    Optional.empty(),
+                    ImmutableList.of());
             assertThat(icebergMetadata.schemaExists(SESSION, databaseName)).as("icebergMetadata.schemaExists(databaseName)")
                     .isFalse();
             assertThat(icebergMetadata.schemaExists(SESSION, trinoSchemaName)).as("icebergMetadata.schemaExists(trinoSchemaName)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.nessie;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
@@ -218,7 +219,10 @@ public class TestTrinoNessieCatalog
                     newDirectExecutorService(),
                     newDirectExecutorService(),
                     0,
-                    ZERO);
+                    ZERO,
+                    ImmutableMap.of(),
+                    Optional.empty(),
+                    ImmutableList.of());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isTrue();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.metastore.TableInfo;
@@ -165,7 +166,10 @@ public class TestTrinoRestCatalog
                     newDirectExecutorService(),
                     newDirectExecutorService(),
                     0,
-                    ZERO);
+                    ZERO,
+                    ImmutableMap.of(),
+                    Optional.empty(),
+                    ImmutableList.of());
             assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                     .isTrue();
             assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -243,7 +243,10 @@ public class TestTrinoSnowflakeCatalog
                 newDirectExecutorService(),
                 newDirectExecutorService(),
                 0,
-                ZERO);
+                ZERO,
+                ImmutableMap.of(),
+                Optional.empty(),
+                ImmutableList.of());
         assertThat(icebergMetadata.schemaExists(SESSION, namespace)).as("icebergMetadata.schemaExists(namespace)")
                 .isTrue();
         assertThat(icebergMetadata.schemaExists(SESSION, schema)).as("icebergMetadata.schemaExists(schema)")


### PR DESCRIPTION
## Overview

This PR adds three new configuration options to the Hive and Iceberg connectors that together enable transparent, zero-metastore-I/O catalog redirection based on schema naming conventions.

## Motivation

Trino already supports catalog redirect for Iceberg, Delta Lake, and Hudi tables detected through the Hive metastore. However, there is no general-purpose mechanism to redirect queries based purely on schema naming, independent of table format.

A common pattern in multi-catalog deployments is encoding the target catalog in the schema name via a prefix (e.g. `analytics_sales` → catalog `iceberg`, schema `sales`). For schemas without a prefix, a default fallback catalog handles all remaining queries. Together, these properties provide full routing coverage with no metastore lookups in either path. The excluded-prefixes option allows fine-grained carve-outs from the default fallback for schemas that must stay in the native catalog.

## Changes

**`hive.schema-prefix-redirect-rules`** / **`iceberg.schema-prefix-redirect-rules`** — comma-separated list of `prefix=catalog` pairs. When a schema name starts with a configured prefix, the prefix is stripped to derive the target schema and the query is redirected to the mapped catalog:

```
hive.schema-prefix-redirect-rules=analytics_=iceberg,reporting_=delta

hive.analytics_sales.orders  →  iceberg.sales.orders   (prefix stripped)
```

**`hive.default-redirect-catalog`** / **`iceberg.default-redirect-catalog`** — fallback catalog for schemas that match no prefix rule. The schema and table name are kept as-is:

```
hive.default-redirect-catalog=iceberg

hive.supply.orders  →  iceberg.supply.orders   (schema unchanged)
```

**`hive.default-redirect-excluded-prefixes`** / **`iceberg.default-redirect-excluded-prefixes`** — comma-separated list of schema name prefixes that bypass the default redirect catalog. Schemas starting with an excluded prefix are kept in the native catalog instead of being redirected to the default catalog:

```
hive.default-redirect-catalog=iceberg
hive.default-redirect-excluded-prefixes=staging_,dev_

hive.staging_analytics.orders  →  stays in HMS   (excluded prefix)
hive.dev_sales.orders          →  stays in HMS   (excluded prefix)
hive.supply.orders             →  iceberg.supply.orders   (no exclusion)
```

All properties are **opt-in and off by default**. No behavior change for existing deployments.

## Behavior

- Prefix rules are evaluated **before** the existing Iceberg/Delta/Hudi redirect checks, with **zero metastore I/O**.
- The default redirect is applied only when no prefix rule matches, also with **zero metastore I/O**.
- Excluded prefixes are checked before applying the default redirect; matching schemas fall through to the standard path.
- If a prefix matches but stripping it leaves an empty schema name, that rule is skipped and evaluation continues.
- Config validation at startup rejects malformed prefix rules (missing `=`, empty prefix, or empty catalog name).

## Testing

`TestHiveConfig` and `TestIcebergConfig` updated to cover the default (empty/null) state and explicit values for all three new properties.