### PR TITLE
Attempt to fix #27486 (flaky pinot tests)

### DIFF
--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
@@ -22,7 +22,11 @@ import com.google.common.net.HttpHeaders;
 import io.airlift.http.client.HeaderNames;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
+import io.airlift.http.client.ResponseHandlerUtils;
 import io.airlift.http.client.StaticBodyGenerator;
+import io.airlift.http.client.UnexpectedResponseException;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonCodec;
 import io.trino.plugin.pinot.auth.password.PinotPasswordAuthenticationProvider;
@@ -54,10 +58,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.Resources.getResource;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.ResponseHandlerUtils.isJsonUtf8Content;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.apache.pinot.common.utils.http.HttpClient.DEFAULT_SOCKET_TIMEOUT_MS;
 import static org.testcontainers.utility.DockerImageName.parse;
@@ -244,7 +250,36 @@ public class TestingPinotCluster
                     .setBodyGenerator(StaticBodyGenerator.createStaticBodyGenerator(bytes))
                     .build();
 
-            PinotSuccessResponse response = doWithRetries(() -> httpClient.execute(request, createJsonResponseHandler(PINOT_SUCCESS_RESPONSE_JSON_CODEC)));
+            PinotSuccessResponse response = doWithRetries(() ->
+                    httpClient.execute(
+                            request,
+                            new ResponseHandler<>()
+                            {
+                                @Override
+                                public PinotSuccessResponse handleException(Request request, Exception exception)
+                                        throws RuntimeException
+                                {
+                                    throw ResponseHandlerUtils.propagate(request, exception);
+                                }
+
+                                @Override
+                                public PinotSuccessResponse handle(Request request, Response response)
+                                        throws RuntimeException
+                                {
+                                    byte[] bytes = ResponseHandlerUtils.getResponseBytes(request, response);
+                                    if (response.getStatusCode() < 200 ||
+                                            response.getStatusCode() >= 300 ||
+                                            !isJsonUtf8Content(response)) {
+                                        throw new UnexpectedResponseException(
+                                                "Unexpected non-successful response (code %d) response: %s".formatted(
+                                                        response.getStatusCode(),
+                                                        new String(bytes, UTF_8)),
+                                                request,
+                                                response);
+                                    }
+                                    return PINOT_SUCCESS_RESPONSE_JSON_CODEC.fromJson(bytes);
+                                }
+                            }));
             checkState(response.getStatus().startsWith(format("Table %s_OFFLINE successfully added", tableName)), "Unexpected response: '%s'", response.getStatus());
         }
     }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestingPinotCluster.java
@@ -43,6 +43,7 @@ import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -113,7 +114,8 @@ public class TestingPinotCluster
                 .withEnv("JAVA_OPTS", "-Xmx512m -Dlog4j2.configurationFile=/opt/pinot/conf/pinot-controller-log4j2.xml -Dplugins.dir=/opt/pinot/plugins")
                 .withCommand("StartController", "-configFileName", controllerConfig)
                 .withNetworkAliases("pinot-controller", "localhost")
-                .withExposedPorts(CONTROLLER_PORT);
+                .withExposedPorts(CONTROLLER_PORT)
+                .waitingFor(Wait.forHttp("/health").forStatusCode(200));
         closer.register(controller::stop);
 
         String brokerConfig = secured ? "/var/pinot/broker/config/pinot-broker-secured.conf" : "/var/pinot/broker/config/pinot-broker.conf";
@@ -124,7 +126,8 @@ public class TestingPinotCluster
                 .withEnv("JAVA_OPTS", "-Xmx512m -Dlog4j2.configurationFile=/opt/pinot/conf/pinot-broker-log4j2.xml -Dplugins.dir=/opt/pinot/plugins")
                 .withCommand("StartBroker", "-clusterName", "pinot", "-zkAddress", getZookeeperInternalHostPort(), "-configFileName", brokerConfig)
                 .withNetworkAliases("pinot-broker", "localhost")
-                .withExposedPorts(BROKER_PORT);
+                .withExposedPorts(BROKER_PORT)
+                .waitingFor(Wait.forHttp("/health").forStatusCode(200));
         closer.register(broker::stop);
 
         String serverConfig = secured ? "/var/pinot/server/config/pinot-server-secured.conf" : "/var/pinot/server/config/pinot-server.conf";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

An attempt to fix flaky test issue #27486. I used my company's CI to stress test with changes to add more debugging info (to answer why status code 400?) I found the following error message ...
```
{"code":400,"error":"Invalid table config for table region_REALTIME: Failed to find instances with tag: DefaultTenant_BROKER for table: region_REALTIME"}
```
This validation error says we can't yet create the realtime table because the broker hasn't connected to the controller yet. Knowing this I dug around and found that the cluster, broker and server are only loosely connected. All the containers will start and open ports even if they aren't participating in a pinot cluster like we expect them to. For example, replace the broker's 
```
.withCommand("StartBroker", "-clusterName", "pinot", "-zkAddress", getZookeeperInternalHostPort(), "-configFileName", brokerConfig)
```
With nonsense ...
```
.withCommand("ERROR")
```

And you will recreate the issue. As for what is likely the issue in practice, I found [this blog post author describing in 2021](https://www.markhneedham.com/blog/2021/11/23/apache-pinot-helix-exception-cluster-structure-not-set-up/) how they tried to use docker compose to bring up pinot containers and sometimes the broker would fail to connect (and silently fail): it was in a race with the pinot controller and needed the controller to write to zookeeper before it performed a read.

I figure waiting for health endpoints on the container will ...
 * tell us if a container has silently failed better
 * let us retry (re-using existing `withStartupAttempts` configuration) if there is a startup failure
 * be a better approximation of some container being "ready". Hopefully pinot doesn't report the controller as ready before it's written cluster info to zookeeper.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required. (test only)
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: