### PR TITLE
CLI: Revert JLine from 4.1.0 to 4.0.15 to avoid FFM issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
     ignore:
       # TODO remove once https://github.com/aws/amazon-redshift-jdbc-driver/issues/148 has been addressed
       - dependency-name: "com.amazon.redshift:redshift-jdbc42"
+      # TODO remove once https://github.com/jline/jline3/issues/1879 has been addressed
+      - dependency-name: "org.jline:jline-*"
   - package-ecosystem: "npm"
     directory: "/core/trino-web-ui/src/main/resources/webapp-preview"
     schedule:

--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -18,7 +18,8 @@
         <airstyle.rewriteUnusedLambdaParameters>false</airstyle.rewriteUnusedLambdaParameters>
         <checkstyle.violation.ignore>UnusedLambdaParameterShouldBeUnnamed,UseEnhancedSwitch</checkstyle.violation.ignore>
         <main-class>io.trino.cli.Trino</main-class>
-        <dep.jline.version>4.1.0</dep.jline.version>
+        <!-- TODO upgrade once https://github.com/jline/jline3/issues/1879 has been addressed -->
+        <dep.jline.version>4.0.15</dep.jline.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
In the latest master, trino-cli exits immediately after it starts on my laptop (Java 25 on M2 Mac).

This seems to be caused by FFM related issue in JLine 4.1.0. It would be better to stay at JLine 4.0.15 or drop jline-terminal-ffm dependency to force using JNI provider regardless of Java version until the issue is fixed on JLine side.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/jline/jline3/issues/1879
- https://github.com/trinodb/trino/pull/29477

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
