### PR TITLE
Add WHEN STALE support for views with auto-refresh on schema-staleness

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -112,6 +112,7 @@ statement
     | CREATE (OR REPLACE)? VIEW qualifiedName
         (COMMENT string)?
         (SECURITY (DEFINER | INVOKER))?
+        (WHEN STALE (REFRESH | FAIL))?
         (WITH properties)? AS rootQuery                                #createView
     | REFRESH MATERIALIZED VIEW qualifiedName                          #refreshMaterializedView
     | DROP MATERIALIZED VIEW (IF EXISTS)? qualifiedName                #dropMaterializedView

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -25,6 +25,7 @@ import io.trino.metadata.ViewColumn;
 import io.trino.metadata.ViewDefinition;
 import io.trino.metadata.ViewPropertyManager;
 import io.trino.security.AccessControl;
+import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.security.Identity;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis;
@@ -146,7 +147,8 @@ public class CreateViewTask
                 session.getPath().getPath().stream()
                         // system path elements currently are not stored
                         .filter(element -> !element.getCatalogName().equals(GlobalSystemConnector.NAME))
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()),
+                toConnectorWhenStaleBehavior(statement.getWhenStaleBehavior()));
 
         metadata.createView(session, name, definition, properties, statement.isReplace());
 
@@ -154,5 +156,17 @@ public class CreateViewTask
         stateMachine.setReferencedTables(analysis.getReferencedTables());
 
         return immediateVoidFuture();
+    }
+
+    private static ConnectorViewDefinition.WhenStaleBehavior toConnectorWhenStaleBehavior(Optional<CreateView.WhenStaleBehavior> whenStale)
+    {
+        if (whenStale.isEmpty()) {
+            return ConnectorViewDefinition.WhenStaleBehavior.FAIL;
+        }
+
+        return switch (whenStale.orElseThrow()) {
+            case FAIL -> ConnectorViewDefinition.WhenStaleBehavior.FAIL;
+            case REFRESH -> ConnectorViewDefinition.WhenStaleBehavior.REFRESH;
+        };
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RefreshViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RefreshViewTask.java
@@ -139,7 +139,8 @@ public class RefreshViewTask
                 columns,
                 viewDefinition.getComment(),
                 viewDefinition.getRunAsIdentity(),
-                viewDefinition.getPath());
+                viewDefinition.getPath(),
+                viewDefinition.getWhenStaleBehavior());
 
         metadata.refreshView(session, viewName, viewDefinitionWithNewColumns);
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1648,7 +1648,8 @@ public final class MetadataManager
                         .collect(toImmutableList()),
                 view.getComment(),
                 runAsIdentity,
-                view.getPath());
+            view.getPath(),
+            view.getWhenStaleBehavior().orElse(ViewDefinition.DEFAULT_WHEN_STALE_BEHAVIOR));
     }
 
     private Optional<ConnectorViewDefinition> getViewInternal(Session session, QualifiedObjectName viewName)

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1648,8 +1648,8 @@ public final class MetadataManager
                         .collect(toImmutableList()),
                 view.getComment(),
                 runAsIdentity,
-            view.getPath(),
-            view.getWhenStaleBehavior().orElse(ViewDefinition.DEFAULT_WHEN_STALE_BEHAVIOR));
+                view.getPath(),
+                view.getWhenStaleBehavior().orElse(ViewDefinition.DEFAULT_WHEN_STALE_BEHAVIOR));
     }
 
     private Optional<ConnectorViewDefinition> getViewInternal(Session session, QualifiedObjectName viewName)

--- a/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
@@ -15,6 +15,7 @@ package io.trino.metadata;
 
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.ConnectorViewDefinition.WhenStaleBehavior;
 import io.trino.spi.security.Identity;
 
 import java.util.List;
@@ -23,15 +24,19 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.connector.ConnectorViewDefinition.WhenStaleBehavior.FAIL;
 import static java.util.Objects.requireNonNull;
 
 public class ViewDefinition
 {
+    public static final WhenStaleBehavior DEFAULT_WHEN_STALE_BEHAVIOR = FAIL;
+
     private final String originalSql;
     private final Optional<String> catalog;
     private final Optional<String> schema;
     private final List<ViewColumn> columns;
     private final Optional<String> comment;
+    private final WhenStaleBehavior whenStaleBehavior;
     private final Optional<Identity> runAsIdentity;
     private final List<CatalogSchemaName> path;
 
@@ -42,13 +47,15 @@ public class ViewDefinition
             List<ViewColumn> columns,
             Optional<String> comment,
             Optional<Identity> runAsIdentity,
-            List<CatalogSchemaName> path)
+            List<CatalogSchemaName> path,
+            WhenStaleBehavior whenStaleBehavior)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
         this.comment = requireNonNull(comment, "comment is null");
+        this.whenStaleBehavior = requireNonNull(whenStaleBehavior, "whenStaleBehavior is null");
         this.runAsIdentity = requireNonNull(runAsIdentity, "runAsIdentity is null");
         this.path = requireNonNull(path, "path is null");
         checkArgument(schema.isEmpty() || catalog.isPresent(), "catalog must be present if schema is present");
@@ -80,6 +87,11 @@ public class ViewDefinition
         return comment;
     }
 
+    public WhenStaleBehavior getWhenStaleBehavior()
+    {
+        return whenStaleBehavior;
+    }
+
     public boolean isRunAsInvoker()
     {
         return runAsIdentity.isEmpty();
@@ -105,6 +117,7 @@ public class ViewDefinition
                         .map(column -> new ConnectorViewDefinition.ViewColumn(column.name(), column.type(), column.comment()))
                         .collect(toImmutableList()),
                 comment,
+                whenStaleBehavior == DEFAULT_WHEN_STALE_BEHAVIOR ? Optional.empty() : Optional.of(whenStaleBehavior),
                 runAsIdentity.map(Identity::getUser),
                 runAsIdentity.isEmpty(),
                 path);
@@ -119,6 +132,7 @@ public class ViewDefinition
                 .add("schema", schema.orElse(null))
                 .add("columns", columns)
                 .add("comment", comment.orElse(null))
+                .add("whenStaleBehavior", whenStaleBehavior)
                 .add("runAsIdentity", runAsIdentity.orElse(null))
                 .add("path", path)
                 .toString();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -61,18 +61,8 @@ import io.trino.security.SecurityContext;
 import io.trino.security.ViewAccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.TrinoWarning;
-import io.trino.spi.connector.CatalogSchemaName;
-import io.trino.spi.connector.CatalogSchemaTableName;
-import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.connector.ColumnMetadata;
-import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.connector.*;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior;
-import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.MaterializedViewFreshness;
-import io.trino.spi.connector.PointerType;
-import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.function.FunctionKind;
 import io.trino.spi.function.OperatorType;
@@ -2663,6 +2653,8 @@ class StatementAnalyzer
                     view.getRunAsIdentity(),
                     view.getPath(),
                     view.getColumns(),
+                    view.getComment(),
+                    ViewDefinition.DEFAULT_WHEN_STALE_BEHAVIOR,
                     freshStorageTable,
                     true);
         }
@@ -2679,6 +2671,8 @@ class StatementAnalyzer
                     view.getRunAsIdentity(),
                     view.getPath(),
                     view.getColumns(),
+                    view.getComment(),
+                    view.getWhenStaleBehavior(),
                     Optional.empty(),
                     false);
         }
@@ -2693,6 +2687,8 @@ class StatementAnalyzer
                 Optional<Identity> owner,
                 List<CatalogSchemaName> path,
                 List<ViewColumn> columns,
+                Optional<String> comment,
+                ConnectorViewDefinition.WhenStaleBehavior whenStaleBehavior,
                 Optional<TableHandle> freshStorageTable,
                 boolean isMaterializedView)
         {
@@ -2713,22 +2709,13 @@ class StatementAnalyzer
                 throw semanticException(VIEW_IS_RECURSIVE, table, "View is recursive");
             }
 
-            // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
-            // This is needed in case the underlying table(s) changed and the query in the view now produces types that
-            // are implicitly coercible to the declared view types.
-            List<Field> viewFields = columns.stream()
-                    .map(column -> Field.newQualified(
-                            table.getName(),
-                            Optional.of(column.name()),
-                            getViewColumnType(column, name, table),
-                            false,
-                            Optional.of(name),
-                            getBranchName(table),
-                            Optional.of(column.name()),
-                            false))
-                    .collect(toImmutableList());
+            List<ViewColumn> viewColumns = columns;
 
             if (freshStorageTable.isPresent()) {
+                // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
+                // This is needed in case the underlying table(s) changed and the query in the view now produces types that
+                // are implicitly coercible to the declared view types.
+                List<Field> viewFields = createViewFields(table, name, viewColumns);
                 List<Field> storageTableFields = analyzeStorageTable(table, viewFields, freshStorageTable.get());
                 analysis.setMaterializedViewStorageTableFields(table, storageTableFields);
             }
@@ -2743,11 +2730,36 @@ class StatementAnalyzer
                 RelationType descriptor = analyzeView(query, name, catalog, schema, owner, path, table);
                 analysis.unregisterTableForView();
 
-                checkViewStaleness(columns, descriptor.getVisibleFields(), name, table)
-                        .ifPresent(explanation -> { throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, explanation); });
+                Optional<String> staleness = checkViewStaleness(columns, descriptor.getVisibleFields(), name, table);
+                if (staleness.isPresent()) {
+                    if (!isMaterializedView && whenStaleBehavior == ConnectorViewDefinition.WhenStaleBehavior.REFRESH) {
+                        accessControl.checkCanRefreshView(session.toSecurityContext(), name);
+
+                        viewColumns = refreshStaleView(
+                                table,
+                                name,
+                                originalSql,
+                                catalog,
+                                schema,
+                                descriptor,
+                                columns,
+                                comment,
+                                owner,
+                                path,
+                                whenStaleBehavior);
+                    }
+                    else {
+                        throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, staleness.orElseThrow());
+                    }
+                }
 
                 analysis.registerNamedQuery(table, query);
             }
+
+            // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
+            // This is needed in case the underlying table(s) changed and the query in the view now produces types that
+            // are implicitly coercible to the declared view types.
+            List<Field> viewFields = createViewFields(table, name, viewColumns);
 
             Scope accessControlScope = Scope.builder()
                     .withRelationType(RelationId.anonymous(), new RelationType(viewFields))
@@ -2757,6 +2769,58 @@ class StatementAnalyzer
             viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow()))));
             return createAndAssignScope(table, scope, viewFields);
         }
+
+            private List<Field> createViewFields(Table table, QualifiedObjectName name, List<ViewColumn> viewColumns)
+            {
+                return viewColumns.stream()
+                    .map(column -> Field.newQualified(
+                        table.getName(),
+                        Optional.of(column.name()),
+                        getViewColumnType(column, name, table),
+                        false,
+                        Optional.of(name),
+                        getBranchName(table),
+                        Optional.of(column.name()),
+                        false))
+                    .collect(toImmutableList());
+            }
+
+            private List<ViewColumn> refreshStaleView(
+                Table table,
+                QualifiedObjectName name,
+                String originalSql,
+                Optional<String> catalog,
+                Optional<String> schema,
+                RelationType descriptor,
+                List<ViewColumn> columns,
+                Optional<String> comment,
+                Optional<Identity> owner,
+                List<CatalogSchemaName> path,
+                ConnectorViewDefinition.WhenStaleBehavior whenStaleBehavior)
+            {
+                Map<String, String> columnComments = columns.stream()
+                    .filter(viewColumn -> viewColumn.comment().isPresent())
+                    .collect(toImmutableMap(ViewColumn::name, viewColumn -> viewColumn.comment().orElseThrow()));
+
+                List<ViewColumn> refreshedColumns = descriptor.getVisibleFields().stream()
+                    .map(field -> new ViewColumn(field.getName().orElseThrow(), field.getType().getTypeId(), Optional.ofNullable(columnComments.get(field.getName().orElseThrow()))))
+                    .collect(toImmutableList());
+
+                metadata.refreshView(
+                    session,
+                    name,
+                    new ViewDefinition(
+                        originalSql,
+                        catalog,
+                        schema,
+                        refreshedColumns,
+                        comment,
+                        owner,
+                        path,
+                        whenStaleBehavior));
+
+                return refreshedColumns;
+            }
 
         private List<Field> analyzeStorageTable(Table table, List<Field> viewFields, TableHandle storageTable)
         {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -61,8 +61,19 @@ import io.trino.security.SecurityContext;
 import io.trino.security.ViewAccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.TrinoWarning;
-import io.trino.spi.connector.*;
+import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PointerType;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.function.FunctionKind;
 import io.trino.spi.function.OperatorType;
@@ -2770,22 +2781,22 @@ class StatementAnalyzer
             return createAndAssignScope(table, scope, viewFields);
         }
 
-            private List<Field> createViewFields(Table table, QualifiedObjectName name, List<ViewColumn> viewColumns)
-            {
-                return viewColumns.stream()
+        private List<Field> createViewFields(Table table, QualifiedObjectName name, List<ViewColumn> viewColumns)
+        {
+            return viewColumns.stream()
                     .map(column -> Field.newQualified(
-                        table.getName(),
-                        Optional.of(column.name()),
-                        getViewColumnType(column, name, table),
-                        false,
-                        Optional.of(name),
-                        getBranchName(table),
-                        Optional.of(column.name()),
-                        false))
+                            table.getName(),
+                            Optional.of(column.name()),
+                            getViewColumnType(column, name, table),
+                            false,
+                            Optional.of(name),
+                            getBranchName(table),
+                            Optional.of(column.name()),
+                            false))
                     .collect(toImmutableList());
-            }
+        }
 
-            private List<ViewColumn> refreshStaleView(
+        private List<ViewColumn> refreshStaleView(
                 Table table,
                 QualifiedObjectName name,
                 String originalSql,
@@ -2797,30 +2808,30 @@ class StatementAnalyzer
                 Optional<Identity> owner,
                 List<CatalogSchemaName> path,
                 ConnectorViewDefinition.WhenStaleBehavior whenStaleBehavior)
-            {
-                Map<String, String> columnComments = columns.stream()
+        {
+            Map<String, String> columnComments = columns.stream()
                     .filter(viewColumn -> viewColumn.comment().isPresent())
                     .collect(toImmutableMap(ViewColumn::name, viewColumn -> viewColumn.comment().orElseThrow()));
 
-                List<ViewColumn> refreshedColumns = descriptor.getVisibleFields().stream()
+            List<ViewColumn> refreshedColumns = descriptor.getVisibleFields().stream()
                     .map(field -> new ViewColumn(field.getName().orElseThrow(), field.getType().getTypeId(), Optional.ofNullable(columnComments.get(field.getName().orElseThrow()))))
                     .collect(toImmutableList());
 
-                metadata.refreshView(
+            metadata.refreshView(
                     session,
                     name,
                     new ViewDefinition(
-                        originalSql,
-                        catalog,
-                        schema,
-                        refreshedColumns,
-                        comment,
-                        owner,
-                        path,
-                        whenStaleBehavior));
+                            originalSql,
+                            catalog,
+                            schema,
+                            refreshedColumns,
+                            comment,
+                            owner,
+                            path,
+                            whenStaleBehavior));
 
-                return refreshedColumns;
-            }
+            return refreshedColumns;
+        }
 
         private List<Field> analyzeStorageTable(Table table, List<Field> viewFields, TableHandle storageTable)
         {

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
@@ -22,8 +22,10 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TablePropertyManager;
+import io.trino.metadata.ViewDefinition;
 import io.trino.metadata.ViewPropertyManager;
 import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.connector.ConnectorViewDefinition.WhenStaleBehavior;
 import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.rewrite.StatementRewrite;
@@ -169,12 +171,33 @@ public class TestCreateViewTask
                 .hasMessage("line 1:88: Invalid value for catalog 'test_catalog' view property 'boolean_property': Cannot convert ['unknown'] to boolean");
     }
 
+    @Test
+    public void testCreateViewWithWhenStaleRefresh()
+    {
+        QualifiedObjectName viewName = qualifiedObjectName("view_with_when_stale_refresh");
+
+        getFutureValue(executeCreateView(asQualifiedName(viewName), Optional.of(CreateView.WhenStaleBehavior.REFRESH), false));
+
+        ViewDefinition viewDefinition = metadata.getView(testSession, viewName).orElseThrow();
+        assertThat(viewDefinition.getWhenStaleBehavior()).isEqualTo(WhenStaleBehavior.REFRESH);
+    }
+
     private ListenableFuture<Void> executeCreateView(QualifiedName viewName, boolean replace)
     {
-        return executeCreateView(viewName, ImmutableList.of(), replace);
+        return executeCreateView(viewName, Optional.empty(), ImmutableList.of(), replace);
     }
 
     private ListenableFuture<Void> executeCreateView(QualifiedName viewName, List<Property> viewProperties, boolean replace)
+    {
+        return executeCreateView(viewName, Optional.empty(), viewProperties, replace);
+    }
+
+    private ListenableFuture<Void> executeCreateView(QualifiedName viewName, Optional<CreateView.WhenStaleBehavior> whenStaleBehavior, boolean replace)
+    {
+        return executeCreateView(viewName, whenStaleBehavior, ImmutableList.of(), replace);
+    }
+
+    private ListenableFuture<Void> executeCreateView(QualifiedName viewName, Optional<CreateView.WhenStaleBehavior> whenStaleBehavior, List<Property> viewProperties, boolean replace)
     {
         Query query = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("mock_table")));
         CreateView statement = new CreateView(
@@ -184,6 +207,7 @@ public class TestCreateViewTask
                 replace,
                 Optional.empty(),
                 Optional.empty(),
+                whenStaleBehavior,
                 viewProperties);
         return new CreateViewTask(
                 plannerContext,

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -3624,20 +3624,20 @@ public class TestAnalyzer
                 .hasMessage("line 1:15: View 'tpch.s1.v2' is stale or in invalid state: column [a] of type bigint projected from query view at position 0 cannot be coerced to column [a] of type varchar stored in view definition");
     }
 
-        @Test
-        public void testStaleViewWhenStaleRefresh()
-        {
-                analyze("SELECT * FROM v2_refresh");
+    @Test
+    public void testStaleViewWhenStaleRefresh()
+    {
+        analyze("SELECT * FROM v2_refresh");
 
-                transaction(transactionManager, plannerContext.getMetadata(), accessControl)
-                                .singleStatement()
-                                .readUncommitted()
-                                .execute(SETUP_SESSION, session -> {
-                                        ViewDefinition refreshed = plannerContext.getMetadata().getView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2_refresh")).orElseThrow();
-                                        assertThat(refreshed.getColumns()).containsExactly(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty()));
-                                        assertThat(refreshed.getWhenStaleBehavior()).isEqualTo(ConnectorViewDefinition.WhenStaleBehavior.REFRESH);
-                                });
-        }
+        transaction(transactionManager, plannerContext.getMetadata(), accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .execute(SETUP_SESSION, session -> {
+                    ViewDefinition refreshed = plannerContext.getMetadata().getView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2_refresh")).orElseThrow();
+                    assertThat(refreshed.getColumns()).containsExactly(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty()));
+                    assertThat(refreshed.getWhenStaleBehavior()).isEqualTo(ConnectorViewDefinition.WhenStaleBehavior.REFRESH);
+                });
+    }
 
     @Test
     public void testStoredViewAnalysisScoping()

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -78,6 +78,7 @@ import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.ColumnLineageInfo;
@@ -3622,6 +3623,21 @@ public class TestAnalyzer
                 .hasErrorCode(VIEW_IS_STALE)
                 .hasMessage("line 1:15: View 'tpch.s1.v2' is stale or in invalid state: column [a] of type bigint projected from query view at position 0 cannot be coerced to column [a] of type varchar stored in view definition");
     }
+
+        @Test
+        public void testStaleViewWhenStaleRefresh()
+        {
+                analyze("SELECT * FROM v2_refresh");
+
+                transaction(transactionManager, plannerContext.getMetadata(), accessControl)
+                                .singleStatement()
+                                .readUncommitted()
+                                .execute(SETUP_SESSION, session -> {
+                                        ViewDefinition refreshed = plannerContext.getMetadata().getView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2_refresh")).orElseThrow();
+                                        assertThat(refreshed.getColumns()).containsExactly(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty()));
+                                        assertThat(refreshed.getWhenStaleBehavior()).isEqualTo(ConnectorViewDefinition.WhenStaleBehavior.REFRESH);
+                                });
+        }
 
     @Test
     public void testStoredViewAnalysisScoping()
@@ -8432,7 +8448,8 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ConnectorViewDefinition.WhenStaleBehavior.FAIL);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v1"), viewData1, ImmutableMap.of(), false));
 
         // stale view (different column type)
@@ -8443,8 +8460,21 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", VARCHAR.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ConnectorViewDefinition.WhenStaleBehavior.FAIL);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2"), viewData2, ImmutableMap.of(), false));
+
+        // stale view with auto-refresh behavior
+        ViewDefinition viewData3 = new ViewDefinition(
+                "select a from t1",
+                Optional.of(TPCH_CATALOG),
+                Optional.of("s1"),
+                ImmutableList.of(new ViewColumn("a", VARCHAR.getTypeId(), Optional.empty())),
+                Optional.of("comment"),
+                Optional.of(Identity.ofUser("user")),
+                ImmutableList.of(),
+                ConnectorViewDefinition.WhenStaleBehavior.REFRESH);
+        inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2_refresh"), viewData3, ImmutableMap.of(), false));
 
         // valid view with uppercase column name
         ViewDefinition viewData4 = new ViewDefinition(
@@ -8454,7 +8484,8 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ConnectorViewDefinition.WhenStaleBehavior.FAIL);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName("tpch", "s1", "v4"), viewData4, ImmutableMap.of(), false));
 
         // recursive view referencing to itself
@@ -8465,7 +8496,8 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.of("comment"),
                 Optional.of(Identity.ofUser("user")),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ConnectorViewDefinition.WhenStaleBehavior.FAIL);
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v5"), viewData5, ImmutableMap.of(), false));
 
         // type analysis for INSERT
@@ -8570,7 +8602,8 @@ public class TestAnalyzer
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ConnectorViewDefinition.WhenStaleBehavior.FAIL);
         inSetupTransaction(session -> metadata.createView(
                 session,
                 tableViewAndMaterializedView,

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1226,7 +1226,7 @@ public final class SqlFormatter
                     .append(" SECURITY ")
                     .append(security.name()));
 
-                node.getWhenStaleBehavior().ifPresent(whenStale -> builder
+            node.getWhenStaleBehavior().ifPresent(whenStale -> builder
                     .append(" WHEN STALE ")
                     .append(whenStale.name()));
 

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1226,6 +1226,10 @@ public final class SqlFormatter
                     .append(" SECURITY ")
                     .append(security.name()));
 
+                node.getWhenStaleBehavior().ifPresent(whenStale -> builder
+                    .append(" WHEN STALE ")
+                    .append(whenStale.name()));
+
             builder.append(formatPropertiesMultiLine(node.getProperties()));
 
             builder.append(" AS\n");

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -981,6 +981,14 @@ class AstBuilder
             security = Optional.of(CreateView.Security.INVOKER);
         }
 
+        Optional<CreateView.WhenStaleBehavior> whenStale = Optional.empty();
+        if (context.REFRESH() != null) {
+            whenStale = Optional.of(CreateView.WhenStaleBehavior.REFRESH);
+        }
+        else if (context.FAIL() != null) {
+            whenStale = Optional.of(CreateView.WhenStaleBehavior.FAIL);
+        }
+
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
             properties = visit(context.properties().propertyAssignments().property(), Property.class);
@@ -993,6 +1001,7 @@ class AstBuilder
                 context.REPLACE() != null,
                 comment,
                 security,
+                whenStale,
                 properties);
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CreateView.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CreateView.java
@@ -30,14 +30,20 @@ public class CreateView
         INVOKER, DEFINER
     }
 
+    public enum WhenStaleBehavior
+    {
+        FAIL, REFRESH
+    }
+
     private final QualifiedName name;
     private final Query query;
     private final boolean replace;
     private final Optional<String> comment;
     private final Optional<Security> security;
+    private final Optional<WhenStaleBehavior> whenStaleBehavior;
     private final List<Property> properties;
 
-    public CreateView(NodeLocation location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security, List<Property> properties)
+    public CreateView(NodeLocation location, QualifiedName name, Query query, boolean replace, Optional<String> comment, Optional<Security> security, Optional<WhenStaleBehavior> whenStaleBehavior, List<Property> properties)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
@@ -45,6 +51,7 @@ public class CreateView
         this.replace = replace;
         this.comment = requireNonNull(comment, "comment is null");
         this.security = requireNonNull(security, "security is null");
+        this.whenStaleBehavior = requireNonNull(whenStaleBehavior, "whenStaleBehavior is null");
         this.properties = ImmutableList.copyOf(properties);
     }
 
@@ -73,6 +80,11 @@ public class CreateView
         return security;
     }
 
+    public Optional<WhenStaleBehavior> getWhenStaleBehavior()
+    {
+        return whenStaleBehavior;
+    }
+
     public List<Property> getProperties()
     {
         return properties;
@@ -96,7 +108,7 @@ public class CreateView
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, query, replace, security, properties);
+        return Objects.hash(name, query, replace, security, whenStaleBehavior, properties);
     }
 
     @Override
@@ -114,6 +126,7 @@ public class CreateView
                 && replace == o.replace
                 && Objects.equals(comment, o.comment)
                 && Objects.equals(security, o.security)
+                && Objects.equals(whenStaleBehavior, o.whenStaleBehavior)
                 && Objects.equals(properties, o.properties);
     }
 
@@ -126,6 +139,7 @@ public class CreateView
                 .add("replace", replace)
                 .add("comment", comment)
                 .add("security", security)
+                .add("whenStaleBehavior", whenStaleBehavior)
                 .add("properties", properties)
                 .toString();
     }

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -71,6 +71,7 @@ import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.tree.ArithmeticUnaryExpression.Sign.MINUS;
 import static io.trino.sql.tree.ArithmeticUnaryExpression.Sign.PLUS;
 import static io.trino.sql.tree.CreateView.Security.DEFINER;
+import static io.trino.sql.tree.CreateView.WhenStaleBehavior.REFRESH;
 import static io.trino.sql.tree.SaveMode.FAIL;
 import static io.trino.sql.tree.SaveMode.IGNORE;
 import static io.trino.sql.tree.SaveMode.REPLACE;
@@ -377,6 +378,7 @@ public class TestSqlFormatter
                         false,
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         ImmutableList.of())))
                 .isEqualTo("CREATE VIEW test AS\n" +
                         "SELECT *\n" +
@@ -389,6 +391,7 @@ public class TestSqlFormatter
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
                         false,
                         Optional.of("攻殻機動隊"),
+                        Optional.empty(),
                         Optional.empty(),
                         ImmutableList.of())))
                 .isEqualTo("CREATE VIEW test COMMENT '攻殻機動隊' AS\n" +
@@ -403,6 +406,7 @@ public class TestSqlFormatter
                         QualifiedName.of("test"),
                         simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
                         false,
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         ImmutableList.of(
@@ -429,10 +433,11 @@ public class TestSqlFormatter
                         false,
                         Optional.of("攻殻機動隊"),
                         Optional.of(DEFINER),
+                        Optional.of(REFRESH),
                         ImmutableList.of(new Property(new Identifier("property"), new StringLiteral("property_value"))))))
                 .isEqualTo(
                         """
-                        CREATE VIEW test COMMENT '攻殻機動隊' SECURITY DEFINER
+                        CREATE VIEW test COMMENT '攻殻機動隊' SECURITY DEFINER WHEN STALE REFRESH
                         WITH (
                            property = 'property_value'
                         ) AS

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -4518,17 +4518,20 @@ public class TestSqlParser
     {
         Query query = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t")));
 
-        assertStatement("CREATE VIEW a AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
-        assertStatement("CREATE OR REPLACE VIEW a AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, true, Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW a AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE OR REPLACE VIEW a AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, true, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.DEFINER), ImmutableList.of()));
-        assertStatement("CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.INVOKER), ImmutableList.of()));
+        assertStatement("CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.DEFINER), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.of(CreateView.Security.INVOKER), Optional.empty(), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW a COMMENT 'comment' SECURITY DEFINER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.of(CreateView.Security.DEFINER), ImmutableList.of()));
-        assertStatement("CREATE VIEW a COMMENT '' SECURITY INVOKER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of(""), Optional.of(CreateView.Security.INVOKER), ImmutableList.of()));
+        assertStatement("CREATE VIEW a WHEN STALE FAIL AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty(), Optional.of(CreateView.WhenStaleBehavior.FAIL), ImmutableList.of()));
+        assertStatement("CREATE VIEW a WHEN STALE REFRESH AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.empty(), Optional.empty(), Optional.of(CreateView.WhenStaleBehavior.REFRESH), ImmutableList.of()));
 
-        assertStatement("CREATE VIEW a COMMENT 'comment' AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.empty(), ImmutableList.of()));
-        assertStatement("CREATE VIEW a COMMENT '' AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of(""), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW a COMMENT 'comment' SECURITY DEFINER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.of(CreateView.Security.DEFINER), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW a COMMENT '' SECURITY INVOKER AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of(""), Optional.of(CreateView.Security.INVOKER), Optional.empty(), ImmutableList.of()));
+
+        assertStatement("CREATE VIEW a COMMENT 'comment' AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of("comment"), Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW a COMMENT '' AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("a"), query, false, Optional.of(""), Optional.empty(), Optional.empty(), ImmutableList.of()));
 
         assertStatement(
                 "CREATE VIEW a WITH (property_1 = 'value_1', property_2 = 2) AS SELECT * FROM t",
@@ -4539,13 +4542,14 @@ public class TestSqlParser
                         false,
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         ImmutableList.of(
                                 new Property(new Identifier("property_1"), new StringLiteral("value_1")),
                                 new Property(new Identifier("property_2"), new LongLiteral("2")))));
 
-        assertStatement("CREATE VIEW bar.foo AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("bar", "foo"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
-        assertStatement("CREATE VIEW \"awesome view\" AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("awesome view"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
-        assertStatement("CREATE VIEW \"awesome schema\".\"awesome view\" AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("awesome schema", "awesome view"), query, false, Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW bar.foo AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("bar", "foo"), query, false, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW \"awesome view\" AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("awesome view"), query, false, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of()));
+        assertStatement("CREATE VIEW \"awesome schema\".\"awesome view\" AS SELECT * FROM t", new CreateView(location(1, 1), QualifiedName.of("awesome schema", "awesome view"), query, false, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of()));
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -291,6 +291,12 @@
                                     <new>method boolean io.trino.spi.type.TypeManager::isTypeRegistered(java.lang.String)</new>
                                     <justification>Required for resolving static method calls on parametric type bases (array, row, map). Cannot be a default that calls getType because parametric bases require parameters and would force exception-driven control flow.</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.connector.ConnectorViewDefinition::&lt;init&gt;(java.lang.String, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.List&lt;io.trino.spi.connector.ConnectorViewDefinition.ViewColumn&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, boolean, java.util.List&lt;io.trino.spi.connector.CatalogSchemaName&gt;)</old>
+                                    <new>method void io.trino.spi.connector.ConnectorViewDefinition::&lt;init&gt;(java.lang.String, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.List&lt;io.trino.spi.connector.ConnectorViewDefinition.ViewColumn&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, boolean, java.util.List&lt;io.trino.spi.connector.CatalogSchemaName&gt;, java.util.Optional&lt;io.trino.spi.connector.ConnectorViewDefinition.WhenStaleBehavior&gt;)</new>
+                                    <justification>Add whenStaleBehavior to represent stale view handling policy in SPI view definitions</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
@@ -26,11 +26,18 @@ import static java.util.stream.Collectors.joining;
 
 public class ConnectorViewDefinition
 {
+    public enum WhenStaleBehavior
+    {
+        FAIL,
+        REFRESH,
+    }
+
     private final String originalSql;
     private final Optional<String> catalog;
     private final Optional<String> schema;
     private final List<ViewColumn> columns;
     private final Optional<String> comment;
+    private final Optional<WhenStaleBehavior> whenStaleBehavior;
     private final Optional<String> owner;
     private final boolean runAsInvoker;
     private final List<CatalogSchemaName> path;
@@ -44,13 +51,15 @@ public class ConnectorViewDefinition
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("owner") Optional<String> owner,
             @JsonProperty("runAsInvoker") boolean runAsInvoker,
-            @JsonProperty("path") List<CatalogSchemaName> path)
+            @JsonProperty("path") List<CatalogSchemaName> path,
+            @JsonProperty("whenStaleBehavior") Optional<WhenStaleBehavior> whenStaleBehavior)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
         this.comment = requireNonNull(comment, "comment is null");
+        this.whenStaleBehavior = requireNonNull(whenStaleBehavior, "whenStaleBehavior is null");
         this.owner = requireNonNull(owner, "owner is null");
         this.runAsInvoker = runAsInvoker;
         this.path = path == null ? List.of() : List.copyOf(path);
@@ -96,6 +105,12 @@ public class ConnectorViewDefinition
     }
 
     @JsonProperty
+    public Optional<WhenStaleBehavior> getWhenStaleBehavior()
+    {
+        return whenStaleBehavior;
+    }
+
+    @JsonProperty
     public Optional<String> getOwner()
     {
         return owner;
@@ -123,7 +138,8 @@ public class ConnectorViewDefinition
                 comment,
                 Optional.empty(),
                 runAsInvoker,
-                path);
+                path,
+                whenStaleBehavior);
     }
 
     @Override
@@ -132,6 +148,7 @@ public class ConnectorViewDefinition
         StringJoiner joiner = new StringJoiner(", ", "[", "]");
         owner.ifPresent(value -> joiner.add("owner=" + value));
         comment.ifPresent(value -> joiner.add("comment=" + value));
+        whenStaleBehavior.ifPresent(value -> joiner.add("whenStaleBehavior=" + value));
         joiner.add("runAsInvoker=" + runAsInvoker);
         joiner.add("columns=" + columns);
         catalog.ifPresent(value -> joiner.add("catalog=" + value));

--- a/core/trino-spi/src/test/java/io/trino/spi/connector/TestConnectorViewDefinition.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/connector/TestConnectorViewDefinition.java
@@ -108,7 +108,8 @@ class TestConnectorViewDefinition
                 Optional.of("comment"),
                 Optional.of("test_owner"),
                 false,
-                ImmutableList.of()));
+                ImmutableList.of(),
+                Optional.empty()));
     }
 
     private static void assertBaseView(ConnectorViewDefinition view)

--- a/docs/src/main/sphinx/sql/create-view.md
+++ b/docs/src/main/sphinx/sql/create-view.md
@@ -6,6 +6,7 @@
 CREATE [ OR REPLACE ] VIEW view_name
 [ COMMENT view_comment ]
 [ SECURITY { DEFINER | INVOKER } ]
+[ WHEN STALE { FAIL | REFRESH } ]
 AS query
 ```
 
@@ -18,6 +19,14 @@ referenced by another query.
 
 The optional `OR REPLACE` clause causes the view to be replaced if it
 already exists rather than raising an error.
+
+The optional `WHEN STALE` clause specifies what happens when schema changes in
+objects referenced by the view make the stored view metadata stale:
+
+* `FAIL` - Querying the stale view fails. This is the default behavior when
+	`WHEN STALE` is not specified.
+* `REFRESH` - Querying the stale view automatically refreshes the stored view
+	schema metadata and continues query analysis using the refreshed definition.
 
 ## Security
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add support for a WHEN STALE clause on regular views so schema-stale views can be refreshed automatically.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Implementation of #29591


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
Release notes are required. Please propose a release note for me.

Closes #29591 