### PR TITLE
Fix ROLLBACK failure on aborted transaction with catalog session properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -399,6 +399,41 @@ public final class Session
                 queryDataEncoding);
     }
 
+    public Session withTransactionId(TransactionId transactionId)
+    {
+        requireNonNull(transactionId, "transactionId is null");
+        checkArgument(this.transactionId.isEmpty(), "Session already has an active transaction");
+
+        return new Session(
+                queryId,
+                querySpan,
+                Optional.of(transactionId),
+                clientTransactionSupport,
+                identity,
+                originalIdentity,
+                source,
+                catalog,
+                schema,
+                path,
+                traceToken,
+                timeZoneKey,
+                locale,
+                remoteUserAddress,
+                userAgent,
+                clientInfo,
+                clientTags,
+                clientCapabilities,
+                resourceEstimates,
+                start,
+                systemProperties,
+                ImmutableMap.of(),
+                sessionPropertyManager,
+                preparedStatements,
+                protocolHeaders,
+                exchangeEncryptionKey,
+                queryDataEncoding);
+    }
+
     public Session withDefaultProperties(Map<String, String> systemPropertyDefaults, Map<String, Map<String, String>> catalogPropertyDefaults, AccessControl accessControl)
     {
         requireNonNull(systemPropertyDefaults, "systemPropertyDefaults is null");

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -329,7 +329,13 @@ public class QueryStateMachine
             // TODO: make autocommit isolation level a session parameter
             TransactionId transactionId = existingTransactionId
                     .orElseGet(() -> transactionManager.beginTransaction(true));
-            session = session.beginTransactionId(transactionId, transactionManager, accessControl);
+            if (transactionControl) {
+                // For COMMIT/ROLLBACK, skip catalog property validation to allow execution even on aborted transactions
+                session = session.withTransactionId(transactionId);
+            }
+            else {
+                session = session.beginTransactionId(transactionId, transactionManager, accessControl);
+            }
         }
 
         if (getRetryPolicy(session) == TASK && externalExchangeEncryptionEnabled) {

--- a/core/trino-main/src/test/java/io/trino/TestSession.java
+++ b/core/trino-main/src/test/java/io/trino/TestSession.java
@@ -55,6 +55,21 @@ public class TestSession
     }
 
     @Test
+    public void testWithTransactionId()
+    {
+        Session session = Session.builder(testSessionBuilder().build())
+                .setCatalogSessionProperty("some_catalog", "some_property", "some_value")
+                .build();
+
+        TransactionId transactionId = TransactionId.create();
+        Session transactionSession = session.withTransactionId(transactionId);
+
+        assertThat(transactionSession.getTransactionId()).isEqualTo(Optional.of(transactionId));
+        // catalog properties are not validated/propagated for transaction control statements
+        assertThat(transactionSession.getCatalogProperties()).isEmpty();
+    }
+
+    @Test
     public void testAddSecondCatalogProperty()
     {
         Session session = Session.builder(testSessionBuilder().build())

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -734,6 +734,55 @@ public class TestQueryStateMachine
         }
     }
 
+    @Test
+    public void testBeginWithTickerSkipsValidationForTransactionControl()
+    {
+        Session session = Session.builder(TEST_SESSION)
+                .setCatalogSessionProperty("some_catalog", "some_property", "some_value")
+                .build();
+
+        TransactionManager transactionManager = createTestTransactionManager();
+        TransactionId transactionId = transactionManager.beginTransaction(false);
+
+        AccessControlManager accessControl = new AccessControlManager(
+                NodeVersion.UNKNOWN,
+                transactionManager,
+                emptyEventListenerManager(),
+                new AccessControlConfig(),
+                OpenTelemetry.noop(),
+                new SecretsResolver(ImmutableMap.of()),
+                DefaultSystemAccessControl.NAME);
+        accessControl.setSystemAccessControls(List.of(AllowAllSystemAccessControl.INSTANCE));
+
+        Metadata metadata = TestingMetadataManager.builder()
+                .withTransactionManager(transactionManager)
+                .build();
+
+        QueryStateMachine stateMachine = QueryStateMachine.beginWithTicker(
+                Optional.of(transactionId),
+                "ROLLBACK",
+                Optional.empty(),
+                session,
+                LOCATION,
+                new ResourceGroupId("test"),
+                true,
+                transactionManager,
+                accessControl,
+                executor,
+                Ticker.systemTicker(),
+                metadata,
+                WarningCollector.NOOP,
+                createPlanOptimizersStatsCollector(),
+                new ExchangeMetricsCollector(ImmutableList::of, java.time.Duration.ofMillis(1)),
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                new NodeVersion("test"));
+
+        assertThat(stateMachine.getSession().getTransactionId()).isEqualTo(Optional.of(transactionId));
+        assertThat(stateMachine.getSession().getCatalogProperties()).isEmpty();
+    }
+
     private QueryStateMachine createQueryStateMachine()
     {
         return queryStateMachine().build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
  
`ROLLBACK` and `COMMIT` fail with `TRANSACTION_ALREADY_ABORTED` when a catalog session property is set and the transaction is already aborted.

`beginWithTicker()` calls `session.beginTransactionId()` for all statements including transaction control operations, which validates catalog properties against the transaction — throwing an exception on aborted transactions.

Fix by introducing `Session.withTransactionId()` that binds the transaction ID without property validation, and using it in the transactionControl path.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

closed #29575

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
  * Fix `ROLLBACK` and `COMMIT` failing with `TRANSACTION_ALREADY_ABORTED` when catalog session properties are set on an aborted transaction. ({issue}`29575`)
```