### PR TITLE
Add SQL/JSON simplified accessor

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -632,8 +632,10 @@ primaryExpression
     | ARRAY '[' (expression (',' expression)*)? ']'                                       #arrayConstructor
     | '[' (expression (',' expression)*)? ']'                                             #arrayConstructor
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
+    | value=primaryExpression '[' ASTERISK ']'                                            #arrayWildcardSubscript
     | identifier                                                                          #columnReference
     | base=primaryExpression '.' fieldName=identifier                                     #dereference
+    | base=primaryExpression '.' stringField=string                                       #stringLiteralDereference
     | name=CURRENT_DATE                                                                   #currentDate
     | name=CURRENT_TIME ('(' precision=INTEGER_VALUE ')')?                                #currentTime
     | name=CURRENT_TIMESTAMP ('(' precision=INTEGER_VALUE ')')?                           #currentTimestamp

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AccessorStep.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AccessorStep.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.analyzer;
+
+import io.trino.sql.tree.Identifier;
+
+/// One step in a SQL:2023 §6.36 simplified-accessor chain.
+///
+/// The chain produced by [JsonAccessorChain#walk(io.trino.sql.tree.Expression)]
+/// is a sequence of these steps, in surface order. Each step maps to a
+/// JSON-path accessor that [JsonAccessorChain#buildPath(java.util.List)]
+/// emits.
+sealed interface AccessorStep
+{
+    /// A member-by-name step (`j.foo`, `j."FooBar"`).
+    record Member(Identifier name)
+            implements AccessorStep {}
+
+    /// An integer-subscript step (`j[3]`).
+    record Index(long value)
+            implements AccessorStep {}
+
+    /// A `.*` wildcard-member step.
+    enum WildcardMember
+            implements AccessorStep
+    {
+        INSTANCE
+    }
+
+    /// A `[*]` wildcard-array step.
+    enum WildcardArray
+            implements AccessorStep
+    {
+        INSTANCE
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -186,6 +186,7 @@ public class Analysis
     private final Map<NodeRef<Expression>, ResolvedFunction> jsonInputFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<Node>, ResolvedFunction> jsonOutputFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<JsonTable>, JsonTableAnalysis> jsonTableAnalyses = new LinkedHashMap<>();
+    private final Map<NodeRef<Expression>, JsonSimplifiedAccessor> jsonSimplifiedAccessors = new LinkedHashMap<>();
 
     private final Map<NodeRef<QuerySpecification>, List<FunctionCall>> aggregates = new LinkedHashMap<>();
     private final Map<NodeRef<OrderBy>, List<Expression>> orderByAggregates = new LinkedHashMap<>();
@@ -1167,6 +1168,62 @@ public class Analysis
     public JsonPathAnalysis getJsonPathAnalysis(Node node)
     {
         return jsonPathAnalyses.get(NodeRef.of(node));
+    }
+
+    public void setJsonSimplifiedAccessor(Expression expression, JsonSimplifiedAccessor recipe)
+    {
+        jsonSimplifiedAccessors.put(NodeRef.of(expression), recipe);
+    }
+
+    public Optional<JsonSimplifiedAccessor> getJsonSimplifiedAccessor(Expression expression)
+    {
+        return Optional.ofNullable(jsonSimplifiedAccessors.get(NodeRef.of(expression)));
+    }
+
+    public sealed interface JsonSimplifiedAccessor
+            permits JsonSimplifiedAccessor.Query, JsonSimplifiedAccessor.Value
+    {
+        ResolvedField column();
+
+        JsonPathAnalysis pathAnalysis();
+
+        ResolvedFunction inputFunction();
+
+        record Query(
+                ResolvedField column,
+                JsonPathAnalysis pathAnalysis,
+                ResolvedFunction inputFunction,
+                ResolvedFunction queryFunction,
+                ResolvedFunction outputFunction)
+                implements JsonSimplifiedAccessor
+        {
+            public Query
+            {
+                requireNonNull(column, "column is null");
+                requireNonNull(pathAnalysis, "pathAnalysis is null");
+                requireNonNull(inputFunction, "inputFunction is null");
+                requireNonNull(queryFunction, "queryFunction is null");
+                requireNonNull(outputFunction, "outputFunction is null");
+            }
+        }
+
+        record Value(
+                ResolvedField column,
+                JsonPathAnalysis pathAnalysis,
+                ResolvedFunction inputFunction,
+                ResolvedFunction valueFunction,
+                Type returnedType)
+                implements JsonSimplifiedAccessor
+        {
+            public Value
+            {
+                requireNonNull(column, "column is null");
+                requireNonNull(pathAnalysis, "pathAnalysis is null");
+                requireNonNull(inputFunction, "inputFunction is null");
+                requireNonNull(valueFunction, "valueFunction is null");
+                requireNonNull(returnedType, "returnedType is null");
+            }
+        }
     }
 
     public void setJsonInputFunctions(Map<NodeRef<Expression>, ResolvedFunction> functions)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -76,6 +76,7 @@ import io.trino.sql.ir.Constant;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
+import io.trino.sql.tree.ArrayWildcardSubscript;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
@@ -395,6 +396,7 @@ public class ExpressionAnalyzer
 
     // for JSON functions
     private final Map<NodeRef<Node>, JsonPathAnalysis> jsonPathAnalyses = new LinkedHashMap<>();
+    private final Map<NodeRef<Expression>, Analysis.JsonSimplifiedAccessor> jsonSimplifiedAccessors = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, ResolvedFunction> jsonInputFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<Node>, ResolvedFunction> jsonOutputFunctions = new LinkedHashMap<>();
 
@@ -576,6 +578,12 @@ public class ExpressionAnalyzer
         return visitor.process(expression, context);
     }
 
+    public boolean analyzeJsonWildcardTarget(Expression target, Scope scope, CorrelationSupport correlationSupport)
+    {
+        Visitor visitor = new Visitor(scope, warningCollector);
+        return visitor.analyzeJsonWildcardTarget(target, Context.notInLambda(scope, correlationSupport));
+    }
+
     private RowType analyzeJsonPathInvocation(JsonTable node, Scope scope, CorrelationSupport correlationSupport)
     {
         Visitor visitor = new Visitor(scope, warningCollector);
@@ -702,6 +710,11 @@ public class ExpressionAnalyzer
     public Map<NodeRef<Node>, JsonPathAnalysis> getJsonPathAnalyses()
     {
         return jsonPathAnalyses;
+    }
+
+    public Map<NodeRef<Expression>, Analysis.JsonSimplifiedAccessor> getJsonSimplifiedAccessors()
+    {
+        return jsonSimplifiedAccessors;
     }
 
     public Map<NodeRef<Expression>, ResolvedFunction> getJsonInputFunctions()
@@ -838,15 +851,7 @@ public class ExpressionAnalyzer
                 }
             }
 
-            if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
-                tableColumnReferences.put(new Analysis.TableAndBranch(field.getOriginTable().get(), field.getOriginBranch()), field.getOriginColumnName().get());
-            }
-
-            sourceFields.add(field);
-
-            fieldId.getRelationId()
-                    .getSourceNode()
-                    .ifPresent(source -> referencedFields.put(NodeRef.of(source), field));
+            recordColumnUsage(resolvedField);
 
             ResolvedField previous = columnReferences.put(NodeRef.of(node), resolvedField);
             checkState(previous == null, "%s already known to refer to %s", node, previous);
@@ -857,11 +862,8 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitDereferenceExpression(DereferenceExpression node, Context context)
         {
-            if (isQualifiedAllFieldsReference(node)) {
-                throw semanticException(NOT_SUPPORTED, node, "<identifier>.* not allowed in this context");
-            }
-
-            QualifiedName qualifiedName = DereferenceExpression.getQualifiedName(node);
+            boolean hasWildcard = isQualifiedAllFieldsReference(node);
+            QualifiedName qualifiedName = hasWildcard ? null : DereferenceExpression.getQualifiedName(node);
 
             // If this Dereference looks like column reference, try match it to column first.
             if (qualifiedName != null) {
@@ -900,9 +902,21 @@ public class ExpressionAnalyzer
                 if (resolvedField.isPresent()) {
                     return handleResolvedField(node, resolvedField.get(), context);
                 }
-                if (!scope.isColumnReference(qualifiedName)) {
-                    throw missingAttributeException(node, qualifiedName);
+            }
+
+            if (!context.isPatternRecognition()) {
+                Optional<Type> type = tryAnalyzeJsonSimplifiedAccessor(node, context);
+                if (type.isPresent()) {
+                    return setExpressionType(node, type.get());
                 }
+            }
+
+            if (hasWildcard) {
+                throw semanticException(NOT_SUPPORTED, node, "<identifier>.* not allowed in this context");
+            }
+
+            if (qualifiedName != null && !context.getScope().isColumnReference(qualifiedName)) {
+                throw missingAttributeException(node, qualifiedName);
             }
 
             Type baseType = process(node.getBase(), context);
@@ -931,6 +945,247 @@ public class ExpressionAnalyzer
             }
 
             return setExpressionType(node, rowFieldType);
+        }
+
+        private Optional<Type> tryAnalyzeJsonSimplifiedAccessor(Expression expression, Context context)
+        {
+            return JsonAccessorChain.walk(expression)
+                    .flatMap(chain -> tryRegisterJsonQueryAccessor(expression, chain, Optional.empty(), context));
+        }
+
+        boolean analyzeJsonWildcardTarget(Expression target, Context context)
+        {
+            return JsonAccessorChain.walkForWildcard(target)
+                    .flatMap(chain -> tryRegisterJsonQueryAccessor(target, chain, Optional.of(AccessorStep.WildcardMember.INSTANCE), context))
+                    .isPresent();
+        }
+
+        private Optional<Type> tryRegisterJsonQueryAccessor(Expression expression, JsonAccessorChain chain, Optional<AccessorStep> trailingStep, Context context)
+        {
+            boolean registered = tryRegisterJsonAccessor(expression, chain, trailingStep, context, (column, pathAnalysis) -> new Analysis.JsonSimplifiedAccessor.Query(
+                    column,
+                    pathAnalysis,
+                    getInputFunction(VARCHAR, JsonFormat.JSON, expression),
+                    plannerContext.getMetadata().resolveBuiltinFunction(JSON_QUERY_FUNCTION_NAME, fromTypes(ImmutableList.of(
+                            JSON_2016,
+                            plannerContext.getTypeManager().getType(new TypeDescriptor(JsonPath2016Type.NAME)),
+                            JSON_NO_PARAMETERS_ROW_TYPE,
+                            TINYINT,
+                            TINYINT,
+                            TINYINT))),
+                    getOutputFunction(VARCHAR, JsonFormat.JSON, expression)));
+            return registered ? Optional.of(setExpressionType(expression, VARCHAR)) : Optional.empty();
+        }
+
+        private Optional<Type> tryRegisterJsonValueAccessor(Expression expression, JsonAccessorChain chain, Type returnedType, Context context)
+        {
+            boolean registered = tryRegisterJsonAccessor(expression, chain, Optional.empty(), context, (column, pathAnalysis) -> new Analysis.JsonSimplifiedAccessor.Value(
+                    column,
+                    pathAnalysis,
+                    getInputFunction(VARCHAR, JsonFormat.JSON, expression),
+                    plannerContext.getMetadata().resolveBuiltinFunction(JSON_VALUE_FUNCTION_NAME, fromTypes(ImmutableList.of(
+                            JSON_2016,
+                            plannerContext.getTypeManager().getType(new TypeDescriptor(JsonPath2016Type.NAME)),
+                            JSON_NO_PARAMETERS_ROW_TYPE,
+                            returnedType,
+                            TINYINT,
+                            new FunctionType(ImmutableList.of(), returnedType),
+                            TINYINT,
+                            new FunctionType(ImmutableList.of(), returnedType)))),
+                    returnedType));
+            return registered ? Optional.of(returnedType) : Optional.empty();
+        }
+
+        @FunctionalInterface
+        private interface JsonAccessorRecipeBuilder
+        {
+            Analysis.JsonSimplifiedAccessor build(ResolvedField column, JsonPathAnalysis pathAnalysis);
+        }
+
+        /// @return `true` when a simplified-accessor recipe was registered
+        ///         for `expression`; `false` when no prefix of the chain
+        ///         resolved to a JSON column.
+        private boolean tryRegisterJsonAccessor(
+                Expression expression,
+                JsonAccessorChain chain,
+                Optional<AccessorStep> trailingStep,
+                Context context,
+                JsonAccessorRecipeBuilder recipe)
+        {
+            Scope scope = context.getScope();
+            List<Identifier> prefix = chain.prefix();
+            for (int prefixLength = prefix.size(); prefixLength >= 1; prefixLength--) {
+                Optional<ResolvedField> resolved = scope.tryResolveField(expression, QualifiedName.of(prefix.subList(0, prefixLength)));
+                if (resolved.isEmpty()) {
+                    continue;
+                }
+                if (!resolved.get().getType().equals(JSON)) {
+                    return false;
+                }
+                ResolvedField column = resolved.get();
+                registerSimplifiedAccessorColumn(column, chain, prefixLength, expression, context);
+                JsonPathAnalysis pathAnalysis = analyzeSimplifiedAccessorPath(expression, chain, prefixLength, trailingStep);
+                jsonSimplifiedAccessors.put(NodeRef.of(expression), recipe.build(column, pathAnalysis));
+                return true;
+            }
+            return false;
+        }
+
+        private JsonPathAnalysis analyzeSimplifiedAccessorPath(Expression expression, JsonAccessorChain chain, int prefixLength, Optional<AccessorStep> trailingStep)
+        {
+            return new JsonPathAnalyzer(
+                    plannerContext.getMetadata(),
+                    createConstantAnalyzer(plannerContext, accessControl, session, ExpressionAnalyzer.this.parameters, WarningCollector.NOOP))
+                    .analyzeJsonPath(
+                            JsonAccessorChain.buildPath(ImmutableList.<AccessorStep>builder()
+                                    .addAll(chain.prefix().subList(prefixLength, chain.prefix().size()).stream()
+                                            .<AccessorStep>map(AccessorStep.Member::new)
+                                            .iterator())
+                                    .addAll(chain.outerSteps())
+                                    .addAll(trailingStep.stream().iterator())
+                                    .build()),
+                            expression.getLocation().orElseThrow(() -> new IllegalStateException("missing NodeLocation in accessor")));
+        }
+
+        private void registerSimplifiedAccessorColumn(ResolvedField column, JsonAccessorChain chain, int prefixLength, Expression expression, Context context)
+        {
+            Optional<Expression> matched = chain.matchedPrefixExpression(prefixLength);
+            if (matched.isEmpty()) {
+                if (!column.isLocal()) {
+                    throw semanticException(NOT_SUPPORTED, expression, "JSON simplified accessor over a column from an outer scope is not supported");
+                }
+                recordColumnUsage(column);
+                return;
+            }
+            // Route the matched sub-expression through the regular visitor so
+            // it lands in `analysis.columnReferences`, where the outer-scope
+            // correlation machinery picks it up.
+            process(matched.get(), context);
+        }
+
+        private void recordColumnUsage(ResolvedField resolvedField)
+        {
+            Field field = resolvedField.getField();
+            if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
+                tableColumnReferences.put(new Analysis.TableAndBranch(field.getOriginTable().get(), field.getOriginBranch()), field.getOriginColumnName().get());
+            }
+            sourceFields.add(field);
+            FieldId.from(resolvedField).getRelationId()
+                    .getSourceNode()
+                    .ifPresent(source -> referencedFields.put(NodeRef.of(source), field));
+        }
+
+        private Optional<Type> tryAnalyzeJsonItemMethodAccessor(FunctionCall node, Context context)
+        {
+            if (context.isPatternRecognition() || context.isInWindow()) {
+                return Optional.empty();
+            }
+            if (node.isDistinct()
+                    || node.getFilter().isPresent()
+                    || node.getOrderBy().isPresent()
+                    || node.getWindow().isPresent()
+                    || node.getProcessingMode().isPresent()
+                    || node.getNullTreatment().isPresent()) {
+                return Optional.empty();
+            }
+            if (node.hasNamedArguments()) {
+                // item methods define only positional precision literals; a named argument
+                // means this is an ordinary function call
+                return Optional.empty();
+            }
+            List<Identifier> parts = node.getName().getOriginalParts();
+            if (parts.size() < 2 || parts.getLast().isDelimited()) {
+                // item-method names are regular identifiers (case-insensitive); a delimited
+                // identifier denotes an ordinary function or member name, never an item method
+                return Optional.empty();
+            }
+            Optional<Type> returnedType = resolveJsonItemMethodReturnType(parts.getLast().getValue(), node.argumentValues());
+            if (returnedType.isEmpty()) {
+                return Optional.empty();
+            }
+            // FunctionCall shape has no Expression sub-node for the receiver
+            // chain (the receiver is the qualified name's prefix). An empty
+            // cursor list keeps `matchedPrefixExpression` empty so outer-scope
+            // resolution falls through to the local-only path.
+            List<Identifier> receiverParts = parts.subList(0, parts.size() - 1);
+            JsonAccessorChain chain = new JsonAccessorChain(receiverParts, ImmutableList.of(), ImmutableList.of());
+            return tryRegisterJsonValueAccessor(node, chain, returnedType.get(), context);
+        }
+
+        private Optional<Type> tryAnalyzeJsonItemMethodAccessor(MethodCall node, Context context)
+        {
+            if (context.isPatternRecognition() || context.isInWindow()) {
+                return Optional.empty();
+            }
+            if (node.getMethod().isDelimited()) {
+                // item-method names are regular identifiers (case-insensitive); a delimited
+                // identifier denotes an ordinary method name, never an item method
+                return Optional.empty();
+            }
+            if (node.getArguments().stream().anyMatch(argument -> argument.getName().isPresent())) {
+                // named arguments denote an ordinary method call, never an item method
+                return Optional.empty();
+            }
+            Optional<Type> returnedType = resolveJsonItemMethodReturnType(
+                    node.getMethod().getValue(),
+                    node.getArguments().stream().map(CallArgument::getValue).collect(toImmutableList()));
+            if (returnedType.isEmpty()) {
+                return Optional.empty();
+            }
+            Optional<JsonAccessorChain> chain = JsonAccessorChain.walk(node.getReceiver());
+            if (chain.isEmpty()) {
+                return Optional.empty();
+            }
+            return tryRegisterJsonValueAccessor(node, chain.get(), returnedType.get(), context);
+        }
+
+        private static Optional<Type> resolveJsonItemMethodReturnType(String methodName, List<Expression> arguments)
+        {
+            List<Integer> integerArguments = new ArrayList<>();
+            for (Expression argument : arguments) {
+                // precision and scale arguments fit in an int; a literal outside that range is not
+                // one of the item-method forms, so the call falls through to method resolution
+                // instead of silently wrapping into a different in-range value
+                if (!(argument instanceof LongLiteral literal) || (int) literal.getParsedValue() != literal.getParsedValue()) {
+                    return Optional.empty();
+                }
+                integerArguments.add((int) literal.getParsedValue());
+            }
+            return switch (methodName.toLowerCase(ENGLISH)) {
+                case "bigint" -> integerArguments.isEmpty() ? Optional.of(BIGINT) : Optional.empty();
+                case "boolean" -> integerArguments.isEmpty() ? Optional.of(BOOLEAN) : Optional.empty();
+                case "date" -> integerArguments.isEmpty() ? Optional.of(DATE) : Optional.empty();
+                case "integer" -> integerArguments.isEmpty() ? Optional.of(INTEGER) : Optional.empty();
+                case "number" -> integerArguments.isEmpty() ? Optional.of(DOUBLE) : Optional.empty();
+                case "string" -> integerArguments.isEmpty() ? Optional.of(VARCHAR) : Optional.empty();
+                case "decimal" -> switch (integerArguments.size()) {
+                    case 0 -> Optional.of(DecimalType.createDecimalType());
+                    case 1 -> Optional.of(DecimalType.createDecimalType(integerArguments.get(0)));
+                    case 2 -> Optional.of(DecimalType.createDecimalType(integerArguments.get(0), integerArguments.get(1)));
+                    default -> Optional.empty();
+                };
+                case "time" -> switch (integerArguments.size()) {
+                    case 0 -> Optional.of(createTimeType(3));
+                    case 1 -> Optional.of(createTimeType(integerArguments.get(0)));
+                    default -> Optional.empty();
+                };
+                case "time_tz" -> switch (integerArguments.size()) {
+                    case 0 -> Optional.of(createTimeWithTimeZoneType(3));
+                    case 1 -> Optional.of(createTimeWithTimeZoneType(integerArguments.get(0)));
+                    default -> Optional.empty();
+                };
+                case "timestamp" -> switch (integerArguments.size()) {
+                    case 0 -> Optional.of(createTimestampType(3));
+                    case 1 -> Optional.of(createTimestampType(integerArguments.get(0)));
+                    default -> Optional.empty();
+                };
+                case "timestamp_tz" -> switch (integerArguments.size()) {
+                    case 0 -> Optional.of(createTimestampWithTimeZoneType(3));
+                    case 1 -> Optional.of(createTimestampWithTimeZoneType(integerArguments.get(0)));
+                    default -> Optional.empty();
+                };
+                default -> Optional.empty();
+            };
         }
 
         @Override
@@ -1244,6 +1499,13 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitSubscriptExpression(SubscriptExpression node, Context context)
         {
+            if (!context.isPatternRecognition()) {
+                Optional<Type> type = tryAnalyzeJsonSimplifiedAccessor(node, context);
+                if (type.isPresent()) {
+                    return setExpressionType(node, type.get());
+                }
+            }
+
             Type baseType = process(node.getBase(), context);
             // Subscript on Row hasn't got a dedicated operator. Its Type is resolved by hand.
             if (baseType instanceof RowType rowType) {
@@ -1267,6 +1529,22 @@ public class ExpressionAnalyzer
 
             // Subscript on Array or Map uses an operator to resolve Type.
             return getOperator(context, node, SUBSCRIPT, node.getBase(), node.getIndex());
+        }
+
+        @Override
+        protected Type visitArrayWildcardSubscript(ArrayWildcardSubscript node, Context context)
+        {
+            if (!context.isPatternRecognition()) {
+                Optional<Type> type = tryAnalyzeJsonSimplifiedAccessor(node, context);
+                if (type.isPresent()) {
+                    return setExpressionType(node, type.get());
+                }
+            }
+            // Surface any column-not-found or type errors on the base before
+            // reporting the catch-all "[*] not allowed" message — otherwise a
+            // mistyped column reads as a syntax complaint.
+            process(node.getBase(), context);
+            throw semanticException(NOT_SUPPORTED, node, "[*] array wildcard accessor is only allowed over a JSON simplified accessor chain");
         }
 
         @Override
@@ -1452,6 +1730,14 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitFunctionCall(FunctionCall node, Context context)
         {
+            // A JSON item method on a JSON-typed receiver resolves as the item method
+            // (SQL:2023 §6.36 case 3.a), shadowing any real method of the same name —
+            // the same precedence as visitMethodCall
+            Optional<Type> asJsonItemMethod = tryAnalyzeJsonItemMethodAccessor(node, context);
+            if (asJsonItemMethod.isPresent()) {
+                return setExpressionType(node, asJsonItemMethod.get());
+            }
+
             // SQL:2023 6.3 Syntax Rule 2: a non-parenthesized value expression primary
             // of the form A.B(args) is treated as a method invocation if it satisfies
             // the rules for one; otherwise it is a routine invocation.
@@ -1909,6 +2195,11 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitMethodCall(MethodCall node, Context context)
         {
+            Optional<Type> asJsonItemMethod = tryAnalyzeJsonItemMethodAccessor(node, context);
+            if (asJsonItemMethod.isPresent()) {
+                return setExpressionType(node, asJsonItemMethod.get());
+            }
+
             Type receiverType = process(node.getReceiver(), context);
             String methodName = node.getMethod().getValue();
 
@@ -4483,6 +4774,25 @@ public class ExpressionAnalyzer
                 analyzer.getWindowFunctions());
     }
 
+    public static boolean analyzeJsonWildcardAccessor(
+            Session session,
+            PlannerContext plannerContext,
+            StatementAnalyzerFactory statementAnalyzerFactory,
+            AccessControl accessControl,
+            Scope scope,
+            Analysis analysis,
+            Expression target,
+            WarningCollector warningCollector,
+            CorrelationSupport correlationSupport)
+    {
+        ExpressionAnalyzer analyzer = new ExpressionAnalyzer(plannerContext, accessControl, statementAnalyzerFactory, analysis, session, warningCollector);
+        boolean recognized = analyzer.analyzeJsonWildcardTarget(target, scope, correlationSupport);
+        if (recognized) {
+            updateAnalysis(analysis, analyzer, session, accessControl);
+        }
+        return recognized;
+    }
+
     public static ParametersTypeAndAnalysis analyzeJsonPathInvocation(
             JsonTable node,
             Session session,
@@ -4644,6 +4954,7 @@ public class ExpressionAnalyzer
         analysis.setJsonPathAnalyses(analyzer.getJsonPathAnalyses());
         analysis.setJsonInputFunctions(analyzer.getJsonInputFunctions());
         analysis.setJsonOutputFunctions(analyzer.getJsonOutputFunctions());
+        analyzer.getJsonSimplifiedAccessors().forEach((key, value) -> analysis.setJsonSimplifiedAccessor(key.getNode(), value));
         analysis.addPredicateCoercions(analyzer.getPredicateCoercions());
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonAccessorChain.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonAccessorChain.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.analyzer;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.jsonpath.tree.ArrayAccessor;
+import io.trino.sql.jsonpath.tree.ContextVariable;
+import io.trino.sql.jsonpath.tree.JsonPath;
+import io.trino.sql.jsonpath.tree.MemberAccessor;
+import io.trino.sql.jsonpath.tree.PathNode;
+import io.trino.sql.jsonpath.tree.SqlValueLiteral;
+import io.trino.sql.tree.ArrayWildcardSubscript;
+import io.trino.sql.tree.DereferenceExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.SubscriptExpression;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/// A SQL:2023 §6.36 simplified accessor like `j.foo[3].bar.*`, split into
+/// two pieces the analyzer needs separately:
+///
+///   1. `[#prefix()]` — the leading identifiers that might form a JSON
+///      column name. For `j.foo[3].bar.*` that's `[j, foo]`.
+///   2. `[#outerSteps()]` — the accessor steps left over. For
+///      `j.foo[3].bar.*` that's `[[3], .bar, .*]`. These never join the
+///      column-name candidate; they always end up in the JSON path that
+///      the column is projected through.
+///
+/// To analyze a chain the caller tries `[#prefix()]` lengths against the
+/// scope (longest first). If a length-`k` prefix matches a JSON column,
+/// the JSON path becomes the remaining `k..prefix.size()` identifiers
+/// followed by `[#outerSteps()]`.
+///
+/// For outer-scope correlated subqueries the caller also needs the
+/// sub-expression of the user's input that corresponds to a matched
+/// prefix — that's what `[#matchedPrefixExpression(int)]` returns, backed
+/// by `[#visitedNodes()]` which records the [Expression] visited at each
+/// step of `[#walk(Expression)]`.
+///
+/// `[#buildPath(List)]` produces the [JsonPath] tree directly (no
+/// path-string round-trip). Per SQL:2023 §6.36 NOTE 198 / NOTE 199,
+/// member-accessor identifiers are emitted verbatim (no implicit case
+/// folding).
+///
+/// @param prefix the leading identifiers of the chain. Some leading subsequence of them
+///         resolves to the JSON column reference (possibly qualified); the identifiers
+///         beyond that subsequence are JSON member names emitted into the path.
+/// @param outerSteps accessor steps left over after `prefix`; always
+///         emitted into the JSON path.
+/// @param visitedNodes the [Expression] visited at each step of `walk`,
+///         used by `matchedPrefixExpression` to recover the
+///         sub-expression for a matched prefix length. Empty for chains
+///         constructed from a qualified name rather than walked from an
+///         expression tree.
+record JsonAccessorChain(List<Identifier> prefix, List<AccessorStep> outerSteps, List<Expression> visitedNodes)
+{
+    JsonAccessorChain
+    {
+        prefix = ImmutableList.copyOf(prefix);
+        outerSteps = ImmutableList.copyOf(outerSteps);
+        visitedNodes = ImmutableList.copyOf(visitedNodes);
+    }
+
+    /// Returns the sub-[Expression] of the user's input that corresponds
+    /// to a matched prefix length.
+    ///
+    /// @param prefixLength number of leading `prefix()` identifiers that
+    ///         resolved to a column.
+    /// @return the matching input sub-expression, or [Optional#empty()]
+    ///         for a chain with no visited nodes.
+    Optional<Expression> matchedPrefixExpression(int prefixLength)
+    {
+        if (visitedNodes.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(visitedNodes.get(visitedNodes.size() - prefixLength));
+    }
+
+    /// Returns a chain for a wildcard receiver, accepting both a bare
+    /// [Identifier] (a single-step column reference such as `j` in
+    /// `SELECT j.*`) and a longer accessor chain that [#walk(Expression)]
+    /// can peel.
+    ///
+    /// `walk` rejects a chain with no steps; this wraps that case so callers
+    /// don't have to duplicate the bare-identifier branch.
+    ///
+    /// @param target the wildcard receiver expression.
+    /// @return the chain when `target` is either a bare `Identifier` or a
+    ///         walkable accessor; empty otherwise.
+    static Optional<JsonAccessorChain> walkForWildcard(Expression target)
+    {
+        if (target instanceof Identifier root) {
+            return Optional.of(new JsonAccessorChain(ImmutableList.of(root), ImmutableList.of(), ImmutableList.of(target)));
+        }
+        return walk(target);
+    }
+
+    static Optional<JsonAccessorChain> walk(Expression target)
+    {
+        List<AccessorStep> stepsReversed = new ArrayList<>();
+        List<Expression> visited = new ArrayList<>();
+        visited.add(target);
+        Expression node = target;
+        boolean progressed = true;
+        while (progressed) {
+            WalkStep walkStep = switch (node) {
+                case DereferenceExpression dereference -> new WalkStep(
+                        dereference.getField().<AccessorStep>map(AccessorStep.Member::new).orElse(AccessorStep.WildcardMember.INSTANCE),
+                        dereference.getBase());
+                case SubscriptExpression subscript when subscript.getIndex() instanceof LongLiteral literal -> new WalkStep(
+                        new AccessorStep.Index(literal.getParsedValue()),
+                        subscript.getBase());
+                case ArrayWildcardSubscript wildcard -> new WalkStep(
+                        AccessorStep.WildcardArray.INSTANCE,
+                        wildcard.getBase());
+                case null, default -> null;
+            };
+            if (walkStep == null) {
+                progressed = false;
+            }
+            else {
+                stepsReversed.add(walkStep.step());
+                node = walkStep.nextNode();
+                visited.add(node);
+            }
+        }
+        if (stepsReversed.isEmpty()) {
+            return Optional.empty();
+        }
+        Collections.reverse(stepsReversed);
+
+        // the loop peels every DereferenceExpression, so the remaining node is the
+        // chain's root: only a bare identifier can anchor a column-reference prefix
+        if (!(node instanceof Identifier root)) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<Identifier> prefix = ImmutableList.<Identifier>builder().add(root);
+        int outerStart = 0;
+        while (outerStart < stepsReversed.size() && stepsReversed.get(outerStart) instanceof AccessorStep.Member member) {
+            prefix.add(member.name());
+            outerStart++;
+        }
+        return Optional.of(new JsonAccessorChain(prefix.build(), stepsReversed.subList(outerStart, stepsReversed.size()), visited));
+    }
+
+    private record WalkStep(AccessorStep step, Expression nextNode) {}
+
+    /// Builds the [JsonPath] tree (`lax $.<…>`) that represents the given
+    /// accessor steps.
+    ///
+    /// The result is the same tree the JSON path parser would produce for
+    /// the canonical string form, but skips the path-string round-trip
+    /// (which would be re-parsed during planning — a form of AST synthesis
+    /// the accessor avoids).
+    ///
+    /// Per SQL:2023 §6.36 NOTE 198 / NOTE 199, no implicit case folding is
+    /// performed: unquoted identifiers contribute their literal value as
+    /// the member-accessor key.
+    ///
+    /// @param steps the accessor steps in source order.
+    /// @return a lax [JsonPath] rooted at a [ContextVariable].
+    static JsonPath buildPath(List<AccessorStep> steps)
+    {
+        PathNode root = new ContextVariable();
+        for (AccessorStep step : steps) {
+            root = switch (step) {
+                case AccessorStep.Member member -> new MemberAccessor(root, Optional.of(member.name().getValue()));
+                case AccessorStep.Index index -> new ArrayAccessor(root, ImmutableList.of(
+                        new ArrayAccessor.Subscript(new SqlValueLiteral(new LongLiteral(Long.toString(index.value()))))));
+                case AccessorStep.WildcardMember _ -> new MemberAccessor(root, Optional.empty());
+                case AccessorStep.WildcardArray _ -> new ArrayAccessor(root, ImmutableList.of());
+            };
+        }
+        return new JsonPath(true, root);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
@@ -122,6 +122,23 @@ public class JsonPathAnalyzer
         return new JsonPathAnalysis((JsonPath) root, types, jsonParameters, datetimeTemplates);
     }
 
+    /// Analyzes a pre-built [JsonPath] tree, skipping the parse step.
+    ///
+    /// Used by SQL:2023 §6.36 simplified-accessor desugaring, which builds
+    /// the path tree directly from the surface AST chain rather than
+    /// synthesizing a path string and re-parsing it.
+    ///
+    /// @param path the pre-built JSON path tree.
+    /// @param location source location to use for diagnostics raised by
+    ///         the type-inference visitor.
+    /// @return the path analysis carrying the inferred type for every
+    ///         visited [io.trino.sql.jsonpath.tree.PathNode].
+    public JsonPathAnalysis analyzeJsonPath(JsonPath path, NodeLocation location)
+    {
+        new Visitor(ImmutableMap.of(), new StringLiteral(location, "")).process(path);
+        return new JsonPathAnalysis(path, types, jsonParameters, datetimeTemplates);
+    }
+
     /**
      * This visitor determines and validates output types of PathNodes, whenever they can be deduced and represented as SQL types.
      * In some cases, the type of a PathNode can be determined without context. E.g., the `double()` method always returns DOUBLE.

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -431,6 +431,7 @@ import static io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch.ONE;
 import static io.trino.sql.tree.SaveMode.IGNORE;
 import static io.trino.sql.tree.SaveMode.REPLACE;
 import static io.trino.sql.util.AstUtils.preOrder;
+import static io.trino.type.JsonType.JSON;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -5019,11 +5020,11 @@ class StatementAnalyzer
 
                 QualifiedName prefix = asQualifiedName(expression);
                 if (prefix != null) {
-                    // analyze prefix as an 'asterisked identifier chain'
-                    AsteriskedIdentifierChainBasis identifierChainBasis = scope.resolveAsteriskedIdentifierChainBasis(prefix, allColumns)
-                            .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, allColumns, "Unable to resolve reference %s", prefix));
-                    if (identifierChainBasis.getBasisType() == TABLE) {
-                        RelationType relationType = identifierChainBasis.getRelationType().orElseThrow();
+                    // analyze prefix as an 'asterisked identifier chain' first: a relation alias
+                    // always takes precedence over a JSON accessor chain reading the same name
+                    Optional<AsteriskedIdentifierChainBasis> identifierChainBasis = scope.resolveAsteriskedIdentifierChainBasis(prefix, allColumns);
+                    if (identifierChainBasis.isPresent() && identifierChainBasis.get().getBasisType() == TABLE) {
+                        RelationType relationType = identifierChainBasis.get().getRelationType().orElseThrow();
                         List<Field> requestedFields = relationType.resolveVisibleFieldsWithRelationPrefix(Optional.of(prefix));
                         List<Field> fields = filterInaccessibleFields(requestedFields);
                         if (fields.isEmpty()) {
@@ -5032,18 +5033,27 @@ class StatementAnalyzer
                             }
                             throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT * not allowed from relation that has no columns");
                         }
-                        boolean local = scope.isLocalScope(identifierChainBasis.getScope().orElseThrow());
+                        boolean local = scope.isLocalScope(identifierChainBasis.get().getScope().orElseThrow());
                         analyzeAllColumnsFromTable(
                                 fields,
                                 allColumns,
                                 node,
-                                local ? scope : identifierChainBasis.getScope().get(),
+                                local ? scope : identifierChainBasis.get().getScope().get(),
                                 outputExpressionBuilder,
                                 selectExpressionBuilder,
                                 relationType,
                                 local);
                         return;
                     }
+                    if (tryAnalyzeJsonWildcardSelectAll(expression, allColumns, scope, outputExpressionBuilder, selectExpressionBuilder)) {
+                        return;
+                    }
+                    if (identifierChainBasis.isEmpty()) {
+                        throw semanticException(TABLE_NOT_FOUND, allColumns, "Unable to resolve reference %s", prefix);
+                    }
+                }
+                else if (tryAnalyzeJsonWildcardSelectAll(expression, allColumns, scope, outputExpressionBuilder, selectExpressionBuilder)) {
+                    return;
                 }
                 // identifierChainBasis.get().getBasisType == FIELD or target expression isn't a QualifiedName
                 analyzeAllFieldsFromRowTypeExpression(expression, allColumns, node, scope, outputExpressionBuilder, selectExpressionBuilder);
@@ -5162,6 +5172,62 @@ class StatementAnalyzer
                 }
             }
             analysis.setSelectAllResultFields(allColumns, itemOutputFieldBuilder.build());
+        }
+
+        private boolean tryAnalyzeJsonWildcardSelectAll(
+                Expression target,
+                AllColumns allColumns,
+                Scope scope,
+                ImmutableList.Builder<Expression> outputExpressionBuilder,
+                ImmutableList.Builder<SelectExpression> selectExpressionBuilder)
+        {
+            if (!isJsonWildcardCandidate(target, scope)) {
+                return false;
+            }
+            if (!allColumns.getAliases().isEmpty()) {
+                validateColumnAliasesCount(allColumns.getAliases(), 1);
+            }
+
+            boolean registered = ExpressionAnalyzer.analyzeJsonWildcardAccessor(
+                    session,
+                    plannerContext,
+                    statementAnalyzerFactory,
+                    accessControl,
+                    scope,
+                    analysis,
+                    target,
+                    warningCollector,
+                    correlationSupport);
+            if (!registered) {
+                return false;
+            }
+
+            Optional<String> fieldName = allColumns.getAliases().isEmpty()
+                    ? Optional.empty()
+                    : Optional.of(allColumns.getAliases().getFirst().getValue());
+            outputExpressionBuilder.add(target);
+            selectExpressionBuilder.add(new SelectExpression(target, Optional.of(ImmutableList.of(target))));
+            analysis.setSelectAllResultFields(allColumns, ImmutableList.of(Field.newUnqualified(fieldName, VARCHAR)));
+            return true;
+        }
+
+        private static boolean isJsonWildcardCandidate(Expression target, Scope scope)
+        {
+            return JsonAccessorChain.walkForWildcard(target)
+                    .map(chain -> resolvesToJsonColumn(target, chain.prefix(), scope))
+                    .orElse(false);
+        }
+
+        private static boolean resolvesToJsonColumn(Expression target, List<Identifier> prefix, Scope scope)
+        {
+            for (int prefixLength = prefix.size(); prefixLength >= 1; prefixLength--) {
+                Optional<ResolvedField> resolved = scope.tryResolveField(target, QualifiedName.of(prefix.subList(0, prefixLength)));
+                if (resolved.isEmpty()) {
+                    continue;
+                }
+                return resolved.get().getType().equals(JSON);
+            }
+            return false;
         }
 
         private void analyzeAllFieldsFromRowTypeExpression(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -55,6 +55,7 @@ import io.trino.sql.ir.Reference;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
+import io.trino.sql.tree.ArrayWildcardSubscript;
 import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
@@ -350,6 +351,14 @@ public class TranslationMap
             return true;
         }
 
+        // a recipe-bearing expression must not be short-circuited to an existing mapping:
+        // for wildcard targets the recipe is keyed by the same NodeRef as the column
+        // reference, so the column branch below would drop the recipe. Answering false
+        // routes it through translateExpression, where the recipe dispatch runs.
+        if (analysis.getJsonSimplifiedAccessor(expression).isPresent()) {
+            return false;
+        }
+
         if (analysis.isColumnReference(expression)) {
             ResolvedField field = analysis.getColumnReferenceFields().get(NodeRef.of(expression));
             return scope.isLocalScope(field.getScope());
@@ -387,6 +396,12 @@ public class TranslationMap
         if (mapped.isPresent()) {
             result = mapped.get();
         }
+        else if (analysis.getJsonSimplifiedAccessor(expr).isPresent()) {
+            // SQL/JSON simplified-accessor recipes are keyed by NodeRef
+            // against the user's surface expression; dispatch them here so
+            // each per-type translate(X) below doesn't need its own check.
+            result = translateJsonSimplifiedAccessor(analysis.getJsonSimplifiedAccessor(expr).get());
+        }
         else {
             result = switch (expr) {
                 case io.trino.sql.tree.FieldReference expression -> translate(expression);
@@ -413,6 +428,7 @@ public class TranslationMap
                 case Trim expression -> translate(expression);
                 case Overlay expression -> translate(expression);
                 case SubscriptExpression expression -> translate(expression);
+                case ArrayWildcardSubscript expression -> translate(expression);
                 case LambdaExpression expression -> translate(expression);
                 case Parameter expression -> translate(expression);
                 case JsonExists expression -> translate(expression);
@@ -949,6 +965,83 @@ public class TranslationMap
         return new FieldReference(translateExpression(expression.getBase()), index);
     }
 
+    private io.trino.sql.ir.Expression translateJsonSimplifiedAccessor(Analysis.JsonSimplifiedAccessor accessor)
+    {
+        return switch (accessor) {
+            case Analysis.JsonSimplifiedAccessor.Query query -> translateJsonSimplifiedAccessorQuery(query);
+            case Analysis.JsonSimplifiedAccessor.Value value -> translateJsonSimplifiedAccessorValue(value);
+        };
+    }
+
+    private io.trino.sql.ir.Expression translateJsonSimplifiedAccessorQuery(Analysis.JsonSimplifiedAccessor.Query accessor)
+    {
+        io.trino.sql.ir.Expression queryCall = new Call(accessor.queryFunction(), ImmutableList.of(
+                simplifiedAccessorInput(accessor),
+                simplifiedAccessorPathExpression(accessor),
+                new Constant(JSON_NO_PARAMETERS_ROW_TYPE, null),
+                new Constant(TINYINT, (long) JsonQuery.ArrayWrapperBehavior.CONDITIONAL.ordinal()),
+                new Constant(TINYINT, (long) JsonQuery.EmptyOrErrorBehavior.NULL.ordinal()),
+                new Constant(TINYINT, (long) JsonQuery.EmptyOrErrorBehavior.NULL.ordinal())));
+
+        Constant errorBehavior = new Constant(TINYINT, (long) JsonQuery.EmptyOrErrorBehavior.NULL.ordinal());
+        Constant omitQuotes = new Constant(BOOLEAN, false);
+        return new Call(accessor.outputFunction(), ImmutableList.of(queryCall, errorBehavior, omitQuotes));
+    }
+
+    private io.trino.sql.ir.Expression translateJsonSimplifiedAccessorValue(Analysis.JsonSimplifiedAccessor.Value accessor)
+    {
+        // JSON_VALUE signature: input, path, params, returnType, emptyBehavior,
+        // emptyDefaultLambda, errorBehavior, errorDefaultLambda. NULL ON EMPTY
+        // and NULL ON ERROR per §6.36 case 3.a; the defaults are no-arg lambdas
+        // that return a typed null of the matching type.
+        Lambda nullDefault = new Lambda(ImmutableList.of(), new Constant(accessor.returnedType(), null));
+        Constant nullBehavior = new Constant(TINYINT, (long) JsonValue.EmptyOrErrorBehavior.NULL.ordinal());
+        return new Call(accessor.valueFunction(), ImmutableList.of(
+                simplifiedAccessorInput(accessor),
+                simplifiedAccessorPathExpression(accessor),
+                new Constant(JSON_NO_PARAMETERS_ROW_TYPE, null),
+                new Constant(accessor.returnedType(), null),
+                nullBehavior,
+                nullDefault,
+                nullBehavior,
+                nullDefault));
+    }
+
+    private io.trino.sql.ir.Expression simplifiedAccessorInput(Analysis.JsonSimplifiedAccessor accessor)
+    {
+        return new Call(
+                accessor.inputFunction(),
+                ImmutableList.of(
+                        new io.trino.sql.ir.Cast(resolveSimplifiedAccessorColumn(accessor.column()), VARCHAR),
+                        new Constant(BOOLEAN, false)));
+    }
+
+    private io.trino.sql.ir.Expression simplifiedAccessorPathExpression(Analysis.JsonSimplifiedAccessor accessor)
+    {
+        IrJsonPath path = new JsonPathTranslator(session, plannerContext)
+                .rewriteToIr(accessor.pathAnalysis(), ImmutableList.of());
+        return new Constant(plannerContext.getTypeManager().getType(new TypeDescriptor(JsonPath2016Type.NAME)), path);
+    }
+
+    private io.trino.sql.ir.Expression resolveSimplifiedAccessorColumn(ResolvedField field)
+    {
+        // SQL:2023 §6.36 syntax rule 2 only requires VEP's declared type to
+        // be JSON; outer-scope references are valid. Walk the translation-
+        // map chain to find the context owning the field's scope and
+        // resolve directly via its `fieldSymbols`. Going through
+        // `rewrite(columnReference)` would re-trigger the recipe for
+        // wildcard targets, where the recipe is keyed on the same
+        // `NodeRef` as the matched column-reference expression.
+        TranslationMap context = this;
+        while (context != null) {
+            if (context.scope.isLocalScope(field.getScope())) {
+                return context.fieldSymbols[field.getHierarchyFieldIndex()].toSymbolReference();
+            }
+            context = context.outerContext.orElse(null);
+        }
+        throw new IllegalStateException("Simplified accessor field has no matching translation context: " + field);
+    }
+
     private io.trino.sql.ir.Expression translate(Array expression)
     {
         List<io.trino.sql.ir.Expression> values = expression.getValues().stream()
@@ -1353,6 +1446,13 @@ public class TranslationMap
                 ImmutableList.of(
                         cast(plannerContext.getTypeManager(), translateExpression(node.getBase()), operator.signature().getArgumentType(0)),
                         cast(plannerContext.getTypeManager(), translateExpression(node.getIndex()), operator.signature().getArgumentType(1))));
+    }
+
+    private io.trino.sql.ir.Expression translate(ArrayWildcardSubscript node)
+    {
+        Analysis.JsonSimplifiedAccessor accessor = analysis.getJsonSimplifiedAccessor(node)
+                .orElseThrow(() -> new IllegalStateException(format("ArrayWildcardSubscript has no JSON simplified accessor recipe: %s", node)));
+        return translateJsonSimplifiedAccessor(accessor);
     }
 
     private io.trino.sql.ir.Expression translate(LambdaExpression node)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonSimplifiedAccessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonSimplifiedAccessor.java
@@ -1,0 +1,690 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestJsonSimplifiedAccessor
+{
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testMemberAccessor()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.foo
+                FROM (VALUES (CAST('{"foo":"bar"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"bar\"]'");
+    }
+
+    @Test
+    public void testNestedMemberAccessor()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.a.b
+                FROM (VALUES (CAST('{"a":{"b":42}}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[42]'");
+    }
+
+    @Test
+    public void testObjectMemberNotWrapped()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.a
+                FROM (VALUES (CAST('{"a":{"b":42}}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '{\"b\":42}'");
+    }
+
+    @Test
+    public void testMissingMember()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.absent
+                FROM (VALUES (CAST('{"foo":"bar"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST(NULL AS VARCHAR)");
+    }
+
+    @Test
+    public void testDelimitedMemberPreservesCase()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j."FooBar"
+                FROM (VALUES (CAST('{"FooBar":"matched","foobar":"not matched"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"matched\"]'");
+    }
+
+    @Test
+    public void testNestedDelimitedMembers()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j."Outer Key"."Inner Key"
+                FROM (VALUES (CAST('{"Outer Key":{"Inner Key":"matched","inner key":"not matched"}}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"matched\"]'");
+
+        // delimited and regular members compose in one chain
+        assertThat(assertions.query(
+                """
+                SELECT j.wrapper."Inner Key".leaf
+                FROM (VALUES (CAST('{"wrapper":{"Inner Key":{"leaf":42}}}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[42]'");
+    }
+
+    @Test
+    public void testNonJsonColumnIsRowFieldAccess()
+    {
+        assertThat(assertions.query(
+                """
+                WITH t(r) AS (SELECT CAST(ROW(1, 'a') AS ROW(x BIGINT, y VARCHAR)))
+                SELECT r.x FROM t
+                """))
+                .matches("VALUES BIGINT '1'");
+    }
+
+    @Test
+    public void testArrayIndexAccessor()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[1]
+                FROM (VALUES (CAST('[10, 20, 30]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[20]'");
+    }
+
+    @Test
+    public void testMemberThenIndex()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.items[0]
+                FROM (VALUES (CAST('{"items":["a","b","c"]}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"a\"]'");
+    }
+
+    @Test
+    public void testIndexThenMember()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[0].label
+                FROM (VALUES (CAST('[{"label":"hi"}]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"hi\"]'");
+    }
+
+    @Test
+    public void testMixedMemberAndIndex()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.rows[1].cells[0]
+                FROM (VALUES (CAST('{"rows":[{"cells":[1]},{"cells":[42,43]}]}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[42]'");
+    }
+
+    @Test
+    public void testIndexOutOfRangeYieldsNull()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[99]
+                FROM (VALUES (CAST('[1, 2, 3]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST(NULL AS VARCHAR)");
+    }
+
+    @Test
+    public void testNegativeIndex()
+    {
+        // the parser folds the sign into the literal, so the chain emits the path $[-1];
+        // SQL/JSON path subscripts are non-negative, and in lax mode the structural error
+        // is suppressed — the result is NULL, exactly as for an out-of-range index
+        assertThat(assertions.query(
+                """
+                SELECT j[-1]
+                FROM (VALUES (CAST('[1, 2, 3]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST(NULL AS VARCHAR)");
+    }
+
+    @Test
+    public void testArraySubscriptOnNonJsonStillWorks()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT a[2] FROM (VALUES (ARRAY['a','b','c'])) AS t(a)
+                """))
+                .matches("VALUES CAST('b' AS VARCHAR(1))");
+    }
+
+    @Test
+    public void testWildcardMemberAccessor()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.*
+                FROM (VALUES (CAST('{"a":1,"b":2}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1,2]'");
+    }
+
+    @Test
+    public void testWildcardAfterMemberChain()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.payload.*
+                FROM (VALUES (CAST('{"payload":{"x":"a","y":"b"}}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"a\",\"b\"]'");
+
+        // member values of mixed types are all collected
+        assertThat(assertions.query(
+                """
+                SELECT j.payload.*
+                FROM (VALUES (CAST('{"payload":{"x":"a","y":true,"z":1,"w":[2],"v":{"k":3}}}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"a\",true,1,[2],{\"k\":3}]'");
+    }
+
+    @Test
+    public void testRelationAliasTakesPrecedenceOverJsonWildcard()
+    {
+        // t.* where t is both a relation alias and a JSON column expands the relation,
+        // preserving pre-existing query semantics over the JSON accessor reading
+        assertThat(assertions.query(
+                """
+                SELECT t.*
+                FROM (VALUES (CAST('{"a":1}' AS JSON))) AS t(t)
+                """))
+                .matches("VALUES CAST('{\"a\":1}' AS JSON)");
+
+        // with no relation named j in scope, the JSON wildcard applies to the column
+        assertThat(assertions.query(
+                """
+                SELECT j.*
+                FROM (VALUES (CAST('{"a":1}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1]'");
+    }
+
+    @Test
+    public void testWildcardAfterArrayIndex()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[0].*
+                FROM (VALUES (CAST('[{"x":1,"y":2}]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1,2]'");
+    }
+
+    @Test
+    public void testWildcardOnRowColumnStillExpandsFields()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT t.r.* FROM (VALUES ROW(CAST(ROW(1, 'a') AS ROW(x BIGINT, y VARCHAR)))) AS t(r)
+                """))
+                .matches("VALUES (BIGINT '1', VARCHAR 'a')");
+    }
+
+    @Test
+    public void testBigintItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.n.bigint()
+                FROM (VALUES (CAST('{"n":42}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES BIGINT '42'");
+    }
+
+    @Test
+    public void testItemMethodPrecedenceOverMethodInvocation()
+    {
+        // The method-invocation feature shares the MethodCall surface with item-method
+        // accessors. An item-method name on a JSON-typed receiver resolves as the item
+        // method (SQL:2023 §6.36 case 3.a), shadowing any real method of the same name —
+        // pinned here so the try-ordering in visitMethodCall is a contract, not an accident.
+        assertThat(assertions.query(
+                """
+                SELECT j.n.bigint()
+                FROM (VALUES (CAST('{"n":42}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES BIGINT '42'");
+
+        // a name that is not an item method falls through to real method resolution
+        assertThat(assertions.query(
+                """
+                SELECT j.something(1)
+                FROM (VALUES (CAST('{"n":42}' AS JSON))) AS t(j)
+                """))
+                .failure()
+                .hasMessageContaining("something");
+
+        // an item-method name with an argument shape the accessor does not define
+        // (bigint takes no arguments) must not be swallowed by the accessor either
+        assertThat(assertions.query(
+                """
+                SELECT j.n.bigint(1)
+                FROM (VALUES (CAST('{"n":42}' AS JSON))) AS t(j)
+                """))
+                .failure()
+                .hasMessageContaining("bigint");
+
+        // a precision literal outside the int range is not an item-method form — it must
+        // fall through rather than silently wrap into a different in-range precision
+        assertThat(assertions.query(
+                """
+                SELECT j.n.decimal(4294967297)
+                FROM (VALUES (CAST('{"n":42}' AS JSON))) AS t(j)
+                """))
+                .failure()
+                .hasMessageContaining("decimal");
+
+        // item-method names are regular identifiers; a delimited name is never an item method
+        assertThat(assertions.query(
+                """
+                SELECT j.n."BIGINT"()
+                FROM (VALUES (CAST('{"n":42}' AS JSON))) AS t(j)
+                """))
+                .failure()
+                .hasMessageContaining("not registered");
+    }
+
+    @Test
+    public void testItemMethodDirectlyOnColumn()
+    {
+        // the 2-part FunctionCall shape: the item method applies to the column itself
+        // (path `lax $`), with no member steps in between
+        assertThat(assertions.query(
+                """
+                SELECT j.bigint()
+                FROM (VALUES (CAST('42' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES BIGINT '42'");
+    }
+
+    @Test
+    public void testStringItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.label.string()
+                FROM (VALUES (CAST('{"label":"hi"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST('hi' AS VARCHAR)");
+    }
+
+    @Test
+    public void testBooleanItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.ok.boolean()
+                FROM (VALUES (CAST('{"ok":true}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES TRUE");
+    }
+
+    @Test
+    public void testIntegerItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.x.integer()
+                FROM (VALUES (CAST('{"x":17}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES INTEGER '17'");
+    }
+
+    @Test
+    public void testNumberItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.d.number()
+                FROM (VALUES (CAST('{"d":3.5}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES DOUBLE '3.5'");
+    }
+
+    @Test
+    public void testDecimalItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.price.decimal(10, 2)
+                FROM (VALUES (CAST('{"price":19.99}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST(19.99 AS DECIMAL(10, 2))");
+    }
+
+    @Test
+    public void testTimestampItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.ts.timestamp(3)
+                FROM (VALUES (CAST('{"ts":"2024-01-02 03:04:05.678"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES TIMESTAMP '2024-01-02 03:04:05.678'");
+    }
+
+    @Test
+    public void testItemMethodMissingMember()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.missing.bigint()
+                FROM (VALUES (CAST('{"present":1}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST(NULL AS BIGINT)");
+    }
+
+    @Test
+    public void testItemMethodAfterSubscript()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.items[1].bigint()
+                FROM (VALUES (CAST('{"items":[10, 20, 30]}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES BIGINT '20'");
+    }
+
+    @Test
+    public void testArrayWildcardAccessor()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[*]
+                FROM (VALUES (CAST('[10, 20, 30]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[10,20,30]'");
+    }
+
+    @Test
+    public void testMemberThenArrayWildcard()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.items[*]
+                FROM (VALUES (CAST('{"items":["a","b"]}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"a\",\"b\"]'");
+    }
+
+    @Test
+    public void testArrayWildcardThenMember()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.rows[*].x
+                FROM (VALUES (CAST('{"rows":[{"x":1},{"x":2}]}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1,2]'");
+    }
+
+    @Test
+    public void testArrayWildcardRejectedOnNonJson()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT a[*] FROM (VALUES (ARRAY['a','b'])) AS t(a)
+                """))
+                .failure().hasMessageContaining("[*] array wildcard accessor is only allowed over a JSON simplified accessor chain");
+    }
+
+    @Test
+    public void testArrayWildcardSurfacesColumnNotFound()
+    {
+        // When the base of an [*] reference doesn't resolve, the
+        // column-not-found error is more useful than the catch-all
+        // "[*] not allowed" message.
+        assertThat(assertions.query(
+                """
+                SELECT badcol[*] FROM (VALUES (CAST('[1]' AS JSON))) AS t(j)
+                """))
+                .failure().hasMessageContaining("Column 'badcol' cannot be resolved");
+    }
+
+    @Test
+    public void testStringLiteralMemberAccessor()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.'foo'
+                FROM (VALUES (CAST('{"foo":1}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1]'");
+    }
+
+    @Test
+    public void testStringLiteralMemberWithSpecialChars()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.'foo bar'
+                FROM (VALUES (CAST('{"foo bar":"yes"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[\"yes\"]'");
+    }
+
+    @Test
+    public void testStringLiteralMemberWithItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.'count'.bigint()
+                FROM (VALUES (CAST('{"count":42}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES BIGINT '42'");
+    }
+
+    @Test
+    public void testUnquotedIdentifierIsCaseSensitiveInPath()
+    {
+        // SQL:2023 §6.36 NOTE 199: no implicit case folding. Unquoted `j.Foo`
+        // emits `lax $.Foo` and matches only the literal `Foo` member.
+        assertThat(assertions.query(
+                """
+                SELECT j.Foo
+                FROM (VALUES (CAST('{"foo":1,"Foo":2}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[2]'");
+    }
+
+    @Test
+    public void testDelimitedIdentifierIsCaseSensitiveInPath()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j."Foo"
+                FROM (VALUES (CAST('{"foo":1,"Foo":2}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[2]'");
+    }
+
+    @Test
+    public void testArrayWildcardThenMemberWildcardInSelectAll()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[*].*
+                FROM (VALUES (CAST('[{"a":1,"b":2}]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1,2]'");
+    }
+
+    @Test
+    public void testItemsArrayWildcardInSelectAll()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.items[*].*
+                FROM (VALUES (CAST('{"items":[{"a":1,"b":2}]}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES VARCHAR '[1,2]'");
+    }
+
+    @Test
+    public void testDateItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.d.date()
+                FROM (VALUES (CAST('{"d":"2024-01-02"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES DATE '2024-01-02'");
+    }
+
+    @Test
+    public void testTimeItemMethodDefaultPrecision()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.t.time()
+                FROM (VALUES (CAST('{"t":"03:04:05.678"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES TIME '03:04:05.678'");
+    }
+
+    @Test
+    public void testTimeItemMethodExplicitPrecision()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.t.time(0)
+                FROM (VALUES (CAST('{"t":"03:04:05"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES TIME '03:04:05'");
+    }
+
+    @Test
+    public void testTimeTzItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.t.time_tz(3)
+                FROM (VALUES (CAST('{"t":"03:04:05.678+01:00"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES TIME '03:04:05.678+01:00'");
+    }
+
+    @Test
+    public void testTimestampTzItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.ts.timestamp_tz(3)
+                FROM (VALUES (CAST('{"ts":"2024-01-02 03:04:05.678 UTC"}' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES TIMESTAMP '2024-01-02 03:04:05.678 UTC'");
+    }
+
+    @Test
+    public void testNegativeIndexYieldsNullInLaxMode()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j[-1]
+                FROM (VALUES (CAST('[10, 20, 30]' AS JSON))) AS t(j)
+                """))
+                .matches("VALUES CAST(NULL AS VARCHAR)");
+    }
+
+    @Test
+    public void testOuterScopeJsonColumn()
+    {
+        // SQL:2023 §6.36 syntax rule 2 doesn't restrict VEP's scope —
+        // any JSON-typed value expression is allowed, including a
+        // correlated outer-scope column reference.
+        assertThat(assertions.query(
+                """
+                SELECT (SELECT o.j.foo)
+                FROM (VALUES (CAST('{"foo":1}' AS JSON))) AS o(j)
+                """))
+                .matches("VALUES VARCHAR '[1]'");
+    }
+
+    @Test
+    public void testOuterScopeJsonColumnWithIndexedItemMethod()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT (SELECT o.j.items[0].bigint())
+                FROM (VALUES (CAST('{"items":[42]}' AS JSON))) AS o(j)
+                """))
+                .matches("VALUES BIGINT '42'");
+    }
+
+    @Test
+    public void testOuterScopeJsonColumnWildcard()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT (SELECT o.j.*)
+                FROM (VALUES (CAST('{"foo":1}' AS JSON))) AS o(j)
+                """))
+                .matches("VALUES VARCHAR '[1]'");
+    }
+
+    @Test
+    public void testOuterScopeJsonColumnFunctionItemMethodRejected()
+    {
+        // The FunctionCall item-method shape (no subscripts in the chain)
+        // has no Expression sub-node distinct from the user's surface,
+        // so the recipe can't hand a sub-tree to `outerContext.rewrite`.
+        // Local-scope works; outer-scope rejects with a clean semantic
+        // error rather than crashing in IR construction.
+        assertThat(assertions.query(
+                """
+                SELECT (SELECT o.j.foo.bigint())
+                FROM (VALUES (CAST('{"foo":42}' AS JSON))) AS o(j)
+                """))
+                .failure().hasMessageContaining("JSON simplified accessor over a column from an outer scope is not supported");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -32,6 +32,7 @@ import io.trino.sql.tree.AnchorPattern;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
+import io.trino.sql.tree.ArrayWildcardSubscript;
 import io.trino.sql.tree.AssignmentStatement;
 import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
@@ -3043,6 +3044,12 @@ class AstBuilder
     }
 
     @Override
+    public Node visitArrayWildcardSubscript(SqlBaseParser.ArrayWildcardSubscriptContext context)
+    {
+        return new ArrayWildcardSubscript(getLocation(context), (Expression) visit(context.value));
+    }
+
+    @Override
     public Node visitSubqueryExpression(SqlBaseParser.SubqueryExpressionContext context)
     {
         return new SubqueryExpression(getLocation(context), (Query) visit(context.query()));
@@ -3055,6 +3062,19 @@ class AstBuilder
                 getLocation(context),
                 (Expression) visit(context.base),
                 (Identifier) visit(context.fieldName));
+    }
+
+    @Override
+    public Node visitStringLiteralDereference(SqlBaseParser.StringLiteralDereferenceContext context)
+    {
+        // SQL:2023 T863: `<base>.<character string literal>` names a JSON
+        // member whose name is the literal's content. Normalize to a
+        // delimited-identifier dereference so downstream analysis treats it
+        // uniformly with `base."name"` (T861); the case-sensitive,
+        // arbitrary-character member name is preserved verbatim.
+        StringLiteral literal = (StringLiteral) visit(context.stringField);
+        Identifier field = new Identifier(getLocation(context.stringField), literal.getValue(), true);
+        return new DereferenceExpression(getLocation(context), (Expression) visit(context.base), field);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ArrayWildcardSubscript.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ArrayWildcardSubscript.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/// SQL:2023 §6.36 T864 array wildcard accessor: `base[*]` selects all
+/// elements of a JSON array. Parallels [DereferenceExpression] with an empty
+/// field for the `base.*` member-wildcard form.
+public class ArrayWildcardSubscript
+        extends Expression
+{
+    private final Expression base;
+
+    public ArrayWildcardSubscript(NodeLocation location, Expression base)
+    {
+        this(Optional.of(location), base);
+    }
+
+    public ArrayWildcardSubscript(Optional<NodeLocation> location, Expression base)
+    {
+        super(location);
+        this.base = requireNonNull(base, "base is null");
+    }
+
+    public Expression getBase()
+    {
+        return base;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitArrayWildcardSubscript(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of(base);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArrayWildcardSubscript that = (ArrayWildcardSubscript) o;
+        return Objects.equals(base, that.base);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(base);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -507,6 +507,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitArrayWildcardSubscript(ArrayWildcardSubscript node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitLongLiteral(LongLiteral node, C context)
     {
         return visitLiteral(node, context);

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -89,7 +89,7 @@ public class TestSqlParserErrorHandling
                         "line 1:13: Invalid numeric literal: -12223222232535343423232435343"),
                 Arguments.of(
                         "select foo.!",
-                        "line 1:12: mismatched input '!'. Expecting: '*', <identifier>"),
+                        "line 1:12: mismatched input '!'. Expecting: '*', <identifier>, <string>"),
                 Arguments.of(
                         "select foo(,1)",
                         "line 1:12: mismatched input ','. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>, <identifier>"),

--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -15,6 +15,10 @@ Trino supports three functions for querying JSON data:
 is based on the same mechanism of exploring and processing JSON input using
 JSON path.
 
+For convenient navigation of `JSON`-typed columns, Trino also supports the
+{ref}`JSON simplified accessor <json-simplified-accessor>` syntax, which lets
+you reach into JSON values using familiar dotted/subscripted notation.
+
 Trino also supports two functions for generating JSON data --
 {ref}`json_array<json-array>`, and {ref}`json_object<json-object>`.
 
@@ -699,6 +703,111 @@ method, the item `"a"` causes type mismatch.
 ```text
 <path>.floor() --> ERROR
 ```
+
+(json-simplified-accessor)=
+## JSON simplified accessor
+
+For convenient navigation of a `JSON`-typed value, Trino lets you write
+dotted/subscripted accessor chains that read as if you were navigating a row
+or array. The receiver of the chain must be a value of declared type `JSON`;
+each step extends a JSON path applied to that value.
+
+| Syntax | Equivalent to |
+|--------|---------------|
+| `j.name` | `JSON_QUERY(j, 'lax $.name' WITH CONDITIONAL ARRAY WRAPPER NULL ON EMPTY NULL ON ERROR)` |
+| `j."FooBar"` | `JSON_QUERY(j, 'lax $."FooBar"' …)` — delimited identifier, case-sensitive |
+| `j.'foo bar'` | same as the delimited form |
+| `j[3]` | `JSON_QUERY(j, 'lax $[3]' …)` — integer subscript |
+| `j[*]` | `JSON_QUERY(j, 'lax $[*]' …)` — array wildcard |
+| `j.*` (in `SELECT`) | `JSON_QUERY(j, 'lax $.*' …)` — member wildcard, produces one `VARCHAR` column |
+| `j.name.bigint()` | `JSON_VALUE(j, 'lax $.name' RETURNING BIGINT …)` — item method |
+| `j.payload.amount.decimal(18,2)` | `JSON_VALUE(j, 'lax $.payload.amount' RETURNING DECIMAL(18,2) …)` |
+
+Member, index, wildcard, and item-method steps compose freely:
+`j.rows[1].cells[*]`, `j.items[0].label`, `j.payload.*`, etc.
+
+### Case sensitivity
+
+Member-name identifiers are matched case-sensitively against the JSON keys
+they reference:
+
+* `j.Foo` matches the member literally named `Foo`.
+* `j."Foo"` and `j.'Foo'` are the same path — both quote the member name.
+
+This is different from regular SQL identifier handling, where `j.foo` and
+`j.FOO` refer to the same column. The JSON path language is case-sensitive,
+and the simplified accessor preserves the source case so JSON keys match
+exactly as written.
+
+Item-method names (`bigint`, `time`, `decimal`, …) are SQL identifiers and
+remain case-insensitive — `j.x.BIGINT()`, `j.x.Bigint()`, and `j.x.bigint()`
+all resolve to the same item method.
+
+### Item methods
+
+Item methods cover the same set of casts that `json_value`'s `RETURNING`
+clause does. The supported names and the type they return:
+
+| Method | Returns |
+|--------|---------|
+| `bigint()` | `BIGINT` |
+| `boolean()` | `BOOLEAN` |
+| `date()` | `DATE` |
+| `decimal()` | `DECIMAL` (unparameterized) |
+| `decimal(p)` | `DECIMAL(p)` |
+| `decimal(p, s)` | `DECIMAL(p, s)` |
+| `integer()` | `INTEGER` |
+| `number()` | `DOUBLE` |
+| `string()` | `VARCHAR` |
+| `time()` | `TIME(3)` |
+| `time(p)` | `TIME(p)` |
+| `time_tz()` | `TIME(3) WITH TIME ZONE` |
+| `time_tz(p)` | `TIME(p) WITH TIME ZONE` |
+| `timestamp()` | `TIMESTAMP(3)` |
+| `timestamp(p)` | `TIMESTAMP(p)` |
+| `timestamp_tz()` | `TIMESTAMP(3) WITH TIME ZONE` |
+| `timestamp_tz(p)` | `TIMESTAMP(p) WITH TIME ZONE` |
+
+The `ON EMPTY` and `ON ERROR` clauses default to `NULL`.
+
+### Member wildcard in `SELECT`
+
+`SELECT j.*` is shorthand for `SELECT JSON_QUERY(j, 'lax $.*' …)`. It
+produces one `VARCHAR` output column whose value is a JSON array of the
+top-level members of `j`. An optional `AS (column_alias)` may supply the
+output column's name:
+
+```
+SELECT j.* AS (payload) FROM (VALUES (CAST('{"a":1,"b":2}' AS JSON))) AS t(j);
+```
+
+```text
+  payload
+-----------
+ [1,2]
+(1 row)
+```
+
+The same wildcard is also recognized inside subscripted chains in a value-
+expression position, where it expands the path under that prefix:
+`j.payload.*`, `j.items[*]`, `j.items[*].label`, etc.
+
+### Outer scope
+
+The receiver of the chain may reference a column from an outer scope, for
+correlated subqueries:
+
+```
+SELECT (SELECT o.j.foo)
+FROM (VALUES (CAST('{"foo":1}' AS JSON))) AS o(j);
+```
+
+An outer-scope receiver is supported for member access (`o.j.foo`),
+subscripts (`o.j.items[0]`), item methods on a subscripted chain
+(`o.j.items[0].bigint()`), and the member wildcard (`o.j.*`). Item methods
+applied directly to a dotted member chain without an intervening subscript —
+e.g. `o.j.foo.bigint()` — are not supported on outer-scope columns; query
+the column locally or insert an explicit `JSON_VALUE` call in those cases.
 
 (json-exists)=
 ## json_exists

--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -272,6 +272,9 @@ is defined.
 In the case of `row_expression.* [ AS ( column_alias [, ...] ) ]`,
 the `row_expression` is an arbitrary expression of type `ROW`.
 All fields of the row define output columns to be included in the result set.
+When the receiver is of type `JSON`, the same surface syntax instead invokes
+the {ref}`JSON simplified accessor <json-simplified-accessor>` — see the JSON
+functions reference for details.
 
 In the case of `relation.*`, all columns of `relation` are included
 in the result set. In this case column aliases are not allowed.


### PR DESCRIPTION
## Description

Implements SQL:2023 §6.36 simplified accessor: a dotted/subscripted chain over a `JSON`-typed value denotes a JSON path lookup instead of a row-field / array access. Covers features T860 (member), T861 (delimited member), T862 (`.*` wildcard), T863 (string-literal member), T864 (`[N]` and `[*]` subscripts), and §6.36 case 3.a item methods (`bigint()`, `boolean()`, `date()`, `decimal(p,s)`, `integer()`, `number()`, `string()`, `time(p)`, `time_tz(p)`, `timestamp(p)`, `timestamp_tz(p)`).

## Additional context and related issues

Grammar additions:
- `primaryExpression '[' ASTERISK ']' #arrayWildcardSubscript` → new `ArrayWildcardSubscript` AST node.
- `primaryExpression '.' string #stringLiteralDereference` → `AstBuilder` normalizes into a delimited-`Identifier` `DereferenceExpression`.

User-facing documentation: new `## JSON simplified accessor` section in `docs/src/main/sphinx/functions/json.md`, cross-referenced from `docs/src/main/sphinx/sql/select.md`.

The recipe currently routes the JSON column through a `Cast(symbolRef, VARCHAR)` → `\$varchar_to_json` detour because Trino's `\$json_query` and `\$json_value` take `JSON_2016` and `JsonInputFunctions` only has character / binary input functions. A follow-up will drop the detour once `StandardTypes.JSON_2016` is unified with `JSON`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for reading values out of a `JSON` column using dotted and subscripted notation, e.g. `SELECT j.customer.name FROM orders` or `SELECT j.items[0].price.decimal(18,2) FROM orders`. ({issue}`...`)
* Add support for `SELECT j.*` over a `JSON` column to return its top-level members as a single value. ({issue}`...`)
```