### PR TITLE
Support Iceberg REST catalog prefixed path storage credentials

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
@@ -18,8 +18,6 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.security.ConnectorIdentity;
 
-import java.util.Map;
-
 import static java.util.Objects.requireNonNull;
 
 public class DefaultIcebergFileSystemFactory
@@ -34,7 +32,7 @@ public class DefaultIcebergFileSystemFactory
     }
 
     @Override
-    public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    public TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
     {
         return fileSystemFactory.create(identity);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1447,7 +1447,7 @@ public class IcebergMetadata
         try {
             // S3 Tables internally assigns a unique location for each table
             if (!isS3Tables(location.toString())) {
-                TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), transaction.table().io().properties());
+                TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergUtil.getTableCredentials(transaction.table().io()));
                 if (!replace && fileSystem.listFiles(location).hasNext()) {
                     throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, format("" +
                             "Cannot create a table on a non-empty location: %s, set 'iceberg.unique-table-location=true' in your Iceberg catalog properties " +
@@ -2356,7 +2356,7 @@ public class IcebergMetadata
         }
 
         Instant expiration = session.getStart().minusMillis(retention.toMillis());
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergUtil.getTableCredentials(table.io()));
         return removeOrphanFiles(
                 table,
                 fileSystem,
@@ -2370,7 +2370,7 @@ public class IcebergMetadata
     {
         IcebergAddFilesHandle addFilesHandle = (IcebergAddFilesHandle) executeHandle.procedureHandle();
         Table table = catalog.loadTable(session, executeHandle.schemaTableName());
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergUtil.getTableCredentials(table.io()));
         long addedDataFiles = addFiles(
                 session,
                 fileSystem,
@@ -2387,7 +2387,7 @@ public class IcebergMetadata
     {
         IcebergAddFilesFromTableHandle addFilesHandle = (IcebergAddFilesFromTableHandle) executeHandle.procedureHandle();
         Table table = catalog.loadTable(session, executeHandle.schemaTableName());
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergUtil.getTableCredentials(table.io()));
         long addedDataFiles = addFilesFromTable(
                 session,
                 fileSystem,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -46,9 +46,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.transformValues;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.maxPartitionsPerWriter;
-import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static java.util.Objects.requireNonNull;
 
@@ -91,23 +91,27 @@ public class IcebergPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
         IcebergWritableTableHandle tableHandle = (IcebergWritableTableHandle) outputTableHandle;
-        return createPageSink(session, tableHandle, getFileIoProperties(tableCredentials));
+        checkState(tableCredentials.isPresent(), "tableCredentials is empty");
+        IcebergTableCredentials icebergTableCredentials = (IcebergTableCredentials) tableCredentials.orElseThrow();
+        return createPageSink(session, tableHandle, icebergTableCredentials);
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
         IcebergWritableTableHandle tableHandle = (IcebergWritableTableHandle) insertTableHandle;
-        return createPageSink(session, tableHandle, getFileIoProperties(tableCredentials));
+        checkState(tableCredentials.isPresent(), "tableCredentials is empty");
+        IcebergTableCredentials icebergTableCredentials = (IcebergTableCredentials) tableCredentials.orElseThrow();
+        return createPageSink(session, tableHandle, icebergTableCredentials);
     }
 
-    private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, Map<String, String> fileIoProperties)
+    private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, IcebergTableCredentials tableCredentials)
     {
         Schema schema = SchemaParser.fromJson(tableHandle.schemaAsJson());
-        return createPageSink(session, tableHandle, schema, fileIoProperties);
+        return createPageSink(session, tableHandle, schema, tableCredentials);
     }
 
-    private IcebergPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, Schema schema, Map<String, String> fileIoProperties)
+    private IcebergPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, Schema schema, IcebergTableCredentials tableCredentials)
     {
         String partitionSpecJson = tableHandle.partitionsSpecsAsJson().get(tableHandle.partitionSpecId());
         PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, partitionSpecJson);
@@ -118,7 +122,7 @@ public class IcebergPageSinkProvider
                 locationProvider,
                 fileWriterFactory,
                 pageIndexerFactory,
-                fileSystemFactory.create(session.getIdentity(), fileIoProperties),
+                fileSystemFactory.create(session.getIdentity(), tableCredentials),
                 tableHandle.partitionColumns(),
                 jsonCodec,
                 session,
@@ -138,6 +142,8 @@ public class IcebergPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
         IcebergTableExecuteHandle executeHandle = (IcebergTableExecuteHandle) tableExecuteHandle;
+        checkState(tableCredentials.isPresent(), "tableCredentials is empty");
+        IcebergTableCredentials icebergTableCredentials = (IcebergTableCredentials) tableCredentials.orElseThrow();
         return switch (executeHandle.procedureId()) {
             case OPTIMIZE -> {
                 IcebergOptimizeHandle optimizeHandle = (IcebergOptimizeHandle) executeHandle.procedureHandle();
@@ -153,7 +159,7 @@ public class IcebergPageSinkProvider
                         locationProvider,
                         fileWriterFactory,
                         pageIndexerFactory,
-                        fileSystemFactory.create(session.getIdentity(), getFileIoProperties(tableCredentials)),
+                        fileSystemFactory.create(session.getIdentity(), icebergTableCredentials),
                         optimizeHandle.partitionColumns(),
                         jsonCodec,
                         session,
@@ -180,7 +186,8 @@ public class IcebergPageSinkProvider
     {
         IcebergMergeTableHandle merge = (IcebergMergeTableHandle) mergeHandle;
         IcebergWritableTableHandle tableHandle = merge.getInsertTableHandle();
-        Map<String, String> fileIoProperties = getFileIoProperties(tableCredentials);
+        checkState(tableCredentials.isPresent(), "tableCredentials is empty");
+        IcebergTableCredentials icebergTableCredentials = (IcebergTableCredentials) tableCredentials.orElseThrow();
         LocationProvider locationProvider = getLocationProvider(tableHandle.name(), tableHandle.outputPath(), tableHandle.storageProperties());
         Schema schema = SchemaParser.fromJson(tableHandle.schemaAsJson());
         Map<Integer, PartitionSpec> partitionsSpecs = transformValues(tableHandle.partitionsSpecsAsJson(), json -> PartitionSpecParser.fromJson(schema, json));
@@ -197,13 +204,13 @@ public class IcebergPageSinkProvider
         else {
             outputSchema = SchemaParser.fromJson(tableHandle.schemaAsJson());
         }
-        ConnectorPageSink pageSink = createPageSink(session, tableHandle, outputSchema, fileIoProperties);
+        ConnectorPageSink pageSink = createPageSink(session, tableHandle, outputSchema, icebergTableCredentials);
 
         return new IcebergMergeSink(
                 formatVersion,
                 locationProvider,
                 fileWriterFactory,
-                fileSystemFactory.create(session.getIdentity(), fileIoProperties),
+                fileSystemFactory.create(session.getIdentity(), icebergTableCredentials),
                 jsonCodec,
                 session,
                 tableHandle.fileFormat(),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -181,7 +181,6 @@ import static io.trino.plugin.iceberg.IcebergSplitSource.partitionMatchesPredica
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
-import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionValues;
 import static io.trino.plugin.iceberg.IcebergUtil.schemaFromHandles;
@@ -258,10 +257,12 @@ public class IcebergPageSourceProvider
             List<ColumnHandle> columns,
             DynamicFilter dynamicFilter)
     {
+        checkState(connectorTableCredentials.isPresent(), "connectorTableCredentials is empty");
+        IcebergTableCredentials icebergTableCredentials = (IcebergTableCredentials) connectorTableCredentials.orElseThrow();
         if (connectorSplit instanceof FilesTableSplit filesTableSplit) {
             return new FilesTablePageSource(
                     typeManager,
-                    fileSystemFactory.create(session.getIdentity(), getFileIoProperties(connectorTableCredentials)),
+                    fileSystemFactory.create(session.getIdentity(), icebergTableCredentials),
                     fileIoFactory,
                     columns.stream().map(SystemColumnHandle.class::cast).map(SystemColumnHandle::columnName).collect(toImmutableList()),
                     filesTableSplit);
@@ -295,7 +296,7 @@ public class IcebergPageSourceProvider
                 split.fileSize(),
                 split.fileRecordCount(),
                 split.fileFormat(),
-                getFileIoProperties(connectorTableCredentials),
+                icebergTableCredentials,
                 split.dataSequenceNumber(),
                 split.fileFirstRowId(),
                 tableHandle.getNameMappingJson().map(NameMappingParser::fromJson));
@@ -317,7 +318,7 @@ public class IcebergPageSourceProvider
             long fileSize,
             long fileRecordCount,
             IcebergFileFormat fileFormat,
-            Map<String, String> fileIoProperties,
+            IcebergTableCredentials icebergTableCredentials,
             long dataSequenceNumber,
             OptionalLong fileFirstRowId,
             Optional<NameMapping> nameMapping)
@@ -335,7 +336,7 @@ public class IcebergPageSourceProvider
 
         // exit early when only reading partition keys from a simple split
         String partition = partitionSpec.partitionToPath(partitionData);
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), fileIoProperties);
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), icebergTableCredentials);
         TrinoInputFile inputFile = isUseFileSizeFromMetadata(session)
                 ? fileSystem.newInputFile(Location.of(path), fileSize)
                 : fileSystem.newInputFile(Location.of(path));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -114,6 +114,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.getPartitionDomain;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionValues;
 import static io.trino.plugin.iceberg.IcebergUtil.getPathDomain;
+import static io.trino.plugin.iceberg.IcebergUtil.getTableCredentials;
 import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
 import static io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex.createStructLikeWrapper;
 import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
@@ -139,7 +140,7 @@ public class IcebergSplitSource
     private final IcebergFileSystemFactory fileSystemFactory;
     private final ConnectorSession session;
     private final IcebergTableHandle tableHandle;
-    private final Map<String, String> fileIoProperties;
+    private final IcebergTableCredentials tableCredentials;
     private final Scan<?, FileScanTask, CombinedScanTask> tableScan;
     private final OptionalLong maxScannedFileSizeInBytes;
     private final Map<Integer, Type.PrimitiveType> fieldIdToType;
@@ -209,7 +210,7 @@ public class IcebergSplitSource
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.session = requireNonNull(session, "session is null");
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
-        this.fileIoProperties = requireNonNull(icebergTable.io().properties(), "fileIoProperties is null");
+        this.tableCredentials = getTableCredentials(icebergTable.io());
         this.tableScan = requireNonNull(tableScan, "tableScan is null");
         this.maxScannedFileSizeInBytes = maxScannedFileSize.isPresent() ? OptionalLong.of(maxScannedFileSize.orElseThrow().toBytes()) : OptionalLong.empty();
         this.fieldIdToType = primitiveFieldTypes(tableScan.schema());
@@ -457,7 +458,7 @@ public class IcebergSplitSource
         }
         Domain fullFileModifiedTimeDomain = fileModifiedTimeDomain.intersect(getFileModifiedTimeDomain(dynamicFilterPredicate));
         if (!fullFileModifiedTimeDomain.isAll()) {
-            long fileModifiedTime = getModificationTime(fileScanTask.file().location(), fileSystemFactory.create(session.getIdentity(), fileIoProperties));
+            long fileModifiedTime = getModificationTime(fileScanTask.file().location(), fileSystemFactory.create(session.getIdentity(), tableCredentials));
             if (!fullFileModifiedTimeDomain.includesNullableValue(packDateTimeWithZone(fileModifiedTime, UTC_KEY))) {
                 return true;
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStorageCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStorageCredentials.java
@@ -13,10 +13,17 @@
  */
 package io.trino.plugin.iceberg;
 
-import io.trino.filesystem.TrinoFileSystem;
-import io.trino.spi.security.ConnectorIdentity;
+import com.google.common.collect.ImmutableMap;
 
-public interface IcebergFileSystemFactory
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record IcebergStorageCredentials(String prefix, Map<String, String> config)
 {
-    TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials);
+    public IcebergStorageCredentials
+    {
+        requireNonNull(prefix, "prefix is null");
+        config = ImmutableMap.copyOf(config);
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentials.java
@@ -13,22 +13,35 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import org.apache.iceberg.io.FileIO;
 
+import java.util.List;
 import java.util.Map;
 
-public record IcebergTableCredentials(Map<String, String> fileIoProperties)
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public record IcebergTableCredentials(Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentials)
         implements ConnectorTableCredentials
 {
     public IcebergTableCredentials
     {
         fileIoProperties = ImmutableMap.copyOf(fileIoProperties);
+        storageCredentials = ImmutableList.copyOf(storageCredentials);
     }
 
     public static IcebergTableCredentials forFileIO(FileIO io)
     {
-        return new IcebergTableCredentials(io.properties());
+        if (io instanceof ForwardingFileIo ioWithCredentials) {
+            return new IcebergTableCredentials(
+                    io.properties(),
+                    ioWithCredentials.credentials().stream()
+                            .map(credential -> new IcebergStorageCredentials(credential.prefix(), credential.config()))
+                            .collect(toImmutableList()));
+        }
+        return new IcebergTableCredentials(io.properties(), ImmutableList.of());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentialsProvider.java
@@ -13,15 +13,19 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.SchemaTableName;
+import org.apache.iceberg.io.FileIO;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergTableCredentialsProvider
@@ -36,8 +40,18 @@ public class IcebergTableCredentialsProvider
 
     public Optional<ConnectorTableCredentials> getTableCredentials(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        return Optional.of(tableCredentials.computeIfAbsent(schemaTableName, key ->
-                new IcebergTableCredentials(catalog.loadTable(session, key).io().properties())));
+        return Optional.of(tableCredentials.computeIfAbsent(schemaTableName, key -> {
+            try (FileIO io = catalog.loadTable(session, key).io()) {
+                if (io instanceof ForwardingFileIo ioWithCredentials) {
+                    return new IcebergTableCredentials(
+                            io.properties(),
+                            ioWithCredentials.credentials().stream()
+                                    .map(credential -> new IcebergStorageCredentials(credential.prefix(), credential.config()))
+                                    .collect(toImmutableList()));
+                }
+                return new IcebergTableCredentials(io.properties(), ImmutableList.of());
+            }
+        }));
     }
 
     public void putTableCredentials(SchemaTableName schemaTableName, IcebergTableCredentials credentials)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -33,13 +33,13 @@ import io.trino.plugin.iceberg.PartitionTransforms.ColumnTransform;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperations;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
 import io.trino.plugin.iceberg.util.DefaultLocationProvider;
 import io.trino.plugin.iceberg.util.ObjectStoreLocationProvider;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.InvocationConvention;
@@ -1383,11 +1383,15 @@ public final class IcebergUtil
         }
     }
 
-    public static Map<String, String> getFileIoProperties(Optional<ConnectorTableCredentials> tableCredentials)
+    public static IcebergTableCredentials getTableCredentials(FileIO fileIo)
     {
-        if (tableCredentials.isPresent()) {
-            return ((IcebergTableCredentials) tableCredentials.get()).fileIoProperties();
+        if (fileIo instanceof ForwardingFileIo ioWithCredentials) {
+            return new IcebergTableCredentials(
+                    fileIo.properties(),
+                    ioWithCredentials.credentials().stream()
+                            .map(credential -> new IcebergStorageCredentials(credential.prefix(), credential.config()))
+                            .collect(toImmutableList()));
         }
-        return ImmutableMap.of();
+        return new IcebergTableCredentials(fileIo.properties(), ImmutableList.of());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -20,6 +20,7 @@ import io.trino.cache.EvictableCacheBuilder;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
@@ -57,13 +58,13 @@ public class IcebergRestCatalogFileSystemFactory
     }
 
     @Override
-    public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    public TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
     {
         if (vendedCredentialsEnabled) {
             CachedVendedCredentialsProviders cached = uncheckedCacheGet(
                     vendedCredentialsProvidersCache,
-                    createVendedCredentialsCacheKey(identity, fileIoProperties),
-                    () -> createVendedCredentialsProviders(fileIoProperties));
+                    createVendedCredentialsCacheKey(identity, tableCredentials.fileIoProperties()),
+                    () -> createVendedCredentialsProviders(tableCredentials.fileIoProperties()));
 
             if (cached.s3VendedCredentialsProvider().isPresent() || cached.gcsVendedCredentialsProvider().isPresent() || cached.azureVendedCredentialsProvider().isPresent()) {
                 return new IcebergRestCatalogFileSystem(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -14,22 +14,29 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.cache.Cache;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.cache.EvictableCacheBuilder;
+import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
 import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
 import static java.util.Objects.requireNonNull;
@@ -63,10 +70,10 @@ public class IcebergRestCatalogFileSystemFactory
         if (vendedCredentialsEnabled) {
             CachedVendedCredentialsProviders cached = uncheckedCacheGet(
                     vendedCredentialsProvidersCache,
-                    createVendedCredentialsCacheKey(identity, tableCredentials.fileIoProperties()),
-                    () -> createVendedCredentialsProviders(tableCredentials.fileIoProperties()));
+                    createVendedCredentialsCacheKey(identity, tableCredentials),
+                    () -> createVendedCredentialsProviders(tableCredentials));
 
-            if (cached.s3VendedCredentialsProvider().isPresent() || cached.gcsVendedCredentialsProvider().isPresent() || cached.azureVendedCredentialsProvider().isPresent()) {
+            if (!cached.s3VendedCredentialsProviders().isEmpty() || !cached.gcsVendedCredentialsProviders().isEmpty() || cached.azureVendedCredentialsProvider().isPresent()) {
                 return new IcebergRestCatalogFileSystem(
                         location -> {
                             if (location.scheme().isEmpty()) {
@@ -74,8 +81,8 @@ public class IcebergRestCatalogFileSystemFactory
                             }
                             // Derive the vended credentials to load from the location scheme
                             Optional<VendedCredentials> vendedCredentials = switch (location.scheme().get()) {
-                                case "s3", "s3a", "s3n" -> cached.s3VendedCredentialsProvider().map(S3VendedCredentialsProvider::getCredentials);
-                                case "gs" -> cached.gcsVendedCredentialsProvider().map(GcsVendedCredentialsProvider::getCredentials);
+                                case "s3", "s3a", "s3n" -> findS3CredentialsForLocation(cached.s3VendedCredentialsProviders(), location);
+                                case "gs" -> findGcsCredentialsForLocation(cached.gcsVendedCredentialsProviders(), location);
                                 case "abfs", "abfss", "wasb", "wasbs" -> cached.azureVendedCredentialsProvider().map(AzureVendedCredentialsProvider::getCredentials);
                                 default -> throw new IllegalArgumentException("Unsupported location scheme for vended credentials: " + location);
                             };
@@ -101,21 +108,73 @@ public class IcebergRestCatalogFileSystemFactory
         return fileSystemFactory.create(identity);
     }
 
-    private static VendedCredentialsCacheKey createVendedCredentialsCacheKey(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    private static Optional<VendedCredentials> findS3CredentialsForLocation(List<Entry<String, S3VendedCredentialsProvider>> providers, Location location)
     {
-        Optional<S3VendedCredentials> s3VendedCredentials = createVendedCredentialsIfPresent(
+        return providers.stream()
+                .filter(e -> location.toString().startsWith(e.getKey()))
+                .max(Comparator.comparingInt(e -> e.getKey().length()))
+                .map(e -> e.getValue().getCredentials());
+    }
+
+    private static Optional<VendedCredentials> findGcsCredentialsForLocation(List<Entry<String, GcsVendedCredentialsProvider>> providers, Location location)
+    {
+        return providers.stream()
+                .filter(e -> location.toString().startsWith(e.getKey()))
+                .max(Comparator.comparingInt(e -> e.getKey().length()))
+                .map(e -> e.getValue().getCredentials());
+    }
+
+    private static VendedCredentialsCacheKey createVendedCredentialsCacheKey(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
+    {
+        return new VendedCredentialsCacheKey(
+                identity.getUser(),
+                createS3VendedCredentials(tableCredentials),
+                createGcsVendedCredentials(tableCredentials),
+                createAzureVendedCredentials(tableCredentials.fileIoProperties()));
+    }
+
+    private static List<Entry<String, S3VendedCredentials>> createS3VendedCredentials(IcebergTableCredentials tableCredentials)
+    {
+        Map<String, String> fileIoProperties = tableCredentials.fileIoProperties();
+        ImmutableList.Builder<Entry<String, S3VendedCredentials>> builder = ImmutableList.builder();
+        // Root-prefix entries built from fileIoProperties — act as catch-all fallback, matching any S3 path
+        createVendedCredentialsIfPresent(
                 fileIoProperties,
                 () -> S3VendedCredentialsProvider.createVendedCredentials(fileIoProperties),
                 S3FileIOProperties.ACCESS_KEY_ID,
                 S3FileIOProperties.SECRET_ACCESS_KEY,
-                S3FileIOProperties.SESSION_TOKEN);
-        Optional<GcsVendedCredentials> gcsVendedCredentials = createVendedCredentialsIfPresent(
+                S3FileIOProperties.SESSION_TOKEN)
+                .ifPresent(cred -> builder.add(Map.entry("s3", cred)));
+
+        for (IcebergStorageCredentials storageCredential : tableCredentials.storageCredentials()) {
+            if (isS3Prefix(storageCredential.prefix())) {
+                builder.add(Map.entry(
+                        storageCredential.prefix(),
+                        S3VendedCredentialsProvider.createVendedCredentials(mergeConfigs(fileIoProperties, storageCredential.config()))));
+            }
+        }
+        return builder.build();
+    }
+
+    private static List<Entry<String, GcsVendedCredentials>> createGcsVendedCredentials(IcebergTableCredentials tableCredentials)
+    {
+        Map<String, String> fileIoProperties = tableCredentials.fileIoProperties();
+        ImmutableList.Builder<Entry<String, GcsVendedCredentials>> builder = ImmutableList.builder();
+        // Root-prefix entries built from fileIoProperties — act as catch-all fallback, matching any GCS path
+        createVendedCredentialsIfPresent(
                 fileIoProperties,
                 () -> GcsVendedCredentialsProvider.createVendedCredentials(fileIoProperties),
-                GCPProperties.GCS_OAUTH2_TOKEN);
-        Optional<AzureVendedCredentials> azureVendedCredentials = createAzureVendedCredentials(fileIoProperties);
+                GCPProperties.GCS_OAUTH2_TOKEN)
+                .ifPresent(cred -> builder.add(Map.entry("gs", cred)));
 
-        return new VendedCredentialsCacheKey(identity.getUser(), s3VendedCredentials, gcsVendedCredentials, azureVendedCredentials);
+        for (IcebergStorageCredentials storageCredential : tableCredentials.storageCredentials()) {
+            if (isGcsPrefix(storageCredential.prefix())) {
+                builder.add(Map.entry(
+                        storageCredential.prefix(),
+                        GcsVendedCredentialsProvider.createVendedCredentials(mergeConfigs(fileIoProperties, storageCredential.config()))));
+            }
+        }
+        return builder.build();
     }
 
     private static <T> Optional<T> createVendedCredentialsIfPresent(
@@ -141,37 +200,74 @@ public class IcebergRestCatalogFileSystemFactory
         return Optional.empty();
     }
 
-    private CachedVendedCredentialsProviders createVendedCredentialsProviders(Map<String, String> fileIoProperties)
+    private CachedVendedCredentialsProviders createVendedCredentialsProviders(IcebergTableCredentials tableCredentials)
     {
-        Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+        Map<String, String> fileIoProperties = tableCredentials.fileIoProperties();
+
+        ImmutableList.Builder<Entry<String, S3VendedCredentialsProvider>> s3ProvidersBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Entry<String, GcsVendedCredentialsProvider>> gcsProvidersBuilder = ImmutableList.builder();
+        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
+
+        // Root-prefix providers built from fileIoProperties — act as catch-all fallback, matching any S3/GCS path
+        createVendedCredentialsProviderIfPresent(
                 fileIoProperties,
                 () -> new S3VendedCredentialsProvider(catalogProperties, fileIoProperties),
                 S3FileIOProperties.ACCESS_KEY_ID,
                 S3FileIOProperties.SECRET_ACCESS_KEY,
-                S3FileIOProperties.SESSION_TOKEN);
-        Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+                S3FileIOProperties.SESSION_TOKEN)
+                .ifPresent(vendedCredentialsProvider -> s3ProvidersBuilder.add(Map.entry("s3", vendedCredentialsProvider)));
+        createVendedCredentialsProviderIfPresent(
                 fileIoProperties,
                 () -> new GcsVendedCredentialsProvider(catalogProperties, fileIoProperties),
-                GCPProperties.GCS_OAUTH2_TOKEN);
-        Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
-
-        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
-        // handle GCS
+                GCPProperties.GCS_OAUTH2_TOKEN)
+                .ifPresent(vendedCredentialsProvider -> gcsProvidersBuilder.add(Map.entry("gs", vendedCredentialsProvider)));
         if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
             addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
         }
 
+        // Per-prefix providers built from merged config (storage credential config overrides fileIoProperties)
+        for (IcebergStorageCredentials storageCredential : tableCredentials.storageCredentials()) {
+            String credentialPrefix = storageCredential.prefix();
+            if (isS3Prefix(credentialPrefix)) {
+                s3ProvidersBuilder.add(Map.entry(credentialPrefix, new S3VendedCredentialsProvider(catalogProperties, mergeConfigs(fileIoProperties, storageCredential.config()))));
+            }
+            else if (isGcsPrefix(credentialPrefix)) {
+                gcsProvidersBuilder.add(Map.entry(credentialPrefix, new GcsVendedCredentialsProvider(catalogProperties, mergeConfigs(fileIoProperties, storageCredential.config()))));
+            }
+        }
+
+        // Azure does not make use of SupportsStorageCredentials mechanism; always from fileIoProperties
+        Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
+
+        // Sort by prefix length descending so longest-prefix match wins
+        List<Entry<String, S3VendedCredentialsProvider>> s3Providers = s3ProvidersBuilder.build().stream()
+                .sorted(Comparator.<Entry<String, S3VendedCredentialsProvider>>comparingInt(e -> e.getKey().length()).reversed())
+                .collect(toImmutableList());
+        List<Entry<String, GcsVendedCredentialsProvider>> gcsProviders = gcsProvidersBuilder.build().stream()
+                .sorted(Comparator.<Entry<String, GcsVendedCredentialsProvider>>comparingInt(e -> e.getKey().length()).reversed())
+                .collect(toImmutableList());
+
         return new CachedVendedCredentialsProviders(
-                s3VendedCredentialsProvider,
-                gcsVendedCredentialsProvider,
+                s3Providers,
+                gcsProviders,
                 azureVendedCredentialsProvider,
                 extraCredentialsBuilder.buildOrThrow());
     }
 
+    private static boolean isS3Prefix(String prefix)
+    {
+        return prefix.startsWith("s3://") || prefix.startsWith("s3a://") || prefix.startsWith("s3n://");
+    }
+
+    private static boolean isGcsPrefix(String prefix)
+    {
+        return prefix.startsWith("gs://");
+    }
+
     private record VendedCredentialsCacheKey(
             String user,
-            Optional<S3VendedCredentials> s3VendedCredentials,
-            Optional<GcsVendedCredentials> gcsVendedCredentials,
+            List<Entry<String, S3VendedCredentials>> s3VendedCredentials,
+            List<Entry<String, GcsVendedCredentials>> gcsVendedCredentials,
             Optional<AzureVendedCredentials> azureVendedCredentials)
     {
         public VendedCredentialsCacheKey
@@ -184,15 +280,15 @@ public class IcebergRestCatalogFileSystemFactory
     }
 
     private record CachedVendedCredentialsProviders(
-            Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider,
-            Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider,
+            List<Entry<String, S3VendedCredentialsProvider>> s3VendedCredentialsProviders,
+            List<Entry<String, GcsVendedCredentialsProvider>> gcsVendedCredentialsProviders,
             Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider,
             Map<String, String> extraCredentials)
     {
         public CachedVendedCredentialsProviders
         {
-            requireNonNull(s3VendedCredentialsProvider, "s3VendedCredentialsProvider is null");
-            requireNonNull(gcsVendedCredentialsProvider, "gcsVendedCredentialsProvider is null");
+            requireNonNull(s3VendedCredentialsProviders, "s3VendedCredentialsProviders is null");
+            requireNonNull(gcsVendedCredentialsProviders, "gcsVendedCredentialsProviders is null");
             requireNonNull(azureVendedCredentialsProvider, "azureVendedCredentialsProvider is null");
             requireNonNull(extraCredentials, "extraCredentials is null");
         }
@@ -231,5 +327,13 @@ public class IcebergRestCatalogFileSystemFactory
         if (value != null) {
             builder.put(extraCredentialKey, value);
         }
+    }
+
+    private static Map<String, String> mergeConfigs(Map<String, String> base, Map<String, String> override)
+    {
+        return ImmutableMap.<String, String>builder()
+                .putAll(base)
+                .putAll(override)
+                .buildKeepingLast();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -20,6 +20,8 @@ import com.google.inject.Inject;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.Security;
@@ -32,13 +34,16 @@ import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.FileIOBuilder;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.RESTUtil;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
@@ -114,11 +119,22 @@ public class TrinoIcebergRestCatalogFactory
                             .uri(config.get(CatalogProperties.URI))
                             .withHeaders(RESTUtil.configHeaders(config))
                             .build(),
-                    (context, config) -> {
+                    (FileIOBuilder) (context, config, credentials) -> {
                         ConnectorIdentity currentIdentity = (context.wrappedIdentity() != null)
                                 ? ((ConnectorIdentity) context.wrappedIdentity())
                                 : ConnectorIdentity.ofUser("fake");
-                        return fileIoFactory.create(fileSystemFactory.create(currentIdentity, config), true, config);
+                        List<IcebergStorageCredentials> storageCredentials = credentials.stream()
+                                .map(credential -> new IcebergStorageCredentials(credential.prefix(), credential.config()))
+                                .collect(toImmutableList());
+                        return fileIoFactory.create(
+                                fileSystemFactory.create(
+                                        currentIdentity,
+                                        new IcebergTableCredentials(
+                                                config,
+                                                storageCredentials)),
+                                true,
+                                config,
+                                storageCredentials);
                     });
             icebergCatalogInstance.initialize(catalogName.toString(), catalogPropertiesProvider.catalogProperties());
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -98,6 +98,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.SUPPORTED_SCHEMA_PROPERTIES;
+import static io.trino.plugin.iceberg.IcebergUtil.getTableCredentials;
 import static io.trino.plugin.iceberg.IcebergUtil.quotedTableName;
 import static io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog.ICEBERG_VIEW_RUN_AS_OWNER;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -518,7 +519,7 @@ public class TrinoRestCatalog
             // So log the exception and continue with deleting the table location
             log.warn(e, "Failed to delete table data referenced by metadata");
         }
-        deleteTableDirectory(fileSystemFactory.create(session.getIdentity(), table.io().properties()), schemaTableName, table.location());
+        deleteTableDirectory(fileSystemFactory.create(session.getIdentity(), getTableCredentials(table.io())), schemaTableName, table.location());
     }
 
     private static void deleteTableDirectory(TrinoFileSystem fileSystem, SchemaTableName schemaTableName, String tableLocation)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
@@ -65,6 +65,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_DATA_ERROR;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
+import static io.trino.plugin.iceberg.IcebergUtil.getTableCredentials;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
@@ -119,7 +120,7 @@ public class DefaultDeletionVectorWriter
         ExistingDeletes existingDeletes = getExistingDeletesByMetadataOnly(icebergTable, snapshotId, deletionVectorBuilders.keySet());
 
         // merge existing deletion vectors into the new ones
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), icebergTable.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), getTableCredentials(icebergTable.io()));
         existingDeletes.deletionVectors().forEach((dataFilePath, deleteFile) -> {
             try (TrinoInput input = fileSystem.newInputFile(Location.of(deleteFile.location()), deleteFile.fileSizeInBytes()).newInput()) {
                 Slice data = input.readFully(deleteFile.contentOffset(), toIntExact(deleteFile.contentSizeInBytes()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
@@ -14,11 +14,13 @@
 package io.trino.plugin.iceberg.fileio;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
 import io.trino.spi.TrinoException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -53,20 +55,22 @@ public class ForwardingFileIo
 
     private final TrinoFileSystem fileSystem;
     private final Map<String, String> properties;
+    private final List<IcebergStorageCredentials> storageCredentials;
     private final boolean useFileSizeFromMetadata;
     private final ExecutorService deleteExecutor;
 
     @VisibleForTesting
     public ForwardingFileIo(TrinoFileSystem fileSystem, boolean useFileSizeFromMetadata)
     {
-        this(fileSystem, ImmutableMap.of(), useFileSizeFromMetadata, newDirectExecutorService());
+        this(fileSystem, ImmutableMap.of(), ImmutableList.of(), useFileSizeFromMetadata, newDirectExecutorService());
     }
 
-    public ForwardingFileIo(TrinoFileSystem fileSystem, Map<String, String> properties, boolean useFileSizeFromMetadata, ExecutorService deleteExecutor)
+    public ForwardingFileIo(TrinoFileSystem fileSystem, Map<String, String> properties, List<IcebergStorageCredentials> storageCredentials, boolean useFileSizeFromMetadata, ExecutorService deleteExecutor)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.deleteExecutor = requireNonNull(deleteExecutor, "executorService is null");
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+        this.storageCredentials = ImmutableList.copyOf(requireNonNull(storageCredentials, "storageCredentials is null"));
         this.useFileSizeFromMetadata = useFileSizeFromMetadata;
     }
 
@@ -187,4 +191,9 @@ public class ForwardingFileIo
 
     @Override
     public void close() {}
+
+    public List<IcebergStorageCredentials> credentials()
+    {
+        return storageCredentials;
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIoFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIoFactory.java
@@ -13,12 +13,15 @@
  */
 package io.trino.plugin.iceberg.fileio;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.plugin.iceberg.ForIcebergFileDelete;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
 import org.apache.iceberg.io.FileIO;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -36,16 +39,16 @@ public class ForwardingFileIoFactory
 
     public FileIO create(TrinoFileSystem fileSystem)
     {
-        return create(fileSystem, true, ImmutableMap.of());
+        return create(fileSystem, true, ImmutableMap.of(), ImmutableList.of());
     }
 
     public FileIO create(TrinoFileSystem fileSystem, boolean useFileSizeFromMetadata)
     {
-        return create(fileSystem, useFileSizeFromMetadata, ImmutableMap.of());
+        return create(fileSystem, useFileSizeFromMetadata, ImmutableMap.of(), ImmutableList.of());
     }
 
-    public FileIO create(TrinoFileSystem fileSystem, boolean useFileSizeFromMetadata, Map<String, String> properties)
+    public FileIO create(TrinoFileSystem fileSystem, boolean useFileSizeFromMetadata, Map<String, String> properties, List<IcebergStorageCredentials> storageCredentials)
     {
-        return new ForwardingFileIo(fileSystem, properties, useFileSizeFromMetadata, deleteExecutor);
+        return new ForwardingFileIo(fileSystem, properties, storageCredentials, useFileSizeFromMetadata, deleteExecutor);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.functions.tablechanges;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.IcebergColumnHandle;
 import io.trino.plugin.iceberg.IcebergPageSourceProvider;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.plugin.iceberg.PartitionData;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -38,12 +39,12 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_ORDINAL_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TIMESTAMP_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TYPE_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_VERSION_ID;
-import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
 import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
 import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.produced;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
@@ -79,9 +80,11 @@ public class TableChangesFunctionProcessor
         requireNonNull(session, "session is null");
         requireNonNull(functionHandle, "functionHandle is null");
         requireNonNull(tableCredentials, "tableCredentials is null");
+        checkState(tableCredentials.isPresent(), "tableCredentials is empty");
         requireNonNull(split, "split is null");
         requireNonNull(icebergPageSourceProvider, "icebergPageSourceProvider is null");
 
+        IcebergTableCredentials icebergTableCredentials = (IcebergTableCredentials) tableCredentials.orElseThrow();
         Schema tableSchema = SchemaParser.fromJson(functionHandle.tableSchemaJson());
         PartitionSpec partitionSpec = PartitionSpecParser.fromJson(tableSchema, split.partitionSpecJson());
 
@@ -131,7 +134,7 @@ public class TableChangesFunctionProcessor
                 split.fileSize(),
                 split.fileRecordCount(),
                 split.fileFormat(),
-                getFileIoProperties(tableCredentials),
+                icebergTableCredentials,
                 0,
                 OptionalLong.empty(),
                 functionHandle.nameMappingJson().map(NameMappingParser::fromJson));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
@@ -142,7 +142,7 @@ class TestIcebergPageSourceProvider
                 dataInputFile.length(),
                 3, // fileRecordCount
                 PARQUET,
-                ImmutableMap.of(),
+                new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of()),
                 0L, // dataSequenceNumber
                 OptionalLong.empty(),
                 Optional.empty())) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefreshTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.gcs.GcsFileSystemConfig;
+import io.trino.filesystem.gcs.GcsFileSystemFactory;
+import io.trino.filesystem.gcs.GcsServiceAccountAuth;
+import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
+import io.trino.filesystem.gcs.GcsStorageFactory;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.gcp.gcs.GCSFileIO;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+
+final class TestIcebergGcsRestCatalogStorageCredentialsRefreshTest
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+{
+    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogStorageCredentialsRefreshTest.class);
+
+    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
+    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+
+    private String oauthToken;
+    private long tokenExpiresAtMs;
+    private String gcpProjectId;
+    private TrinoFileSystem fileSystem;
+
+    @BeforeAll
+    public void initFileSystem()
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        GcsFileSystemConfig config = new GcsFileSystemConfig();
+        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
+        GcsStorageFactory storageFactory;
+        try {
+            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+    }
+
+    @AfterAll
+    public void removeTestData()
+    {
+        if (fileSystem == null) {
+            return;
+        }
+        try {
+            fileSystem.deleteDirectory(Location.of(warehouseLocation));
+        }
+        catch (IOException e) {
+            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
+            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+        }
+    }
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+            throws Exception
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
+                .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        AccessToken accessToken = credentials.refreshAccessToken();
+        oauthToken = accessToken.getTokenValue();
+        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
+
+        JsonMapper mapper = new JsonMapper();
+        JsonNode jsonKey = mapper.readTree(gcpCredentials);
+        gcpProjectId = jsonKey.get("project_id").asText();
+
+        return "gs://%s/gcs-storage-creds-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, GCSFileIO.class.getName())
+                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        VendedCredentialsRestCatalogAdapter adapter = new VendedCredentialsRestCatalogAdapter(backendCatalog)
+        {
+            @Override
+            protected <T extends RESTResponse> T execute(
+                    HTTPRequest request,
+                    Class<T> responseType,
+                    Consumer<ErrorResponse> errorHandler,
+                    Consumer<Map<String, String>> responseHeaders)
+            {
+                T response = super.execute(request, responseType, errorHandler, responseHeaders);
+                if (response instanceof LoadTableResponse loadTableResponse) {
+                    String host = request.headers().entries("host").stream()
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("Host header not found in request"))
+                            .value();
+                    String restServerUri = "http://" + host;
+                    return responseType.cast(LoadTableResponse.builder()
+                            .withTableMetadata(loadTableResponse.tableMetadata())
+                            .addAllConfig(loadTableResponse.config())
+                            .addCredential(ImmutableCredential.builder()
+                                    .prefix("gs://" + gcpStorageBucket + "/")
+                                    .putAllConfig(ImmutableMap.<String, String>builder()
+                                            .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                                            .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, "true")
+                                            .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                                            .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(sessionTokenExpirationTime.get().toEpochMilli()))
+                                            .buildOrThrow())
+                                    .build())
+                            .build());
+                }
+                return response;
+            }
+
+            @Override
+            public Map<String, String> getVendedCredentialsConfig(String restServerUri)
+            {
+                // Credentials are returned as storage credentials in the credentials list, not as flat config
+                return ImmutableMap.of();
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "gs://" + gcpStorageBucket + "/";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                return ImmutableMap.<String, String>builder()
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                        .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
+                        .buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.gcs.enabled", "true")
+                .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .buildOrThrow();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import io.trino.filesystem.FileIterator;
@@ -23,6 +24,7 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
@@ -65,7 +67,7 @@ final class TestIcebergRestCatalogFileSystemFactory
                 S3FileIOProperties.SECRET_ACCESS_KEY, "test-secret-key",
                 S3FileIOProperties.SESSION_TOKEN, "test-session-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("s3://bucket/path"));
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(fileIoProperties, ImmutableList.of())).newInputFile(Location.of("s3://bucket/path"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -89,7 +91,7 @@ final class TestIcebergRestCatalogFileSystemFactory
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 GCPProperties.GCS_OAUTH2_TOKEN, "ya29.test-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(fileIoProperties, ImmutableList.of())).newInputFile(Location.of("gs://bucket/path"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -116,7 +118,7 @@ final class TestIcebergRestCatalogFileSystemFactory
                 .put(GCPProperties.GCS_PROJECT_ID, "my-gcp-project")
                 .buildOrThrow();
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("gs://bucket/path"));
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(fileIoProperties, ImmutableList.of())).newInputFile(Location.of("gs://bucket/path"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -142,7 +144,7 @@ final class TestIcebergRestCatalogFileSystemFactory
                 GCPProperties.GCS_PROJECT_ID, "my-gcp-project");
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
-        factory.create(originalIdentity, fileIoProperties);
+        factory.create(originalIdentity, new IcebergTableCredentials(fileIoProperties, ImmutableList.of()));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -161,7 +163,7 @@ final class TestIcebergRestCatalogFileSystemFactory
         IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
-        factory.create(originalIdentity, ImmutableMap.of());
+        factory.create(originalIdentity, new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of()));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isSameAs(originalIdentity);
@@ -181,7 +183,7 @@ final class TestIcebergRestCatalogFileSystemFactory
         Map<String, String> fileIoProperties = ImmutableMap.of(
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(fileIoProperties, ImmutableList.of())).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -204,7 +206,7 @@ final class TestIcebergRestCatalogFileSystemFactory
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account1", "sas-token-1",
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account2", "sas-token-2");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@account1.dfs.core.windows.net/some/path/file"));
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(fileIoProperties, ImmutableList.of())).newInputFile(Location.of("abfs://container@account1.dfs.core.windows.net/some/path/file"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -226,7 +228,7 @@ final class TestIcebergRestCatalogFileSystemFactory
 
         Map<String, String> fileIoProperties = ImmutableMap.of(AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
 
-        factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(fileIoProperties, ImmutableList.of())).newInputFile(Location.of("abfs://container@mystorageaccount.dfs.core.windows.net/some/path/file"));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
@@ -249,7 +251,7 @@ final class TestIcebergRestCatalogFileSystemFactory
                 AzureProperties.ADLS_SAS_TOKEN_PREFIX + "mystorageaccount", "sv=2022-test-sas-token");
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
-        factory.create(originalIdentity, fileIoProperties);
+        factory.create(originalIdentity, new IcebergTableCredentials(fileIoProperties, ImmutableList.of()));
 
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -24,6 +24,7 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
 import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.security.ConnectorIdentity;
@@ -256,6 +257,157 @@ final class TestIcebergRestCatalogFileSystemFactory
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
         assertThat(identity.getExtraCredentials()).isEmpty();
+    }
+
+    @Test
+    void testS3StorageCredentialsSinglePrefix()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials storageCredential = new IcebergStorageCredentials(
+                "s3://bucket-a/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-a",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-a",
+                        S3FileIOProperties.SESSION_TOKEN, "token-a"));
+
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of(storageCredential)))
+                .newInputFile(Location.of("s3://bucket-a/path/file"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "key-a")
+                .containsEntry(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, "secret-a")
+                .containsEntry(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, "token-a");
+    }
+
+    @Test
+    void testS3StorageCredentialsMultiplePrefixes()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentityA = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityB = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityRoot = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            switch (identity.getExtraCredentials().getOrDefault(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "")) {
+                case "key-a" -> capturedIdentityA.set(identity);
+                case "key-b" -> capturedIdentityB.set(identity);
+                default -> capturedIdentityRoot.set(identity);
+            }
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "key-root",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "secret-root",
+                S3FileIOProperties.SESSION_TOKEN, "token-root");
+        IcebergStorageCredentials credentialA = new IcebergStorageCredentials(
+                "s3://bucket-a/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-a",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-a",
+                        S3FileIOProperties.SESSION_TOKEN, "token-a"));
+        IcebergStorageCredentials credentialB = new IcebergStorageCredentials(
+                "s3://bucket-b/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-b",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-b",
+                        S3FileIOProperties.SESSION_TOKEN, "token-b"));
+
+        IcebergTableCredentials tableCredentials = new IcebergTableCredentials(fileIoProperties, ImmutableList.of(credentialA, credentialB));
+        TrinoFileSystem fileSystem = factory.create(ConnectorIdentity.ofUser("test"), tableCredentials);
+
+        fileSystem.newInputFile(Location.of("s3://bucket-a/path/file"));
+        assertThat(capturedIdentityA.get()).isNotNull();
+        assertThat(capturedIdentityA.get().getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "key-a")
+                .containsEntry(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, "secret-a")
+                .containsEntry(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, "token-a");
+
+        fileSystem.newInputFile(Location.of("s3://bucket-b/data/file"));
+        assertThat(capturedIdentityB.get()).isNotNull();
+        assertThat(capturedIdentityB.get().getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "key-b")
+                .containsEntry(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, "secret-b")
+                .containsEntry(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, "token-b");
+
+        // bucket-c has no per-prefix credential — falls back to the root credential from fileIoProperties
+        fileSystem.newInputFile(Location.of("s3://bucket-c/other/file"));
+        assertThat(capturedIdentityRoot.get()).isNotNull();
+        assertThat(capturedIdentityRoot.get().getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "key-root")
+                .containsEntry(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, "secret-root")
+                .containsEntry(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, "token-root");
+    }
+
+    @Test
+    void testGcsStorageCredentialsSinglePrefix()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials storageCredential = new IcebergStorageCredentials(
+                "gs://gcs-bucket/",
+                ImmutableMap.of(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.token-for-gcs-bucket"));
+
+        factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of(storageCredential)))
+                .newInputFile(Location.of("gs://gcs-bucket/path/file"));
+
+        ConnectorIdentity identity = capturedIdentity.get();
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.token-for-gcs-bucket");
+    }
+
+    @Test
+    void testGcsStorageCredentialsMultiplePrefixes()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentityA = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityB = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            if (identity.getExtraCredentials().getOrDefault(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "").equals("ya29.token-a")) {
+                capturedIdentityA.set(identity);
+            }
+            else {
+                capturedIdentityB.set(identity);
+            }
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials credentialA = new IcebergStorageCredentials(
+                "gs://bucket-a/",
+                ImmutableMap.of(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.token-a"));
+        IcebergStorageCredentials credentialB = new IcebergStorageCredentials(
+                "gs://bucket-b/",
+                ImmutableMap.of(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.token-b"));
+
+        IcebergTableCredentials tableCredentials = new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of(credentialA, credentialB));
+        TrinoFileSystem fileSystem = factory.create(ConnectorIdentity.ofUser("test"), tableCredentials);
+
+        fileSystem.newInputFile(Location.of("gs://bucket-a/path/file"));
+        assertThat(capturedIdentityA.get()).isNotNull();
+        assertThat(capturedIdentityA.get().getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.token-a");
+
+        fileSystem.newInputFile(Location.of("gs://bucket-b/data/file"));
+        assertThat(capturedIdentityB.get()).isNotNull();
+        assertThat(capturedIdentityB.get().getExtraCredentials())
+                .containsEntry(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.token-b");
     }
 
     private static IcebergRestCatalogFileSystemFactory createFactory(TrinoFileSystemFactory delegate, boolean vendedCredentialsEnabled)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogStorageCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogStorageCredentialsRefreshTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.containers.Minio;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.testcontainers.containers.Network;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+
+final class TestIcebergS3RestCatalogStorageCredentialsRefreshTest
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+{
+    private final String bucketName = "test-iceberg-storage-creds-rest-" + randomNameSuffix();
+    private Minio minio;
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+    {
+        Network network = closeAfterClass(Network.newNetwork());
+        minio = closeAfterClass(Minio.builder().withNetwork(network).build());
+        minio.start();
+        minio.createBucket(bucketName);
+        return "s3://%s/default/".formatted(bucketName);
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, S3FileIO.class.getName())
+                .put(S3FileIOProperties.PATH_STYLE_ACCESS, "true")
+                .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                .put(S3FileIOProperties.ACCESS_KEY_ID, MINIO_ROOT_USER)
+                .put(S3FileIOProperties.SECRET_ACCESS_KEY, MINIO_ROOT_PASSWORD)
+                .put(S3FileIOProperties.ENDPOINT, minio.getMinioAddress())
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        VendedCredentialsRestCatalogAdapter adapter = new VendedCredentialsRestCatalogAdapter(backendCatalog)
+        {
+            @Override
+            protected <T extends RESTResponse> T execute(
+                    HTTPRequest request,
+                    Class<T> responseType,
+                    Consumer<ErrorResponse> errorHandler,
+                    Consumer<Map<String, String>> responseHeaders)
+            {
+                T response = super.execute(request, responseType, errorHandler, responseHeaders);
+                if (response instanceof LoadTableResponse loadTableResponse) {
+                    String host = request.headers().entries("host").stream()
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("Host header not found in request"))
+                            .value();
+                    String restServerUri = "http://" + host;
+                    Credentials sessionCredentials = getSessionCredentials();
+                    return responseType.cast(LoadTableResponse.builder()
+                            .withTableMetadata(loadTableResponse.tableMetadata())
+                            .addAllConfig(loadTableResponse.config())
+                            .addCredential(ImmutableCredential.builder()
+                                    .prefix("s3://" + bucketName + "/")
+                                    .putAllConfig(ImmutableMap.<String, String>builder()
+                                            .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                                            .put(S3FileIOProperties.ACCESS_KEY_ID, sessionCredentials.accessKeyId())
+                                            .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
+                                            .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
+                                            .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
+                                            .put(AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                                            .put("s3.session-token-expires-at-ms", Long.toString(sessionTokenExpirationTime.get().toEpochMilli()))
+                                            .buildOrThrow())
+                                    .build())
+                            .build());
+                }
+                return response;
+            }
+
+            @Override
+            public Map<String, String> getVendedCredentialsConfig(String restServerUri)
+            {
+                // Credentials are returned as storage credentials in the credentials list, not as flat config
+                return ImmutableMap.of();
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "s3://" + bucketName + "/";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                Credentials sessionCredentials = getSessionCredentials();
+                return ImmutableMap.<String, String>builder()
+                        .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                        .put(S3FileIOProperties.ACCESS_KEY_ID, sessionCredentials.accessKeyId())
+                        .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
+                        .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
+                        .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put("s3.session-token-expires-at-ms", Long.toString(sessionCredentials.expiration().toEpochMilli()))
+                        .buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.s3.enabled", "true")
+                .put("s3.region", MINIO_REGION)
+                .put("s3.endpoint", minio.getMinioAddress())
+                .put("s3.path-style-access", "true")
+                .buildOrThrow();
+    }
+
+    public Credentials getSessionCredentials()
+    {
+        AwsCredentials rootCredentials = AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
+        try (StsClient stsClient = StsClient.builder()
+                .endpointOverride(URI.create(minio.getMinioAddress()))
+                .credentialsProvider(StaticCredentialsProvider.create(rootCredentials))
+                .region(Region.of(MINIO_REGION))
+                .build()) {
+            AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(AssumeRoleRequest.builder().build());
+            return assumeRoleResponse.credentials();
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
@@ -36,7 +36,7 @@ public class DelegatingRestSessionCatalog
 
     DelegatingRestSessionCatalog(RESTCatalogAdapter adapter, Catalog delegate)
     {
-        super(_ -> adapter, null);
+        super(_ -> adapter, (FileIOBuilder) null);
         this.adapter = requireNonNull(adapter, "adapter is null");
         this.delegate = requireNonNull(delegate, "delegate catalog is null");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <dep.frontend-node.version>v24.12.0</dep.frontend-node.version>
         <dep.frontend-npm.version>11.7.0</dep.frontend-npm.version>
         <dep.httpcore5.version>5.4.2</dep.httpcore5.version>
-        <dep.iceberg.version>1.11.0</dep.iceberg.version>
+        <dep.iceberg.version>1.11.0-SNAPSHOT</dep.iceberg.version>
         <dep.jna.version>5.18.1</dep.jna.version>
         <dep.jsonwebtoken.version>0.13.0</dep.jsonwebtoken.version>
         <dep.jts.version>1.20.0</dep.jts.version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Alternative approach to https://github.com/trinodb/trino/pull/28425 which tackles the very same issue.
When loading a table in Iceberg, besides receiving `table.io().properties()` fileIoProperties, if `table.io()` implements `SupportStorageCredentials` there are additional prefixed storage credentials there will be delivered when loading the table.

The main changes of this contribution are being done in `io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogFileSystemFactory` class.


When a table's FileIO implements `SupportsStorageCredentials`, the REST
catalog delivers per-path-prefix credential sets in addition to the
global fileIoProperties. The factory now builds one vended-credentials
provider per `IcebergStorageCredentials` entry (merged over the root
fileIoProperties, matching `S3FileIO`/`GCSFileIO` behavior), alongside a
root-prefix catch-all provider from fileIoProperties. Longest-prefix
matching selects the right credential at file-access time.

`VendedCredentialsCacheKey` is updated to carry prefix-keyed credential
lists (mirroring `CachedVendedCredentialsProviders`), and
`applyRefreshedCredentials` in S3/GCS providers is fixed to filter by
the provider's own prefix instead of throwing on multiple credentials.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This contribution builds further on top of https://github.com/trinodb/trino/pull/28998

⚠️ ⚠️ ⚠️ 
This contribution is currently blocked by the actual design of `apache/iceberg` with regards to `ioBuilder` initialization in the method `org.apache.iceberg.rest.RESTSessionCatalog#newFileIO(org.apache.iceberg.catalog.SessionCatalog.SessionContext, java.util.Map<java.lang.String,java.lang.String>, java.util.List<org.apache.iceberg.rest.credentials.Credential>)`
See discussion: https://github.com/apache/iceberg/pull/15752/changes#r3288574387

Contentious `apache/iceberg` PR https://github.com/apache/iceberg/pull/15752

**Potential fix in `apache/iceberg`**
Motivates https://github.com/apache/iceberg/pull/16536

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support in Iceberg REST catalog for prefixed path storage credentials. ({issue}`issuenumber`)
```
