### PR TITLE
Only run CI disk cleanup when needed

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -36,7 +36,15 @@ runs:
       - name: Free additional disk space
         if: ${{ format('{0}', inputs.cleanup-node) == 'true' }}
         shell: bash
-        run: ./.github/bin/free-disk-space.sh
+        run: |
+          available_kb=$(df -k . | awk 'NR == 2 {print $4}')
+          available_gb=$((available_kb / 1024 / 1024))
+          if ((available_gb < 40)); then
+            echo "Only ${available_gb} GiB available, running disk cleanup"
+            ./.github/bin/free-disk-space.sh
+          else
+            echo "Skipping disk cleanup, ${available_gb} GiB available"
+          fi
       - uses: actions/setup-java@v5
         if: ${{ inputs.java-version != '' }}
         with:
@@ -142,3 +150,6 @@ runs:
         if: ${{ inputs.java-version != '' }}
         shell: bash
         run: echo "::add-matcher::.github/problem-matcher.json"
+      - name: Display disk usage
+        shell: bash
+        run: df -h .

--- a/.github/bin/free-disk-space.sh
+++ b/.github/bin/free-disk-space.sh
@@ -35,11 +35,11 @@ function free_up_disk_space_ubuntu()
 }
 
 echo "Disk space usage before cleaning:"
-df -k .
+df -h .
 
 echo "::group::Clearing up disk usage"
 time free_up_disk_space_ubuntu
 echo "::endgroup::"
 
 echo "Disk space usage after cleaning:"
-df -k .
+df -h .


### PR DESCRIPTION
## Description

Most runners have ~90GB of free disk space now, so we don't need to spend several minutes cleaning the disk. Check available disk space and only cleanup if needed.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
