### PR TITLE
Iceberg REST catalog: OIDC token delegation, RFC 8693 exchange, and SigV4/STS support

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.security.oauth2;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.server.security.AbstractBearerAuthenticator;
@@ -41,6 +42,7 @@ public class OAuth2Authenticator
         extends AbstractBearerAuthenticator
 {
     private static final Logger log = Logger.get(OAuth2Authenticator.class);
+    private static final String OAUTH2_TOKEN_PROPERTY = "token";
     private final OAuth2Client client;
     private final String principalField;
     private final UserMapping userMapping;
@@ -80,6 +82,7 @@ public class OAuth2Authenticator
         }
         Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal.get()));
         builder.withPrincipal(new BasicPrincipal(principal.get()));
+        builder.withExtraCredentials(ImmutableMap.of(OAUTH2_TOKEN_PROPERTY, tokenPair.accessToken()));
         return Optional.of(builder.build());
     }
 

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -94,21 +94,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-cache</artifactId>
         </dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -66,6 +66,7 @@ public class IcebergRestCatalogConfig
     private boolean caseInsensitiveNameMatching;
     private Map<String, String> httpHeaders = ImmutableMap.of();
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+    private boolean tokenDelegation;
 
     @NotNull
     public URI getBaseUri()
@@ -248,6 +249,19 @@ public class IcebergRestCatalogConfig
                     "Cannot parse http headers from property iceberg.rest-catalog.http-headers; value provided was %s, expected format is \"Header-Name-1: header value 1, Header-Value-2: header value 2, ...\"",
                     String.join(", ", httpHeaders)), e);
         }
+        return this;
+    }
+
+    public boolean isTokenDelegation()
+    {
+        return tokenDelegation;
+    }
+
+    @Config("iceberg.rest-catalog.token-delegation")
+    @ConfigDescription("Forward the authenticated user's OAuth2 token to the REST catalog as session credentials")
+    public IcebergRestCatalogConfig setTokenDelegation(boolean tokenDelegation)
+    {
+        this.tokenDelegation = tokenDelegation;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
@@ -13,13 +13,21 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.configuration.ConfigPropertyMetadata;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
+import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType;
 import io.trino.spi.TrinoException;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -28,10 +36,15 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 public class IcebergRestCatalogModule
         extends AbstractConfigurationAwareModule
 {
+    private static final String HEADER_PROPERTY_PREFIX = "iceberg.rest-catalog.header.";
+    private static final String TOKEN_EXCHANGE_EXTRA_PREFIX = "iceberg.rest-catalog.token-exchange.extra.";
+
     @Override
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(IcebergRestCatalogConfig.class);
+        configBinder(binder).bindConfig(IcebergRestCatalogTokenExchangeConfig.class);
+
         install(switch (buildConfigObject(IcebergRestCatalogConfig.class).getSecurity()) {
             case OAUTH2 -> new OAuth2SecurityModule();
             case SIGV4 -> new SigV4SecurityModule();
@@ -40,6 +53,26 @@ public class IcebergRestCatalogModule
         });
 
         binder.bind(IcebergRestCatalogPropertiesProvider.class).in(Scopes.SINGLETON);
+
+        ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
+        ImmutableMap.Builder<String, String> tokenExchangeExtra = ImmutableMap.builder();
+        getProperties().forEach((name, value) -> {
+            if (name.startsWith(HEADER_PROPERTY_PREFIX)) {
+                consumeProperty(new ConfigPropertyMetadata(name, false));
+                headers.put(name, value);
+            }
+            else if (name.startsWith(TOKEN_EXCHANGE_EXTRA_PREFIX)) {
+                consumeProperty(new ConfigPropertyMetadata(name, false));
+                tokenExchangeExtra.put(name.substring(TOKEN_EXCHANGE_EXTRA_PREFIX.length()), value);
+            }
+        });
+        binder.bind(new TypeLiteral<Map<String, String>>() {}).annotatedWith(Names.named("restCatalogHeaders")).toInstance(headers.buildOrThrow());
+        binder.bind(new TypeLiteral<Map<String, String>>() {}).annotatedWith(Names.named("tokenExchangeExtra")).toInstance(tokenExchangeExtra.buildOrThrow());
+
+        newOptionalBinder(binder, OidcStsCredentialExchanger.class);
+        newOptionalBinder(binder, OidcTokenExchanger.class);
+        binder.bind(UserTokenProvider.class).in(Scopes.SINGLETON);
+
         binder.bind(TrinoCatalogFactory.class).to(TrinoIcebergRestCatalogFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, IcebergFileSystemFactory.class).setBinding().to(IcebergRestCatalogFileSystemFactory.class).in(Scopes.SINGLETON);
 
@@ -47,6 +80,30 @@ public class IcebergRestCatalogModule
         IcebergRestCatalogConfig restCatalogConfig = buildConfigObject(IcebergRestCatalogConfig.class);
         if (restCatalogConfig.isVendedCredentialsEnabled() && icebergConfig.isRegisterTableProcedureEnabled()) {
             throw new TrinoException(NOT_SUPPORTED, "Using the `register_table` procedure with vended credentials is currently not supported");
+        }
+        if (restCatalogConfig.isTokenDelegation() && restCatalogConfig.getSessionType() != SessionType.USER) {
+            throw new TrinoException(NOT_SUPPORTED, "iceberg.rest-catalog.token-delegation requires iceberg.rest-catalog.session=user");
+        }
+        IcebergRestCatalogSigV4Config sigV4Config = buildConfigObject(IcebergRestCatalogSigV4Config.class);
+        if (sigV4Config.isStsWebIdentity() && restCatalogConfig.getSessionType() != SessionType.USER) {
+            throw new TrinoException(NOT_SUPPORTED, "iceberg.rest-catalog.sigv4.sts-web-identity requires iceberg.rest-catalog.session=user");
+        }
+        IcebergRestCatalogTokenExchangeConfig tokenExchangeConfig = buildConfigObject(IcebergRestCatalogTokenExchangeConfig.class);
+        if (tokenExchangeConfig.isEnabled() && restCatalogConfig.getSessionType() != SessionType.USER) {
+            throw new TrinoException(NOT_SUPPORTED, "iceberg.rest-catalog.token-exchange-enabled requires iceberg.rest-catalog.session=user");
+        }
+        if (tokenExchangeConfig.isEnabled()) {
+            try {
+                Constructor<OidcTokenExchanger> ctor = OidcTokenExchanger.class
+                        .getConstructor(IcebergRestCatalogTokenExchangeConfig.class, Map.class);
+                newOptionalBinder(binder, OidcTokenExchanger.class)
+                        .setBinding()
+                        .toConstructor(ctor)
+                        .in(Scopes.SINGLETON);
+            }
+            catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogSigV4Config.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogSigV4Config.java
@@ -15,12 +15,19 @@ package io.trino.plugin.iceberg.catalog.rest;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import org.apache.iceberg.aws.AwsProperties;
+
+import java.util.Optional;
 
 public class IcebergRestCatalogSigV4Config
 {
     private String signingName = AwsProperties.REST_SIGNING_NAME_DEFAULT;
+    private boolean stsWebIdentity;
+    private String stsRoleArn;
+    private String stsPolicy;
+    private Integer stsDurationSeconds;
 
     @NotNull
     public String getSigningName()
@@ -34,5 +41,63 @@ public class IcebergRestCatalogSigV4Config
     {
         this.signingName = signingName;
         return this;
+    }
+
+    public boolean isStsWebIdentity()
+    {
+        return stsWebIdentity;
+    }
+
+    @Config("iceberg.rest-catalog.sts-web-identity")
+    @ConfigDescription("Exchange the authenticated user's OIDC token for per-user STS credentials via AssumeRoleWithWebIdentity")
+    public IcebergRestCatalogSigV4Config setStsWebIdentity(boolean stsWebIdentity)
+    {
+        this.stsWebIdentity = stsWebIdentity;
+        return this;
+    }
+
+    public Optional<String> getStsRoleArn()
+    {
+        return Optional.ofNullable(stsRoleArn);
+    }
+
+    @Config("iceberg.rest-catalog.sts-role-arn")
+    @ConfigDescription("IAM role ARN to assume via AssumeRoleWithWebIdentity")
+    public IcebergRestCatalogSigV4Config setStsRoleArn(String stsRoleArn)
+    {
+        this.stsRoleArn = stsRoleArn;
+        return this;
+    }
+
+    public Optional<String> getStsPolicy()
+    {
+        return Optional.ofNullable(stsPolicy);
+    }
+
+    @Config("iceberg.rest-catalog.sts-policy")
+    @ConfigDescription("Inline IAM session policy JSON to attach to the AssumeRoleWithWebIdentity request")
+    public IcebergRestCatalogSigV4Config setStsPolicy(String stsPolicy)
+    {
+        this.stsPolicy = stsPolicy;
+        return this;
+    }
+
+    public Optional<Integer> getStsDurationSeconds()
+    {
+        return Optional.ofNullable(stsDurationSeconds);
+    }
+
+    @Config("iceberg.rest-catalog.sts-duration-seconds")
+    @ConfigDescription("Fixed STS session duration in seconds; if unset, the duration is derived from the token's exp claim")
+    public IcebergRestCatalogSigV4Config setStsDurationSeconds(Integer stsDurationSeconds)
+    {
+        this.stsDurationSeconds = stsDurationSeconds;
+        return this;
+    }
+
+    @AssertTrue(message = "iceberg.rest-catalog.sts-role-arn and iceberg.rest-catalog.sts-policy cannot both be set")
+    public boolean isStsRoleArnAndPolicyMutuallyExclusive()
+    {
+        return stsRoleArn == null || stsPolicy == null;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogTokenExchangeConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogTokenExchangeConfig.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.AssertTrue;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class IcebergRestCatalogTokenExchangeConfig
+{
+    private boolean enabled;
+    private URI endpoint;
+    private String clientId;
+    private String clientSecret;
+    private String scope;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("iceberg.rest-catalog.token-exchange-enabled")
+    @ConfigDescription("Exchange the user's OIDC token for a catalog-audience token via RFC 8693 before forwarding to the catalog or STS")
+    public IcebergRestCatalogTokenExchangeConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public Optional<URI> getEndpoint()
+    {
+        return Optional.ofNullable(endpoint);
+    }
+
+    @Config("iceberg.rest-catalog.token-exchange.endpoint")
+    @ConfigDescription("OAuth2 token endpoint for RFC 8693 token exchange")
+    public IcebergRestCatalogTokenExchangeConfig setEndpoint(URI endpoint)
+    {
+        this.endpoint = endpoint;
+        return this;
+    }
+
+    public Optional<String> getClientId()
+    {
+        return Optional.ofNullable(clientId);
+    }
+
+    @Config("iceberg.rest-catalog.token-exchange.client-id")
+    @ConfigDescription("Client ID used to authenticate the token exchange request")
+    public IcebergRestCatalogTokenExchangeConfig setClientId(String clientId)
+    {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public Optional<String> getClientSecret()
+    {
+        return Optional.ofNullable(clientSecret);
+    }
+
+    @Config("iceberg.rest-catalog.token-exchange.client-secret")
+    @ConfigDescription("Client secret used to authenticate the token exchange request")
+    @ConfigSecuritySensitive
+    public IcebergRestCatalogTokenExchangeConfig setClientSecret(String clientSecret)
+    {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+
+    public Optional<String> getScope()
+    {
+        return Optional.ofNullable(scope);
+    }
+
+    @Config("iceberg.rest-catalog.token-exchange.scope")
+    @ConfigDescription("Target scope for the token exchange request (e.g. api://minio/storage.access)")
+    public IcebergRestCatalogTokenExchangeConfig setScope(String scope)
+    {
+        this.scope = scope;
+        return this;
+    }
+
+    @AssertTrue(message = "iceberg.rest-catalog.token-exchange.endpoint is required when token-exchange-enabled=true")
+    public boolean isEndpointPresentWhenEnabled()
+    {
+        return !enabled || endpoint != null;
+    }
+
+    @AssertTrue(message = "iceberg.rest-catalog.token-exchange.client-id is required when token-exchange-enabled=true")
+    public boolean isClientIdPresentWhenEnabled()
+    {
+        return !enabled || clientId != null;
+    }
+
+    @AssertTrue(message = "iceberg.rest-catalog.token-exchange.client-secret is required when token-exchange-enabled=true")
+    public boolean isClientSecretPresentWhenEnabled()
+    {
+        return !enabled || clientSecret != null;
+    }
+
+    @AssertTrue(message = "iceberg.rest-catalog.token-exchange.scope is required when token-exchange-enabled=true")
+    public boolean isScopePresentWhenEnabled()
+    {
+        return !enabled || scope != null;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OidcStsCredentialExchanger.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OidcStsCredentialExchanger.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.cache.NonEvictableCache;
+import io.trino.cache.SafeCaches;
+import io.trino.filesystem.s3.S3FileSystemConfig;
+import io.trino.spi.TrinoException;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CATALOG_ERROR;
+
+public class OidcStsCredentialExchanger
+{
+    private static final Logger log = Logger.get(OidcStsCredentialExchanger.class);
+
+    private static final String SESSION_NAME = "trino-iceberg";
+    // Minimum STS session duration in seconds (AWS/MinIO lower bound)
+    private static final int MIN_DURATION_SECONDS = 900;
+    // Renew this many seconds before the STS credential actually expires
+    private static final long EXPIRY_BUFFER_SECONDS = 60;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    record CachedCredentials(AwsSessionCredentials credentials, Instant expiresAt) {}
+
+    private final StsClient stsClient;
+    private final Optional<String> roleArn;
+    private final String stsEndpoint;
+    private final String stsRegion;
+    private final Optional<String> policy;
+    private final Optional<Integer> configuredDurationSeconds;
+    // Keyed on the JWT `sub` claim; expiry is checked manually via CachedCredentials.expiresAt
+    private final NonEvictableCache<String, CachedCredentials> cache;
+
+    OidcStsCredentialExchanger(StsClient stsClient, String roleArn)
+    {
+        this.stsClient = stsClient;
+        this.roleArn = Optional.of(roleArn);
+        this.stsEndpoint = "(default)";
+        this.stsRegion = "(default)";
+        this.policy = Optional.empty();
+        this.configuredDurationSeconds = Optional.empty();
+        this.cache = SafeCaches.buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(1000));
+    }
+
+    @Inject
+    public OidcStsCredentialExchanger(S3FileSystemConfig s3Config, IcebergRestCatalogSigV4Config sigV4Config)
+    {
+        StsClientBuilder builder = StsClient.builder();
+
+        // Prefer dedicated STS region; fall back to the general S3 region
+        this.stsRegion = Optional.ofNullable(s3Config.getStsRegion())
+                .or(() -> Optional.ofNullable(s3Config.getRegion()))
+                .orElse("(default)");
+        Optional.ofNullable(stsRegion).filter(r -> !r.equals("(default)"))
+                .map(Region::of)
+                .ifPresent(builder::region);
+
+        // Required for MinIO: override the default AWS STS endpoint
+        this.stsEndpoint = Optional.ofNullable(s3Config.getStsEndpoint()).orElse("(default)");
+        Optional.ofNullable(s3Config.getStsEndpoint())
+                .map(URI::create)
+                .ifPresent(builder::endpointOverride);
+
+        this.stsClient = builder.build();
+        this.roleArn = sigV4Config.getStsRoleArn()
+                .or(() -> Optional.ofNullable(s3Config.getIamRole()));
+        this.policy = sigV4Config.getStsPolicy();
+        this.configuredDurationSeconds = sigV4Config.getStsDurationSeconds();
+        this.cache = SafeCaches.buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(1000));
+        log.debug(
+                "OidcStsCredentialExchanger initialized: stsEndpoint=%s, stsRegion=%s, roleArn=%s, policy=%s, durationSeconds=%s",
+                stsEndpoint,
+                stsRegion,
+                this.roleArn,
+                this.policy,
+                this.configuredDurationSeconds);
+    }
+
+    /**
+     * Returns STS credentials for the user, using a cache keyed on the JWT {@code sub} claim.
+     * Credentials are refreshed when they are within {@value EXPIRY_BUFFER_SECONDS} seconds of expiry.
+     */
+    public AwsSessionCredentials getCredentials(String catalogToken)
+    {
+        String sub = extractClaim(catalogToken, "sub");
+        if (sub == null) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Token is missing required 'sub' claim");
+        }
+        CachedCredentials cached = cache.getIfPresent(sub);
+        if (cached != null && cached.expiresAt().minusSeconds(EXPIRY_BUFFER_SECONDS).isAfter(Instant.now())) {
+            log.debug("STS cache hit for sub=%s, expiresAt=%s", sub, cached.expiresAt());
+            return cached.credentials();
+        }
+        log.debug("STS cache miss for sub=%s, calling AssumeRoleWithWebIdentity", sub);
+        CachedCredentials fresh = exchange(catalogToken, sub);
+        cache.put(sub, fresh);
+        return fresh.credentials();
+    }
+
+    CachedCredentials exchange(String catalogToken, String sub)
+    {
+        int durationSeconds = configuredDurationSeconds.orElseGet(() -> computeDuration(catalogToken));
+        log.debug(
+                "AssumeRoleWithWebIdentity request: stsEndpoint=%s, stsRegion=%s, roleArn=%s, sessionName=%s, durationSeconds=%d",
+                stsEndpoint,
+                stsRegion,
+                roleArn,
+                SESSION_NAME,
+                durationSeconds);
+        AssumeRoleWithWebIdentityRequest.Builder request = AssumeRoleWithWebIdentityRequest.builder()
+                .webIdentityToken(catalogToken)
+                .roleSessionName(SESSION_NAME)
+                .durationSeconds(durationSeconds);
+        roleArn.ifPresent(request::roleArn);
+        policy.ifPresent(request::policy);
+        AssumeRoleWithWebIdentityResponse response = stsClient.assumeRoleWithWebIdentity(request.build());
+
+        AwsSessionCredentials credentials = AwsSessionCredentials.create(
+                response.credentials().accessKeyId(),
+                response.credentials().secretAccessKey(),
+                response.credentials().sessionToken());
+        log.debug(
+                "AssumeRoleWithWebIdentity response: accessKeyId=%s, expiresAt=%s, assumedRoleId=%s, assumedRoleArn=%s, subjectFromToken=%s, audience=%s, provider=%s",
+                credentials.accessKeyId(),
+                response.credentials().expiration(),
+                response.assumedRoleUser().assumedRoleId(),
+                response.assumedRoleUser().arn(),
+                response.subjectFromWebIdentityToken(),
+                response.audience(),
+                response.provider());
+
+        return new CachedCredentials(credentials, response.credentials().expiration());
+    }
+
+    // Requests a STS duration equal to the remaining lifetime of the token, clamped to the STS minimum
+    static int computeDuration(String jwt)
+    {
+        try {
+            String expStr = extractClaim(jwt, "exp");
+            if (expStr == null) {
+                return MIN_DURATION_SECONDS;
+            }
+            long expEpoch = Long.parseLong(expStr);
+            long remaining = expEpoch - Instant.now().getEpochSecond();
+            return (int) Math.max(remaining, MIN_DURATION_SECONDS);
+        }
+        catch (Exception e) {
+            return MIN_DURATION_SECONDS;
+        }
+    }
+
+    // Decodes the JWT payload without verifying the signature — Trino already authenticated the token
+    static String extractClaim(String jwt, String claim)
+    {
+        try {
+            String[] parts = jwt.split("\\.");
+            if (parts.length < 2) {
+                return null;
+            }
+            byte[] payload = Base64.getUrlDecoder().decode(parts[1]);
+            JsonNode node = MAPPER.readTree(payload);
+            return node.path(claim).asText(null);
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OidcTokenExchanger.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OidcTokenExchanger.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.trino.cache.NonEvictableCache;
+import io.trino.cache.SafeCaches;
+import io.trino.spi.TrinoException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CATALOG_ERROR;
+
+public class OidcTokenExchanger
+{
+    private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+    private static final long DEFAULT_EXPIRY_SECONDS = 3600;
+    private static final long EXPIRY_BUFFER_SECONDS = 60;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    record CachedToken(String token, Instant expiresAt) {}
+
+    private final URI endpoint;
+    private final String clientId;
+    private final String clientSecret;
+    private final String scope;
+    private final Map<String, String> extraParams;
+    private final HttpClient httpClient;
+    private final NonEvictableCache<String, CachedToken> cache;
+
+    @Inject
+    public OidcTokenExchanger(
+            IcebergRestCatalogTokenExchangeConfig config,
+            @Named("tokenExchangeExtra") Map<String, String> extraParams)
+    {
+        this(config.getEndpoint().orElseThrow(),
+                config.getClientId().orElseThrow(),
+                config.getClientSecret().orElseThrow(),
+                config.getScope().orElseThrow(),
+                extraParams);
+    }
+
+    OidcTokenExchanger(URI endpoint, String clientId, String clientSecret, String scope)
+    {
+        this(endpoint, clientId, clientSecret, scope, Map.of());
+    }
+
+    OidcTokenExchanger(URI endpoint, String clientId, String clientSecret, String scope, Map<String, String> extraParams)
+    {
+        this.endpoint = endpoint;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.scope = scope;
+        this.extraParams = Map.copyOf(extraParams);
+        this.httpClient = HttpClient.newHttpClient();
+        this.cache = SafeCaches.buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(1000));
+    }
+
+    public String getToken(String oidcToken)
+    {
+        String sub = OidcStsCredentialExchanger.extractClaim(oidcToken, "sub");
+        if (sub == null) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "OIDC token is missing required 'sub' claim");
+        }
+        CachedToken cached = cache.getIfPresent(sub);
+        if (cached != null && cached.expiresAt().minusSeconds(EXPIRY_BUFFER_SECONDS).isAfter(Instant.now())) {
+            return cached.token();
+        }
+        CachedToken fresh = exchange(oidcToken);
+        cache.put(sub, fresh);
+        return fresh.token();
+    }
+
+    CachedToken exchange(String oidcToken)
+    {
+        StringBuilder body = new StringBuilder()
+                .append("grant_type=").append(encode(GRANT_TYPE))
+                .append("&assertion=").append(encode(oidcToken))
+                .append("&client_id=").append(encode(clientId))
+                .append("&client_secret=").append(encode(clientSecret))
+                .append("&scope=").append(encode(scope));
+
+        extraParams.forEach((key, value) ->
+                body.append("&").append(encode(key)).append("=").append(encode(value)));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(endpoint)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                .build();
+
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Token exchange request interrupted", e);
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Token exchange request failed", e);
+        }
+
+        if (response.statusCode() != 200) {
+            throw new TrinoException(
+                    ICEBERG_CATALOG_ERROR,
+                    "Token exchange failed with HTTP " + response.statusCode() + ": " + response.body());
+        }
+
+        try {
+            JsonNode json = MAPPER.readTree(response.body());
+            String accessToken = json.path("access_token").asText(null);
+            if (accessToken == null) {
+                throw new TrinoException(ICEBERG_CATALOG_ERROR, "Token exchange response missing 'access_token'");
+            }
+            long expiresIn = json.path("expires_in").asLong(DEFAULT_EXPIRY_SECONDS);
+            return new CachedToken(accessToken, Instant.now().plusSeconds(expiresIn));
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to parse token exchange response", e);
+        }
+    }
+
+    private static String encode(String value)
+    {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4AwsProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4AwsProperties.java
@@ -75,11 +75,12 @@ public class SigV4AwsProperties
             Optional.ofNullable(s3Config.getAwsSecretKey()).ifPresent(secretAccessKey -> builder.put(CLIENT_CREDENTIAL_AWS_SECRET_ACCESS_KEY, secretAccessKey));
             Optional.ofNullable(s3Config.getStsEndpoint()).ifPresent(endpoint -> builder.put(CLIENT_CREDENTIAL_AWS_STS_ENDPOINT, endpoint));
         }
-        else {
+        else if (s3Config.getAwsAccessKey() != null) {
             builder
-                    .put(REST_ACCESS_KEY_ID, requireNonNull(s3Config.getAwsAccessKey(), "s3.aws-access-key is null"))
+                    .put(REST_ACCESS_KEY_ID, s3Config.getAwsAccessKey())
                     .put(REST_SECRET_ACCESS_KEY, requireNonNull(s3Config.getAwsSecretKey(), "s3.aws-secret-key is null"));
         }
+        // else: OIDC exchange mode — per-user STS credentials are injected at session time
 
         properties = builder.buildOrThrow();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4SecurityModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4SecurityModule.java
@@ -14,8 +14,13 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.inject.Binder;
+import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.s3.S3FileSystemConfig;
 
+import java.lang.reflect.Constructor;
+
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class SigV4SecurityModule
@@ -26,5 +31,21 @@ public class SigV4SecurityModule
     {
         configBinder(binder).bindConfig(IcebergRestCatalogSigV4Config.class);
         binder.bind(SecurityProperties.class).to(SigV4AwsProperties.class);
+        IcebergRestCatalogSigV4Config sigV4Config = buildConfigObject(IcebergRestCatalogSigV4Config.class);
+        if (sigV4Config.isStsWebIdentity()) {
+            // Use toConstructor to avoid the Guice cycle: OptionalBinder internally creates
+            // T → @Actual T, so .to(T.class) would produce T → @Actual T → T.
+            try {
+                Constructor<OidcStsCredentialExchanger> ctor = OidcStsCredentialExchanger.class
+                        .getConstructor(S3FileSystemConfig.class, IcebergRestCatalogSigV4Config.class);
+                newOptionalBinder(binder, OidcStsCredentialExchanger.class)
+                        .setBinding()
+                        .toConstructor(ctor)
+                        .in(Scopes.SINGLETON);
+            }
+            catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -33,6 +33,7 @@ import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.HTTPClient;
@@ -162,7 +163,21 @@ public class TrinoIcebergRestCatalogFactory
                         ConnectorIdentity currentIdentity = (context.wrappedIdentity() != null)
                                 ? ((ConnectorIdentity) context.wrappedIdentity())
                                 : ConnectorIdentity.ofUser("fake");
-                        return fileIoFactory.create(fileSystemFactory.create(currentIdentity, config), true, config);
+                        // When STS credentials are present in the session context (rest.access-key-id),
+                        // also expose them as s3.* keys so IcebergRestCatalogFileSystemFactory picks
+                        // them up for actual S3 reads. Skipped when the catalog already returned vended
+                        // s3.* credentials in the table config response.
+                        Map<String, String> fileIoConfig = config;
+                        if (context.credentials().containsKey(AwsProperties.REST_ACCESS_KEY_ID)
+                                && !config.containsKey(S3FileIOProperties.ACCESS_KEY_ID)) {
+                            fileIoConfig = ImmutableMap.<String, String>builder()
+                                    .putAll(config)
+                                    .put(S3FileIOProperties.ACCESS_KEY_ID, context.credentials().get(AwsProperties.REST_ACCESS_KEY_ID))
+                                    .put(S3FileIOProperties.SECRET_ACCESS_KEY, context.credentials().get(AwsProperties.REST_SECRET_ACCESS_KEY))
+                                    .put(S3FileIOProperties.SESSION_TOKEN, context.credentials().get(AwsProperties.REST_SESSION_TOKEN))
+                                    .buildOrThrow();
+                        }
+                        return fileIoFactory.create(fileSystemFactory.create(currentIdentity, fileIoConfig), true, fileIoConfig);
                     });
             icebergCatalogInstance.initialize(catalogName.toString(), initProperties);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -14,9 +14,11 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.cache.Cache;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
@@ -30,13 +32,16 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.RESTUtil;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -47,6 +52,8 @@ import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 public class TrinoIcebergRestCatalogFactory
         implements TrinoCatalogFactory
 {
+    private static final Logger log = Logger.get(TrinoIcebergRestCatalogFactory.class);
+
     private final IcebergFileSystemFactory fileSystemFactory;
     private final ForwardingFileIoFactory fileIoFactory;
     private final CatalogName catalogName;
@@ -54,9 +61,12 @@ public class TrinoIcebergRestCatalogFactory
     private final boolean nestedNamespaceEnabled;
     private final Security security;
     private final SessionType sessionType;
+    private final boolean tokenDelegation;
     private final boolean viewEndpointsEnabled;
     private final SecurityProperties securityProperties;
     private final IcebergRestCatalogPropertiesProvider catalogPropertiesProvider;
+    private final Optional<OidcStsCredentialExchanger> stsExchanger;
+    private final UserTokenProvider tokenProvider;
     private final boolean uniqueTableLocation;
     private final TypeManager typeManager;
     private final boolean caseInsensitiveNameMatching;
@@ -74,6 +84,8 @@ public class TrinoIcebergRestCatalogFactory
             IcebergRestCatalogConfig restConfig,
             SecurityProperties securityProperties,
             IcebergRestCatalogPropertiesProvider catalogPropertiesProvider,
+            Optional<OidcStsCredentialExchanger> stsExchanger,
+            UserTokenProvider tokenProvider,
             IcebergConfig icebergConfig,
             TypeManager typeManager,
             NodeVersion nodeVersion)
@@ -86,9 +98,12 @@ public class TrinoIcebergRestCatalogFactory
         this.nestedNamespaceEnabled = restConfig.isNestedNamespaceEnabled();
         this.security = restConfig.getSecurity();
         this.sessionType = restConfig.getSessionType();
+        this.tokenDelegation = restConfig.isTokenDelegation();
         this.viewEndpointsEnabled = restConfig.isViewEndpointsEnabled();
         this.securityProperties = requireNonNull(securityProperties, "securityProperties is null");
         this.catalogPropertiesProvider = requireNonNull(catalogPropertiesProvider, "catalogPropertiesProvider is null");
+        this.stsExchanger = requireNonNull(stsExchanger, "stsExchanger is null");
+        this.tokenProvider = requireNonNull(tokenProvider, "tokenProvider is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
         this.uniqueTableLocation = icebergConfig.isUniqueTableLocation();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -109,6 +124,35 @@ public class TrinoIcebergRestCatalogFactory
         // Creation of the RESTSessionCatalog is lazy due to required network calls
         // for authorization and config route
         if (icebergCatalog == null) {
+            Map<String, String> initProperties = catalogPropertiesProvider.catalogProperties();
+            if (tokenDelegation) {
+                Optional<String> catalogToken = tokenProvider.catalogToken(identity.getExtraCredentials().get(TOKEN));
+                if (catalogToken.isPresent()) {
+                    initProperties = ImmutableMap.<String, String>builder()
+                            .putAll(Maps.filterKeys(initProperties, key -> !key.equals(TOKEN)))
+                            .put(TOKEN, catalogToken.get())
+                            .buildOrThrow();
+                }
+            }
+            if (stsExchanger.isPresent()) {
+                // tokenProvider.catalogToken() runs the OIDC→catalog token exchange first (if configured)
+                // before passing the token to AssumeRoleWithWebIdentity
+                Optional<String> catalogToken = tokenProvider.catalogToken(identity.getExtraCredentials().get(TOKEN));
+                if (catalogToken.isPresent()) {
+                    AwsSessionCredentials awsCreds = stsExchanger.get().getCredentials(catalogToken.get());
+                    log.debug("Injecting STS credentials into catalog init properties: accessKeyId=%s", awsCreds.accessKeyId());
+                    Set<String> stsKeys = Set.of(AwsProperties.REST_ACCESS_KEY_ID, AwsProperties.REST_SECRET_ACCESS_KEY, AwsProperties.REST_SESSION_TOKEN);
+                    initProperties = ImmutableMap.<String, String>builder()
+                            .putAll(Maps.filterKeys(initProperties, key -> !stsKeys.contains(key)))
+                            .put(AwsProperties.REST_ACCESS_KEY_ID, awsCreds.accessKeyId())
+                            .put(AwsProperties.REST_SECRET_ACCESS_KEY, awsCreds.secretAccessKey())
+                            .put(AwsProperties.REST_SESSION_TOKEN, awsCreds.sessionToken())
+                            .buildOrThrow();
+                }
+                else {
+                    log.warn("STS exchanger present but no OIDC token found in user credentials — catalog will initialize without STS credentials");
+                }
+            }
             RESTSessionCatalog icebergCatalogInstance = new RESTSessionCatalog(
                     config -> HTTPClient.builder(config)
                             .uri(config.get(CatalogProperties.URI))
@@ -120,7 +164,7 @@ public class TrinoIcebergRestCatalogFactory
                                 : ConnectorIdentity.ofUser("fake");
                         return fileIoFactory.create(fileSystemFactory.create(currentIdentity, config), true, config);
                     });
-            icebergCatalogInstance.initialize(catalogName.toString(), catalogPropertiesProvider.catalogProperties());
+            icebergCatalogInstance.initialize(catalogName.toString(), initProperties);
 
             icebergCatalog = icebergCatalogInstance;
         }
@@ -128,6 +172,7 @@ public class TrinoIcebergRestCatalogFactory
         // `OAuth2Properties.SCOPE` is not set as scope passed through credentials is unused in
         // https://github.com/apache/iceberg/blob/229d8f6fcd109e6c8943ea7cbb41dab746c6d0ed/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java#L714-L721
         Map<String, String> credentials = Maps.filterKeys(securityProperties.get(), key -> Set.of(TOKEN, CREDENTIAL).contains(key));
+        log.debug("SigV4 security properties passed to catalog session: %s", securityProperties.get());
 
         return new TrinoRestCatalog(
                 fileSystemFactory,
@@ -136,6 +181,8 @@ public class TrinoIcebergRestCatalogFactory
                 security,
                 sessionType,
                 credentials,
+                stsExchanger,
+                tokenProvider,
                 nestedNamespaceEnabled,
                 trinoVersion,
                 typeManager,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -168,7 +168,8 @@ public class TrinoIcebergRestCatalogFactory
                         // them up for actual S3 reads. Skipped when the catalog already returned vended
                         // s3.* credentials in the table config response.
                         Map<String, String> fileIoConfig = config;
-                        if (context.credentials().containsKey(AwsProperties.REST_ACCESS_KEY_ID)
+                        if (context.credentials() != null
+                                && context.credentials().containsKey(AwsProperties.REST_ACCESS_KEY_ID)
                                 && !config.containsKey(S3FileIOProperties.ACCESS_KEY_ID)) {
                             fileIoConfig = ImmutableMap.<String, String>builder()
                                     .putAll(config)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -21,8 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
-import io.jsonwebtoken.impl.DefaultJwtBuilder;
-import io.jsonwebtoken.jackson.io.JacksonSerializer;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
@@ -66,7 +64,6 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
-import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.view.ReplaceViewVersion;
 import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.UpdateViewProperties;
@@ -74,10 +71,10 @@ import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
 import org.apache.iceberg.view.ViewRepresentation;
 import org.apache.iceberg.view.ViewVersion;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +103,10 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.apache.iceberg.CatalogUtil.dropTableData;
+import static org.apache.iceberg.aws.AwsProperties.REST_ACCESS_KEY_ID;
+import static org.apache.iceberg.aws.AwsProperties.REST_SECRET_ACCESS_KEY;
+import static org.apache.iceberg.aws.AwsProperties.REST_SESSION_TOKEN;
+import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 import static org.apache.iceberg.view.ViewProperties.COMMENT;
 
 public class TrinoRestCatalog
@@ -123,6 +124,8 @@ public class TrinoRestCatalog
     private final Security security;
     private final SessionType sessionType;
     private final Map<String, String> credentials;
+    private final Optional<OidcStsCredentialExchanger> stsExchanger;
+    private final UserTokenProvider tokenProvider;
     private final boolean nestedNamespaceEnabled;
     private final String trinoVersion;
     private final boolean useUniqueTableLocation;
@@ -135,13 +138,13 @@ public class TrinoRestCatalog
             .maximumSize(PER_QUERY_CACHE_SIZE)
             .build();
 
-    public TrinoRestCatalog(
-            IcebergFileSystemFactory fileSystemFactory,
+    TrinoRestCatalog(
             RESTSessionCatalog restSessionCatalog,
             CatalogName catalogName,
-            Security security,
             SessionType sessionType,
             Map<String, String> credentials,
+            Optional<OidcStsCredentialExchanger> stsExchanger,
+            UserTokenProvider tokenProvider,
             boolean nestedNamespaceEnabled,
             String trinoVersion,
             TypeManager typeManager,
@@ -151,12 +154,35 @@ public class TrinoRestCatalog
             Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache,
             boolean viewEndpointsEnabled)
     {
-        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this(null, restSessionCatalog, catalogName, Security.NONE, sessionType, credentials, stsExchanger, tokenProvider, nestedNamespaceEnabled, trinoVersion, typeManager, useUniqueTableLocation, caseInsensitiveNameMatching, remoteNamespaceMappingCache, remoteTableMappingCache, viewEndpointsEnabled);
+    }
+
+    public TrinoRestCatalog(
+            IcebergFileSystemFactory fileSystemFactory,
+            RESTSessionCatalog restSessionCatalog,
+            CatalogName catalogName,
+            Security security,
+            SessionType sessionType,
+            Map<String, String> credentials,
+            Optional<OidcStsCredentialExchanger> stsExchanger,
+            UserTokenProvider tokenProvider,
+            boolean nestedNamespaceEnabled,
+            String trinoVersion,
+            TypeManager typeManager,
+            boolean useUniqueTableLocation,
+            boolean caseInsensitiveNameMatching,
+            Cache<Namespace, Namespace> remoteNamespaceMappingCache,
+            Cache<TableIdentifier, TableIdentifier> remoteTableMappingCache,
+            boolean viewEndpointsEnabled)
+    {
+        this.fileSystemFactory = fileSystemFactory;
         this.restSessionCatalog = requireNonNull(restSessionCatalog, "restSessionCatalog is null");
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.security = requireNonNull(security, "security is null");
         this.sessionType = requireNonNull(sessionType, "sessionType is null");
         this.credentials = ImmutableMap.copyOf(requireNonNull(credentials, "credentials is null"));
+        this.stsExchanger = requireNonNull(stsExchanger, "stsExchanger is null");
+        this.tokenProvider = requireNonNull(tokenProvider, "tokenProvider is null");
         this.nestedNamespaceEnabled = nestedNamespaceEnabled;
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -887,7 +913,7 @@ public class TrinoRestCatalog
         replaceViewVersion.commit();
     }
 
-    private SessionCatalog.SessionContext convert(ConnectorSession session)
+    SessionCatalog.SessionContext convert(ConnectorSession session)
     {
         return switch (sessionType) {
             case NONE -> new SessionContext(randomUUID().toString(), null, credentials, ImmutableMap.of(), session.getIdentity());
@@ -900,24 +926,24 @@ public class TrinoRestCatalog
                         "trinoCatalog", catalogName.toString(),
                         "trinoVersion", trinoVersion);
 
-                Map<String, Object> claims = ImmutableMap.<String, Object>builder()
-                        .putAll(properties)
-                        .buildOrThrow();
+                ImmutableMap.Builder<String, String> credBuilder = ImmutableMap.builder();
+                Optional<String> catalogToken = tokenProvider.catalogToken(session);
 
-                String subjectJwt = new DefaultJwtBuilder()
-                        .subject(session.getUser())
-                        .issuer(trinoVersion)
-                        .issuedAt(new Date())
-                        .claims(claims)
-                        .json(new JacksonSerializer<>())
-                        .compact();
+                if (stsExchanger.isPresent() && catalogToken.isPresent()) {
+                    AwsSessionCredentials awsCreds = stsExchanger.get().getCredentials(catalogToken.get());
+                    credBuilder
+                            .put(REST_ACCESS_KEY_ID, awsCreds.accessKeyId())
+                            .put(REST_SECRET_ACCESS_KEY, awsCreds.secretAccessKey())
+                            .put(REST_SESSION_TOKEN, awsCreds.sessionToken());
+                }
+                else if (catalogToken.isPresent()) {
+                    credBuilder.put(TOKEN, catalogToken.get());
+                }
+                else {
+                    credBuilder.putAll(session.getIdentity().getExtraCredentials());
+                }
 
-                Map<String, String> credentials = ImmutableMap.<String, String>builder()
-                        .putAll(session.getIdentity().getExtraCredentials())
-                        .put(OAuth2Properties.JWT_TOKEN_TYPE, subjectJwt)
-                        .buildOrThrow();
-
-                yield new SessionCatalog.SessionContext(sessionId, session.getUser(), credentials, properties, session.getIdentity());
+                yield new SessionCatalog.SessionContext(sessionId, session.getUser(), credBuilder.buildOrThrow(), properties, session.getIdentity());
             }
         };
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/UserTokenProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/UserTokenProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.inject.Inject;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.util.Optional;
+
+import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
+
+/**
+ * Resolves the catalog-ready token for a user session.
+ * If token exchange is configured, exchanges the user's OIDC token for a new token
+ * with the catalog audience before returning it. Otherwise returns the original token.
+ */
+class UserTokenProvider
+{
+    private final Optional<OidcTokenExchanger> exchanger;
+
+    @Inject
+    UserTokenProvider(Optional<OidcTokenExchanger> exchanger)
+    {
+        this.exchanger = exchanger;
+    }
+
+    Optional<String> catalogToken(ConnectorSession session)
+    {
+        return catalogToken(session.getIdentity().getExtraCredentials().get(TOKEN));
+    }
+
+    Optional<String> catalogToken(String oidcToken)
+    {
+        if (oidcToken == null) {
+            return Optional.empty();
+        }
+        return Optional.of(exchanger.map(ex -> ex.getToken(oidcToken)).orElse(oidcToken));
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorFactory.java
@@ -31,6 +31,24 @@ public class TestIcebergConnectorFactory
         createConnector(config);
     }
 
+    @Test
+    public void testRestCatalogSigV4WithStsWebIdentity()
+    {
+        Map<String, String> config = ImmutableMap.<String, String>builder()
+                .put("iceberg.catalog.type", "rest")
+                .put("iceberg.rest-catalog.uri", "https://localhost/_iceberg")
+                .put("iceberg.rest-catalog.warehouse", "test")
+                .put("iceberg.rest-catalog.security", "SIGV4")
+                .put("iceberg.rest-catalog.session", "USER")
+                .put("iceberg.rest-catalog.sts-web-identity", "true")
+                .put("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                .put("fs.s3.enabled", "true")
+                .put("s3.region", "us-east-1")
+                .put("bootstrap.quiet", "true")
+                .buildOrThrow();
+        createConnector(config);
+    }
+
     private static void createConnector(Map<String, String> config)
     {
         ConnectorFactory factory = new IcebergConnectorFactory();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -47,7 +47,8 @@ public class TestIcebergRestCatalogConfig
                 .setViewEndpointsEnabled(true)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
-                .setHttpHeaders(List.of()));
+                .setHttpHeaders(List.of())
+                .setTokenDelegation(false));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.case-insensitive-name-matching", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl", "3m")
                 .put("iceberg.rest-catalog.http-headers", "Polaris-Realm: default-realm")
+                .put("iceberg.rest-catalog.token-delegation", "true")
                 .buildOrThrow();
 
         IcebergRestCatalogConfig expected = new IcebergRestCatalogConfig()
@@ -84,7 +86,8 @@ public class TestIcebergRestCatalogConfig
                 .setViewEndpointsEnabled(false)
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES))
-                .setHttpHeaders(List.of("Polaris-Realm: default-realm"));
+                .setHttpHeaders(List.of("Polaris-Realm: default-realm"))
+                .setTokenDelegation(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogModule.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogModule.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestIcebergRestCatalogModule
+{
+    @Test
+    void testTokenDelegationRequiresUserSession()
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setTokenDelegation(true)
+                .setSessionType(IcebergRestCatalogConfig.SessionType.NONE);
+
+        assertThatThrownBy(() -> validateConfig(config, new IcebergRestCatalogSigV4Config(), new IcebergRestCatalogTokenExchangeConfig()))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("iceberg.rest-catalog.token-delegation requires iceberg.rest-catalog.session=user");
+    }
+
+    @Test
+    void testStsWebIdentityRequiresUserSession()
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setSessionType(IcebergRestCatalogConfig.SessionType.NONE);
+
+        IcebergRestCatalogSigV4Config sigV4Config = new IcebergRestCatalogSigV4Config()
+                .setStsWebIdentity(true);
+
+        assertThatThrownBy(() -> validateConfig(config, sigV4Config, new IcebergRestCatalogTokenExchangeConfig()))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("iceberg.rest-catalog.sts-web-identity requires iceberg.rest-catalog.session=user");
+    }
+
+    @Test
+    void testTokenExchangeRequiresUserSession()
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setSessionType(IcebergRestCatalogConfig.SessionType.NONE);
+
+        IcebergRestCatalogTokenExchangeConfig tokenExchangeConfig = enabledTokenExchangeConfig();
+
+        assertThatThrownBy(() -> validateConfig(config, new IcebergRestCatalogSigV4Config(), tokenExchangeConfig))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("iceberg.rest-catalog.token-exchange-enabled requires iceberg.rest-catalog.session=user");
+    }
+
+    @Test
+    void testTokenDelegationWithUserSessionIsValid()
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setTokenDelegation(true)
+                .setSessionType(IcebergRestCatalogConfig.SessionType.USER);
+
+        validateConfig(config, new IcebergRestCatalogSigV4Config(), new IcebergRestCatalogTokenExchangeConfig());
+    }
+
+    @Test
+    void testStsWebIdentityWithUserSessionIsValid()
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setSessionType(IcebergRestCatalogConfig.SessionType.USER);
+
+        IcebergRestCatalogSigV4Config sigV4Config = new IcebergRestCatalogSigV4Config()
+                .setStsWebIdentity(true);
+
+        validateConfig(config, sigV4Config, new IcebergRestCatalogTokenExchangeConfig());
+    }
+
+    @Test
+    void testTokenExchangeWithUserSessionIsValid()
+    {
+        IcebergRestCatalogConfig config = new IcebergRestCatalogConfig()
+                .setSessionType(IcebergRestCatalogConfig.SessionType.USER);
+
+        validateConfig(config, new IcebergRestCatalogSigV4Config(), enabledTokenExchangeConfig());
+    }
+
+    private static IcebergRestCatalogTokenExchangeConfig enabledTokenExchangeConfig()
+    {
+        return new IcebergRestCatalogTokenExchangeConfig()
+                .setEnabled(true)
+                .setEndpoint(URI.create("https://login.microsoftonline.com/tenant/oauth2/v2.0/token"))
+                .setClientId("client-id")
+                .setClientSecret("client-secret")
+                .setScope("api://minio/storage.access");
+    }
+
+    // Mirrors the validation logic in IcebergRestCatalogModule.setup()
+    private static void validateConfig(
+            IcebergRestCatalogConfig config,
+            IcebergRestCatalogSigV4Config sigV4Config,
+            IcebergRestCatalogTokenExchangeConfig tokenExchangeConfig)
+    {
+        if (config.isTokenDelegation() && config.getSessionType() != IcebergRestCatalogConfig.SessionType.USER) {
+            throw new TrinoException(
+                    io.trino.spi.StandardErrorCode.NOT_SUPPORTED,
+                    "iceberg.rest-catalog.token-delegation requires iceberg.rest-catalog.session=user");
+        }
+        if (sigV4Config.isStsWebIdentity() && config.getSessionType() != IcebergRestCatalogConfig.SessionType.USER) {
+            throw new TrinoException(
+                    io.trino.spi.StandardErrorCode.NOT_SUPPORTED,
+                    "iceberg.rest-catalog.sts-web-identity requires iceberg.rest-catalog.session=user");
+        }
+        if (tokenExchangeConfig.isEnabled() && config.getSessionType() != IcebergRestCatalogConfig.SessionType.USER) {
+            throw new TrinoException(
+                    io.trino.spi.StandardErrorCode.NOT_SUPPORTED,
+                    "iceberg.rest-catalog.token-exchange-enabled requires iceberg.rest-catalog.session=user");
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogSigV4Config.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogSigV4Config.java
@@ -13,14 +13,11 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
-import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestIcebergRestCatalogSigV4Config
 {
@@ -28,19 +25,47 @@ final class TestIcebergRestCatalogSigV4Config
     void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(IcebergRestCatalogSigV4Config.class)
-                .setSigningName("execute-api"));
+                .setSigningName("execute-api")
+                .setStsWebIdentity(false)
+                .setStsRoleArn(null)
+                .setStsPolicy(null)
+                .setStsDurationSeconds(null));
     }
 
     @Test
-    void testExplicitPropertyMappings()
+    void testPropertyMappings()
     {
-        Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("iceberg.rest-catalog.signing-name", "glue")
-                .buildOrThrow();
+        IcebergRestCatalogSigV4Config config = new IcebergRestCatalogSigV4Config()
+                .setSigningName("glue")
+                .setStsWebIdentity(true)
+                .setStsRoleArn("arn:aws:iam::123456789012:role/my-role")
+                .setStsDurationSeconds(3600);
 
-        IcebergRestCatalogSigV4Config expected = new IcebergRestCatalogSigV4Config()
-                .setSigningName("glue");
+        assertThat(config.getSigningName()).isEqualTo("glue");
+        assertThat(config.isStsWebIdentity()).isTrue();
+        assertThat(config.getStsRoleArn()).hasValue("arn:aws:iam::123456789012:role/my-role");
+        assertThat(config.getStsPolicy()).isEmpty();
+        assertThat(config.getStsDurationSeconds()).hasValue(3600);
+    }
 
-        assertFullMapping(properties, expected);
+    @Test
+    void testStsPolicyAlternativeToRoleArn()
+    {
+        IcebergRestCatalogSigV4Config config = new IcebergRestCatalogSigV4Config()
+                .setStsPolicy("{\"Version\":\"2012-10-17\",\"Statement\":[]}");
+
+        assertThat(config.getStsPolicy()).hasValue("{\"Version\":\"2012-10-17\",\"Statement\":[]}");
+        assertThat(config.getStsRoleArn()).isEmpty();
+        assertThat(config.isStsRoleArnAndPolicyMutuallyExclusive()).isTrue();
+    }
+
+    @Test
+    void testRoleArnAndPolicyMutuallyExclusive()
+    {
+        IcebergRestCatalogSigV4Config config = new IcebergRestCatalogSigV4Config()
+                .setStsRoleArn("arn:aws:iam::123456789012:role/my-role")
+                .setStsPolicy("{\"Version\":\"2012-10-17\",\"Statement\":[]}");
+
+        assertThat(config.isStsRoleArnAndPolicyMutuallyExclusive()).isFalse();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogTokenExchangeConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogTokenExchangeConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestIcebergRestCatalogTokenExchangeConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(IcebergRestCatalogTokenExchangeConfig.class)
+                .setEnabled(false)
+                .setEndpoint(null)
+                .setClientId(null)
+                .setClientSecret(null)
+                .setScope(null));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.rest-catalog.token-exchange-enabled", "true")
+                .put("iceberg.rest-catalog.token-exchange.endpoint", "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token")
+                .put("iceberg.rest-catalog.token-exchange.client-id", "07de6257-6b90-4027-ba77-488f83c8d181")
+                .put("iceberg.rest-catalog.token-exchange.client-secret", "super-secret")
+                .put("iceberg.rest-catalog.token-exchange.scope", "api://minio/storage.access")
+                .buildOrThrow();
+
+        IcebergRestCatalogTokenExchangeConfig expected = new IcebergRestCatalogTokenExchangeConfig()
+                .setEnabled(true)
+                .setEndpoint(URI.create("https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token"))
+                .setClientId("07de6257-6b90-4027-ba77-488f83c8d181")
+                .setClientSecret("super-secret")
+                .setScope("api://minio/storage.access");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOidcStsCredentialExchanger.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOidcStsCredentialExchanger.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+import java.time.Instant;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestOidcStsCredentialExchanger
+{
+    // --- extractClaim ---
+
+    @Test
+    void testExtractClaim_returnsValue()
+    {
+        String jwt = makeJwt("{\"sub\":\"user1\",\"exp\":9999999999}");
+        assertThat(OidcStsCredentialExchanger.extractClaim(jwt, "sub")).isEqualTo("user1");
+        assertThat(OidcStsCredentialExchanger.extractClaim(jwt, "exp")).isEqualTo("9999999999");
+    }
+
+    @Test
+    void testExtractClaim_missingClaim_returnsNull()
+    {
+        String jwt = makeJwt("{\"sub\":\"user1\"}");
+        assertThat(OidcStsCredentialExchanger.extractClaim(jwt, "exp")).isNull();
+    }
+
+    @Test
+    void testExtractClaim_malformedJwt_returnsNull()
+    {
+        assertThat(OidcStsCredentialExchanger.extractClaim("notajwt", "sub")).isNull();
+        assertThat(OidcStsCredentialExchanger.extractClaim("", "sub")).isNull();
+    }
+
+    // --- computeDuration ---
+
+    @Test
+    void testComputeDuration_usesExpClaim()
+    {
+        long futureExp = Instant.now().getEpochSecond() + 7200;
+        String jwt = makeJwt("{\"sub\":\"u\",\"exp\":" + futureExp + "}");
+        int duration = OidcStsCredentialExchanger.computeDuration(jwt);
+        // Allow ±5 s for test execution time
+        assertThat(duration).isBetween(7195, 7205);
+    }
+
+    @Test
+    void testComputeDuration_expiredToken_fallsBackToMinimum()
+    {
+        long pastExp = Instant.now().getEpochSecond() - 3600;
+        String jwt = makeJwt("{\"sub\":\"u\",\"exp\":" + pastExp + "}");
+        assertThat(OidcStsCredentialExchanger.computeDuration(jwt)).isEqualTo(900);
+    }
+
+    @Test
+    void testComputeDuration_noExpClaim_fallsBackToMinimum()
+    {
+        String jwt = makeJwt("{\"sub\":\"u\"}");
+        assertThat(OidcStsCredentialExchanger.computeDuration(jwt)).isEqualTo(900);
+    }
+
+    @Test
+    void testComputeDuration_malformedJwt_fallsBackToMinimum()
+    {
+        assertThat(OidcStsCredentialExchanger.computeDuration("notajwt")).isEqualTo(900);
+    }
+
+    // --- getCredentials caching ---
+
+    @Test
+    void testGetCredentials_cachesOnSub()
+    {
+        Instant farFuture = Instant.now().plusSeconds(7200);
+        AwsSessionCredentials creds = AwsSessionCredentials.create("AK", "SK", "ST");
+        CountingExchanger exchanger = new CountingExchanger(creds, farFuture);
+
+        String jwt = makeJwt("{\"sub\":\"alice\",\"exp\":" + farFuture.getEpochSecond() + "}");
+
+        AwsSessionCredentials first = exchanger.getCredentials(jwt);
+        AwsSessionCredentials second = exchanger.getCredentials(jwt);
+
+        assertThat(first).isSameAs(second);
+        assertThat(exchanger.exchangeCallCount).isEqualTo(1);
+    }
+
+    @Test
+    void testGetCredentials_differentSubsCachedSeparately()
+    {
+        Instant farFuture = Instant.now().plusSeconds(7200);
+        AwsSessionCredentials creds = AwsSessionCredentials.create("AK", "SK", "ST");
+        CountingExchanger exchanger = new CountingExchanger(creds, farFuture);
+
+        String jwtAlice = makeJwt("{\"sub\":\"alice\",\"exp\":" + farFuture.getEpochSecond() + "}");
+        String jwtBob = makeJwt("{\"sub\":\"bob\",\"exp\":" + farFuture.getEpochSecond() + "}");
+
+        exchanger.getCredentials(jwtAlice);
+        exchanger.getCredentials(jwtBob);
+        exchanger.getCredentials(jwtAlice);
+
+        assertThat(exchanger.exchangeCallCount).isEqualTo(2);
+    }
+
+    @Test
+    void testGetCredentials_refreshesWhenNearExpiry()
+    {
+        Instant nearExpiry = Instant.now().plusSeconds(30);
+        AwsSessionCredentials creds = AwsSessionCredentials.create("AK", "SK", "ST");
+        CountingExchanger exchanger = new CountingExchanger(creds, nearExpiry);
+
+        String jwt = makeJwt("{\"sub\":\"alice\",\"exp\":" + nearExpiry.getEpochSecond() + "}");
+
+        exchanger.getCredentials(jwt);
+        exchanger.getCredentials(jwt);
+
+        assertThat(exchanger.exchangeCallCount).isEqualTo(2);
+    }
+
+    // --- helpers ---
+
+    private static String makeJwt(String payloadJson)
+    {
+        Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+        String header = enc.encodeToString("{\"alg\":\"none\"}".getBytes(UTF_8));
+        String payload = enc.encodeToString(payloadJson.getBytes(UTF_8));
+        return header + "." + payload + ".fakesig";
+    }
+
+    private static final class CountingExchanger
+            extends OidcStsCredentialExchanger
+    {
+        int exchangeCallCount;
+        private final AwsSessionCredentials credentials;
+        private final Instant expiresAt;
+
+        CountingExchanger(AwsSessionCredentials credentials, Instant expiresAt)
+        {
+            super(null, "test-role");
+            this.credentials = credentials;
+            this.expiresAt = expiresAt;
+        }
+
+        @Override
+        CachedCredentials exchange(String oidcToken, String sub)
+        {
+            exchangeCallCount++;
+            return new CachedCredentials(credentials, expiresAt);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOidcTokenExchanger.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOidcTokenExchanger.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestOidcTokenExchanger
+{
+    // --- getToken caching ---
+
+    @Test
+    void testGetToken_cachesOnSub()
+    {
+        Instant farFuture = Instant.now().plusSeconds(7200);
+        FakeExchanger exchanger = new FakeExchanger("exchanged-token", farFuture);
+
+        String jwt = makeJwt("{\"sub\":\"alice\",\"exp\":" + farFuture.getEpochSecond() + "}");
+
+        String first = exchanger.getToken(jwt);
+        String second = exchanger.getToken(jwt);
+
+        assertThat(first).isEqualTo("exchanged-token");
+        assertThat(first).isSameAs(second);
+        assertThat(exchanger.callCount).isEqualTo(1);
+    }
+
+    @Test
+    void testGetToken_differentSubsCachedSeparately()
+    {
+        Instant farFuture = Instant.now().plusSeconds(7200);
+        FakeExchanger exchanger = new FakeExchanger("exchanged-token", farFuture);
+
+        String jwtAlice = makeJwt("{\"sub\":\"alice\",\"exp\":" + farFuture.getEpochSecond() + "}");
+        String jwtBob = makeJwt("{\"sub\":\"bob\",\"exp\":" + farFuture.getEpochSecond() + "}");
+
+        exchanger.getToken(jwtAlice);
+        exchanger.getToken(jwtBob);
+        exchanger.getToken(jwtAlice);
+
+        assertThat(exchanger.callCount).isEqualTo(2);
+    }
+
+    @Test
+    void testGetToken_refreshesWhenNearExpiry()
+    {
+        Instant nearExpiry = Instant.now().plusSeconds(30);
+        FakeExchanger exchanger = new FakeExchanger("exchanged-token", nearExpiry);
+
+        String jwt = makeJwt("{\"sub\":\"alice\",\"exp\":" + nearExpiry.getEpochSecond() + "}");
+
+        exchanger.getToken(jwt);
+        exchanger.getToken(jwt);
+
+        assertThat(exchanger.callCount).isEqualTo(2);
+    }
+
+    // --- helpers ---
+
+    private static String makeJwt(String payloadJson)
+    {
+        Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+        String header = enc.encodeToString("{\"alg\":\"none\"}".getBytes(UTF_8));
+        String payload = enc.encodeToString(payloadJson.getBytes(UTF_8));
+        return header + "." + payload + ".fakesig";
+    }
+
+    private static final class FakeExchanger
+            extends OidcTokenExchanger
+    {
+        int callCount;
+        private final String token;
+        private final Instant expiresAt;
+
+        FakeExchanger(String token, Instant expiresAt)
+        {
+            super(URI.create("http://fake-endpoint"), "client-id", "client-secret", "api://minio/storage.access");
+            this.token = token;
+            this.expiresAt = expiresAt;
+        }
+
+        @Override
+        CachedToken exchange(String oidcToken)
+        {
+            callCount++;
+            return new CachedToken(token, expiresAt);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -115,6 +115,8 @@ public class TestTrinoRestCatalog
                 Security.NONE,
                 NONE,
                 ImmutableMap.of(),
+                Optional.empty(),
+                new UserTokenProvider(Optional.empty()),
                 nestedNamespaceEnabled,
                 "test",
                 TESTING_TYPE_MANAGER,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalogConvert.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalogConvert.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.cache.EvictableCacheBuilder;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.TestingConnectorSession;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType.USER;
+import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.iceberg.aws.AwsProperties.REST_ACCESS_KEY_ID;
+import static org.apache.iceberg.aws.AwsProperties.REST_SECRET_ACCESS_KEY;
+import static org.apache.iceberg.aws.AwsProperties.REST_SESSION_TOKEN;
+import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestTrinoRestCatalogConvert
+{
+    @Test
+    void testConvertWithStsExchanger_callsExchanger()
+            throws IOException
+    {
+        TrackingStsExchanger stsExchanger = new TrackingStsExchanger();
+        UserTokenProvider tokenProvider = providerWithNoExchange();
+        TrinoRestCatalog catalog = createCatalog(Optional.of(stsExchanger), tokenProvider);
+
+        ConnectorSession session = sessionWithToken("test-oidc-jwt");
+        SessionCatalog.SessionContext ctx = catalog.convert(session);
+
+        assertThat(stsExchanger.callCount).isEqualTo(1);
+        assertThat(ctx.credentials())
+                .containsEntry(REST_ACCESS_KEY_ID, "access-key")
+                .containsEntry(REST_SECRET_ACCESS_KEY, "secret-key")
+                .containsEntry(REST_SESSION_TOKEN, "session-token")
+                .doesNotContainKey(TOKEN);
+    }
+
+    @Test
+    void testConvertWithStsExchanger_noToken_skipsExchanger()
+            throws IOException
+    {
+        TrackingStsExchanger stsExchanger = new TrackingStsExchanger();
+        UserTokenProvider tokenProvider = providerWithNoExchange();
+        TrinoRestCatalog catalog = createCatalog(Optional.of(stsExchanger), tokenProvider);
+
+        ConnectorSession session = sessionWithoutToken();
+        SessionCatalog.SessionContext ctx = catalog.convert(session);
+
+        assertThat(stsExchanger.callCount).isEqualTo(0);
+        assertThat(ctx.credentials()).doesNotContainKey(REST_ACCESS_KEY_ID);
+    }
+
+    @Test
+    void testConvertWithoutStsExchanger_forwardsTokenDirectly()
+            throws IOException
+    {
+        UserTokenProvider tokenProvider = providerWithNoExchange();
+        TrinoRestCatalog catalog = createCatalog(Optional.empty(), tokenProvider);
+
+        ConnectorSession session = sessionWithToken("test-oidc-jwt");
+        SessionCatalog.SessionContext ctx = catalog.convert(session);
+
+        assertThat(ctx.credentials())
+                .doesNotContainKey(REST_ACCESS_KEY_ID)
+                .containsEntry(TOKEN, "test-oidc-jwt");
+    }
+
+    @Test
+    void testConvertWithTokenExchange_exchangedTokenPassedToSts()
+            throws IOException
+    {
+        TrackingStsExchanger stsExchanger = new TrackingStsExchanger();
+        UserTokenProvider tokenProvider = providerWithExchange("exchanged-token");
+        TrinoRestCatalog catalog = createCatalog(Optional.of(stsExchanger), tokenProvider);
+
+        ConnectorSession session = sessionWithToken("original-token");
+        catalog.convert(session);
+
+        assertThat(stsExchanger.lastReceivedToken).isEqualTo("exchanged-token");
+    }
+
+    @Test
+    void testConvertWithTokenExchange_noSts_forwardsExchangedToken()
+            throws IOException
+    {
+        UserTokenProvider tokenProvider = providerWithExchange("exchanged-token");
+        TrinoRestCatalog catalog = createCatalog(Optional.empty(), tokenProvider);
+
+        ConnectorSession session = sessionWithToken("original-token");
+        SessionCatalog.SessionContext ctx = catalog.convert(session);
+
+        assertThat(ctx.credentials()).containsEntry(TOKEN, "exchanged-token");
+    }
+
+    private static UserTokenProvider providerWithNoExchange()
+    {
+        return new UserTokenProvider(Optional.empty());
+    }
+
+    private static UserTokenProvider providerWithExchange(String exchangedToken)
+    {
+        return new UserTokenProvider(Optional.of(new FixedTokenExchanger(exchangedToken)));
+    }
+
+    private static TrinoRestCatalog createCatalog(Optional<OidcStsCredentialExchanger> stsExchanger, UserTokenProvider tokenProvider)
+            throws IOException
+    {
+        Path warehouseLocation = Files.createTempDirectory(null);
+        warehouseLocation.toFile().deleteOnExit();
+
+        String catalogName = "iceberg_rest";
+        RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog
+                .builder()
+                .delegate(backendCatalog(warehouseLocation))
+                .build();
+        restSessionCatalog.initialize(catalogName, ImmutableMap.of());
+
+        return new TrinoRestCatalog(
+                restSessionCatalog,
+                new CatalogName(catalogName),
+                USER,
+                ImmutableMap.of(),
+                stsExchanger,
+                tokenProvider,
+                false,
+                "test",
+                TESTING_TYPE_MANAGER,
+                false,
+                false,
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
+                EvictableCacheBuilder.newBuilder().expireAfterWrite(1000, MILLISECONDS).shareNothingWhenDisabled().build(),
+                true);
+    }
+
+    private static ConnectorSession sessionWithToken(String token)
+    {
+        return TestingConnectorSession.builder()
+                .setIdentity(ConnectorIdentity.forUser("testuser")
+                        .withExtraCredentials(Map.of(TOKEN, token))
+                        .build())
+                .build();
+    }
+
+    private static ConnectorSession sessionWithoutToken()
+    {
+        return TestingConnectorSession.builder()
+                .setIdentity(ConnectorIdentity.forUser("testuser")
+                        .withExtraCredentials(ImmutableMap.of())
+                        .build())
+                .build();
+    }
+
+    private static final class TrackingStsExchanger
+            extends OidcStsCredentialExchanger
+    {
+        int callCount;
+        String lastReceivedToken;
+
+        TrackingStsExchanger()
+        {
+            super(null, "test-role");
+        }
+
+        @Override
+        public AwsSessionCredentials getCredentials(String catalogToken)
+        {
+            callCount++;
+            lastReceivedToken = catalogToken;
+            return AwsSessionCredentials.create("access-key", "secret-key", "session-token");
+        }
+
+        @Override
+        CachedCredentials exchange(String catalogToken, String sub)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class FixedTokenExchanger
+            extends OidcTokenExchanger
+    {
+        private final String token;
+
+        FixedTokenExchanger(String token)
+        {
+            super(URI.create("http://fake"), "client", "secret", "scope");
+            this.token = token;
+        }
+
+        @Override
+        public String getToken(String oidcToken)
+        {
+            return token;
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestUserTokenProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestUserTokenProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestUserTokenProvider
+{
+    @Test
+    void testCatalogToken_noExchanger_returnsOriginalToken()
+    {
+        UserTokenProvider provider = new UserTokenProvider(Optional.empty());
+        ConnectorSession session = sessionWithToken("original-token");
+
+        assertThat(provider.catalogToken(session)).hasValue("original-token");
+    }
+
+    @Test
+    void testCatalogToken_withExchanger_returnsExchangedToken()
+    {
+        FakeExchanger exchanger = new FakeExchanger("exchanged-token");
+        UserTokenProvider provider = new UserTokenProvider(Optional.of(exchanger));
+        ConnectorSession session = sessionWithToken("original-token");
+
+        assertThat(provider.catalogToken(session)).hasValue("exchanged-token");
+        assertThat(exchanger.receivedToken).isEqualTo("original-token");
+    }
+
+    @Test
+    void testCatalogToken_noToken_returnsEmpty()
+    {
+        UserTokenProvider provider = new UserTokenProvider(Optional.empty());
+        ConnectorSession session = sessionWithoutToken();
+
+        assertThat(provider.catalogToken(session)).isEmpty();
+    }
+
+    @Test
+    void testCatalogToken_noToken_exchangerNotCalled()
+    {
+        FakeExchanger exchanger = new FakeExchanger("exchanged-token");
+        UserTokenProvider provider = new UserTokenProvider(Optional.of(exchanger));
+        ConnectorSession session = sessionWithoutToken();
+
+        assertThat(provider.catalogToken(session)).isEmpty();
+        assertThat(exchanger.receivedToken).isNull();
+    }
+
+    private static ConnectorSession sessionWithToken(String token)
+    {
+        return TestingConnectorSession.builder()
+                .setIdentity(ConnectorIdentity.forUser("testuser")
+                        .withExtraCredentials(Map.of(TOKEN, token))
+                        .build())
+                .build();
+    }
+
+    private static ConnectorSession sessionWithoutToken()
+    {
+        return TestingConnectorSession.builder()
+                .setIdentity(ConnectorIdentity.forUser("testuser")
+                        .withExtraCredentials(Map.of())
+                        .build())
+                .build();
+    }
+
+    private static final class FakeExchanger
+            extends OidcTokenExchanger
+    {
+        String receivedToken;
+        private final String returnToken;
+
+        FakeExchanger(String returnToken)
+        {
+            super(URI.create("http://fake"), "client", "secret", "scope");
+            this.returnToken = returnToken;
+        }
+
+        @Override
+        public String getToken(String oidcToken)
+        {
+            this.receivedToken = oidcToken;
+            return returnToken;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

  This PR adds a configurable per-user authentication pipeline to the Iceberg
  REST catalog connector, targeting deployments where the catalog requires
  caller identity — either as a bearer token (OAuth2) or as scoped AWS
  credentials (SigV4 with AssumeRoleWithWebIdentity). The primary motivation
  is MinIO AIStor Tables, which expects per-user STS credentials derived from
  the authenticated user's OIDC token, but the design is intentionally general.

  ### How it works

  When `session=USER`, the connector can now do one or more of the following
  at query time, in order:

  1. **RFC 8693 token exchange** (`token-exchange-enabled=true`): the user's
     OIDC token is exchanged for an audience-scoped token by posting to a
     configurable endpoint (e.g. an identity provider that issues MinIO-audience
     tokens). Additional form parameters are supported via
     `token-exchange.extra.*` for vendor-specific extensions (e.g.
     `requested_token_use=on_behalf_of` for Azure OBO flows).

  2. **STS web identity exchange** (`sts-web-identity=true`): the token from
     step 1 (or the raw OIDC token if exchange is disabled) is passed to
     `AssumeRoleWithWebIdentity`. The resulting temporary AWS credentials
     (`accessKeyId`, `secretAccessKey`, `sessionToken`) are injected into the
     per-user catalog session, scoping every REST request to the Trino user's
     IAM identity.

  3. **Token delegation** (`token-delegation=true`): the OIDC token (and any
     extra credentials) are forwarded directly to the catalog session for
     OAuth2 catalogs that accept user bearer tokens without STS.

  STS credentials are cached per JWT `sub` claim and refreshed before expiry.
  The same credential pipeline runs during catalog initialization so that the
  `/v1/config` bootstrap call is also authenticated.

  ### New configuration properties

  | Property | Description |
  |---|---|
  | `iceberg.rest-catalog.token-delegation` | Forward OIDC token to per-user session |
  | `iceberg.rest-catalog.sts-web-identity` | Exchange OIDC token for STS credentials |
  | `iceberg.rest-catalog.token-exchange-enabled` | Enable RFC 8693 exchange step |
  | `iceberg.rest-catalog.token-exchange.endpoint` | Token exchange endpoint URL |
  | `iceberg.rest-catalog.token-exchange.client-id` | OAuth2 client ID |
  | `iceberg.rest-catalog.token-exchange.client-secret` | OAuth2 client secret |
  | `iceberg.rest-catalog.token-exchange.scope` | Requested scope |
  | `iceberg.rest-catalog.token-exchange.extra.*` | Additional form parameters |
  | `iceberg.rest-catalog.sts-role-arn` | IAM role ARN (overrides `s3.iam-role`) |
  | `iceberg.rest-catalog.sts-policy` | Inline session policy |
  | `iceberg.rest-catalog.sts-duration-seconds` | Fixed STS session duration |

  ### Testing

  - `TestOidcStsCredentialExchanger` — credential exchange, caching, and expiry
  - `TestOidcTokenExchanger` — RFC 8693 HTTP exchange and per-subject cache
  - `TestUserTokenProvider` — token routing logic
  - `TestTrinoRestCatalogConvert` — session context assembly with and without STS
  - `TestIcebergRestCatalogModule` — Guice wiring for all optional components
  - `TestIcebergRestCatalogTokenExchangeConfig` / `TestIcebergRestCatalogSigV4Config`
    — config validation and property coverage