### PR TITLE
Patch CVE-2026-8178 without dependency upgrade in Redshift connector

### DIFF
--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClientModule.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClientModule.java
@@ -57,6 +57,7 @@ public class RedshiftClientModule
     public void setup(Binder binder)
     {
         configBinder(binder).bindConfig(RedshiftConfig.class);
+        configBinder(binder).bindConfig(RedshiftJdbcConfig.class);
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(RedshiftClient.class).in(SINGLETON);
         configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setBulkListColumns(true));
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(SINGLETON);

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftJdbcConfig.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftJdbcConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import com.amazon.redshift.util.RedshiftException;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import jakarta.validation.constraints.AssertTrue;
+
+import java.util.Enumeration;
+
+import static com.amazon.redshift.Driver.parseURL;
+
+public class RedshiftJdbcConfig
+        extends BaseJdbcConfig
+{
+    @AssertTrue(message = "JDBC URL for redshift connector may contain illegal datatype parameters (CVE-2026-8178)")
+    public boolean isUrlValid()
+            throws RedshiftException
+    {
+        Enumeration<?> propertyNames = parseURL(getConnectionUrl(), null).propertyNames();
+        while (propertyNames.hasMoreElements()) {
+            // Looking for things that use this recently removed classloading for CVE-2026-8178.
+            // https://github.com/aws/amazon-redshift-jdbc-driver/blob/67cc11b3c7aeaa417bd7c830ccfb2841e6977820/src/main/java/com/amazon/redshift/jdbc/RedshiftConnectionImpl.java#L903
+            if (((String) propertyNames.nextElement()).startsWith("datatype.")) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftJdbcConfig.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftJdbcConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import jakarta.validation.constraints.AssertTrue;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static io.airlift.testing.ValidationAssertions.assertValidates;
+
+public class TestRedshiftJdbcConfig
+{
+    @Test
+    public void testIsUrlValid()
+    {
+        assertValidates(new RedshiftJdbcConfig()
+                .setConnectionUrl("jdbc:redshift://datatype.com:5439/dev"));
+
+        assertValidates(new RedshiftJdbcConfig()
+                .setConnectionUrl("jdbc:redshift://datatype.com:5439/dev?user=admin&password=secret"));
+        assertValidates(new RedshiftJdbcConfig()
+                .setConnectionUrl("jdbc:redshift://example.com:5439/dev;ssl=true;user=admin"));
+        assertValidates(new RedshiftJdbcConfig()
+                .setConnectionUrl("jdbc:redshift://example.com:5439/dev;key=datatype.value"));
+
+        assertFailsConnectionUrlValidation("jdbc:redshift://example.com:5439/dev?datatype.geometry=GEOMETRY");
+        assertFailsConnectionUrlValidation("jdbc:redshift://example.com:5439/dev;datatype.geometry=GEOMETRY");
+    }
+
+    private void assertFailsConnectionUrlValidation(String connectionUrl)
+    {
+        assertFailsValidation(
+                new RedshiftJdbcConfig()
+                        .setConnectionUrl(connectionUrl),
+                "urlValid",
+                "JDBC URL for redshift connector may contain illegal datatype parameters (CVE-2026-8178)",
+                AssertTrue.class);
+    }
+}


### PR DESCRIPTION
## Description

An idea to patch the CVE without doing the jdbc driver upgrade.

I explored patching the CVE without upgrading to avoid running into [this bug](https://github.com/aws/amazon-redshift-jdbc-driver/issues/148). The upgrade looked more complex (we'd want to override `getTables` of `BaseJdbcClient` and try to not use a `tableNamePattern` or recreate it with queries on system tables that do work [this second idea I didn't try]).

I've commented the exact lines I suspect are behind the CVE (though [the exact details aren't available on this page](https://github.com/advisories/GHSA-wmmv-vvg5-993q)) and verify in a new `BaseJdbcConfig` subclass that "datatype" parameters aren't in use.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

[Full bug report shows issues listing tables with long "LIKE" patterns on redshift](https://github.com/aws/amazon-redshift-jdbc-driver/blob/67cc11b3c7aeaa417bd7c830ccfb2841e6977820/src/main/java/com/amazon/redshift/jdbc/RedshiftConnectionImpl.java#L903). This issue isn't present in older versions of the jdbc driver, though they are unpatched.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Invalidate redshift configs using query parameters related to CVE-2026-8178. ({issue}`29520`)
```
