### PR TITLE
Configure Google Docker Hub mirror in CI setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -45,6 +45,9 @@ runs:
           else
             echo "Skipping disk cleanup, ${available_gb} GiB available"
           fi
+      - name: Configure Docker Hub mirror
+        shell: bash
+        run: ./.github/bin/configure-docker-hub-mirror.sh
       - uses: actions/setup-java@v5
         if: ${{ inputs.java-version != '' }}
         with:

--- a/.github/bin/configure-docker-hub-mirror.sh
+++ b/.github/bin/configure-docker-hub-mirror.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+readonly MIRROR='https://mirror.gcr.io'
+readonly DAEMON_CONFIG='/etc/docker/daemon.json'
+
+current_config=$(mktemp)
+updated_config=$(mktemp)
+trap 'rm -f "${current_config}" "${updated_config}"' EXIT
+
+# Start from the runner's existing Docker daemon config, if any.
+if sudo test -f "${DAEMON_CONFIG}"; then
+    sudo cp "${DAEMON_CONFIG}" "${current_config}"
+else
+    echo '{}' > "${current_config}"
+fi
+
+# Preserve existing config and append mirror.gcr.io if it is not already present.
+jq --arg mirror "${MIRROR}" '
+    if (.["registry-mirrors"] // [] | type) != "array" then
+        error("registry-mirrors must be an array")
+    else
+        (.["registry-mirrors"] // []) as $mirrors |
+        .["registry-mirrors"] = if ($mirrors | index($mirror)) then $mirrors else $mirrors + [$mirror] end
+    end
+' "${current_config}" > "${updated_config}"
+
+# Restart Docker only when the daemon config changed.
+if cmp -s "${current_config}" "${updated_config}"; then
+    echo "Docker Hub registry mirror is already configured"
+else
+    sudo install -D -m 0644 "${updated_config}" "${DAEMON_CONFIG}"
+    sudo systemctl restart docker
+fi
+
+# Show Docker info for CI log verification.
+docker info


### PR DESCRIPTION
## Description

Configure CI runners to use Google's Docker Hub registry mirror (`https://mirror.gcr.io`).

The shared CI setup action now runs a small script that preserves the existing Docker daemon config, adds `mirror.gcr.io` to `registry-mirrors`, restarts Docker when needed, and prints the registry mirror section from `docker info` for verification.

This should improve reliability and latency for Docker-heavy CI jobs and Testcontainers-based tests that pull public Docker Hub images.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
