### PR TITLE
Example code to show that geospatial UDFs are not possible

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/PluginClassLoader.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginClassLoader.java
@@ -30,36 +30,36 @@ public class PluginClassLoader
         extends URLClassLoader
 {
     private final String pluginName;
-    private final ClassLoader spiClassLoader;
+    private final SharedPackagesClassLoader sharedPackagesClassLoader;
     private final List<String> spiPackages;
     private final List<String> spiResources;
 
     public PluginClassLoader(
             String pluginName,
             List<URL> urls,
-            ClassLoader spiClassLoader,
+            SharedPackagesClassLoader sharedPackagesClassLoader,
             List<String> spiPackages)
     {
         this(pluginName,
                 urls,
-                spiClassLoader,
+                sharedPackagesClassLoader,
                 spiPackages,
                 spiPackages.stream()
                         .map(PluginClassLoader::classNameToResource)
                         .collect(toImmutableList()));
     }
 
-    private PluginClassLoader(
+    PluginClassLoader(
             String pluginName,
             List<URL> urls,
-            ClassLoader spiClassLoader,
+            SharedPackagesClassLoader sharedPackagesClassLoader,
             Iterable<String> spiPackages,
             Iterable<String> spiResources)
     {
         // plugins should not have access to the system (application) class loader
         super(urls.toArray(new URL[0]), getPlatformClassLoader());
         this.pluginName = requireNonNull(pluginName, "pluginName is null");
-        this.spiClassLoader = requireNonNull(spiClassLoader, "spiClassLoader is null");
+        this.sharedPackagesClassLoader = requireNonNull(sharedPackagesClassLoader, "sharedExtensionClassLoader is null");
         this.spiPackages = ImmutableList.copyOf(spiPackages);
         this.spiResources = ImmutableList.copyOf(spiResources);
     }
@@ -67,7 +67,7 @@ public class PluginClassLoader
     public PluginClassLoader withUrl(URL url)
     {
         List<URL> urls = ImmutableList.<URL>builder().add(getURLs()).add(url).build();
-        return new PluginClassLoader(pluginName, urls, spiClassLoader, spiPackages, spiResources);
+        return new PluginClassLoader(pluginName, urls, sharedPackagesClassLoader, spiPackages, spiResources);
     }
 
     public String getId()
@@ -98,9 +98,9 @@ public class PluginClassLoader
             }
 
             // If this is an SPI class, only check SPI class loader
-            if (isSpiClass(name)) {
+            if (isSpiClass(name) || sharedPackagesClassLoader.isSharedClass(name)) {
                 try {
-                    return resolveClass(spiClassLoader.loadClass(name), resolve);
+                    return resolveClass(sharedPackagesClassLoader.loadClass(name), resolve);
                 }
                 catch (ClassNotFoundException e) {
                     if (hasClassLocally(name, resolve)) {
@@ -139,7 +139,7 @@ public class PluginClassLoader
     {
         // If this is an SPI resource, only check SPI class loader
         if (isSpiResource(name)) {
-            return spiClassLoader.getResource(name);
+            return sharedPackagesClassLoader.getResource(name);
         }
 
         // Look for resource locally
@@ -152,7 +152,7 @@ public class PluginClassLoader
     {
         // If this is an SPI resource, use SPI resources
         if (isSpiClass(name)) {
-            return spiClassLoader.getResources(name);
+            return sharedPackagesClassLoader.getResources(name);
         }
 
         // Use local resources

--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -38,6 +38,7 @@ import io.trino.server.security.PasswordAuthenticatorManager;
 import io.trino.spi.Plugin;
 import io.trino.spi.block.BlockEncoding;
 import io.trino.spi.catalog.CatalogStoreFactory;
+import io.trino.spi.classloader.SharedPluginPackages;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.eventlistener.EventListenerFactory;
@@ -55,12 +56,13 @@ import io.trino.spi.type.ParametricType;
 import io.trino.spi.type.Type;
 
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Arrays.asList;
@@ -70,12 +72,20 @@ import static java.util.Objects.requireNonNull;
 public class PluginManager
         implements PluginInstaller
 {
-    private static final List<String> SPI_PACKAGES = ImmutableList.<String>builder()
+    public static final List<String> SPI_PACKAGES = ImmutableList.<String>builder()
             .add("io.trino.spi.")
             .add("com.fasterxml.jackson.annotation.")
             .add("io.airlift.slice.")
             .add("io.opentelemetry.api.")
             .add("io.opentelemetry.context.")
+            .build();
+
+    private static final List<String> FORBIDDEN_PACKAGES = ImmutableList.<String>builder()
+            .add("java.")
+            .add("javax.")
+            .add("sun.")
+            .add("io.trino.")
+            .add("jdk.")
             .build();
 
     private static final Logger log = Logger.get(PluginManager.class);
@@ -99,6 +109,7 @@ public class PluginManager
     private final BlockEncodingManager blockEncodingManager;
     private final HandleResolver handleResolver;
     private final AtomicBoolean pluginsLoading = new AtomicBoolean();
+    private final SharedPackagesClassLoader sharedPackagesClassLoader = new SharedPackagesClassLoader(PluginManager.class.getClassLoader());
 
     @Inject
     public PluginManager(
@@ -148,16 +159,48 @@ public class PluginManager
             return;
         }
 
-        pluginsProvider.loadPlugins(this::loadPlugin, PluginManager::createClassLoader);
+        pluginsProvider.loadPlugins(this::preloadPlugin);
+        pluginsProvider.loadPlugins(this::loadPlugin);
 
         typeRegistry.verifyTypes();
     }
 
-    private void loadPlugin(String plugin, Supplier<PluginClassLoader> createClassLoader)
+    private void preloadPlugin(
+            String pluginPath,
+            String pluginName,
+            List<URL> urls)
     {
-        log.info("-- Loading plugin %s --", plugin);
+        log.info("-- Preloading plugin %s --", pluginPath);
+        effectiveSpiPackages(pluginPath, urls);
+    }
 
-        PluginClassLoader pluginClassLoader = createClassLoader.get();
+    private List<String> effectiveSpiPackages(String pluginPath, List<URL> urls)
+    {
+        URLClassLoader discoveryClassLoader = new URLClassLoader(urls.toArray(URL[]::new), sharedPackagesClassLoader);
+        ServiceLoader<Plugin> discoveryServiceLoader = ServiceLoader.load(Plugin.class, discoveryClassLoader);
+        List<Plugin> discoveredPlugins = ImmutableList.copyOf(discoveryServiceLoader);
+
+        checkState(!discoveredPlugins.isEmpty(), "%s - No service providers of type %s", pluginPath, Plugin.class.getName());
+
+        List<String> pluginSharedPackages = getSharedPackages(discoveredPlugins);
+        sharedPackagesClassLoader.registerPackages(pluginSharedPackages);
+        sharedPackagesClassLoader.addUrls(urls);
+
+        return ImmutableList.<String>builder()
+                .addAll(SPI_PACKAGES)
+                .addAll(pluginSharedPackages)
+                .build();
+    }
+
+    private void loadPlugin(
+            String pluginPath,
+            String pluginName,
+            List<URL> urls)
+    {
+        log.info("-- Loading plugin %s --", pluginPath);
+        List<String> effectiveSpiPackages = effectiveSpiPackages(pluginPath, urls);
+
+        PluginClassLoader pluginClassLoader = new PluginClassLoader(pluginName, urls, sharedPackagesClassLoader, effectiveSpiPackages);
 
         log.debug("Classpath for plugin:");
         for (URL url : pluginClassLoader.getURLs()) {
@@ -166,10 +209,27 @@ public class PluginManager
 
         handleResolver.registerClassLoader(pluginClassLoader);
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(pluginClassLoader)) {
-            loadPlugin(plugin, pluginClassLoader);
+            loadPlugin(pluginPath, pluginClassLoader);
         }
 
-        log.info("-- Finished loading plugin %s --", plugin);
+        log.info("-- Finished loading plugin %s --", pluginPath);
+    }
+
+    public static List<String> getSharedPackages(Collection<Plugin> plugins)
+    {
+        ImmutableList.Builder<String> sharedPackages = ImmutableList.builder();
+        for (Plugin plugin : plugins) {
+            SharedPluginPackages annotation = plugin.getClass().getAnnotation(SharedPluginPackages.class);
+
+            if (annotation != null) {
+                for (String spiPackage : annotation.value()) {
+                    sharedPackages.add(spiPackage.endsWith(".") ? spiPackage : spiPackage.concat("."));
+                    log.info("Added shared package %s", spiPackage);
+                    checkState(FORBIDDEN_PACKAGES.stream().noneMatch(spiPackage::startsWith), "Forbidden shared package: %s".formatted(spiPackage));
+                }
+            }
+        }
+        return sharedPackages.build();
     }
 
     private void loadPlugin(String pluginPath, PluginClassLoader pluginClassLoader)
@@ -288,19 +348,32 @@ public class PluginManager
         }
     }
 
-    public static PluginClassLoader createClassLoader(String pluginName, List<URL> urls)
+    private List<String> discoverSharedPackages(
+            ClassLoader discoveryClassLoader,
+            String pluginClassName)
     {
-        ClassLoader parent = PluginManager.class.getClassLoader();
-        return new PluginClassLoader(pluginName, urls, parent, SPI_PACKAGES);
+        try {
+            Class<?> pluginClass = discoveryClassLoader.loadClass(pluginClassName);
+
+            SharedPluginPackages annotation = pluginClass.getAnnotation(SharedPluginPackages.class);
+            if (annotation == null) {
+                return List.of();
+            }
+
+            return List.of(annotation.value());
+        }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed loading plugin class: " + pluginClassName, e);
+        }
     }
 
     public interface PluginsProvider
     {
-        void loadPlugins(Loader loader, ClassLoaderFactory createClassLoader);
+        void loadPlugins(Loader loader);
 
         interface Loader
         {
-            void load(String description, Supplier<PluginClassLoader> getClassLoader);
+            void load(String pluginPath, String pluginName, List<URL> urls);
         }
 
         interface ClassLoaderFactory

--- a/core/trino-main/src/main/java/io/trino/server/ServerPluginsProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerPluginsProvider.java
@@ -47,7 +47,7 @@ public class ServerPluginsProvider
     }
 
     @Override
-    public void loadPlugins(Loader loader, ClassLoaderFactory createClassLoader)
+    public void loadPlugins(Loader loader)
     {
         executeUntilFailure(
                 executor,
@@ -57,7 +57,7 @@ public class ServerPluginsProvider
                         .map(Path::toAbsolutePath)
                         .map(path -> (Callable<?>) () -> {
                             String name = path.getFileName().toString();
-                            loader.load(name, () -> createClassLoader.create(name, buildClassPath(path)));
+                            loader.load(path.toString(), name, buildClassPath(path));
                             return null;
                         })
                         .collect(toImmutableList()));

--- a/core/trino-main/src/main/java/io/trino/server/SharedPackagesClassLoader.java
+++ b/core/trino-main/src/main/java/io/trino/server/SharedPackagesClassLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SharedPackagesClassLoader
+        extends URLClassLoader
+{
+    private final Set<String> sharedPackages = ConcurrentHashMap.newKeySet();
+
+    public SharedPackagesClassLoader(ClassLoader parent)
+    {
+        super(new URL[0], parent);
+    }
+
+    public void registerPackages(Collection<String> packages)
+    {
+        sharedPackages.addAll(packages);
+    }
+
+    public void addUrls(Collection<URL> urls)
+    {
+        for (URL url : urls) {
+            addURL(url);
+        }
+    }
+
+    public boolean isSharedClass(String className)
+    {
+        return sharedPackages.stream().anyMatch(className::startsWith);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -504,7 +504,7 @@ public class PlanTester
                 noop(),
                 noopTracer());
         this.pluginManager = new PluginManager(
-                (_, _) -> {},
+                _ -> {},
                 Optional.empty(),
                 catalogFactory,
                 globalFunctionCatalog,

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAccumulatorCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAccumulatorCompiler.java
@@ -19,7 +19,9 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.operator.aggregation.state.StateCompiler;
 import io.trino.operator.window.InternalWindowIndex;
+import io.trino.server.PluginClassLoader;
 import io.trino.server.PluginManager;
+import io.trino.server.SharedPackagesClassLoader;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -46,6 +48,7 @@ import static io.trino.operator.aggregation.AccumulatorCompiler.generateAccumula
 import static io.trino.operator.aggregation.AggregationFunctionAdapter.AggregationParameterKind.INPUT_CHANNEL;
 import static io.trino.operator.aggregation.AggregationFunctionAdapter.AggregationParameterKind.STATE;
 import static io.trino.operator.aggregation.AggregationFunctionAdapter.normalizeInputMethod;
+import static io.trino.server.PluginManager.SPI_PACKAGES;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
 import static io.trino.util.Reflection.methodHandle;
@@ -81,7 +84,7 @@ public class TestAccumulatorCompiler
         TimestampType parameterType = TimestampType.TIMESTAMP_NANOS;
         assertThat(parameterType.getJavaType()).isEqualTo(LongTimestamp.class);
 
-        ClassLoader pluginClassLoader = PluginManager.createClassLoader("test", ImmutableList.of());
+        PluginClassLoader pluginClassLoader = new PluginClassLoader("test", ImmutableList.of(), new SharedPackagesClassLoader(PluginManager.class.getClassLoader()), SPI_PACKAGES);
         DynamicClassLoader classLoader = new DynamicClassLoader(pluginClassLoader);
         Class<? extends AccumulatorState> stateInterface = IsolatedClass.isolateClass(
                 classLoader,

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -97,6 +97,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/geospatial-example">
+        <artifact id="${project.groupId}:trino-geospatial-example:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/hive">
         <artifact id="${project.groupId}:trino-hive:zip:${project.version}">
             <unpack />

--- a/core/trino-spi/src/main/java/io/trino/spi/classloader/SharedPluginPackages.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/classloader/SharedPluginPackages.java
@@ -11,21 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.geospatialexample;
+package io.trino.spi.classloader;
 
-import com.google.common.collect.ImmutableSet;
-import io.trino.spi.Plugin;
-import io.trino.spi.classloader.SharedPluginPackages;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-import java.util.Set;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@SharedPluginPackages("org.locationtech.jts")
-public class GeospatialExamplePlugin
-        implements Plugin
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface SharedPluginPackages
 {
-    @Override
-    public Set<Class<?>> getFunctions()
-    {
-        return ImmutableSet.of(ExampleFunction.class);
-    }
+    String[] value();
 }

--- a/plugin/trino-geospatial-example/pom.xml
+++ b/plugin/trino-geospatial-example/pom.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>481-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-geospatial-example</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - Geospatial example</description>
+
+    <properties>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-geospatial</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-parser</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <rules>
+                        <bannedDependencies>
+                            <includes combine.children="append">
+                                <!-- Legacy HDFS file system uses AWS S3 SDK v1 -->
+                                <include>com.amazonaws:*:*</include>
+                            </includes>
+                        </bannedDependencies>
+                    </rules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-geospatial-example/src/main/java/io/trino/plugin/geospatialexample/ExampleFunction.java
+++ b/plugin/trino-geospatial-example/src/main/java/io/trino/plugin/geospatialexample/ExampleFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatialexample;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.locationtech.jts.geom.Geometry;
+
+public class ExampleFunction
+{
+    @ScalarFunction("geospatial_example")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice example(@SqlType(StandardTypes.GEOMETRY) Geometry geometry)
+    {
+        return Slices.utf8Slice("works as expected, type " + geometry.getClass().getSimpleName());
+    }
+}

--- a/plugin/trino-geospatial-example/src/main/java/io/trino/plugin/geospatialexample/GeospatialExamplePlugin.java
+++ b/plugin/trino-geospatial-example/src/main/java/io/trino/plugin/geospatialexample/GeospatialExamplePlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatialexample;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.Plugin;
+
+import java.util.Set;
+
+public class GeospatialExamplePlugin
+        implements Plugin
+{
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.of(ExampleFunction.class);
+    }
+}

--- a/plugin/trino-geospatial-example/src/test/java/io/trino/plugin/geospatialexample/TestExampleFunction.java
+++ b/plugin/trino-geospatial-example/src/test/java/io/trino/plugin/geospatialexample/TestExampleFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatialexample;
+
+import io.trino.plugin.geospatial.GeoPlugin;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestExampleFunction
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addPlugin(new GeoPlugin());
+        assertions.addPlugin(new GeospatialExamplePlugin());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testExample()
+    {
+        assertThat(assertions.expression("geospatial_example(ST_POINT(1.234, 1.234))"))
+                .hasType(VARCHAR)
+                .isEqualTo("works as expected, type Point");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>plugin/trino-faker</module>
         <module>plugin/trino-functions-python</module>
         <module>plugin/trino-geospatial</module>
+        <module>plugin/trino-geospatial-example</module>
         <module>plugin/trino-google-sheets</module>
         <module>plugin/trino-hive</module>
         <module>plugin/trino-http-event-listener</module>
@@ -1091,6 +1092,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-geospatial</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-geospatial-example</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginLoader.java
+++ b/testing/trino-plugin-reader/src/main/java/io/trino/server/PluginLoader.java
@@ -17,10 +17,11 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.Plugin;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -43,6 +44,7 @@ public class PluginLoader
     public static final String RESOURCE_GROUP_CONFIGURATION_MANAGER = "resourceGroupConfigurationManager:";
     public static final String SESSION_PROPERTY_CONFIGURATION_MANAGER = "sessionPropertyConfigurationManager:";
     public static final String EXCHANGE_MANAGER = "exchangeManager:";
+    private static final SharedPackagesClassLoader SHARED_EXTENSION_CLASS_LOADER = new SharedPackagesClassLoader(PluginLoader.class.getClassLoader());
 
     private PluginLoader() {}
 
@@ -73,13 +75,34 @@ public class PluginLoader
         config.setInstalledPluginsDirs(path);
         ServerPluginsProvider pluginsProvider = new ServerPluginsProvider(config, directExecutor());
         ImmutableList.Builder<Plugin> plugins = ImmutableList.builder();
-        pluginsProvider.loadPlugins((_, createClassLoader) -> loadPlugin(createClassLoader, plugins), PluginManager::createClassLoader);
+        pluginsProvider.loadPlugins((pluginPath, pluginName, urls) -> loadPlugin(pluginPath, pluginName, urls, plugins));
         return plugins.build();
     }
 
-    private static void loadPlugin(Supplier<PluginClassLoader> createClassLoader, ImmutableList.Builder<Plugin> plugins)
+    private static void loadPlugin(
+            String pluginPath,
+            String pluginName,
+            List<URL> urls,
+            ImmutableList.Builder<Plugin> plugins)
     {
-        PluginClassLoader pluginClassLoader = createClassLoader.get();
+        URLClassLoader discoveryClassLoader = new URLClassLoader(urls.toArray(URL[]::new), SHARED_EXTENSION_CLASS_LOADER);
+        ServiceLoader<Plugin> discoveryServiceLoader = ServiceLoader.load(Plugin.class, discoveryClassLoader);
+        List<Plugin> discoveredPlugins = ImmutableList.copyOf(discoveryServiceLoader);
+
+        checkState(!discoveredPlugins.isEmpty(), "No service providers of type %s in classpath %s", Plugin.class.getName(), pluginPath);
+
+        List<String> pluginSharedPackages = PluginManager.getSharedPackages(discoveredPlugins);
+
+        SHARED_EXTENSION_CLASS_LOADER.registerPackages(pluginSharedPackages);
+        SHARED_EXTENSION_CLASS_LOADER.addUrls(urls);
+
+        List<String> effectiveSpiPackages =
+                ImmutableList.<String>builder()
+                        .addAll(PluginManager.SPI_PACKAGES)
+                        .addAll(pluginSharedPackages)
+                        .build();
+
+        PluginClassLoader pluginClassLoader = new PluginClassLoader(pluginName, urls, SHARED_EXTENSION_CLASS_LOADER, effectiveSpiPackages);
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(pluginClassLoader)) {
             loadServicePlugin(pluginClassLoader, plugins);
         }

--- a/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentPluginsProvider.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentPluginsProvider.java
@@ -48,6 +48,8 @@ public class DevelopmentPluginsProvider
     private final ArtifactResolver resolver;
     private final List<String> plugins;
     private final Executor executor;
+    private final SharedPackagesClassLoader sharedPackagesClassLoader = new SharedPackagesClassLoader(
+            DevelopmentPluginsProvider.class.getClassLoader());
 
     @Inject
     public DevelopmentPluginsProvider(DevelopmentLoaderConfig config, @ForStartup Executor executor)
@@ -58,22 +60,22 @@ public class DevelopmentPluginsProvider
     }
 
     @Override
-    public void loadPlugins(Loader loader, ClassLoaderFactory createClassLoader)
+    public void loadPlugins(Loader loader)
     {
         executeUntilFailure(
                 executor,
                 plugins.stream()
-                        .map(plugin -> (Callable<?>) () -> {
-                            loader.load(plugin, () -> buildClassLoader(plugin, createClassLoader));
+                        .map(_ -> (Callable<?>) () -> {
+//                            loader.load(plugin, plugin, () -> buildClassLoader(plugin));
                             return null;
                         })
                         .collect(toImmutableList()));
     }
 
-    private PluginClassLoader buildClassLoader(String plugin, ClassLoaderFactory classLoaderFactory)
+    private PluginClassLoader buildClassLoader(String plugin)
     {
         try {
-            return doBuildClassLoader(plugin, urls -> classLoaderFactory.create(plugin, urls));
+            return doBuildClassLoader(plugin, urls -> new PluginClassLoader(plugin, urls, sharedPackagesClassLoader, List.of()));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
## Description
Tests work fine, but in production the following exception is thrown:
```
trino> select geospatial_example(ST_Point(1.234, 1.234));
Query 20260518_205813_00001_hwcaa failed:
Exact implementation of system.builtin.geospatial_example do not match expected java types
```

Update: second commit with idea to fix this.

Allow developers to annotate a plugin with a package name that should be loaded as a shared package, to make sure it is loaded in a single classloader and interchangeable.

```
trino> select geospatial_example(ST_Point(1.234, 1.234));
             _col0             
-------------------------------
 works as expected, type Point 
(1 row)
```