### PR TITLE
Add named arguments for ordinary function calls

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -99,7 +99,7 @@ statement
         SET PROPERTIES propertyAssignments                             #setTableProperties
     | ALTER TABLE tableName=qualifiedName
         EXECUTE procedureName=identifier
-        ('(' (callArgument (',' callArgument)*)? ')')?
+        ('(' (argument (',' argument)*)? ')')?
         (WHERE where=booleanExpression)?                               #tableExecute
     | ALTER ownedEntityKind qualifiedName SET AUTHORIZATION principal  #setAuthorization
     | ANALYZE qualifiedName (WITH properties)?                         #analyze
@@ -122,7 +122,7 @@ statement
     | DROP VIEW (IF EXISTS)? qualifiedName                             #dropView
     | ALTER VIEW from=qualifiedName RENAME TO to=qualifiedName         #renameView
     | ALTER VIEW viewName=qualifiedName REFRESH                        #refreshView
-    | CALL qualifiedName '(' (callArgument (',' callArgument)*)? ')'   #call
+    | CALL qualifiedName '(' (argument (',' argument)*)? ')'           #call
     | CREATE (OR REPLACE)? functionSpecification                       #createFunction
     | DROP FUNCTION (IF EXISTS)? functionDeclaration                   #dropFunction
     | CREATE (OR REPLACE)? BRANCH (IF NOT EXISTS)? branch=identifier
@@ -604,7 +604,7 @@ primaryExpression
         filter? over?                                                                     #listagg
     | processingMode? qualifiedName '(' (label=identifier '.')? ASTERISK ')'
         filter? over?                                                                     #functionCall
-    | processingMode? qualifiedName '(' (setQuantifier? expression (',' expression)*)?
+    | processingMode? qualifiedName '(' (setQuantifier? argument (',' argument)*)?
         orderBy? ')' filter? (nullTreatment? over)?                                       #functionCall
     | qualifiedName '::' identifier '(' (expression (',' expression)*)? ')'               #staticMethodCall
     | primaryExpression '.' identifier '(' (expression (',' expression)*)? ')'            #methodCall
@@ -902,7 +902,7 @@ levelOfIsolation
     | SERIALIZABLE                        #serializable
     ;
 
-callArgument
+argument
     : expression                    #positionalArgument
     | identifier '=>' expression    #namedArgument
     ;

--- a/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundle.java
@@ -35,13 +35,16 @@ import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.Signature;
 import io.trino.spi.function.WindowFunction;
 import io.trino.spi.function.WindowFunctionSupplier;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -50,6 +53,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static java.lang.String.format;
 import static java.time.Duration.ofHours;
 import static java.util.Objects.requireNonNull;
 
@@ -88,7 +92,47 @@ public class InternalFunctionBundle
 
         this.functions = functions.stream()
                 .collect(toImmutableMap(function -> function.getFunctionMetadata().getFunctionId(), Function.identity()));
+
+        validateNamedArgumentPositions(functions);
     }
+
+    /// Per (name, arity), every overload that declares a named parameter must place
+    /// it at the same slot. The runtime binder relies on a representative overload's
+    /// positions when reordering named arguments; without agreement, the binding
+    /// would be ambiguous, so this is rejected at registration rather than runtime.
+    private static void validateNamedArgumentPositions(List<? extends SqlFunction> functions)
+    {
+        Map<NameArity, Map<String, Integer>> declaredPositions = new HashMap<>();
+        for (SqlFunction function : functions) {
+            FunctionMetadata metadata = function.getFunctionMetadata();
+            Signature signature = metadata.getSignature();
+            if (signature.isVariableArity()) {
+                continue;
+            }
+            List<Signature.Argument> arguments = signature.getArguments();
+            for (String name : metadata.getNames()) {
+                Map<String, Integer> positions = declaredPositions.computeIfAbsent(new NameArity(name, arguments.size()), _ -> new HashMap<>());
+                for (int i = 0; i < arguments.size(); i++) {
+                    Optional<String> parameterName = arguments.get(i).name();
+                    if (parameterName.isEmpty()) {
+                        continue;
+                    }
+                    Integer existing = positions.putIfAbsent(parameterName.get(), i);
+                    if (existing != null && existing != i) {
+                        throw new IllegalArgumentException(format(
+                                "Overloads of %s at arity %s declare parameter %s at different positions: %s vs %s",
+                                name,
+                                arguments.size(),
+                                parameterName.get(),
+                                existing,
+                                i));
+                    }
+                }
+            }
+        }
+    }
+
+    private record NameArity(String name, int arity) {}
 
     @Override
     public Collection<FunctionMetadata> getFunctions()

--- a/core/trino-main/src/main/java/io/trino/operator/ParametricImplementationsGroup.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ParametricImplementationsGroup.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.function.FunctionNullability;
 import io.trino.spi.function.Signature;
+import io.trino.spi.function.Signature.Argument;
 import io.trino.spi.type.TypeSignature;
 
 import java.util.List;
@@ -27,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.operator.annotations.FunctionsParserHelper.validateSignaturesCompatibility;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
  * This class represents set of three collections representing implementations of operators
@@ -138,7 +140,9 @@ public class ParametricImplementationsGroup<T extends ParametricImplementation>
             if (!implementation.getSignature().isGeneric()
                     && implementation.getSignature().getArgumentTypes().stream().noneMatch(TypeSignature::isCalculated)
                     && !implementation.getSignature().getReturnType().isCalculated()) {
-                exactImplementations.put(implementation.getSignature(), implementation);
+                // Lookup is by `BoundSignature.toSignature()`, which has no argument
+                // names; strip names from the key so the match is structural only.
+                exactImplementations.put(withoutArgumentNames(implementation.getSignature()), implementation);
             }
             else if (implementation.hasSpecializedTypeParameters()) {
                 specializedImplementations.add(implementation);
@@ -148,13 +152,25 @@ public class ParametricImplementationsGroup<T extends ParametricImplementation>
             }
         }
 
+        private static Signature withoutArgumentNames(Signature signature)
+        {
+            if (signature.getArguments().stream().allMatch(argument -> argument.name().isEmpty())) {
+                return signature;
+            }
+            List<Argument> stripped = signature.getArguments().stream()
+                    .map(Argument::type)
+                    .map(Argument::of)
+                    .collect(toUnmodifiableList());
+            return Signature.builder(signature).arguments(stripped).build();
+        }
+
         private static <T extends ParametricImplementation> Signature determineGenericSignature(
                 Map<Signature, T> exactImplementations,
                 List<T> specializedImplementations,
                 List<T> genericImplementations)
         {
             if (specializedImplementations.isEmpty() && genericImplementations.isEmpty()) {
-                return getOnlyElement(exactImplementations.keySet());
+                return getOnlyElement(exactImplementations.values()).getSignature();
             }
 
             Optional<Signature> signature = Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
@@ -26,6 +26,7 @@ import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionNullability;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.SqlNullable;
@@ -266,7 +267,7 @@ public class ParametricAggregationImplementation
             argumentNativeContainerTypes = parseSignatureArgumentsTypes(inputFunction);
 
             // determine TypeSignatures of function declaration
-            signatureBuilder.argumentTypes(getInputTypesSignatures(inputFunction));
+            addInputTypeSignatures(signatureBuilder, inputFunction);
             signatureBuilder.returnType(parseTypeSignature(outputFunction.getAnnotation(OutputFunction.class).value(), literalParameters));
 
             inputHandle = methodHandle(inputFunction);
@@ -446,21 +447,38 @@ public class ParametricAggregationImplementation
             return containsAnnotation(annotations, annotation -> annotation instanceof BlockPosition);
         }
 
-        public List<TypeSignature> getInputTypesSignatures(Method inputFunction)
+        /// Appends to `signatureBuilder` the argument type — and, if the parameter
+        /// carries a [Name] annotation, its declared name — for every [SqlType]
+        /// input parameter of the aggregation function. Rejects `@Name` on a
+        /// non-`@SqlType` parameter, since the declared name has nothing to attach
+        /// to. (`@Name` itself is not `@Repeatable`, so the compiler enforces a
+        /// single annotation per parameter.)
+        private void addInputTypeSignatures(Signature.Builder signatureBuilder, Method inputFunction)
         {
-            ImmutableList.Builder<TypeSignature> builder = ImmutableList.builder();
-
             Annotation[][] parameterAnnotations = inputFunction.getParameterAnnotations();
             for (Annotation[] annotations : parameterAnnotations) {
+                SqlType sqlType = null;
+                String declaredName = null;
                 for (Annotation annotation : annotations) {
-                    if (annotation instanceof SqlType sqlType) {
-                        String typeName = sqlType.value();
-                        builder.add(parseTypeSignature(typeName, literalParameters));
+                    if (annotation instanceof SqlType type) {
+                        sqlType = type;
+                    }
+                    else if (annotation instanceof Name name) {
+                        declaredName = name.value();
                     }
                 }
+                if (sqlType == null) {
+                    checkArgument(declaredName == null, "Method [%s] has @Name on a parameter without @SqlType", inputFunction);
+                    continue;
+                }
+                TypeSignature typeSignature = parseTypeSignature(sqlType.value(), literalParameters);
+                if (declaredName != null) {
+                    signatureBuilder.argumentType(typeSignature, declaredName);
+                }
+                else {
+                    signatureBuilder.argumentType(typeSignature);
+                }
             }
-
-            return builder.build();
         }
 
         private static boolean isAggregationMetaAnnotation(Annotation annotation)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
@@ -37,6 +37,7 @@ import io.trino.spi.function.InOut;
 import io.trino.spi.function.InvocationConvention.InvocationArgumentConvention;
 import io.trino.spi.function.InvocationConvention.InvocationReturnConvention;
 import io.trino.spi.function.IsNull;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
@@ -551,6 +552,7 @@ public class ParametricScalarImplementation
                 // Skip injected parameters
                 if (parameterType == ConnectorSession.class) {
                     checkCondition(!hasConnectorSession, FUNCTION_IMPLEMENTATION_ERROR, "Method [%s] has more than 1 ConnectorSession in the parameter list", method);
+                    checkArgument(!parameter.isAnnotationPresent(Name.class), "Method [%s] has @Name on a non-@SqlType parameter", method);
                     hasConnectorSession = true;
                     parameterIndex++;
                     continue;
@@ -559,6 +561,7 @@ public class ParametricScalarImplementation
                 Optional<Annotation> implementationDependency = getImplementationDependencyAnnotation(parameter);
                 if (implementationDependency.isPresent()) {
                     checkCondition(!encounteredNonDependencyAnnotation, FUNCTION_IMPLEMENTATION_ERROR, "Method [%s] has parameters annotated with Dependency annotations that appears after other parameters", method);
+                    checkArgument(!parameter.isAnnotationPresent(Name.class), "Method [%s] has @Name on a non-@SqlType parameter", method);
 
                     // check if only declared typeParameters and literalParameters are used
                     validateImplementationDependencyAnnotation(method, implementationDependency.get(), typeParameterNames, literalParameters);
@@ -578,7 +581,17 @@ public class ParametricScalarImplementation
                             .findFirst()
                             .orElseThrow(() -> new IllegalArgumentException(format("Method [%s] is missing @SqlType annotation for parameter", method)));
                     TypeSignature typeSignature = parseTypeSignature(type.value(), literalParameters);
-                    signatureBuilder.argumentType(typeSignature);
+                    // @Name is not @Repeatable, so the compiler guarantees at most one.
+                    Optional<Name> nameAnnotation = Stream.of(annotations)
+                            .filter(Name.class::isInstance)
+                            .map(Name.class::cast)
+                            .findFirst();
+                    if (nameAnnotation.isPresent()) {
+                        signatureBuilder.argumentType(typeSignature, nameAnnotation.get().value());
+                    }
+                    else {
+                        signatureBuilder.argumentType(typeSignature);
+                    }
 
                     if (typeSignature.getBase().equals(FunctionType.NAME)) {
                         // function type

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -420,8 +420,9 @@ class AggregationAnalyzer
         {
             if (functionResolver.isAggregationFunction(session, node.getName(), accessControl)) {
                 if (node.getWindow().isEmpty()) {
-                    List<FunctionCall> aggregateFunctions = extractAggregateFunctions(node.getArguments(), session, functionResolver, accessControl);
-                    List<Expression> windowExpressions = extractWindowExpressions(node.getArguments());
+                    List<Expression> arguments = node.argumentValues();
+                    List<FunctionCall> aggregateFunctions = extractAggregateFunctions(arguments, session, functionResolver, accessControl);
+                    List<Expression> windowExpressions = extractWindowExpressions(arguments);
 
                     if (!aggregateFunctions.isEmpty()) {
                         throw semanticException(
@@ -446,14 +447,14 @@ class AggregationAnalyzer
                                 .map(SortItem::getSortKey)
                                 .collect(toImmutableList());
                         if (node.isDistinct()) {
-                            List<FieldId> fieldIds = node.getArguments().stream()
+                            List<FieldId> fieldIds = arguments.stream()
                                     .map(NodeRef::of)
                                     .map(columnReferences::get)
                                     .filter(Objects::nonNull)
                                     .map(ResolvedField::getFieldId)
                                     .collect(toImmutableList());
                             for (Expression sortKey : sortKeys) {
-                                if (!node.getArguments().contains(sortKey)) {
+                                if (!arguments.contains(sortKey)) {
                                     ResolvedField field = columnReferences.get(NodeRef.of(sortKey));
                                     if (field == null || !fieldIds.contains(field.getFieldId())) {
                                         throw semanticException(
@@ -477,7 +478,7 @@ class AggregationAnalyzer
 
                     // in case of aggregate function in ORDER BY, ensure that no output fields are referenced from aggregation's arguments or filter
                     if (orderByScope.isPresent()) {
-                        node.getArguments()
+                        arguments
                                 .forEach(argument -> verifyNoOrderByReferencesToOutputColumns(
                                         argument,
                                         COLUMN_NOT_FOUND,
@@ -507,7 +508,7 @@ class AggregationAnalyzer
                 }
             }
 
-            return node.getArguments().stream().allMatch(expression -> process(expression, context));
+            return node.argumentValues().stream().allMatch(expression -> process(expression, context));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -226,6 +226,8 @@ public class Analysis
     private final Map<NodeRef<Relation>, List<Type>> relationCoercions = new LinkedHashMap<>();
     private final Map<NodeRef<Node>, RoutineEntry> resolvedFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<FunctionCall>, Identifier> methodCallReceivers = new LinkedHashMap<>();
+
+    private final Map<NodeRef<FunctionCall>, List<Integer>> argumentBindings = new LinkedHashMap<>();
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
 
     private final Map<Field, ColumnHandle> columns = new LinkedHashMap<>();
@@ -729,6 +731,26 @@ public class Analysis
     public Optional<Identifier> getMethodCallReceiver(FunctionCall node)
     {
         return Optional.ofNullable(methodCallReceivers.get(NodeRef.of(node)));
+    }
+
+    /// Records the mapping from signature position to AST argument index for a
+    /// function call. Position `i` of the binding list holds the AST index whose
+    /// value supplies signature parameter `i`. For a call written entirely
+    /// positionally this is the identity binding `[0, 1, ..., N-1]`; for a call
+    /// with named arguments it reorders so the named values land at their declared
+    /// positions.
+    public void setArgumentBinding(FunctionCall node, List<Integer> binding)
+    {
+        argumentBindings.put(NodeRef.of(node), List.copyOf(binding));
+    }
+
+    public List<Integer> getArgumentBinding(FunctionCall node)
+    {
+        List<Integer> binding = argumentBindings.get(NodeRef.of(node));
+        if (binding == null) {
+            throw new IllegalStateException("argument binding not recorded for: " + node);
+        }
+        return binding;
     }
 
     public Set<NodeRef<Expression>> getColumnReferences()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Multimap;
 import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CatalogFunctionMetadata;
 import io.trino.metadata.FunctionResolver;
 import io.trino.metadata.LanguageFunctionAnalysisException;
 import io.trino.metadata.OperatorNotFoundException;
@@ -35,7 +36,10 @@ import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.OperatorType;
+import io.trino.spi.function.Signature;
 import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DateType;
@@ -78,6 +82,7 @@ import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
@@ -332,6 +337,7 @@ public class ExpressionAnalyzer
 
     private final Map<NodeRef<Node>, ResolvedFunction> resolvedFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<FunctionCall>, Identifier> methodCallReceivers = new LinkedHashMap<>();
+    private final Map<NodeRef<FunctionCall>, List<Integer>> argumentBindings = new LinkedHashMap<>();
     private final Set<NodeRef<SubqueryExpression>> subqueries = new LinkedHashSet<>();
     private final Set<NodeRef<ExistsPredicate>> existsSubqueries = new LinkedHashSet<>();
     private final Map<NodeRef<Expression>, Type> expressionCoercions = new LinkedHashMap<>();
@@ -443,6 +449,11 @@ public class ExpressionAnalyzer
     public Map<NodeRef<FunctionCall>, Identifier> getMethodCallReceivers()
     {
         return unmodifiableMap(methodCallReceivers);
+    }
+
+    public Map<NodeRef<FunctionCall>, List<Integer>> getArgumentBindings()
+    {
+        return unmodifiableMap(argumentBindings);
     }
 
     public Map<NodeRef<Expression>, Type> getExpressionTypes()
@@ -1330,7 +1341,7 @@ public class ExpressionAnalyzer
                     isAggregation &&
                     node.getName().getSuffix().equalsIgnoreCase("count");
             // argument of the form `label.*` is only allowed for row pattern count function
-            node.getArguments().stream()
+            node.argumentValues().stream()
                     .filter(DereferenceExpression::isQualifiedAllFieldsReference)
                     .findAny()
                     .ifPresent(allRowsReference -> {
@@ -1338,6 +1349,10 @@ public class ExpressionAnalyzer
                             throw semanticException(INVALID_FUNCTION_ARGUMENT, allRowsReference, "label.* syntax is only supported as the only argument of row pattern count function");
                         }
                     });
+
+            if (node.hasNamedArguments() && isPatternRecognitionFunction(node)) {
+                throw semanticException(INVALID_FUNCTION_ARGUMENT, node, "Named arguments are not supported for pattern recognition function %s", node.getName());
+            }
 
             if (context.isPatternRecognition()) {
                 if (isPatternRecognitionFunction(node)) {
@@ -1397,14 +1412,24 @@ public class ExpressionAnalyzer
                 coerceType(expression, type, BOOLEAN, "Filter expression");
             }
 
-            List<TypeSignatureProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);
+            List<Expression> argumentValues = node.argumentValues();
+            List<TypeSignatureProvider> rawTypes = getCallArgumentTypes(argumentValues, context);
+            // rawTypes may be shorter than the AST argument count when a `label.*`
+            // entry is consumed by getCallArgumentTypes; bind to rawTypes.size() so
+            // identity-binding of positional calls still indexes safely.
+            boolean hasNamedArguments = node.hasNamedArguments();
+            List<Integer> argumentBinding = hasNamedArguments
+                    ? computeArgumentBinding(node)
+                    : identityBinding(rawTypes.size());
+            List<TypeSignatureProvider> argumentTypes = argumentBinding.stream()
+                    .map(rawTypes::get)
+                    .collect(toImmutableList());
 
             if (QualifiedName.of("LISTAGG").equals(node.getName())) {
                 // Due to fact that the LISTAGG function is transformed out of pragmatic reasons
                 // in a synthetic function call, the type expression of this function call is evaluated
                 // explicitly here in order to make sure that it is a varchar.
-                List<Expression> arguments = node.getArguments();
-                Expression expression = arguments.getFirst();
+                Expression expression = argumentValues.getFirst();
                 Type expressionType = process(expression, context);
                 if (!(expressionType instanceof VarcharType)) {
                     throw semanticException(TYPE_MISMATCH, node, "Expected expression of varchar, but '%s' has %s type", expression, expressionType.getDisplayName());
@@ -1448,7 +1473,7 @@ public class ExpressionAnalyzer
 
             BoundSignature signature = function.signature();
             for (int i = 0; i < argumentTypes.size(); i++) {
-                Expression expression = node.getArguments().get(i);
+                Expression expression = node.getArguments().get(argumentBinding.get(i)).getValue();
                 Type expectedType = signature.getArgumentTypes().get(i);
                 if (expectedType == null) {
                     throw new NullPointerException(format("Type '%s' not found", signature.getArgumentTypes().get(i)));
@@ -1466,6 +1491,7 @@ public class ExpressionAnalyzer
                 }
             }
             resolvedFunctions.put(NodeRef.of(node), function);
+            argumentBindings.put(NodeRef.of(node), argumentBinding);
 
             // must run after arguments are processed and labels are recorded
             if (context.isPatternRecognition() && isAggregation) {
@@ -1476,10 +1502,170 @@ public class ExpressionAnalyzer
             return setExpressionType(node, type);
         }
 
+        /// Computes the binding from signature-position to AST argument index. Returns the
+        /// identity binding for a call without named arguments; otherwise pairs each named
+        /// argument with the position where its name appears in the function's declared
+        /// parameter names, leaving positional arguments at their written positions.
+        ///
+        // TODO: name-to-position resolution properly belongs in the function binder / type
+        //  inference engine. Doing it here means we walk the function search path twice —
+        //  once for the binding, once for the type-based resolution. Lifting it into the
+        //  binder is a much bigger change.
+        private List<Integer> computeArgumentBinding(FunctionCall node)
+        {
+            List<CallArgument> arguments = node.getArguments();
+            int arity = arguments.size();
+            int firstNamedArgument = findFirstNamedArgument(arguments);
+            verifyNoDuplicateNames(arguments);
+
+            // SQL name resolution picks the first path entry that has any candidate;
+            // we stop iterating the path after that. Registration enforces that
+            // overloads of the same name at the same arity place each named parameter
+            // at the same position (see InternalFunctionBundle), so the first
+            // arity-matching overload that fits is enough to build the binding.
+            List<FunctionMetadata> candidates = findCandidates(node.getName());
+            Optional<FunctionMetadata> chosen = Optional.empty();
+            for (FunctionMetadata candidate : candidates) {
+                if (candidate.getSignature().isVariableArity()) {
+                    // Variadic + named args is intentionally unsupported.
+                    continue;
+                }
+                List<Signature.Argument> declared = candidate.getSignature().getArguments();
+                if (declared.size() == arity && satisfiesNamedArguments(arguments, firstNamedArgument, declared)) {
+                    chosen = Optional.of(candidate);
+                    break;
+                }
+            }
+
+            if (chosen.isEmpty()) {
+                Set<String> knownNames = new LinkedHashSet<>();
+                for (FunctionMetadata candidate : candidates) {
+                    if (candidate.getSignature().isVariableArity()) {
+                        continue;
+                    }
+                    candidate.getSignature().getArguments().forEach(argument -> argument.name().ifPresent(knownNames::add));
+                }
+                for (int i = firstNamedArgument; i < arity; i++) {
+                    Identifier name = arguments.get(i).getName().orElseThrow();
+                    if (!knownNames.contains(name.getValue())) {
+                        throw semanticException(INVALID_FUNCTION_ARGUMENT, name, "No argument named %s for function %s", name.getValue(), node.getName());
+                    }
+                }
+                // Names are known but no overload accepts them — typically because a
+                // name maps to a slot already supplied positionally. Surface that
+                // specifically; otherwise fall through to a generic message.
+                for (FunctionMetadata candidate : candidates) {
+                    for (int i = firstNamedArgument; i < arity; i++) {
+                        Identifier name = arguments.get(i).getName().orElseThrow();
+                        OptionalInt declaredPosition = findArgumentPosition(candidate.getSignature().getArguments(), name.getValue());
+                        if (declaredPosition.isPresent() && declaredPosition.getAsInt() < firstNamedArgument) {
+                            throw semanticException(
+                                    INVALID_FUNCTION_ARGUMENT,
+                                    name,
+                                    "Named argument %s for function %s refers to parameter position %s, which is already supplied positionally",
+                                    name.getValue(),
+                                    node.getName(),
+                                    declaredPosition.getAsInt());
+                        }
+                    }
+                }
+                throw semanticException(INVALID_FUNCTION_ARGUMENT, node, "No overload of function %s accepts the given named arguments", node.getName());
+            }
+
+            List<Signature.Argument> chosenArguments = chosen.get().getSignature().getArguments();
+            List<Integer> binding = new ArrayList<>(identityBinding(arity));
+            for (int i = firstNamedArgument; i < arity; i++) {
+                Identifier name = arguments.get(i).getName().orElseThrow();
+                int signaturePosition = findArgumentPosition(chosenArguments, name.getValue()).orElseThrow();
+                binding.set(signaturePosition, i);
+            }
+            return List.copyOf(binding);
+        }
+
+        /// Returns the index of the first named argument (or `arguments.size()` for
+        /// a purely positional call). Throws if any positional argument appears after
+        /// a named one, enforcing the SQL-spec "positional before named" rule.
+        private static int findFirstNamedArgument(List<CallArgument> arguments)
+        {
+            int position = 0;
+            while (position < arguments.size() && arguments.get(position).getName().isEmpty()) {
+                position++;
+            }
+            for (int i = position; i < arguments.size(); i++) {
+                if (arguments.get(i).getName().isEmpty()) {
+                    throw semanticException(INVALID_FUNCTION_ARGUMENT, arguments.get(i), "Positional arguments cannot follow named arguments");
+                }
+            }
+            return position;
+        }
+
+        private static void verifyNoDuplicateNames(List<CallArgument> arguments)
+        {
+            Set<String> seen = new HashSet<>();
+            for (int i = 0; i < arguments.size(); i++) {
+                if (arguments.get(i).getName().isEmpty()) {
+                    continue;
+                }
+                Identifier name = arguments.get(i).getName().orElseThrow();
+                if (!seen.add(name.getValue())) {
+                    throw semanticException(INVALID_FUNCTION_ARGUMENT, name, "Duplicate named argument: %s", name.getValue());
+                }
+            }
+        }
+
+        private static boolean satisfiesNamedArguments(List<CallArgument> actualArguments, int firstNamedArgument, List<Signature.Argument> formalArguments)
+        {
+            for (int i = firstNamedArgument; i < actualArguments.size(); i++) {
+                String name = actualArguments.get(i).getName().orElseThrow().getValue();
+                OptionalInt declaredPosition = findArgumentPosition(formalArguments, name);
+                if (declaredPosition.isEmpty() || declaredPosition.getAsInt() < firstNamedArgument) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private List<FunctionMetadata> findCandidates(QualifiedName name)
+        {
+            for (CatalogSchemaFunctionName candidateName : FunctionResolver.toPath(session, name, accessControl)) {
+                Collection<CatalogFunctionMetadata> candidates = plannerContext.getMetadata().getFunctions(session, candidateName);
+                if (!candidates.isEmpty()) {
+                    return candidates.stream()
+                            .map(CatalogFunctionMetadata::functionMetadata)
+                            .collect(toImmutableList());
+                }
+            }
+            return List.of();
+        }
+
+        private static OptionalInt findArgumentPosition(List<Signature.Argument> arguments, String name)
+        {
+            for (int i = 0; i < arguments.size(); i++) {
+                if (arguments.get(i).name().equals(Optional.of(name))) {
+                    return OptionalInt.of(i);
+                }
+            }
+            return OptionalInt.empty();
+        }
+
+        private static List<Integer> identityBinding(int arity)
+        {
+            ImmutableList.Builder<Integer> result = ImmutableList.builderWithExpectedSize(arity);
+            for (int i = 0; i < arity; i++) {
+                result.add(i);
+            }
+            return result.build();
+        }
+
         private Optional<Type> tryResolveAsInstanceMethod(FunctionCall node, Context context)
         {
             QualifiedName name = node.getName();
             if (name.getParts().size() != 2) {
+                return Optional.empty();
+            }
+            if (node.hasNamedArguments()) {
+                // Method-call syntax (receiver.method(...)) does not support named arguments;
+                // fall through to ordinary function resolution so the caller sees a clear error.
                 return Optional.empty();
             }
             if (node.isDistinct()
@@ -1507,9 +1693,10 @@ public class ExpressionAnalyzer
             }
             Type receiverType = resolvedReceiver.get().getField().getType();
 
+            List<Expression> argumentValues = node.argumentValues();
             MethodResolution resolution;
             try {
-                resolution = resolveInstanceMethodCall(receiverType, method.getValue(), node.getArguments(), context);
+                resolution = resolveInstanceMethodCall(receiverType, method.getValue(), argumentValues, context);
             }
             catch (TrinoException e) {
                 return Optional.empty();
@@ -1518,8 +1705,9 @@ public class ExpressionAnalyzer
             // Commit to method-call interpretation: record the receiver field reference.
             process(receiver, context);
 
-            Type result = analyzeInstanceMethodInvocation(node, receiver, receiverType, method.getValue(), node.getArguments(), resolution, context);
+            Type result = analyzeInstanceMethodInvocation(node, receiver, receiverType, method.getValue(), argumentValues, resolution, context);
             methodCallReceivers.put(NodeRef.of(node), receiver);
+            argumentBindings.put(NodeRef.of(node), identityBinding(node.getArguments().size()));
             return Optional.of(result);
         }
 
@@ -2005,7 +2193,7 @@ public class ExpressionAnalyzer
 
             Optional<String> label = Optional.empty();
             if (node.getArguments().size() == 1) {
-                Node argument = node.getArguments().getFirst();
+                Expression argument = node.getArguments().getFirst().getValue();
                 if (!(argument instanceof Identifier identifier)) {
                     throw semanticException(TYPE_MISMATCH, argument, "CLASSIFIER function argument should be primary pattern variable or subset name. Actual: %s", argument.getClass().getSimpleName());
                 }
@@ -2037,7 +2225,7 @@ public class ExpressionAnalyzer
 
             Navigation navigation = context.getPatternRecognitionContext().navigation();
             Type type = process(
-                    node.getArguments().getFirst(),
+                    node.getArguments().getFirst().getValue(),
                     context.withNavigation(new Navigation(
                             navigation.anchor(),
                             navigation.mode(),
@@ -2069,7 +2257,7 @@ public class ExpressionAnalyzer
             };
 
             Type type = process(
-                    node.getArguments().getFirst(),
+                    node.getArguments().getFirst().getValue(),
                     context.withNavigation(new Navigation(
                             anchor,
                             mapProcessingMode(node.getProcessingMode()),
@@ -2099,7 +2287,7 @@ public class ExpressionAnalyzer
         {
             int offset = defaultOffset;
             if (node.getArguments().size() == 2) {
-                offset = (int) ((LongLiteral) node.getArguments().get(1)).getParsedValue();
+                offset = (int) ((LongLiteral) node.getArguments().get(1).getValue()).getParsedValue();
             }
             return offset;
         }
@@ -2134,10 +2322,10 @@ public class ExpressionAnalyzer
             }
             if (node.getArguments().size() == 2) {
                 // TODO the offset argument must be effectively constant, not necessarily a number. This could be extended with the use of ConstantAnalyzer.
-                if (!(node.getArguments().get(1) instanceof LongLiteral)) {
+                if (!(node.getArguments().get(1).getValue() instanceof LongLiteral)) {
                     throw semanticException(INVALID_FUNCTION_ARGUMENT, node, "%s pattern recognition navigation function requires a number as the second argument", node.getName());
                 }
-                long offset = ((LongLiteral) node.getArguments().get(1)).getParsedValue();
+                long offset = ((LongLiteral) node.getArguments().get(1).getValue()).getParsedValue();
                 if (offset < 0) {
                     throw semanticException(NUMERIC_VALUE_OUT_OF_RANGE, node, "%s pattern recognition navigation function requires a non-negative number as the second argument (actual: %s)", node.getName(), offset);
                 }
@@ -2153,7 +2341,7 @@ public class ExpressionAnalyzer
             String name = node.getName().getSuffix();
 
             // It is allowed to nest FIRST and LAST functions within PREV and NEXT functions. Only immediate nesting is supported
-            List<FunctionCall> nestedNavigationFunctions = extractExpressions(ImmutableList.of(node.getArguments().getFirst()), FunctionCall.class).stream()
+            List<FunctionCall> nestedNavigationFunctions = extractExpressions(ImmutableList.of(node.getArguments().getFirst().getValue()), FunctionCall.class).stream()
                     .filter(this::isPatternNavigationFunction)
                     .collect(toImmutableList());
             if (!nestedNavigationFunctions.isEmpty()) {
@@ -2182,7 +2370,7 @@ public class ExpressionAnalyzer
                             nestedName,
                             name);
                 }
-                if (nested != node.getArguments().getFirst()) {
+                if (nested != node.getArguments().getFirst().getValue()) {
                     throw semanticException(
                             INVALID_NAVIGATION_NESTING,
                             nested,
@@ -2216,16 +2404,17 @@ public class ExpressionAnalyzer
 
         private ArgumentLabel validateLabelConsistency(FunctionCall node, int argumentIndex)
         {
-            Set<Optional<String>> referenceLabels = extractExpressions(node.getArguments(), Expression.class).stream()
+            List<Expression> argumentValues = node.argumentValues();
+            Set<Optional<String>> referenceLabels = extractExpressions(argumentValues, Expression.class).stream()
                     .map(child -> labels.get(NodeRef.of(child)))
                     .filter(Objects::nonNull)
                     .collect(toImmutableSet());
 
-            Set<Optional<String>> classifierLabels = extractExpressions(ImmutableList.of(node.getArguments().get(argumentIndex)), FunctionCall.class).stream()
+            Set<Optional<String>> classifierLabels = extractExpressions(ImmutableList.of(argumentValues.get(argumentIndex)), FunctionCall.class).stream()
                     .filter(this::isClassifierFunction)
-                    .map(functionCall -> functionCall.getArguments().stream()
+                    .map(functionCall -> functionCall.argumentValues().stream()
                             .findFirst()
-                            .map(argument -> label((Identifier) argument)))
+                            .map(value -> label((Identifier) value)))
                     .collect(toImmutableSet());
 
             Set<Optional<String>> allLabels = ImmutableSet.<Optional<String>>builder()
@@ -2290,11 +2479,13 @@ public class ExpressionAnalyzer
             checkNoNestedNavigations(node);
             Set<String> labels = analyzeAggregationLabels(node);
 
-            List<FunctionCall> matchNumberCalls = extractExpressions(node.getArguments(), FunctionCall.class).stream()
+            List<Expression> argumentValues = node.argumentValues();
+
+            List<FunctionCall> matchNumberCalls = extractExpressions(argumentValues, FunctionCall.class).stream()
                     .filter(this::isMatchNumberFunction)
                     .collect(toImmutableList());
 
-            List<FunctionCall> classifierCalls = extractExpressions(node.getArguments(), FunctionCall.class).stream()
+            List<FunctionCall> classifierCalls = extractExpressions(argumentValues, FunctionCall.class).stream()
                     .filter(this::isClassifierFunction)
                     .collect(toImmutableList());
 
@@ -2302,7 +2493,7 @@ public class ExpressionAnalyzer
                     node,
                     new AggregationDescriptor(
                             function,
-                            node.getArguments(),
+                            argumentValues,
                             mapProcessingMode(node.getProcessingMode()),
                             labels,
                             matchNumberCalls,
@@ -2311,7 +2502,7 @@ public class ExpressionAnalyzer
 
         private void checkNoNestedAggregations(FunctionCall node)
         {
-            extractExpressions(node.getArguments(), FunctionCall.class).stream()
+            extractExpressions(node.argumentValues(), FunctionCall.class).stream()
                     .filter(function -> functionResolver.isAggregationFunction(session, function.getName(), accessControl))
                     .findFirst()
                     .ifPresent(aggregation -> {
@@ -2326,7 +2517,7 @@ public class ExpressionAnalyzer
 
         private void checkNoNestedNavigations(FunctionCall node)
         {
-            extractExpressions(node.getArguments(), FunctionCall.class).stream()
+            extractExpressions(node.argumentValues(), FunctionCall.class).stream()
                     .filter(this::isPatternNavigationFunction)
                     .findFirst()
                     .ifPresent(navigation -> {
@@ -4095,6 +4286,7 @@ public class ExpressionAnalyzer
         analysis.addFrameBoundCalculations(analyzer.getFrameBoundCalculations());
         analyzer.getResolvedFunctions().forEach((key, value) -> analysis.addResolvedFunction(key.getNode(), value, session.getUser()));
         analyzer.getMethodCallReceivers().forEach((key, value) -> analysis.addMethodCallReceiver(key.getNode(), value));
+        analyzer.getArgumentBindings().forEach((key, value) -> analysis.setArgumentBinding(key.getNode(), value));
         analysis.addColumnReferences(analyzer.getColumnReferences());
         analysis.addLambdaArgumentReferences(analyzer.getLambdaArgumentReferences());
         analysis.addTableColumnReferences(accessControl, session.getIdentity(), analyzer.getTableColumnReferences());

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -433,7 +433,6 @@ import static io.trino.sql.tree.SaveMode.IGNORE;
 import static io.trino.sql.tree.SaveMode.REPLACE;
 import static io.trino.sql.util.AstUtils.preOrder;
 import static io.trino.type.UnknownType.UNKNOWN;
-import static io.trino.util.MoreLists.mappedCopy;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -4705,7 +4704,7 @@ class StatementAnalyzer
                 if (windowFunction.getFilter().isPresent()) {
                     throw semanticException(NOT_SUPPORTED, node, "FILTER is not yet supported for window functions");
                 }
-                List<Expression> nestedWindowExpressions = new ArrayList<>(extractWindowExpressions(windowFunction.getArguments()));
+                List<Expression> nestedWindowExpressions = new ArrayList<>(extractWindowExpressions(windowFunction.argumentValues()));
                 windowFunction.getOrderBy().map(OrderBy::getChildren).map(ExpressionTreeUtils::extractWindowExpressions).ifPresent(nestedWindowExpressions::addAll);
                 if (!nestedWindowExpressions.isEmpty()) {
                     throw semanticException(NESTED_WINDOW, nestedWindowExpressions.getFirst(), "Cannot nest window functions or row pattern measures inside window function arguments");
@@ -4727,7 +4726,9 @@ class StatementAnalyzer
                     throw semanticException(NULL_TREATMENT_NOT_ALLOWED, windowFunction, "Cannot specify null treatment clause for %s function", windowFunction.getName());
                 }
 
-                List<Type> argumentTypes = mappedCopy(windowFunction.getArguments(), analysis::getType);
+                List<Type> argumentTypes = windowFunction.argumentValues().stream()
+                        .map(analysis::getType)
+                        .collect(toImmutableList());
 
                 ResolvedFunction resolvedFunction = functionResolver.resolveFunction(session, windowFunction.getName(), fromTypes(argumentTypes), accessControl);
                 FunctionKind kind = resolvedFunction.functionKind();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -80,6 +80,7 @@ import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowFrameType;
 import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.FetchFirst;
 import io.trino.sql.tree.FrameBound;
@@ -502,6 +503,17 @@ class QueryPlanner
             }
         }
         return result.build();
+    }
+
+    /// Argument values in resolved-signature order. For positional calls the binding is
+    /// the identity; for named calls it reorders so values land at their declared positions.
+    private List<io.trino.sql.tree.Expression> argumentsInSignatureOrder(FunctionCall function)
+    {
+        List<CallArgument> arguments = function.getArguments();
+        return analysis.getArgumentBinding(function).stream()
+                .map(arguments::get)
+                .map(CallArgument::getValue)
+                .collect(toImmutableList());
     }
 
     public PlanNode plan(Delete node)
@@ -1152,6 +1164,7 @@ class QueryPlanner
         analysis.getAggregates(node).stream()
                 .map(FunctionCall::getArguments)
                 .flatMap(List::stream)
+                .map(CallArgument::getValue)
                 .filter(expression -> !(expression instanceof LambdaExpression)) // lambda expression is generated at execution time
                 .forEach(inputBuilder::add);
 
@@ -1293,7 +1306,7 @@ class QueryPlanner
             //   What can happen currently is that if the argument requires a coercion, the argument will take a different input that the ORDER BY clause, which is undefined behavior
             Aggregation aggregation = new Aggregation(
                     analysis.getResolvedFunction(function).get(),
-                    function.getArguments().stream()
+                    argumentsInSignatureOrder(function).stream()
                             .map(argument -> {
                                 if (argument instanceof LambdaExpression) {
                                     return subPlan.rewrite(argument);
@@ -1487,7 +1500,7 @@ class QueryPlanner
             }
 
             for (FunctionCall windowFunction : functionCalls) {
-                inputsBuilder.addAll(windowFunction.getArguments().stream()
+                inputsBuilder.addAll(windowFunction.argumentValues().stream()
                         .filter(argument -> !(argument instanceof LambdaExpression)) // lambda expression is generated at execution time
                         .collect(Collectors.toList()));
                 inputsBuilder.addAll(getSortItemsFromOrderBy(windowFunction.getOrderBy()).stream()
@@ -1806,7 +1819,7 @@ class QueryPlanner
 
             WindowNode.Function function = new WindowNode.Function(
                     analysis.getResolvedFunction(windowFunction).get(),
-                    windowFunction.getArguments().stream()
+                    argumentsInSignatureOrder(windowFunction).stream()
                             .map(argument -> {
                                 if (argument instanceof LambdaExpression) {
                                     return subPlan.rewrite(argument);
@@ -1888,7 +1901,7 @@ class QueryPlanner
 
             WindowNode.Function function = new WindowNode.Function(
                     analysis.getResolvedFunction(windowFunction).get(),
-                    windowFunction.getArguments().stream()
+                    argumentsInSignatureOrder(windowFunction).stream()
                             .map(argument -> {
                                 if (argument instanceof LambdaExpression) {
                                     return subPlan.rewrite(argument);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -64,6 +64,7 @@ import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
@@ -676,11 +677,21 @@ public class TranslationMap
     private io.trino.sql.ir.Expression translate(FunctionCall expression)
     {
         if (analysis.isPatternNavigationFunction(expression)) {
-            return translate(expression.getArguments().getFirst(), false);
+            return translate(expression.getArguments().getFirst().getValue(), false);
         }
 
         Optional<ResolvedFunction> resolvedFunction = analysis.getResolvedFunction(expression);
         checkArgument(resolvedFunction.isPresent(), "Function has not been analyzed: %s", expression);
+
+        // Emit arguments in resolved signature order: for positional calls the binding
+        // is the identity; for named calls it reorders so values land at their
+        // declared positions.
+        List<CallArgument> arguments = expression.getArguments();
+        List<io.trino.sql.ir.Expression> translated = analysis.getArgumentBinding(expression).stream()
+                .map(arguments::get)
+                .map(CallArgument::getValue)
+                .map(this::translateExpression)
+                .collect(toImmutableList());
 
         Optional<Identifier> methodReceiver = analysis.getMethodCallReceiver(expression);
         if (methodReceiver.isPresent()) {
@@ -688,17 +699,11 @@ public class TranslationMap
                     resolvedFunction.get(),
                     ImmutableList.<io.trino.sql.ir.Expression>builder()
                             .add(translateExpression(methodReceiver.get()))
-                            .addAll(expression.getArguments().stream()
-                                    .map(this::translateExpression)
-                                    .collect(toImmutableList()))
+                            .addAll(translated)
                             .build());
         }
 
-        return new Call(
-                resolvedFunction.get(),
-                expression.getArguments().stream()
-                        .map(this::translateExpression)
-                        .collect(toImmutableList()));
+        return new Call(resolvedFunction.get(), translated);
     }
 
     private io.trino.sql.ir.Expression translate(StaticMethodCall expression)

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -32,7 +32,6 @@ import io.trino.sql.analyzer.QueryType;
 import io.trino.sql.analyzer.RelationId;
 import io.trino.sql.analyzer.RelationType;
 import io.trino.sql.analyzer.Scope;
-import io.trino.sql.analyzer.TypeSignatureTranslator;
 import io.trino.sql.tree.AssignmentStatement;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.CaseStatement;
@@ -113,10 +112,9 @@ public class SqlRoutineAnalyzer
                 .returnType(toTypeSignature(function.getReturnsClause().getReturnType()));
 
         validateArguments(function);
-        function.getParameters().stream()
-                .map(ParameterDeclaration::getType)
-                .map(TypeSignatureTranslator::toTypeSignature)
-                .forEach(signatureBuilder::argumentType);
+        for (ParameterDeclaration parameter : function.getParameters()) {
+            signatureBuilder.argumentType(toTypeSignature(parameter.getType()), parameter.getName().orElseThrow().getValue());
+        }
         Signature signature = signatureBuilder.build();
 
         FunctionMetadata.Builder builder = FunctionMetadata.scalarBuilder(functionName)

--- a/core/trino-main/src/test/java/io/trino/metadata/TestSignature.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestSignature.java
@@ -13,17 +13,19 @@
  */
 package io.trino.metadata;
 
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.JsonMapperProvider;
 import io.trino.spi.function.Signature;
+import io.trino.spi.function.Signature.Argument;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 import io.trino.type.TypeDeserializer;
 import io.trino.type.TypeSignatureDeserializer;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -34,16 +36,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSignature
 {
+    private static final JsonCodec<Signature> CODEC = new JsonCodecFactory(
+            new JsonMapperProvider()
+                    .withJsonDeserializers(ImmutableMap.of(
+                            Type.class, new TypeDeserializer(TESTING_TYPE_MANAGER),
+                            TypeSignature.class, new TypeSignatureDeserializer()))
+                    .get())
+            .prettyPrint()
+            .jsonCodec(Signature.class);
+
     @Test
     public void testSerializationRoundTrip()
     {
-        JsonMapper jsonMapper = new JsonMapperProvider()
-                .withJsonDeserializers(ImmutableMap.of(
-                        Type.class, new TypeDeserializer(TESTING_TYPE_MANAGER),
-                        TypeSignature.class, new TypeSignatureDeserializer()))
-                .get();
-        JsonCodec<Signature> codec = new JsonCodecFactory(jsonMapper).prettyPrint().jsonCodec(Signature.class);
-
         Signature expected = Signature.builder()
                 .returnType(BIGINT)
                 .argumentType(BOOLEAN)
@@ -51,10 +55,45 @@ public class TestSignature
                 .argumentType(VARCHAR)
                 .build();
 
-        String json = codec.toJson(expected);
-        Signature actual = codec.fromJson(json);
+        String json = CODEC.toJson(expected);
+        Signature actual = CODEC.fromJson(json);
 
-        assertThat(actual.getReturnType()).isEqualTo(expected.getReturnType());
-        assertThat(actual.getArgumentTypes()).isEqualTo(expected.getArgumentTypes());
+        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.getArguments()).allSatisfy(argument -> assertThat(argument.name()).isEmpty());
+    }
+
+    @Test
+    public void testArgumentNamesRoundTrip()
+    {
+        Signature expected = Signature.builder()
+                .returnType(VARCHAR.getTypeSignature())
+                .argumentType(VARCHAR.getTypeSignature(), "string")
+                .argumentType(BIGINT.getTypeSignature(), "from")
+                .argumentType(BIGINT.getTypeSignature())
+                .build();
+
+        assertThat(expected.getArguments())
+                .extracting(Argument::name)
+                .containsExactly(Optional.of("string"), Optional.of("from"), Optional.empty());
+
+        Signature actual = CODEC.fromJson(CODEC.toJson(expected));
+        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.getArguments())
+                .extracting(Argument::name)
+                .containsExactly(Optional.of("string"), Optional.of("from"), Optional.empty());
+    }
+
+    @Test
+    public void testEqualityIncludesArgumentNames()
+    {
+        Signature withName = Signature.builder()
+                .returnType(BIGINT)
+                .argumentType(BIGINT.getTypeSignature(), "x")
+                .build();
+        Signature withoutName = Signature.builder()
+                .returnType(BIGINT)
+                .argumentType(BIGINT)
+                .build();
+        assertThat(withName).isNotEqualTo(withoutName);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
@@ -54,6 +54,7 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.InputFunction;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.OperatorDependency;
 import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.Signature;
@@ -154,6 +155,38 @@ public class TestAnnotationEngineForAggregates
         assertThat(aggregationMetadata.isOrderSensitive()).isFalse();
         assertThat(aggregationMetadata.getIntermediateTypes()).isNotEmpty();
         aggregation.specialize(boundSignature, NO_FUNCTION_DEPENDENCIES);
+    }
+
+    @AggregationFunction("name_without_sqltype_aggregate")
+    @Description("@Name on a non-@SqlType parameter is rejected")
+    public static final class NameWithoutSqlType
+    {
+        @InputFunction
+        public static void input(
+                @Name("state") @AggregationState NullableDoubleState state,
+                @SqlType(DOUBLE) double value)
+        {
+            // noop this is only for annotation testing purposes
+        }
+
+        @CombineFunction
+        public static void combine(@AggregationState NullableDoubleState combine1, @AggregationState NullableDoubleState combine2)
+        {
+            // noop this is only for annotation testing purposes
+        }
+
+        @OutputFunction(DOUBLE)
+        public static void output(@AggregationState NullableDoubleState state, BlockBuilder out)
+        {
+            // noop this is only for annotation testing purposes
+        }
+    }
+
+    @Test
+    public void testNameAnnotationOnNonSqlTypeParameter()
+    {
+        assertThatThrownBy(() -> parseFunctionDefinitions(NameWithoutSqlType.class))
+                .hasMessageMatching("Method .* has @Name on a parameter without @SqlType");
     }
 
     @AggregationFunction("input_parameters_wrong_order")

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestNamedArgumentAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestNamedArgumentAggregation.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import io.trino.metadata.InternalFunctionBundle;
+import io.trino.operator.aggregation.state.NullableLongState;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AggregationFunction;
+import io.trino.spi.function.AggregationState;
+import io.trino.spi.function.CombineFunction;
+import io.trino.spi.function.InputFunction;
+import io.trino.spi.function.Name;
+import io.trino.spi.function.OutputFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestNamedArgumentAggregation
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.extractFunctions(NamedDiffSum.class));
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testAggregateNamedArgumentsBoundByName()
+    {
+        // The aggregate computes sum(a - b). Non-commutative, so binding order is observable.
+        assertThat(assertions.query("SELECT named_diff_sum(a, b) FROM (VALUES (BIGINT '10', BIGINT '3')) t(a, b)"))
+                .matches("VALUES BIGINT '7'");
+        assertThat(assertions.query("SELECT named_diff_sum(a => a, b => b) FROM (VALUES (BIGINT '10', BIGINT '3')) t(a, b)"))
+                .matches("VALUES BIGINT '7'");
+        // Swapped named arguments: relies on the planner applying the analyzer's binding.
+        assertThat(assertions.query("SELECT named_diff_sum(b => b, a => a) FROM (VALUES (BIGINT '10', BIGINT '3')) t(a, b)"))
+                .matches("VALUES BIGINT '7'");
+    }
+
+    @Test
+    public void testWindowNamedArgumentsBoundByName()
+    {
+        // Window form of the aggregate must apply the same binding.
+        assertThat(assertions.query(
+                "SELECT named_diff_sum(b => b, a => a) OVER () FROM (VALUES (BIGINT '10', BIGINT '3')) t(a, b)"))
+                .matches("VALUES BIGINT '7'");
+    }
+
+    @AggregationFunction("named_diff_sum")
+    public static final class NamedDiffSum
+    {
+        private NamedDiffSum() {}
+
+        @InputFunction
+        public static void input(
+                @AggregationState NullableLongState state,
+                @SqlType(StandardTypes.BIGINT) @Name("a") long a,
+                @SqlType(StandardTypes.BIGINT) @Name("b") long b)
+        {
+            state.setValue(state.getValue() + (a - b));
+            state.setNull(false);
+        }
+
+        @CombineFunction
+        public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState other)
+        {
+            if (other.isNull()) {
+                return;
+            }
+            if (state.isNull()) {
+                state.setValue(other.getValue());
+                state.setNull(false);
+            }
+            else {
+                state.setValue(state.getValue() + other.getValue());
+            }
+        }
+
+        @OutputFunction(StandardTypes.BIGINT)
+        public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+        {
+            NullableLongState.write(BIGINT, state, out);
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/CustomFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/CustomFunctions.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slices;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
@@ -71,5 +72,14 @@ public final class CustomFunctions
     {
         Slice message = rowType.getFields().getFirst().getType().getSlice(sqlRow.getRawFieldBlock(0), sqlRow.getRawIndex());
         return Slices.utf8Slice(message.toStringUtf8() + " " + session.getUser());
+    }
+
+    @ScalarFunction("named_subtract")
+    @SqlType(StandardTypes.BIGINT)
+    public static long namedSubtract(
+            @Name("left") @SqlType(StandardTypes.BIGINT) long left,
+            @Name("right") @SqlType(StandardTypes.BIGINT) long right)
+    {
+        return left - right;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestCustomFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestCustomFunctions.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -96,5 +97,33 @@ public class TestCustomFunctions
     {
         assertThat(assertions.function("connector_session_row", "row('goodbye')"))
                 .isEqualTo("goodbye user");
+    }
+
+    @Test
+    public void testNamedArguments()
+    {
+        // Positional call still works.
+        assertThat(assertions.function("named_subtract", "10", "3"))
+                .isEqualTo(7L);
+
+        // Both arguments by name, in declared order.
+        assertThat(assertions.expression("named_subtract(\"left\" => 10, \"right\" => 3)"))
+                .isEqualTo(7L);
+
+        // Both arguments by name, swapped.
+        assertThat(assertions.expression("named_subtract(\"right\" => 3, \"left\" => 10)"))
+                .isEqualTo(7L);
+
+        // Mixed positional then named.
+        assertThat(assertions.expression("named_subtract(10, \"right\" => 3)"))
+                .isEqualTo(7L);
+
+        // Positional value followed by a named arg that targets the already-filled slot.
+        assertThatThrownBy(() -> assertions.expression("named_subtract(10, \"left\" => 3)").evaluate())
+                .hasMessageContaining("Named argument left for function named_subtract refers to parameter position 0, which is already supplied positionally");
+
+        // Unknown name reports the offending identifier at its column.
+        assertThatThrownBy(() -> assertions.expression("named_subtract(\"left\" => 1, bogus => 2)").evaluate())
+                .hasMessageContaining("No argument named bogus for function named_subtract");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMethodCall.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.parallel.Execution;
 
 import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -182,6 +183,17 @@ public class TestMethodCall
                 .matches("BIGINT '5'");
         assertThat(assertions.expression("('hello').Char_Length()"))
                 .matches("BIGINT '5'");
+    }
+
+    @Test
+    public void testNamedArgumentsRejectedOnMethodCall()
+    {
+        // Method-call syntax (receiver.method(...)) does not support named arguments.
+        // The call must not silently bind by position; instance-method resolution declines
+        // it, and ordinary function resolution then rejects the unknown argument name.
+        assertTrinoExceptionThrownBy(() -> assertions.getQueryRunner().execute("SELECT s.repeat(count => 3) FROM (VALUES VARCHAR 'ab') t(s)"))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("No argument named count");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestScalarValidation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestScalarValidation.java
@@ -17,6 +17,7 @@ import io.trino.metadata.InternalFunctionBundle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.IsNull;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
@@ -439,6 +440,28 @@ public class TestScalarValidation
         assertThatThrownBy(() -> extractParametricScalar(ConstructorWithInvalidTypeParameters.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageMatching("Expected type parameter not to take parameters, but got 'k' on method .*");
+    }
+
+    @Test
+    public void testNameAnnotationOnConnectorSessionParameter()
+    {
+        assertThatThrownBy(() -> extractScalars(NameOnConnectorSession.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("Method .* has @Name on a non-@SqlType parameter");
+    }
+
+    public static final class NameOnConnectorSession
+    {
+        private NameOnConnectorSession() {}
+
+        @ScalarFunction
+        @SqlType(StandardTypes.BIGINT)
+        public static long bad(
+                @Name("session") ConnectorSession session,
+                @SqlType(StandardTypes.BIGINT) long x)
+        {
+            return x;
+        }
     }
 
     private static void extractParametricScalar(Class<?> clazz)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -266,6 +266,27 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testNamedArgumentsRejectedForFunctionsWithoutDeclaredNames()
+    {
+        // No built-in function declares parameter names yet, so any named-arg call should
+        // fail with a "no argument named X" diagnostic pointing at the offending name.
+        assertFails("SELECT substr('abc', \"from\" => 1)")
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("No argument named from for function substr");
+
+        // Duplicate named arguments are caught before lookup so the error points at the
+        // second occurrence rather than failing in candidate filtering.
+        assertFails("SELECT some_fn(x => 1, x => 2)")
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Duplicate named argument: x");
+
+        // Positional after named is rejected at analysis time.
+        assertFails("SELECT some_fn(x => 1, 2)")
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Positional arguments cannot follow named arguments");
+    }
+
+    @Test
     public void testNonComparableGroupBy()
     {
         assertFails("SELECT * FROM (SELECT approx_set(1)) GROUP BY 1")
@@ -6880,9 +6901,10 @@ public class TestAnalyzer
                 .hasErrorCode(NOT_SUPPORTED)
                 .hasMessage("line 1:52: Invalid table argument INPUT. Table functions are not allowed as table function arguments");
 
-        assertThatThrownBy(() -> analyze("SELECT * FROM TABLE(system.table_argument_function(input => my_schema.my_table_function(arg => 1)))"))
-                .isInstanceOf(ParsingException.class)
-                .hasMessageContaining("line 1:93: mismatched input '=>'.");
+        // same diagnostic when the inner call uses named-argument syntax (now accepted at parse time)
+        assertFails("SELECT * FROM TABLE(system.table_argument_function(input => my_schema.my_table_function(arg => 1)))")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("line 1:52: Invalid table argument INPUT. Table functions are not allowed as table function arguments");
 
         // cannot pass a table function as the argument, also preceding nested table function with TABLE is incorrect
         assertThatThrownBy(() -> analyze("SELECT * FROM TABLE(system.table_argument_function(input => TABLE(my_schema.my_table_function(1))))"))

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
@@ -277,6 +277,93 @@ public class TestInlineFunctions
     }
 
     @Test
+    public void testNamedArguments()
+    {
+        // SQL UDFs declare their parameter names, so callers can use the named-argument form.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN CASE
+                        WHEN value < lo THEN lo
+                        WHEN value > hi THEN hi
+                        ELSE value
+                    END
+                SELECT clamp(value => 7, lo => 0, hi => 5)
+                """))
+                .matches("VALUES BIGINT '5'");
+
+        // Order of named arguments at the call site does not matter.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN CASE
+                        WHEN value < lo THEN lo
+                        WHEN value > hi THEN hi
+                        ELSE value
+                    END
+                SELECT clamp(hi => 5, lo => 0, value => -3)
+                """))
+                .matches("VALUES BIGINT '0'");
+
+        // Mixed positional then named.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN CASE
+                        WHEN value < lo THEN lo
+                        WHEN value > hi THEN hi
+                        ELSE value
+                    END
+                SELECT clamp(7, hi => 5, lo => 0)
+                """))
+                .matches("VALUES BIGINT '5'");
+
+        // A name that the function does not declare is rejected with a precise diagnostic.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN value
+                SELECT clamp(value => 1, lo => 0, top => 5)
+                """))
+                .failure()
+                .hasMessageContaining("No argument named top for function clamp");
+
+        // A named argument that refers to a position already supplied positionally is
+        // an explicit error, not a silent re-binding. Here `value` is parameter 0,
+        // which the positional `1` already fills.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN value
+                SELECT clamp(1, value => 2, lo => 3)
+                """))
+                .failure()
+                .hasMessageContaining("Named argument value for function clamp refers to parameter position 0, which is already supplied positionally");
+
+        // Wrong arity surfaces "No argument named X" pointing at the truly unknown
+        // name rather than masking it behind a candidate-not-found error.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN value
+                SELECT clamp(1, value => 2, lo => 3, high => 4)
+                """))
+                .failure()
+                .hasMessageContaining("No argument named high for function clamp");
+
+        // All names valid but arity wrong AND positional+named conflict — the conflict is
+        // reported even though no candidate's arity matches the call.
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
+                    RETURN value
+                SELECT clamp(1, value => 2, lo => 3, hi => 4)
+                """))
+                .failure()
+                .hasMessageContaining("Named argument value for function clamp refers to parameter position 0, which is already supplied positionally");
+    }
+
+    @Test
     public void testInlineSqlFunctions()
     {
         assertThat(assertions.query(

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -27,6 +27,7 @@ import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
@@ -480,7 +481,9 @@ public final class ExpressionFormatter
                         .append(" ");
             }
 
-            String arguments = joinExpressions(node.getArguments());
+            String arguments = node.getArguments().stream()
+                    .map(argument -> process(argument, context))
+                    .collect(joining(", "));
             if (node.getArguments().isEmpty() && "count".equalsIgnoreCase(node.getName().getSuffix())) {
                 arguments = "*";
             }
@@ -511,6 +514,15 @@ public final class ExpressionFormatter
                 builder.append(" OVER ").append(formatWindow(node.getWindow().get()));
             }
 
+            return builder.toString();
+        }
+
+        @Override
+        protected String visitCallArgument(CallArgument node, Void context)
+        {
+            StringBuilder builder = new StringBuilder();
+            node.getName().ifPresent(name -> builder.append(formatExpression(name)).append(" => "));
+            builder.append(process(node.getValue(), context));
             return builder.toString();
         }
 
@@ -990,12 +1002,12 @@ public final class ExpressionFormatter
         {
             StringBuilder builder = new StringBuilder();
 
-            List<Expression> arguments = node.getArguments();
-            Expression expression = arguments.get(0);
-            Expression separator = arguments.get(1);
-            BooleanLiteral overflowError = (BooleanLiteral) arguments.get(2);
-            Expression overflowFiller = arguments.get(3);
-            BooleanLiteral showOverflowEntryCount = (BooleanLiteral) arguments.get(4);
+            List<CallArgument> arguments = node.getArguments();
+            Expression expression = arguments.get(0).getValue();
+            Expression separator = arguments.get(1).getValue();
+            BooleanLiteral overflowError = (BooleanLiteral) arguments.get(2).getValue();
+            Expression overflowFiller = arguments.get(3).getValue();
+            BooleanLiteral showOverflowEntryCount = (BooleanLiteral) arguments.get(4).getValue();
 
             String innerArguments = joinExpressions(ImmutableList.of(expression, separator));
             if (node.isDistinct()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -954,8 +954,8 @@ class AstBuilder
     public Node visitTableExecute(SqlBaseParser.TableExecuteContext context)
     {
         List<CallArgument> arguments = ImmutableList.of();
-        if (context.callArgument() != null) {
-            arguments = visit(context.callArgument(), CallArgument.class);
+        if (context.argument() != null) {
+            arguments = visit(context.argument(), CallArgument.class);
         }
 
         return new TableExecute(
@@ -1145,7 +1145,7 @@ class AstBuilder
         return new Call(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
-                visit(context.callArgument(), CallArgument.class));
+                visit(context.argument(), CallArgument.class));
     }
 
     @Override
@@ -3068,71 +3068,85 @@ class AstBuilder
 
         SqlBaseParser.ProcessingModeContext processingMode = context.processingMode();
 
+        List<CallArgument> arguments = visit(context.argument(), CallArgument.class);
+        if (context.label != null) {
+            // `f(label.*)` form — captured separately by the grammar, never has named args.
+            // Rewrite to a synthetic single-argument list before arity-sensitive operator branches.
+            DereferenceExpression labelRef = new DereferenceExpression(getLocation(context.label), (Identifier) visit(context.label));
+            arguments = ImmutableList.of(new CallArgument(labelRef.getLocation().orElse(null), Optional.empty(), labelRef));
+        }
+        boolean hasNamedArguments = arguments.stream().anyMatch(argument -> argument.getName().isPresent());
+
         if (name.toString().equalsIgnoreCase("if")) {
-            check(context.expression().size() == 2 || context.expression().size() == 3, "Invalid number of arguments for 'if' function", context);
+            check(arguments.size() == 2 || arguments.size() == 3, "Invalid number of arguments for 'if' function", context);
             check(window.isEmpty(), "OVER clause not valid for 'if' function", context);
             check(!distinct, "DISTINCT not valid for 'if' function", context);
             check(nullTreatment == null, "Null treatment clause not valid for 'if' function", context);
             check(processingMode == null, "Running or final semantics not valid for 'if' function", context);
             check(filter.isEmpty(), "FILTER not valid for 'if' function", context);
+            check(!hasNamedArguments, "Named arguments are not supported for 'if' function", context);
 
             Expression elseExpression = null;
-            if (context.expression().size() == 3) {
-                elseExpression = (Expression) visit(context.expression(2));
+            if (arguments.size() == 3) {
+                elseExpression = arguments.get(2).getValue();
             }
 
             return new IfExpression(
                     getLocation(context),
-                    (Expression) visit(context.expression(0)),
-                    (Expression) visit(context.expression(1)),
+                    arguments.get(0).getValue(),
+                    arguments.get(1).getValue(),
                     elseExpression);
         }
 
         if (name.toString().equalsIgnoreCase("nullif")) {
-            check(context.expression().size() == 2, "Invalid number of arguments for 'nullif' function", context);
+            check(arguments.size() == 2, "Invalid number of arguments for 'nullif' function", context);
             check(window.isEmpty(), "OVER clause not valid for 'nullif' function", context);
             check(!distinct, "DISTINCT not valid for 'nullif' function", context);
             check(nullTreatment == null, "Null treatment clause not valid for 'nullif' function", context);
             check(processingMode == null, "Running or final semantics not valid for 'nullif' function", context);
             check(filter.isEmpty(), "FILTER not valid for 'nullif' function", context);
+            check(!hasNamedArguments, "Named arguments are not supported for 'nullif' function", context);
 
             return new NullIfExpression(
                     getLocation(context),
-                    (Expression) visit(context.expression(0)),
-                    (Expression) visit(context.expression(1)));
+                    arguments.get(0).getValue(),
+                    arguments.get(1).getValue());
         }
 
         if (name.toString().equalsIgnoreCase("coalesce")) {
-            check(context.expression().size() >= 2, "The 'coalesce' function must have at least two arguments", context);
+            check(arguments.size() >= 2, "The 'coalesce' function must have at least two arguments", context);
             check(window.isEmpty(), "OVER clause not valid for 'coalesce' function", context);
             check(!distinct, "DISTINCT not valid for 'coalesce' function", context);
             check(nullTreatment == null, "Null treatment clause not valid for 'coalesce' function", context);
             check(processingMode == null, "Running or final semantics not valid for 'coalesce' function", context);
             check(filter.isEmpty(), "FILTER not valid for 'coalesce' function", context);
+            check(!hasNamedArguments, "Named arguments are not supported for 'coalesce' function", context);
 
-            return new CoalesceExpression(getLocation(context), visit(context.expression(), Expression.class));
+            return new CoalesceExpression(getLocation(context), arguments.stream().map(CallArgument::getValue).collect(toImmutableList()));
         }
 
         if (name.toString().equalsIgnoreCase("try")) {
-            check(context.expression().size() == 1, "The 'try' function must have exactly one argument", context);
+            check(arguments.size() == 1, "The 'try' function must have exactly one argument", context);
             check(window.isEmpty(), "OVER clause not valid for 'try' function", context);
             check(!distinct, "DISTINCT not valid for 'try' function", context);
             check(nullTreatment == null, "Null treatment clause not valid for 'try' function", context);
             check(processingMode == null, "Running or final semantics not valid for 'try' function", context);
             check(filter.isEmpty(), "FILTER not valid for 'try' function", context);
+            check(!hasNamedArguments, "Named arguments are not supported for 'try' function", context);
 
-            return new TryExpression(getLocation(context), (Expression) visit(getOnlyElement(context.expression())));
+            return new TryExpression(getLocation(context), getOnlyElement(arguments).getValue());
         }
 
         if (name.toString().equalsIgnoreCase("format")) {
-            check(context.expression().size() >= 2, "The 'format' function must have at least two arguments", context);
+            check(arguments.size() >= 2, "The 'format' function must have at least two arguments", context);
             check(window.isEmpty(), "OVER clause not valid for 'format' function", context);
             check(!distinct, "DISTINCT not valid for 'format' function", context);
             check(nullTreatment == null, "Null treatment clause not valid for 'format' function", context);
             check(processingMode == null, "Running or final semantics not valid for 'format' function", context);
             check(filter.isEmpty(), "FILTER not valid for 'format' function", context);
+            check(!hasNamedArguments, "Named arguments are not supported for 'format' function", context);
 
-            return new Format(getLocation(context), visit(context.expression(), Expression.class));
+            return new Format(getLocation(context), arguments.stream().map(CallArgument::getValue).collect(toImmutableList()));
         }
 
         Optional<NullTreatment> nulls = Optional.empty();
@@ -3155,13 +3169,8 @@ class AstBuilder
             }
         }
 
-        List<Expression> arguments = visit(context.expression(), Expression.class);
-        if (context.label != null) {
-            arguments = ImmutableList.of(new DereferenceExpression(getLocation(context.label), (Identifier) visit(context.label)));
-        }
-
         return new FunctionCall(
-                Optional.of(getLocation(context)),
+                getLocation(context),
                 name,
                 window,
                 filter,

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CallArgument.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CallArgument.java
@@ -54,7 +54,16 @@ public final class CallArgument
     @Override
     public List<Node> getChildren()
     {
-        return ImmutableList.of(value);
+        ImmutableList.Builder<Node> children = ImmutableList.builder();
+        name.ifPresent(children::add);
+        children.add(value);
+        return children.build();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -212,8 +212,8 @@ public abstract class DefaultTraversalVisitor<C>
     @Override
     protected Void visitFunctionCall(FunctionCall node, C context)
     {
-        for (Expression argument : node.getArguments()) {
-            process(argument, context);
+        for (CallArgument argument : node.getArguments()) {
+            process(argument.getValue(), context);
         }
 
         if (node.getOrderBy().isPresent()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -16,6 +16,7 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -513,7 +514,13 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            List<Expression> arguments = rewrite(node.getArguments(), context);
+            List<CallArgument> arguments = new ArrayList<>(node.getArguments().size());
+            for (CallArgument argument : node.getArguments()) {
+                Expression rewrittenValue = rewrite(argument.getValue(), context.get());
+                arguments.add(rewrittenValue == argument.getValue()
+                        ? argument
+                        : new CallArgument(argument.getLocation().orElse(null), argument.getName(), rewrittenValue));
+            }
 
             Optional<OrderBy> orderBy = node.getOrderBy();
             if (orderBy.isPresent()) {
@@ -523,10 +530,10 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            if (!sameElements(node.getArguments(), arguments) || !sameElements(window, node.getWindow())
+            if (!sameElements(arguments, node.getArguments()) || !sameElements(window, node.getWindow())
                     || !sameElements(filter, node.getFilter()) || !sameElements(orderBy, node.getOrderBy())) {
                 return new FunctionCall(
-                        node.getLocation(),
+                        node.getLocation().orElse(null),
                         node.getName(),
                         window,
                         filter,

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/FunctionCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/FunctionCall.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class FunctionCall
         extends Expression
@@ -32,7 +32,7 @@ public class FunctionCall
     private final boolean distinct;
     private final Optional<NullTreatment> nullTreatment;
     private final Optional<ProcessingMode> processingMode;
-    private final List<Expression> arguments;
+    private final List<CallArgument> arguments;
 
     @Deprecated
     public FunctionCall(QualifiedName name, List<Expression> arguments)
@@ -45,6 +45,7 @@ public class FunctionCall
         this(Optional.of(location), name, Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.empty(), Optional.empty(), arguments);
     }
 
+    @Deprecated
     public FunctionCall(
             Optional<NodeLocation> location,
             QualifiedName name,
@@ -56,15 +57,24 @@ public class FunctionCall
             Optional<ProcessingMode> processingMode,
             List<Expression> arguments)
     {
-        super(location);
-        requireNonNull(name, "name is null");
-        requireNonNull(window, "window is null");
+        this(location.orElse(null), name, window, filter, orderBy, distinct, nullTreatment, processingMode, arguments.stream()
+                .map(expression -> new CallArgument(expression.getLocation().orElse(null), Optional.empty(), expression))
+                .collect(toImmutableList()));
+    }
+
+    public FunctionCall(
+            NodeLocation location,
+            QualifiedName name,
+            Optional<Window> window,
+            Optional<Expression> filter,
+            Optional<OrderBy> orderBy,
+            boolean distinct,
+            Optional<NullTreatment> nullTreatment,
+            Optional<ProcessingMode> processingMode,
+            List<CallArgument> arguments)
+    {
+        super(Optional.ofNullable(location));
         window.ifPresent(node -> checkArgument(node instanceof WindowReference || node instanceof WindowSpecification, "unexpected window: %s", node.getClass().getSimpleName()));
-        requireNonNull(filter, "filter is null");
-        requireNonNull(orderBy, "orderBy is null");
-        requireNonNull(nullTreatment, "nullTreatment is null");
-        requireNonNull(processingMode, "processingMode is null");
-        requireNonNull(arguments, "arguments is null");
 
         this.name = name;
         this.window = window;
@@ -73,7 +83,7 @@ public class FunctionCall
         this.distinct = distinct;
         this.nullTreatment = nullTreatment;
         this.processingMode = processingMode;
-        this.arguments = arguments;
+        this.arguments = ImmutableList.copyOf(arguments);
     }
 
     public QualifiedName getName()
@@ -106,9 +116,21 @@ public class FunctionCall
         return processingMode;
     }
 
-    public List<Expression> getArguments()
+    public List<CallArgument> getArguments()
     {
         return arguments;
+    }
+
+    public boolean hasNamedArguments()
+    {
+        return arguments.stream().anyMatch(argument -> argument.getName().isPresent());
+    }
+
+    public List<Expression> argumentValues()
+    {
+        return arguments.stream()
+                .map(CallArgument::getValue)
+                .collect(toImmutableList());
     }
 
     public Optional<Expression> getFilter()

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -232,6 +232,7 @@ import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.TransactionAccessMode;
 import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TruncateTable;
+import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.Union;
 import io.trino.sql.tree.Unnest;
 import io.trino.sql.tree.Update;
@@ -371,6 +372,54 @@ public class TestSqlParser
 
         // Parametric receiver types are not allowed in the grammar.
         assertInvalidExpression("varchar(5)::parse('42')", "mismatched input '::'.*");
+    }
+
+    @Test
+    public void testNamedFunctionArguments()
+    {
+        assertThat(expression("substr(string => 'hello', \"from\" => 2)"))
+                .isEqualTo(new FunctionCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "substr", false))),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                new CallArgument(location(1, 8), Optional.of(new Identifier(location(1, 8), "string", false)), new StringLiteral(location(1, 18), "hello")),
+                                new CallArgument(location(1, 27), Optional.of(new Identifier(location(1, 27), "from", true)), new LongLiteral(location(1, 37), "2")))));
+
+        // Mixed positional + named: positional must come first.
+        assertThat(expression("f(1, 2, x => 3)"))
+                .isEqualTo(new FunctionCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "f", false))),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                new CallArgument(location(1, 3), Optional.empty(), new LongLiteral(location(1, 3), "1")),
+                                new CallArgument(location(1, 6), Optional.empty(), new LongLiteral(location(1, 6), "2")),
+                                new CallArgument(location(1, 9), Optional.of(new Identifier(location(1, 9), "x", false)), new LongLiteral(location(1, 14), "3")))));
+
+        // The operator-style names handled in AstBuilder don't accept named arguments.
+        assertInvalidExpression("if(cond => true, 1, 2)", "Named arguments are not supported for 'if' function");
+        assertInvalidExpression("coalesce(a => 1, 2)", "Named arguments are not supported for 'coalesce' function");
+        assertInvalidExpression("nullif(a => 1, b => 2)", "Named arguments are not supported for 'nullif' function");
+        assertInvalidExpression("try(a => 1)", "Named arguments are not supported for 'try' function");
+        assertInvalidExpression("format(fmt => '%s', x => 1)", "Named arguments are not supported for 'format' function");
+
+        // The `f(label.*)` grammar form is rewritten to a single synthetic argument before
+        // arity-sensitive operator branches run, so `try(t.*)` parses with arity 1.
+        assertThat(expression("try(t.*)"))
+                .isEqualTo(new TryExpression(
+                        location(1, 1),
+                        new DereferenceExpression(location(1, 5), new Identifier(location(1, 5), "t", false))));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -92,16 +92,16 @@ public class TestSqlParserErrorHandling
                         "line 1:12: mismatched input '!'. Expecting: '*', <identifier>"),
                 Arguments.of(
                         "select foo(,1)",
-                        "line 1:12: mismatched input ','. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>"),
+                        "line 1:12: mismatched input ','. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>, <identifier>"),
                 Arguments.of(
                         "select foo ( ,1)",
-                        "line 1:14: mismatched input ','. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>"),
+                        "line 1:14: mismatched input ','. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>, <identifier>"),
                 Arguments.of(
                         "select foo(DISTINCT)",
-                        "line 1:20: mismatched input ')'. Expecting: <expression>"),
+                        "line 1:20: mismatched input ')'. Expecting: <expression>, <identifier>"),
                 Arguments.of(
                         "select foo(DISTINCT ,1)",
-                        "line 1:21: mismatched input ','. Expecting: <expression>"),
+                        "line 1:21: mismatched input ','. Expecting: <expression>, <identifier>"),
                 Arguments.of(
                         "CREATE )",
                         "line 1:8: mismatched input ')'. Expecting: 'BRANCH', 'CATALOG', 'FUNCTION', 'MATERIALIZED', 'OR', 'ROLE', 'SCHEMA', 'TABLE', 'VIEW'"),
@@ -219,7 +219,7 @@ public class TestSqlParserErrorHandling
                         "line 1:13: mismatched input '2'. Expecting: '%', '(', ')', '*', '+', ',', '-', '->', '.', '/', '::', 'AND', 'AT', 'OR', 'OVER', '[', '||', <predicate>, <string>"),
                 Arguments.of(
                         "SELECT count(DISTINCT *) FROM (VALUES 1)",
-                        "line 1:23: mismatched input '*'. Expecting: <expression>"));
+                        "line 1:23: mismatched input '*'. Expecting: <expression>, <identifier>"));
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -327,6 +327,25 @@
                                     <new>method boolean io.trino.spi.type.TypeManager::isTypeRegistered(java.lang.String)</new>
                                     <justification>Required for resolving static method calls on parametric type bases (array, row, map). Cannot be a default that calls getType because parametric bases require parameters and would force exception-driven control flow.</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter io.trino.spi.function.Signature io.trino.spi.function.Signature::fromJson(java.util.List&lt;io.trino.spi.function.TypeVariableConstraint&gt;, java.util.List&lt;io.trino.spi.function.LongVariableConstraint&gt;, io.trino.spi.type.TypeSignature, ===java.util.List&lt;io.trino.spi.type.TypeSignature&gt;===, boolean)</old>
+                                    <new>parameter io.trino.spi.function.Signature io.trino.spi.function.Signature::fromJson(java.util.List&lt;io.trino.spi.function.TypeVariableConstraint&gt;, java.util.List&lt;io.trino.spi.function.LongVariableConstraint&gt;, io.trino.spi.type.TypeSignature, ===java.util.List&lt;io.trino.spi.function.Signature.Argument&gt;===, boolean)</new>
+                                    <justification>Replace parallel argumentTypes list with structural Signature.Argument list to carry parameter names</justification>
+                                </item>
+                                <item>
+                                    <code>java.annotation.attributeValueChanged</code>
+                                    <old>parameter io.trino.spi.function.Signature io.trino.spi.function.Signature::fromJson(java.util.List&lt;io.trino.spi.function.TypeVariableConstraint&gt;, java.util.List&lt;io.trino.spi.function.LongVariableConstraint&gt;, io.trino.spi.type.TypeSignature, ===java.util.List&lt;io.trino.spi.type.TypeSignature&gt;===, boolean)</old>
+                                    <new>parameter io.trino.spi.function.Signature io.trino.spi.function.Signature::fromJson(java.util.List&lt;io.trino.spi.function.TypeVariableConstraint&gt;, java.util.List&lt;io.trino.spi.function.LongVariableConstraint&gt;, io.trino.spi.type.TypeSignature, ===java.util.List&lt;io.trino.spi.function.Signature.Argument&gt;===, boolean)</new>
+                                    <justification>JsonProperty value renamed from argumentTypes to arguments</justification>
+                                </item>
+                                <item>
+                                    <code>java.annotation.removed</code>
+                                    <old>method java.util.List&lt;io.trino.spi.type.TypeSignature&gt; io.trino.spi.function.Signature::getArgumentTypes()</old>
+                                    <new>method java.util.List&lt;io.trino.spi.type.TypeSignature&gt; io.trino.spi.function.Signature::getArgumentTypes()</new>
+                                    <annotationType>com.fasterxml.jackson.annotation.JsonProperty</annotationType>
+                                    <justification>getArgumentTypes() is now a derived view; JsonProperty moved to getArguments()</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Name.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Name.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/// Declares the SQL-visible parameter name for a scalar, aggregate, or window
+/// function argument. Combined with [SqlType], the name lets callers invoke
+/// the function with the named-argument form `name => value`.
+///
+/// A function whose arguments carry no `@Name` annotation has no declared names
+/// and can only be called positionally.
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface Name
+{
+    String value();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
@@ -22,34 +22,46 @@ import io.trino.spi.type.TypeSignature;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static java.util.stream.Stream.concat;
 
 public class Signature
 {
+    public record Argument(@JsonProperty("type") TypeSignature type, @JsonProperty("name") Optional<String> name)
+    {
+        public static Argument of(TypeSignature type)
+        {
+            return new Argument(type, Optional.empty());
+        }
+
+        public static Argument of(TypeSignature type, String name)
+        {
+            return new Argument(type, Optional.of(name));
+        }
+    }
+
     private final List<TypeVariableConstraint> typeVariableConstraints;
     private final List<LongVariableConstraint> longVariableConstraints;
     private final TypeSignature returnType;
-    private final List<TypeSignature> argumentTypes;
+    private final List<Argument> arguments;
     private final boolean variableArity;
 
     private Signature(
             List<TypeVariableConstraint> typeVariableConstraints,
             List<LongVariableConstraint> longVariableConstraints,
             TypeSignature returnType,
-            List<TypeSignature> argumentTypes,
+            List<Argument> arguments,
             boolean variableArity)
     {
-        requireNonNull(typeVariableConstraints, "typeVariableConstraints is null");
-        requireNonNull(longVariableConstraints, "longVariableConstraints is null");
-
         this.typeVariableConstraints = List.copyOf(typeVariableConstraints);
         this.longVariableConstraints = List.copyOf(longVariableConstraints);
         this.returnType = requireNonNull(returnType, "returnType is null");
-        this.argumentTypes = List.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
+        this.arguments = List.copyOf(arguments);
         this.variableArity = variableArity;
     }
 
@@ -60,9 +72,16 @@ public class Signature
     }
 
     @JsonProperty
+    public List<Argument> getArguments()
+    {
+        return arguments;
+    }
+
     public List<TypeSignature> getArgumentTypes()
     {
-        return argumentTypes;
+        return arguments.stream()
+                .map(Argument::type)
+                .collect(toUnmodifiableList());
     }
 
     @JsonProperty
@@ -94,7 +113,7 @@ public class Signature
     @Override
     public int hashCode()
     {
-        return Objects.hash(typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, variableArity);
+        return Objects.hash(typeVariableConstraints, longVariableConstraints, returnType, arguments, variableArity);
     }
 
     @Override
@@ -109,7 +128,7 @@ public class Signature
         return Objects.equals(this.typeVariableConstraints, other.typeVariableConstraints) &&
                 Objects.equals(this.longVariableConstraints, other.longVariableConstraints) &&
                 Objects.equals(this.returnType, other.returnType) &&
-                Objects.equals(this.argumentTypes, other.argumentTypes) &&
+                Objects.equals(this.arguments, other.arguments) &&
                 this.variableArity == other.variableArity;
     }
 
@@ -122,7 +141,7 @@ public class Signature
                 .collect(Collectors.toList());
 
         return (allConstraints.isEmpty() ? "" : allConstraints.stream().collect(joining(",", "<", ">"))) +
-                argumentTypes.stream().map(Objects::toString).collect(joining(",", "(", ")")) +
+                arguments.stream().map(Argument::type).map(Objects::toString).collect(joining(",", "(", ")")) +
                 ":" + returnType;
     }
 
@@ -131,12 +150,25 @@ public class Signature
         return new Builder();
     }
 
+    public static Builder builder(Signature base)
+    {
+        Builder builder = new Builder()
+                .typeVariableConstraints(base.typeVariableConstraints)
+                .longVariableConstraints(base.longVariableConstraints)
+                .returnType(base.returnType)
+                .arguments(base.arguments);
+        if (base.variableArity) {
+            builder.variableArity();
+        }
+        return builder;
+    }
+
     public static final class Builder
     {
         private final List<TypeVariableConstraint> typeVariableConstraints = new ArrayList<>();
         private final List<LongVariableConstraint> longVariableConstraints = new ArrayList<>();
         private TypeSignature returnType;
-        private final List<TypeSignature> argumentTypes = new ArrayList<>();
+        private final List<Argument> arguments = new ArrayList<>();
         private boolean variableArity;
 
         private Builder() {}
@@ -222,6 +254,12 @@ public class Signature
             return this;
         }
 
+        public Builder longVariableConstraints(List<LongVariableConstraint> longVariableConstraints)
+        {
+            this.longVariableConstraints.addAll(longVariableConstraints);
+            return this;
+        }
+
         public Builder argumentType(Type type)
         {
             return argumentType(type.getTypeSignature());
@@ -229,13 +267,33 @@ public class Signature
 
         public Builder argumentType(TypeSignature type)
         {
-            argumentTypes.add(requireNonNull(type, "type is null"));
+            arguments.add(Argument.of(type));
             return this;
+        }
+
+        public Builder argumentType(TypeSignature type, String name)
+        {
+            arguments.add(Argument.of(type, name));
+            return this;
+        }
+
+        public Builder argumentType(Type type, String name)
+        {
+            return argumentType(type.getTypeSignature(), name);
         }
 
         public Builder argumentTypes(List<TypeSignature> argumentTypes)
         {
-            this.argumentTypes.addAll(requireNonNull(argumentTypes, "argumentTypes is null"));
+            for (TypeSignature argumentType : argumentTypes) {
+                argumentType(argumentType);
+            }
+            return this;
+        }
+
+        public Builder arguments(List<Argument> arguments)
+        {
+            this.arguments.clear();
+            this.arguments.addAll(arguments);
             return this;
         }
 
@@ -247,7 +305,7 @@ public class Signature
 
         public Signature build()
         {
-            return new Signature(typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, variableArity);
+            return new Signature(typeVariableConstraints, longVariableConstraints, returnType, arguments, variableArity);
         }
     }
 
@@ -258,9 +316,9 @@ public class Signature
             @JsonProperty("typeVariableConstraints") List<TypeVariableConstraint> typeVariableConstraints,
             @JsonProperty("longVariableConstraints") List<LongVariableConstraint> longVariableConstraints,
             @JsonProperty("returnType") TypeSignature returnType,
-            @JsonProperty("argumentTypes") List<TypeSignature> argumentTypes,
+            @JsonProperty("arguments") List<Argument> arguments,
             @JsonProperty("variableArity") boolean variableArity)
     {
-        return new Signature(typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, variableArity);
+        return new Signature(typeVariableConstraints, longVariableConstraints, returnType, arguments, variableArity);
     }
 }

--- a/docs/src/main/sphinx/develop/functions.md
+++ b/docs/src/main/sphinx/develop/functions.md
@@ -88,6 +88,33 @@ to avoid unexpected results.
   native container type when using `@SqlNullable`. The method must be annotated with
   `@SqlNullable` if it can return `NULL` when the arguments are non-null.
 
+- `@Name`:
+
+  The `@Name` annotation declares the SQL-visible parameter name for an
+  argument. With a declared name the function is invocable using the
+  named-argument form `f(name => value)` in addition to the positional form.
+  Functions without `@Name` annotations on their parameters can only be called
+  positionally. For example:
+
+  ```java
+  @ScalarFunction("clamp")
+  @SqlType(StandardTypes.BIGINT)
+  public static long clamp(
+          @Name("value") @SqlType(StandardTypes.BIGINT) long value,
+          @Name("lo") @SqlType(StandardTypes.BIGINT) long lo,
+          @Name("hi") @SqlType(StandardTypes.BIGINT) long hi)
+  {
+      return Math.max(lo, Math.min(hi, value));
+  }
+  ```
+
+  After registration the function is callable both ways:
+
+  ```sql
+  SELECT clamp(7, 0, 5);
+  SELECT clamp(value => 7, hi => 5, lo => 0);
+  ```
+
 ## Parametric scalar functions
 
 Scalar functions that have type parameters have some additional complexity.

--- a/docs/src/main/sphinx/udf/sql.md
+++ b/docs/src/main/sphinx/udf/sql.md
@@ -59,6 +59,33 @@ Find simple examples in each statement documentation, and refer to the
 [](/udf/sql/examples) for more complex use cases that combine multiple
 statements.
 
+(udf-sql-named-arguments)=
+## Named arguments
+
+Because a SQL UDF declares its parameters by name, you can invoke it using
+the named-argument form `name => value` in addition to passing arguments by
+position. Named arguments can appear in any order, and you can mix positional
+arguments (which must come first) with named ones:
+
+```sql
+WITH
+  FUNCTION clamp(value bigint, lo bigint, hi bigint)
+    RETURNS bigint
+    RETURN CASE
+        WHEN value < lo THEN lo
+        WHEN value > hi THEN hi
+        ELSE value
+    END
+SELECT
+    clamp(7, 0, 5),                       -- positional: 5
+    clamp(value => 7, lo => 0, hi => 5),  -- all named: 5
+    clamp(7, hi => 5, lo => 0);           -- mixed: 5
+```
+
+If you pass a name the function does not declare, the query fails with a
+diagnostic that points at the offending identifier. Passing a positional
+argument after a named one is a syntax error.
+
 (udf-sql-label)=
 ## Labels
 


### PR DESCRIPTION
## Description

Implements SQL:2023 feature **T524** so that ordinary scalar and aggregate function calls accept the `name => value` argument form already supported by procedures, table functions, and `ALTER TABLE ... EXECUTE`:

```sql
SELECT substr(string => 'abcdef', "from" => 2, length => 3);
-- 'bcd'

CREATE FUNCTION clamp(value bigint, lo bigint, hi bigint) RETURNS bigint
RETURN least(greatest(value, lo), hi);

SELECT clamp(hi => 10, lo => 0, value => 42);
-- 10
```

## Additional context and related issues

### SPI

- `Signature` carries a parallel `List<Optional<String>>` of declared parameter names. Names are descriptive metadata, so `equals`/`hashCode` exclude them — signatures with the same types are still interchangeable for binding. New entry points: `Signature.Builder.argumentType(type, name)` and `FunctionMetadata.findArgumentPosition(name)`.
- A new `@Name` SPI annotation lets authors of Java-backed scalar and aggregate functions declare SQL-visible parameter names alongside `@SqlType`. Opt-in: functions without `@Name` continue to register with unnamed parameters and remain positional-only. **No built-in function is retrofitted in this PR.**
- JSON round-trips via a new `argumentNames` property appended to the deserialization parameter list so older payloads still load.

### Grammar / analyzer / planner

The grammar accepts `callArgument` in place of `expression` in the non-asterisk `functionCall` production. `FunctionCall` grows a parallel `argumentNames` list of `Optional<Identifier>`. `AstBuilder` rejects named arguments on operator-style names that desugar into dedicated AST nodes (`IF`, `NULLIF`, `COALESCE`, `TRY`, `FORMAT`) and on positional-after-named ordering.

When a call carries named arguments, `ExpressionAnalyzer` looks up the function's candidates on the search path, filters to non-variadic overloads whose declared parameter names cover every name in the call, and computes a signature-position → AST-index binding. Argument types are reordered before invoking the resolver; the binding is stored on `Analysis` and re-applied when the planner builds the IR `Call`.

### SQL UDFs

SQL UDFs declared with `CREATE FUNCTION f(a bigint, b bigint) ...` already require parameter names at the syntax level. `SqlRoutineAnalyzer.extractFunctionMetadata` records each `ParameterDeclaration`'s declared name on the registered `Signature`, so every SQL UDF is automatically invocable by name without any further opt-in.

### Design choices

- Named arguments must come after all positional arguments at the call site (matches PTF and the Python convention).
- Variadic candidates are excluded — parameter positions aren't meaningful for an open-ended tail.
- For overloads at the same arity, all candidates must agree on the position of every named argument; otherwise the bundle is rejected at function-registration time with `Named arguments not supported: overloads of F declare parameter X at different positions`. This sidesteps per-overload pre-resolution for v1.
- An undeclared parameter is treated as "unnamed" and never matches, so a name unknown to every overload at the arity raises `No argument named X for function Y` pointing at the offending identifier.

### Diagnostics

- Unknown name: `No argument named X for function Y`
- Positional after named: parser error at the offending positional argument
- Operator-style functions: `Named arguments are not allowed for function X`

### Not in scope

- Retrofitting any existing built-in function with `@Name`.
- Per-overload pre-resolution when overloads at the same arity declare different parameter names (currently rejected at registration).
- Named arguments on variadic functions, pattern-recognition functions, and the operator-style wrappers (rejected with clear messages).

## Release notes

```
## General
* Add support for named arguments in scalar and aggregate function calls. ({issue}`29530`)
```