### PR TITLE
Map PostgreSQL `point` type to Trino `geometry` type

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -216,7 +216,7 @@ this table:
 * - `ARRAY`
   - Disabled, `ARRAY`, or `JSON`
   - See [](postgresql-array-type-handling) for more information.
-* - `GEOMETRY`, `GEOMETRY(GEOMETRY TYPE, SRID)`
+* - `GEOMETRY`, `GEOMETRY(GEOMETRY TYPE, SRID)`, `POINT`
   - `GEOMETRY`
   -
 :::

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
@@ -216,6 +216,15 @@ public final class GeometryUtils
         return UnaryUnionOp.union(geometries);
     }
 
+    /**
+     * Create a JTS Point from x/y coordinates.
+     */
+    public static Point createPoint(double x, double y)
+    {
+        Coordinate coordinate = new Coordinate(x, y);
+        return GEOMETRY_FACTORY.createPoint(coordinate);
+    }
+
     private static void flattenGeometry(Geometry geometry, List<Geometry> output)
     {
         if (geometry.isEmpty()) {

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeometryType.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeometryType.java
@@ -21,7 +21,7 @@ public class GeometryType
     public static final String NAME = "Geometry";
     public static final GeometryType GEOMETRY = new GeometryType();
 
-    private GeometryType()
+    public GeometryType()
     {
         super(new TypeSignature(NAME));
     }

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -43,6 +43,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-geospatial-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-matching</artifactId>
         </dependency>
 
@@ -64,6 +69,11 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -117,7 +117,10 @@ import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 import org.postgresql.core.TypeInfo;
+import org.postgresql.geometric.PGpoint;
 import org.postgresql.jdbc.PgConnection;
 
 import java.io.IOException;
@@ -158,6 +161,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.geospatial.GeometryUtils.createPoint;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
 import static io.trino.plugin.base.util.JsonTypeUtil.toJsonValue;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
@@ -589,6 +593,7 @@ public class PostgreSqlClient
             case "hstore" -> Optional.of(hstoreColumnMapping());
             case "vector" -> Optional.of(vectorColumnMapping());
             case "geometry" -> Optional.of(geometryColumnMapping());
+            case "point" -> Optional.of(pointColumnMapping());
             default -> Optional.empty();
         };
         if (typeNameMapping.isPresent()) {
@@ -1951,6 +1956,54 @@ public class PostgreSqlClient
                         geometryType.writeObject(blockBuilder, value);
                         Slice slice = geometryType.getSlice(blockBuilder.build(), 0);
                         statement.setBytes(index, slice.getBytes());
+                    }
+                },
+                DISABLE_PUSHDOWN);
+    }
+
+    private ColumnMapping pointColumnMapping()
+    {
+        return ColumnMapping.objectMapping(
+                geometryType,
+                new ObjectReadFunction()
+                {
+                    @Override
+                    public Class<?> getJavaType()
+                    {
+                        return geometryType.getJavaType();
+                    }
+
+                    @Override
+                    public Object readObject(ResultSet resultSet, int columnIndex)
+                            throws SQLException
+                    {
+                        PGpoint pgPoint = (PGpoint) resultSet.getObject(columnIndex);
+                        BlockBuilder blockBuilder = geometryType.createBlockBuilder(null, 1);
+                        geometryType.writeObject(blockBuilder, createPoint(pgPoint.x, pgPoint.y));
+                        return geometryType.getObject(blockBuilder.build(), 0);
+                    }
+                },
+                new ObjectWriteFunction()
+                {
+                    @Override
+                    public Class<?> getJavaType()
+                    {
+                        return geometryType.getJavaType();
+                    }
+
+                    @Override
+                    public void set(PreparedStatement statement, int index, Object value)
+                            throws SQLException
+                    {
+                        Geometry geometry = (Geometry) value;
+                        if (!(geometry instanceof Point point)) {
+                            throw new TrinoException(JDBC_ERROR, format(
+                                    "Expected Point geometry when writing to PostgreSQL point column, but got %s (%s)",
+                                    geometry.getGeometryType(),
+                                    geometry.getClass().getName()));
+                        }
+                        PGpoint pgPoint = new PGpoint(point.getCoordinate().x, point.getCoordinate().y);
+                        statement.setObject(index, pgPoint);
                     }
                 },
                 DISABLE_PUSHDOWN);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -865,6 +865,9 @@ public class PostgreSqlClient
         if (type.equals(uuidType)) {
             return WriteMapping.sliceMapping("uuid", uuidWriteFunction());
         }
+        if (type.equals(geometryType)) {
+            return WriteMapping.objectMapping("geometry", geometryWriteFunction());
+        }
         if (type instanceof ArrayType arrayType && getArrayMapping(session) == AS_ARRAY) {
             Type elementType = arrayType.getElementType();
             String elementDataType = toWriteMapping(session, elementType).getDataType();
@@ -1934,31 +1937,36 @@ public class PostgreSqlClient
                         return geometryType.getObject(blockBuilder.build(), 0);
                     }
                 },
-                new ObjectWriteFunction()
-                {
-                    @Override
-                    public Class<?> getJavaType()
-                    {
-                        return geometryType.getJavaType();
-                    }
-
-                    @Override
-                    public String getBindExpression()
-                    {
-                        return "ST_GeomFromEWKB(?)";
-                    }
-
-                    @Override
-                    public void set(PreparedStatement statement, int index, Object value)
-                            throws SQLException
-                    {
-                        BlockBuilder blockBuilder = geometryType.createBlockBuilder(null, 1);
-                        geometryType.writeObject(blockBuilder, value);
-                        Slice slice = geometryType.getSlice(blockBuilder.build(), 0);
-                        statement.setBytes(index, slice.getBytes());
-                    }
-                },
+                geometryWriteFunction(),
                 DISABLE_PUSHDOWN);
+    }
+
+    private ObjectWriteFunction geometryWriteFunction()
+    {
+        return new ObjectWriteFunction()
+        {
+            @Override
+            public Class<?> getJavaType()
+            {
+                return geometryType.getJavaType();
+            }
+
+            @Override
+            public String getBindExpression()
+            {
+                return "ST_GeomFromEWKB(?)";
+            }
+
+            @Override
+            public void set(PreparedStatement statement, int index, Object value)
+                    throws SQLException
+            {
+                BlockBuilder blockBuilder = geometryType.createBlockBuilder(null, 1);
+                geometryType.writeObject(blockBuilder, value);
+                Slice slice = geometryType.getSlice(blockBuilder.build(), 0);
+                statement.setBytes(index, slice.getBytes());
+            }
+        };
     }
 
     private ColumnMapping pointColumnMapping()

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgreSqlTypeMappingTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/BasePostgreSqlTypeMappingTest.java
@@ -15,6 +15,7 @@ package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.plugin.geospatial.GeometryType;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
@@ -1927,6 +1928,22 @@ public abstract class BasePostgreSqlTypeMappingTest
                 .addRoundTrip("money", "10.54", createUnboundedVarcharType(), "CAST('$10.54' AS VARCHAR)")
                 .addRoundTrip("money", "1.000000042E7", createUnboundedVarcharType(), "CAST('$10,000,000.42' AS VARCHAR)")
                 .execute(getQueryRunner(), postgresCreateAndInsert("trino_test_money"));
+    }
+
+    @Test
+    public void testPoint()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("point", "NULL", new GeometryType(), "CAST(NULL AS GEOMETRY)")
+                .addRoundTrip("point", "'(1,2)'", new GeometryType(), "ST_POINT(1,2)")
+                .addRoundTrip("point", "'(1.23456789,-0.123456789)'", new GeometryType(), "ST_POINT(1.23456789,-0.123456789)")
+                .execute(getQueryRunner(), postgresCreateAndInsert("trino_test_point"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("point", "CAST(NULL AS GEOMETRY)", new GeometryType(), "CAST(NULL AS GEOMETRY)")
+                .addRoundTrip("point", "ST_Point(1,2)", new GeometryType(), "ST_POINT(1,2)")
+                .addRoundTrip("point", "ST_Point(1.23456789,-0.123456789)", new GeometryType(), "ST_POINT(1.23456789,-0.123456789)")
+                .execute(getQueryRunner(), postgresCreateAndTrinoInsert("trino_test_point"));
     }
 
     private void testUnsupportedDataTypeAsIgnored(Session session, String dataTypeName, String databaseValue)

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlGeometryType.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlGeometryType.java
@@ -91,6 +91,39 @@ final class TestPostgreSqlGeometryType
     }
 
     @Test
+    void testPointRead()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_point_read", "(geom point)")) {
+            postgreSqlServer.execute("INSERT INTO " + table.getName() + " VALUES (NULL), (point(1.23, -1))");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES NULL, ST_Point(1.23, -1)");
+        }
+    }
+
+    @Test
+    void testPointWrite()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_point_write", "(geom point)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES NULL, St_Point(12.345, -1.2)", 2);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES NULL, ST_Point(12.345, -1.2)");
+        }
+
+        assertQueryFails(
+                "CREATE TABLE trino_test_point AS SELECT ST_Point(1, 2) AS point",
+                "Unsupported column type: Geometry");
+    }
+
+    @Test
+    void testPointWriteFailure()
+    {
+        try (TestTable table = new TestTable(postgreSqlServer::execute, "test_point_write", "(geom point)")) {
+            assertQueryFails("INSERT INTO " + table.getName() + " VALUES (ST_LineString(ARRAY[ST_Point(0,0), ST_Point(1,1)]))",
+                    "Expected Point geometry when writing to PostgreSQL point column, but got LineString.*");
+        }
+    }
+
+    @Test
     void testGeometryNullRead()
     {
         try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_null_read", "(id int, geom geometry)")) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlGeometryType.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlGeometryType.java
@@ -19,6 +19,7 @@ import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.utility.DockerImageName;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestPostgreSqlGeometryType
@@ -64,6 +65,14 @@ final class TestPostgreSqlGeometryType
             assertThat(query("SELECT * FROM " + table.getName()))
                     .matches("VALUES ST_Point(1, 1)");
         }
+        try (TestTable testTable = newTrinoTable(
+                "test_geometry_ctas",
+                "AS SELECT ST_Point(1, 1) geom")) {
+            assertThat(query(format("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'", testTable.getName())))
+                    .matches("VALUES (varchar'geom', varchar'Geometry')");
+            assertThat(query("SELECT * FROM " + testTable.getName()))
+                    .matches("VALUES ST_Point(1, 1)");
+        }
     }
 
     @Test
@@ -71,6 +80,16 @@ final class TestPostgreSqlGeometryType
     {
         try (TestTable table = new TestTable(postgreSqlServer::execute, "test_geometry_write", "(geom geometry)")) {
             assertUpdate("INSERT INTO " + table.getName() + " VALUES (ST_SetSRID(ST_Point(1, 1), 4326))", 1);
+            assertThat(query("SELECT ST_SRID(geom) FROM " + table.getName()))
+                    .matches("VALUES 4326");
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES ST_Point(1, 1)");
+        }
+        try (TestTable table = newTrinoTable(
+                "test_geometry_ctas_with_srid",
+                "AS SELECT ST_SetSRID(ST_Point(1, 1), 4326) geom")) {
+            assertThat(query(format("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '%s'", table.getName())))
+                    .matches("VALUES (varchar'geom', varchar'Geometry')");
             assertThat(query("SELECT ST_SRID(geom) FROM " + table.getName()))
                     .matches("VALUES 4326");
             assertThat(query("SELECT * FROM " + table.getName()))
@@ -108,10 +127,6 @@ final class TestPostgreSqlGeometryType
             assertThat(query("SELECT * FROM " + table.getName()))
                     .matches("VALUES NULL, ST_Point(12.345, -1.2)");
         }
-
-        assertQueryFails(
-                "CREATE TABLE trino_test_point AS SELECT ST_Point(1, 2) AS point",
-                "Unsupported column type: Geometry");
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/postgresql/TestPostgresqlGeometryType.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/postgresql/TestPostgresqlGeometryType.java
@@ -19,6 +19,7 @@ import io.trino.tempto.ProductTest;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tests.product.TestGroups.POSTGRESQL;
 import static io.trino.tests.product.TestGroups.POSTGRESQL_POSTGIS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onPostgres;
@@ -70,5 +71,39 @@ public class TestPostgresqlGeometryType
                 .containsOnly(row(1));
         assertThat(onTrino().executeQuery("SELECT ST_AsText(geom) FROM postgresql." + TABLE_NAME + " WHERE geom IS NOT NULL"))
                 .containsOnly(row("POINT (5 6)"));
+    }
+
+    @Test(groups = {POSTGRESQL_POSTGIS, PROFILE_SPECIFIC_TESTS})
+    public void testCTASGeometryFromTrino()
+    {
+        onTrino().executeQuery("CREATE TABLE postgresql." + TABLE_NAME + " AS SELECT ST_GeometryFromText('POINT (3 4)') AS geom");
+
+        assertThat(onPostgres().executeQuery("SELECT ST_AsText(geom) FROM " + TABLE_NAME))
+                .containsOnly(row("POINT(3 4)"));
+        assertThat(onTrino().executeQuery("SELECT ST_AsText(geom) FROM postgresql." + TABLE_NAME))
+                .containsOnly(row("POINT (3 4)"));
+    }
+
+    @Test(groups = {POSTGRESQL, PROFILE_SPECIFIC_TESTS})
+    public void testReadPointFromPostgres()
+    {
+        onPostgres().executeQuery("CREATE TABLE " + TABLE_NAME + " (id SERIAL PRIMARY KEY, loc point)");
+        onPostgres().executeQuery("INSERT INTO " + TABLE_NAME + " (loc) VALUES ('(1.123456789, -0.123456789)')");
+
+        assertThat(onTrino().executeQuery("SELECT ST_AsText(loc) FROM postgresql." + TABLE_NAME))
+                .containsOnly(row("POINT (1.123456789 -0.123456789)"));
+    }
+
+    @Test(groups = {POSTGRESQL, PROFILE_SPECIFIC_TESTS})
+    public void testWritePointFromTrino()
+    {
+        onPostgres().executeQuery("CREATE TABLE " + TABLE_NAME + " (id SERIAL PRIMARY KEY, loc point)");
+
+        onTrino().executeQuery("INSERT INTO postgresql." + TABLE_NAME + " (loc) VALUES (st_point(1, 2))");
+
+        assertThat(onPostgres().executeQuery("SELECT loc::varchar FROM " + TABLE_NAME))
+                .containsOnly(row("(1,2)"));
+        assertThat(onTrino().executeQuery("SELECT ST_AsText(loc) FROM postgresql." + TABLE_NAME))
+                .containsOnly(row("POINT (1 2)"));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Adds mapping for PostgreSQL’s built-in native `point` type to Trino’s `Geometry` type, enabling read/write interoperability similar to existing `geometry` handling.
The PostgreSQL native `point` type (written as `(x,y)`) is completely separate from PostGIS GEOMETRY types so, special conversion to JTS geometry is needed.

**Changes:**
- Add a new `point` column mapping in `PostgreSqlClient` that reads PostgreSQL `point` values as JTS `Point` and writes JTS `Point` into PostgreSQL `point`.
- Add `GeometryUtils.createPoint(x, y)` helper for constructing a JTS point.
- Add basic read/write tests for the new `point` mapping.



---

💡 <a href="/trinodb/trino/new/master?filename=.github/instructions/*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Postgres
* Map Postgres native point type to Geometry type
```
