### PR TITLE
Fix duplicate variable binding in SqlRoutineCompiler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineCompiler.java
@@ -100,13 +100,11 @@ import static io.trino.sql.gen.BytecodeUtils.boxPrimitiveIfNecessary;
 import static io.trino.sql.gen.BytecodeUtils.unboxPrimitiveIfNecessary;
 import static io.trino.sql.gen.LambdaBytecodeGenerator.preGenerateLambdaExpression;
 import static io.trino.sql.gen.LambdaExpressionExtractor.extractLambdaExpressions;
-import static io.trino.sql.routine.SqlRoutinePlanner.variableReferenceName;
 import static io.trino.util.CompilerUtils.defineClass;
 import static io.trino.util.CompilerUtils.makeClassName;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 
 public final class SqlRoutineCompiler
 {
@@ -228,15 +226,12 @@ public final class SqlRoutineCompiler
 
         scope.declareVariable(boolean.class, "wasNull");
 
-        Map<IrVariable, Variable> variables = VariableExtractor.extract(routine).stream().distinct()
-                .collect(toImmutableMap(identity(), variable -> getOrDeclareVariable(scope, variable)));
+        Map<Integer, Variable> variables = VariableExtractor.extract(routine).stream()
+                .collect(toImmutableMap(IrVariable::field, variable -> getOrDeclareVariable(scope, variable), (a, _) -> a));
 
         // Build mapping from reference names (used in Expression) to scope variable names (used in bytecode)
-        ImmutableMap.Builder<String, String> referenceNameToScopeNameBuilder = ImmutableMap.builder();
-        for (IrVariable variable : variables.keySet()) {
-            referenceNameToScopeNameBuilder.put(variableReferenceName(variable), name(variable));
-        }
-        Map<String, String> referenceNameToScopeName = referenceNameToScopeNameBuilder.buildOrThrow();
+        Map<String, String> referenceNameToScopeName = variables.keySet().stream()
+                .collect(toImmutableMap(SqlRoutinePlanner::variableReferenceName, SqlRoutineCompiler::name));
 
         BytecodeVisitor visitor = new BytecodeVisitor(classDefinition, cachedInstanceBinder, compiledLambdaMap, variables, referenceNameToScopeName);
         method.getBody().append(visitor.process(routine, scope));
@@ -298,7 +293,7 @@ public final class SqlRoutineCompiler
         private final ClassDefinition classDefinition;
         private final CachedInstanceBinder cachedInstanceBinder;
         private final Map<Lambda, CompiledLambda> compiledLambdaMap;
-        private final Map<IrVariable, Variable> variables;
+        private final Map<Integer, Variable> variables;
         private final Map<String, String> referenceNameToScopeName;
 
         private final Map<IrLabel, LabelNode> continueLabels = new HashMap<>();
@@ -308,7 +303,7 @@ public final class SqlRoutineCompiler
                 ClassDefinition classDefinition,
                 CachedInstanceBinder cachedInstanceBinder,
                 Map<Lambda, CompiledLambda> compiledLambdaMap,
-                Map<IrVariable, Variable> variables,
+                Map<Integer, Variable> variables,
                 Map<String, String> referenceNameToScopeName)
         {
             this.classDefinition = requireNonNull(classDefinition, "classDefinition is null");
@@ -335,7 +330,7 @@ public final class SqlRoutineCompiler
         {
             return new BytecodeBlock()
                     .append(compile(node.value(), scope))
-                    .putVariable(variables.get(node.target()));
+                    .putVariable(variables.get(node.target().field()));
         }
 
         @Override
@@ -345,7 +340,7 @@ public final class SqlRoutineCompiler
 
             for (IrVariable sqlVariable : node.variables()) {
                 block.append(compile(sqlVariable.defaultValue(), scope))
-                        .putVariable(variables.get(sqlVariable));
+                        .putVariable(variables.get(sqlVariable.field()));
             }
 
             LabelNode continueLabel = new LabelNode("continue");

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
@@ -397,6 +397,11 @@ public final class SqlRoutinePlanner
 
     static String variableReferenceName(IrVariable variable)
     {
-        return "$sqlvar_" + variable.field();
+        return variableReferenceName(variable.field());
+    }
+
+    static String variableReferenceName(int field)
+    {
+        return "$sqlvar_" + field;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlFunctions.java
@@ -338,6 +338,35 @@ class TestSqlFunctions
     }
 
     @Test
+    void testWhileWithIfElseifSettingSameVariable()
+    {
+        // Exercise a routine variable with a Block-valued default (ARRAY[]) so that a JSON
+        // round-trip of the IR produces non-equal IrVariable records for the same field —
+        // SqlRoutineCompiler must dedupe by field number, not by record identity.
+        @Language("SQL") String sql =
+                """
+                FUNCTION test_generate_series(start_value bigint, end_value bigint, step bigint)
+                RETURNS bigint
+                BEGIN
+                  DECLARE result array(bigint) DEFAULT array[];
+                  DECLARE current bigint DEFAULT start_value;
+                  WHILE current <= end_value DO
+                    IF step > 0 THEN
+                      SET result = concat(result, array[current]);
+                      SET current = current + step;
+                    ELSEIF step < 0 THEN
+                      SET current = current - step;
+                    ELSE
+                      RETURN 0;
+                    END IF;
+                  END WHILE;
+                  RETURN cardinality(result);
+                END
+                """;
+        assertFunction(sql, handle -> assertThat(handle.invoke(1L, 3L, 1L)).isEqualTo(3L));
+    }
+
+    @Test
     void testRepeat()
     {
         @Language("SQL") String sql =


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Compiling a `LANGUAGE SQL` UDF on a worker fails with `IllegalArgumentException: Multiple entries with same key: $sqlvar_N=vN and $sqlvar_N=vN` from `ImmutableMap.buildOrThrow` in `SqlRoutineCompiler.generateRunMethod` whenever the routine declares a variable with a non-primitive default  value (e.g. `ARRAY[]`).

Root cause: the compiler keyed routine variables by `IrVariable` record equality. `IrVariable.defaultValue` may be a `Constant` whose `value` is a `Block`, and `Block.equals` is identity-based. After the IR is serialized to JSON for worker delivery and deserialized, the `IrVariable` carried in `IrBlock.variables` and the one carried in each `IrSet.target` for the same logical variable end up as non-equal records sharing the same `field` number. `.distinct()` keeps both, and the loop that builds the reference-name to scope-name map then puts the same key twice.

Fix: key the compiler's variable map by `field()` — the actual identity of a routine variable — and derive the reference-name map from that. The visitor lookups use `IrVariable.field()` directly. An `int` overload of `SqlRoutinePlanner.variableReferenceName` is added for that.

The underlying `Constant.equals` semantics are deliberately left unchanged; field-number keying makes the routine compiler robust regardless of `Expression` equality behavior.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #29529.

Regression introduced by 6816fac6dde ("Replace RowExpression with Expression in bytecode compilation"), which added the reference-name to scope-name map. The error surfaces at runtime specialization on a worker, not at `CREATE FUNCTION`, because the JSON round-trip is what breaks record equality.

A regression test is added in `TestSqlFunctions`. `assertFunction` already exercises both the in-process compile path and the serialize/deserialize path, so the new test covers the failing case directly.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix query failure for SQL UDFs that declare a variable with a non-primitive default value (e.g. ``ARRAY[]``). (#29529)```
