### PR TITLE
Group by location scheme first when deleting multiple files via IcebergRestCatalogFileSystem

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
@@ -103,9 +103,10 @@ public class IcebergRestCatalogFileSystem
     public void deleteFiles(Collection<Location> locations)
             throws IOException
     {
-        Map<TrinoFileSystem, List<Location>> groups = locations.stream().collect(groupingBy(loader));
-        for (var entry : groups.entrySet()) {
-            entry.getKey().deleteFiles(entry.getValue());
+        Map<String, List<Location>> byScheme = locations.stream()
+                .collect(groupingBy(location -> location.scheme().orElseThrow()));
+        for (List<Location> group : byScheme.values()) {
+            fileSystem(group.getFirst()).deleteFiles(group);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
@@ -132,6 +132,13 @@ public class IcebergRestCatalogFileSystem
     }
 
     @Override
+    public FileIterator listFilesStartingFrom(Location location, String startingFrom)
+            throws IOException
+    {
+        return fileSystem(location).listFilesStartingFrom(location, startingFrom);
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystem.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystem.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.trino.filesystem.TrinoFileSystem;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+final class TestIcebergRestCatalogFileSystem
+{
+    @Test
+    void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(TrinoFileSystem.class, IcebergRestCatalogFileSystem.class);
+    }
+}


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

In `deleteFiles` method

```
 groupingBy(loader)
```

was calling loader.apply(location) once per location and used the resulting `TrinoFileSystem` instance as the map key.

Since loader creates a new object each time and `TrinoFileSystem` doesn't implement equals, every location lands in its own group — the batching intent is defeated.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow-up regression bugfix from https://github.com/trinodb/trino/pull/28998

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
