### PR TITLE
Add native file system cache

### DIFF
--- a/docs/src/main/sphinx/object-storage.md
+++ b/docs/src/main/sphinx/object-storage.md
@@ -87,6 +87,8 @@ Trino also provides the following additional support and features for object
 storage:
 
 * [](/object-storage/file-system-cache)
+* [](/object-storage/file-system-native-cache)
+* [](/object-storage/file-system-alluxio)
 * [](/object-storage/metastores)
 * [](/object-storage/file-formats)
 
@@ -99,8 +101,9 @@ storage:
 /object-storage/file-system-s3
 /object-storage/file-system-local
 /object-storage/file-system-hdfs
-/object-storage/file-system-alluxio
 /object-storage/file-system-cache
+/object-storage/file-system-native-cache
+/object-storage/file-system-alluxio
 /object-storage/metastores
 /object-storage/file-formats
 ```

--- a/docs/src/main/sphinx/object-storage.md
+++ b/docs/src/main/sphinx/object-storage.md
@@ -88,6 +88,7 @@ Trino also provides the following additional support and features for object
 storage:
 
 * [](/object-storage/file-system-cache)
+* [](/object-storage/file-system-native-cache)
 * [](/object-storage/file-system-alluxio)
 * [](/object-storage/metastores)
 * [](/object-storage/file-formats)
@@ -102,6 +103,7 @@ storage:
 /object-storage/file-system-local
 /object-storage/file-system-hdfs
 /object-storage/file-system-cache
+/object-storage/file-system-native-cache
 /object-storage/file-system-alluxio
 /object-storage/metastores
 /object-storage/file-formats

--- a/docs/src/main/sphinx/object-storage/file-system-cache.md
+++ b/docs/src/main/sphinx/object-storage/file-system-cache.md
@@ -7,13 +7,17 @@ and processed on these workers. Repeated queries with different parameters, or
 even different queries from different users, often access, and therefore
 transfer, the same objects.
 
-Trino includes support for caching these files with the help of the open
-source [Alluxio](https://github.com/Alluxio/alluxio) libraries with catalogs
-using the following connectors:
+Trino includes support for caching these files on local storage attached to the
+Trino cluster nodes. The [native file system cache
+implementation](/object-storage/file-system-native-cache) is managed by Trino.
+Catalogs using the following connectors support file system caching:
 
 * [](/connector/delta-lake)
 * [](/connector/hive)
 * [](/connector/iceberg)
+
+For an external cache layer backed by an Alluxio cluster, see
+[](/object-storage/file-system-alluxio).
 
 (fs-cache-distributed)=
 ## Distributed caching
@@ -101,6 +105,10 @@ enable and configure caching for the specific catalogs.
   - Description
 * - `fs.cache.enabled`
   - Enable object storage caching. Defaults to no caching with the value `false`.
+* - `fs.cache.type`
+  - Cache implementation to use. Use `NATIVE` for the native file system cache.
+    Native-cache-specific properties are documented in
+    [](/object-storage/file-system-native-cache).
 * - `fs.cache.directories`
   - Required, comma-separated list of absolute paths to directories to use for
     caching. All directories must exist on the coordinator and all workers.
@@ -118,7 +126,7 @@ enable and configure caching for the specific catalogs.
     `fs.cache.max-disk-usage-percentages` is required.
 * - `fs.cache.max-disk-usage-percentages`
   - Comma-separated list of maximum percentage values of the used disk for each
-    directory. Each value is an integer between 1 and 100. Order of values must
+    directory. Each value is an integer between 0 and 100. Order of values must
     be identical to the directories list. If multiple directories use the same
     disk, ensure that total percentages per drive remains below 100 percent.
     Configuring either `fs.cache.max-sizes` or
@@ -142,10 +150,12 @@ enable and configure caching for the specific catalogs.
 
 ## Monitoring
 
-The cache exposes the
+The native cache exposes JMX metrics under
+`io.trino.filesystem.cache.local.NativeFileSystemCacheStats`. The Alluxio-based
+cache exposes the
 [Alluxio JMX client metrics](https://docs.alluxio.io/ee-da/user/stable/en/reference/Metrics-List.html#client-metrics)
-under the `org.alluxio` package, and metrics on external reads and cache reads under
-`io.trino.filesystem.alluxio.AlluxioCacheStats`.
+under the `org.alluxio` package, and metrics on external reads and cache reads
+under `io.trino.filesystem.alluxio.AlluxioCacheStats`.
 
 The cache code uses [OpenTelemetry tracing](/admin/opentelemetry).
 

--- a/docs/src/main/sphinx/object-storage/file-system-native-cache.md
+++ b/docs/src/main/sphinx/object-storage/file-system-native-cache.md
@@ -1,0 +1,118 @@
+# Native file system cache
+
+Trino can cache data read through supported file systems on local storage
+attached to each coordinator and worker. The native cache implementation stores
+file data as fixed-size chunks in local directories managed by Trino, without
+requiring an Alluxio cluster or Alluxio cache manager.
+
+Enable the native cache with the following catalog properties:
+
+```properties
+fs.cache.enabled=true
+fs.cache.type=NATIVE
+fs.cache.directories=/mnt/cache0,/mnt/cache1
+fs.cache.max-sizes=1TB,1TB
+```
+
+The native cache is local to each Trino node and each catalog. When multiple
+catalogs use caching, configure different cache directories for each catalog.
+
+## Behavior
+
+The native cache stores cached data in chunks. A cached source file can have
+many chunk files, and the final chunk can be smaller than the configured chunk
+size. The cache survives Trino process restart because the chunk files and recent
+access tracking files are stored on disk.
+
+On startup, Trino scans each cache directory in the background to rebuild cache
+accounting and clean stale temporary files. Each cache directory has its own
+background task, so nodes with multiple local disks scan and maintain those
+directories independently. Reads can use existing cached chunks while this scan
+runs, and new cache writes are allowed. Eviction based on configured cache limits
+starts after accounting is known for the directory. Cache writes are skipped when
+the local file system reports too little usable space for the chunk.
+
+Eviction is approximate and per cache directory. Trino tracks recent file access
+with bounded-memory Bloom filters and uses this recent-access history when
+choosing eviction candidates. When a directory is under pressure, Trino samples
+cached file groups, prefers expired and not-recently-accessed groups, and deletes
+all cached chunks for a selected file group. This is intentionally simpler than
+tracking a precise LRU order for every cached chunk.
+
+The cache also has low-rate per-directory maintenance tasks that clean stale
+temporary files and remove expired cached file groups on a best-effort basis.
+
+## Storage recommendations
+
+Use dedicated local flash storage for cache directories. The cache stores many
+files and assumes the local file system handles large directory trees
+efficiently. Avoid shared storage, network file systems, and the operating
+system root volume. The local file system must support atomic moves within each
+cache directory.
+
+On cloud instances with multiple local disks, configure one cache directory per
+disk and assign a matching size or disk usage percentage for each directory.
+
+## Configuration
+
+Use the properties from the following table in your catalog properties file.
+
+:::{list-table} Native file system cache configuration properties
+:widths: 30, 70
+:header-rows: 1
+
+* - Property
+  - Description
+* - `fs.cache.enabled`
+  - Enable file system caching. Defaults to `false`.
+* - `fs.cache.type`
+  - Cache implementation to use. Set to `NATIVE` for the native file system
+    cache.
+* - `fs.cache.directories`
+  - Required, comma-separated list of absolute paths to cache directories.
+    The paths, or their closest existing parents, must be readable and writable
+    on all Trino nodes that use the catalog.
+* - `fs.cache.max-sizes`
+  - Comma-separated list of maximum [data sizes](prop-type-data-size), one for
+    each cache directory. Configure either `fs.cache.max-sizes` or
+    `fs.cache.max-disk-usage-percentages`.
+* - `fs.cache.max-disk-usage-percentages`
+  - Comma-separated list of maximum percentages of total disk size, one for each
+    cache directory. Each value is an integer between 0 and 100. Configure either
+    `fs.cache.max-sizes` or `fs.cache.max-disk-usage-percentages`.
+* - `fs.cache.page-size`
+  - Cached chunk [data size](prop-type-data-size). Defaults to `1MB`. Values
+    must be between `64kB` and `15MB`.
+* - `fs.cache.ttl`
+  - Maximum [duration](prop-type-duration) cached file groups are kept before
+    they are eligible for best-effort eviction. Defaults to `7d`. A value of
+    `0s` makes cached file groups immediately eligible for eviction.
+* - `fs.cache.max-files-per-directory`
+  - Maximum number of cached chunk files in each cache directory. Defaults to
+    `10000000`.
+* - `fs.cache.access-history-duration`
+  - Duration of approximate recent-access history used by eviction. Defaults to
+    `24h`.
+* - `fs.cache.access-bucket-duration`
+  - Duration of each recent-access tracking bucket. Defaults to `10m`.
+* - `fs.cache.access-tracking-memory`
+  - Maximum memory used for approximate recent-access tracking across cache
+    directories for the catalog. Defaults to `256MB`.
+* - `fs.cache.preferred-hosts-count`
+  - Number of preferred nodes for scheduling splits that read the same file.
+    Defaults to `2`. More information in
+    [](fs-cache-distributed).
+:::
+
+For multiple cache directories, the values of `fs.cache.directories` and the
+chosen size limit property must have the same number of entries in the same
+order.
+
+## Monitoring
+
+The native cache exposes JMX metrics from
+`io.trino.filesystem.cache.local.NativeFileSystemCacheStats`, including external
+reads, cache reads, cache writes, skipped writes, cached bytes, cached files,
+evictions, expired files, stale temporary files, and access records.
+
+The cache code uses [OpenTelemetry tracing](/admin/opentelemetry).

--- a/docs/src/main/sphinx/object-storage/file-system-native-cache.md
+++ b/docs/src/main/sphinx/object-storage/file-system-native-cache.md
@@ -1,0 +1,117 @@
+# Native file system cache
+
+Trino can cache data read through supported file systems on local storage
+attached to each coordinator and worker. The native cache implementation stores
+file data as fixed-size chunks in local directories managed by Trino, without
+requiring an Alluxio cluster or Alluxio cache manager.
+
+Enable the native cache with the following catalog properties:
+
+```properties
+fs.cache.enabled=true
+fs.cache.type=NATIVE
+fs.cache.directories=/mnt/cache0,/mnt/cache1
+fs.cache.max-sizes=1TB,1TB
+```
+
+The native cache is local to each Trino node and each catalog. When multiple
+catalogs use caching, configure different cache directories for each catalog.
+
+## Behavior
+
+The native cache stores cached data in chunks. A cached source file can have
+many chunk files, and the final chunk can be smaller than the configured chunk
+size. The cache survives Trino process restart because the chunk files and recent
+access tracking files are stored on disk.
+
+On startup, Trino scans each cache directory in the background to rebuild cache
+accounting and clean stale temporary files. Each cache directory has its own
+background task, so nodes with multiple local disks scan and maintain those
+directories independently. Reads can use existing cached chunks while this scan
+runs, and new cache writes are allowed. Eviction based on configured cache limits
+starts after accounting is known for the directory. Cache writes are skipped when
+the local file system reports too little usable space for the chunk.
+
+Eviction is approximate and per cache directory. Trino tracks recent file access
+with bounded-memory Bloom filters and uses this recent-access history when
+choosing eviction candidates. When a directory is under pressure, Trino samples
+cached file groups, prefers expired and not-recently-accessed groups, and deletes
+all cached chunks for a selected file group. This is intentionally simpler than
+tracking a precise LRU order for every cached chunk.
+
+The cache also has low-rate per-directory maintenance tasks that clean stale
+temporary files and remove expired cached file groups on a best-effort basis.
+
+## Storage recommendations
+
+Use dedicated local flash storage for cache directories. The cache stores many
+files and assumes the local file system handles large directory trees
+efficiently. Avoid shared storage, network file systems, and the operating
+system root volume.
+
+On cloud instances with multiple local disks, configure one cache directory per
+disk and assign a matching size or disk usage percentage for each directory.
+
+## Configuration
+
+Use the properties from the following table in your catalog properties file.
+
+:::{list-table} Native file system cache configuration properties
+:widths: 30, 70
+:header-rows: 1
+
+* - Property
+  - Description
+* - `fs.cache.enabled`
+  - Enable file system caching. Defaults to `false`.
+* - `fs.cache.type`
+  - Cache implementation to use. Set to `NATIVE` for the native file system
+    cache.
+* - `fs.cache.directories`
+  - Required, comma-separated list of absolute paths to cache directories.
+    The paths, or their closest existing parents, must be readable and writable
+    on all Trino nodes that use the catalog.
+* - `fs.cache.max-sizes`
+  - Comma-separated list of maximum [data sizes](prop-type-data-size), one for
+    each cache directory. Configure either `fs.cache.max-sizes` or
+    `fs.cache.max-disk-usage-percentages`.
+* - `fs.cache.max-disk-usage-percentages`
+  - Comma-separated list of maximum percentages of total disk size, one for each
+    cache directory. Each value is an integer between 0 and 100. Configure either
+    `fs.cache.max-sizes` or `fs.cache.max-disk-usage-percentages`.
+* - `fs.cache.page-size`
+  - Cached chunk [data size](prop-type-data-size). Defaults to `1MB`. Values
+    must be between `64kB` and `15MB`.
+* - `fs.cache.ttl`
+  - Maximum [duration](prop-type-duration) cached file groups are kept before
+    they are eligible for best-effort eviction. Defaults to `7d`. A value of
+    `0s` makes cached file groups immediately eligible for eviction.
+* - `fs.cache.max-files-per-directory`
+  - Maximum number of cached chunk files in each cache directory. Defaults to
+    `10000000`.
+* - `fs.cache.access-history-duration`
+  - Duration of approximate recent-access history used by eviction. Defaults to
+    `24h`.
+* - `fs.cache.access-bucket-duration`
+  - Duration of each recent-access tracking bucket. Defaults to `10m`.
+* - `fs.cache.access-tracking-memory`
+  - Maximum memory used for approximate recent-access tracking across cache
+    directories for the catalog. Defaults to `256MB`.
+* - `fs.cache.preferred-hosts-count`
+  - Number of preferred nodes for scheduling splits that read the same file.
+    Defaults to `2`. More information in
+    [](fs-cache-distributed).
+:::
+
+For multiple cache directories, the values of `fs.cache.directories` and the
+chosen size limit property must have the same number of entries in the same
+order.
+
+## Monitoring
+
+The native cache exposes JMX metrics from
+`io.trino.filesystem.cache.local.NativeFileSystemCacheStats`, including external
+reads, cache reads, cache writes, skipped writes, cached bytes, cached files,
+evictions, expired files, stale temporary files, and access records.
+
+The cache code uses [OpenTelemetry tracing](/admin/opentelemetry).

--- a/lib/trino-filesystem-cache/README.md
+++ b/lib/trino-filesystem-cache/README.md
@@ -1,0 +1,441 @@
+# Native file system cache design
+
+This module contains Trino's native file system cache implementation. It is a
+small local-file cache for `TrinoFileSystemCache`, intended to replace the
+Alluxio-backed cache without turning Trino into a cache storage project.
+
+The cache stores page-aligned chunks as deterministic files under configured
+local cache directories. It uses no global index, no database, and no storage
+engine. Restart recovery comes from the on-disk layout plus a background scan.
+
+## Goals
+
+- Preserve the existing Trino file system cache contract.
+- Keep the read path small and predictable.
+- Keep the cache's CPU, memory, filesystem metadata, and background IO burden
+  low enough that Trino query processing remains the primary consumer of worker
+  resources.
+- Store cached data as ordinary local files.
+- Bound byte usage and local file count per cache directory.
+- Avoid per-read filesystem metadata updates.
+- Survive process restart without a persistent index.
+- Keep cache failures from becoming query correctness failures.
+- Make the implementation understandable to maintainers who are not cache
+  specialists.
+
+## Non-goals
+
+- Perfect LRU eviction.
+- Exact per-chunk access tracking.
+- A global persistent cache index.
+- Multi-process sharing of one cache directory.
+- Support for network or shared filesystems as cache storage.
+- A packed cache file format.
+
+## Behavior Preserved
+
+The native cache keeps the important behavior and deployment model of the
+existing file system cache:
+
+- A worker can use multiple local cache directories, normally one directory per
+  local disk.
+- Each cache directory has its own size limit. Operators can configure explicit
+  sizes with `fs.cache.max-sizes`, or derive per-directory limits from
+  `fs.cache.max-disk-usage-percentages`.
+- Cache directories are assumed to be roughly the same size for placement
+  purposes. The cache still supports different configured limits per directory,
+  but it does not try to perform weighted placement across uneven disks.
+- Each cache directory is managed independently. A full directory evicts from
+  that directory; it does not borrow capacity from another directory.
+- Each cache directory is owned by one Trino process and one cache
+  configuration. It is not shared with other processes or with another cache
+  instance using different connector/cache settings.
+- Cache identity remains delegated to `CacheKeyProvider`.
+- Source reads are aligned to cache page boundaries before filling the cache.
+- The default page size remains `1MB`.
+- Tail chunks and small files may be smaller than the page size.
+- The default TTL remains `7d`.
+- TTL remains a cleanup policy for cached data, not a query correctness
+  boundary. The existing Alluxio cache receives the TTL as a cache-manager
+  eviction setting; Trino does not synchronously remove cached entries exactly
+  at the TTL boundary.
+- Cache read failures are treated as misses where possible.
+- Cache write failures skip the cache write and continue serving the source
+  read.
+- Split affinity remains separate from the cache storage format.
+
+## Behavior Changed
+
+The implementation changes from an Alluxio `CacheManager` to Trino-owned local
+files and Trino-owned eviction:
+
+- Cache entries are stored in a Trino-defined versioned directory layout.
+- Eviction is approximate and sample-based.
+- Eviction candidates are whole file groups, not individual page files.
+- Recent access is tracked at file granularity with rotating Bloom filters.
+- LRU-like preference is limited to the configured recent-access window.
+- Files outside the recent-access window are treated as equally cold unless
+  they are older than the TTL.
+- Native TTL cleanup is performed by startup scan, maintenance scan, and
+  pressure eviction.
+- A file-count limit prevents small-file-heavy workloads from growing local file
+  count without bound.
+
+The low-resource requirement drives the approximate design. The cache uses
+file-level access tracking, rotating Bloom filters, bounded eviction samples,
+and low-rate maintenance instead of exact LRU, per-page access timestamps, or a
+persistent cache index. False positives and imperfect ordering are acceptable
+because they reduce cache precision, not query correctness.
+
+## Storage Assumptions
+
+The cache is intended for local flash storage. Cloud workers commonly expose
+several local NVMe devices, so each configured cache directory is treated as an
+independent cache device with independent limits, accounting, maintenance, and
+eviction.
+
+Operators should not place cache directories on network filesystems, shared
+filesystems, root partitions, or directories shared by multiple Trino
+processes. The implementation assumes:
+
+```text
+one cache directory is owned by one Trino process
+```
+
+The filesystem must support atomic moves within a cache directory. The cache
+verifies this on startup and refuses to use a cache directory where an atomic
+move cannot be performed. The filesystem should also tolerate a large number of
+files and should be provisioned with enough inodes for the configured
+file-count limit.
+
+## Cache Identity
+
+The cache receives a file-level cache key from `CacheKeyProvider`. The native
+cache hashes that key before using it in a local path:
+
+```text
+fileHash = SHA-256(cacheKey)
+```
+
+The source location is also hashed:
+
+```text
+locationHash = SHA-256(location.toString())
+```
+
+`cacheKey` can be long and may contain characters unsuitable for paths. Hashing
+keeps the layout compact and path-safe. SHA-256 collisions are ignored for this
+cache purpose.
+
+## Directory Layout
+
+The on-disk layout is versioned:
+
+```text
+<cache-dir>/v1/data/<locationHash[0..2]>/<locationHash[2..4]>/<locationHash>/<fileHash>/<page>.cache
+<cache-dir>/v1/data/<locationHash[0..2]>/<locationHash[2..4]>/<locationHash>/<fileHash>/<page>.tmp.<uuid>
+<cache-dir>/v1/access/<bucketStartMillis>.bloom
+```
+
+Page names are fixed-width hexadecimal page indexes:
+
+```text
+0000000000000000.cache
+0000000000000001.cache
+0000000000000002.cache
+```
+
+All cached pages for one source file version live under one `fileHash`
+directory. That directory is the file group, and it is the unit of pressure
+eviction and TTL expiration.
+
+## Cache Directory Placement
+
+Each source location maps to one configured cache directory:
+
+```text
+directoryIndex = hash(location.toString()).hashCode() mod directoryCount
+```
+
+This intentionally simple placement assumes configured cache directories are
+backed by roughly equal local disks. Operators can still configure different
+limits per directory, but the placement algorithm does not weight new cache
+entries by those limits.
+
+Reads for a location use only the selected directory. Expiration tries every
+configured cache directory, so it remains conservative if directory placement
+changes in a future version.
+
+When `fs.cache.max-disk-usage-percentages` is configured, each percentage is
+converted to an absolute byte limit using the filesystem containing the
+corresponding cache directory. This preserves per-directory limit behavior and
+allows different configured limits per disk.
+
+## Read Path
+
+The native cache follows the same broad read shape as the existing cache:
+
+1. Compute page indexes from file position and configured page size.
+2. Try to read requested bytes from local page files.
+3. At the first miss, align the remaining read to page boundaries.
+4. Read the aligned range from the source file.
+5. Write page files for the aligned range.
+6. Copy the requested bytes into the caller's buffer.
+
+`TrinoInput` positioned reads continue to use positioned source reads. For
+`TrinoInputStream`, the cache keeps a source stream and seeks it when necessary,
+so sequential misses do not reopen the source for every page.
+
+For cached stream reads, a one-page in-memory buffer avoids repeated local file
+reads for small sequential reads inside the same cached page.
+
+## Writes
+
+Cache writes are opportunistic:
+
+```text
+write <page>.tmp.<uuid>
+move to <page>.cache
+```
+
+The temporary file is created in the same directory as the final page file. The
+final move does not replace an existing page. If another query wins the race and
+creates the same page first, the losing writer deletes its temporary file and
+the read still succeeds from the source data it already fetched.
+
+The implementation accepts duplicate source reads during concurrent fills. It
+does not keep an in-memory in-flight map for the first version.
+
+## Startup Scan And Accounting
+
+The cache has no persistent index. Each cache directory keeps in-memory counters
+for:
+
+```text
+currentBytes
+currentFiles
+```
+
+After startup, each cache directory is scanned asynchronously. The scan rebuilds
+byte and file counters, removes stale temporary files, and deletes file groups
+older than the TTL.
+
+Queries can use the cache while the initial scan is running. Writes made during
+the scan are tracked in memory so the final scan result does not double count
+pages written by the current process after the scanner has already passed their
+file group.
+
+If eviction cannot find candidates even though accounting says the cache is
+full, the cache performs another scan to reconcile accounting before giving up
+on the write.
+
+## Maintenance
+
+Each cache directory has a single maintenance executor. It starts the initial
+scan and then runs periodic maintenance. Background tasks catch
+`RuntimeException` and `Error`, log the failure, and continue scheduling future
+maintenance.
+
+Maintenance does low-rate filesystem cleanup:
+
+- delete stale temporary files
+- sample file groups
+- delete TTL-expired file groups
+- improve accounting over time
+
+Maintenance is not in the query read path and does not need to cover the whole
+cache quickly. On a very large cache it may take many hours or longer for
+maintenance to naturally walk all file groups. Correctness does not depend on
+that scan being complete.
+
+## Access Tracking
+
+Access tracking is often one of the most resource-intensive parts of a cache.
+Traditional designs may keep large exact in-memory structures, maintain an
+on-disk LRU index, or update filesystem metadata on every hit. Those approaches
+make eviction more precise, but they also add CPU, memory, disk IO, or metadata
+write load to the Trino worker.
+
+The native cache instead keeps access tracking deliberately small. It tracks
+recent access by time bucket and uses probabilistic Bloom filters inside those
+buckets. The goal is not to know the exact last access time for every cached
+page. The goal is to cheaply answer whether a file was probably accessed in the
+recent window, and approximately how recent that access was.
+
+The cache does not update filesystem `mtime` on hits. That would create random
+metadata writes proportional to cache hits. Each cache directory has a
+`BloomFilterAccessTracker`. On every cache hit, the cache records the file hash:
+
+```text
+currentBucket.put(fileHash)
+```
+
+The access record is file-level, not page-level. A hit for any cached page marks
+the source file version as recently used.
+
+The tracker keeps rotating Bloom filter buckets. Defaults are:
+
+```text
+fs.cache.access-history-duration = 24h
+fs.cache.access-bucket-duration = 10m
+fs.cache.access-tracking-memory = 256MB
+```
+
+Memory is divided across buckets. If a bucket receives more distinct file hashes
+than expected, the Bloom filter false-positive rate rises. False positives only
+protect some cold files longer than necessary; they do not affect correctness.
+
+On bucket rotation, the old bucket is persisted under `v1/access` with a
+temporary file and atomic move. On restart, recent persisted buckets are loaded
+back into memory. The current mutable bucket is not a write-ahead log; accesses
+since the last rotation can be lost on process crash.
+
+When eviction asks about a file hash, the tracker searches buckets from newest
+to oldest and returns the newest matching bucket start time. Files absent from
+all buckets are treated as colder than files present in any bucket.
+
+## Eviction
+
+Eviction is per cache directory. If one directory is over its byte or file-count
+limit, the cache evicts from that directory only.
+
+Eviction starts when a new write would exceed either configured limit:
+
+```text
+currentBytes + newPageBytes > maxBytes
+currentFiles + 1 > maxFiles
+```
+
+Once eviction starts, it collects down to a low watermark:
+
+```text
+lowWatermark = 90% of max
+```
+
+This prevents the cache from hovering at the hard limit and doing tiny eviction
+work on every write.
+
+This is the pressure path. A separate background maintenance task periodically
+sweeps the cache directory, deletes expired file groups, and reconciles
+accounting. Depending on cache churn and system load, that sweep can keep usage
+below the high watermark most of the time, so pressure eviction may run
+infrequently.
+
+Pressure eviction samples file groups instead of scanning the whole cache:
+
+```text
+sample = next 8192 file groups after evictionCursor
+if end is reached, wrap and continue from the beginning
+```
+
+The cursor is a path cursor into the lexicographic directory walk. It is not
+persisted. Resetting it on restart is acceptable.
+
+The sampled file groups are sorted by:
+
+1. expired groups first
+2. groups absent from all recent Bloom filters
+3. groups present in older Bloom buckets
+4. groups present in newer Bloom buckets
+
+Eviction deletes whole file groups until the pending write would leave both byte
+and file counters at or below the low watermark. If the sample is exhausted and
+the low watermark has not been reached, the cache samples again from the next
+cursor position.
+
+The fixed sample size is a deliberate resource bound, and it has an important
+consequence. If the sampled file groups are physically smaller than the amount
+that must be collected between the high limit and the low watermark, the cache
+will delete the whole sample and move to the next sample. In that case, the
+Bloom-filter sort order does little work because every candidate in the sample
+is removed. The directory walk may look sequential in the code, but file groups
+are stored under SHA-256 hashes, so a full-sample delete is effectively deleting
+a random hash-distributed slice of the cache.
+
+This is an acceptable degradation for the first implementation. It keeps
+eviction work bounded and avoids global indexing or full-cache scans. Larger
+sample sizes improve the chance that the sort order matters; smaller sample
+sizes reduce eviction CPU and filesystem work but more often degrade to random
+hash-slice deletion under pressure. If this behavior is too random in practice,
+the simplest improvement is increasing the sample size. A more selective
+follow-up could use a two-pass approach, such as first sampling enough file
+groups to cover the high-to-low collection target and then sorting that larger
+candidate set before deleting.
+
+If no candidates can be deleted, accounting is reconciled with a scan. If the
+write still cannot fit, the cache skips the cache write.
+
+## Expiration
+
+`expire(Location)` deletes the deterministic location directory:
+
+```text
+<cache-dir>/v1/data/<locationHash[0..2]>/<locationHash[2..4]>/<locationHash>
+```
+
+The cache tries that location path in every configured cache directory. This
+requires no global index and no reverse lookup from cache key to path.
+
+## Configuration
+
+Existing cache configuration remains central:
+
+```text
+fs.cache.enabled
+fs.cache.type
+fs.cache.directories
+fs.cache.max-sizes
+fs.cache.max-disk-usage-percentages
+fs.cache.ttl
+fs.cache.page-size
+fs.cache.preferred-hosts-count
+```
+
+Native-cache-specific guardrails:
+
+```text
+fs.cache.max-files-per-directory
+fs.cache.access-history-duration
+fs.cache.access-bucket-duration
+fs.cache.access-tracking-memory
+```
+
+Defaults:
+
+```text
+fs.cache.page-size = 1MB
+fs.cache.ttl = 7d
+fs.cache.max-files-per-directory = 10000000
+fs.cache.access-history-duration = 24h
+fs.cache.access-bucket-duration = 10m
+fs.cache.access-tracking-memory = 256MB
+```
+
+## Failure Behavior
+
+The source filesystem remains authoritative. The cache should degrade rather
+than fail queries when possible:
+
+- missing cache pages are misses
+- malformed or short cache pages are deleted and treated as misses
+- failed cache writes are skipped
+- full cache directories skip writes when eviction cannot make space
+- stale temporary files are cleaned asynchronously
+- expiration and maintenance cleanup are best effort
+
+User-visible failures should come from the source filesystem or from cache
+configuration/health problems, not from ordinary cache misses.
+
+## Observability
+
+The cache records JMX stats for reads, writes, skipped writes, cached bytes,
+cached files, eviction, expiration, stale temporary cleanup, and access records.
+
+Tracing spans preserve cache observability around:
+
+- cached reads
+- external reads
+- cache writes
+
+Spans include the cache key, source location, read or write position, and size
+where available.

--- a/lib/trino-filesystem-cache/README.md
+++ b/lib/trino-filesystem-cache/README.md
@@ -1,0 +1,438 @@
+# Native file system cache design
+
+This module contains Trino's native file system cache implementation. It is a
+small local-file cache for `TrinoFileSystemCache`, intended to replace the
+Alluxio-backed cache without turning Trino into a cache storage project.
+
+The cache stores page-aligned chunks as deterministic files under configured
+local cache directories. It uses no global index, no database, and no storage
+engine. Restart recovery comes from the on-disk layout plus a background scan.
+
+## Goals
+
+- Preserve the existing Trino file system cache contract.
+- Keep the read path small and predictable.
+- Keep the cache's CPU, memory, filesystem metadata, and background IO burden
+  low enough that Trino query processing remains the primary consumer of worker
+  resources.
+- Store cached data as ordinary local files.
+- Bound byte usage and local file count per cache directory.
+- Avoid per-read filesystem metadata updates.
+- Survive process restart without a persistent index.
+- Keep cache failures from becoming query correctness failures.
+- Make the implementation understandable to maintainers who are not cache
+  specialists.
+
+## Non-goals
+
+- Perfect LRU eviction.
+- Exact per-chunk access tracking.
+- A global persistent cache index.
+- Multi-process sharing of one cache directory.
+- Support for network or shared filesystems as cache storage.
+- A packed cache file format.
+
+## Behavior Preserved
+
+The native cache keeps the important behavior and deployment model of the
+existing file system cache:
+
+- A worker can use multiple local cache directories, normally one directory per
+  local disk.
+- Each cache directory has its own size limit. Operators can configure explicit
+  sizes with `fs.cache.max-sizes`, or derive per-directory limits from
+  `fs.cache.max-disk-usage-percentages`.
+- Cache directories are assumed to be roughly the same size for placement
+  purposes. The cache still supports different configured limits per directory,
+  but it does not try to perform weighted placement across uneven disks.
+- Each cache directory is managed independently. A full directory evicts from
+  that directory; it does not borrow capacity from another directory.
+- Each cache directory is owned by one Trino process and one cache
+  configuration. It is not shared with other processes or with another cache
+  instance using different connector/cache settings.
+- Cache identity remains delegated to `CacheKeyProvider`.
+- Source reads are aligned to cache page boundaries before filling the cache.
+- The default page size remains `1MB`.
+- Tail chunks and small files may be smaller than the page size.
+- The default TTL remains `7d`.
+- TTL remains a cleanup policy for cached data, not a query correctness
+  boundary. The existing Alluxio cache receives the TTL as a cache-manager
+  eviction setting; Trino does not synchronously remove cached entries exactly
+  at the TTL boundary.
+- Cache read failures are treated as misses where possible.
+- Cache write failures skip the cache write and continue serving the source
+  read.
+- Split affinity remains separate from the cache storage format.
+
+## Behavior Changed
+
+The implementation changes from an Alluxio `CacheManager` to Trino-owned local
+files and Trino-owned eviction:
+
+- Cache entries are stored in a Trino-defined versioned directory layout.
+- Eviction is approximate and sample-based.
+- Eviction candidates are whole file groups, not individual page files.
+- Recent access is tracked at file granularity with rotating Bloom filters.
+- LRU-like preference is limited to the configured recent-access window.
+- Files outside the recent-access window are treated as equally cold unless
+  they are older than the TTL.
+- Native TTL cleanup is performed by startup scan, maintenance scan, and
+  pressure eviction.
+- A file-count limit prevents small-file-heavy workloads from growing local file
+  count without bound.
+
+The low-resource requirement drives the approximate design. The cache uses
+file-level access tracking, rotating Bloom filters, bounded eviction samples,
+and low-rate maintenance instead of exact LRU, per-page access timestamps, or a
+persistent cache index. False positives and imperfect ordering are acceptable
+because they reduce cache precision, not query correctness.
+
+## Storage Assumptions
+
+The cache is intended for local flash storage. Cloud workers commonly expose
+several local NVMe devices, so each configured cache directory is treated as an
+independent cache device with independent limits, accounting, maintenance, and
+eviction.
+
+Operators should not place cache directories on network filesystems, shared
+filesystems, root partitions, or directories shared by multiple Trino
+processes. The implementation assumes:
+
+```text
+one cache directory is owned by one Trino process
+```
+
+The filesystem should tolerate a large number of files and should be provisioned
+with enough inodes for the configured file-count limit.
+
+## Cache Identity
+
+The cache receives a file-level cache key from `CacheKeyProvider`. The native
+cache hashes that key before using it in a local path:
+
+```text
+fileHash = SHA-256(cacheKey)
+```
+
+The source location is also hashed:
+
+```text
+locationHash = SHA-256(location.toString())
+```
+
+`cacheKey` can be long and may contain characters unsuitable for paths. Hashing
+keeps the layout compact and path-safe. SHA-256 collisions are ignored for this
+cache purpose.
+
+## Directory Layout
+
+The on-disk layout is versioned:
+
+```text
+<cache-dir>/v1/data/<locationHash[0..2]>/<locationHash[2..4]>/<locationHash>/<fileHash>/<page>.cache
+<cache-dir>/v1/data/<locationHash[0..2]>/<locationHash[2..4]>/<locationHash>/<fileHash>/<page>.tmp.<uuid>
+<cache-dir>/v1/access/<bucketStartMillis>.bloom
+```
+
+Page names are fixed-width hexadecimal page indexes:
+
+```text
+0000000000000000.cache
+0000000000000001.cache
+0000000000000002.cache
+```
+
+All cached pages for one source file version live under one `fileHash`
+directory. That directory is the file group, and it is the unit of pressure
+eviction and TTL expiration.
+
+## Cache Directory Placement
+
+Each source location maps to one configured cache directory:
+
+```text
+directoryIndex = hash(location.toString()).hashCode() mod directoryCount
+```
+
+This intentionally simple placement assumes configured cache directories are
+backed by roughly equal local disks. Operators can still configure different
+limits per directory, but the placement algorithm does not weight new cache
+entries by those limits.
+
+Reads for a location use only the selected directory. Expiration tries every
+configured cache directory, so it remains conservative if directory placement
+changes in a future version.
+
+When `fs.cache.max-disk-usage-percentages` is configured, each percentage is
+converted to an absolute byte limit using the filesystem containing the
+corresponding cache directory. This preserves per-directory limit behavior and
+allows different configured limits per disk.
+
+## Read Path
+
+The native cache follows the same broad read shape as the existing cache:
+
+1. Compute page indexes from file position and configured page size.
+2. Try to read requested bytes from local page files.
+3. At the first miss, align the remaining read to page boundaries.
+4. Read the aligned range from the source file.
+5. Write page files for the aligned range.
+6. Copy the requested bytes into the caller's buffer.
+
+`TrinoInput` positioned reads continue to use positioned source reads. For
+`TrinoInputStream`, the cache keeps a source stream and seeks it when necessary,
+so sequential misses do not reopen the source for every page.
+
+For cached stream reads, a one-page in-memory buffer avoids repeated local file
+reads for small sequential reads inside the same cached page.
+
+## Writes
+
+Cache writes are opportunistic:
+
+```text
+write <page>.tmp.<uuid>
+move to <page>.cache
+```
+
+The temporary file is created in the same directory as the final page file. The
+final move does not replace an existing page. If another query wins the race and
+creates the same page first, the losing writer deletes its temporary file and
+the read still succeeds from the source data it already fetched.
+
+The implementation accepts duplicate source reads during concurrent fills. It
+does not keep an in-memory in-flight map for the first version.
+
+## Startup Scan And Accounting
+
+The cache has no persistent index. Each cache directory keeps in-memory counters
+for:
+
+```text
+currentBytes
+currentFiles
+```
+
+After startup, each cache directory is scanned asynchronously. The scan rebuilds
+byte and file counters, removes stale temporary files, and deletes file groups
+older than the TTL.
+
+Queries can use the cache while the initial scan is running. Writes made during
+the scan are tracked in memory so the final scan result does not double count
+pages written by the current process after the scanner has already passed their
+file group.
+
+If eviction cannot find candidates even though accounting says the cache is
+full, the cache performs another scan to reconcile accounting before giving up
+on the write.
+
+## Maintenance
+
+Each cache directory has a single maintenance executor. It starts the initial
+scan and then runs periodic maintenance. Background tasks catch
+`RuntimeException` and `Error`, log the failure, and continue scheduling future
+maintenance.
+
+Maintenance does low-rate filesystem cleanup:
+
+- delete stale temporary files
+- sample file groups
+- delete TTL-expired file groups
+- improve accounting over time
+
+Maintenance is not in the query read path and does not need to cover the whole
+cache quickly. On a very large cache it may take many hours or longer for
+maintenance to naturally walk all file groups. Correctness does not depend on
+that scan being complete.
+
+## Access Tracking
+
+Access tracking is often one of the most resource-intensive parts of a cache.
+Traditional designs may keep large exact in-memory structures, maintain an
+on-disk LRU index, or update filesystem metadata on every hit. Those approaches
+make eviction more precise, but they also add CPU, memory, disk IO, or metadata
+write load to the Trino worker.
+
+The native cache instead keeps access tracking deliberately small. It tracks
+recent access by time bucket and uses probabilistic Bloom filters inside those
+buckets. The goal is not to know the exact last access time for every cached
+page. The goal is to cheaply answer whether a file was probably accessed in the
+recent window, and approximately how recent that access was.
+
+The cache does not update filesystem `mtime` on hits. That would create random
+metadata writes proportional to cache hits. Each cache directory has a
+`BloomFilterAccessTracker`. On every cache hit, the cache records the file hash:
+
+```text
+currentBucket.put(fileHash)
+```
+
+The access record is file-level, not page-level. A hit for any cached page marks
+the source file version as recently used.
+
+The tracker keeps rotating Bloom filter buckets. Defaults are:
+
+```text
+fs.cache.access-history-duration = 24h
+fs.cache.access-bucket-duration = 10m
+fs.cache.access-tracking-memory = 256MB
+```
+
+Memory is divided across buckets. If a bucket receives more distinct file hashes
+than expected, the Bloom filter false-positive rate rises. False positives only
+protect some cold files longer than necessary; they do not affect correctness.
+
+On bucket rotation, the old bucket is persisted under `v1/access` with a
+temporary file and atomic move. On restart, recent persisted buckets are loaded
+back into memory. The current mutable bucket is not a write-ahead log; accesses
+since the last rotation can be lost on process crash.
+
+When eviction asks about a file hash, the tracker searches buckets from newest
+to oldest and returns the newest matching bucket start time. Files absent from
+all buckets are treated as colder than files present in any bucket.
+
+## Eviction
+
+Eviction is per cache directory. If one directory is over its byte or file-count
+limit, the cache evicts from that directory only.
+
+Eviction starts when a new write would exceed either configured limit:
+
+```text
+currentBytes + newPageBytes > maxBytes
+currentFiles + 1 > maxFiles
+```
+
+Once eviction starts, it collects down to a low watermark:
+
+```text
+lowWatermark = 90% of max
+```
+
+This prevents the cache from hovering at the hard limit and doing tiny eviction
+work on every write.
+
+This is the pressure path. A separate background maintenance task periodically
+sweeps the cache directory, deletes expired file groups, and reconciles
+accounting. Depending on cache churn and system load, that sweep can keep usage
+below the high watermark most of the time, so pressure eviction may run
+infrequently.
+
+Pressure eviction samples file groups instead of scanning the whole cache:
+
+```text
+sample = next 8192 file groups after evictionCursor
+if end is reached, wrap and continue from the beginning
+```
+
+The cursor is a path cursor into the lexicographic directory walk. It is not
+persisted. Resetting it on restart is acceptable.
+
+The sampled file groups are sorted by:
+
+1. expired groups first
+2. groups absent from all recent Bloom filters
+3. groups present in older Bloom buckets
+4. groups present in newer Bloom buckets
+
+Eviction deletes whole file groups until the pending write would leave both byte
+and file counters at or below the low watermark. If the sample is exhausted and
+the low watermark has not been reached, the cache samples again from the next
+cursor position.
+
+The fixed sample size is a deliberate resource bound, and it has an important
+consequence. If the sampled file groups are physically smaller than the amount
+that must be collected between the high limit and the low watermark, the cache
+will delete the whole sample and move to the next sample. In that case, the
+Bloom-filter sort order does little work because every candidate in the sample
+is removed. The directory walk may look sequential in the code, but file groups
+are stored under SHA-256 hashes, so a full-sample delete is effectively deleting
+a random hash-distributed slice of the cache.
+
+This is an acceptable degradation for the first implementation. It keeps
+eviction work bounded and avoids global indexing or full-cache scans. Larger
+sample sizes improve the chance that the sort order matters; smaller sample
+sizes reduce eviction CPU and filesystem work but more often degrade to random
+hash-slice deletion under pressure. If this behavior is too random in practice,
+the simplest improvement is increasing the sample size. A more selective
+follow-up could use a two-pass approach, such as first sampling enough file
+groups to cover the high-to-low collection target and then sorting that larger
+candidate set before deleting.
+
+If no candidates can be deleted, accounting is reconciled with a scan. If the
+write still cannot fit, the cache skips the cache write.
+
+## Expiration
+
+`expire(Location)` deletes the deterministic location directory:
+
+```text
+<cache-dir>/v1/data/<locationHash[0..2]>/<locationHash[2..4]>/<locationHash>
+```
+
+The cache tries that location path in every configured cache directory. This
+requires no global index and no reverse lookup from cache key to path.
+
+## Configuration
+
+Existing cache configuration remains central:
+
+```text
+fs.cache.enabled
+fs.cache.type
+fs.cache.directories
+fs.cache.max-sizes
+fs.cache.max-disk-usage-percentages
+fs.cache.ttl
+fs.cache.page-size
+node-scheduler.cache-preferred-hosts-count
+```
+
+Native-cache-specific guardrails:
+
+```text
+fs.cache.max-files-per-directory
+fs.cache.access-history-duration
+fs.cache.access-bucket-duration
+fs.cache.access-tracking-memory
+```
+
+Defaults:
+
+```text
+fs.cache.page-size = 1MB
+fs.cache.ttl = 7d
+fs.cache.max-files-per-directory = 10000000
+fs.cache.access-history-duration = 24h
+fs.cache.access-bucket-duration = 10m
+fs.cache.access-tracking-memory = 256MB
+```
+
+## Failure Behavior
+
+The source filesystem remains authoritative. The cache should degrade rather
+than fail queries when possible:
+
+- missing cache pages are misses
+- malformed or short cache pages are deleted and treated as misses
+- failed cache writes are skipped
+- full cache directories skip writes when eviction cannot make space
+- stale temporary files are cleaned asynchronously
+- expiration and maintenance cleanup are best effort
+
+User-visible failures should come from the source filesystem or from cache
+configuration/health problems, not from ordinary cache misses.
+
+## Observability
+
+The cache records JMX stats for reads, writes, skipped writes, cached bytes,
+cached files, eviction, expiration, stale temporary cleanup, and access records.
+
+Tracing spans preserve cache observability around:
+
+- cached reads
+- external reads
+- cache writes
+
+Spans include the cache key, source location, read or write position, and size
+where available.

--- a/lib/trino-filesystem-cache/pom.xml
+++ b/lib/trino-filesystem-cache/pom.xml
@@ -19,6 +19,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -31,7 +37,17 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
         </dependency>
 
         <dependency>
@@ -52,6 +68,11 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>
@@ -91,6 +112,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-cache/pom.xml
+++ b/lib/trino-filesystem-cache/pom.xml
@@ -9,9 +9,9 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>trino-filesystem-manager</artifactId>
+    <artifactId>trino-filesystem-cache</artifactId>
     <name>${project.artifactId}</name>
-    <description>Trino - Native file system manager</description>
+    <description>Trino Filesystem - Native cache</description>
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
@@ -35,6 +35,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
@@ -46,37 +51,35 @@
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-azure</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-cache</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-cache-alluxio</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-gcs</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-s3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>tracing</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -88,6 +91,26 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-cache/pom.xml
+++ b/lib/trino-filesystem-cache/pom.xml
@@ -9,9 +9,9 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>trino-filesystem-manager</artifactId>
+    <artifactId>trino-filesystem-cache</artifactId>
     <name>${project.artifactId}</name>
-    <description>Trino - Native file system manager</description>
+    <description>Trino Filesystem - Native cache</description>
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
@@ -35,6 +35,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
@@ -46,42 +51,35 @@
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-alluxio</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-azure</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-cache</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-cache-alluxio</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-gcs</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-filesystem-s3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>tracing</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -93,6 +91,26 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/BloomFilterAccessTracker.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/BloomFilterAccessTracker.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.Funnels;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+
+final class BloomFilterAccessTracker
+{
+    private static final Logger log = Logger.get(BloomFilterAccessTracker.class);
+
+    private static final String ACCESS_DIRECTORY = "access";
+
+    private static final Funnel<CharSequence> FUNNEL = Funnels.stringFunnel(UTF_8);
+    private static final double FALSE_POSITIVE_PROBABILITY = 0.03;
+
+    private final Path accessDirectory;
+    private final Clock clock;
+    private final long bucketMillis;
+    private final long historyMillis;
+    private final int bucketCount;
+    private final long expectedInsertionsPerBucket;
+    private final NativeFileSystemCacheStats stats;
+    @GuardedBy("this")
+    private final Deque<Bucket> history = new ArrayDeque<>();
+    @GuardedBy("this")
+    private Bucket current;
+
+    BloomFilterAccessTracker(Path root, Duration historyDuration, Duration bucketDuration, DataSize memory, NativeFileSystemCacheStats stats)
+            throws IOException
+    {
+        this(root, historyDuration, bucketDuration, memory, Clock.systemUTC(), stats);
+    }
+
+    @VisibleForTesting
+    BloomFilterAccessTracker(Path root, Duration historyDuration, Duration bucketDuration, DataSize memory, Clock clock, NativeFileSystemCacheStats stats)
+            throws IOException
+    {
+        this.accessDirectory = root.resolve(CacheFileLayout.VERSION_DIRECTORY).resolve(ACCESS_DIRECTORY);
+        this.clock = requireNonNull(clock, "clock is null");
+        this.bucketMillis = Math.max(1, bucketDuration.roundTo(TimeUnit.MILLISECONDS));
+        this.historyMillis = Math.max(bucketMillis, historyDuration.roundTo(TimeUnit.MILLISECONDS));
+        this.bucketCount = Math.max(1, (int) Math.ceil(historyMillis / (double) bucketMillis));
+        long bucketBytes = Math.max(1024, memory.toBytes() / bucketCount);
+        this.expectedInsertionsPerBucket = bucketBytes;
+        this.stats = requireNonNull(stats, "stats is null");
+
+        Files.createDirectories(accessDirectory);
+        loadPersistedBuckets();
+        current = new Bucket(bucketStart(clock.millis()), newFilter());
+    }
+
+    synchronized void record(String fileHash)
+    {
+        rotateIfNeeded();
+        current.filter().put(fileHash);
+        stats.recordAccess();
+    }
+
+    synchronized boolean mightContain(String fileHash)
+    {
+        return lastAccessTime(fileHash).isPresent();
+    }
+
+    synchronized OptionalLong lastAccessTime(String fileHash)
+    {
+        rotateIfNeeded();
+        if (current.filter().mightContain(fileHash)) {
+            return OptionalLong.of(current.startMillis());
+        }
+        for (Iterator<Bucket> iterator = history.descendingIterator(); iterator.hasNext(); ) {
+            Bucket bucket = iterator.next();
+            if (bucket.filter().mightContain(fileHash)) {
+                return OptionalLong.of(bucket.startMillis());
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    @GuardedBy("this")
+    private void rotateIfNeeded()
+    {
+        long now = clock.millis();
+        if (now < current.startMillis() + bucketMillis) {
+            return;
+        }
+        persist(current);
+        history.addLast(current);
+        trimHistory(now);
+        current = new Bucket(bucketStart(now), newFilter());
+    }
+
+    @GuardedBy("this")
+    private void loadPersistedBuckets()
+            throws IOException
+    {
+        long now = clock.millis();
+        if (!Files.exists(accessDirectory)) {
+            return;
+        }
+        List<Path> bucketFiles;
+        try (var stream = Files.list(accessDirectory)) {
+            bucketFiles = stream
+                    .filter(path -> path.getFileName().toString().endsWith(".bloom"))
+                    .sorted(Comparator.comparing(Path::getFileName))
+                    .collect(toImmutableList());
+        }
+        for (Path bucketFile : bucketFiles) {
+            long startMillis;
+            try {
+                startMillis = bucketStart(bucketFile);
+            }
+            catch (RuntimeException _) {
+                deleteIfExists(bucketFile);
+                continue;
+            }
+            if (now - startMillis > historyMillis) {
+                deleteIfExists(bucketFile);
+                continue;
+            }
+            try (InputStream input = Files.newInputStream(bucketFile)) {
+                history.addLast(new Bucket(startMillis, BloomFilter.readFrom(input, FUNNEL)));
+            }
+            catch (IOException | RuntimeException _) {
+                deleteIfExists(bucketFile);
+            }
+        }
+        trimHistory(now);
+    }
+
+    private void persist(Bucket bucket)
+    {
+        Path path = bucketPath(bucket.startMillis());
+        Path temporaryPath = accessDirectory.resolve(path.getFileName() + ".tmp." + randomUUID());
+        try {
+            try (OutputStream output = Files.newOutputStream(temporaryPath, CREATE_NEW, WRITE)) {
+                bucket.filter().writeTo(output);
+            }
+            Files.move(temporaryPath, path, ATOMIC_MOVE);
+        }
+        catch (IOException | RuntimeException e) {
+            log.warn(e, "Failed to persist native file system cache access bucket: %s", path);
+            deleteIfExists(temporaryPath);
+        }
+    }
+
+    @GuardedBy("this")
+    private void trimHistory(long now)
+    {
+        while (!history.isEmpty() && now - history.peekFirst().startMillis() > historyMillis) {
+            deleteIfExists(bucketPath(history.removeFirst().startMillis()));
+        }
+        while (history.size() >= bucketCount) {
+            deleteIfExists(bucketPath(history.removeFirst().startMillis()));
+        }
+    }
+
+    private long bucketStart(long millis)
+    {
+        return millis - (millis % bucketMillis);
+    }
+
+    private Path bucketPath(long startMillis)
+    {
+        return accessDirectory.resolve(startMillis + ".bloom");
+    }
+
+    private static long bucketStart(Path path)
+    {
+        String fileName = path.getFileName().toString();
+        return Long.parseLong(fileName.substring(0, fileName.length() - ".bloom".length()));
+    }
+
+    private BloomFilter<CharSequence> newFilter()
+    {
+        return BloomFilter.create(FUNNEL, expectedInsertionsPerBucket, FALSE_POSITIVE_PROBABILITY);
+    }
+
+    private static void deleteIfExists(Path path)
+    {
+        try {
+            Files.deleteIfExists(path);
+        }
+        catch (IOException _) {
+        }
+    }
+
+    @Override
+    public synchronized String toString()
+    {
+        return toStringHelper(this)
+                .add("accessDirectory", accessDirectory)
+                .add("bucketMillis", bucketMillis)
+                .add("bucketCount", bucketCount)
+                .add("expectedInsertionsPerBucket", expectedInsertionsPerBucket)
+                .toString();
+    }
+
+    private record Bucket(long startMillis, BloomFilter<CharSequence> filter)
+    {
+        private Bucket
+        {
+            requireNonNull(filter, "filter is null");
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/CacheFileLayout.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/CacheFileLayout.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.Location;
+
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+final class CacheFileLayout
+{
+    static final String DATA_DIRECTORY = "data";
+    static final String VERSION_DIRECTORY = "v1";
+
+    private final Path root;
+
+    CacheFileLayout(Path root)
+    {
+        this.root = requireNonNull(root, "root is null").toAbsolutePath().normalize();
+    }
+
+    CacheFile cacheFile(Location location, String cacheKey)
+    {
+        String fileHash = hash(cacheKey);
+        Path fileGroupPath = locationPath(location)
+                .resolve(fileHash)
+                .normalize();
+        if (!fileGroupPath.startsWith(root)) {
+            throw new IllegalArgumentException("Cache path escapes root: " + fileGroupPath);
+        }
+        return new CacheFile(fileHash, fileGroupPath);
+    }
+
+    Path locationPath(Location location)
+    {
+        String locationHash = hash(location.toString());
+        Path locationPath = root.resolve(VERSION_DIRECTORY)
+                .resolve(DATA_DIRECTORY)
+                .resolve(locationHash.substring(0, 2))
+                .resolve(locationHash.substring(2, 4))
+                .resolve(locationHash)
+                .normalize();
+        if (!locationPath.startsWith(root)) {
+            throw new IllegalArgumentException("Cache path escapes root: " + locationPath);
+        }
+        return locationPath;
+    }
+
+    static String hash(String value)
+    {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(UTF_8)));
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 is not available", e);
+        }
+    }
+
+    record CacheFile(String fileHash, Path fileGroupPath)
+    {
+        CacheFile
+        {
+            requireNonNull(fileHash, "fileHash is null");
+            requireNonNull(fileGroupPath, "fileGroupPath is null");
+        }
+
+        Path pagePath(long pageIndex)
+        {
+            return fileGroupPath.resolve("%016x.cache".formatted(pageIndex));
+        }
+
+        Path temporaryPagePath(long pageIndex, String suffix)
+        {
+            return fileGroupPath.resolve("%016x.tmp.%s".formatted(pageIndex, suffix));
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("fileHash", fileHash)
+                    .add("fileGroupPath", fileGroupPath)
+                    .toString();
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.Location;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collection;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+
+final class NativeCacheDirectory
+{
+    private final Path root;
+    private final CacheFileLayout layout;
+    private final NativeFileSystemCacheStats stats;
+
+    NativeCacheDirectory(Path root, NativeFileSystemCacheStats stats)
+            throws IOException
+    {
+        this.root = requireNonNull(root, "root is null").toAbsolutePath().normalize();
+        this.layout = new CacheFileLayout(this.root);
+        this.stats = requireNonNull(stats, "stats is null");
+        Path dataRoot = this.root.resolve(CacheFileLayout.VERSION_DIRECTORY).resolve(CacheFileLayout.DATA_DIRECTORY);
+        Files.createDirectories(dataRoot);
+        verifyAtomicMove(dataRoot);
+    }
+
+    CacheFileLayout.CacheFile cacheFile(Location location, String cacheKey)
+    {
+        return layout.cacheFile(location, cacheKey);
+    }
+
+    boolean readPage(CacheFileLayout.CacheFile cacheFile, long pageIndex, int pageOffset, int length, int expectedPageLength, byte[] buffer, int bufferOffset)
+            throws IOException
+    {
+        Path pagePath = cacheFile.pagePath(pageIndex);
+        try {
+            if (Files.size(pagePath) != expectedPageLength) {
+                deleteIfExists(pagePath);
+                return false;
+            }
+            try (InputStream input = Files.newInputStream(pagePath)) {
+                input.skipNBytes(pageOffset);
+                if (input.readNBytes(buffer, bufferOffset, length) != length) {
+                    deleteIfExists(pagePath);
+                    return false;
+                }
+            }
+            stats.recordCacheRead(length);
+            return true;
+        }
+        catch (NoSuchFileException | EOFException _) {
+            return false;
+        }
+    }
+
+    void writePage(CacheFileLayout.CacheFile cacheFile, long pageIndex, byte[] page, int offset, int length)
+    {
+        Path pagePath = cacheFile.pagePath(pageIndex);
+        Path temporaryPath = cacheFile.temporaryPagePath(pageIndex, randomUUID().toString());
+        try {
+            Files.createDirectories(pagePath.getParent());
+            try (OutputStream output = Files.newOutputStream(temporaryPath, CREATE_NEW, WRITE)) {
+                output.write(page, offset, length);
+            }
+            Files.move(temporaryPath, pagePath, ATOMIC_MOVE);
+            stats.recordCacheWrite();
+        }
+        catch (FileAlreadyExistsException _) {
+            deleteIfExists(temporaryPath);
+        }
+        catch (IOException | RuntimeException e) {
+            stats.recordCacheWriteFailure();
+            deleteIfExists(temporaryPath);
+        }
+    }
+
+    void expire(Location location)
+            throws IOException
+    {
+        deleteRecursively(layout.locationPath(location));
+    }
+
+    void expire(Collection<Location> locations)
+            throws IOException
+    {
+        for (Location location : locations) {
+            expire(location);
+        }
+    }
+
+    private static void deleteIfExists(Path path)
+    {
+        try {
+            Files.deleteIfExists(path);
+        }
+        catch (IOException _) {
+        }
+    }
+
+    private static void verifyAtomicMove(Path directory)
+            throws IOException
+    {
+        Path source = Files.createTempFile(directory, ".atomic-move-check-", ".tmp");
+        Path target = directory.resolve(source.getFileName() + ".moved");
+        try {
+            Files.move(source, target, ATOMIC_MOVE);
+        }
+        finally {
+            deleteIfExists(source);
+            deleteIfExists(target);
+        }
+    }
+
+    private static void deleteRecursively(Path path)
+            throws IOException
+    {
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<>()
+            {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+                        throws IOException
+                {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exception)
+                        throws IOException
+                {
+                    if (exception instanceof NoSuchFileException) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    throw exception;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path directory, IOException exception)
+                        throws IOException
+                {
+                    if (exception != null && !(exception instanceof NoSuchFileException)) {
+                        throw exception;
+                    }
+                    Files.deleteIfExists(directory);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        catch (NoSuchFileException _) {
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("root", root)
+                .toString();
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
@@ -13,43 +13,102 @@
  */
 package io.trino.filesystem.cache.local;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.units.Duration;
 import io.trino.filesystem.Location;
+import io.trino.filesystem.cache.local.NativeCacheDirectoryWalker.DeletionStats;
+import io.trino.filesystem.cache.local.NativeCacheDirectoryWalker.FileGroup;
+import io.trino.filesystem.cache.local.NativeCacheDirectoryWalker.ScanResult;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.cache.local.CacheFileLayout.DATA_DIRECTORY;
+import static io.trino.filesystem.cache.local.CacheFileLayout.VERSION_DIRECTORY;
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 
 final class NativeCacheDirectory
 {
+    private static final int EVICTION_SAMPLE_SIZE = 8192;
+    private static final double LOW_WATERMARK_FACTOR = 0.9;
+
     private final Path root;
     private final CacheFileLayout layout;
+    private final NativeCacheDirectoryWalker walker;
     private final NativeFileSystemCacheStats stats;
+    private final long maxBytes;
+    private final long lowWatermarkBytes;
+    private final long maxFiles;
+    private final long lowWatermarkFiles;
+    private final int evictionSampleSize;
+    private final LongSupplier usableSpaceSupplier;
+    private final BloomFilterAccessTracker accessTracker;
+    private final AtomicLong currentBytes = new AtomicLong();
+    private final AtomicLong currentFiles = new AtomicLong();
+    private final AtomicBoolean initializationStarted = new AtomicBoolean();
+    private final AtomicBoolean initialized = new AtomicBoolean();
+    private final Object initializationLock = new Object();
+    // Pages written by this process during the initial scan are accounted separately, so the scan does not double count them.
+    private final Set<Path> initializationWrites = ConcurrentHashMap.newKeySet();
+    private final Set<Path> activeTemporaryFiles = ConcurrentHashMap.newKeySet();
+    @GuardedBy("initializationLock")
+    private Path initializationScanCursor;
+    @GuardedBy("this")
+    private Path evictionCursor;
 
-    NativeCacheDirectory(Path root, NativeFileSystemCacheStats stats)
+    NativeCacheDirectory(Path root, long maxBytes, long maxFiles, Optional<Duration> ttl, BloomFilterAccessTracker accessTracker, NativeFileSystemCacheStats stats)
             throws IOException
     {
+        this(root, maxBytes, maxFiles, ttl, accessTracker, Clock.systemUTC(), stats, EVICTION_SAMPLE_SIZE, () -> root.toAbsolutePath().normalize().toFile().getUsableSpace());
+    }
+
+    @VisibleForTesting
+    NativeCacheDirectory(Path root, long maxBytes, long maxFiles, Optional<Duration> ttl, BloomFilterAccessTracker accessTracker, Clock clock, NativeFileSystemCacheStats stats, int evictionSampleSize, LongSupplier usableSpaceSupplier)
+            throws IOException
+    {
+        checkArgument(evictionSampleSize > 0, "evictionSampleSize must be positive");
         this.root = requireNonNull(root, "root is null").toAbsolutePath().normalize();
         this.layout = new CacheFileLayout(this.root);
         this.stats = requireNonNull(stats, "stats is null");
-        Path dataRoot = this.root.resolve(CacheFileLayout.VERSION_DIRECTORY).resolve(CacheFileLayout.DATA_DIRECTORY);
+        this.maxBytes = maxBytes;
+        this.lowWatermarkBytes = (long) (maxBytes * LOW_WATERMARK_FACTOR);
+        this.maxFiles = maxFiles;
+        this.lowWatermarkFiles = (long) (maxFiles * LOW_WATERMARK_FACTOR);
+        this.evictionSampleSize = evictionSampleSize;
+        this.usableSpaceSupplier = requireNonNull(usableSpaceSupplier, "usableSpaceSupplier is null");
+        Optional<Long> ttlMillis = requireNonNull(ttl, "ttl is null")
+                .map(duration -> duration.roundTo(TimeUnit.MILLISECONDS));
+        this.accessTracker = requireNonNull(accessTracker, "accessTracker is null");
+        Clock cacheClock = requireNonNull(clock, "clock is null");
+        Path dataRoot = this.root.resolve(VERSION_DIRECTORY).resolve(DATA_DIRECTORY);
         Files.createDirectories(dataRoot);
         verifyAtomicMove(dataRoot);
+        this.walker = new NativeCacheDirectoryWalker(dataRoot, ttlMillis, cacheClock, this.accessTracker, this.stats, initializationWrites, activeTemporaryFiles);
     }
 
     CacheFileLayout.CacheFile cacheFile(Location location, String cacheKey)
@@ -63,17 +122,18 @@ final class NativeCacheDirectory
         Path pagePath = cacheFile.pagePath(pageIndex);
         try {
             if (Files.size(pagePath) != expectedPageLength) {
-                deleteIfExists(pagePath);
+                deleteCachedPage(pagePath);
                 return false;
             }
             try (InputStream input = Files.newInputStream(pagePath)) {
                 input.skipNBytes(pageOffset);
                 if (input.readNBytes(buffer, bufferOffset, length) != length) {
-                    deleteIfExists(pagePath);
+                    deleteCachedPage(pagePath);
                     return false;
                 }
             }
             stats.recordCacheRead(length);
+            accessTracker.record(cacheFile.fileHash());
             return true;
         }
         catch (NoSuchFileException | EOFException _) {
@@ -85,12 +145,26 @@ final class NativeCacheDirectory
     {
         Path pagePath = cacheFile.pagePath(pageIndex);
         Path temporaryPath = cacheFile.temporaryPagePath(pageIndex, randomUUID().toString());
+        boolean initializationWrite = false;
+        boolean pageWritten = false;
         try {
+            if (Files.exists(pagePath)) {
+                stats.recordCacheWriteSkip();
+                return;
+            }
+            initializationWrite = beginInitializationWrite(pagePath);
+            if (!reserve(length) || !hasUsableSpace(length)) {
+                stats.recordCacheWriteSkip();
+                return;
+            }
             Files.createDirectories(pagePath.getParent());
+            activeTemporaryFiles.add(temporaryPath);
             try (OutputStream output = Files.newOutputStream(temporaryPath, CREATE_NEW, WRITE)) {
                 output.write(page, offset, length);
             }
             Files.move(temporaryPath, pagePath, ATOMIC_MOVE);
+            pageWritten = true;
+            recordCachedPage(length);
             stats.recordCacheWrite();
         }
         catch (FileAlreadyExistsException _) {
@@ -100,12 +174,18 @@ final class NativeCacheDirectory
             stats.recordCacheWriteFailure();
             deleteIfExists(temporaryPath);
         }
+        finally {
+            activeTemporaryFiles.remove(temporaryPath);
+            if (initializationWrite && !pageWritten) {
+                initializationWrites.remove(pagePath);
+            }
+        }
     }
 
     void expire(Location location)
             throws IOException
     {
-        deleteRecursively(layout.locationPath(location));
+        deleteRecursively(layout.locationPath(location), false);
     }
 
     void expire(Collection<Location> locations)
@@ -113,6 +193,48 @@ final class NativeCacheDirectory
     {
         for (Location location : locations) {
             expire(location);
+        }
+    }
+
+    void maintenance()
+    {
+        if (!initialized.get()) {
+            initialize();
+            return;
+        }
+        walker.cleanTemporaryFiles(evictionSampleSize);
+        for (FileGroup fileGroup : sampleFileGroups()) {
+            if (!fileGroup.expired()) {
+                continue;
+            }
+            try {
+                deleteRecursively(fileGroup.path(), true);
+            }
+            catch (IOException _) {
+            }
+        }
+    }
+
+    void initialize()
+    {
+        if (!initializationStarted.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            ScanResult scanResult = scan();
+            synchronized (initializationLock) {
+                setCurrentUsage(new ScanResult(
+                        scanResult.files() + currentFiles.get(),
+                        scanResult.bytes() + currentBytes.get()));
+                initialized.set(true);
+                initializationWrites.clear();
+                initializationScanCursor = null;
+            }
+        }
+        catch (RuntimeException e) {
+            initializationStarted.set(false);
+            throw e;
         }
     }
 
@@ -139,44 +261,199 @@ final class NativeCacheDirectory
         }
     }
 
-    private static void deleteRecursively(Path path)
-            throws IOException
+    private boolean reserve(long bytes)
     {
-        try {
-            Files.walkFileTree(path, new SimpleFileVisitor<>()
-            {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
-                        throws IOException
-                {
-                    Files.deleteIfExists(file);
-                    return FileVisitResult.CONTINUE;
-                }
+        if (bytes > maxBytes) {
+            return false;
+        }
+        if (!initialized.get()) {
+            return true;
+        }
+        if (fits(bytes, 1)) {
+            return true;
+        }
+        evictToFit(bytes, 1);
+        return fits(bytes, 1);
+    }
 
-                @Override
-                public FileVisitResult visitFileFailed(Path file, IOException exception)
-                        throws IOException
-                {
-                    if (exception instanceof NoSuchFileException) {
-                        return FileVisitResult.CONTINUE;
-                    }
-                    throw exception;
-                }
+    private boolean fits(long bytes, long files)
+    {
+        return currentBytes.get() + bytes <= maxBytes && currentFiles.get() + files <= maxFiles;
+    }
 
-                @Override
-                public FileVisitResult postVisitDirectory(Path directory, IOException exception)
-                        throws IOException
-                {
-                    if (exception != null && !(exception instanceof NoSuchFileException)) {
-                        throw exception;
-                    }
-                    Files.deleteIfExists(directory);
-                    return FileVisitResult.CONTINUE;
+    @VisibleForTesting
+    boolean isInitialized()
+    {
+        return initialized.get();
+    }
+
+    private boolean hasUsableSpace(long bytes)
+    {
+        return usableSpaceSupplier.getAsLong() >= bytes;
+    }
+
+    private void evictToFit(long bytes, long files)
+    {
+        while (!belowLowWatermark(bytes, files)) {
+            List<FileGroup> candidates = new ArrayList<>(sampleFileGroups());
+            if (candidates.isEmpty()) {
+                reconcileAccounting();
+                return;
+            }
+            candidates.sort(comparing(FileGroup::expired).reversed()
+                    .thenComparing(FileGroup::accessTimeForEviction));
+            boolean deleted = false;
+            for (FileGroup candidate : candidates) {
+                DeletionStats deletionStats;
+                try {
+                    deletionStats = deleteRecursively(candidate.path(), candidate.expired());
                 }
+                catch (IOException _) {
+                    continue;
+                }
+                if (deletionStats.files() > 0) {
+                    stats.recordEviction(deletionStats.files(), deletionStats.bytes());
+                    deleted = true;
+                    if (belowLowWatermark(bytes, files)) {
+                        return;
+                    }
+                }
+            }
+            if (!deleted) {
+                reconcileAccounting();
+                return;
+            }
+        }
+    }
+
+    private boolean belowLowWatermark(long bytes, long files)
+    {
+        return currentBytes.get() + bytes <= lowWatermarkBytes && currentFiles.get() + files <= lowWatermarkFiles;
+    }
+
+    private void reconcileAccounting()
+    {
+        if (initialized.get()) {
+            setCurrentUsage(scan());
+        }
+    }
+
+    private void setCurrentUsage(ScanResult scanResult)
+    {
+        long previousBytes = currentBytes.getAndSet(scanResult.bytes());
+        long previousFiles = currentFiles.getAndSet(scanResult.files());
+        stats.adjustCachedFiles(scanResult.files() - previousFiles, scanResult.bytes() - previousBytes);
+    }
+
+    private ScanResult scan()
+    {
+        return walker.scan(this::markInitializationScanned);
+    }
+
+    private synchronized List<FileGroup> sampleFileGroups()
+    {
+        List<FileGroup> sample = collectFileGroupsAfterCursor();
+        if (sample.size() < evictionSampleSize) {
+            List<FileGroup> wrappedSample = new ArrayList<>(sample);
+            wrappedSample.addAll(collectFileGroupsFromBeginning(evictionSampleSize - sample.size()));
+            sample = List.copyOf(wrappedSample);
+        }
+        if (!sample.isEmpty()) {
+            evictionCursor = sample.getLast().path();
+        }
+        return sample;
+    }
+
+    @GuardedBy("this")
+    private List<FileGroup> collectFileGroupsAfterCursor()
+    {
+        return walker.collectFileGroups(evictionCursor, true, evictionSampleSize);
+    }
+
+    @GuardedBy("this")
+    private List<FileGroup> collectFileGroupsFromBeginning(int limit)
+    {
+        if (evictionCursor == null) {
+            return List.of();
+        }
+        return walker.collectFileGroups(evictionCursor, false, limit);
+    }
+
+    private boolean beginInitializationWrite(Path pagePath)
+    {
+        Path fileGroupPath = requireNonNull(pagePath.getParent(), "pagePath parent is null");
+        synchronized (initializationLock) {
+            if (initialized.get()) {
+                return false;
+            }
+            if (initializationScanCursor != null && fileGroupPath.compareTo(initializationScanCursor) <= 0) {
+                return false;
+            }
+            initializationWrites.add(pagePath);
+            return true;
+        }
+    }
+
+    private void markInitializationScanned(Path fileGroupPath)
+    {
+        synchronized (initializationLock) {
+            if (initialized.get()) {
+                return;
+            }
+            if (initializationScanCursor == null || fileGroupPath.compareTo(initializationScanCursor) > 0) {
+                initializationScanCursor = fileGroupPath;
+            }
+            Path scannedThrough = initializationScanCursor;
+            initializationWrites.removeIf(pagePath -> {
+                Path pageFileGroupPath = pagePath.getParent();
+                return pageFileGroupPath != null && pageFileGroupPath.compareTo(scannedThrough) <= 0;
             });
         }
-        catch (NoSuchFileException _) {
+    }
+
+    private void recordCachedPage(long bytes)
+    {
+        currentBytes.addAndGet(bytes);
+        currentFiles.incrementAndGet();
+        stats.addCachedFile(bytes);
+    }
+
+    private void deleteCachedPage(Path path)
+    {
+        try {
+            if (!Files.exists(path)) {
+                return;
+            }
+            long bytes = Files.size(path);
+            if (Files.deleteIfExists(path)) {
+                if (initialized.get()) {
+                    currentBytes.addAndGet(-bytes);
+                    currentFiles.decrementAndGet();
+                    stats.removeCachedFiles(1, bytes);
+                }
+            }
         }
+        catch (IOException _) {
+        }
+    }
+
+    private DeletionStats deleteRecursively(Path path, boolean expired)
+            throws IOException
+    {
+        DeletionStats deletionStats = walker.deleteRecursively(path);
+        if (deletionStats.files() > 0) {
+            if (initialized.get()) {
+                currentBytes.addAndGet(-deletionStats.bytes());
+                currentFiles.addAndGet(-deletionStats.files());
+                stats.removeCachedFiles(deletionStats.files(), deletionStats.bytes());
+            }
+            if (expired) {
+                for (long index = 0; index < deletionStats.files(); index++) {
+                    stats.recordExpiredFile();
+                }
+            }
+        }
+        return deletionStats;
     }
 
     @Override
@@ -184,6 +461,8 @@ final class NativeCacheDirectory
     {
         return toStringHelper(this)
                 .add("root", root)
+                .add("maxBytes", maxBytes)
+                .add("maxFiles", maxFiles)
                 .toString();
     }
 }

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
@@ -13,40 +13,100 @@
  */
 package io.trino.filesystem.cache.local;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.units.Duration;
 import io.trino.filesystem.Location;
+import io.trino.filesystem.cache.local.NativeCacheDirectoryWalker.DeletionStats;
+import io.trino.filesystem.cache.local.NativeCacheDirectoryWalker.FileGroup;
+import io.trino.filesystem.cache.local.NativeCacheDirectoryWalker.ScanResult;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.cache.local.CacheFileLayout.DATA_DIRECTORY;
+import static io.trino.filesystem.cache.local.CacheFileLayout.VERSION_DIRECTORY;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 
 final class NativeCacheDirectory
 {
+    private static final int EVICTION_SAMPLE_SIZE = 8192;
+    private static final double LOW_WATERMARK_FACTOR = 0.9;
+
     private final Path root;
     private final CacheFileLayout layout;
+    private final NativeCacheDirectoryWalker walker;
     private final NativeFileSystemCacheStats stats;
+    private final long maxBytes;
+    private final long lowWatermarkBytes;
+    private final long maxFiles;
+    private final long lowWatermarkFiles;
+    private final int evictionSampleSize;
+    private final LongSupplier usableSpaceSupplier;
+    private final BloomFilterAccessTracker accessTracker;
+    private final AtomicLong currentBytes = new AtomicLong();
+    private final AtomicLong currentFiles = new AtomicLong();
+    private final AtomicBoolean initializationStarted = new AtomicBoolean();
+    private final AtomicBoolean initialized = new AtomicBoolean();
+    private final Object initializationLock = new Object();
+    // Pages written by this process during the initial scan are accounted separately, so the scan does not double count them.
+    private final Set<Path> initializationWrites = ConcurrentHashMap.newKeySet();
+    private final Set<Path> activeTemporaryFiles = ConcurrentHashMap.newKeySet();
+    @GuardedBy("initializationLock")
+    private Path initializationScanCursor;
+    @GuardedBy("this")
+    private Path evictionCursor;
 
-    NativeCacheDirectory(Path root, NativeFileSystemCacheStats stats)
+    NativeCacheDirectory(Path root, long maxBytes, long maxFiles, Optional<Duration> ttl, BloomFilterAccessTracker accessTracker, NativeFileSystemCacheStats stats)
             throws IOException
     {
+        this(root, maxBytes, maxFiles, ttl, accessTracker, Clock.systemUTC(), stats, EVICTION_SAMPLE_SIZE, () -> root.toAbsolutePath().normalize().toFile().getUsableSpace());
+    }
+
+    @VisibleForTesting
+    NativeCacheDirectory(Path root, long maxBytes, long maxFiles, Optional<Duration> ttl, BloomFilterAccessTracker accessTracker, Clock clock, NativeFileSystemCacheStats stats, int evictionSampleSize, LongSupplier usableSpaceSupplier)
+            throws IOException
+    {
+        checkArgument(evictionSampleSize > 0, "evictionSampleSize must be positive");
         this.root = requireNonNull(root, "root is null").toAbsolutePath().normalize();
         this.layout = new CacheFileLayout(this.root);
         this.stats = requireNonNull(stats, "stats is null");
-        Files.createDirectories(this.root.resolve(CacheFileLayout.VERSION_DIRECTORY).resolve(CacheFileLayout.DATA_DIRECTORY));
+        this.maxBytes = maxBytes;
+        this.lowWatermarkBytes = (long) (maxBytes * LOW_WATERMARK_FACTOR);
+        this.maxFiles = maxFiles;
+        this.lowWatermarkFiles = (long) (maxFiles * LOW_WATERMARK_FACTOR);
+        this.evictionSampleSize = evictionSampleSize;
+        this.usableSpaceSupplier = requireNonNull(usableSpaceSupplier, "usableSpaceSupplier is null");
+        Optional<Long> ttlMillis = requireNonNull(ttl, "ttl is null")
+                .map(duration -> duration.roundTo(TimeUnit.MILLISECONDS));
+        this.accessTracker = requireNonNull(accessTracker, "accessTracker is null");
+        Clock cacheClock = requireNonNull(clock, "clock is null");
+        Path dataRoot = this.root.resolve(VERSION_DIRECTORY).resolve(DATA_DIRECTORY);
+        Files.createDirectories(dataRoot);
+        this.walker = new NativeCacheDirectoryWalker(dataRoot, ttlMillis, cacheClock, this.accessTracker, this.stats, initializationWrites, activeTemporaryFiles);
     }
 
     CacheFileLayout.CacheFile cacheFile(Location location, String cacheKey)
@@ -60,17 +120,18 @@ final class NativeCacheDirectory
         Path pagePath = cacheFile.pagePath(pageIndex);
         try {
             if (Files.size(pagePath) != expectedPageLength) {
-                deleteIfExists(pagePath);
+                deleteCachedPage(pagePath);
                 return false;
             }
             try (InputStream input = Files.newInputStream(pagePath)) {
                 input.skipNBytes(pageOffset);
                 if (input.readNBytes(buffer, bufferOffset, length) != length) {
-                    deleteIfExists(pagePath);
+                    deleteCachedPage(pagePath);
                     return false;
                 }
             }
             stats.recordCacheRead(length);
+            accessTracker.record(cacheFile.fileHash());
             return true;
         }
         catch (NoSuchFileException | EOFException _) {
@@ -82,12 +143,26 @@ final class NativeCacheDirectory
     {
         Path pagePath = cacheFile.pagePath(pageIndex);
         Path temporaryPath = cacheFile.temporaryPagePath(pageIndex, randomUUID().toString());
+        boolean initializationWrite = false;
+        boolean pageWritten = false;
         try {
+            if (Files.exists(pagePath)) {
+                stats.recordCacheWriteSkip();
+                return;
+            }
+            initializationWrite = beginInitializationWrite(pagePath);
+            if (!reserve(length) || !hasUsableSpace(length)) {
+                stats.recordCacheWriteSkip();
+                return;
+            }
             Files.createDirectories(pagePath.getParent());
+            activeTemporaryFiles.add(temporaryPath);
             try (OutputStream output = Files.newOutputStream(temporaryPath, CREATE_NEW, WRITE)) {
                 output.write(page, offset, length);
             }
             Files.move(temporaryPath, pagePath);
+            pageWritten = true;
+            recordCachedPage(length);
             stats.recordCacheWrite();
         }
         catch (FileAlreadyExistsException _) {
@@ -97,12 +172,18 @@ final class NativeCacheDirectory
             stats.recordCacheWriteFailure();
             deleteIfExists(temporaryPath);
         }
+        finally {
+            activeTemporaryFiles.remove(temporaryPath);
+            if (initializationWrite && !pageWritten) {
+                initializationWrites.remove(pagePath);
+            }
+        }
     }
 
     void expire(Location location)
             throws IOException
     {
-        deleteRecursively(layout.locationPath(location));
+        deleteRecursively(layout.locationPath(location), false);
     }
 
     void expire(Collection<Location> locations)
@@ -110,6 +191,48 @@ final class NativeCacheDirectory
     {
         for (Location location : locations) {
             expire(location);
+        }
+    }
+
+    void maintenance()
+    {
+        if (!initialized.get()) {
+            initialize();
+            return;
+        }
+        walker.cleanTemporaryFiles(evictionSampleSize);
+        for (FileGroup fileGroup : sampleFileGroups()) {
+            if (!fileGroup.expired()) {
+                continue;
+            }
+            try {
+                deleteRecursively(fileGroup.path(), true);
+            }
+            catch (IOException _) {
+            }
+        }
+    }
+
+    void initialize()
+    {
+        if (!initializationStarted.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            ScanResult scanResult = scan();
+            synchronized (initializationLock) {
+                setCurrentUsage(new ScanResult(
+                        scanResult.files() + currentFiles.get(),
+                        scanResult.bytes() + currentBytes.get()));
+                initialized.set(true);
+                initializationWrites.clear();
+                initializationScanCursor = null;
+            }
+        }
+        catch (RuntimeException e) {
+            initializationStarted.set(false);
+            throw e;
         }
     }
 
@@ -122,44 +245,199 @@ final class NativeCacheDirectory
         }
     }
 
-    private static void deleteRecursively(Path path)
-            throws IOException
+    private boolean reserve(long bytes)
     {
-        try {
-            Files.walkFileTree(path, new SimpleFileVisitor<>()
-            {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
-                        throws IOException
-                {
-                    Files.deleteIfExists(file);
-                    return FileVisitResult.CONTINUE;
-                }
+        if (bytes > maxBytes) {
+            return false;
+        }
+        if (!initialized.get()) {
+            return true;
+        }
+        if (fits(bytes, 1)) {
+            return true;
+        }
+        evictToFit(bytes, 1);
+        return fits(bytes, 1);
+    }
 
-                @Override
-                public FileVisitResult visitFileFailed(Path file, IOException exception)
-                        throws IOException
-                {
-                    if (exception instanceof NoSuchFileException) {
-                        return FileVisitResult.CONTINUE;
-                    }
-                    throw exception;
-                }
+    private boolean fits(long bytes, long files)
+    {
+        return currentBytes.get() + bytes <= maxBytes && currentFiles.get() + files <= maxFiles;
+    }
 
-                @Override
-                public FileVisitResult postVisitDirectory(Path directory, IOException exception)
-                        throws IOException
-                {
-                    if (exception != null && !(exception instanceof NoSuchFileException)) {
-                        throw exception;
-                    }
-                    Files.deleteIfExists(directory);
-                    return FileVisitResult.CONTINUE;
+    @VisibleForTesting
+    boolean isInitialized()
+    {
+        return initialized.get();
+    }
+
+    private boolean hasUsableSpace(long bytes)
+    {
+        return usableSpaceSupplier.getAsLong() >= bytes;
+    }
+
+    private void evictToFit(long bytes, long files)
+    {
+        while (!belowLowWatermark(bytes, files)) {
+            List<FileGroup> candidates = new ArrayList<>(sampleFileGroups());
+            if (candidates.isEmpty()) {
+                reconcileAccounting();
+                return;
+            }
+            candidates.sort(comparing(FileGroup::expired).reversed()
+                    .thenComparing(FileGroup::accessTimeForEviction));
+            boolean deleted = false;
+            for (FileGroup candidate : candidates) {
+                DeletionStats deletionStats;
+                try {
+                    deletionStats = deleteRecursively(candidate.path(), candidate.expired());
                 }
+                catch (IOException _) {
+                    continue;
+                }
+                if (deletionStats.files() > 0) {
+                    stats.recordEviction(deletionStats.files(), deletionStats.bytes());
+                    deleted = true;
+                    if (belowLowWatermark(bytes, files)) {
+                        return;
+                    }
+                }
+            }
+            if (!deleted) {
+                reconcileAccounting();
+                return;
+            }
+        }
+    }
+
+    private boolean belowLowWatermark(long bytes, long files)
+    {
+        return currentBytes.get() + bytes <= lowWatermarkBytes && currentFiles.get() + files <= lowWatermarkFiles;
+    }
+
+    private void reconcileAccounting()
+    {
+        if (initialized.get()) {
+            setCurrentUsage(scan());
+        }
+    }
+
+    private void setCurrentUsage(ScanResult scanResult)
+    {
+        long previousBytes = currentBytes.getAndSet(scanResult.bytes());
+        long previousFiles = currentFiles.getAndSet(scanResult.files());
+        stats.adjustCachedFiles(scanResult.files() - previousFiles, scanResult.bytes() - previousBytes);
+    }
+
+    private ScanResult scan()
+    {
+        return walker.scan(this::markInitializationScanned);
+    }
+
+    private synchronized List<FileGroup> sampleFileGroups()
+    {
+        List<FileGroup> sample = collectFileGroupsAfterCursor();
+        if (sample.size() < evictionSampleSize) {
+            List<FileGroup> wrappedSample = new ArrayList<>(sample);
+            wrappedSample.addAll(collectFileGroupsFromBeginning(evictionSampleSize - sample.size()));
+            sample = List.copyOf(wrappedSample);
+        }
+        if (!sample.isEmpty()) {
+            evictionCursor = sample.getLast().path();
+        }
+        return sample;
+    }
+
+    @GuardedBy("this")
+    private List<FileGroup> collectFileGroupsAfterCursor()
+    {
+        return walker.collectFileGroups(evictionCursor, true, evictionSampleSize);
+    }
+
+    @GuardedBy("this")
+    private List<FileGroup> collectFileGroupsFromBeginning(int limit)
+    {
+        if (evictionCursor == null) {
+            return List.of();
+        }
+        return walker.collectFileGroups(evictionCursor, false, limit);
+    }
+
+    private boolean beginInitializationWrite(Path pagePath)
+    {
+        Path fileGroupPath = requireNonNull(pagePath.getParent(), "pagePath parent is null");
+        synchronized (initializationLock) {
+            if (initialized.get()) {
+                return false;
+            }
+            if (initializationScanCursor != null && fileGroupPath.compareTo(initializationScanCursor) <= 0) {
+                return false;
+            }
+            initializationWrites.add(pagePath);
+            return true;
+        }
+    }
+
+    private void markInitializationScanned(Path fileGroupPath)
+    {
+        synchronized (initializationLock) {
+            if (initialized.get()) {
+                return;
+            }
+            if (initializationScanCursor == null || fileGroupPath.compareTo(initializationScanCursor) > 0) {
+                initializationScanCursor = fileGroupPath;
+            }
+            Path scannedThrough = initializationScanCursor;
+            initializationWrites.removeIf(pagePath -> {
+                Path pageFileGroupPath = pagePath.getParent();
+                return pageFileGroupPath != null && pageFileGroupPath.compareTo(scannedThrough) <= 0;
             });
         }
-        catch (NoSuchFileException _) {
+    }
+
+    private void recordCachedPage(long bytes)
+    {
+        currentBytes.addAndGet(bytes);
+        currentFiles.incrementAndGet();
+        stats.addCachedFile(bytes);
+    }
+
+    private void deleteCachedPage(Path path)
+    {
+        try {
+            if (!Files.exists(path)) {
+                return;
+            }
+            long bytes = Files.size(path);
+            if (Files.deleteIfExists(path)) {
+                if (initialized.get()) {
+                    currentBytes.addAndGet(-bytes);
+                    currentFiles.decrementAndGet();
+                    stats.removeCachedFiles(1, bytes);
+                }
+            }
         }
+        catch (IOException _) {
+        }
+    }
+
+    private DeletionStats deleteRecursively(Path path, boolean expired)
+            throws IOException
+    {
+        DeletionStats deletionStats = walker.deleteRecursively(path);
+        if (deletionStats.files() > 0) {
+            if (initialized.get()) {
+                currentBytes.addAndGet(-deletionStats.bytes());
+                currentFiles.addAndGet(-deletionStats.files());
+                stats.removeCachedFiles(deletionStats.files(), deletionStats.bytes());
+            }
+            if (expired) {
+                for (long index = 0; index < deletionStats.files(); index++) {
+                    stats.recordExpiredFile();
+                }
+            }
+        }
+        return deletionStats;
     }
 
     @Override
@@ -167,6 +445,8 @@ final class NativeCacheDirectory
     {
         return toStringHelper(this)
                 .add("root", root)
+                .add("maxBytes", maxBytes)
+                .add("maxFiles", maxFiles)
                 .toString();
     }
 }

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectory.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.Location;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collection;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+
+final class NativeCacheDirectory
+{
+    private final Path root;
+    private final CacheFileLayout layout;
+    private final NativeFileSystemCacheStats stats;
+
+    NativeCacheDirectory(Path root, NativeFileSystemCacheStats stats)
+            throws IOException
+    {
+        this.root = requireNonNull(root, "root is null").toAbsolutePath().normalize();
+        this.layout = new CacheFileLayout(this.root);
+        this.stats = requireNonNull(stats, "stats is null");
+        Files.createDirectories(this.root.resolve(CacheFileLayout.VERSION_DIRECTORY).resolve(CacheFileLayout.DATA_DIRECTORY));
+    }
+
+    CacheFileLayout.CacheFile cacheFile(Location location, String cacheKey)
+    {
+        return layout.cacheFile(location, cacheKey);
+    }
+
+    boolean readPage(CacheFileLayout.CacheFile cacheFile, long pageIndex, int pageOffset, int length, int expectedPageLength, byte[] buffer, int bufferOffset)
+            throws IOException
+    {
+        Path pagePath = cacheFile.pagePath(pageIndex);
+        try {
+            if (Files.size(pagePath) != expectedPageLength) {
+                deleteIfExists(pagePath);
+                return false;
+            }
+            try (InputStream input = Files.newInputStream(pagePath)) {
+                input.skipNBytes(pageOffset);
+                if (input.readNBytes(buffer, bufferOffset, length) != length) {
+                    deleteIfExists(pagePath);
+                    return false;
+                }
+            }
+            stats.recordCacheRead(length);
+            return true;
+        }
+        catch (NoSuchFileException | EOFException _) {
+            return false;
+        }
+    }
+
+    void writePage(CacheFileLayout.CacheFile cacheFile, long pageIndex, byte[] page, int offset, int length)
+    {
+        Path pagePath = cacheFile.pagePath(pageIndex);
+        Path temporaryPath = cacheFile.temporaryPagePath(pageIndex, randomUUID().toString());
+        try {
+            Files.createDirectories(pagePath.getParent());
+            try (OutputStream output = Files.newOutputStream(temporaryPath, CREATE_NEW, WRITE)) {
+                output.write(page, offset, length);
+            }
+            Files.move(temporaryPath, pagePath);
+            stats.recordCacheWrite();
+        }
+        catch (FileAlreadyExistsException _) {
+            deleteIfExists(temporaryPath);
+        }
+        catch (IOException | RuntimeException e) {
+            stats.recordCacheWriteFailure();
+            deleteIfExists(temporaryPath);
+        }
+    }
+
+    void expire(Location location)
+            throws IOException
+    {
+        deleteRecursively(layout.locationPath(location));
+    }
+
+    void expire(Collection<Location> locations)
+            throws IOException
+    {
+        for (Location location : locations) {
+            expire(location);
+        }
+    }
+
+    private static void deleteIfExists(Path path)
+    {
+        try {
+            Files.deleteIfExists(path);
+        }
+        catch (IOException _) {
+        }
+    }
+
+    private static void deleteRecursively(Path path)
+            throws IOException
+    {
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<>()
+            {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+                        throws IOException
+                {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exception)
+                        throws IOException
+                {
+                    if (exception instanceof NoSuchFileException) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    throw exception;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path directory, IOException exception)
+                        throws IOException
+                {
+                    if (exception != null && !(exception instanceof NoSuchFileException)) {
+                        throw exception;
+                    }
+                    Files.deleteIfExists(directory);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        catch (NoSuchFileException _) {
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("root", root)
+                .toString();
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectoryWalker.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheDirectoryWalker.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+final class NativeCacheDirectoryWalker
+{
+    private static final int FILE_GROUP_DEPTH = 4;
+    private static final long STALE_TEMPORARY_FILE_MILLIS = TimeUnit.HOURS.toMillis(1);
+
+    private final Path dataRoot;
+    private final NativeFileSystemCacheStats stats;
+    private final Optional<Long> ttlMillis;
+    private final Clock clock;
+    private final BloomFilterAccessTracker accessTracker;
+    private final Set<Path> initializationWrites;
+    private final Set<Path> activeTemporaryFiles;
+
+    NativeCacheDirectoryWalker(
+            Path dataRoot,
+            Optional<Long> ttlMillis,
+            Clock clock,
+            BloomFilterAccessTracker accessTracker,
+            NativeFileSystemCacheStats stats,
+            Set<Path> initializationWrites,
+            Set<Path> activeTemporaryFiles)
+    {
+        this.dataRoot = requireNonNull(dataRoot, "dataRoot is null");
+        this.ttlMillis = requireNonNull(ttlMillis, "ttlMillis is null");
+        this.clock = requireNonNull(clock, "clock is null");
+        this.accessTracker = requireNonNull(accessTracker, "accessTracker is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.initializationWrites = requireNonNull(initializationWrites, "initializationWrites is null");
+        this.activeTemporaryFiles = requireNonNull(activeTemporaryFiles, "activeTemporaryFiles is null");
+    }
+
+    ScanResult scan(Consumer<Path> fileGroupScanned)
+    {
+        if (!Files.exists(dataRoot)) {
+            return new ScanResult(0, 0);
+        }
+        cleanTemporaryFiles(Integer.MAX_VALUE);
+        return scanFileGroups(dataRoot, 0, requireNonNull(fileGroupScanned, "fileGroupScanned is null"));
+    }
+
+    void cleanTemporaryFiles(int limit)
+    {
+        if (!Files.exists(dataRoot)) {
+            return;
+        }
+        try (var paths = Files.find(dataRoot, 5, this::isStaleTemporaryFile)) {
+            for (Path path : paths.limit(limit).toList()) {
+                if (Files.deleteIfExists(path)) {
+                    stats.recordStaleTemporaryFile();
+                }
+            }
+        }
+        catch (IOException _) {
+        }
+    }
+
+    List<FileGroup> collectFileGroups(Path cursor, boolean afterCursor, int limit)
+    {
+        if (!Files.isDirectory(dataRoot) || limit <= 0) {
+            return List.of();
+        }
+        List<FileGroup> fileGroups = new ArrayList<>();
+        try {
+            collectFileGroups(dataRoot, 0, cursor, afterCursor, limit, fileGroups);
+        }
+        catch (IOException _) {
+        }
+        return List.copyOf(fileGroups);
+    }
+
+    DeletionStats deleteRecursively(Path path)
+            throws IOException
+    {
+        DeletionStats deletionStats = new DeletionStats();
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<>()
+            {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+                        throws IOException
+                {
+                    if (Files.deleteIfExists(file)) {
+                        if (isCachePage(file)) {
+                            deletionStats.addCachedFile(attributes.size());
+                        }
+                        else if (isTemporary(file)) {
+                            stats.recordStaleTemporaryFile();
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exception)
+                        throws IOException
+                {
+                    if (exception instanceof NoSuchFileException) {
+                        return FileVisitResult.CONTINUE;
+                    }
+                    throw exception;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path directory, IOException exception)
+                        throws IOException
+                {
+                    if (exception != null && !(exception instanceof NoSuchFileException)) {
+                        throw exception;
+                    }
+                    Files.deleteIfExists(directory);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        catch (NoSuchFileException _) {
+        }
+        return deletionStats;
+    }
+
+    private ScanResult scanFileGroups(Path directory, int depth, Consumer<Path> fileGroupScanned)
+    {
+        if (depth == FILE_GROUP_DEPTH) {
+            Optional<FileGroup> fileGroup = fileGroup(directory);
+            fileGroupScanned.accept(directory);
+            if (fileGroup.isEmpty()) {
+                return new ScanResult(0, 0);
+            }
+            FileGroup group = fileGroup.orElseThrow();
+            if (group.expired()) {
+                try {
+                    DeletionStats deletionStats = deleteRecursively(group.path());
+                    for (long index = 0; index < deletionStats.files(); index++) {
+                        stats.recordExpiredFile();
+                    }
+                }
+                catch (IOException _) {
+                }
+                return new ScanResult(0, 0);
+            }
+            return new ScanResult(group.files(), group.bytes());
+        }
+
+        long bytes = 0;
+        long files = 0;
+        try {
+            for (Path child : sortedDirectories(directory)) {
+                ScanResult scanResult = scanFileGroups(child, depth + 1, fileGroupScanned);
+                bytes += scanResult.bytes();
+                files += scanResult.files();
+            }
+        }
+        catch (IOException _) {
+        }
+        return new ScanResult(files, bytes);
+    }
+
+    private void collectFileGroups(Path directory, int depth, Path cursor, boolean afterCursor, int limit, List<FileGroup> fileGroups)
+            throws IOException
+    {
+        if (fileGroups.size() >= limit) {
+            return;
+        }
+        if (depth == FILE_GROUP_DEPTH) {
+            if (cursor == null || (afterCursor == (directory.compareTo(cursor) > 0))) {
+                fileGroup(directory).ifPresent(fileGroups::add);
+            }
+            return;
+        }
+        for (Path child : sortedDirectories(directory)) {
+            collectFileGroups(child, depth + 1, cursor, afterCursor, limit, fileGroups);
+            if (fileGroups.size() >= limit) {
+                return;
+            }
+        }
+    }
+
+    private Optional<FileGroup> fileGroup(Path path)
+    {
+        long bytes = 0;
+        long files = 0;
+        Instant lastModified = Instant.EPOCH;
+        try (var pages = Files.list(path)) {
+            for (Path page : pages.toList()) {
+                if (!Files.isRegularFile(page) || !isCachePage(page)) {
+                    continue;
+                }
+                if (initializationWrites.contains(page)) {
+                    continue;
+                }
+                files++;
+                bytes += Files.size(page);
+                Instant modified = Files.getLastModifiedTime(page).toInstant();
+                if (modified.isAfter(lastModified)) {
+                    lastModified = modified;
+                }
+            }
+        }
+        catch (IOException _) {
+            return Optional.empty();
+        }
+        if (files == 0) {
+            return Optional.empty();
+        }
+        String fileHash = path.getFileName().toString();
+        return Optional.of(new FileGroup(path, fileHash, files, bytes, lastModified, isExpired(lastModified), accessTracker.lastAccessTime(fileHash)));
+    }
+
+    private boolean isExpired(Instant lastModified)
+    {
+        return ttlMillis
+                .map(ttl -> clock.millis() - lastModified.toEpochMilli() > ttl)
+                .orElse(false);
+    }
+
+    private boolean isStaleTemporaryFile(Path path, BasicFileAttributes attributes)
+    {
+        return attributes.isRegularFile()
+                && isTemporary(path)
+                && !activeTemporaryFiles.contains(path)
+                && clock.millis() - attributes.lastModifiedTime().toMillis() > STALE_TEMPORARY_FILE_MILLIS;
+    }
+
+    private static List<Path> sortedDirectories(Path directory)
+            throws IOException
+    {
+        try (var children = Files.list(directory)) {
+            return children
+                    .filter(Files::isDirectory)
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    private static boolean isCachePage(Path path)
+    {
+        return path.getFileName().toString().endsWith(".cache");
+    }
+
+    private static boolean isTemporary(Path path)
+    {
+        return path.getFileName().toString().contains(".tmp.");
+    }
+
+    record FileGroup(Path path, String fileHash, long files, long bytes, Instant lastModified, boolean expired, OptionalLong lastAccessTime)
+    {
+        private static final long NO_ACCESS_TIME = Long.MIN_VALUE;
+
+        FileGroup
+        {
+            requireNonNull(path, "path is null");
+            requireNonNull(fileHash, "fileHash is null");
+            requireNonNull(lastModified, "lastModified is null");
+            requireNonNull(lastAccessTime, "lastAccessTime is null");
+        }
+
+        long accessTimeForEviction()
+        {
+            return lastAccessTime.orElse(NO_ACCESS_TIME);
+        }
+    }
+
+    record ScanResult(long files, long bytes) {}
+
+    static final class DeletionStats
+    {
+        private long files;
+        private long bytes;
+
+        void addCachedFile(long bytes)
+        {
+            files++;
+            this.bytes += bytes;
+        }
+
+        long files()
+        {
+            return files;
+        }
+
+        long bytes()
+        {
+            return bytes;
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheFile.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheFile.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.tracing.Tracing.CheckedSupplier;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static com.google.common.primitives.Ints.saturatedCast;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_SIZE;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_WRITE_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_WRITE_SIZE;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_KEY;
+import static io.trino.filesystem.tracing.Tracing.CheckedRunnable;
+import static io.trino.filesystem.tracing.Tracing.withTracing;
+import static java.lang.Math.addExact;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+final class NativeCacheFile
+{
+    private final Tracer tracer;
+    private final TrinoInputFile delegate;
+    private final String cacheKey;
+    private final NativeCacheDirectory cacheDirectory;
+    private final CacheFileLayout.CacheFile cacheFile;
+    private final NativeFileSystemCacheStats stats;
+    private final int pageSize;
+    private final long fileLength;
+
+    NativeCacheFile(Tracer tracer, TrinoInputFile delegate, String cacheKey, NativeCacheDirectory cacheDirectory, NativeFileSystemCacheStats stats, int pageSize, long fileLength)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.cacheKey = requireNonNull(cacheKey, "cacheKey is null");
+        this.cacheDirectory = requireNonNull(cacheDirectory, "cacheDirectory is null");
+        this.cacheFile = cacheDirectory.cacheFile(delegate.location(), cacheKey);
+        this.stats = requireNonNull(stats, "stats is null");
+        this.pageSize = pageSize;
+        this.fileLength = fileLength;
+    }
+
+    Location location()
+    {
+        return delegate.location();
+    }
+
+    long fileLength()
+    {
+        return fileLength;
+    }
+
+    TrinoInputFile delegate()
+    {
+        return delegate;
+    }
+
+    int pageSize()
+    {
+        return pageSize;
+    }
+
+    void validateRead(long position, int length)
+            throws IOException
+    {
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (length == 0) {
+            return;
+        }
+        long endPosition;
+        try {
+            endPosition = addExact(position, length);
+        }
+        catch (ArithmeticException e) {
+            throw new EOFException("Read request overflows file size: " + delegate.location());
+        }
+        if (endPosition > fileLength) {
+            throw new EOFException("Cannot read %s bytes at %s. File size is %s: %s".formatted(length, position, fileLength, delegate.location()));
+        }
+    }
+
+    boolean readPage(long pageIndex, int pageOffset, int length, int expectedPageLength, byte[] buffer, int bufferOffset)
+            throws IOException
+    {
+        return cacheDirectory.readPage(cacheFile, pageIndex, pageOffset, length, expectedPageLength, buffer, bufferOffset);
+    }
+
+    int readCached(long position, int length, CheckedSupplier<Integer, IOException> read)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("NativeCache.readCached")
+                .setAttribute(CACHE_KEY, cacheKey)
+                .setAttribute(CACHE_FILE_LOCATION, location().toString())
+                .setAttribute(CACHE_FILE_READ_SIZE, (long) length)
+                .setAttribute(CACHE_FILE_READ_POSITION, position)
+                .startSpan();
+        return withTracing(span, read);
+    }
+
+    void readExternalStream(long position, int length, CheckedRunnable<IOException> read)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("NativeCache.readExternalStream")
+                .setAttribute(CACHE_KEY, cacheKey)
+                .setAttribute(CACHE_FILE_LOCATION, location().toString())
+                .setAttribute(CACHE_FILE_READ_SIZE, (long) length)
+                .setAttribute(CACHE_FILE_READ_POSITION, position)
+                .startSpan();
+        withTracing(span, read);
+    }
+
+    void recordExternalRead(long bytes)
+    {
+        stats.recordExternalRead(bytes);
+    }
+
+    void writePages(long pageStart, byte[] readBuffer)
+    {
+        Span span = tracer.spanBuilder("NativeCache.writeCache")
+                .setAttribute(CACHE_KEY, cacheKey)
+                .setAttribute(CACHE_FILE_LOCATION, location().toString())
+                .setAttribute(CACHE_FILE_WRITE_SIZE, (long) readBuffer.length)
+                .setAttribute(CACHE_FILE_WRITE_POSITION, pageStart)
+                .startSpan();
+        withTracing(span, () -> {
+            int offset = 0;
+            long currentPageStart = pageStart;
+            while (offset < readBuffer.length) {
+                long pageIndex = currentPageStart / pageSize;
+                int pageLength = min(pageSize, readBuffer.length - offset);
+                cacheDirectory.writePage(cacheFile, pageIndex, readBuffer, offset, pageLength);
+                currentPageStart += pageLength;
+                offset += pageLength;
+            }
+        });
+    }
+
+    int expectedPageLength(long pageIndex)
+    {
+        long pageStart = pageIndex * (long) pageSize;
+        return saturatedCast(min(pageSize, fileLength - pageStart));
+    }
+
+    PageAlignedRead alignRead(long position, int length)
+    {
+        long pageStart = position - (position % pageSize);
+        int pageOffset = (int) (position % pageSize);
+        long readEnd = position + length;
+        long alignedReadEnd = readEnd + (pageSize - (readEnd % pageSize)) % pageSize;
+        long pageEnd = min(alignedReadEnd, fileLength);
+        return new PageAlignedRead(pageStart, pageEnd, pageOffset);
+    }
+
+    record PageAlignedRead(long pageStart, long pageEnd, int pageOffset)
+    {
+        int length()
+        {
+            return toIntExact(pageEnd - pageStart);
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheInput.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheInput.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.TrinoInput;
+
+import java.io.IOException;
+
+import static java.lang.Math.min;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+final class NativeCacheInput
+        implements TrinoInput
+{
+    private final NativeCacheFile cacheFile;
+    private TrinoInput input;
+    private boolean closed;
+
+    NativeCacheInput(NativeCacheFile cacheFile)
+    {
+        this.cacheFile = requireNonNull(cacheFile, "cacheFile is null");
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, length, buffer.length);
+        cacheFile.validateRead(position, length);
+        if (length == 0) {
+            return;
+        }
+
+        int bytesRead = readCached(position, buffer, bufferOffset, length);
+        readExternal(position + bytesRead, buffer, bufferOffset + bytesRead, length - bytesRead);
+    }
+
+    private int readCached(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        return cacheFile.readCached(position, length, () -> {
+            int remaining = length;
+            long currentPosition = position;
+            int currentBufferOffset = bufferOffset;
+            while (remaining > 0) {
+                long pageIndex = currentPosition / cacheFile.pageSize();
+                int pageOffset = (int) (currentPosition % cacheFile.pageSize());
+                int expectedPageLength = cacheFile.expectedPageLength(pageIndex);
+                int bytesToRead = min(remaining, expectedPageLength - pageOffset);
+                if (cacheFile.readPage(pageIndex, pageOffset, bytesToRead, expectedPageLength, buffer, currentBufferOffset)) {
+                    currentPosition += bytesToRead;
+                    currentBufferOffset += bytesToRead;
+                    remaining -= bytesToRead;
+                    continue;
+                }
+
+                return length - remaining;
+            }
+            return length;
+        });
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int maxLength)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, maxLength, buffer.length);
+
+        int readSize = (int) min(cacheFile.fileLength(), maxLength);
+        readFully(cacheFile.fileLength() - readSize, buffer, bufferOffset, readSize);
+        return readSize;
+    }
+
+    private void readExternal(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return;
+        }
+        cacheFile.readExternalStream(position, length, () -> {
+            NativeCacheFile.PageAlignedRead aligned = cacheFile.alignRead(position, length);
+            byte[] readBuffer = new byte[aligned.length()];
+            getInput().readFully(aligned.pageStart(), readBuffer, 0, readBuffer.length);
+            cacheFile.writePages(aligned.pageStart(), readBuffer);
+            System.arraycopy(readBuffer, aligned.pageOffset(), buffer, bufferOffset, length);
+            cacheFile.recordExternalRead(readBuffer.length);
+        });
+    }
+
+    private TrinoInput getInput()
+            throws IOException
+    {
+        if (input == null) {
+            input = cacheFile.delegate().newInput();
+        }
+        return input;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Input closed: " + cacheFile.location());
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            if (input != null) {
+                input.close();
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheInput.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheInput.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.TrinoInput;
+
+import java.io.IOException;
+
+import static java.lang.Math.min;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+final class NativeCacheInput
+        implements TrinoInput
+{
+    private final NativeCacheFile cacheFile;
+    private TrinoInput input;
+    private boolean closed;
+
+    NativeCacheInput(NativeCacheFile cacheFile)
+    {
+        this.cacheFile = requireNonNull(cacheFile, "cacheFile is null");
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, length, buffer.length);
+        cacheFile.validateRead(position, length);
+        if (length == 0) {
+            return;
+        }
+
+        int bytesRead = readCached(position, buffer, bufferOffset, length);
+        readExternal(position + bytesRead, buffer, bufferOffset + bytesRead, length - bytesRead);
+    }
+
+    private int readCached(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        return cacheFile.readCached(position, length, () -> {
+            int remaining = length;
+            long currentPosition = position;
+            int currentBufferOffset = bufferOffset;
+            while (remaining > 0) {
+                long pageIndex = currentPosition / cacheFile.pageSize();
+                int pageOffset = (int) (currentPosition % cacheFile.pageSize());
+                int expectedPageLength = cacheFile.expectedPageLength(pageIndex);
+                int bytesToRead = min(remaining, expectedPageLength - pageOffset);
+                if (cacheFile.readPage(pageIndex, pageOffset, bytesToRead, expectedPageLength, buffer, currentBufferOffset)) {
+                    currentPosition += bytesToRead;
+                    currentBufferOffset += bytesToRead;
+                    remaining -= bytesToRead;
+                    continue;
+                }
+
+                return length - remaining;
+            }
+            return length;
+        });
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int maxLength)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, maxLength, buffer.length);
+
+        int readSize = (int) min(cacheFile.fileLength(), maxLength);
+        readFully(cacheFile.fileLength() - readSize, buffer, bufferOffset, readSize);
+        return readSize;
+    }
+
+    private void readExternal(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return;
+        }
+        NativeCacheFile.PageAlignedRead aligned = cacheFile.alignRead(position, length);
+        byte[] readBuffer = new byte[aligned.length()];
+        getInput().readFully(aligned.pageStart(), readBuffer, 0, readBuffer.length);
+        cacheFile.writePages(aligned.pageStart(), readBuffer);
+        System.arraycopy(readBuffer, aligned.pageOffset(), buffer, bufferOffset, length);
+        cacheFile.recordExternalRead(readBuffer.length);
+    }
+
+    private TrinoInput getInput()
+            throws IOException
+    {
+        if (input == null) {
+            input = cacheFile.delegate().newInput();
+        }
+        return input;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Input closed: " + cacheFile.location());
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            if (input != null) {
+                input.close();
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheInputStream.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeCacheInputStream.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.primitives.Longs;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+final class NativeCacheInputStream
+        extends TrinoInputStream
+{
+    private final NativeCacheFile cacheFile;
+    private TrinoInputStream inputStream;
+    private byte[] pageBuffer;
+    private long pageBufferIndex = -1;
+    private int pageBufferLength;
+    private long position;
+    private boolean closed;
+
+    NativeCacheInputStream(NativeCacheFile cacheFile)
+    {
+        this.cacheFile = requireNonNull(cacheFile, "cacheFile is null");
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        ensureOpen();
+        return 0;
+    }
+
+    @Override
+    public long getPosition()
+    {
+        return position;
+    }
+
+    @Override
+    public void seek(long position)
+            throws IOException
+    {
+        ensureOpen();
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (position > cacheFile.fileLength()) {
+            throw new IOException("Cannot seek to %s. File size is %s: %s".formatted(position, cacheFile.fileLength(), cacheFile.location()));
+        }
+        this.position = position;
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        ensureOpen();
+        byte[] buffer = new byte[1];
+        int read = read(buffer, 0, 1);
+        if (read == -1) {
+            return -1;
+        }
+        return buffer[0] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(offset, length, buffer.length);
+        if (length == 0) {
+            return 0;
+        }
+        if (position >= cacheFile.fileLength()) {
+            return -1;
+        }
+
+        int bytesToRead = toIntExact(min(length, cacheFile.fileLength() - position));
+        readFullyFromStream(position, buffer, offset, bytesToRead);
+        position += bytesToRead;
+        return bytesToRead;
+    }
+
+    private void readFullyFromStream(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        cacheFile.validateRead(position, length);
+        int bytesRead = readCached(position, buffer, bufferOffset, length);
+        readExternal(position + bytesRead, buffer, bufferOffset + bytesRead, length - bytesRead);
+    }
+
+    private int readCached(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        return cacheFile.readCached(position, length, () -> {
+            int remaining = length;
+            long currentPosition = position;
+            int currentBufferOffset = bufferOffset;
+            while (remaining > 0) {
+                long pageIndex = currentPosition / cacheFile.pageSize();
+                int pageOffset = (int) (currentPosition % cacheFile.pageSize());
+                int expectedPageLength = cacheFile.expectedPageLength(pageIndex);
+                int bytesToRead = min(remaining, expectedPageLength - pageOffset);
+                if (readPageBuffer(pageIndex, pageOffset, bytesToRead, buffer, currentBufferOffset)) {
+                    currentPosition += bytesToRead;
+                    currentBufferOffset += bytesToRead;
+                    remaining -= bytesToRead;
+                    continue;
+                }
+                if (shouldBufferCacheRead(pageOffset, bytesToRead, expectedPageLength) && fillPageBuffer(pageIndex, expectedPageLength)) {
+                    continue;
+                }
+                if (cacheFile.readPage(pageIndex, pageOffset, bytesToRead, expectedPageLength, buffer, currentBufferOffset)) {
+                    currentPosition += bytesToRead;
+                    currentBufferOffset += bytesToRead;
+                    remaining -= bytesToRead;
+                    continue;
+                }
+
+                return length - remaining;
+            }
+            return length;
+        });
+    }
+
+    private static boolean shouldBufferCacheRead(int pageOffset, int bytesToRead, int expectedPageLength)
+    {
+        return bytesToRead < expectedPageLength - pageOffset;
+    }
+
+    private boolean readPageBuffer(long pageIndex, int pageOffset, int length, byte[] buffer, int bufferOffset)
+    {
+        if (pageBufferIndex != pageIndex || pageOffset + length > pageBufferLength) {
+            return false;
+        }
+        System.arraycopy(pageBuffer, pageOffset, buffer, bufferOffset, length);
+        return true;
+    }
+
+    private boolean fillPageBuffer(long pageIndex, int expectedPageLength)
+            throws IOException
+    {
+        if (pageBuffer == null) {
+            pageBuffer = new byte[cacheFile.pageSize()];
+        }
+        if (!cacheFile.readPage(pageIndex, 0, expectedPageLength, expectedPageLength, pageBuffer, 0)) {
+            pageBufferIndex = -1;
+            pageBufferLength = 0;
+            return false;
+        }
+        pageBufferIndex = pageIndex;
+        pageBufferLength = expectedPageLength;
+        return true;
+    }
+
+    private void readExternal(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return;
+        }
+        cacheFile.readExternalStream(position, length, () -> {
+            NativeCacheFile.PageAlignedRead aligned = cacheFile.alignRead(position, length);
+            byte[] readBuffer = new byte[aligned.length()];
+            TrinoInputStream stream = getInputStream();
+            if (stream.getPosition() != aligned.pageStart()) {
+                stream.seek(aligned.pageStart());
+            }
+            int bytesRead = stream.readNBytes(readBuffer, 0, readBuffer.length);
+            if (bytesRead != readBuffer.length) {
+                throw new EOFException("Read %s of %s requested bytes: %s".formatted(bytesRead, readBuffer.length, cacheFile.location()));
+            }
+            cacheFile.writePages(aligned.pageStart(), readBuffer);
+            System.arraycopy(readBuffer, aligned.pageOffset(), buffer, bufferOffset, length);
+            cacheFile.recordExternalRead(bytesRead);
+        });
+    }
+
+    private TrinoInputStream getInputStream()
+            throws IOException
+    {
+        if (inputStream == null) {
+            inputStream = cacheFile.delegate().newStream();
+        }
+        return inputStream;
+    }
+
+    @Override
+    public long skip(long length)
+            throws IOException
+    {
+        ensureOpen();
+        length = Longs.constrainToRange(length, 0, cacheFile.fileLength() - position);
+        position += length;
+        return length;
+    }
+
+    @Override
+    public void skipNBytes(long n)
+            throws IOException
+    {
+        ensureOpen();
+        if (n <= 0) {
+            return;
+        }
+        long newPosition;
+        try {
+            newPosition = Math.addExact(position, n);
+        }
+        catch (ArithmeticException e) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, position, cacheFile.fileLength(), cacheFile.location()));
+        }
+        if (newPosition > cacheFile.fileLength()) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, position, cacheFile.fileLength(), cacheFile.location()));
+        }
+        position = newPosition;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Input stream closed: " + cacheFile.location());
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCache.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCache.java
@@ -15,64 +15,54 @@ package io.trino.filesystem.cache.local;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.TracerProvider;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInput;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoInputStream;
 import io.trino.filesystem.cache.TrinoFileSystemCache;
+import jakarta.annotation.PreDestroy;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.IntStream;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.filesystem.cache.local.NativeFileSystemCacheConfig.CACHE_DIRECTORIES;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.HOURS;
 
 public class NativeFileSystemCache
         implements TrinoFileSystemCache
 {
-    private final Tracer tracer;
+    private static final Logger log = Logger.get(NativeFileSystemCache.class);
+
     private final List<NativeCacheDirectory> cacheDirectories;
-    private final NativeFileSystemCacheStats stats;
     private final int pageSize;
+    private final NativeFileSystemCacheStats stats;
+    private final Tracer tracer;
+    private final List<ScheduledExecutorService> maintenanceExecutors;
 
     @Inject
-    public NativeFileSystemCache(Tracer tracer, NativeFileSystemCacheConfig config, NativeFileSystemCacheStats stats)
+    public NativeFileSystemCache(NativeFileSystemCacheConfig config, NativeFileSystemCacheStats stats, Tracer tracer)
     {
-        this.tracer = requireNonNull(tracer, "tracer is null");
-        requireNonNull(config, "config is null");
-        this.stats = requireNonNull(stats, "stats is null");
+        this.cacheDirectories = createCacheDirectories(requireNonNull(config, "config is null"), requireNonNull(stats, "stats is null"));
         this.pageSize = toIntExact(config.getCachePageSize().toBytes());
-        validate(config);
-        this.cacheDirectories = config.getCacheDirectories().stream()
-                .map(Path::of)
-                .map(path -> createCacheDirectory(path, stats))
+        this.stats = stats;
+        this.tracer = tracer;
+        this.maintenanceExecutors = IntStream.range(0, cacheDirectories.size())
+                .mapToObj(index -> newSingleThreadScheduledExecutor(daemonThreadsNamed("native-file-system-cache-maintenance-" + index)))
                 .collect(toImmutableList());
-    }
-
-    @VisibleForTesting
-    NativeFileSystemCache(List<Path> cacheDirectories, DataSize pageSize, NativeFileSystemCacheStats stats)
-    {
-        this(TracerProvider.noop().get("native-file-system-cache"), cacheDirectories, pageSize, stats);
-    }
-
-    @VisibleForTesting
-    NativeFileSystemCache(Tracer tracer, List<Path> cacheDirectories, DataSize pageSize, NativeFileSystemCacheStats stats)
-    {
-        this.stats = requireNonNull(stats, "stats is null");
-        this.tracer = requireNonNull(tracer, "tracer is null");
-        this.pageSize = toIntExact(pageSize.toBytes());
-        this.cacheDirectories = cacheDirectories.stream()
-                .map(path -> createCacheDirectory(path, stats))
-                .collect(toImmutableList());
+        startMaintenance();
     }
 
     @Override
@@ -114,6 +104,41 @@ public class NativeFileSystemCache
         }
     }
 
+    @PreDestroy
+    public void shutdown()
+    {
+        maintenanceExecutors.forEach(ScheduledExecutorService::shutdownNow);
+    }
+
+    private void startMaintenance()
+    {
+        for (int index = 0; index < cacheDirectories.size(); index++) {
+            startMaintenance(cacheDirectories.get(index), maintenanceExecutors.get(index));
+        }
+    }
+
+    private static void startMaintenance(NativeCacheDirectory cacheDirectory, ScheduledExecutorService maintenanceExecutor)
+    {
+        maintenanceExecutor.execute(() -> {
+            try {
+                cacheDirectory.initialize();
+            }
+            catch (RuntimeException | Error e) {
+                // This background task runs without a retained Future to report failures.
+                log.error(e, "Error initializing native file system cache directory: %s", cacheDirectory);
+            }
+        });
+        maintenanceExecutor.scheduleWithFixedDelay(() -> {
+            try {
+                cacheDirectory.maintenance();
+            }
+            catch (RuntimeException | Error e) {
+                // scheduleWithFixedDelay stops future executions when a failure escapes.
+                log.error(e, "Error maintaining native file system cache directory: %s", cacheDirectory);
+            }
+        }, 1, 1, HOURS);
+    }
+
     private NativeCacheFile cacheFile(TrinoInputFile delegate, String key)
             throws IOException
     {
@@ -126,30 +151,55 @@ public class NativeFileSystemCache
         return cacheDirectories.get(index);
     }
 
-    private static NativeCacheDirectory createCacheDirectory(Path path, NativeFileSystemCacheStats stats)
+    @VisibleForTesting
+    List<NativeCacheDirectory> getCacheDirectories()
     {
-        try {
-            return new NativeCacheDirectory(path, stats);
-        }
-        catch (IOException e) {
-            throw new IllegalArgumentException("Failed to initialize cache directory: " + path, e);
-        }
+        return cacheDirectories;
     }
 
-    private static void validate(NativeFileSystemCacheConfig config)
+    private static List<NativeCacheDirectory> createCacheDirectories(NativeFileSystemCacheConfig config, NativeFileSystemCacheStats stats)
     {
-        checkArgument(!config.getCacheDirectories().isEmpty(), "%s must be specified", CACHE_DIRECTORIES);
-        config.getCacheDirectories().forEach(directory -> canWrite(Path.of(directory)));
+        List<DataSize> maxCacheSizes = maxCacheSizes(config);
+        DataSize accessTrackingMemory = DataSize.ofBytes(Math.max(1, config.getAccessTrackingMemory().toBytes() / config.getCacheDirectories().size()));
+        return IntStream.range(0, config.getCacheDirectories().size())
+                .mapToObj(index -> {
+                    Path path = Path.of(config.getCacheDirectories().get(index));
+                    try {
+                        BloomFilterAccessTracker accessTracker = new BloomFilterAccessTracker(path, config.getAccessHistoryDuration(), config.getAccessBucketDuration(), accessTrackingMemory, stats);
+                        return new NativeCacheDirectory(path, maxCacheSizes.get(index).toBytes(), config.getMaxCacheFilesPerDirectory(), config.getCacheTTL(), accessTracker, stats);
+                    }
+                    catch (IOException e) {
+                        throw new IllegalArgumentException("Failed to initialize cache directory: " + path, e);
+                    }
+                })
+                .collect(toImmutableList());
     }
 
-    private static void canWrite(Path path)
+    private static List<DataSize> maxCacheSizes(NativeFileSystemCacheConfig config)
+    {
+        if (!config.getMaxCacheSizes().isEmpty()) {
+            return config.getMaxCacheSizes();
+        }
+        List<DataSize> sizes = new ArrayList<>(config.getCacheDirectories().size());
+        for (int index = 0; index < config.getCacheDirectories().size(); index++) {
+            long totalSpace = totalSpace(Path.of(config.getCacheDirectories().get(index)));
+            sizes.add(DataSize.ofBytes(Math.round(config.getMaxCacheDiskUsagePercentages().get(index) / 100.0 * totalSpace)));
+        }
+        return sizes;
+    }
+
+    @VisibleForTesting
+    static long totalSpace(Path path)
     {
         Path originalPath = path;
         while (!Files.exists(path) && path.getParent() != null) {
             path = path.getParent();
         }
-        checkArgument(Files.isDirectory(path), "Cache directory %s is not a directory", path);
-        checkArgument(Files.isReadable(path), "Cannot read from cache directory %s", originalPath);
-        checkArgument(Files.isWritable(path), "Cannot write to cache directory %s", originalPath);
+        try {
+            return Files.getFileStore(path).getTotalSpace();
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("Failed to get total space for cache directory: " + originalPath, e);
+        }
     }
 }

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCache.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCache.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.filesystem.cache.local.NativeFileSystemCacheConfig.CACHE_DIRECTORIES;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class NativeFileSystemCache
+        implements TrinoFileSystemCache
+{
+    private final Tracer tracer;
+    private final List<NativeCacheDirectory> cacheDirectories;
+    private final NativeFileSystemCacheStats stats;
+    private final int pageSize;
+
+    @Inject
+    public NativeFileSystemCache(Tracer tracer, NativeFileSystemCacheConfig config, NativeFileSystemCacheStats stats)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        requireNonNull(config, "config is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.pageSize = toIntExact(config.getCachePageSize().toBytes());
+        validate(config);
+        this.cacheDirectories = config.getCacheDirectories().stream()
+                .map(Path::of)
+                .map(path -> createCacheDirectory(path, stats))
+                .collect(toImmutableList());
+    }
+
+    @VisibleForTesting
+    NativeFileSystemCache(List<Path> cacheDirectories, DataSize pageSize, NativeFileSystemCacheStats stats)
+    {
+        this(TracerProvider.noop().get("native-file-system-cache"), cacheDirectories, pageSize, stats);
+    }
+
+    @VisibleForTesting
+    NativeFileSystemCache(Tracer tracer, List<Path> cacheDirectories, DataSize pageSize, NativeFileSystemCacheStats stats)
+    {
+        this.stats = requireNonNull(stats, "stats is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.pageSize = toIntExact(pageSize.toBytes());
+        this.cacheDirectories = cacheDirectories.stream()
+                .map(path -> createCacheDirectory(path, stats))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public TrinoInput cacheInput(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new NativeCacheInput(cacheFile(delegate, key));
+    }
+
+    @Override
+    public TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new NativeCacheInputStream(cacheFile(delegate, key));
+    }
+
+    @Override
+    public long cacheLength(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return delegate.length();
+    }
+
+    @Override
+    public void expire(Location location)
+            throws IOException
+    {
+        for (NativeCacheDirectory cacheDirectory : cacheDirectories) {
+            cacheDirectory.expire(location);
+        }
+    }
+
+    @Override
+    public void expire(Collection<Location> locations)
+            throws IOException
+    {
+        for (NativeCacheDirectory cacheDirectory : cacheDirectories) {
+            cacheDirectory.expire(locations);
+        }
+    }
+
+    private NativeCacheFile cacheFile(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new NativeCacheFile(tracer, delegate, key, cacheDirectory(delegate.location()), stats, pageSize, delegate.length());
+    }
+
+    private NativeCacheDirectory cacheDirectory(Location location)
+    {
+        int index = Math.floorMod(CacheFileLayout.hash(location.toString()).hashCode(), cacheDirectories.size());
+        return cacheDirectories.get(index);
+    }
+
+    private static NativeCacheDirectory createCacheDirectory(Path path, NativeFileSystemCacheStats stats)
+    {
+        try {
+            return new NativeCacheDirectory(path, stats);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("Failed to initialize cache directory: " + path, e);
+        }
+    }
+
+    private static void validate(NativeFileSystemCacheConfig config)
+    {
+        checkArgument(!config.getCacheDirectories().isEmpty(), "%s must be specified", CACHE_DIRECTORIES);
+        config.getCacheDirectories().forEach(directory -> canWrite(Path.of(directory)));
+    }
+
+    private static void canWrite(Path path)
+    {
+        Path originalPath = path;
+        while (!Files.exists(path) && path.getParent() != null) {
+            path = path.getParent();
+        }
+        checkArgument(Files.isDirectory(path), "Cache directory %s is not a directory", path);
+        checkArgument(Files.isReadable(path), "Cannot read from cache directory %s", originalPath);
+        checkArgument(Files.isWritable(path), "Cannot write to cache directory %s", originalPath);
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheConfig.java
@@ -17,18 +17,33 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 
 public class NativeFileSystemCacheConfig
 {
-    static final String CACHE_DIRECTORIES = "fs.cache.directories";
+    private static final String CACHE_DIRECTORIES = "fs.cache.directories";
+    private static final String CACHE_MAX_SIZES = "fs.cache.max-sizes";
+    private static final String CACHE_MAX_PERCENTAGES = "fs.cache.max-disk-usage-percentages";
 
     private List<String> cacheDirectories = ImmutableList.of();
+    private List<DataSize> maxCacheSizes = ImmutableList.of();
+    private Optional<Duration> cacheTTL = Optional.of(Duration.valueOf("7d"));
+    private List<Integer> maxCacheDiskUsagePercentages = ImmutableList.of();
     private DataSize cachePageSize = DataSize.valueOf("1MB");
+    private long maxCacheFilesPerDirectory = 10_000_000;
+    private Duration accessHistoryDuration = Duration.valueOf("24h");
+    private Duration accessBucketDuration = Duration.valueOf("10m");
+    private DataSize accessTrackingMemory = DataSize.valueOf("256MB");
 
     @NotNull
     public List<String> getCacheDirectories()
@@ -44,6 +59,52 @@ public class NativeFileSystemCacheConfig
         return this;
     }
 
+    public List<DataSize> getMaxCacheSizes()
+    {
+        return maxCacheSizes;
+    }
+
+    @Config(CACHE_MAX_SIZES)
+    @ConfigDescription("The maximum cache size for a cache directory. Use a comma-separated list of sizes to specify allowed maximum values for each directory.")
+    public NativeFileSystemCacheConfig setMaxCacheSizes(List<DataSize> maxCacheSizes)
+    {
+        this.maxCacheSizes = ImmutableList.copyOf(maxCacheSizes);
+        return this;
+    }
+
+    @NotNull
+    public Optional<@MinDuration("0s") Duration> getCacheTTL()
+    {
+        return cacheTTL;
+    }
+
+    @Config("fs.cache.ttl")
+    @ConfigDescription("Maximum duration cached files are kept before they are eligible for best-effort eviction")
+    public NativeFileSystemCacheConfig setCacheTTL(Duration cacheTTL)
+    {
+        this.cacheTTL = Optional.of(cacheTTL);
+        return this;
+    }
+
+    public NativeFileSystemCacheConfig disableTTL()
+    {
+        this.cacheTTL = Optional.empty();
+        return this;
+    }
+
+    public List<@Min(0) @Max(100) Integer> getMaxCacheDiskUsagePercentages()
+    {
+        return maxCacheDiskUsagePercentages;
+    }
+
+    @Config(CACHE_MAX_PERCENTAGES)
+    @ConfigDescription("The maximum percentage (0-100) of total disk size the cache can use. Use a comma-separated list of percentage values if supplying several cache directories.")
+    public NativeFileSystemCacheConfig setMaxCacheDiskUsagePercentages(List<Integer> maxCacheDiskUsagePercentages)
+    {
+        this.maxCacheDiskUsagePercentages = ImmutableList.copyOf(maxCacheDiskUsagePercentages);
+        return this;
+    }
+
     @NotNull
     @MaxDataSize("15MB")
     @MinDataSize("64kB")
@@ -53,10 +114,97 @@ public class NativeFileSystemCacheConfig
     }
 
     @Config("fs.cache.page-size")
-    @ConfigDescription("Page size for cache")
+    @ConfigDescription("Size of cached file chunks")
     public NativeFileSystemCacheConfig setCachePageSize(DataSize cachePageSize)
     {
         this.cachePageSize = cachePageSize;
         return this;
+    }
+
+    @Min(1)
+    public long getMaxCacheFilesPerDirectory()
+    {
+        return maxCacheFilesPerDirectory;
+    }
+
+    @Config("fs.cache.max-files-per-directory")
+    @ConfigDescription("Maximum number of cached chunk files in each cache directory")
+    public NativeFileSystemCacheConfig setMaxCacheFilesPerDirectory(long maxCacheFilesPerDirectory)
+    {
+        this.maxCacheFilesPerDirectory = maxCacheFilesPerDirectory;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1m")
+    public Duration getAccessHistoryDuration()
+    {
+        return accessHistoryDuration;
+    }
+
+    @Config("fs.cache.access-history-duration")
+    @ConfigDescription("Duration of approximate recent cache access history to keep for eviction")
+    public NativeFileSystemCacheConfig setAccessHistoryDuration(Duration accessHistoryDuration)
+    {
+        this.accessHistoryDuration = accessHistoryDuration;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1m")
+    public Duration getAccessBucketDuration()
+    {
+        return accessBucketDuration;
+    }
+
+    @Config("fs.cache.access-bucket-duration")
+    @ConfigDescription("Duration of each approximate access tracking bucket")
+    public NativeFileSystemCacheConfig setAccessBucketDuration(Duration accessBucketDuration)
+    {
+        this.accessBucketDuration = accessBucketDuration;
+        return this;
+    }
+
+    @NotNull
+    @MinDataSize("1MB")
+    public DataSize getAccessTrackingMemory()
+    {
+        return accessTrackingMemory;
+    }
+
+    @Config("fs.cache.access-tracking-memory")
+    @ConfigDescription("Maximum memory used for approximate recent access tracking")
+    public NativeFileSystemCacheConfig setAccessTrackingMemory(DataSize accessTrackingMemory)
+    {
+        this.accessTrackingMemory = accessTrackingMemory;
+        return this;
+    }
+
+    @AssertTrue(message = CACHE_DIRECTORIES + " must be specified")
+    public boolean isCacheDirectoriesConfigured()
+    {
+        return !cacheDirectories.isEmpty();
+    }
+
+    @AssertTrue(message = "Either " + CACHE_MAX_SIZES + " or " + CACHE_MAX_PERCENTAGES + " must be specified")
+    public boolean isCacheMaxSizeConfigured()
+    {
+        return maxCacheSizes.isEmpty() ^ maxCacheDiskUsagePercentages.isEmpty();
+    }
+
+    @AssertTrue(message = CACHE_DIRECTORIES + " and configured cache size limits must have the same size")
+    public boolean isCacheMaxSizeCountValid()
+    {
+        if (!isCacheMaxSizeConfigured()) {
+            return true;
+        }
+        int size = maxCacheSizes.isEmpty() ? maxCacheDiskUsagePercentages.size() : maxCacheSizes.size();
+        return cacheDirectories.size() == size;
+    }
+
+    @AssertTrue(message = "fs.cache.access-history-duration must be greater than or equal to fs.cache.access-bucket-duration")
+    public boolean isAccessDurationValid()
+    {
+        return accessHistoryDuration.toMillis() >= accessBucketDuration.toMillis();
     }
 }

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.MaxDataSize;
+import io.airlift.units.MinDataSize;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public class NativeFileSystemCacheConfig
+{
+    static final String CACHE_DIRECTORIES = "fs.cache.directories";
+
+    private List<String> cacheDirectories = ImmutableList.of();
+    private DataSize cachePageSize = DataSize.valueOf("1MB");
+
+    @NotNull
+    public List<String> getCacheDirectories()
+    {
+        return cacheDirectories;
+    }
+
+    @Config(CACHE_DIRECTORIES)
+    @ConfigDescription("Base directory to cache data. Use a comma-separated list to cache data in multiple directories.")
+    public NativeFileSystemCacheConfig setCacheDirectories(List<String> cacheDirectories)
+    {
+        this.cacheDirectories = ImmutableList.copyOf(cacheDirectories);
+        return this;
+    }
+
+    @NotNull
+    @MaxDataSize("15MB")
+    @MinDataSize("64kB")
+    public DataSize getCachePageSize()
+    {
+        return cachePageSize;
+    }
+
+    @Config("fs.cache.page-size")
+    @ConfigDescription("Page size for cache")
+    public NativeFileSystemCacheConfig setCachePageSize(DataSize cachePageSize)
+    {
+        this.cachePageSize = cachePageSize;
+        return this;
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheModule.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheModule.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.inject.Binder;
+import com.google.inject.Provider;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.cache.CacheSplitAffinityProvider;
+import io.trino.filesystem.cache.SplitAffinityProvider;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+import io.trino.spi.catalog.CatalogName;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class NativeFileSystemCacheModule
+        extends AbstractConfigurationAwareModule
+{
+    private final boolean isCoordinator;
+
+    public NativeFileSystemCacheModule(boolean isCoordinator)
+    {
+        this.isCoordinator = isCoordinator;
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(NativeFileSystemCacheConfig.class);
+        binder.bind(NativeFileSystemCacheStats.class).in(SINGLETON);
+        Provider<CatalogName> catalogName = binder.getProvider(CatalogName.class);
+        newExporter(binder).export(NativeFileSystemCacheStats.class)
+                .as(generator -> generator.generatedNameOf(NativeFileSystemCacheStats.class, catalogName.get().toString()));
+
+        if (isCoordinator) {
+            newOptionalBinder(binder, SplitAffinityProvider.class).setBinding().to(CacheSplitAffinityProvider.class).in(SINGLETON);
+        }
+        binder.bind(TrinoFileSystemCache.class).to(NativeFileSystemCache.class).in(SINGLETON);
+    }
+}

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheStats.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheStats.java
@@ -25,6 +25,15 @@ public class NativeFileSystemCacheStats
     private final AtomicLong externalReads = new AtomicLong();
     private final AtomicLong cacheWrites = new AtomicLong();
     private final AtomicLong cacheWriteFailures = new AtomicLong();
+    private final AtomicLong cacheWriteSkips = new AtomicLong();
+    private final AtomicLong cachedBytes = new AtomicLong();
+    private final AtomicLong cachedFiles = new AtomicLong();
+    private final AtomicLong evictionCount = new AtomicLong();
+    private final AtomicLong evictionBytes = new AtomicLong();
+    private final AtomicLong evictionFiles = new AtomicLong();
+    private final AtomicLong expiredFiles = new AtomicLong();
+    private final AtomicLong staleTemporaryFiles = new AtomicLong();
+    private final AtomicLong accessRecords = new AtomicLong();
 
     void recordCacheRead(long bytes)
     {
@@ -46,6 +55,50 @@ public class NativeFileSystemCacheStats
     void recordCacheWriteFailure()
     {
         cacheWriteFailures.incrementAndGet();
+    }
+
+    void recordCacheWriteSkip()
+    {
+        cacheWriteSkips.incrementAndGet();
+    }
+
+    void addCachedFile(long bytes)
+    {
+        cachedFiles.incrementAndGet();
+        cachedBytes.addAndGet(bytes);
+    }
+
+    void removeCachedFiles(long files, long bytes)
+    {
+        adjustCachedFiles(-files, -bytes);
+    }
+
+    void adjustCachedFiles(long files, long bytes)
+    {
+        cachedFiles.addAndGet(files);
+        cachedBytes.addAndGet(bytes);
+    }
+
+    void recordEviction(long files, long bytes)
+    {
+        evictionCount.incrementAndGet();
+        evictionFiles.addAndGet(files);
+        evictionBytes.addAndGet(bytes);
+    }
+
+    void recordExpiredFile()
+    {
+        expiredFiles.incrementAndGet();
+    }
+
+    void recordStaleTemporaryFile()
+    {
+        staleTemporaryFiles.incrementAndGet();
+    }
+
+    void recordAccess()
+    {
+        accessRecords.incrementAndGet();
     }
 
     @Managed
@@ -82,5 +135,59 @@ public class NativeFileSystemCacheStats
     public long getCacheWriteFailures()
     {
         return cacheWriteFailures.get();
+    }
+
+    @Managed
+    public long getCacheWriteSkips()
+    {
+        return cacheWriteSkips.get();
+    }
+
+    @Managed
+    public long getCachedBytes()
+    {
+        return cachedBytes.get();
+    }
+
+    @Managed
+    public long getCachedFiles()
+    {
+        return cachedFiles.get();
+    }
+
+    @Managed
+    public long getEvictionCount()
+    {
+        return evictionCount.get();
+    }
+
+    @Managed
+    public long getEvictionBytes()
+    {
+        return evictionBytes.get();
+    }
+
+    @Managed
+    public long getEvictionFiles()
+    {
+        return evictionFiles.get();
+    }
+
+    @Managed
+    public long getExpiredFiles()
+    {
+        return expiredFiles.get();
+    }
+
+    @Managed
+    public long getStaleTemporaryFiles()
+    {
+        return staleTemporaryFiles.get();
+    }
+
+    @Managed
+    public long getAccessRecords()
+    {
+        return accessRecords.get();
     }
 }

--- a/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheStats.java
+++ b/lib/trino-filesystem-cache/src/main/java/io/trino/filesystem/cache/local/NativeFileSystemCacheStats.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import org.weakref.jmx.Managed;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class NativeFileSystemCacheStats
+{
+    private final AtomicLong cacheReadBytes = new AtomicLong();
+    private final AtomicLong externalReadBytes = new AtomicLong();
+    private final AtomicLong cacheReads = new AtomicLong();
+    private final AtomicLong externalReads = new AtomicLong();
+    private final AtomicLong cacheWrites = new AtomicLong();
+    private final AtomicLong cacheWriteFailures = new AtomicLong();
+
+    void recordCacheRead(long bytes)
+    {
+        cacheReads.incrementAndGet();
+        cacheReadBytes.addAndGet(bytes);
+    }
+
+    void recordExternalRead(long bytes)
+    {
+        externalReads.incrementAndGet();
+        externalReadBytes.addAndGet(bytes);
+    }
+
+    void recordCacheWrite()
+    {
+        cacheWrites.incrementAndGet();
+    }
+
+    void recordCacheWriteFailure()
+    {
+        cacheWriteFailures.incrementAndGet();
+    }
+
+    @Managed
+    public long getCacheReadBytes()
+    {
+        return cacheReadBytes.get();
+    }
+
+    @Managed
+    public long getExternalReadBytes()
+    {
+        return externalReadBytes.get();
+    }
+
+    @Managed
+    public long getCacheReads()
+    {
+        return cacheReads.get();
+    }
+
+    @Managed
+    public long getExternalReads()
+    {
+        return externalReads.get();
+    }
+
+    @Managed
+    public long getCacheWrites()
+    {
+        return cacheWrites.get();
+    }
+
+    @Managed
+    public long getCacheWriteFailures()
+    {
+        return cacheWriteFailures.get();
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/IncompleteStreamMemoryFileSystem.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/IncompleteStreamMemoryFileSystem.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.memory.MemoryFileSystem;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Random;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Simulates a file system where TrinoInputStream.read(buffer, offset, length) can return fewer than length bytes.
+ */
+class IncompleteStreamMemoryFileSystem
+        extends MemoryFileSystem
+{
+    @Override
+    public TrinoInputFile newInputFile(Location location)
+    {
+        return new IncompleteStreamInputFile(super.newInputFile(location));
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length)
+    {
+        return new IncompleteStreamInputFile(super.newInputFile(location, length));
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new IncompleteStreamInputFile(super.newInputFile(location, length, lastModified));
+    }
+
+    private record IncompleteStreamInputFile(TrinoInputFile delegate)
+            implements TrinoInputFile
+    {
+        private IncompleteStreamInputFile
+        {
+            requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public TrinoInput newInput()
+                throws IOException
+        {
+            return delegate.newInput();
+        }
+
+        @Override
+        public TrinoInputStream newStream()
+                throws IOException
+        {
+            return new IncompleteTrinoInputStream(delegate.newStream());
+        }
+
+        @Override
+        public long length()
+                throws IOException
+        {
+            return delegate.length();
+        }
+
+        @Override
+        public Instant lastModified()
+                throws IOException
+        {
+            return delegate.lastModified();
+        }
+
+        @Override
+        public boolean exists()
+                throws IOException
+        {
+            return delegate.exists();
+        }
+
+        @Override
+        public Location location()
+        {
+            return delegate.location();
+        }
+    }
+
+    private static class IncompleteTrinoInputStream
+            extends TrinoInputStream
+    {
+        private final TrinoInputStream delegate;
+        private final Random random = new Random(42);
+
+        IncompleteTrinoInputStream(TrinoInputStream delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length)
+                throws IOException
+        {
+            if (length == 0) {
+                return 0;
+            }
+            return delegate.read(buffer, offset, random.nextInt(1, length + 1));
+        }
+
+        @Override
+        public long getPosition()
+                throws IOException
+        {
+            return delegate.getPosition();
+        }
+
+        @Override
+        public void seek(long position)
+                throws IOException
+        {
+            delegate.seek(position);
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/IncompleteStreamMemoryFileSystem.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/IncompleteStreamMemoryFileSystem.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.memory.MemoryFileSystem;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Random;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Simulates a file system where TrinoInputStream.read(buffer, offset, length) can return fewer than length bytes.
+ */
+class IncompleteStreamMemoryFileSystem
+        extends MemoryFileSystem
+{
+    @Override
+    public TrinoInputFile newInputFile(Location location)
+    {
+        return new IncompleteStreamInputFile(super.newInputFile(location));
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length)
+    {
+        return new IncompleteStreamInputFile(super.newInputFile(location, length));
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+    {
+        return new IncompleteStreamInputFile(super.newInputFile(location, length, lastModified));
+    }
+
+    private record IncompleteStreamInputFile(TrinoInputFile delegate)
+            implements TrinoInputFile
+    {
+        private IncompleteStreamInputFile
+        {
+            requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public TrinoInput newInput()
+                throws IOException
+        {
+            return delegate.newInput();
+        }
+
+        @Override
+        public TrinoInputStream newStream()
+                throws IOException
+        {
+            return new IncompleteTrinoInputStream(delegate.newStream());
+        }
+
+        @Override
+        public long length()
+                throws IOException
+        {
+            return delegate.length();
+        }
+
+        @Override
+        public Instant lastModified()
+                throws IOException
+        {
+            return delegate.lastModified();
+        }
+
+        @Override
+        public boolean exists()
+                throws IOException
+        {
+            return delegate.exists();
+        }
+
+        @Override
+        public Location location()
+        {
+            return delegate.location();
+        }
+    }
+
+    private static class IncompleteTrinoInputStream
+            extends TrinoInputStream
+    {
+        private final TrinoInputStream delegate;
+        private final Random random = new Random(42);
+
+        IncompleteTrinoInputStream(TrinoInputStream delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length)
+                throws IOException
+        {
+            return delegate.read(buffer, offset, random.nextInt(0, length + 1));
+        }
+
+        @Override
+        public long getPosition()
+                throws IOException
+        {
+            return delegate.getPosition();
+        }
+
+        @Override
+        public void seek(long position)
+                throws IOException
+        {
+            delegate.seek(position);
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestBloomFilterAccessTracker.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestBloomFilterAccessTracker.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestBloomFilterAccessTracker
+{
+    @Test
+    void testRotatedBucketsSurviveRestart(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingClock clock = new TestingClock();
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        BloomFilterAccessTracker tracker = new BloomFilterAccessTracker(cacheRoot, Duration.valueOf("10m"), Duration.valueOf("1m"), DataSize.valueOf("1MB"), clock, stats);
+
+        tracker.record("first");
+        clock.advanceMillis(61_000);
+        tracker.record("second");
+
+        BloomFilterAccessTracker restarted = new BloomFilterAccessTracker(cacheRoot, Duration.valueOf("10m"), Duration.valueOf("1m"), DataSize.valueOf("1MB"), clock, new NativeFileSystemCacheStats());
+
+        assertThat(restarted.mightContain("first")).isTrue();
+        assertThat(restarted.lastAccessTime("first")).hasValue(0);
+        assertThat(restarted.mightContain("unknown")).isFalse();
+        assertThat(restarted.lastAccessTime("unknown")).isEmpty();
+        assertThat(stats.getAccessRecords()).isEqualTo(2);
+    }
+
+    @Test
+    void testLastAccessTimeUsesNewestMatchingBucket(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingClock clock = new TestingClock();
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        BloomFilterAccessTracker tracker = new BloomFilterAccessTracker(cacheRoot, Duration.valueOf("10m"), Duration.valueOf("1m"), DataSize.valueOf("1MB"), clock, stats);
+
+        tracker.record("file");
+        clock.advanceMillis(61_000);
+        tracker.record("other");
+        clock.advanceMillis(61_000);
+        tracker.record("file");
+
+        assertThat(tracker.lastAccessTime("file")).hasValue(120_000);
+    }
+
+    private static class TestingClock
+            extends Clock
+    {
+        private long millis;
+
+        void advanceMillis(long millis)
+        {
+            this.millis += millis;
+        }
+
+        @Override
+        public ZoneId getZone()
+        {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Instant instant()
+        {
+            return Instant.ofEpochMilli(millis);
+        }
+
+        @Override
+        public long millis()
+        {
+            return millis;
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestCacheFileLayout.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestCacheFileLayout.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.trino.filesystem.Location;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestCacheFileLayout
+{
+    @Test
+    void testLayoutUsesStableHashes(@TempDir Path cacheRoot)
+    {
+        CacheFileLayout layout = new CacheFileLayout(cacheRoot);
+        Location location = Location.of("s3://bucket/table/file.orc");
+        String cacheKey = "s3://bucket/table/file.orc#version";
+
+        String locationHash = CacheFileLayout.hash(location.toString());
+        String fileHash = CacheFileLayout.hash(cacheKey);
+
+        CacheFileLayout.CacheFile cacheFile = layout.cacheFile(location, cacheKey);
+
+        assertThat(cacheFile.fileHash()).isEqualTo(fileHash);
+        assertThat(cacheFile.fileGroupPath()).isEqualTo(cacheRoot.toAbsolutePath().normalize()
+                .resolve("v1")
+                .resolve("data")
+                .resolve(locationHash.substring(0, 2))
+                .resolve(locationHash.substring(2, 4))
+                .resolve(locationHash)
+                .resolve(fileHash));
+        assertThat(cacheFile.pagePath(42)).isEqualTo(cacheFile.fileGroupPath().resolve("000000000000002a.cache"));
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestFuzzNativeCacheFileSystem.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestFuzzNativeCacheFileSystem.java
@@ -16,6 +16,8 @@ package io.trino.filesystem.cache.local;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.cache.CacheFileSystem;
@@ -188,7 +190,15 @@ class TestFuzzNativeCacheFileSystem
             Path cacheDirectory = Files.createDirectory(tempDirectory.resolve("cache"));
             return new CacheFileSystem(
                     new IncompleteStreamMemoryFileSystem(),
-                    new NativeFileSystemCache(List.of(cacheDirectory), PAGE_SIZE, new NativeFileSystemCacheStats()),
+                    new NativeFileSystemCache(
+                            new NativeFileSystemCacheConfig()
+                                    .setCacheDirectories(List.of(cacheDirectory.toString()))
+                                    .setCachePageSize(PAGE_SIZE)
+                                    .setMaxCacheSizes(List.of(CACHE_SIZE))
+                                    .setMaxCacheFilesPerDirectory(Long.MAX_VALUE / 2)
+                                    .setCacheTTL(Duration.valueOf("7d")),
+                            new NativeFileSystemCacheStats(),
+                            TracerProvider.noop().get("test")),
                     new DefaultCacheKeyProvider());
         }
 

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestFuzzNativeCacheFileSystem.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestFuzzNativeCacheFileSystem.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_METHOD)
+class TestFuzzNativeCacheFileSystem
+{
+    private static final DataSize CACHE_SIZE = DataSize.ofBytes(8 * 1024);
+    private static final DataSize PAGE_SIZE = DataSize.ofBytes(128);
+
+    @Test
+    void testFuzzTrinoInputReadFully()
+            throws IOException
+    {
+        fuzzTrinoInputOperation(
+                (fileSystem, location) -> fileSystem.newInputFile(location).newInput(),
+                (input, position, buffer, bufferOffset, readLength) -> {
+                    input.readFully(position, buffer, bufferOffset, readLength);
+                    return readLength;
+                });
+    }
+
+    @Test
+    void testFuzzTrinoInputReadTail()
+            throws IOException
+    {
+        fuzzTrinoInputOperation(
+                (fileSystem, location) -> fileSystem.newInputFile(location).newInput(),
+                (input, _, buffer, bufferOffset, readLength) -> input.readTail(buffer, bufferOffset, readLength));
+    }
+
+    @Test
+    void testFuzzTrinoInputStreamRead()
+            throws IOException
+    {
+        fuzzTrinoInputOperation(
+                (fileSystem, location) -> fileSystem.newInputFile(location).newStream(),
+                (input, position, buffer, bufferOffset, readLength) -> {
+                    input.seek(position);
+                    return input.read(buffer, bufferOffset, readLength);
+                });
+    }
+
+    @Test
+    void testFuzzTrinoInputStreamReadSkip()
+            throws IOException
+    {
+        fuzzTrinoInputOperation(
+                (fileSystem, location) -> fileSystem.newInputFile(location).newStream(),
+                (input, position, buffer, bufferOffset, readLength) -> {
+                    input.skip(position);
+                    return input.read(buffer, bufferOffset, readLength);
+                });
+    }
+
+    private static <T> void fuzzTrinoInputOperation(CreateTrinoInput<T> createInput, TrinoInputOperation<T> operation)
+            throws IOException
+    {
+        Random random = new Random(42);
+        try (TestFileSystem expectedFileSystemState = new TestMemoryFileSystem();
+                TestFileSystem actualFileSystemState = new TestNativeCacheFileSystem()) {
+            TrinoFileSystem expectedFileSystem = expectedFileSystemState.create();
+            TrinoFileSystem testFileSystem = actualFileSystemState.create();
+
+            Location expectedLocation = expectedFileSystemState.tempLocation();
+            Location testLocation = actualFileSystemState.tempLocation();
+
+            int fileSize = random.nextInt(0, toIntExact(CACHE_SIZE.toBytes() / 2));
+
+            createTestFile(expectedFileSystem, expectedLocation, fileSize);
+            createTestFile(testFileSystem, testLocation, fileSize);
+
+            T expectedInput = createInput.apply(expectedFileSystem, expectedLocation);
+            T actualInput = createInput.apply(testFileSystem, testLocation);
+
+            for (int i = 0; i < 1000; i++) {
+                applyOperation(random, fileSize, expectedInput, actualInput, operation);
+            }
+        }
+    }
+
+    private static <T> void applyOperation(Random random, int fileSize, T expectedInput, T actualInput, TrinoInputOperation<T> operation)
+            throws IOException
+    {
+        long position = random.nextLong(0, fileSize + 1);
+        int bufferSize = random.nextInt(0, fileSize + 1);
+        int bufferOffset = random.nextInt(0, bufferSize + 1);
+        int readLength = bufferSize - bufferOffset;
+        byte[] bufferExpected = new byte[bufferSize];
+        byte[] bufferActual = new byte[bufferSize];
+
+        int expectedBytesRead = operation.apply(expectedInput, position, bufferExpected, bufferOffset, readLength);
+        int actualBytesRead = operation.apply(actualInput, position, bufferActual, bufferOffset, readLength);
+
+        assertThat(actualBytesRead).isEqualTo(expectedBytesRead);
+        assertThat(Slices.wrappedBuffer(bufferActual)).isEqualTo(Slices.wrappedBuffer(bufferExpected));
+    }
+
+    private static void createTestFile(TrinoFileSystem fileSystem, Location location, int fileSize)
+            throws IOException
+    {
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            byte[] bytes = new byte[4];
+            Slice slice = Slices.wrappedBuffer(bytes);
+            for (int i = 0; i < fileSize; i++) {
+                slice.setInt(0, i);
+                output.write(bytes, 0, min(fileSize - i, 4));
+            }
+        }
+    }
+
+    private interface TestFileSystem
+            extends Closeable
+    {
+        TrinoFileSystem create()
+                throws IOException;
+
+        Location tempLocation();
+    }
+
+    private static class TestMemoryFileSystem
+            implements TestFileSystem
+    {
+        @Override
+        public TrinoFileSystem create()
+        {
+            return new MemoryFileSystemFactory().create(ConnectorIdentity.ofUser(""));
+        }
+
+        @Override
+        public Location tempLocation()
+        {
+            return Location.of("memory:///fuzz");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class TestNativeCacheFileSystem
+            implements TestFileSystem
+    {
+        private Path tempDirectory;
+
+        @Override
+        public TrinoFileSystem create()
+                throws IOException
+        {
+            tempDirectory = Files.createTempDirectory("test");
+            Path cacheDirectory = Files.createDirectory(tempDirectory.resolve("cache"));
+            return new CacheFileSystem(
+                    new IncompleteStreamMemoryFileSystem(),
+                    new NativeFileSystemCache(List.of(cacheDirectory), PAGE_SIZE, new NativeFileSystemCacheStats()),
+                    new DefaultCacheKeyProvider());
+        }
+
+        @Override
+        public Location tempLocation()
+        {
+            return Location.of("memory:///fuzz");
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            deleteRecursively(tempDirectory, ALLOW_INSECURE);
+        }
+    }
+
+    private interface TrinoInputOperation<T>
+    {
+        int apply(T input, long position, byte[] buffer, int bufferOffset, int readLength)
+                throws IOException;
+    }
+
+    private interface CreateTrinoInput<T>
+    {
+        T apply(TrinoFileSystem fileSystem, Location location)
+                throws IOException;
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystem.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystem.java
@@ -14,6 +14,8 @@
 package io.trino.filesystem.cache.local;
 
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
@@ -48,7 +50,15 @@ public class TestNativeCacheFileSystem
         memoryFileSystem = new IncompleteStreamMemoryFileSystem();
         fileSystem = new CacheFileSystem(
                 memoryFileSystem,
-                new NativeFileSystemCache(List.of(cacheDirectory), DataSize.valueOf("32003B"), new NativeFileSystemCacheStats()),
+                new NativeFileSystemCache(
+                        new NativeFileSystemCacheConfig()
+                                .setCacheDirectories(List.of(cacheDirectory.toString()))
+                                .setCachePageSize(DataSize.valueOf("32003B"))
+                                .setMaxCacheSizes(List.of(DataSize.valueOf("1GB")))
+                                .setMaxCacheFilesPerDirectory(Long.MAX_VALUE / 2)
+                                .setCacheTTL(Duration.valueOf("7d")),
+                        new NativeFileSystemCacheStats(),
+                        TracerProvider.noop().get("test")),
                 new DefaultCacheKeyProvider());
     }
 

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystem.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystem.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.airlift.units.DataSize;
+import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestNativeCacheFileSystem
+        extends AbstractTestTrinoFileSystem
+{
+    private MemoryFileSystem memoryFileSystem;
+    private CacheFileSystem fileSystem;
+    private Path tempDirectory;
+
+    @BeforeAll
+    void beforeAll()
+            throws IOException
+    {
+        tempDirectory = Files.createTempDirectory("test");
+        Path cacheDirectory = Files.createDirectory(tempDirectory.resolve("cache"));
+        memoryFileSystem = new IncompleteStreamMemoryFileSystem();
+        fileSystem = new CacheFileSystem(
+                memoryFileSystem,
+                new NativeFileSystemCache(List.of(cacheDirectory), DataSize.valueOf("32003B"), new NativeFileSystemCacheStats()),
+                new DefaultCacheKeyProvider());
+    }
+
+    @AfterAll
+    void afterAll()
+            throws IOException
+    {
+        deleteRecursively(tempDirectory, ALLOW_INSECURE);
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return false;
+    }
+
+    @Override
+    protected TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return Location.of("memory://");
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        assertThat(memoryFileSystem.isEmpty()).isTrue();
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
@@ -17,6 +17,7 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.filesystem.Location;
@@ -117,7 +118,15 @@ final class TestNativeCacheFileSystemAccessOperations
     {
         TestingTelemetry telemetry = TestingTelemetry.create("local-cache");
         TracingFileSystemFactory tracingFileSystemFactory = new TracingFileSystemFactory(telemetry.getTracer(), new MemoryFileSystemFactory());
-        NativeFileSystemCache cache = new NativeFileSystemCache(telemetry.getTracer(), List.of(cacheRoot), DataSize.ofBytes(PAGE_SIZE), new NativeFileSystemCacheStats());
+        NativeFileSystemCache cache = new NativeFileSystemCache(
+                new NativeFileSystemCacheConfig()
+                        .setCacheDirectories(List.of(cacheRoot.toString()))
+                        .setCachePageSize(DataSize.ofBytes(PAGE_SIZE))
+                        .setMaxCacheSizes(List.of(DataSize.valueOf("1GB")))
+                        .setMaxCacheFilesPerDirectory(Long.MAX_VALUE / 2)
+                        .setCacheTTL(Duration.valueOf("7d")),
+                new NativeFileSystemCacheStats(),
+                telemetry.getTracer());
         CacheFileSystem fileSystem = new CacheFileSystem(
                 tracingFileSystemFactory.create(ConnectorIdentity.ofUser("test")),
                 new TracingFileSystemCache(telemetry.getTracer(), cache),

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.airlift.units.DataSize;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.CacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.filesystem.tracing.TracingFileSystemCache;
+import io.trino.filesystem.tracing.TracingFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.TestingTelemetry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_SIZE;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_WRITE_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_WRITE_SIZE;
+import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_LOCATION;
+import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_READ_SIZE;
+import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestNativeCacheFileSystemAccessOperations
+{
+    private static final int PAGE_SIZE = 128;
+    private static final CacheKeyProvider PATH_CACHE_KEY_PROVIDER = inputFile -> Optional.of(inputFile.location().path());
+
+    @Test
+    void testPositionedReadTracing(@TempDir Path cacheRoot)
+            throws IOException
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///positioned");
+        byte[] content = "hello world".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        List<SpanData> spans = fileSystem.telemetry().captureSpans(() -> {
+            TrinoInputFile inputFile = fileSystem.fileSystem().newInputFile(location);
+            try (TrinoInput input = inputFile.newInput()) {
+                assertThat(input.readFully(0, content.length)).isEqualTo(wrappedBuffer(content));
+                assertThat(input.readFully(0, content.length)).isEqualTo(wrappedBuffer(content));
+            }
+        });
+
+        assertMultisetsEqual(getCacheOperations(spans), ImmutableMultiset.<CacheOperationSpan>builder()
+                .addCopies(new CacheOperationSpan("NativeCache.readCached", location.toString(), 0, content.length), 2)
+                .add(new CacheOperationSpan("Input.readFully", location.toString(), 0, content.length))
+                .add(new CacheOperationSpan("NativeCache.readExternalStream", location.toString(), 0, content.length))
+                .add(new CacheOperationSpan("NativeCache.writeCache", location.toString(), 0, content.length))
+                .build());
+    }
+
+    @Test
+    void testStreamReadTracing(@TempDir Path cacheRoot)
+            throws IOException
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///stream");
+        byte[] content = "hello world".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        List<SpanData> spans = fileSystem.telemetry().captureSpans(() -> {
+            byte[] buffer = new byte[content.length];
+            try (TrinoInputStream stream = fileSystem.fileSystem().newInputFile(location).newStream()) {
+                assertThat(stream.read(buffer, 0, buffer.length)).isEqualTo(buffer.length);
+            }
+            assertThat(buffer).isEqualTo(content);
+
+            try (TrinoInputStream stream = fileSystem.fileSystem().newInputFile(location).newStream()) {
+                assertThat(stream.read(buffer, 0, buffer.length)).isEqualTo(buffer.length);
+            }
+            assertThat(buffer).isEqualTo(content);
+        });
+
+        assertMultisetsEqual(getCacheOperations(spans), ImmutableMultiset.<CacheOperationSpan>builder()
+                .addCopies(new CacheOperationSpan("NativeCache.readCached", location.toString(), 0, content.length), 2)
+                .add(new CacheOperationSpan("NativeCache.readExternalStream", location.toString(), 0, content.length))
+                .add(new CacheOperationSpan("NativeCache.writeCache", location.toString(), 0, content.length))
+                .build());
+    }
+
+    private static TestingCacheFileSystem createFileSystem(Path cacheRoot)
+    {
+        TestingTelemetry telemetry = TestingTelemetry.create("local-cache");
+        TracingFileSystemFactory tracingFileSystemFactory = new TracingFileSystemFactory(telemetry.getTracer(), new MemoryFileSystemFactory());
+        NativeFileSystemCache cache = new NativeFileSystemCache(telemetry.getTracer(), List.of(cacheRoot), DataSize.ofBytes(PAGE_SIZE), new NativeFileSystemCacheStats());
+        CacheFileSystem fileSystem = new CacheFileSystem(
+                tracingFileSystemFactory.create(ConnectorIdentity.ofUser("test")),
+                new TracingFileSystemCache(telemetry.getTracer(), cache),
+                PATH_CACHE_KEY_PROVIDER);
+        return new TestingCacheFileSystem(fileSystem, telemetry);
+    }
+
+    private static Multiset<CacheOperationSpan> getCacheOperations(List<SpanData> spans)
+    {
+        return spans.stream()
+                .filter(span -> span.getName().startsWith("Input.") || span.getName().startsWith("NativeCache."))
+                .map(CacheOperationSpan::create)
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private record TestingCacheFileSystem(CacheFileSystem fileSystem, TestingTelemetry telemetry)
+    {
+        void write(Location location, byte[] content)
+                throws IOException
+        {
+            try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+                output.write(content);
+            }
+        }
+    }
+
+    private record CacheOperationSpan(String spanName, String location, long position, long length)
+    {
+        static CacheOperationSpan create(SpanData span)
+        {
+            Attributes attributes = span.getAttributes();
+
+            long length = switch (span.getName()) {
+                case "NativeCache.readCached", "NativeCache.readExternalStream" -> requireNonNull(attributes.get(CACHE_FILE_READ_SIZE));
+                case "NativeCache.writeCache" -> requireNonNull(attributes.get(CACHE_FILE_WRITE_SIZE));
+                case "Input.readFully" -> requireNonNull(attributes.get(FILE_READ_SIZE));
+                default -> throw new IllegalArgumentException("Unrecognized span " + span.getName() + " [" + span.getAttributes() + "]");
+            };
+
+            long position = switch (span.getName()) {
+                case "NativeCache.readCached", "NativeCache.readExternalStream" -> requireNonNull(attributes.get(CACHE_FILE_READ_POSITION));
+                case "NativeCache.writeCache" -> requireNonNull(attributes.get(CACHE_FILE_WRITE_POSITION));
+                case "Input.readFully" -> requireNonNull(attributes.get(FILE_READ_POSITION));
+                default -> throw new IllegalArgumentException("Unrecognized span " + span.getName() + " [" + span.getAttributes() + "]");
+            };
+
+            return new CacheOperationSpan(span.getName(), getLocation(span), position, length);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "CacheOperationSpan(\"%s\", \"%s\", %d, %d)".formatted(spanName, location, position, length);
+        }
+    }
+
+    private static String getLocation(SpanData span)
+    {
+        if (span.getName().startsWith("Input.")) {
+            return requireNonNull(span.getAttributes().get(FILE_LOCATION));
+        }
+        return requireNonNull(span.getAttributes().get(CACHE_FILE_LOCATION));
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
@@ -17,6 +17,7 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.filesystem.Location;
@@ -116,7 +117,15 @@ final class TestNativeCacheFileSystemAccessOperations
     {
         TestingTelemetry telemetry = TestingTelemetry.create("local-cache");
         TracingFileSystemFactory tracingFileSystemFactory = new TracingFileSystemFactory(telemetry.getTracer(), new MemoryFileSystemFactory());
-        NativeFileSystemCache cache = new NativeFileSystemCache(telemetry.getTracer(), List.of(cacheRoot), DataSize.ofBytes(PAGE_SIZE), new NativeFileSystemCacheStats());
+        NativeFileSystemCache cache = new NativeFileSystemCache(
+                new NativeFileSystemCacheConfig()
+                        .setCacheDirectories(List.of(cacheRoot.toString()))
+                        .setCachePageSize(DataSize.ofBytes(PAGE_SIZE))
+                        .setMaxCacheSizes(List.of(DataSize.valueOf("1GB")))
+                        .setMaxCacheFilesPerDirectory(Long.MAX_VALUE / 2)
+                        .setCacheTTL(Duration.valueOf("7d")),
+                new NativeFileSystemCacheStats(),
+                telemetry.getTracer());
         CacheFileSystem fileSystem = new CacheFileSystem(
                 tracingFileSystemFactory.create(ConnectorIdentity.ofUser("test")),
                 new TracingFileSystemCache(telemetry.getTracer(), cache),

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeCacheFileSystemAccessOperations.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.airlift.units.DataSize;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.CacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.filesystem.tracing.TracingFileSystemCache;
+import io.trino.filesystem.tracing.TracingFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.TestingTelemetry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_READ_SIZE;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_WRITE_POSITION;
+import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_WRITE_SIZE;
+import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_LOCATION;
+import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_READ_POSITION;
+import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_READ_SIZE;
+import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestNativeCacheFileSystemAccessOperations
+{
+    private static final int PAGE_SIZE = 128;
+    private static final CacheKeyProvider PATH_CACHE_KEY_PROVIDER = inputFile -> Optional.of(inputFile.location().path());
+
+    @Test
+    void testPositionedReadTracing(@TempDir Path cacheRoot)
+            throws IOException
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///positioned");
+        byte[] content = "hello world".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        List<SpanData> spans = fileSystem.telemetry().captureSpans(() -> {
+            TrinoInputFile inputFile = fileSystem.fileSystem().newInputFile(location);
+            try (TrinoInput input = inputFile.newInput()) {
+                assertThat(input.readFully(0, content.length)).isEqualTo(wrappedBuffer(content));
+                assertThat(input.readFully(0, content.length)).isEqualTo(wrappedBuffer(content));
+            }
+        });
+
+        assertMultisetsEqual(getCacheOperations(spans), ImmutableMultiset.<CacheOperationSpan>builder()
+                .addCopies(new CacheOperationSpan("NativeCache.readCached", location.toString(), 0, content.length), 2)
+                .add(new CacheOperationSpan("Input.readFully", location.toString(), 0, content.length))
+                .add(new CacheOperationSpan("NativeCache.writeCache", location.toString(), 0, content.length))
+                .build());
+    }
+
+    @Test
+    void testStreamReadTracing(@TempDir Path cacheRoot)
+            throws IOException
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///stream");
+        byte[] content = "hello world".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        List<SpanData> spans = fileSystem.telemetry().captureSpans(() -> {
+            byte[] buffer = new byte[content.length];
+            try (TrinoInputStream stream = fileSystem.fileSystem().newInputFile(location).newStream()) {
+                assertThat(stream.read(buffer, 0, buffer.length)).isEqualTo(buffer.length);
+            }
+            assertThat(buffer).isEqualTo(content);
+
+            try (TrinoInputStream stream = fileSystem.fileSystem().newInputFile(location).newStream()) {
+                assertThat(stream.read(buffer, 0, buffer.length)).isEqualTo(buffer.length);
+            }
+            assertThat(buffer).isEqualTo(content);
+        });
+
+        assertMultisetsEqual(getCacheOperations(spans), ImmutableMultiset.<CacheOperationSpan>builder()
+                .addCopies(new CacheOperationSpan("NativeCache.readCached", location.toString(), 0, content.length), 2)
+                .add(new CacheOperationSpan("NativeCache.readExternalStream", location.toString(), 0, content.length))
+                .add(new CacheOperationSpan("NativeCache.writeCache", location.toString(), 0, content.length))
+                .build());
+    }
+
+    private static TestingCacheFileSystem createFileSystem(Path cacheRoot)
+    {
+        TestingTelemetry telemetry = TestingTelemetry.create("local-cache");
+        TracingFileSystemFactory tracingFileSystemFactory = new TracingFileSystemFactory(telemetry.getTracer(), new MemoryFileSystemFactory());
+        NativeFileSystemCache cache = new NativeFileSystemCache(telemetry.getTracer(), List.of(cacheRoot), DataSize.ofBytes(PAGE_SIZE), new NativeFileSystemCacheStats());
+        CacheFileSystem fileSystem = new CacheFileSystem(
+                tracingFileSystemFactory.create(ConnectorIdentity.ofUser("test")),
+                new TracingFileSystemCache(telemetry.getTracer(), cache),
+                PATH_CACHE_KEY_PROVIDER);
+        return new TestingCacheFileSystem(fileSystem, telemetry);
+    }
+
+    private static Multiset<CacheOperationSpan> getCacheOperations(List<SpanData> spans)
+    {
+        return spans.stream()
+                .filter(span -> span.getName().startsWith("Input.") || span.getName().startsWith("NativeCache."))
+                .map(CacheOperationSpan::create)
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private record TestingCacheFileSystem(CacheFileSystem fileSystem, TestingTelemetry telemetry)
+    {
+        void write(Location location, byte[] content)
+                throws IOException
+        {
+            try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+                output.write(content);
+            }
+        }
+    }
+
+    private record CacheOperationSpan(String spanName, String location, long position, long length)
+    {
+        static CacheOperationSpan create(SpanData span)
+        {
+            Attributes attributes = span.getAttributes();
+
+            long length = switch (span.getName()) {
+                case "NativeCache.readCached", "NativeCache.readExternalStream" -> requireNonNull(attributes.get(CACHE_FILE_READ_SIZE));
+                case "NativeCache.writeCache" -> requireNonNull(attributes.get(CACHE_FILE_WRITE_SIZE));
+                case "Input.readFully" -> requireNonNull(attributes.get(FILE_READ_SIZE));
+                default -> throw new IllegalArgumentException("Unrecognized span " + span.getName() + " [" + span.getAttributes() + "]");
+            };
+
+            long position = switch (span.getName()) {
+                case "NativeCache.readCached", "NativeCache.readExternalStream" -> requireNonNull(attributes.get(CACHE_FILE_READ_POSITION));
+                case "NativeCache.writeCache" -> requireNonNull(attributes.get(CACHE_FILE_WRITE_POSITION));
+                case "Input.readFully" -> requireNonNull(attributes.get(FILE_READ_POSITION));
+                default -> throw new IllegalArgumentException("Unrecognized span " + span.getName() + " [" + span.getAttributes() + "]");
+            };
+
+            return new CacheOperationSpan(span.getName(), getLocation(span), position, length);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "CacheOperationSpan(\"%s\", \"%s\", %d, %d)".formatted(spanName, location, position, length);
+        }
+    }
+
+    private static String getLocation(SpanData span)
+    {
+        if (span.getName().startsWith("Input.")) {
+            return requireNonNull(span.getAttributes().get(FILE_LOCATION));
+        }
+        return requireNonNull(span.getAttributes().get(CACHE_FILE_LOCATION));
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCache.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCache.java
@@ -15,6 +15,8 @@ package io.trino.filesystem.cache.local;
 
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.TracerProvider;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInput;
@@ -28,11 +30,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.airlift.slice.Slices.wrappedBuffer;
@@ -214,7 +220,8 @@ final class TestNativeFileSystemCache
             throws Exception
     {
         NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
-        NativeCacheDirectory cacheDirectory = new NativeCacheDirectory(cacheRoot, stats);
+        NativeCacheDirectory cacheDirectory = createCacheDirectory(cacheRoot, stats);
+        cacheDirectory.initialize();
         CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///duplicate"), "key");
         byte[] first = "first page".getBytes(UTF_8);
         byte[] second = "other page".getBytes(UTF_8);
@@ -229,6 +236,324 @@ final class TestNativeFileSystemCache
         assertThat(stats.getCacheWriteFailures()).isEqualTo(0);
     }
 
+    @Test
+    void testWritesAreAllowedBeforeInitialScanCompletes(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = createCacheDirectory(cacheRoot, stats);
+        CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///initializing"), "key");
+        byte[] page = "page".getBytes(UTF_8);
+
+        cacheDirectory.writePage(cacheFile, 0, page, 0, page.length);
+
+        byte[] buffer = new byte[page.length];
+        assertThat(cacheDirectory.readPage(cacheFile, 0, 0, page.length, page.length, buffer, 0)).isTrue();
+        assertThat(buffer).isEqualTo(page);
+        assertThat(stats.getCacheWrites()).isEqualTo(1);
+        assertThat(stats.getCacheWriteSkips()).isEqualTo(0);
+        assertThat(stats.getCachedFiles()).isEqualTo(1);
+
+        cacheDirectory.initialize();
+
+        assertThat(cacheDirectory.readPage(cacheFile, 0, 0, page.length, page.length, buffer, 0)).isTrue();
+        assertThat(buffer).isEqualTo(page);
+        assertThat(stats.getCachedFiles()).isEqualTo(1);
+    }
+
+    @Test
+    void testReadsAreAllowedUntilInitialScanCompletes(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = createCacheDirectory(cacheRoot, stats);
+        cacheDirectory.initialize();
+        CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///initializing-read"), "key");
+        byte[] page = "page".getBytes(UTF_8);
+        cacheDirectory.writePage(cacheFile, 0, page, 0, page.length);
+
+        NativeFileSystemCacheStats restartStats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory restartingCacheDirectory = createCacheDirectory(cacheRoot, restartStats);
+        CacheFileLayout.CacheFile newCacheFile = restartingCacheDirectory.cacheFile(Location.of("memory:///initializing-new-write"), "key");
+        byte[] newPage = "new-page".getBytes(UTF_8);
+        restartingCacheDirectory.writePage(newCacheFile, 0, newPage, 0, newPage.length);
+
+        byte[] buffer = new byte[page.length];
+        assertThat(restartingCacheDirectory.readPage(cacheFile, 0, 0, page.length, page.length, buffer, 0)).isTrue();
+        assertThat(buffer).isEqualTo(page);
+        assertThat(restartStats.getCacheReads()).isEqualTo(1);
+
+        restartingCacheDirectory.initialize();
+
+        byte[] newBuffer = new byte[newPage.length];
+        assertThat(restartingCacheDirectory.readPage(newCacheFile, 0, 0, newPage.length, newPage.length, newBuffer, 0)).isTrue();
+        assertThat(newBuffer).isEqualTo(newPage);
+        assertThat(restartStats.getCachedFiles()).isEqualTo(2);
+    }
+
+    @Test
+    void testSkipsWriteWhenPageExceedsMaxSize(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, new MemoryFileSystem(), DataSize.valueOf("64kB"), DataSize.valueOf("10B"), 100, Optional.of(Duration.valueOf("7d")));
+        Location location = Location.of("memory:///too-large");
+        byte[] content = "content larger than cache".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(2);
+        assertThat(fileSystem.stats().getCacheWrites()).isEqualTo(0);
+        assertThat(fileSystem.stats().getCacheWriteSkips()).isEqualTo(2);
+    }
+
+    @Test
+    void testSkipsWriteWhenFileSystemHasNoUsableSpace(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = new NativeCacheDirectory(
+                cacheRoot,
+                DataSize.valueOf("1MB").toBytes(),
+                100,
+                Optional.of(Duration.valueOf("7d")),
+                createAccessTracker(cacheRoot, stats),
+                Clock.systemUTC(),
+                stats,
+                2,
+                () -> 0);
+        cacheDirectory.initialize();
+        CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///no-usable-space"), "key");
+        byte[] page = "page".getBytes(UTF_8);
+
+        cacheDirectory.writePage(cacheFile, 0, page, 0, page.length);
+
+        byte[] buffer = new byte[page.length];
+        assertThat(cacheDirectory.readPage(cacheFile, 0, 0, page.length, page.length, buffer, 0)).isFalse();
+        assertThat(stats.getCacheWrites()).isEqualTo(0);
+        assertThat(stats.getCacheWriteSkips()).isEqualTo(1);
+        assertThat(stats.getCachedFiles()).isEqualTo(0);
+    }
+
+    @Test
+    void testAccountingIsReconciledWhenEvictionFindsNoCandidates(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, new MemoryFileSystem(), DataSize.valueOf("64kB"), DataSize.valueOf("4B"), 100, Optional.of(Duration.valueOf("7d")));
+        Location first = Location.of("memory:///accounting-first");
+        Location second = Location.of("memory:///accounting-second");
+        byte[] firstContent = "abcd".getBytes(UTF_8);
+        byte[] secondContent = "wxyz".getBytes(UTF_8);
+        fileSystem.write(first, firstContent);
+        fileSystem.write(second, secondContent);
+
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.stats().getCachedFiles()).isEqualTo(1);
+        deleteCacheFiles(cacheRoot);
+
+        assertThat(fileSystem.readFully(second)).isEqualTo(wrappedBuffer(secondContent));
+        assertThat(fileSystem.stats().getCacheWriteSkips()).isEqualTo(0);
+        assertThat(fileSystem.stats().getCachedFiles()).isEqualTo(1);
+        assertThat(fileSystem.stats().getCachedBytes()).isEqualTo(secondContent.length);
+    }
+
+    @Test
+    void testEvictsWhenByteLimitIsExceeded(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, new MemoryFileSystem(), DataSize.valueOf("64kB"), DataSize.valueOf("96kB"), 100, Optional.of(Duration.valueOf("7d")));
+        Location first = Location.of("memory:///first");
+        Location second = Location.of("memory:///second");
+        byte[] firstContent = page(1);
+        byte[] secondContent = page(2);
+        fileSystem.write(first, firstContent);
+        fileSystem.write(second, secondContent);
+
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.readFully(second)).isEqualTo(wrappedBuffer(secondContent));
+        assertThat(fileSystem.stats().getEvictionCount()).isGreaterThanOrEqualTo(1);
+
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(3);
+    }
+
+    @Test
+    void testEvictsWhenFileCountLimitIsExceeded(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, new MemoryFileSystem(), DataSize.valueOf("64kB"), DataSize.valueOf("1MB"), 1, Optional.of(Duration.valueOf("7d")));
+        Location first = Location.of("memory:///first-file-count");
+        Location second = Location.of("memory:///second-file-count");
+        byte[] firstContent = "first".getBytes(UTF_8);
+        byte[] secondContent = "second".getBytes(UTF_8);
+        fileSystem.write(first, firstContent);
+        fileSystem.write(second, secondContent);
+
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.readFully(second)).isEqualTo(wrappedBuffer(secondContent));
+
+        assertThat(fileSystem.stats().getEvictionCount()).isGreaterThanOrEqualTo(1);
+        assertThat(fileSystem.stats().getCachedFiles()).isEqualTo(1);
+    }
+
+    @Test
+    void testFileCountEvictionStopsAtLowWatermark(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, new MemoryFileSystem(), DataSize.valueOf("64kB"), DataSize.valueOf("1MB"), 10, Optional.of(Duration.valueOf("7d")));
+        for (int index = 0; index < 11; index++) {
+            Location location = Location.of("memory:///file-count-low-watermark-%s".formatted(index));
+            fileSystem.write(location, "x".getBytes(UTF_8));
+            assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer("x".getBytes(UTF_8)));
+        }
+
+        assertThat(fileSystem.stats().getEvictionCount()).isGreaterThanOrEqualTo(1);
+        assertThat(fileSystem.stats().getCachedFiles()).isEqualTo(9);
+    }
+
+    @Test
+    void testFileCountEvictionContinuesAcrossSamplesUntilLowWatermark(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = new NativeCacheDirectory(
+                cacheRoot,
+                DataSize.valueOf("1MB").toBytes(),
+                10,
+                Optional.of(Duration.valueOf("7d")),
+                createAccessTracker(cacheRoot, stats),
+                Clock.systemUTC(),
+                stats,
+                1,
+                () -> Long.MAX_VALUE);
+        cacheDirectory.initialize();
+        byte[] page = "x".getBytes(UTF_8);
+        for (int index = 0; index < 11; index++) {
+            CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///file-count-low-watermark-small-sample-%s".formatted(index)), "key-%s".formatted(index));
+            cacheDirectory.writePage(cacheFile, 0, page, 0, page.length);
+        }
+
+        assertThat(stats.getEvictionCount()).isGreaterThanOrEqualTo(2);
+        assertThat(stats.getCachedFiles()).isEqualTo(9);
+    }
+
+    @Test
+    void testStartupScanDeletesExpiredFileGroups(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        MemoryFileSystem delegate = new MemoryFileSystem();
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, delegate, DataSize.valueOf("64kB"), DataSize.valueOf("1MB"), 100, Optional.empty());
+        Location location = Location.of("memory:///expired");
+        byte[] content = "expired content".getBytes(UTF_8);
+        fileSystem.write(location, content);
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+
+        try (var paths = Files.walk(cacheRoot)) {
+            for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                Files.setLastModifiedTime(path, FileTime.from(Instant.EPOCH));
+            }
+        }
+
+        TestingCacheFileSystem restartedFileSystem = createFileSystem(cacheRoot, delegate, DataSize.valueOf("64kB"), DataSize.valueOf("1MB"), 100, Optional.of(new Duration(1, TimeUnit.MILLISECONDS)));
+
+        assertThat(restartedFileSystem.stats().getExpiredFiles()).isGreaterThanOrEqualTo(1);
+        assertThat(restartedFileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(restartedFileSystem.stats().getExternalReads()).isEqualTo(1);
+    }
+
+    @Test
+    void testMaintenanceCursorAdvancesAndWraps(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = new NativeCacheDirectory(
+                cacheRoot,
+                DataSize.valueOf("1MB").toBytes(),
+                100,
+                Optional.of(new Duration(1, TimeUnit.MILLISECONDS)),
+                createAccessTracker(cacheRoot, stats),
+                Clock.systemUTC(),
+                stats,
+                2,
+                () -> Long.MAX_VALUE);
+        cacheDirectory.initialize();
+        byte[] page = "page".getBytes(UTF_8);
+        for (int index = 0; index < 5; index++) {
+            CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///maintenance-%s".formatted(index)), "key");
+            cacheDirectory.writePage(cacheFile, 0, page, 0, page.length);
+        }
+        setCacheFilesLastModifiedTime(cacheRoot, FileTime.from(Instant.EPOCH));
+
+        cacheDirectory.maintenance();
+        assertThat(countCacheFiles(cacheRoot)).isEqualTo(3);
+
+        cacheDirectory.maintenance();
+        assertThat(countCacheFiles(cacheRoot)).isEqualTo(1);
+
+        cacheDirectory.maintenance();
+        assertThat(countCacheFiles(cacheRoot)).isEqualTo(0);
+        assertThat(stats.getExpiredFiles()).isEqualTo(5);
+    }
+
+    @Test
+    void testStartupScanDeletesOnlyStaleTemporaryFiles(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = createCacheDirectory(cacheRoot, stats);
+        Path staleTemporaryFile = cacheDirectory.cacheFile(Location.of("memory:///stale-temporary"), "key")
+                .temporaryPagePath(0, "stale");
+        Path recentTemporaryFile = cacheDirectory.cacheFile(Location.of("memory:///recent-temporary"), "key")
+                .temporaryPagePath(0, "recent");
+        Files.createDirectories(staleTemporaryFile.getParent());
+        Files.createDirectories(recentTemporaryFile.getParent());
+        Files.writeString(staleTemporaryFile, "stale");
+        Files.writeString(recentTemporaryFile, "recent");
+        Files.setLastModifiedTime(staleTemporaryFile, FileTime.fromMillis(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2)));
+
+        cacheDirectory.initialize();
+
+        assertThat(staleTemporaryFile).doesNotExist();
+        assertThat(recentTemporaryFile).exists();
+        assertThat(stats.getStaleTemporaryFiles()).isEqualTo(1);
+    }
+
+    @Test
+    void testEvictionPrefersFilesAbsentFromRecentAccessBloomFilter(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, new MemoryFileSystem(), DataSize.valueOf("64kB"), DataSize.valueOf("256kB"), 100, Optional.of(Duration.valueOf("7d")));
+        Location first = Location.of("memory:///recent-first");
+        Location second = Location.of("memory:///cold-second");
+        Location third = Location.of("memory:///third");
+        Location fourth = Location.of("memory:///fourth");
+        Location fifth = Location.of("memory:///fifth");
+        byte[] firstContent = page(1);
+        byte[] secondContent = page(2);
+        byte[] thirdContent = page(3);
+        byte[] fourthContent = page(4);
+        byte[] fifthContent = page(5);
+        fileSystem.write(first, firstContent);
+        fileSystem.write(second, secondContent);
+        fileSystem.write(third, thirdContent);
+        fileSystem.write(fourth, fourthContent);
+        fileSystem.write(fifth, fifthContent);
+
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.readFully(second)).isEqualTo(wrappedBuffer(secondContent));
+        assertThat(fileSystem.readFully(third)).isEqualTo(wrappedBuffer(thirdContent));
+        assertThat(fileSystem.readFully(fourth)).isEqualTo(wrappedBuffer(fourthContent));
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(4);
+
+        assertThat(fileSystem.readFully(fifth)).isEqualTo(wrappedBuffer(fifthContent));
+        assertThat(fileSystem.readFully(first)).isEqualTo(wrappedBuffer(firstContent));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(5);
+        assertThat(fileSystem.stats().getEvictionCount()).isGreaterThanOrEqualTo(2);
+        assertThat(fileSystem.stats().getCachedFiles()).isEqualTo(3);
+    }
+
     private static TestingCacheFileSystem createFileSystem(Path cacheRoot)
     {
         return createFileSystem(cacheRoot, new MemoryFileSystem());
@@ -241,13 +566,110 @@ final class TestNativeFileSystemCache
 
     private static TestingCacheFileSystem createFileSystem(Path cacheRoot, TrinoFileSystem delegate)
     {
+        return createFileSystem(cacheRoot, delegate, DataSize.valueOf("64kB"), DataSize.valueOf("1GB"), Long.MAX_VALUE / 2, Optional.of(Duration.valueOf("7d")));
+    }
+
+    private static TestingCacheFileSystem createFileSystem(Path cacheRoot, TrinoFileSystem delegate, DataSize pageSize, DataSize maxCacheSize, long maxFiles, Optional<Duration> ttl)
+    {
         NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
-        NativeFileSystemCache cache = new NativeFileSystemCache(List.of(cacheRoot), DataSize.valueOf("64kB"), stats);
+        NativeFileSystemCache cache = new NativeFileSystemCache(
+                nativeCacheConfig(cacheRoot, pageSize, maxCacheSize, maxFiles, ttl),
+                stats,
+                TracerProvider.noop().get("test"));
         CacheFileSystem fileSystem = new CacheFileSystem(
                 delegate,
                 cache,
                 PATH_CACHE_KEY_PROVIDER);
+        waitUntilInitialized(cache);
         return new TestingCacheFileSystem(fileSystem, cache, stats);
+    }
+
+    private static void waitUntilInitialized(NativeFileSystemCache cache)
+    {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        for (NativeCacheDirectory cacheDirectory : cache.getCacheDirectories()) {
+            while (!cacheDirectory.isInitialized()) {
+                if (System.nanoTime() > deadline) {
+                    throw new AssertionError("Timed out waiting for native file system cache initialization");
+                }
+                try {
+                    Thread.sleep(10);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private static NativeFileSystemCacheConfig nativeCacheConfig(Path cacheRoot, DataSize pageSize, DataSize maxCacheSize, long maxFiles, Optional<Duration> ttl)
+    {
+        NativeFileSystemCacheConfig config = new NativeFileSystemCacheConfig()
+                .setCacheDirectories(List.of(cacheRoot.toString()))
+                .setCachePageSize(pageSize)
+                .setMaxCacheSizes(List.of(maxCacheSize))
+                .setMaxCacheFilesPerDirectory(maxFiles);
+        ttl.ifPresentOrElse(config::setCacheTTL, config::disableTTL);
+        return config;
+    }
+
+    private static NativeCacheDirectory createCacheDirectory(Path cacheRoot, NativeFileSystemCacheStats stats)
+            throws IOException
+    {
+        return new NativeCacheDirectory(cacheRoot, DataSize.valueOf("1MB").toBytes(), 100, Optional.of(Duration.valueOf("7d")), createAccessTracker(cacheRoot, stats), stats);
+    }
+
+    private static BloomFilterAccessTracker createAccessTracker(Path cacheRoot, NativeFileSystemCacheStats stats)
+            throws IOException
+    {
+        return new BloomFilterAccessTracker(cacheRoot, Duration.valueOf("24h"), Duration.valueOf("10m"), DataSize.valueOf("1MB"), stats);
+    }
+
+    private static byte[] page(int seed)
+    {
+        byte[] page = new byte[64 * 1024];
+        for (int index = 0; index < page.length; index++) {
+            page[index] = (byte) ((index + seed) % 251);
+        }
+        return page;
+    }
+
+    private static void deleteCacheFiles(Path cacheRoot)
+            throws IOException
+    {
+        try (var paths = Files.walk(cacheRoot)) {
+            for (Path path : paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".cache"))
+                    .toList()) {
+                Files.delete(path);
+            }
+        }
+    }
+
+    private static long countCacheFiles(Path cacheRoot)
+            throws IOException
+    {
+        try (var paths = Files.walk(cacheRoot)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".cache"))
+                    .count();
+        }
+    }
+
+    private static void setCacheFilesLastModifiedTime(Path cacheRoot, FileTime time)
+            throws IOException
+    {
+        try (var paths = Files.walk(cacheRoot)) {
+            for (Path path : paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".cache"))
+                    .toList()) {
+                Files.setLastModifiedTime(path, time);
+            }
+        }
     }
 
     private record TestingCacheFileSystem(CacheFileSystem fileSystem, NativeFileSystemCache cache, NativeFileSystemCacheStats stats)

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCache.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCache.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import io.airlift.slice.Slice;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.CacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestNativeFileSystemCache
+{
+    private static final CacheKeyProvider PATH_CACHE_KEY_PROVIDER = inputFile -> Optional.of(inputFile.location().path());
+
+    @Test
+    void testReadFullyCachesData(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///hello");
+        byte[] content = "hello world".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+        assertThat(fileSystem.stats().getExternalReadBytes()).isEqualTo(content.length);
+        assertThat(fileSystem.stats().getCacheReadBytes()).isEqualTo(content.length);
+    }
+
+    @Test
+    void testPositionedReadFillsPageAlignedRange(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///large");
+        byte[] content = new byte[70 * 1024];
+        for (int index = 0; index < content.length; index++) {
+            content[index] = (byte) (index % 251);
+        }
+        fileSystem.write(location, content);
+
+        TrinoInputFile inputFile = fileSystem.newInputFile(location);
+        byte[] buffer = new byte[10];
+        try (TrinoInput input = inputFile.newInput()) {
+            input.readFully(10, buffer, 0, buffer.length);
+        }
+        assertThat(buffer).containsExactly(Arrays.copyOfRange(content, 10, 20));
+        assertThat(fileSystem.stats().getExternalReadBytes()).isEqualTo(64 * 1024);
+
+        byte[] cachedBuffer = new byte[10];
+        try (TrinoInput input = fileSystem.newInputFile(location).newInput()) {
+            input.readFully(20, cachedBuffer, 0, cachedBuffer.length);
+        }
+        assertThat(cachedBuffer).containsExactly(Arrays.copyOfRange(content, 20, 30));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+    }
+
+    @Test
+    void testStreamCachesData(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///stream");
+        byte[] content = "streamed content".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        byte[] buffer = new byte[content.length];
+        try (TrinoInputStream stream = fileSystem.newInputFile(location).newStream()) {
+            assertThat(stream.read(buffer, 0, 6)).isEqualTo(6);
+            stream.seek(0);
+            assertThat(stream.read(buffer, 0, buffer.length)).isEqualTo(buffer.length);
+        }
+        assertThat(buffer).isEqualTo(content);
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+
+        byte[] cached = new byte[content.length];
+        try (TrinoInputStream stream = fileSystem.newInputFile(location).newStream()) {
+            assertThat(stream.read(cached, 0, cached.length)).isEqualTo(cached.length);
+        }
+        assertThat(cached).isEqualTo(content);
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+    }
+
+    @Test
+    void testStreamMissesReuseExternalStream(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        CountingMemoryFileSystem delegate = new CountingMemoryFileSystem();
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, delegate);
+        Location location = Location.of("memory:///sequential-stream");
+        byte[] content = new byte[150 * 1024];
+        for (int index = 0; index < content.length; index++) {
+            content[index] = (byte) (index % 251);
+        }
+        fileSystem.write(location, content);
+
+        byte[] actual = new byte[content.length];
+        int offset = 0;
+        try (TrinoInputStream stream = fileSystem.newInputFile(location).newStream()) {
+            while (offset < actual.length) {
+                int read = stream.read(actual, offset, Math.min(1024, actual.length - offset));
+                assertThat(read).isGreaterThan(0);
+                offset += read;
+            }
+            assertThat(stream.read()).isEqualTo(-1);
+        }
+
+        assertThat(actual).isEqualTo(content);
+        assertThat(delegate.newInputCount()).isEqualTo(0);
+        assertThat(delegate.newStreamCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testStreamSmallReadsUsePageBuffer(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        MemoryFileSystem delegate = new MemoryFileSystem();
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, delegate);
+        Location location = Location.of("memory:///small-stream-reads");
+        byte[] content = new byte[64 * 1024];
+        for (int index = 0; index < content.length; index++) {
+            content[index] = (byte) (index % 251);
+        }
+        fileSystem.write(location, content);
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+
+        TestingCacheFileSystem restartedFileSystem = createFileSystem(cacheRoot, delegate);
+
+        try (TrinoInputStream stream = restartedFileSystem.newInputFile(location).newStream()) {
+            for (int index = 0; index < 10; index++) {
+                assertThat(stream.read()).isEqualTo(content[index] & 0xFF);
+            }
+        }
+
+        assertThat(restartedFileSystem.stats().getCacheReads()).isEqualTo(1);
+        assertThat(restartedFileSystem.stats().getExternalReads()).isEqualTo(0);
+    }
+
+    @Test
+    void testExpireRemovesCachedData(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot);
+        Location location = Location.of("memory:///expire");
+        byte[] content = "cached".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+
+        fileSystem.cache().expire(location);
+
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(2);
+    }
+
+    @Test
+    void testCacheSurvivesRestart(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        MemoryFileSystem delegate = new MemoryFileSystem();
+        TestingCacheFileSystem fileSystem = createFileSystem(cacheRoot, delegate);
+        Location location = Location.of("memory:///restart");
+        byte[] content = "persistent cache".getBytes(UTF_8);
+        fileSystem.write(location, content);
+
+        assertThat(fileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(fileSystem.stats().getExternalReads()).isEqualTo(1);
+
+        TestingCacheFileSystem restartedFileSystem = createFileSystem(cacheRoot, delegate);
+
+        assertThat(restartedFileSystem.readFully(location)).isEqualTo(wrappedBuffer(content));
+        assertThat(restartedFileSystem.stats().getExternalReads()).isEqualTo(0);
+        assertThat(restartedFileSystem.stats().getCacheReadBytes()).isEqualTo(content.length);
+    }
+
+    @Test
+    void testDuplicatePageWriteDoesNotOverwriteExistingPage(@TempDir Path cacheRoot)
+            throws Exception
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeCacheDirectory cacheDirectory = new NativeCacheDirectory(cacheRoot, stats);
+        CacheFileLayout.CacheFile cacheFile = cacheDirectory.cacheFile(Location.of("memory:///duplicate"), "key");
+        byte[] first = "first page".getBytes(UTF_8);
+        byte[] second = "other page".getBytes(UTF_8);
+
+        cacheDirectory.writePage(cacheFile, 0, first, 0, first.length);
+        cacheDirectory.writePage(cacheFile, 0, second, 0, second.length);
+
+        byte[] buffer = new byte[first.length];
+        assertThat(cacheDirectory.readPage(cacheFile, 0, 0, first.length, first.length, buffer, 0)).isTrue();
+        assertThat(buffer).isEqualTo(first);
+        assertThat(stats.getCacheWrites()).isEqualTo(1);
+        assertThat(stats.getCacheWriteFailures()).isEqualTo(0);
+    }
+
+    private static TestingCacheFileSystem createFileSystem(Path cacheRoot)
+    {
+        return createFileSystem(cacheRoot, new MemoryFileSystem());
+    }
+
+    private static TestingCacheFileSystem createFileSystem(Path cacheRoot, MemoryFileSystem delegate)
+    {
+        return createFileSystem(cacheRoot, (TrinoFileSystem) delegate);
+    }
+
+    private static TestingCacheFileSystem createFileSystem(Path cacheRoot, TrinoFileSystem delegate)
+    {
+        NativeFileSystemCacheStats stats = new NativeFileSystemCacheStats();
+        NativeFileSystemCache cache = new NativeFileSystemCache(List.of(cacheRoot), DataSize.valueOf("64kB"), stats);
+        CacheFileSystem fileSystem = new CacheFileSystem(
+                delegate,
+                cache,
+                PATH_CACHE_KEY_PROVIDER);
+        return new TestingCacheFileSystem(fileSystem, cache, stats);
+    }
+
+    private record TestingCacheFileSystem(CacheFileSystem fileSystem, NativeFileSystemCache cache, NativeFileSystemCacheStats stats)
+    {
+        TrinoInputFile newInputFile(Location location)
+        {
+            return fileSystem.newInputFile(location);
+        }
+
+        void write(Location location, byte[] content)
+                throws IOException
+        {
+            try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+                output.write(content);
+            }
+        }
+
+        Slice readFully(Location location)
+                throws IOException
+        {
+            TrinoInputFile inputFile = fileSystem.newInputFile(location);
+            int length = (int) inputFile.length();
+            try (TrinoInput input = inputFile.newInput()) {
+                return input.readFully(0, length);
+            }
+        }
+    }
+
+    private static class CountingMemoryFileSystem
+            extends MemoryFileSystem
+    {
+        private final AtomicInteger newInputCount = new AtomicInteger();
+        private final AtomicInteger newStreamCount = new AtomicInteger();
+
+        @Override
+        public TrinoInputFile newInputFile(Location location)
+        {
+            return new CountingInputFile(super.newInputFile(location));
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length)
+        {
+            return new CountingInputFile(super.newInputFile(location, length));
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+        {
+            return new CountingInputFile(super.newInputFile(location, length, lastModified));
+        }
+
+        int newInputCount()
+        {
+            return newInputCount.get();
+        }
+
+        int newStreamCount()
+        {
+            return newStreamCount.get();
+        }
+
+        private class CountingInputFile
+                implements TrinoInputFile
+        {
+            private final TrinoInputFile delegate;
+
+            CountingInputFile(TrinoInputFile delegate)
+            {
+                this.delegate = delegate;
+            }
+
+            @Override
+            public TrinoInput newInput()
+                    throws IOException
+            {
+                newInputCount.incrementAndGet();
+                return delegate.newInput();
+            }
+
+            @Override
+            public TrinoInputStream newStream()
+                    throws IOException
+            {
+                newStreamCount.incrementAndGet();
+                return delegate.newStream();
+            }
+
+            @Override
+            public long length()
+                    throws IOException
+            {
+                return delegate.length();
+            }
+
+            @Override
+            public Instant lastModified()
+                    throws IOException
+            {
+                return delegate.lastModified();
+            }
+
+            @Override
+            public boolean exists()
+                    throws IOException
+            {
+                return delegate.exists();
+            }
+
+            @Override
+            public Location location()
+            {
+                return delegate.location();
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCacheConfig.java
@@ -15,37 +15,117 @@ package io.trino.filesystem.cache.local;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestNativeFileSystemCacheConfig
 {
+    @Test
+    void testInvalidConfiguration()
+    {
+        assertFailsValidation(
+                new NativeFileSystemCacheConfig()
+                        .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("1B"))),
+                "cacheDirectoriesConfigured",
+                "fs.cache.directories must be specified",
+                AssertTrue.class);
+        assertFailsValidation(
+                new NativeFileSystemCacheConfig()
+                        .setCacheDirectories(ImmutableList.of("/cache1", "/cache2"))
+                        .setMaxCacheDiskUsagePercentages(ImmutableList.of(0))
+                        .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("1B"))),
+                "cacheMaxSizeConfigured",
+                "Either fs.cache.max-sizes or fs.cache.max-disk-usage-percentages must be specified",
+                AssertTrue.class);
+        assertFailsValidation(
+                new NativeFileSystemCacheConfig()
+                        .setCacheDirectories(ImmutableList.of("/cache1", "/cache2"))
+                        .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("1B"))),
+                "cacheMaxSizeCountValid",
+                "fs.cache.directories and configured cache size limits must have the same size",
+                AssertTrue.class);
+        assertFailsValidation(
+                new NativeFileSystemCacheConfig()
+                        .setCacheDirectories(ImmutableList.of("/cache1", "/cache2"))
+                        .setMaxCacheDiskUsagePercentages(ImmutableList.of(0)),
+                "cacheMaxSizeCountValid",
+                "fs.cache.directories and configured cache size limits must have the same size",
+                AssertTrue.class);
+        assertFailsValidation(
+                new NativeFileSystemCacheConfig()
+                        .setCacheDirectories(ImmutableList.of("/cache"))
+                        .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("1B")))
+                        .setAccessHistoryDuration(Duration.valueOf("1m"))
+                        .setAccessBucketDuration(Duration.valueOf("2m")),
+                "accessDurationValid",
+                "fs.cache.access-history-duration must be greater than or equal to fs.cache.access-bucket-duration",
+                AssertTrue.class);
+    }
+
     @Test
     void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(NativeFileSystemCacheConfig.class)
                 .setCacheDirectories(ImmutableList.of())
-                .setCachePageSize(DataSize.valueOf("1MB")));
+                .setCachePageSize(DataSize.valueOf("1MB"))
+                .setMaxCacheSizes(ImmutableList.of())
+                .setMaxCacheDiskUsagePercentages(ImmutableList.of())
+                .setCacheTTL(Duration.valueOf("7d"))
+                .setMaxCacheFilesPerDirectory(10_000_000)
+                .setAccessHistoryDuration(Duration.valueOf("24h"))
+                .setAccessBucketDuration(Duration.valueOf("10m"))
+                .setAccessTrackingMemory(DataSize.valueOf("256MB")));
     }
 
     @Test
-    void testExplicitPropertyMappings()
+    void testExplicitPropertyMappings(@TempDir Path cacheDirectory)
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("fs.cache.directories", "/cache1,/cache2")
+                .put("fs.cache.directories", cacheDirectory.toString())
                 .put("fs.cache.page-size", "7MB")
+                .put("fs.cache.max-sizes", "1GB")
+                .put("fs.cache.ttl", "1d")
+                .put("fs.cache.max-files-per-directory", "1000")
+                .put("fs.cache.access-history-duration", "1h")
+                .put("fs.cache.access-bucket-duration", "5m")
+                .put("fs.cache.access-tracking-memory", "16MB")
                 .buildOrThrow();
 
         NativeFileSystemCacheConfig expected = new NativeFileSystemCacheConfig()
-                .setCacheDirectories(ImmutableList.of("/cache1", "/cache2"))
-                .setCachePageSize(DataSize.valueOf("7MB"));
+                .setCacheDirectories(ImmutableList.of(cacheDirectory.toString()))
+                .setCachePageSize(DataSize.valueOf("7MB"))
+                .setMaxCacheSizes(ImmutableList.of(DataSize.valueOf("1GB")))
+                .setCacheTTL(Duration.valueOf("1d"))
+                .setMaxCacheFilesPerDirectory(1000)
+                .setAccessHistoryDuration(Duration.valueOf("1h"))
+                .setAccessBucketDuration(Duration.valueOf("5m"))
+                .setAccessTrackingMemory(DataSize.valueOf("16MB"));
 
-        assertFullMapping(properties, expected);
+        assertFullMapping(properties, expected, ImmutableSet.of("fs.cache.max-disk-usage-percentages"));
+    }
+
+    @Test
+    void testTotalSpaceCalculation()
+            throws IOException
+    {
+        Path cacheDirectory = Files.createTempDirectory(null);
+
+        assertThat(NativeFileSystemCache.totalSpace(cacheDirectory)).isEqualTo(Files.getFileStore(cacheDirectory).getTotalSpace());
+        assertThat(NativeFileSystemCache.totalSpace(cacheDirectory.resolve(Path.of("does-not-exist")))).isEqualTo(Files.getFileStore(cacheDirectory).getTotalSpace());
     }
 }

--- a/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache/src/test/java/io/trino/filesystem/cache/local/TestNativeFileSystemCacheConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache.local;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestNativeFileSystemCacheConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(NativeFileSystemCacheConfig.class)
+                .setCacheDirectories(ImmutableList.of())
+                .setCachePageSize(DataSize.valueOf("1MB")));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("fs.cache.directories", "/cache1,/cache2")
+                .put("fs.cache.page-size", "7MB")
+                .buildOrThrow();
+
+        NativeFileSystemCacheConfig expected = new NativeFileSystemCacheConfig()
+                .setCacheDirectories(ImmutableList.of("/cache1", "/cache2"))
+                .setCachePageSize(DataSize.valueOf("7MB"));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -23,12 +23,19 @@ import static java.lang.System.getenv;
 @DefunctConfig("fs.alluxio.enabled")
 public class FileSystemConfig
 {
+    public enum CacheType
+    {
+        ALLUXIO,
+        NATIVE,
+    }
+
     private boolean hadoopEnabled;
     private boolean azureEnabled;
     private boolean s3Enabled;
     private boolean gcsEnabled;
     private boolean localEnabled;
     private boolean cacheEnabled;
+    private CacheType cacheType = CacheType.ALLUXIO;
 
     // Enable leak detection if configured or if running in a CI environment
     private boolean trackingEnabled = getenv("CONTINUOUS_INTEGRATION") != null;
@@ -106,6 +113,19 @@ public class FileSystemConfig
     public FileSystemConfig setCacheEnabled(boolean enabled)
     {
         this.cacheEnabled = enabled;
+        return this;
+    }
+
+    public CacheType getCacheType()
+    {
+        return cacheType;
+    }
+
+    @Config("fs.cache.type")
+    @ConfigDescription("File system cache implementation to use when file system cache is enabled")
+    public FileSystemConfig setCacheType(CacheType cacheType)
+    {
+        this.cacheType = cacheType;
         return this;
     }
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -21,6 +21,12 @@ import static java.lang.System.getenv;
 
 public class FileSystemConfig
 {
+    public enum CacheType
+    {
+        ALLUXIO,
+        NATIVE,
+    }
+
     private boolean hadoopEnabled;
     private boolean alluxioEnabled;
     private boolean azureEnabled;
@@ -28,6 +34,7 @@ public class FileSystemConfig
     private boolean gcsEnabled;
     private boolean localEnabled;
     private boolean cacheEnabled;
+    private CacheType cacheType = CacheType.ALLUXIO;
 
     // Enable leak detection if configured or if running in a CI environment
     private boolean trackingEnabled = getenv("CONTINUOUS_INTEGRATION") != null;
@@ -117,6 +124,19 @@ public class FileSystemConfig
     public FileSystemConfig setCacheEnabled(boolean enabled)
     {
         this.cacheEnabled = enabled;
+        return this;
+    }
+
+    public CacheType getCacheType()
+    {
+        return cacheType;
+    }
+
+    @Config("fs.cache.type")
+    @ConfigDescription("File system cache implementation to use when file system cache is enabled")
+    public FileSystemConfig setCacheType(CacheType cacheType)
+    {
+        this.cacheType = cacheType;
         return this;
     }
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -32,6 +32,7 @@ import io.trino.filesystem.cache.DefaultCacheKeyProvider;
 import io.trino.filesystem.cache.NoopSplitAffinityProvider;
 import io.trino.filesystem.cache.SplitAffinityProvider;
 import io.trino.filesystem.cache.TrinoFileSystemCache;
+import io.trino.filesystem.cache.local.NativeFileSystemCacheModule;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsFileSystemModule;
 import io.trino.filesystem.local.LocalFileSystemConfig;
@@ -121,7 +122,10 @@ public class FileSystemModule
         newOptionalBinder(binder, MemoryFileSystemCache.class);
 
         if (config.isCacheEnabled()) {
-            install(new AlluxioFileSystemCacheModule(isCoordinator));
+            switch (config.getCacheType()) {
+                case ALLUXIO -> install(new AlluxioFileSystemCacheModule(isCoordinator));
+                case NATIVE -> install(new NativeFileSystemCacheModule(isCoordinator));
+            }
         }
         if (coordinatorFileCaching) {
             install(new MemoryFileSystemCacheModule(isCoordinator));

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -34,6 +34,7 @@ import io.trino.filesystem.cache.DefaultCacheKeyProvider;
 import io.trino.filesystem.cache.NoopSplitAffinityProvider;
 import io.trino.filesystem.cache.SplitAffinityProvider;
 import io.trino.filesystem.cache.TrinoFileSystemCache;
+import io.trino.filesystem.cache.local.NativeFileSystemCacheModule;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsFileSystemModule;
 import io.trino.filesystem.local.LocalFileSystemConfig;
@@ -128,7 +129,10 @@ public class FileSystemModule
         newOptionalBinder(binder, MemoryFileSystemCache.class);
 
         if (config.isCacheEnabled()) {
-            install(new AlluxioFileSystemCacheModule(isCoordinator));
+            switch (config.getCacheType()) {
+                case ALLUXIO -> install(new AlluxioFileSystemCacheModule(isCoordinator));
+                case NATIVE -> install(new NativeFileSystemCacheModule(isCoordinator));
+            }
         }
         if (coordinatorFileCaching) {
             install(new MemoryFileSystemCacheModule(isCoordinator));

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -22,6 +22,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecated
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.filesystem.manager.FileSystemConfig.CacheType.NATIVE;
 import static java.lang.System.getenv;
 
 public class TestFileSystemConfig
@@ -38,6 +39,7 @@ public class TestFileSystemConfig
                 .setGcsEnabled(false)
                 .setLocalEnabled(false)
                 .setCacheEnabled(false)
+                .setCacheType(FileSystemConfig.CacheType.ALLUXIO)
                 .setTrackingEnabled(RUNNING_IN_CI));
     }
 
@@ -51,6 +53,7 @@ public class TestFileSystemConfig
                 .put("fs.gcs.enabled", "true")
                 .put("fs.local.enabled", "true")
                 .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "NATIVE")
                 .put("fs.tracking.enabled", Boolean.toString(!RUNNING_IN_CI))
                 .buildOrThrow();
 
@@ -61,6 +64,7 @@ public class TestFileSystemConfig
                 .setGcsEnabled(true)
                 .setLocalEnabled(true)
                 .setCacheEnabled(true)
+                .setCacheType(NATIVE)
                 .setTrackingEnabled(!RUNNING_IN_CI);
 
         assertFullMapping(properties, expected);

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -22,6 +22,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecated
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.filesystem.manager.FileSystemConfig.CacheType.NATIVE;
 import static java.lang.System.getenv;
 
 public class TestFileSystemConfig
@@ -39,6 +40,7 @@ public class TestFileSystemConfig
                 .setGcsEnabled(false)
                 .setLocalEnabled(false)
                 .setCacheEnabled(false)
+                .setCacheType(FileSystemConfig.CacheType.ALLUXIO)
                 .setTrackingEnabled(RUNNING_IN_CI));
     }
 
@@ -53,6 +55,7 @@ public class TestFileSystemConfig
                 .put("fs.gcs.enabled", "true")
                 .put("fs.local.enabled", "true")
                 .put("fs.cache.enabled", "true")
+                .put("fs.cache.type", "NATIVE")
                 .put("fs.tracking.enabled", Boolean.toString(!RUNNING_IN_CI))
                 .buildOrThrow();
 
@@ -64,6 +67,7 @@ public class TestFileSystemConfig
                 .setGcsEnabled(true)
                 .setLocalEnabled(true)
                 .setCacheEnabled(true)
+                .setCacheType(NATIVE)
                 .setTrackingEnabled(!RUNNING_IN_CI);
 
         assertFullMapping(properties, expected);

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>lib/trino-cache</module>
         <module>lib/trino-filesystem</module>
         <module>lib/trino-filesystem-azure</module>
+        <module>lib/trino-filesystem-cache</module>
         <module>lib/trino-filesystem-cache-alluxio</module>
         <module>lib/trino-filesystem-gcs</module>
         <module>lib/trino-filesystem-manager</module>
@@ -1005,6 +1006,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-filesystem-azure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-filesystem-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>lib/trino-filesystem</module>
         <module>lib/trino-filesystem-alluxio</module>
         <module>lib/trino-filesystem-azure</module>
+        <module>lib/trino-filesystem-cache</module>
         <module>lib/trino-filesystem-cache-alluxio</module>
         <module>lib/trino-filesystem-gcs</module>
         <module>lib/trino-filesystem-manager</module>
@@ -1061,6 +1062,12 @@
             <dependency>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-filesystem-azure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-filesystem-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Description

Adds a Trino-managed native file system cache implementation. The cache stores page-aligned file chunks in local cache directories and can be enabled with:

```properties
fs.cache.enabled=true
fs.cache.type=NATIVE
```

The implementation is intentionally simple and avoids a global on-disk index. Cache files are placed under deterministic hash-based paths, access tracking uses bounded time-bucketed Bloom filters, and eviction works per cache directory by sampling file groups and deleting whole cached source files.


## Additional context and related issues

**See the first commit for a detailed design document.**

The design prioritizes low resource impact on Trino over exact cache replacement behavior:

* Cache accounting is rebuilt asynchronously on startup, so cached reads and writes can continue while the initial scan runs.
* Access tracking does not update filesystem mtimes on cache hits. Instead, accesses are recorded in bounded Bloom-filter buckets.
* Eviction starts at the configured high limit and collects down to a low watermark.
* Pressure eviction samples hash-distributed file groups, sorts them by expiration and recent access bucket, and deletes whole file groups.
* A periodic maintenance sweep removes expired file groups and reconciles accounting, which can keep usage below the high watermark depending on cache churn.
* Cache directories are assumed to be owned by one Trino cache instance and backed by local storage suitable for a large number of files.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Add support for using the [native file system cache](/object-storage/file-system-native-cache)
  with `fs.cache.enabled=true` and `fs.cache.type=NATIVE`. ({issue}`issuenumber`)

## Hive connector
* Add support for using the [native file system cache](/object-storage/file-system-native-cache)
  with `fs.cache.enabled=true` and `fs.cache.type=NATIVE`. ({issue}`issuenumber`)

## Iceberg connector
* Add support for using the [native file system cache](/object-storage/file-system-native-cache)
  with `fs.cache.enabled=true` and `fs.cache.type=NATIVE`. ({issue}`issuenumber`)
```
