### PR TITLE
Remove redundant Hive storage product tests

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -8940,6 +8940,125 @@ public abstract class BaseHiveConnectorTest
                 });
     }
 
+    @Test
+    public void testNestedTimestampContainerPrecision()
+    {
+        record TimestampTestData(int id, HiveTimestampPrecision writePrecision, String writeValue, String millisValue, String microsValue, String nanosValue)
+        {
+            String readValue(HiveTimestampPrecision precision)
+            {
+                return switch (precision) {
+                    case MILLISECONDS -> millisValue;
+                    case MICROSECONDS -> microsValue;
+                    case NANOSECONDS -> nanosValue;
+                };
+            }
+        }
+
+        List<TimestampTestData> testData = ImmutableList.of(
+                new TimestampTestData(
+                        1,
+                        HiveTimestampPrecision.MILLISECONDS,
+                        "2020-01-02 12:01:00.999",
+                        "2020-01-02 12:01:00.999",
+                        "2020-01-02 12:01:00.999000",
+                        "2020-01-02 12:01:00.999000000"),
+                new TimestampTestData(
+                        2,
+                        HiveTimestampPrecision.MICROSECONDS,
+                        "2020-01-02 12:01:00.111499",
+                        "2020-01-02 12:01:00.111",
+                        "2020-01-02 12:01:00.111499",
+                        "2020-01-02 12:01:00.111499000"),
+                new TimestampTestData(
+                        3,
+                        HiveTimestampPrecision.NANOSECONDS,
+                        "2020-01-02 12:01:00.111499999",
+                        "2020-01-02 12:01:00.111",
+                        "2020-01-02 12:01:00.111500",
+                        "2020-01-02 12:01:00.111499999"));
+
+        for (HiveStorageFormat format : ImmutableList.of(HiveStorageFormat.ORC, HiveStorageFormat.PARQUET, HiveStorageFormat.RCBINARY, HiveStorageFormat.RCTEXT, HiveStorageFormat.SEQUENCEFILE, HiveStorageFormat.TEXTFILE)) {
+            String tableName = "test_nested_timestamp_container_precision_" + format.name().toLowerCase(ENGLISH);
+            try {
+                assertUpdate(format(
+                        """
+                        CREATE TABLE %s (
+                           id INTEGER,
+                           arr ARRAY(TIMESTAMP),
+                           map MAP(TIMESTAMP, TIMESTAMP),
+                           row ROW(col TIMESTAMP),
+                           nested ARRAY(MAP(TIMESTAMP, ROW(col ARRAY(TIMESTAMP))))
+                        )
+                        WITH (format = '%s')
+                        """,
+                        tableName,
+                        format));
+
+                for (TimestampTestData entry : testData) {
+                    String timestamp = format("TIMESTAMP '%s'", entry.writeValue());
+                    assertUpdate(
+                            withTimestampPrecision(getSession(), entry.writePrecision()),
+                            format(
+                                    """
+                                    INSERT INTO %s VALUES (
+                                        %s,
+                                        array[%3$s],
+                                        map(array[%3$s], array[%3$s]),
+                                        row(%3$s),
+                                        array[map(array[%3$s], array[row(array[%3$s])])]
+                                    )
+                                    """,
+                                    tableName,
+                                    entry.id(),
+                                    timestamp),
+                            1);
+                }
+
+                for (HiveTimestampPrecision precision : HiveTimestampPrecision.values()) {
+                    Session session = withTimestampPrecision(getSession(), precision);
+                    String type = format("timestamp(%d)", precision.getPrecision());
+                    assertQuery(
+                            session,
+                            format("SELECT typeof(arr), typeof(map), typeof(row), typeof(nested) FROM %s LIMIT 1", tableName),
+                            format(
+                                    "VALUES ('array(%1$s)', 'map(%1$s, %1$s)', 'row(\"col\" %1$s)', 'array(map(%1$s, row(\"col\" array(%1$s))))')",
+                                    type));
+                    assertQuery(
+                            session,
+                            format(
+                                    """
+                                    SELECT
+                                       id,
+                                       CAST(arr[1] AS VARCHAR),
+                                       CAST(map_entries(map)[1][1] AS VARCHAR),
+                                       CAST(map_entries(map)[1][2] AS VARCHAR),
+                                       CAST(row.col AS VARCHAR),
+                                       CAST(map_entries(nested[1])[1][1] AS VARCHAR),
+                                       CAST(map_entries(nested[1])[1][2].col[1] AS VARCHAR)
+                                    FROM %s
+                                    ORDER BY id
+                                    """,
+                                    tableName),
+                            testData.stream()
+                                    .map(entry -> timestampContainerExpectedRow(entry.id(), entry.readValue(precision)))
+                                    .collect(joining(", ", "VALUES ", "")));
+                }
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            }
+        }
+    }
+
+    private static String timestampContainerExpectedRow(int id, String value)
+    {
+        return format(
+                "(%s, '%2$s', '%2$s', '%2$s', '%2$s', '%2$s', '%2$s')",
+                id,
+                value);
+    }
+
     private void testTimestampPrecisionWrites(Session session, String tableName, BiConsumer<String, HiveTimestampPrecision> populateData)
     {
         populateData.accept("2019-02-03 18:30:00.123", HiveTimestampPrecision.MILLISECONDS);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4552,6 +4552,28 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testInsertWithNullFormat()
+    {
+        for (HiveStorageFormat storageFormat : ImmutableList.of(HiveStorageFormat.TEXTFILE, HiveStorageFormat.RCTEXT, HiveStorageFormat.SEQUENCEFILE)) {
+            String tableName = "test_insert_with_null_format_" + storageFormat.name().toLowerCase(ENGLISH);
+            assertUpdate(format(
+                    "CREATE TABLE %s (value VARCHAR) WITH (format = '%s', null_format = 'null_value')",
+                    tableName,
+                    storageFormat));
+
+            assertUpdate(
+                    format(
+                            "INSERT INTO %s VALUES ('null_value'), (NULL), ('non-null'), (''), ('\\N')",
+                            tableName),
+                    5);
+
+            assertThat(query("SELECT * FROM " + tableName))
+                    .matches("VALUES NULL, NULL, VARCHAR 'non-null', VARCHAR '', VARCHAR '\\N'");
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testCreateExternalTableWithDataNotAllowed()
             throws IOException
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4556,15 +4556,11 @@ public abstract class BaseHiveConnectorTest
     {
         for (HiveStorageFormat storageFormat : ImmutableList.of(HiveStorageFormat.TEXTFILE, HiveStorageFormat.RCTEXT, HiveStorageFormat.SEQUENCEFILE)) {
             String tableName = "test_insert_with_null_format_" + storageFormat.name().toLowerCase(ENGLISH);
-            assertUpdate(format(
-                    "CREATE TABLE %s (value VARCHAR) WITH (format = '%s', null_format = 'null_value')",
-                    tableName,
-                    storageFormat));
+            assertUpdate("CREATE TABLE %s (value VARCHAR) WITH (format = '%s', null_format = 'null_value')"
+                    .formatted(tableName, storageFormat));
 
             assertUpdate(
-                    format(
-                            "INSERT INTO %s VALUES ('null_value'), (NULL), ('non-null'), (''), ('\\N')",
-                            tableName),
+                    "INSERT INTO %s VALUES ('null_value'), (NULL), ('non-null'), (''), ('\\N')".formatted(tableName),
                     5);
 
             assertThat(query("SELECT * FROM " + tableName))
@@ -8955,7 +8951,7 @@ public abstract class BaseHiveConnectorTest
             }
         }
 
-        List<TimestampTestData> testData = ImmutableList.of(
+        List<TimestampTestData> testData = List.of(
                 new TimestampTestData(
                         1,
                         HiveTimestampPrecision.MILLISECONDS,
@@ -8978,10 +8974,10 @@ public abstract class BaseHiveConnectorTest
                         "2020-01-02 12:01:00.111500",
                         "2020-01-02 12:01:00.111499999"));
 
-        for (HiveStorageFormat format : ImmutableList.of(HiveStorageFormat.ORC, HiveStorageFormat.PARQUET, HiveStorageFormat.RCBINARY, HiveStorageFormat.RCTEXT, HiveStorageFormat.SEQUENCEFILE, HiveStorageFormat.TEXTFILE)) {
-            String tableName = "test_nested_timestamp_container_precision_" + format.name().toLowerCase(ENGLISH);
+        for (HiveStorageFormat storageFormat : List.of(HiveStorageFormat.ORC, HiveStorageFormat.PARQUET, HiveStorageFormat.RCBINARY, HiveStorageFormat.RCTEXT, HiveStorageFormat.SEQUENCEFILE, HiveStorageFormat.TEXTFILE)) {
+            String tableName = "test_nested_timestamp_container_precision_" + storageFormat.name().toLowerCase(ENGLISH);
             try {
-                assertUpdate(format(
+                assertUpdate(
                         """
                         CREATE TABLE %s (
                            id INTEGER,
@@ -8991,55 +8987,45 @@ public abstract class BaseHiveConnectorTest
                            nested ARRAY(MAP(TIMESTAMP, ROW(col ARRAY(TIMESTAMP))))
                         )
                         WITH (format = '%s')
-                        """,
-                        tableName,
-                        format));
+                        """.formatted(tableName, storageFormat));
 
                 for (TimestampTestData entry : testData) {
-                    String timestamp = format("TIMESTAMP '%s'", entry.writeValue());
+                    String timestamp = "TIMESTAMP '%s'".formatted(entry.writeValue());
                     assertUpdate(
                             withTimestampPrecision(getSession(), entry.writePrecision()),
-                            format(
-                                    """
-                                    INSERT INTO %s VALUES (
-                                        %s,
-                                        array[%3$s],
-                                        map(array[%3$s], array[%3$s]),
-                                        row(%3$s),
-                                        array[map(array[%3$s], array[row(array[%3$s])])]
-                                    )
-                                    """,
-                                    tableName,
-                                    entry.id(),
-                                    timestamp),
+                            """
+                            INSERT INTO %s VALUES (
+                                %s,
+                                array[%3$s],
+                                map(array[%3$s], array[%3$s]),
+                                row(%3$s),
+                                array[map(array[%3$s], array[row(array[%3$s])])]
+                            )
+                            """.formatted(tableName, entry.id(), timestamp),
                             1);
                 }
 
                 for (HiveTimestampPrecision precision : HiveTimestampPrecision.values()) {
                     Session session = withTimestampPrecision(getSession(), precision);
-                    String type = format("timestamp(%d)", precision.getPrecision());
+                    String type = "timestamp(%d)".formatted(precision.getPrecision());
                     assertQuery(
                             session,
-                            format("SELECT typeof(arr), typeof(map), typeof(row), typeof(nested) FROM %s LIMIT 1", tableName),
-                            format(
-                                    "VALUES ('array(%1$s)', 'map(%1$s, %1$s)', 'row(\"col\" %1$s)', 'array(map(%1$s, row(\"col\" array(%1$s))))')",
-                                    type));
+                            "SELECT typeof(arr), typeof(map), typeof(row), typeof(nested) FROM %s LIMIT 1".formatted(tableName),
+                            "VALUES ('array(%1$s)', 'map(%1$s, %1$s)', 'row(\"col\" %1$s)', 'array(map(%1$s, row(\"col\" array(%1$s))))')".formatted(type));
                     assertQuery(
                             session,
-                            format(
-                                    """
-                                    SELECT
-                                       id,
-                                       CAST(arr[1] AS VARCHAR),
-                                       CAST(map_entries(map)[1][1] AS VARCHAR),
-                                       CAST(map_entries(map)[1][2] AS VARCHAR),
-                                       CAST(row.col AS VARCHAR),
-                                       CAST(map_entries(nested[1])[1][1] AS VARCHAR),
-                                       CAST(map_entries(nested[1])[1][2].col[1] AS VARCHAR)
-                                    FROM %s
-                                    ORDER BY id
-                                    """,
-                                    tableName),
+                            """
+                            SELECT
+                               id,
+                               CAST(arr[1] AS VARCHAR),
+                               CAST(map_entries(map)[1][1] AS VARCHAR),
+                               CAST(map_entries(map)[1][2] AS VARCHAR),
+                               CAST(row.col AS VARCHAR),
+                               CAST(map_entries(nested[1])[1][1] AS VARCHAR),
+                               CAST(map_entries(nested[1])[1][2].col[1] AS VARCHAR)
+                            FROM %s
+                            ORDER BY id
+                            """.formatted(tableName),
                             testData.stream()
                                     .map(entry -> timestampContainerExpectedRow(entry.id(), entry.readValue(precision)))
                                     .collect(joining(", ", "VALUES ", "")));
@@ -9053,10 +9039,7 @@ public abstract class BaseHiveConnectorTest
 
     private static String timestampContainerExpectedRow(int id, String value)
     {
-        return format(
-                "(%s, '%2$s', '%2$s', '%2$s', '%2$s', '%2$s', '%2$s')",
-                id,
-                value);
+        return "(%s, '%2$s', '%2$s', '%2$s', '%2$s', '%2$s', '%2$s')".formatted(id, value);
     }
 
     private void testTimestampPrecisionWrites(Session session, String tableName, BiConsumer<String, HiveTimestampPrecision> populateData)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -23,7 +23,6 @@ import io.trino.tempto.ProductTest;
 import io.trino.tempto.assertions.QueryAssert.Row;
 import io.trino.tempto.hadoop.hdfs.HdfsClient;
 import io.trino.tempto.query.QueryExecutionException;
-import io.trino.tempto.query.QueryExecutor.QueryParam;
 import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
 import io.trino.tests.product.utils.JdbcDriverUtils;
@@ -33,10 +32,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
-import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -52,7 +49,6 @@ import static io.trino.plugin.hive.HiveTimestampPrecision.MICROSECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
-import static io.trino.tempto.query.QueryExecutor.param;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.HMS_ONLY;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
@@ -276,37 +272,6 @@ public class TestHiveStorageFormats
                 // nanoseconds are not supported with Avro
                 .filter(format -> !"AVRO".equals(format.getName()))
                 .iterator();
-    }
-
-    @Test(dataProvider = "storageFormatsWithNullFormat", groups = {STORAGE_FORMATS_DETAILED, HMS_ONLY})
-    public void testInsertAndSelectWithNullFormat(StorageFormat storageFormat)
-    {
-        String nullFormat = "null_value";
-        String tableName = format(
-                "test_storage_format_%s_insert_and_select_with_null_format",
-                storageFormat.getName());
-        onTrino().executeQuery(format(
-                "CREATE TABLE %s (value VARCHAR) " +
-                        "WITH (format = '%s', null_format = '%s')",
-                tableName,
-                storageFormat.getName(),
-                nullFormat));
-
-        // \N is the default null format
-        String[] values = {nullFormat, null, "non-null", "", "\\N"};
-        Row[] storedValues = Arrays.stream(values).map(Row::row).toArray(Row[]::new);
-        storedValues[0] = row((Object) null); // if you put in the null format, it saves as null
-
-        String placeholders = String.join(", ", nCopies(values.length, "(?)"));
-        onTrino().executeQuery(
-                format("INSERT INTO %s VALUES %s", tableName, placeholders),
-                Arrays.stream(values)
-                        .map(value -> param(JDBCType.VARCHAR, value))
-                        .toArray(QueryParam[]::new));
-
-        assertThat(onTrino().executeQuery(format("SELECT * FROM %s", tableName))).containsOnly(storedValues);
-
-        onTrino().executeQuery(format("DROP TABLE %s", tableName));
     }
 
     @Test(dataProvider = "storageFormatsWithZeroByteFile", groups = STORAGE_FORMATS_DETAILED)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -13,9 +13,7 @@
  */
 package io.trino.tests.product.hive;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -44,16 +42,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.immutableEntry;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MICROSECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
@@ -82,8 +75,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestHiveStorageFormats
         extends ProductTest
 {
-    private static final String TPCH_SCHEMA = "tiny";
-
     @Inject(optional = true)
     @Named("databases.trino.admin_role_enabled")
     private boolean adminRoleEnabled;
@@ -287,154 +278,6 @@ public class TestHiveStorageFormats
                 .iterator();
     }
 
-    @Test
-    public void verifyDataProviderCompleteness()
-    {
-        String formatsDescription = (String) onTrino().executeQuery("SELECT description FROM system.metadata.table_properties WHERE catalog_name = CURRENT_CATALOG AND property_name = 'format'").getOnlyValue();
-        Pattern pattern = Pattern.compile("Hive storage format for the table. Possible values: \\[([A-Z]+(, [A-z]+)+)]");
-        assertThat(formatsDescription).matches(pattern);
-        Matcher matcher = pattern.matcher(formatsDescription);
-        verify(matcher.matches());
-
-        // HiveStorageFormat.values
-        List<String> allFormats = Splitter.on(",").trimResults().splitToList(matcher.group(1));
-
-        Set<String> allFormatsToTest = allFormats.stream()
-                // Hive CSV storage format only supports VARCHAR, so needs to be excluded from any generic tests
-                .filter(format -> !"CSV".equals(format))
-                // REGEX is read-only
-                .filter(format -> !"REGEX".equals(format))
-                // ESRI is read-only
-                .filter(format -> !"ESRI".equals(format))
-                // ESRI_GEO_JSON is read-only
-                .filter(format -> !"ESRI_GEO_JSON".equals(format))
-                // SEQUENCEFILE_PROTOBUF is read-only
-                .filter(format -> !"SEQUENCEFILE_PROTOBUF".equals(format))
-                // TODO when using JSON serde Hive fails with ClassNotFoundException: org.apache.hive.hcatalog.data.JsonSerDe
-                .filter(format -> !"JSON".equals(format))
-                // OPENX is not supported in Hive by default
-                .filter(format -> !"OPENX_JSON".equals(format))
-                .collect(toImmutableSet());
-
-        assertThat(ImmutableSet.copyOf(storageFormats()))
-                .isEqualTo(allFormatsToTest);
-    }
-
-    @Test(dataProvider = "storageFormatsWithConfiguration", groups = {STORAGE_FORMATS, HMS_ONLY})
-    public void testInsertIntoTable(StorageFormat storageFormat)
-    {
-        // only admin user is allowed to change session properties
-        setAdminRole();
-        setSessionProperties(storageFormat);
-
-        String tableName = "storage_formats_test_insert_into_" + storageFormat.getName().toLowerCase(ENGLISH);
-
-        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-
-        String createTable = format(
-                "CREATE TABLE %s(" +
-                        "   orderkey      BIGINT," +
-                        "   partkey       BIGINT," +
-                        "   suppkey       BIGINT," +
-                        "   linenumber    INTEGER," +
-                        "   quantity      DOUBLE," +
-                        "   extendedprice DOUBLE," +
-                        "   discount      DOUBLE," +
-                        "   tax           DOUBLE," +
-                        "   linestatus    VARCHAR," +
-                        "   shipinstruct  VARCHAR," +
-                        "   shipmode      VARCHAR," +
-                        "   comment       VARCHAR," +
-                        "   returnflag    VARCHAR" +
-                        ") WITH (%s)",
-                tableName,
-                storageFormat.getStoragePropertiesAsSql());
-        onTrino().executeQuery(createTable);
-
-        String insertInto = format("INSERT INTO %s " +
-                "SELECT " +
-                "orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
-                "linestatus, shipinstruct, shipmode, comment, returnflag " +
-                "FROM tpch.%s.lineitem", tableName, TPCH_SCHEMA);
-        onTrino().executeQuery(insertInto);
-
-        assertResultEqualForLineitemTable(
-                "select sum(tax), sum(discount), sum(linenumber) from %s", tableName);
-
-        onTrino().executeQuery(format("DROP TABLE %s", tableName));
-    }
-
-    @Test(dataProvider = "storageFormatsWithConfiguration", groups = {STORAGE_FORMATS, HMS_ONLY})
-    public void testCreateTableAs(StorageFormat storageFormat)
-    {
-        // only admin user is allowed to change session properties
-        setAdminRole();
-        setSessionProperties(storageFormat);
-
-        String tableName = "storage_formats_test_create_table_as_select_" + storageFormat.getName().toLowerCase(ENGLISH);
-
-        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-
-        String createTableAsSelect = format(
-                "CREATE TABLE %s WITH (%s) AS " +
-                        "SELECT " +
-                        "partkey, suppkey, extendedprice " +
-                        "FROM tpch.%s.lineitem",
-                tableName,
-                storageFormat.getStoragePropertiesAsSql(),
-                TPCH_SCHEMA);
-        onTrino().executeQuery(createTableAsSelect);
-
-        assertResultEqualForLineitemTable(
-                "select sum(extendedprice), sum(suppkey), count(partkey) from %s", tableName);
-
-        onTrino().executeQuery(format("DROP TABLE %s", tableName));
-    }
-
-    @Test(dataProvider = "storageFormatsWithConfiguration", groups = {STORAGE_FORMATS, HMS_ONLY})
-    public void testInsertIntoPartitionedTable(StorageFormat storageFormat)
-    {
-        // only admin user is allowed to change session properties
-        setAdminRole();
-        setSessionProperties(storageFormat);
-
-        String tableName = "storage_formats_test_insert_into_partitioned_" + storageFormat.getName().toLowerCase(ENGLISH);
-
-        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-
-        String createTable = format(
-                "CREATE TABLE %s(" +
-                        "   orderkey      BIGINT," +
-                        "   partkey       BIGINT," +
-                        "   suppkey       BIGINT," +
-                        "   linenumber    INTEGER," +
-                        "   quantity      DOUBLE," +
-                        "   extendedprice DOUBLE," +
-                        "   discount      DOUBLE," +
-                        "   tax           DOUBLE," +
-                        "   linestatus    VARCHAR," +
-                        "   shipinstruct  VARCHAR," +
-                        "   shipmode      VARCHAR," +
-                        "   comment       VARCHAR," +
-                        "   returnflag    VARCHAR" +
-                        ") WITH (format='%s', partitioned_by = ARRAY['returnflag'])",
-                tableName,
-                storageFormat.getName());
-        onTrino().executeQuery(createTable);
-
-        String insertInto = format("INSERT INTO %s " +
-                "SELECT " +
-                "orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
-                "linestatus, shipinstruct, shipmode, comment, returnflag " +
-                "FROM tpch.%s.lineitem", tableName, TPCH_SCHEMA);
-        onTrino().executeQuery(insertInto);
-
-        assertResultEqualForLineitemTable(
-                "select sum(tax), sum(discount), sum(length(returnflag)) from %s", tableName);
-
-        onTrino().executeQuery(format("DROP TABLE %s", tableName));
-    }
-
     @Test(dataProvider = "storageFormatsWithNullFormat", groups = {STORAGE_FORMATS_DETAILED, HMS_ONLY})
     public void testInsertAndSelectWithNullFormat(StorageFormat storageFormat)
     {
@@ -512,33 +355,6 @@ public class TestHiveStorageFormats
                 .containsOnly(row("non-null"), row((Object) null), row((Object) null));
 
         onHive().executeQuery(format("DROP TABLE %s", tableName));
-    }
-
-    @Test(dataProvider = "storageFormatsWithConfiguration", groups = {STORAGE_FORMATS, HMS_ONLY})
-    public void testCreatePartitionedTableAs(StorageFormat storageFormat)
-    {
-        // only admin user is allowed to change session properties
-        setAdminRole();
-        setSessionProperties(storageFormat);
-
-        String tableName = "storage_formats_test_create_table_as_select_partitioned_" + storageFormat.getName().toLowerCase(ENGLISH);
-
-        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
-
-        String createTableAsSelect = format(
-                "CREATE TABLE %s WITH (%s, partitioned_by = ARRAY['returnflag']) AS " +
-                        "SELECT " +
-                        "tax, discount, returnflag " +
-                        "FROM tpch.%s.lineitem",
-                tableName,
-                storageFormat.getStoragePropertiesAsSql(),
-                TPCH_SCHEMA);
-        onTrino().executeQuery(createTableAsSelect);
-
-        assertResultEqualForLineitemTable(
-                "select sum(tax), sum(discount), sum(length(returnflag)) from %s", tableName);
-
-        onTrino().executeQuery(format("DROP TABLE %s", tableName));
     }
 
     @Test(groups = STORAGE_FORMATS)
@@ -695,23 +511,6 @@ public class TestHiveStorageFormats
         }
 
         assertSimpleTimestamps(tableName, TIMESTAMPS_FROM_HIVE);
-        onTrino().executeQuery("DROP TABLE " + tableName);
-    }
-
-    @Test(dataProvider = "storageFormatsWithNanosecondPrecision", groups = {STORAGE_FORMATS_DETAILED, HMS_ONLY})
-    public void testTimestampCreatedFromTrino(StorageFormat storageFormat)
-    {
-        String tableName = createSimpleTimestampTable("timestamps_from_trino", storageFormat);
-
-        // insert records one by one so that we have one file per record, which
-        // allows us to exercise predicate push-down in Parquet (which only
-        // works when the value range has a min = max)
-        for (TimestampAndPrecision entry : TIMESTAMPS_FROM_TRINO) {
-            setTimestampPrecision(entry.getPrecision());
-            onTrino().executeQuery(format("INSERT INTO %s VALUES (%s, TIMESTAMP '%s')", tableName, entry.getId(), entry.getWriteValue()));
-        }
-
-        assertSimpleTimestamps(tableName, TIMESTAMPS_FROM_TRINO);
         onTrino().executeQuery("DROP TABLE " + tableName);
     }
 
@@ -934,27 +733,6 @@ public class TestHiveStorageFormats
         onTrino().executeQuery(
                 format("CREATE TABLE %s %s WITH (%s)", tableName, sql, format.getStoragePropertiesAsSql()));
         return tableName;
-    }
-
-    /**
-     * Run the given query on the given table and the TPCH {@code lineitem} table
-     * (in the schema {@code TPCH_SCHEMA}, asserting that the results are equal.
-     */
-    private static void assertResultEqualForLineitemTable(String query, String tableName)
-    {
-        QueryResult expected = onTrino().executeQuery(format(query, "tpch." + TPCH_SCHEMA + ".lineitem"));
-        List<Row> expectedRows = expected.rows().stream()
-                .map(columns -> row(columns.toArray()))
-                .collect(toImmutableList());
-        QueryResult actual = onTrino().executeQuery(format(query, tableName));
-        assertThat(actual)
-                .hasColumns(expected.getColumnTypes())
-                .containsExactlyInOrder(expectedRows);
-    }
-
-    private void setAdminRole()
-    {
-        setAdminRole(onTrino().getConnection());
     }
 
     private void setAdminRole(Connection connection)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -50,7 +49,6 @@ import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.tests.product.TestGroups.HMS_ONLY;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS_DETAILED;
 import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_ISSUES;
@@ -158,63 +156,6 @@ public class TestHiveStorageFormats
                     "2028-01-01 00:00:00.000",
                     "2027-12-31 23:59:59.999999",
                     "2027-12-31 23:59:59.999999499"));
-
-    // These check that values are correctly rounded on insertion
-    private static final List<TimestampAndPrecision> TIMESTAMPS_FROM_TRINO = List.of(
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.999", // millis as millis (no rounding)
-                    MILLISECONDS,
-                    "2020-01-02 12:01:00.999",
-                    "2020-01-02 12:01:00.999000",
-                    "2020-01-02 12:01:00.999000000"),
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.111499999", // nanos as millis rounds down (largest)
-                    MILLISECONDS,
-                    "2020-01-02 12:01:00.111",
-                    "2020-01-02 12:01:00.111000",
-                    "2020-01-02 12:01:00.111000000"),
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.1115", // micros as millis rounds up (smallest)
-                    MILLISECONDS,
-                    "2020-01-02 12:01:00.112",
-                    "2020-01-02 12:01:00.112000",
-                    "2020-01-02 12:01:00.112000000"),
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.111333", // micros as micros (no rounding)
-                    MICROSECONDS,
-                    "2020-01-02 12:01:00.111",
-                    "2020-01-02 12:01:00.111333",
-                    "2020-01-02 12:01:00.111333000"),
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.1113334", // nanos as micros rounds down
-                    MICROSECONDS,
-                    "2020-01-02 12:01:00.111",
-                    "2020-01-02 12:01:00.111333",
-                    "2020-01-02 12:01:00.111333000"),
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.111333777", // nanos as micros rounds up
-                    MICROSECONDS,
-                    "2020-01-02 12:01:00.111",
-                    "2020-01-02 12:01:00.111334",
-                    "2020-01-02 12:01:00.111334000"),
-            timestampAndPrecision(
-                    "2020-01-02 12:01:00.111333444", // nanos as nanos (no rounding)
-                    NANOSECONDS,
-                    "2020-01-02 12:01:00.111",
-                    "2020-01-02 12:01:00.111333",
-                    "2020-01-02 12:01:00.111333444"),
-            timestampAndPrecision(
-                    "2020-01-02 23:59:59.999911333", // nanos as millis rounds up to next day
-                    MILLISECONDS,
-                    "2020-01-03 00:00:00.000",
-                    "2020-01-03 00:00:00.000000",
-                    "2020-01-03 00:00:00.000000000"),
-            timestampAndPrecision(
-                    "2020-12-31 23:59:59.99999", // micros as millis rounds up to next year
-                    MILLISECONDS,
-                    "2021-01-01 00:00:00.000",
-                    "2021-01-01 00:00:00.000000",
-                    "2021-01-01 00:00:00.000000000"));
 
     @DataProvider
     public static String[] storageFormats()
@@ -507,36 +448,6 @@ public class TestHiveStorageFormats
         }
 
         assertStructTimestamps(tableName, TIMESTAMPS_FROM_HIVE);
-        onTrino().executeQuery(format("DROP TABLE %s", tableName));
-    }
-
-    @Test(dataProvider = "storageFormatsWithNanosecondPrecision", groups = {STORAGE_FORMATS_DETAILED, HMS_ONLY})
-    public void testStructTimestampsFromTrino(StorageFormat format)
-    {
-        String tableName = createStructTimestampTable("trino_struct_timestamp", format);
-        setAdminRole(onTrino().getConnection());
-
-        // Insert data grouped by write-precision so it rounds as expected
-        TIMESTAMPS_FROM_TRINO.stream()
-                .collect(Collectors.groupingBy(TimestampAndPrecision::getPrecision))
-                .forEach((precision, data) -> {
-                    setTimestampPrecision(precision);
-                    onTrino().executeQuery(format(
-                            "INSERT INTO %s VALUES (%s)",
-                            tableName,
-                            data.stream()
-                                    .map(entry -> format(
-                                            "%s,"
-                                                    + " array[%2$s],"
-                                                    + " map(array[%2$s], array[%2$s]),"
-                                                    + " row(%2$s),"
-                                                    + " array[map(array[%2$s], array[row(array[%2$s])])]",
-                                            entry.getId(),
-                                            format("TIMESTAMP '%s'", entry.getWriteValue())))
-                                    .collect(joining("), ("))));
-                });
-
-        assertStructTimestamps(tableName, TIMESTAMPS_FROM_TRINO);
         onTrino().executeQuery(format("DROP TABLE %s", tableName));
     }
 


### PR DESCRIPTION
## Description

Remove redundant Hive storage format product tests that only write and read through Trino. These cases do not need the product-test environment because the same Trino-side storage format behavior is covered in the Hive module.

The removed INSERT and CTAS storage format coverage is covered by `BaseHiveConnectorTest`, and file-format reader/writer coverage is covered by `TestHiveFileFormats`.

This also moves two Trino-only edge cases into `BaseHiveConnectorTest`:

- `null_format` write/read behavior
- nested timestamp container precision behavior

The remaining product tests in `TestHiveStorageFormats` continue to cover Hive/Trino interoperability or large writer cases that still need product-test coverage.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
