### PR TITLE
Remove deprecated methods without ConnectorTableCredentials parameter from ConnectorPageSourceProvider & ConnectorPageSinkProvider

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -224,6 +224,30 @@
                                 <item>
                                     <ignore>true</ignore>
                                     <code>java.method.noLongerDefault</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSink io.trino.spi.connector.ConnectorPageSinkProvider::createPageSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorInsertTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId)</old>
+                                    <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.nowAbstract</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSink io.trino.spi.connector.ConnectorPageSinkProvider::createPageSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorInsertTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId)</old>
+                                    <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.noLongerDefault</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSink io.trino.spi.connector.ConnectorPageSinkProvider::createPageSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorOutputTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId)</old>
+                                    <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.nowAbstract</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSink io.trino.spi.connector.ConnectorPageSinkProvider::createPageSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorOutputTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId)</old>
+                                    <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.noLongerDefault</code>
                                     <old>method io.trino.spi.connector.ConnectorPageSource io.trino.spi.connector.ConnectorPageSourceProvider::createPageSource(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorSplit, io.trino.spi.connector.ConnectorTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, java.util.List&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.connector.DynamicFilter)</old>
                                     <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
                                 </item>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -223,6 +223,18 @@
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
                                     <ignore>true</ignore>
+                                    <code>java.method.noLongerDefault</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSource io.trino.spi.connector.ConnectorPageSourceProvider::createPageSource(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorSplit, io.trino.spi.connector.ConnectorTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, java.util.List&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.connector.DynamicFilter)</old>
+                                    <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.nowAbstract</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSource io.trino.spi.connector.ConnectorPageSourceProvider::createPageSource(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorSplit, io.trino.spi.connector.ConnectorTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, java.util.List&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.connector.DynamicFilter)</old>
+                                    <justification>Removed deprecated method without ConnectorTableCredentials parameter</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
                                     <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
                                     <old>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, boolean[])</old>
                                     <new>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, boolean[])</new>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
@@ -22,15 +22,6 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 public interface ConnectorPageSinkProvider
 {
     /**
-     * @deprecated Implement {@link #createPageSink(ConnectorTransactionHandle, ConnectorSession, ConnectorOutputTableHandle, Optional, ConnectorPageSinkId)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, ConnectorPageSinkId pageSinkId)
-    {
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating new tables");
-    }
-
-    /**
      * Creates a {@link ConnectorPageSink} for writing data to a newly created table.
      *
      * @param transactionHandle the transaction handle for this operation
@@ -40,24 +31,12 @@ public interface ConnectorPageSinkProvider
      * @param pageSinkId unique identifier for this page sink instance
      * @return a page sink for writing data to the new table
      */
-    default ConnectorPageSink createPageSink(
+    ConnectorPageSink createPageSink(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
             ConnectorOutputTableHandle outputTableHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
-    {
-        return createPageSink(transactionHandle, session, outputTableHandle, pageSinkId);
-    }
-
-    /**
-     * @deprecated Implement {@link #createPageSink(ConnectorTransactionHandle, ConnectorSession, ConnectorInsertTableHandle, Optional, ConnectorPageSinkId)}
-     */
-    @Deprecated(forRemoval = true)
-    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, ConnectorPageSinkId pageSinkId)
-    {
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support insert operations");
-    }
+            ConnectorPageSinkId pageSinkId);
 
     /**
      * Creates a {@link ConnectorPageSink} for inserting data into an existing table.
@@ -69,15 +48,12 @@ public interface ConnectorPageSinkProvider
      * @param pageSinkId unique identifier for this page sink instance
      * @return a page sink for inserting data into the table
      */
-    default ConnectorPageSink createPageSink(
+    ConnectorPageSink createPageSink(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
             ConnectorInsertTableHandle insertTableHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
-    {
-        return createPageSink(transactionHandle, session, insertTableHandle, pageSinkId);
-    }
+            ConnectorPageSinkId pageSinkId);
 
     /**
      * Creates a {@link ConnectorPageSink} for executing a table procedure that writes data.
@@ -95,15 +71,6 @@ public interface ConnectorPageSinkProvider
             ConnectorTableExecuteHandle tableExecuteHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
             ConnectorPageSinkId pageSinkId)
-    {
-        return createPageSink(transactionHandle, session, tableExecuteHandle, pageSinkId);
-    }
-
-    /**
-     * @deprecated Implement {@link #createPageSink(ConnectorTransactionHandle, ConnectorSession, ConnectorTableExecuteHandle, Optional, ConnectorPageSinkId)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, ConnectorPageSinkId pageSinkId)
     {
         throw new IllegalArgumentException("createPageSink not supported for tableExecuteHandle");
     }
@@ -124,15 +91,6 @@ public interface ConnectorPageSinkProvider
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
             ConnectorPageSinkId pageSinkId)
-    {
-        return createMergeSink(transactionHandle, session, mergeHandle, pageSinkId);
-    }
-
-    /**
-     * @deprecated Implement {@link #createMergeSink(ConnectorTransactionHandle, ConnectorSession, ConnectorMergeTableHandle, Optional, ConnectorPageSinkId)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, ConnectorPageSinkId pageSinkId)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support SQL MERGE operations");
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProvider.java
@@ -13,12 +13,8 @@
  */
 package io.trino.spi.connector;
 
-import io.trino.spi.TrinoException;
-
 import java.util.List;
 import java.util.Optional;
-
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public interface ConnectorPageSourceProvider
 {
@@ -33,34 +29,14 @@ public interface ConnectorPageSourceProvider
      * @param columns columns that should show up in the output page, in this order
      * @param dynamicFilter optionally remove rows that don't satisfy this predicate
      */
-    default ConnectorPageSource createPageSource(
+    ConnectorPageSource createPageSource(
             ConnectorTransactionHandle transaction,
             ConnectorSession session,
             ConnectorSplit split,
             ConnectorTableHandle table,
             Optional<ConnectorTableCredentials> tableCredentials,
             List<ColumnHandle> columns,
-            DynamicFilter dynamicFilter)
-    {
-        return createPageSource(transaction, session, split, table, columns, dynamicFilter);
-    }
-
-    /**
-     * @param columns columns that should show up in the output page, in this order
-     * @param dynamicFilter optionally remove rows that don't satisfy this predicate
-     * @deprecated Implement {@link #createPageSource(ConnectorTransactionHandle, ConnectorSession, ConnectorSplit, ConnectorTableHandle, Optional, List, DynamicFilter)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    default ConnectorPageSource createPageSource(
-            ConnectorTransactionHandle transaction,
-            ConnectorSession session,
-            ConnectorSplit split,
-            ConnectorTableHandle table,
-            List<ColumnHandle> columns,
-            DynamicFilter dynamicFilter)
-    {
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support reading tables");
-    }
+            DynamicFilter dynamicFilter);
 
     /**
      * Get the total memory that needs to be reserved in the memory pool.

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
@@ -27,13 +27,10 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
-import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.eventlistener.EventListener;
@@ -45,7 +42,6 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -68,8 +64,7 @@ public class TestClassLoaderSafeWrappers
                 ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createPageSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorInsertTableHandle.class, ConnectorPageSinkId.class),
                 ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createPageSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorTableExecuteHandle.class, ConnectorPageSinkId.class),
                 ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createMergeSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorMergeTableHandle.class, ConnectorPageSinkId.class)));
-        testClassLoaderSafe(ConnectorPageSourceProvider.class, ClassLoaderSafeConnectorPageSourceProvider.class, ImmutableSet.of(
-                ClassLoaderSafeConnectorPageSourceProvider.class.getMethod("createPageSource", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorSplit.class, ConnectorTableHandle.class, List.class, DynamicFilter.class)));
+        testClassLoaderSafe(ConnectorPageSourceProvider.class, ClassLoaderSafeConnectorPageSourceProvider.class);
         testClassLoaderSafe(ConnectorSplitManager.class, ClassLoaderSafeConnectorSplitManager.class);
         testClassLoaderSafe(ConnectorNodePartitioningProvider.class, ClassLoaderSafeNodePartitioningProvider.class);
         testClassLoaderSafe(ConnectorSplitSource.class, ClassLoaderSafeConnectorSplitSource.class);

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
@@ -13,24 +13,16 @@
  */
 package io.trino.plugin.base.classloader;
 
-import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ConnectorAccessControl;
-import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorMergeSink;
-import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
-import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
-import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
-import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
-import io.trino.spi.connector.ConnectorTableExecuteHandle;
-import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.eventlistener.EventListener;
@@ -59,11 +51,7 @@ public class TestClassLoaderSafeWrappers
         testClassLoaderSafe(ConnectorMetadata.class, ClassLoaderSafeConnectorMetadata.class);
         testClassLoaderSafe(ConnectorMergeSink.class, ClassLoaderSafeConnectorMergeSink.class);
         testClassLoaderSafe(ConnectorPageSink.class, ClassLoaderSafeConnectorPageSink.class);
-        testClassLoaderSafe(ConnectorPageSinkProvider.class, ClassLoaderSafeConnectorPageSinkProvider.class, ImmutableSet.of(
-                ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createPageSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorOutputTableHandle.class, ConnectorPageSinkId.class),
-                ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createPageSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorInsertTableHandle.class, ConnectorPageSinkId.class),
-                ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createPageSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorTableExecuteHandle.class, ConnectorPageSinkId.class),
-                ClassLoaderSafeConnectorPageSinkProvider.class.getMethod("createMergeSink", ConnectorTransactionHandle.class, ConnectorSession.class, ConnectorMergeTableHandle.class, ConnectorPageSinkId.class)));
+        testClassLoaderSafe(ConnectorPageSinkProvider.class, ClassLoaderSafeConnectorPageSinkProvider.class);
         testClassLoaderSafe(ConnectorPageSourceProvider.class, ClassLoaderSafeConnectorPageSourceProvider.class);
         testClassLoaderSafe(ConnectorSplitManager.class, ClassLoaderSafeConnectorSplitManager.class);
         testClassLoaderSafe(ConnectorNodePartitioningProvider.class, ClassLoaderSafeNodePartitioningProvider.class);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

After deprecating the methods  without table credentials in 431df4c9 , this contribution (done in a subsequent Trino release) removes completely the now deprecated & unused methods from:
- `ConnectorPageSourceProvider`
- `ConnectorPageSinkProvider`

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow-up from https://github.com/trinodb/trino/pull/28830

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Remove deprecated methods  from `ConnectorPageSourceProvider`. ({issue}`29562`)
* Remove deprecated methods  from `ConnectorPageSinkProvider`. ({issue}`29562`)
```
