### PR TITLE
Document truncate(x, d) two-argument variant

### DIFF
--- a/docs/src/main/sphinx/functions/math.md
+++ b/docs/src/main/sphinx/functions/math.md
@@ -112,6 +112,13 @@ Returns the square root of `x`.
 Returns `x` rounded to integer by dropping digits after decimal point.
 :::
 
+:::{function} truncate(x, d) -> [same as input]
+:noindex: true
+
+Returns `x` truncated to `d` decimal places. `d` can be negative,
+in which case `d` digits to the left of the decimal point are zeroed out.
+:::
+
 :::{function} width_bucket(x, bound1, bound2, n) -> bigint
 Returns the bin number of `x` in an equi-width histogram with the
 specified `bound1` and `bound2` bounds and `n` number of buckets.


### PR DESCRIPTION
## Description

Add documentation for the two-argument `truncate(x, d)` function, which
truncates `x` to `d` decimal places. The single-argument form was documented
but the two-argument variant for decimal types was missing.

Follows the same pattern as the existing `round(x, d)` entry.

## Additional context and related issues

Fixes #28765

Three prior PRs attempted this fix but none landed:
- #28769 and #28771 were closed as duplicates of #28767
- #28767 went stale and was auto-closed after six weeks (CLA not completed)

The two-argument form is implemented in `MathFunctions.TruncateN` for
decimal types.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: