### PR TITLE
Stabilize direct Trino client timeout test

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/client/direct/TestDirectTrinoClient.java
+++ b/testing/trino-tests/src/test/java/io/trino/client/direct/TestDirectTrinoClient.java
@@ -45,6 +45,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 public class TestDirectTrinoClient
 {
+    private static final String CLIENT_TIMEOUT = "2s";
+
     private QueryRunner queryRunner;
     private QueryRunner queryRunnerWithTaskRetry;
 
@@ -54,7 +56,7 @@ public class TestDirectTrinoClient
         queryRunner = new StandaloneQueryRunner(
                 TEST_SESSION,
                 builder -> builder.overrideProperties(ImmutableMap.of(
-                        "query.client.timeout", "1s")));
+                        "query.client.timeout", CLIENT_TIMEOUT)));
         queryRunner.installPlugin(new BlackHolePlugin());
         queryRunner.createCatalog("blackhole", "blackhole");
         queryRunner.execute("CREATE SCHEMA blackhole.test_schema");
@@ -73,7 +75,7 @@ public class TestDirectTrinoClient
         queryRunnerWithTaskRetry = new StandaloneQueryRunner(
                 TEST_SESSION,
                 builder -> builder.overrideProperties(ImmutableMap.of(
-                        "query.client.timeout", "1s",
+                        "query.client.timeout", CLIENT_TIMEOUT,
                         "retry-policy", "TASK")));
         queryRunnerWithTaskRetry.installPlugin(new TpchPlugin());
         queryRunnerWithTaskRetry.createCatalog("tpch", "tpch", ImmutableMap.of("tpch.splits-per-node", "1"));


### PR DESCRIPTION
## Description

`TestDirectTrinoClient` configured `query.client.timeout` to the minimum legal value of `1s`. Recent CI failures showed queries being abandoned after only ~1.1-1.4s without a heartbeat, coinciding with GC/scheduling pauses while the direct client test was running.

This increases only this test class's client timeout to `2s`, keeping the blackhole query's `3s` page delay long enough to continue exercising direct-client heartbeat behavior during blocked result handling.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
