### PR TITLE
Add tests to verify CREATE OR REPLACE VIEW clears SECURITY INVOKER pr…

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -483,11 +483,15 @@ public class TrinoJdbcCatalog
                 .withProperties(properties.buildOrThrow())
                 .withLocation(defaultTableLocation(session, schemaViewName));
 
+        View view;
         if (replace) {
-            viewBuilder.createOrReplace();
+            view = viewBuilder.createOrReplace();
         }
         else {
-            viewBuilder.create();
+            view = viewBuilder.create();
+        }
+        if (replace && definition.getOwner().isEmpty() && view.properties().containsKey(ICEBERG_VIEW_RUN_AS_OWNER)) {
+            view.updateProperties().remove(ICEBERG_VIEW_RUN_AS_OWNER).commit();
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -680,11 +680,15 @@ public class TrinoRestCatalog
                 .withProperties(properties.buildOrThrow())
                 .withLocation(defaultTableLocation(session, schemaViewName));
         try {
+            View view;
             if (replace) {
-                viewBuilder.createOrReplace();
+                view = viewBuilder.createOrReplace();
             }
             else {
-                viewBuilder.create();
+                view = viewBuilder.create();
+            }
+            if (replace && definition.getOwner().isEmpty() && view.properties().containsKey(ICEBERG_VIEW_RUN_AS_OWNER)) {
+                view.updateProperties().remove(ICEBERG_VIEW_RUN_AS_OWNER).commit();
             }
         }
         catch (RESTException e) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
@@ -42,6 +42,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog.ICEBERG_VIEW_RUN_AS_OWNER;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -188,6 +189,28 @@ public abstract class BaseIcebergJdbcCatalogConnectorSmokeTest
         assertQueryFails("SELECT * FROM " + viewName, "Cannot read unsupported dialect 'spark' for view '.*'");
 
         jdbcCatalog.dropView(identifier);
+    }
+
+    protected void assertCreateOrReplaceViewClearsRunAsOwner()
+    {
+        String viewName = "test_replace_view_security_" + randomNameSuffix();
+
+        try {
+            assertUpdate("CREATE VIEW " + viewName + " SECURITY DEFINER AS SELECT 1 x");
+            assertThat((String) computeScalar("SHOW CREATE VIEW " + viewName))
+                    .contains("SECURITY DEFINER");
+
+            assertUpdate("CREATE OR REPLACE VIEW " + viewName + " SECURITY INVOKER AS SELECT 1 x");
+
+            assertThat((String) computeScalar("SHOW CREATE VIEW " + viewName))
+                    .contains("SECURITY INVOKER")
+                    .doesNotContain("SECURITY DEFINER");
+            assertThat(jdbcCatalog.loadView(toIdentifier(viewName)).properties())
+                    .doesNotContainKey(ICEBERG_VIEW_RUN_AS_OWNER);
+        }
+        finally {
+            assertUpdate("DROP VIEW IF EXISTS " + viewName);
+        }
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.catalog.jdbc;
 
 import io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion;
+import org.junit.jupiter.api.Test;
 
 final class TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest
         extends BaseIcebergJdbcCatalogConnectorSmokeTest
@@ -21,5 +22,11 @@ final class TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest
     public TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest()
     {
         super(SchemaVersion.V1);
+    }
+
+    @Test
+    void testCreateOrReplaceViewClearsRunAsOwner()
+    {
+        assertCreateOrReplaceViewClearsRunAsOwner();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
@@ -43,6 +43,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog.ICEBERG_VIEW_RUN_AS_OWNER;
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
@@ -111,6 +112,29 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     public void teardown()
     {
         backend = null; // closed by closeAfterClass
+    }
+
+    @Test
+    void testCreateOrReplaceViewClearsRunAsOwner()
+    {
+        String viewName = "test_replace_view_security_" + randomNameSuffix();
+
+        try {
+            assertUpdate("CREATE VIEW " + viewName + " SECURITY DEFINER AS SELECT 1 x");
+            assertThat((String) computeScalar("SHOW CREATE VIEW " + viewName))
+                    .contains("SECURITY DEFINER");
+
+            assertUpdate("CREATE OR REPLACE VIEW " + viewName + " SECURITY INVOKER AS SELECT 1 x");
+
+            assertThat((String) computeScalar("SHOW CREATE VIEW " + viewName))
+                    .contains("SECURITY INVOKER")
+                    .doesNotContain("SECURITY DEFINER");
+            assertThat(backend.loadView(toIdentifier(viewName)).properties())
+                    .doesNotContainKey(ICEBERG_VIEW_RUN_AS_OWNER);
+        }
+        finally {
+            assertUpdate("DROP VIEW IF EXISTS " + viewName);
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix Iceberg view replacement so that replacing a `SECURITY DEFINER` view with a `SECURITY INVOKER` view clears the persisted Trino owner metadata.

Trino stores Iceberg `SECURITY DEFINER` view ownership in the Iceberg view property `trino.run-as-owner`. When a view is replaced through Iceberg's view builder, new properties are merged into the existing view metadata, but properties that are absent from the replacement definition are not removed. As a result, this sequence left the old owner property behind:

```sql
CREATE VIEW v SECURITY DEFINER AS SELECT 1;
CREATE OR REPLACE VIEW v SECURITY INVOKER AS SELECT 1;
```

After replacement, `SHOW CREATE VIEW` could still report the view as `SECURITY DEFINER` because the stale `trino.run-as-owner` property remained in the Iceberg view metadata.

This change updates both Iceberg catalog implementations that create Trino Iceberg views:

* `TrinoJdbcCatalog`
* `TrinoRestCatalog`

After a successful `CREATE OR REPLACE VIEW`, if the replacement definition has no owner and the returned Iceberg view still contains `trino.run-as-owner`, the connector removes that property with `view.updateProperties().remove(...).commit()`.

The removal is limited to replacement operations that produce owner-less view definitions, which corresponds to `SECURITY INVOKER`. Creating or replacing `SECURITY DEFINER` views continues to set `trino.run-as-owner` normally.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/29535.

The root cause is that Iceberg view property updates during replacement do not implicitly delete properties omitted from `ViewBuilder.withProperties(...)`. For Trino's security mode encoding, that means moving from `SECURITY DEFINER` to `SECURITY INVOKER` needs an explicit property removal step.

Tests added:

* `BaseIcebergJdbcCatalogConnectorSmokeTest.assertCreateOrReplaceViewClearsRunAsOwner()` verifies the JDBC catalog behavior and directly inspects Iceberg view metadata.
* `TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.testCreateOrReplaceViewClearsRunAsOwner()` enables that coverage for the JDBC V1 schema path.
* `TestIcebergTrinoRestCatalogConnectorSmokeTest.testCreateOrReplaceViewClearsRunAsOwner()` verifies the REST catalog behavior and directly inspects the backend Iceberg view metadata.

The tests assert both externally visible SQL behavior and persisted Iceberg metadata:

* `SHOW CREATE VIEW` changes from `SECURITY DEFINER` to `SECURITY INVOKER` after replacement.
* The view properties no longer contain `trino.run-as-owner` after the final replacement.

Validation performed:

```text
./mvnw -pl plugin/trino-iceberg airstyle:format -Dincludes=**/TrinoRestCatalog.java,**/TrinoJdbcCatalog.java,**/TestIcebergTrinoRestCatalogConnectorSmokeTest.java,**/BaseIcebergJdbcCatalogConnectorSmokeTest.java,**/TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.java
```

```text
./mvnw -pl plugin/trino-iceberg airstyle:check -Dincludes=**/TrinoRestCatalog.java,**/TrinoJdbcCatalog.java,**/TestIcebergTrinoRestCatalogConnectorSmokeTest.java,**/BaseIcebergJdbcCatalogConnectorSmokeTest.java,**/TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest.java
```

```text
./mvnw -pl plugin/trino-iceberg -Dtest=TestIcebergJdbcCatalogV1SchemaConnectorSmokeTest#testCreateOrReplaceViewClearsRunAsOwner,TestIcebergTrinoRestCatalogConnectorSmokeTest#testCreateOrReplaceViewClearsRunAsOwner test
```

Result:

```text
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Additional external repro validation against a patched Trino 481 image confirmed the expected behavior for an Iceberg REST catalog:

```text
A1 security: SECURITY INVOKER
A2 security: SECURITY DEFINER
A3 security: SECURITY INVOKER
metadata properties: {}
run-as-owner present: False
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix `CREATE OR REPLACE VIEW` for Iceberg views so replacing a `SECURITY DEFINER` view with a `SECURITY INVOKER` view clears the stored owner metadata. ({issue}`29535`)
```

