### PR TITLE
Verify Hive INSERT failure via stack trace in TestHiveSparkCompatibility

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
@@ -47,6 +47,7 @@ import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveSparkCompatibility
         extends ProductTest
@@ -725,7 +726,8 @@ public class TestHiveSparkCompatibility
             result.add(null);
             assertThat(onHive().executeQuery("SELECT * FROM " + tableName)).containsOnly(new Row(result), new Row(result));
             assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO " + tableName + " VALUES(2)")).hasMessageFindingMatch("Output format org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat with SerDe org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe is not supported");
-            assertQueryFailure(() -> onHive().executeQuery("INSERT INTO " + tableName + " VALUES(2)")).hasMessageFindingMatch(".*Error while processing statement.*");
+            assertThatThrownBy(() -> onHive().executeQuery("INSERT INTO " + tableName + " VALUES(2)"))
+                    .hasStackTraceContaining("org.apache.hadoop.hive.serde2.io.ParquetHiveRecord cannot be cast to org.apache.hadoop.io.BytesWritable");
         }
         finally {
             onHive().executeQuery("DROP TABLE IF EXISTS " + tableName);


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

assertQueryFailure(...).hasMessageFindingMatch(".*Error while processing
statement.*") relies on a Hive-formatted error string that is not stable
across environments and Hive versions. Switch to assertThatThrownBy(...)
.hasStackTraceContaining(...) to assert the specific ClassCastException
that causes the INSERT to fail, which is a more direct and reliable signal.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
