### PR TITLE
Reject OMIT QUOTES when JSON_QUERY returns JSON

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -3098,6 +3098,16 @@ public class ExpressionAnalyzer
                     throw semanticException(TYPE_MISMATCH, node, "Unknown type: %s", declaredReturnedType.get());
                 }
             }
+
+            // SQL:2023 §6.35 SR 3: if the effective returned type is JSON, the quotes behavior shall be KEEP.
+            // OMIT QUOTES would require emitting a bare unquoted scalar, which is not valid JSON; the spec
+            // closes the hole at analysis time, not at runtime (§9.44, which handles the JSON target, has no
+            // QUOTES parameter). On trunk the only reachable JSON-effective return type is an explicit
+            // RETURNING JSON — analyzeJsonPathInvocation's getInputFunction rejects JSON-typed inputs, so
+            // the SR 1 "JSON-typed input with no RETURNING" branch can't be exercised today.
+            if (quotesBehavior.filter(behavior -> behavior == JsonQuery.QuotesBehavior.OMIT).isPresent() && JSON.equals(returnedType)) {
+                throw semanticException(INVALID_FUNCTION_ARGUMENT, node, "OMIT QUOTES behavior is not allowed when JSON_QUERY returns JSON");
+            }
             JsonFormat outputFormat = declaredOutputFormat.orElse(JsonFormat.JSON); // default
 
             // resolve function to format output

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.BaseEncoding.base16;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.JSON_INPUT_CONVERSION_ERROR;
 import static io.trino.spi.StandardErrorCode.JSON_OUTPUT_CONVERSION_ERROR;
 import static io.trino.spi.StandardErrorCode.PATH_EVALUATION_ERROR;
@@ -393,6 +394,28 @@ public class TestJsonQueryFunction
         assertThat(assertions.query(
                 "SELECT json_query('" + INPUT + "', 'lax $' OMIT QUOTES ON SCALAR STRING)"))
                 .matches("VALUES cast('[\"a\",\"b\",\"c\"]' AS varchar)");
+    }
+
+    @Test
+    public void testOmitQuotesRejectedWhenReturnTypeIsJson()
+    {
+        // SQL:2023 §6.35 SR 3: explicit RETURNING JSON
+        assertThat(assertions.query(
+                "SELECT json_query('" + INPUT + "', 'lax $' RETURNING json OMIT QUOTES ON SCALAR STRING)"))
+                .failure()
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("OMIT QUOTES behavior is not allowed when JSON_QUERY returns JSON");
+
+        // default RETURNING (VARCHAR) leaves OMIT QUOTES legal — SR 1 maps the input's varchar type to the
+        // return type, and SR 3 only applies to JSON returns. Both a direct character input and a JSON_QUERY
+        // input fall in this bucket today (the SQL/JSON producers default to VARCHAR; an explicit
+        // RETURNING JSON on the input would be caught at JSON_QUERY's input-coercion step).
+        assertThat(assertions.query(
+                "SELECT json_query('" + INPUT + "', 'lax \"some scalar text value\"' OMIT QUOTES ON SCALAR STRING)"))
+                .matches("VALUES cast('some scalar text value' AS varchar)");
+        assertThat(assertions.query(
+                "SELECT json_query(json_query('" + INPUT + "', 'lax \"some scalar text value\"'), 'lax $' OMIT QUOTES ON SCALAR STRING)"))
+                .matches("VALUES cast('some scalar text value' AS varchar)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

SQL:2023 §6.35 SR 3 requires the quotes behavior to be KEEP when `JSON_QUERY` returns JSON. OMIT QUOTES on a JSON return would require emitting a bare unquoted scalar, which is not valid JSON — the runtime path (§9.44, which handles the JSON target) has no QUOTES parameter, so the spec closes the hole at analysis time.

The check is `JSON.equals(returnedType)` — on trunk that's the only reachable effective-JSON path. SR 1 also says a JSON-typed input (with no explicit RETURNING) makes the effective return type JSON, but `JSON_QUERY`'s input-coercion step rejects JSON-typed inputs today (`getInputFunction` only resolves for character/binary string inputs), so the SR 1 branch isn't reachable through analysis on trunk. Pre-rejecting it there would be unreachable code.

Standalone analyzer check — no runtime / type-system changes.

## Test plan

- [x] New `TestJsonQueryFunction#testOmitQuotesRejectedWhenReturnTypeIsJson` covers: explicit `RETURNING json` rejected; default-RETURNING (VARCHAR) with direct varchar input and with varchar-returning JSON_QUERY input both legal.
- [x] Existing `TestJsonQueryFunction#testQuotesBehavior` cases still pass.