### PR TITLE
Limit output page size in RegularTableFunctionPartition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/function/RegularTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/RegularTableFunctionPartition.java
@@ -44,8 +44,10 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -74,6 +76,9 @@ public class RegularTableFunctionPartition
 
     // number of processed input positions from partition start. all sources have been processed up to this position, except the sources whose partitions ended earlier.
     private int processedPositions;
+
+    // maximum number of output rows per page, derived from average pass-through bytes per row in PagesIndex
+    private final int maxRowsPerOutputPage;
 
     public RegularTableFunctionPartition(
             PagesIndex pagesIndex,
@@ -110,6 +115,27 @@ public class RegularTableFunctionPartition
         for (int i = 0; i < passThroughSpecifications.size(); i++) {
             passThroughProviders[i] = createColumnProvider(passThroughSpecifications.get(i));
         }
+        this.maxRowsPerOutputPage = computeMaxRowsPerOutputPage(passThroughSpecifications);
+    }
+
+    private int computeMaxRowsPerOutputPage(List<PassThroughColumnSpecification> passThroughSpecifications)
+    {
+        long totalPassthroughBytes = 0;
+        for (PassThroughColumnSpecification spec : passThroughSpecifications) {
+            if (!spec.isPartitioningColumn()) {
+                for (Block block : pagesIndex.getChannel(spec.inputChannel())) {
+                    totalPassthroughBytes += block.getSizeInBytes();
+                }
+            }
+        }
+        if (totalPassthroughBytes == 0) {
+            return Integer.MAX_VALUE;
+        }
+        long averageBytesPerRow = totalPassthroughBytes / pagesIndex.getPositionCount();
+        if (averageBytesPerRow == 0) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) max(1, min((long) DEFAULT_MAX_PAGE_SIZE_IN_BYTES / averageBytesPerRow, Integer.MAX_VALUE));
     }
 
     @Override
@@ -118,10 +144,17 @@ public class RegularTableFunctionPartition
         return WorkProcessor.create(new WorkProcessor.Process<>()
         {
             List<Optional<Page>> inputPages = prepareInputPages();
+            // un-materialized table function result pending split; null when no split is in progress
+            Page pendingPage;
+            int pendingOffset;
 
             @Override
             public WorkProcessor.ProcessState<Page> process()
             {
+                if (pendingPage != null) {
+                    return WorkProcessor.ProcessState.ofResult(nextChunk());
+                }
+
                 TableFunctionProcessorState state = tableFunction.process(inputPages);
                 boolean functionGotNoData = inputPages == null;
                 if (state == FINISHED) {
@@ -135,12 +168,25 @@ public class RegularTableFunctionPartition
                     inputPages = prepareInputPages();
                 }
                 if (processed.getResult() != null) {
-                    return WorkProcessor.ProcessState.ofResult(appendPassThroughColumns(processed.getResult()));
+                    pendingPage = processed.getResult();
+                    pendingOffset = 0;
+                    return WorkProcessor.ProcessState.ofResult(nextChunk());
                 }
                 if (functionGotNoData) {
                     throw new TrinoException(FUNCTION_IMPLEMENTATION_ERROR, "When function got no input, it should either produce output or return Blocked state");
                 }
                 return WorkProcessor.ProcessState.blocked(immediateFuture(null));
+            }
+
+            private Page nextChunk()
+            {
+                int chunkSize = min(maxRowsPerOutputPage, pendingPage.getPositionCount() - pendingOffset);
+                Page chunk = appendPassThroughColumns(pendingPage.getRegion(pendingOffset, chunkSize));
+                pendingOffset += chunkSize;
+                if (pendingOffset >= pendingPage.getPositionCount()) {
+                    pendingPage = null;
+                }
+                return chunk;
             }
         });
     }

--- a/core/trino-main/src/main/java/io/trino/operator/function/RegularTableFunctionPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/RegularTableFunctionPartition.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.WorkProcessor;
 import io.trino.spi.Page;
@@ -80,6 +82,8 @@ public class RegularTableFunctionPartition
     // maximum number of output rows per page, derived from average pass-through bytes per row in PagesIndex
     private final int maxRowsPerOutputPage;
 
+    private final LocalMemoryContext memoryContext;
+
     public RegularTableFunctionPartition(
             PagesIndex pagesIndex,
             int partitionStart,
@@ -89,7 +93,8 @@ public class RegularTableFunctionPartition
             int passThroughSourcesCount,
             List<List<Integer>> requiredChannels,
             Optional<Map<Integer, Integer>> markerChannels,
-            List<PassThroughColumnSpecification> passThroughSpecifications)
+            List<PassThroughColumnSpecification> passThroughSpecifications,
+            AggregatedMemoryContext memoryContext)
     {
         checkArgument(pagesIndex.getPositionCount() != 0, "PagesIndex is empty for regular table function partition");
         this.pagesIndex = pagesIndex;
@@ -116,6 +121,7 @@ public class RegularTableFunctionPartition
             passThroughProviders[i] = createColumnProvider(passThroughSpecifications.get(i));
         }
         this.maxRowsPerOutputPage = computeMaxRowsPerOutputPage(passThroughSpecifications);
+        this.memoryContext = memoryContext.newLocalMemoryContext(RegularTableFunctionPartition.class.getSimpleName());
     }
 
     private int computeMaxRowsPerOutputPage(List<PassThroughColumnSpecification> passThroughSpecifications)
@@ -158,6 +164,7 @@ public class RegularTableFunctionPartition
                 TableFunctionProcessorState state = tableFunction.process(inputPages);
                 boolean functionGotNoData = inputPages == null;
                 if (state == FINISHED) {
+                    memoryContext.close();
                     return WorkProcessor.ProcessState.finished();
                 }
                 if (state instanceof Blocked blocked) {
@@ -170,6 +177,7 @@ public class RegularTableFunctionPartition
                 if (processed.getResult() != null) {
                     pendingPage = processed.getResult();
                     pendingOffset = 0;
+                    memoryContext.setBytes(pendingPage.getRetainedSizeInBytes());
                     return WorkProcessor.ProcessState.ofResult(nextChunk());
                 }
                 if (functionGotNoData) {
@@ -185,6 +193,7 @@ public class RegularTableFunctionPartition
                 pendingOffset += chunkSize;
                 if (pendingOffset >= pendingPage.getPositionCount()) {
                     pendingPage = null;
+                    memoryContext.setBytes(0);
                 }
                 return chunk;
             }

--- a/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
@@ -592,7 +592,8 @@ public class TableFunctionOperator
                         passThroughSourcesCount,
                         requiredChannels,
                         markerChannels,
-                        passThroughSpecifications);
+                        passThroughSpecifications,
+                        operatorContext.aggregateUserMemoryContext());
 
                 partitionStart = partitionEnd;
                 return WorkProcessor.ProcessState.ofResult(partition);

--- a/core/trino-main/src/test/java/io/trino/operator/function/TestRegularTableFunctionPartition.java
+++ b/core/trino-main/src/test/java/io/trino/operator/function/TestRegularTableFunctionPartition.java
@@ -15,6 +15,7 @@ package io.trino.operator.function;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.RowPagesBuilder;
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.WorkProcessor;
 import io.trino.operator.function.RegularTableFunctionPartition.PassThroughColumnSpecification;
@@ -69,7 +70,8 @@ public class TestRegularTableFunctionPartition
                 1,   // passThroughSourcesCount
                 ImmutableList.of(ImmutableList.of(1)),   // requiredChannels: channel 1
                 Optional.empty(),                         // single source → no marker channels
-                ImmutableList.of(new PassThroughColumnSpecification(false, 0, 0)));
+                ImmutableList.of(new PassThroughColumnSpecification(false, 0, 0)),
+                AggregatedMemoryContext.newSimpleAggregatedMemoryContext());
         // pass-through spec: non-partitioning, input channel 0 (VARCHAR), index at output channel 0
 
         List<Page> outputPages = new ArrayList<>();

--- a/core/trino-main/src/test/java/io/trino/operator/function/TestRegularTableFunctionPartition.java
+++ b/core/trino-main/src/test/java/io/trino/operator/function/TestRegularTableFunctionPartition.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.function;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.RowPagesBuilder;
+import io.trino.operator.PagesIndex;
+import io.trino.operator.WorkProcessor;
+import io.trino.operator.function.RegularTableFunctionPartition.PassThroughColumnSpecification;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.table.TableFunctionDataProcessor;
+import io.trino.spi.function.table.TableFunctionProcessorState;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
+import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.usedInputAndProduced;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRegularTableFunctionPartition
+{
+    @Test
+    public void testOutputPageSizeBoundedWhenPassThroughDataIsLarge()
+    {
+        // When a table function expands one input row into many output rows the pass-through
+        // block builder in NonPartitioningColumnProvider is created with a null BlockBuilderStatus,
+        // so it grows without bound. With a 4 KB pass-through column and 2000 output rows the
+        // single block would be ~8 MB — well above DEFAULT_MAX_PAGE_SIZE_IN_BYTES (1 MB).
+        //
+        // After the fix, appendPassThroughColumns splits the result into multiple pages so that
+        // every page stays within the size limit.
+
+        // PagesIndex: channel 0 = VARCHAR pass-through (4 KB), channel 1 = BIGINT (required by TF)
+        PagesIndex pagesIndex = new PagesIndex.TestingFactory(false)
+                .newPagesIndex(ImmutableList.of(VARCHAR, BIGINT), 1);
+        pagesIndex.addPage(RowPagesBuilder.rowPagesBuilder(VARCHAR, BIGINT)
+                .row("x".repeat(4096), 0L)
+                .build()
+                .get(0));
+
+        // A processor that reads the single input row and emits 2000 output rows,
+        // each carrying a pass-through index pointing back to input row 0.
+        TableFunctionDataProcessor processor = new ExpandingProcessor(2000);
+
+        RegularTableFunctionPartition partition = new RegularTableFunctionPartition(
+                pagesIndex,
+                0,   // partitionStart
+                1,   // partitionEnd
+                processor,
+                0,   // properChannelsCount  (processor produces no proper columns)
+                1,   // passThroughSourcesCount
+                ImmutableList.of(ImmutableList.of(1)),   // requiredChannels: channel 1
+                Optional.empty(),                         // single source → no marker channels
+                ImmutableList.of(new PassThroughColumnSpecification(false, 0, 0)));
+        // pass-through spec: non-partitioning, input channel 0 (VARCHAR), index at output channel 0
+
+        List<Page> outputPages = new ArrayList<>();
+        WorkProcessor<Page> output = partition.toOutputPages();
+        output.iterator().forEachRemaining(outputPages::add);
+
+        // splitIntoPages must have fired: with avgBytesPerRow=4096 and limit=1MB,
+        // maxRowsPerOutputPage = 256, so 2000 rows → ceil(2000/256) = 8 pages.
+        assertThat(outputPages.size())
+                .as("number of output pages (proves splitIntoPages was called)")
+                .isEqualTo(8);
+
+        // Each output page must stay within a reasonable size bound.
+        for (Page page : outputPages) {
+            assertThat(page.getSizeInBytes())
+                    .as("output page size")
+                    .isLessThanOrEqualTo((long) DEFAULT_MAX_PAGE_SIZE_IN_BYTES * 2);
+        }
+
+        // Total row count across all pages must equal the expansion factor.
+        int totalRows = outputPages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat(totalRows).isEqualTo(2000);
+    }
+
+    private static class ExpandingProcessor
+            implements TableFunctionDataProcessor
+    {
+        private final int expansionFactor;
+        private boolean inputConsumed;
+
+        ExpandingProcessor(int expansionFactor)
+        {
+            this.expansionFactor = expansionFactor;
+        }
+
+        @Override
+        public TableFunctionProcessorState process(List<Optional<Page>> input)
+        {
+            if (input == null || inputConsumed) {
+                return FINISHED;
+            }
+            inputConsumed = true;
+            BlockBuilder indexBuilder = BIGINT.createFixedSizeBlockBuilder(expansionFactor);
+            for (int i = 0; i < expansionFactor; i++) {
+                BIGINT.writeLong(indexBuilder, 0L);
+            }
+            return usedInputAndProduced(new Page(indexBuilder.build()));
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonTable.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonTable.java
@@ -19,11 +19,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.stream.IntStream;
+
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.PATH_EVALUATION_ERROR;
 import static io.trino.spi.StandardErrorCode.UNSUPPORTED_SUBQUERY;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -970,5 +973,49 @@ public class TestJsonTable
                             ('[["g", "h"], ["i", "j"], ["k", "l"]]',         1,         null,      null,                    'i',                    1,        null,      null),
                             ('[["g", "h"], ["i", "j"], ["k", "l"]]',         1,         null,      null,                    'j',                    2,        null,      null)
                         """);
+    }
+
+    @Test
+    public void testPassThroughColumnCorrectness()
+    {
+        // Each input row has a pass-through column (id) that must be propagated to every expanded output row.
+        assertThat(assertions.query(
+                """
+                SELECT id, CAST(val AS VARCHAR(1)) val
+                FROM (VALUES (1, '["a","b","c"]'), (2, '["d","e"]')) t(id, json_col),
+                JSON_TABLE(json_col, 'lax $[*]' COLUMNS (val varchar PATH 'lax $'))
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, 'a'),
+                            (1, 'b'),
+                            (1, 'c'),
+                            (2, 'd'),
+                            (2, 'e')
+                        """);
+    }
+
+    @Test
+    public void testPassThroughColumnsWithLargeExpansion()
+    {
+        // Regression test for pass-through block overflow.
+        // Two input rows with distinct 512-byte pass-through values, each expanded by a 3000-element
+        // JSON array. Total pass-through data per partition = 3000 × 512B ≈ 1.5 MB, which exceeds
+        // DEFAULT_MAX_PAGE_SIZE_IN_BYTES (1 MB) and exercises the page-splitting fix.
+        String value1 = "a".repeat(512);
+        String value2 = "b".repeat(512);
+        String jsonArray = IntStream.rangeClosed(1, 3000)
+                .mapToObj(String::valueOf)
+                .collect(joining(",", "[", "]"));
+
+        assertThat(assertions.query(
+                "SELECT pt, count(*) " +
+                        "FROM (VALUES ('" + value1 + "'), ('" + value2 + "')) t(pt), " +
+                        "JSON_TABLE('" + jsonArray + "', 'lax $[*]' COLUMNS (val bigint PATH 'lax $')) " +
+                        "GROUP BY pt " +
+                        "ORDER BY pt"))
+                .matches(
+                        "VALUES ('" + value1 + "', BIGINT '3000'), ('" + value2 + "', BIGINT '3000')");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Before this change, `RegularTableFunctionPartition` had no size limit on pass-through columns. 
As a result, the accumulated block could exceed the maximum Block size. 
After this change, the output is split into pages, each within the `DEFAULT_MAX_PAGE_SIZE_IN_BYTES` size limit.
The split is based on average entry size, so it is a probablistic approach.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Minimize the chance of block capacity overflow for table functions.
```
