### PR TITLE
Support datetime() method in JSON path

### DIFF
--- a/core/trino-main/src/main/antlr4/io/trino/json/JsonDateTimeTemplateLexer.g4
+++ b/core/trino-main/src/main/antlr4/io/trino/json/JsonDateTimeTemplateLexer.g4
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tokens for SQL/JSON path datetime() format templates per ISO/IEC 9075-2:2023 §9.46.
+// Templates have no nesting or precedence, so a lexer with no parser rules suffices —
+// the consumer iterates over the token stream directly.
+lexer grammar JsonDateTimeTemplateLexer;
+
+options { caseInsensitive = true; }
+
+YYYY : 'YYYY';
+YYY  : 'YYY';
+YY   : 'YY';
+Y    : 'Y';
+
+RRRR : 'RRRR';
+RR   : 'RR';
+
+MM   : 'MM';
+DDD  : 'DDD';
+DD   : 'DD';
+
+HH24 : 'HH24';
+HH12 : 'HH12';
+HH   : 'HH';
+
+MI    : 'MI';
+SSSSS : 'SSSSS';
+SS    : 'SS';
+
+// FF1..FF9 are the standard widths; FF10..FF12 extend coverage to Trino's
+// maximum TIME / TIMESTAMP precision of 12.
+FRACTION : 'FF' [0-9] [0-9]?;
+
+AM_PM : ('A' | 'P') '.M.';
+
+TZH : 'TZH';
+TZM : 'TZM';
+
+DELIMITER
+    : '-' | '.' | '/' | ',' | '\'' | ';' | ':' | ' '
+    ;
+
+// Double-quoted literal text (e.g. `YYYY"T"HH24:MI:SS`). An embedded quote is
+// escaped as `""`. The unescape step is performed in the consumer.
+QUOTED_LITERAL
+    : '"' ('""' | ~'"')* '"'
+    ;

--- a/core/trino-main/src/main/java/io/trino/json/JsonDateTimeTemplate.java
+++ b/core/trino-main/src/main/java/io/trino/json/JsonDateTimeTemplate.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.trino.json.JsonDateTimeTemplateParser.Parsed;
+import io.trino.json.ir.TypedValue;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/// Parsed SQL/JSON path `datetime(<template>)` format template per ISO/IEC 9075-2:2023 §9.46.
+///
+/// Represents an immutable, pre-validated template that the runtime can apply to a
+/// value string via [#parseValue(String)].
+public final class JsonDateTimeTemplate
+{
+    private final String template;
+    private final Type type;
+    private final int precision;
+    private final List<Segment> segments;
+
+    public static JsonDateTimeTemplate parse(String template)
+    {
+        Parsed parsed = JsonDateTimeTemplateParser.parse(template);
+        return new JsonDateTimeTemplate(parsed.template(), parsed.type(), parsed.precision(), parsed.segments());
+    }
+
+    @JsonCreator
+    public JsonDateTimeTemplate(
+            @JsonProperty("template") String template,
+            @JsonProperty("type") Type type,
+            @JsonProperty("precision") int precision)
+    {
+        Parsed parsed = JsonDateTimeTemplateParser.parse(template);
+        if (!parsed.type().equals(type)) {
+            throw new IllegalArgumentException(format("datetime() template type mismatch: expected %s, found %s", parsed.type().getDisplayName(), type.getDisplayName()));
+        }
+        if (parsed.precision() != precision) {
+            throw new IllegalArgumentException(format("datetime() template precision mismatch: expected %s, found %s", parsed.precision(), precision));
+        }
+        this.template = parsed.template();
+        this.type = type;
+        this.precision = precision;
+        this.segments = parsed.segments();
+    }
+
+    private JsonDateTimeTemplate(String template, Type type, int precision, List<Segment> segments)
+    {
+        this.template = requireNonNull(template, "template is null");
+        this.type = requireNonNull(type, "type is null");
+        this.precision = precision;
+        this.segments = ImmutableList.copyOf(segments);
+    }
+
+    /// The template in canonical form: field tokens upper-cased, literal text verbatim.
+    /// Templates that differ only in the case of their field tokens are equal.
+    @JsonProperty
+    public String getTemplate()
+    {
+        return template;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public int getPrecision()
+    {
+        return precision;
+    }
+
+    public TypedValue parseValue(String value)
+    {
+        return JsonDateTimeValueParser.parse(segments, type, value);
+    }
+
+    @Override
+    public boolean equals(Object object)
+    {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof JsonDateTimeTemplate other)) {
+            return false;
+        }
+        return precision == other.precision &&
+                template.equals(other.template) &&
+                type.equals(other.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(template, type, precision);
+    }
+
+    @Override
+    public String toString()
+    {
+        return template;
+    }
+
+    sealed interface Segment
+            permits FieldSegment, LiteralSegment {}
+
+    record LiteralSegment(String literal)
+            implements Segment
+    {
+        LiteralSegment
+        {
+            requireNonNull(literal, "literal is null");
+        }
+    }
+
+    record FieldSegment(Field field, int width, boolean delimited)
+            implements Segment
+    {
+        FieldSegment
+        {
+            requireNonNull(field, "field is null");
+        }
+    }
+
+    enum Field
+    {
+        YEAR,
+        ROUNDED_YEAR,
+        MONTH,
+        DAY,
+        DAY_OF_YEAR,
+        HOUR12,
+        HOUR24,
+        MINUTE,
+        SECOND,
+        SECOND_OF_DAY,
+        FRACTION,
+        AM_PM,
+        TIME_ZONE_HOUR,
+        TIME_ZONE_MINUTE,
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/json/JsonDateTimeTemplateParser.java
+++ b/core/trino-main/src/main/java/io/trino/json/JsonDateTimeTemplateParser.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.json;
+
+import io.trino.json.JsonDateTimeTemplate.Field;
+import io.trino.json.JsonDateTimeTemplate.FieldSegment;
+import io.trino.json.JsonDateTimeTemplate.LiteralSegment;
+import io.trino.json.JsonDateTimeTemplate.Segment;
+import io.trino.spi.type.Type;
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static org.antlr.v4.runtime.Token.EOF;
+
+/// Lexes and validates a datetime() format-template string per ISO/IEC 9075-2:2023 §9.46.
+final class JsonDateTimeTemplateParser
+{
+    private static final ANTLRErrorListener ERROR_LISTENER = new BaseErrorListener()
+    {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String message, RecognitionException e)
+        {
+            throw new IllegalArgumentException(format("invalid datetime() format template at position %d: %s", charPositionInLine, message));
+        }
+    };
+
+    private JsonDateTimeTemplateParser() {}
+
+    /// The `template` is the canonical form of the parsed template: field tokens upper-cased,
+    /// literal text preserved verbatim.
+    record Parsed(String template, Type type, int precision, List<Segment> segments) {}
+
+    public static Parsed parse(String template)
+    {
+        if (template.isEmpty()) {
+            throw new IllegalArgumentException("datetime() format template is empty");
+        }
+
+        JsonDateTimeTemplateLexer lexer = new JsonDateTimeTemplateLexer(CharStreams.fromString(template));
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(ERROR_LISTENER);
+
+        List<Segment> segments = new ArrayList<>();
+        TemplateState state = new TemplateState();
+        // The lexer matches field tokens case-insensitively, so `yyyy-mm-dd` and `YYYY-MM-DD`
+        // describe the same template. Rebuild the template in a canonical spelling as it is
+        // lexed, so that equivalent templates are indistinguishable to equals() and toString().
+        // Only the field tokens are folded: literal text is matched case-sensitively.
+        StringBuilder canonical = new StringBuilder(template.length());
+        // Whether the previously-emitted segment was a DELIMITER literal (not a quoted literal).
+        // Two adjacent delimiters are rejected to avoid ambiguous templates like `YYYY--MM`,
+        // but a delimiter next to a quoted literal (e.g. `YYYY-"T"MM`) is fine.
+        boolean previousWasDelimiter = false;
+        // Track the most recent un-finalized FieldSegment so we can resolve its `delimited`
+        // flag in this same pass: it depends on what follows the field (a literal/EOF closes it
+        // delimited, a field closes it un-delimited).
+        int pendingFieldIndex = -1;
+        boolean pendingFieldDelimitedLeft = false;
+        boolean leftIsBoundary = true;
+        for (Token lexerToken = lexer.nextToken(); lexerToken.getType() != EOF; lexerToken = lexer.nextToken()) {
+            int type = lexerToken.getType();
+            if (type == JsonDateTimeTemplateLexer.DELIMITER || type == JsonDateTimeTemplateLexer.QUOTED_LITERAL) {
+                String literal = toLiteral(lexerToken);
+                if (literal.isEmpty()) {
+                    throw new IllegalArgumentException("datetime() format template cannot contain empty quoted literal");
+                }
+                if (previousWasDelimiter && type == JsonDateTimeTemplateLexer.DELIMITER) {
+                    throw new IllegalArgumentException("datetime() format template cannot contain consecutive delimiters");
+                }
+                if (pendingFieldIndex != -1) {
+                    finalizePendingField(segments, pendingFieldIndex, pendingFieldDelimitedLeft, true);
+                    pendingFieldIndex = -1;
+                }
+                segments.add(new LiteralSegment(literal));
+                canonical.append(lexerToken.getText());
+                previousWasDelimiter = type == JsonDateTimeTemplateLexer.DELIMITER;
+                leftIsBoundary = true;
+            }
+            else {
+                FieldSegment fieldSegment = toFieldSegment(lexerToken);
+                state.add(fieldSegment.field(), fieldSegment.width());
+                canonical.append(lexerToken.getText().toUpperCase(ENGLISH));
+                if (pendingFieldIndex != -1) {
+                    // A field follows another field directly — the previous field is not right-delimited.
+                    finalizePendingField(segments, pendingFieldIndex, pendingFieldDelimitedLeft, false);
+                }
+                segments.add(fieldSegment);
+                pendingFieldIndex = segments.size() - 1;
+                pendingFieldDelimitedLeft = leftIsBoundary;
+                leftIsBoundary = false;
+                previousWasDelimiter = false;
+            }
+        }
+
+        // End of input — close any pending field with right boundary = literal/EOF.
+        if (pendingFieldIndex != -1) {
+            finalizePendingField(segments, pendingFieldIndex, pendingFieldDelimitedLeft, true);
+        }
+
+        if (state.isEmpty()) {
+            throw new IllegalArgumentException("datetime() format template must contain at least one datetime field");
+        }
+
+        return new Parsed(canonical.toString(), state.type(), state.precision, List.copyOf(segments));
+    }
+
+    private static void finalizePendingField(List<Segment> segments, int index, boolean delimitedLeft, boolean delimitedRight)
+    {
+        FieldSegment pending = (FieldSegment) segments.get(index);
+        segments.set(index, new FieldSegment(pending.field(), pending.width(), delimitedLeft && delimitedRight));
+    }
+
+    private static FieldSegment toFieldSegment(Token lexerToken)
+    {
+        return switch (lexerToken.getType()) {
+            case JsonDateTimeTemplateLexer.YYYY -> new FieldSegment(Field.YEAR, 4, false);
+            case JsonDateTimeTemplateLexer.YYY -> new FieldSegment(Field.YEAR, 3, false);
+            case JsonDateTimeTemplateLexer.YY -> new FieldSegment(Field.YEAR, 2, false);
+            case JsonDateTimeTemplateLexer.Y -> new FieldSegment(Field.YEAR, 1, false);
+            case JsonDateTimeTemplateLexer.RRRR -> new FieldSegment(Field.ROUNDED_YEAR, 4, false);
+            case JsonDateTimeTemplateLexer.RR -> new FieldSegment(Field.ROUNDED_YEAR, 2, false);
+            case JsonDateTimeTemplateLexer.MM -> new FieldSegment(Field.MONTH, 2, false);
+            case JsonDateTimeTemplateLexer.DD -> new FieldSegment(Field.DAY, 2, false);
+            case JsonDateTimeTemplateLexer.DDD -> new FieldSegment(Field.DAY_OF_YEAR, 3, false);
+            case JsonDateTimeTemplateLexer.HH, JsonDateTimeTemplateLexer.HH12 -> new FieldSegment(Field.HOUR12, 2, false);
+            case JsonDateTimeTemplateLexer.HH24 -> new FieldSegment(Field.HOUR24, 2, false);
+            case JsonDateTimeTemplateLexer.MI -> new FieldSegment(Field.MINUTE, 2, false);
+            case JsonDateTimeTemplateLexer.SS -> new FieldSegment(Field.SECOND, 2, false);
+            case JsonDateTimeTemplateLexer.SSSSS -> new FieldSegment(Field.SECOND_OF_DAY, 5, false);
+            case JsonDateTimeTemplateLexer.FRACTION -> new FieldSegment(Field.FRACTION, fractionWidth(lexerToken.getText()), false);
+            case JsonDateTimeTemplateLexer.AM_PM -> new FieldSegment(Field.AM_PM, 0, false);
+            case JsonDateTimeTemplateLexer.TZH -> new FieldSegment(Field.TIME_ZONE_HOUR, 3, false);
+            case JsonDateTimeTemplateLexer.TZM -> new FieldSegment(Field.TIME_ZONE_MINUTE, 2, false);
+            default -> throw new IllegalStateException("unexpected datetime() template field token: " + lexerToken.getText());
+        };
+    }
+
+    private static int fractionWidth(String text)
+    {
+        // FF1..FF9 are the standard widths; FF10..FF12 extend coverage to Trino's
+        // maximum TIME / TIMESTAMP precision of 12.
+        int width = Integer.parseInt(text.substring(2));
+        if (width < 1 || width > 12) {
+            throw new IllegalArgumentException("invalid datetime() format template fraction width: " + text);
+        }
+        return width;
+    }
+
+    private static String toLiteral(Token lexerToken)
+    {
+        if (lexerToken.getType() == JsonDateTimeTemplateLexer.DELIMITER) {
+            return lexerToken.getText();
+        }
+        // Strip surrounding quotes and unescape doubled embedded quotes.
+        String quoted = lexerToken.getText();
+        return quoted.substring(1, quoted.length() - 1).replace("\"\"", "\"");
+    }
+
+    private static final class TemplateState
+    {
+        private boolean year;
+        private boolean roundedYear;
+        private boolean month;
+        private boolean day;
+        private boolean dayOfYear;
+        private boolean hour12;
+        private boolean hour24;
+        private boolean minute;
+        private boolean second;
+        private boolean secondOfDay;
+        private boolean fraction;
+        private boolean amPm;
+        private boolean timeZoneHour;
+        private boolean timeZoneMinute;
+        private int precision;
+
+        public void add(Field field, int width)
+        {
+            switch (field) {
+                case YEAR -> checkUnique("year", year);
+                case ROUNDED_YEAR -> checkUnique("rounded year", roundedYear);
+                case MONTH -> checkUnique("month", month);
+                case DAY -> checkUnique("day", day);
+                case DAY_OF_YEAR -> checkUnique("day of year", dayOfYear);
+                case HOUR12 -> checkUnique("12-hour field", hour12);
+                case HOUR24 -> checkUnique("24-hour field", hour24);
+                case MINUTE -> checkUnique("minute", minute);
+                case SECOND -> checkUnique("second", second);
+                case SECOND_OF_DAY -> checkUnique("second-of-day", secondOfDay);
+                case FRACTION -> checkUnique("fraction", fraction);
+                case AM_PM -> checkUnique("AM/PM", amPm);
+                case TIME_ZONE_HOUR -> checkUnique("time zone hour", timeZoneHour);
+                case TIME_ZONE_MINUTE -> checkUnique("time zone minute", timeZoneMinute);
+            }
+
+            switch (field) {
+                case YEAR -> year = true;
+                case ROUNDED_YEAR -> roundedYear = true;
+                case MONTH -> month = true;
+                case DAY -> day = true;
+                case DAY_OF_YEAR -> dayOfYear = true;
+                case HOUR12 -> hour12 = true;
+                case HOUR24 -> hour24 = true;
+                case MINUTE -> minute = true;
+                case SECOND -> second = true;
+                case SECOND_OF_DAY -> secondOfDay = true;
+                case AM_PM -> amPm = true;
+                case TIME_ZONE_HOUR -> timeZoneHour = true;
+                case TIME_ZONE_MINUTE -> timeZoneMinute = true;
+                case FRACTION -> {
+                    fraction = true;
+                    precision = Math.max(precision, width);
+                }
+            }
+        }
+
+        public boolean isEmpty()
+        {
+            return !(year || roundedYear || month || day || dayOfYear || hour12 || hour24 || minute || second || secondOfDay || fraction || amPm || timeZoneHour || timeZoneMinute);
+        }
+
+        public Type type()
+        {
+            validate();
+            boolean hasDateFields = year || roundedYear || month || day || dayOfYear;
+            boolean hasTimeFields = hour12 || hour24 || minute || second || secondOfDay || fraction || amPm;
+            boolean hasTimeZoneFields = timeZoneHour || timeZoneMinute;
+
+            if (hasDateFields) {
+                if (hasTimeZoneFields) {
+                    return createTimestampWithTimeZoneType(precision);
+                }
+                if (hasTimeFields) {
+                    return createTimestampType(precision);
+                }
+                return DATE;
+            }
+
+            if (hasTimeZoneFields) {
+                return createTimeWithTimeZoneType(precision);
+            }
+            return createTimeType(precision);
+        }
+
+        private void validate()
+        {
+            if (year && roundedYear) {
+                throw new IllegalArgumentException("datetime() format template cannot contain both year and rounded year fields");
+            }
+            if (dayOfYear && (month || day)) {
+                throw new IllegalArgumentException("datetime() format template with DDD cannot contain MM or DD");
+            }
+            if (hour24 && (hour12 || amPm)) {
+                throw new IllegalArgumentException("datetime() format template with HH24 cannot contain HH, HH12, A.M. or P.M.");
+            }
+            if (hour12 && !amPm) {
+                throw new IllegalArgumentException("datetime() format template with HH or HH12 requires A.M. or P.M.");
+            }
+            if (amPm && !hour12) {
+                throw new IllegalArgumentException("datetime() format template with A.M. or P.M. requires HH or HH12");
+            }
+            if (secondOfDay && (hour12 || hour24 || minute || second || amPm)) {
+                throw new IllegalArgumentException("datetime() format template with SSSSS cannot contain HH, HH12, HH24, MI, SS, A.M. or P.M.");
+            }
+            if (timeZoneMinute && !timeZoneHour) {
+                throw new IllegalArgumentException("datetime() format template with TZM requires TZH");
+            }
+        }
+
+        private static void checkUnique(String fieldName, boolean seen)
+        {
+            if (seen) {
+                throw new IllegalArgumentException(format("datetime() format template contains duplicate %s field", fieldName));
+            }
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/json/JsonDateTimeValueParser.java
+++ b/core/trino-main/src/main/java/io/trino/json/JsonDateTimeValueParser.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.json;
+
+import io.trino.json.JsonDateTimeTemplate.FieldSegment;
+import io.trino.json.JsonDateTimeTemplate.LiteralSegment;
+import io.trino.json.JsonDateTimeTemplate.Segment;
+import io.trino.json.ir.TypedValue;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.LongTimeWithTimeZone;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.OptionalInt;
+
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.DateTimeEncoding.packTimeWithTimeZone;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
+import static io.trino.type.DateTimes.longTimestamp;
+import static io.trino.type.DateTimes.rescale;
+import static java.lang.Character.isDigit;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.multiplyExact;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/// Applies a parsed [JsonDateTimeTemplate] to a value string and produces a
+/// [TypedValue] of the template's inferred type.
+final class JsonDateTimeValueParser
+{
+    private JsonDateTimeValueParser() {}
+
+    public static TypedValue parse(List<Segment> segments, Type type, String value)
+    {
+        Cursor cursor = new Cursor(value);
+        ParsedValues parsedValues = new ParsedValues();
+        for (Segment segment : segments) {
+            switch (segment) {
+                case LiteralSegment literal -> cursor.expect(literal.literal());
+                case FieldSegment field -> parseField(field, cursor, parsedValues);
+            }
+        }
+
+        if (!cursor.atEnd()) {
+            throw new IllegalArgumentException("unexpected trailing input");
+        }
+
+        return buildTypedValue(type, parsedValues);
+    }
+
+    private static TypedValue buildTypedValue(Type type, ParsedValues parsedValues)
+    {
+        // Per SQL:2023 §9.46, default values for unspecified fields are fixed constants, not
+        // session-dependent values. Using session.getStart() would make the same query yield
+        // different results depending on when it's evaluated.
+        int year = parsedValues.resolveYear();
+        if (parsedValues.dayOfYear.isPresent()) {
+            LocalDate date = LocalDate.ofYearDay(year, parsedValues.dayOfYear.getAsInt());
+            year = date.getYear();
+            parsedValues.month = OptionalInt.of(date.getMonthValue());
+            parsedValues.day = OptionalInt.of(date.getDayOfMonth());
+        }
+
+        int month = parsedValues.month.orElse(1);
+        int day = parsedValues.day.orElse(1);
+        int hour = parsedValues.resolveHour();
+        int minute = parsedValues.resolveMinute();
+        int second = parsedValues.resolveSecond();
+        long fractionPicos = parsedValues.fractionPicos();
+
+        return switch (type) {
+            case DateType _ -> new TypedValue(type, (long) toIntExact(LocalDate.of(year, month, day).toEpochDay()));
+            case TimeType timeType -> new TypedValue(timeType, timeOfDayPicos(hour, minute, second, fractionPicos));
+            case TimeWithTimeZoneType timeWithTimeZoneType -> {
+                int offsetMinutes = parsedValues.resolveOffsetMinutes();
+                long picos = timeOfDayPicos(hour, minute, second, fractionPicos);
+                if (timeWithTimeZoneType.getPrecision() <= TimeWithTimeZoneType.MAX_SHORT_PRECISION) {
+                    long nanos = picos / PICOSECONDS_PER_NANOSECOND;
+                    yield new TypedValue(timeWithTimeZoneType, packTimeWithTimeZone(nanos, offsetMinutes));
+                }
+                yield TypedValue.fromValueAsObject(timeWithTimeZoneType, new LongTimeWithTimeZone(picos, offsetMinutes));
+            }
+            case TimestampType timestampType -> {
+                long epochSecond = LocalDateTime.of(year, month, day, hour, minute, second).toEpochSecond(ZoneOffset.UTC);
+                if (timestampType.getPrecision() <= TimestampType.MAX_SHORT_PRECISION) {
+                    long epochMicros = multiplyExact(epochSecond, MICROSECONDS_PER_SECOND) + fractionPicos / PICOSECONDS_PER_MICROSECOND;
+                    yield new TypedValue(timestampType, epochMicros);
+                }
+                yield TypedValue.fromValueAsObject(timestampType, longTimestamp(epochSecond, fractionPicos));
+            }
+            case TimestampWithTimeZoneType timestampWithTimeZoneType -> {
+                int offsetMinutes = parsedValues.resolveOffsetMinutes();
+                ZoneOffset zoneOffset = ZoneOffset.ofTotalSeconds(offsetMinutes * 60);
+                long epochSecond = LocalDateTime.of(year, month, day, hour, minute, second).toEpochSecond(zoneOffset);
+                if (timestampWithTimeZoneType.getPrecision() <= TimestampWithTimeZoneType.MAX_SHORT_PRECISION) {
+                    long epochMillis = epochSecond * MILLISECONDS_PER_SECOND + fractionPicos / PICOSECONDS_PER_MILLISECOND;
+                    yield new TypedValue(timestampWithTimeZoneType, packDateTimeWithZone(epochMillis, zoneOffset.getId()));
+                }
+                yield TypedValue.fromValueAsObject(
+                        timestampWithTimeZoneType,
+                        LongTimestampWithTimeZone.fromEpochSecondsAndFraction(epochSecond, fractionPicos, getTimeZoneKey(zoneOffset.getId())));
+            }
+            default -> throw new IllegalStateException("unexpected datetime() template type: " + type);
+        };
+    }
+
+    private static long timeOfDayPicos(int hour, int minute, int second, long fractionPicos)
+    {
+        return (((hour * 60L) + minute) * 60 + second) * PICOSECONDS_PER_SECOND + fractionPicos;
+    }
+
+    private static void parseField(FieldSegment segment, Cursor cursor, ParsedValues values)
+    {
+        switch (segment.field()) {
+            case YEAR -> {
+                values.year = OptionalInt.of(readUnsignedNumber(cursor, segment));
+                values.yearDigits = cursor.previousDigits().length();
+            }
+            case ROUNDED_YEAR -> {
+                values.roundedYear = OptionalInt.of(readUnsignedNumber(cursor, segment));
+                values.roundedYearDigits = cursor.previousDigits().length();
+            }
+            case MONTH -> values.month = OptionalInt.of(readUnsignedNumber(cursor, segment));
+            case DAY -> values.day = OptionalInt.of(readUnsignedNumber(cursor, segment));
+            case DAY_OF_YEAR -> values.dayOfYear = OptionalInt.of(readUnsignedNumber(cursor, segment));
+            case HOUR12 -> {
+                // Bounds-check at parse time. `resolveHour` does `hour12 % 12`, so an
+                // out-of-range value (e.g. 13 A.M., 25 P.M.) would fold silently into a
+                // valid-looking hour and never reach `parseTime`'s validator.
+                int hour12 = readUnsignedNumber(cursor, segment);
+                if (hour12 < 1 || hour12 > 12) {
+                    throw new IllegalArgumentException("hour-of-half-day value out of range [1, 12]: " + hour12);
+                }
+                values.hour12 = OptionalInt.of(hour12);
+            }
+            case HOUR24 -> values.hour24 = OptionalInt.of(readUnsignedNumber(cursor, segment));
+            case MINUTE -> values.minute = OptionalInt.of(readUnsignedNumber(cursor, segment));
+            case SECOND -> values.second = OptionalInt.of(readUnsignedNumber(cursor, segment));
+            case SECOND_OF_DAY -> {
+                // Bounds-check here, not downstream. SECOND_OF_DAY is decomposed by resolveHour /
+                // resolveMinute / resolveSecond (floorDiv / floorMod against 3600 / 60), so an
+                // out-of-range input like 99999 would synthesize a superficially-valid time
+                // (e.g. 27:46:39) and fail downstream with a message that doesn't mention the
+                // template field or its range.
+                int secondOfDay = readUnsignedNumber(cursor, segment);
+                if (secondOfDay < 0 || secondOfDay > 86399) {
+                    throw new IllegalArgumentException("second-of-day value out of range [0, 86399]: " + secondOfDay);
+                }
+                values.secondOfDay = OptionalInt.of(secondOfDay);
+            }
+            case FRACTION -> {
+                values.fractionValue = readUnsignedLongNumber(cursor, segment);
+                values.fractionDigits = cursor.previousDigits().length();
+            }
+            case AM_PM -> values.pm = readAmPm(cursor);
+            case TIME_ZONE_HOUR -> readTimeZoneHour(cursor, segment, values);
+            case TIME_ZONE_MINUTE -> {
+                // Bounds-check at parse time. `resolveOffsetMinutes` does `offsetMinute + offsetHour * 60`,
+                // so a value like 99 would carry into the hours (e.g. `+05:99` → `+06:39`) and
+                // would never raise an error for clearly-invalid input.
+                int timeZoneMinute = readUnsignedNumber(cursor, segment);
+                if (timeZoneMinute < 0 || timeZoneMinute > 59) {
+                    throw new IllegalArgumentException("time-zone-minute value out of range [0, 59]: " + timeZoneMinute);
+                }
+                values.timeZoneMinute = OptionalInt.of(timeZoneMinute);
+            }
+        }
+    }
+
+    private static int readUnsignedNumber(Cursor cursor, FieldSegment segment)
+    {
+        return Integer.parseInt(cursor.readDigits(minimumDigits(segment), segment.width()));
+    }
+
+    // FRACTION values at FF10..FF12 precision don't fit in int; use a long variant.
+    private static long readUnsignedLongNumber(Cursor cursor, FieldSegment segment)
+    {
+        return Long.parseLong(cursor.readDigits(minimumDigits(segment), segment.width()));
+    }
+
+    private static int minimumDigits(FieldSegment segment)
+    {
+        // Delimited fields tolerate variable widths; un-delimited fields must consume
+        // exactly their declared width to avoid ambiguity with the next field.
+        return segment.delimited() ? 1 : segment.width();
+    }
+
+    private static boolean readAmPm(Cursor cursor)
+    {
+        if (cursor.regionMatchesIgnoreCase("A.M.")) {
+            cursor.advance("A.M.".length());
+            return false;
+        }
+        if (cursor.regionMatchesIgnoreCase("P.M.")) {
+            cursor.advance("P.M.".length());
+            return true;
+        }
+        throw new IllegalArgumentException(format("invalid AM/PM marker at position %d", cursor.position()));
+    }
+
+    private static void readTimeZoneHour(Cursor cursor, FieldSegment segment, ParsedValues values)
+    {
+        if (cursor.atEnd()) {
+            throw new IllegalArgumentException(format("expected time zone hour at position %d", cursor.position()));
+        }
+
+        char signCharacter = cursor.current();
+        if (signCharacter != '+' && signCharacter != '-' && signCharacter != ' ') {
+            throw new IllegalArgumentException(format("time zone hour must start with '+', '-' or space at position %d", cursor.position()));
+        }
+        cursor.advance(1);
+
+        String hourDigits = segment.delimited() ? cursor.readDigits(1, 2) : cursor.readFixedDigits(2);
+        // Track sign as a separate flag so offsets like `-00:30` (where the signed hour
+        // would round to 0) preserve the negative bit through resolveOffsetMinutes.
+        values.timeZoneHour = OptionalInt.of(Integer.parseInt(hourDigits));
+        values.timeZoneOffsetNegative = signCharacter == '-';
+    }
+
+    private static final class ParsedValues
+    {
+        private OptionalInt year = OptionalInt.empty();
+        private int yearDigits;
+        private OptionalInt roundedYear = OptionalInt.empty();
+        private int roundedYearDigits;
+        private OptionalInt month = OptionalInt.empty();
+        private OptionalInt day = OptionalInt.empty();
+        private OptionalInt dayOfYear = OptionalInt.empty();
+        private OptionalInt hour12 = OptionalInt.empty();
+        private OptionalInt hour24 = OptionalInt.empty();
+        private OptionalInt minute = OptionalInt.empty();
+        private OptionalInt second = OptionalInt.empty();
+        private OptionalInt secondOfDay = OptionalInt.empty();
+        private boolean pm;
+        private long fractionValue;
+        private int fractionDigits;
+        private OptionalInt timeZoneHour = OptionalInt.empty();
+        private OptionalInt timeZoneMinute = OptionalInt.empty();
+        private boolean timeZoneOffsetNegative;
+
+        // Fixed reference year (1970, per SQL:2023's use of epoch-based defaults) used to fill in the
+        // century/millennium prefix when the template specifies only low-order year digits.
+        private static final int REFERENCE_YEAR = 1970;
+
+        public int resolveYear()
+        {
+            if (year.isPresent()) {
+                return prefixYear(REFERENCE_YEAR, year.getAsInt(), yearDigits);
+            }
+            if (roundedYear.isPresent()) {
+                return roundYear(REFERENCE_YEAR, roundedYear.getAsInt(), roundedYearDigits);
+            }
+            return REFERENCE_YEAR;
+        }
+
+        public int resolveHour()
+        {
+            if (secondOfDay.isPresent()) {
+                return floorDiv(secondOfDay.getAsInt(), 3600);
+            }
+            if (hour24.isPresent()) {
+                return hour24.getAsInt();
+            }
+            if (hour12.isPresent()) {
+                int hour = hour12.getAsInt() % 12;
+                if (pm) {
+                    hour += 12;
+                }
+                return hour;
+            }
+            return 0;
+        }
+
+        public int resolveMinute()
+        {
+            if (secondOfDay.isPresent()) {
+                return floorDiv(floorMod(secondOfDay.getAsInt(), 3600), 60);
+            }
+            return minute.orElse(0);
+        }
+
+        public int resolveSecond()
+        {
+            if (secondOfDay.isPresent()) {
+                return floorMod(secondOfDay.getAsInt(), 60);
+            }
+            return second.orElse(0);
+        }
+
+        public long fractionPicos()
+        {
+            return fractionDigits > 0 ? rescale(fractionValue, fractionDigits, 12) : 0L;
+        }
+
+        public int resolveOffsetMinutes()
+        {
+            if (!timeZoneHour.isPresent()) {
+                return 0;
+            }
+            int magnitude = timeZoneHour.getAsInt() * 60 + timeZoneMinute.orElse(0);
+            return timeZoneOffsetNegative ? -magnitude : magnitude;
+        }
+
+        private static int prefixYear(int currentYear, int value, int digits)
+        {
+            if (digits >= 4) {
+                return value;
+            }
+            int prefix = floorDiv(currentYear, pow10(digits));
+            return prefix * pow10(digits) + value;
+        }
+
+        private static int roundYear(int currentYear, int value, int digits)
+        {
+            if (digits > 2) {
+                return value;
+            }
+
+            int currentCentury = floorDiv(currentYear, 100) * 100;
+            int currentTwoDigits = floorMod(currentYear, 100);
+            if (currentTwoDigits <= 49) {
+                return value <= 49 ? currentCentury + value : currentCentury - 100 + value;
+            }
+            return value <= 49 ? currentCentury + 100 + value : currentCentury + value;
+        }
+
+        private static int pow10(int exponent)
+        {
+            int value = 1;
+            for (int index = 0; index < exponent; index++) {
+                value *= 10;
+            }
+            return value;
+        }
+    }
+
+    private static final class Cursor
+    {
+        private final String value;
+        private int position;
+        private String previousDigits = "";
+
+        private Cursor(String value)
+        {
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public boolean atEnd()
+        {
+            return position == value.length();
+        }
+
+        public char current()
+        {
+            return value.charAt(position);
+        }
+
+        public int position()
+        {
+            return position;
+        }
+
+        public void expect(String literal)
+        {
+            if (!value.startsWith(literal, position)) {
+                throw new IllegalArgumentException(format("expected literal '%s' at position %d", literal, position));
+            }
+            position += literal.length();
+        }
+
+        public boolean regionMatchesIgnoreCase(String text)
+        {
+            return value.regionMatches(true, position, text, 0, text.length());
+        }
+
+        public void advance(int length)
+        {
+            position += length;
+        }
+
+        public String readDigits(int minimumDigits, int maximumDigits)
+        {
+            int start = position;
+            int count = 0;
+            while (position < value.length() && isDigit(value.charAt(position)) && count < maximumDigits) {
+                position++;
+                count++;
+            }
+            if (count < minimumDigits) {
+                throw new IllegalArgumentException(format("expected at least %d digits at position %d", minimumDigits, start));
+            }
+            previousDigits = value.substring(start, position);
+            return previousDigits;
+        }
+
+        public String readFixedDigits(int digits)
+        {
+            int start = position;
+            String result = readDigits(digits, digits);
+            if (result.length() != digits) {
+                throw new IllegalArgumentException(format("expected %d digits at position %d", digits, start));
+            }
+            return result;
+        }
+
+        public String previousDigits()
+        {
+            return previousDigits;
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -109,9 +109,23 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.sql.analyzer.ExpressionAnalyzer.isCharacterStringType;
+import static io.trino.type.DateTimes.extractTimePrecision;
+import static io.trino.type.DateTimes.extractTimestampPrecision;
+import static io.trino.type.DateTimes.parseTime;
+import static io.trino.type.DateTimes.parseTimeWithTimeZone;
+import static io.trino.type.DateTimes.parseTimestamp;
+import static io.trino.type.DateTimes.parseTimestampWithTimeZone;
+import static io.trino.type.DateTimes.timeHasTimeZone;
+import static io.trino.type.DateTimes.timestampHasTimeZone;
 import static io.trino.type.DecimalCasts.longDecimalToDouble;
 import static io.trino.type.DecimalCasts.shortDecimalToDouble;
+import static io.trino.util.DateTimeUtils.parseDate;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
@@ -645,9 +659,64 @@ class PathEvaluationVisitor
     }
 
     @Override
-    protected List<Object> visitIrDatetimeMethod(IrDatetimeMethod node, PathEvaluationContext context) // TODO
+    protected List<Object> visitIrDatetimeMethod(IrDatetimeMethod node, PathEvaluationContext context)
     {
-        throw new UnsupportedOperationException("date method is not yet supported");
+        List<Object> sequence = process(node.base(), context);
+
+        if (lax) {
+            sequence = unwrapArrays(sequence);
+        }
+
+        ImmutableList.Builder<Object> outputSequence = ImmutableList.builder();
+        for (Object object : sequence) {
+            TypedValue value;
+            if (object instanceof TypedValue typed) {
+                if (!isCharacterStringType(typed.getType())) {
+                    throw itemTypeError("TEXT", typed.getType().getDisplayName());
+                }
+                value = typed;
+            }
+            else {
+                JsonNode jsonNode = (JsonNode) object;
+                value = getTextTypedValue(jsonNode)
+                        .orElseThrow(() -> itemTypeError("TEXT", jsonNode.getNodeType().name()));
+            }
+            try {
+                outputSequence.add(getDatetime(value));
+            }
+            catch (RuntimeException e) {
+                // A value that cannot be parsed must surface as a path evaluation error, so that
+                // the ON ERROR clause of the enclosing function applies.
+                throw new PathEvaluationException(e);
+            }
+        }
+
+        return outputSequence.build();
+    }
+
+    private static TypedValue getDatetime(TypedValue typedValue)
+    {
+        String value = ((Slice) typedValue.getObjectValue()).toStringUtf8();
+
+        // The standard datetime shapes are unambiguously distinguishable by their separators:
+        // a TIMESTAMP value has a space between date and time, a TIME value has at least one
+        // colon, and a DATE value has neither. Dispatch on shape so each input passes through
+        // the matching parser exactly once.
+        if (value.indexOf(' ') >= 0) {
+            int precision = extractTimestampPrecision(value);
+            if (timestampHasTimeZone(value)) {
+                return TypedValue.fromValueAsObject(createTimestampWithTimeZoneType(precision), parseTimestampWithTimeZone(precision, value));
+            }
+            return TypedValue.fromValueAsObject(createTimestampType(precision), parseTimestamp(precision, value));
+        }
+        if (value.indexOf(':') >= 0) {
+            int precision = extractTimePrecision(value);
+            if (timeHasTimeZone(value)) {
+                return TypedValue.fromValueAsObject(createTimeWithTimeZoneType(precision), parseTimeWithTimeZone(precision, value));
+            }
+            return new TypedValue(createTimeType(precision), parseTime(value));
+        }
+        return new TypedValue(DATE, (long) parseDate(value));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -682,7 +682,9 @@ class PathEvaluationVisitor
                         .orElseThrow(() -> itemTypeError("TEXT", jsonNode.getNodeType().name()));
             }
             try {
-                outputSequence.add(getDatetime(value));
+                outputSequence.add(node.format()
+                        .map(template -> template.parseValue(((Slice) value.getObjectValue()).toStringUtf8()))
+                        .orElseGet(() -> getDatetime(value)));
             }
             catch (RuntimeException e) {
                 // A value that cannot be parsed must surface as a path evaluation error, so that

--- a/core/trino-main/src/main/java/io/trino/json/ir/IrDatetimeMethod.java
+++ b/core/trino-main/src/main/java/io/trino/json/ir/IrDatetimeMethod.java
@@ -13,13 +13,14 @@
  */
 package io.trino.json.ir;
 
+import io.trino.json.JsonDateTimeTemplate;
 import io.trino.spi.type.Type;
 
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record IrDatetimeMethod(IrPathNode base, Optional<String> format, Optional<Type> type)
+public record IrDatetimeMethod(IrPathNode base, Optional<JsonDateTimeTemplate> format, Optional<Type> type)
         implements IrPathNode
 {
     public IrDatetimeMethod

--- a/core/trino-main/src/main/java/io/trino/json/ir/TypedValue.java
+++ b/core/trino-main/src/main/java/io/trino/json/ir/TypedValue.java
@@ -15,6 +15,8 @@ package io.trino.json.ir;
 
 import io.trino.spi.type.Type;
 
+import java.util.Objects;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -132,5 +134,27 @@ public class TypedValue
     public Object getValueAsObject()
     {
         return valueAsObject;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TypedValue other)) {
+            return false;
+        }
+        return type.equals(other.type)
+                && longValue == other.longValue
+                && Double.compare(doubleValue, other.doubleValue) == 0
+                && booleanValue == other.booleanValue
+                && Objects.equals(objectValue, other.objectValue);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, objectValue, longValue, doubleValue, booleanValue);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slices;
+import io.trino.json.JsonDateTimeTemplate;
 import io.trino.json.XQueryRegex;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.OperatorNotFoundException;
@@ -72,7 +73,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.spi.StandardErrorCode.INVALID_PATH;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.function.OperatorType.NEGATION;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -97,6 +97,7 @@ public class JsonPathAnalyzer
     private final ExpressionAnalyzer literalAnalyzer;
     private final Map<PathNodeRef<PathNode>, Type> types = new LinkedHashMap<>();
     private final Set<PathNodeRef<PathNode>> jsonParameters = new LinkedHashSet<>();
+    private final Map<PathNodeRef<PathNode>, JsonDateTimeTemplate> datetimeTemplates = new LinkedHashMap<>();
 
     public JsonPathAnalyzer(Metadata metadata, ExpressionAnalyzer literalAnalyzer)
     {
@@ -111,14 +112,14 @@ public class JsonPathAnalyzer
                 .orElseThrow(() -> new IllegalStateException("missing NodeLocation in path"));
         PathNode root = PathParser.withRelativeErrorLocation(pathStart).parseJsonPath(path.getValue());
         new Visitor(parameterTypes, path).process(root);
-        return new JsonPathAnalysis((JsonPath) root, types, jsonParameters);
+        return new JsonPathAnalysis((JsonPath) root, types, jsonParameters, datetimeTemplates);
     }
 
     public JsonPathAnalysis analyzeImplicitJsonPath(String path, NodeLocation location)
     {
         PathNode root = PathParser.withFixedErrorLocation(new Location(location.getLineNumber(), location.getColumnNumber())).parseJsonPath(path);
         new Visitor(ImmutableMap.of(), new StringLiteral(path)).process(root);
-        return new JsonPathAnalysis((JsonPath) root, types, jsonParameters);
+        return new JsonPathAnalysis((JsonPath) root, types, jsonParameters, datetimeTemplates);
     }
 
     /**
@@ -258,7 +259,16 @@ public class JsonPathAnalyzer
                 throw semanticException(INVALID_PATH, pathNode, "JSON path datetime() method requires character string argument (found %s)", sourceType.getDisplayName());
             }
             if (node.getFormat().isPresent()) {
-                throw semanticException(NOT_SUPPORTED, pathNode, "datetime() format template is not yet supported");
+                JsonDateTimeTemplate template;
+                try {
+                    template = JsonDateTimeTemplate.parse(node.getFormat().get());
+                }
+                catch (IllegalArgumentException e) {
+                    throw semanticException(INVALID_PATH, pathNode, e, "invalid datetime() format template in JSON path: %s", e.getMessage());
+                }
+                types.put(PathNodeRef.of(node), template.getType());
+                datetimeTemplates.put(PathNodeRef.of(node), template);
+                return template.getType();
             }
 
             return null;
@@ -546,12 +556,14 @@ public class JsonPathAnalyzer
         private final JsonPath path;
         private final Map<PathNodeRef<PathNode>, Type> types;
         private final Set<PathNodeRef<PathNode>> jsonParameters;
+        private final Map<PathNodeRef<PathNode>, JsonDateTimeTemplate> datetimeTemplates;
 
-        public JsonPathAnalysis(JsonPath path, Map<PathNodeRef<PathNode>, Type> types, Set<PathNodeRef<PathNode>> jsonParameters)
+        public JsonPathAnalysis(JsonPath path, Map<PathNodeRef<PathNode>, Type> types, Set<PathNodeRef<PathNode>> jsonParameters, Map<PathNodeRef<PathNode>, JsonDateTimeTemplate> datetimeTemplates)
         {
             this.path = requireNonNull(path, "path is null");
             this.types = ImmutableMap.copyOf(requireNonNull(types, "types is null"));
             this.jsonParameters = ImmutableSet.copyOf(requireNonNull(jsonParameters, "jsonParameters is null"));
+            this.datetimeTemplates = ImmutableMap.copyOf(requireNonNull(datetimeTemplates, "datetimeTemplates is null"));
         }
 
         public JsonPath getPath()
@@ -572,6 +584,14 @@ public class JsonPathAnalyzer
         public Set<PathNodeRef<PathNode>> getJsonParameters()
         {
             return jsonParameters;
+        }
+
+        /// Returns the validated [JsonDateTimeTemplate] for a `datetime(<template>)`
+        /// method node, populated during analysis. Lets the translator skip the
+        /// second `JsonDateTimeTemplate.parse` of the same template string.
+        public JsonDateTimeTemplate getDatetimeTemplate(PathNode pathNode)
+        {
+            return datetimeTemplates.get(PathNodeRef.of(pathNode));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/JsonPathAnalyzer.java
@@ -257,8 +257,11 @@ public class JsonPathAnalyzer
             if (sourceType != null && !isCharacterStringType(sourceType)) {
                 throw semanticException(INVALID_PATH, pathNode, "JSON path datetime() method requires character string argument (found %s)", sourceType.getDisplayName());
             }
-            // TODO process the format template, record the processed format, and deduce the returned type
-            throw semanticException(NOT_SUPPORTED, pathNode, "datetime method in JSON path is not yet supported");
+            if (node.getFormat().isPresent()) {
+                throw semanticException(NOT_SUPPORTED, pathNode, "datetime() format template is not yet supported");
+            }
+
+            return null;
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/JsonPathTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/JsonPathTranslator.java
@@ -123,7 +123,7 @@ class JsonPathTranslator
     public IrJsonPath rewriteToIr(JsonPathAnalysis pathAnalysis, List<String> parametersOrder)
     {
         PathNode root = pathAnalysis.getPath().getRoot();
-        IrPathNode rewritten = new Rewriter(session, plannerContext, pathAnalysis.getTypes(), pathAnalysis.getJsonParameters(), parametersOrder).process(root);
+        IrPathNode rewritten = new Rewriter(session, plannerContext, pathAnalysis, parametersOrder).process(root);
 
         return new IrJsonPath(pathAnalysis.getPath().isLax(), rewritten);
     }
@@ -132,22 +132,22 @@ class JsonPathTranslator
             extends JsonPathTreeVisitor<IrPathNode, Void>
     {
         private final LiteralInterpreter literalInterpreter;
+        private final JsonPathAnalysis pathAnalysis;
         private final Map<PathNodeRef<PathNode>, Type> types;
         private final Set<PathNodeRef<PathNode>> jsonParameters;
         private final List<String> parametersOrder;
 
-        public Rewriter(Session session, PlannerContext plannerContext, Map<PathNodeRef<PathNode>, Type> types, Set<PathNodeRef<PathNode>> jsonParameters, List<String> parametersOrder)
+        public Rewriter(Session session, PlannerContext plannerContext, JsonPathAnalysis pathAnalysis, List<String> parametersOrder)
         {
             requireNonNull(session, "session is null");
             requireNonNull(plannerContext, "plannerContext is null");
-            requireNonNull(types, "types is null");
-            requireNonNull(jsonParameters, "jsonParameters is null");
-            requireNonNull(jsonParameters, "jsonParameters is null");
+            requireNonNull(pathAnalysis, "pathAnalysis is null");
             requireNonNull(parametersOrder, "parametersOrder is null");
 
             this.literalInterpreter = new LiteralInterpreter(plannerContext, session);
-            this.types = types;
-            this.jsonParameters = jsonParameters;
+            this.pathAnalysis = pathAnalysis;
+            this.types = pathAnalysis.getTypes();
+            this.jsonParameters = pathAnalysis.getJsonParameters();
             this.parametersOrder = parametersOrder;
         }
 
@@ -225,7 +225,10 @@ class JsonPathTranslator
         protected IrPathNode visitDatetimeMethod(DatetimeMethod node, Void context)
         {
             IrPathNode base = process(node.getBase());
-            return new IrDatetimeMethod(base, node.getFormat(), Optional.ofNullable(types.get(PathNodeRef.of(node))));
+            return new IrDatetimeMethod(
+                    base,
+                    Optional.ofNullable(pathAnalysis.getDatetimeTemplate(node)),
+                    Optional.ofNullable(types.get(PathNodeRef.of(node))));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/JsonPathTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/JsonPathTranslator.java
@@ -26,6 +26,7 @@ import io.trino.json.ir.IrCeilingMethod;
 import io.trino.json.ir.IrComparisonPredicate;
 import io.trino.json.ir.IrConjunctionPredicate;
 import io.trino.json.ir.IrContextVariable;
+import io.trino.json.ir.IrDatetimeMethod;
 import io.trino.json.ir.IrDescendantMemberAccessor;
 import io.trino.json.ir.IrDisjunctionPredicate;
 import io.trino.json.ir.IrDoubleMethod;
@@ -223,11 +224,8 @@ class JsonPathTranslator
         @Override
         protected IrPathNode visitDatetimeMethod(DatetimeMethod node, Void context)
         {
-            // TODO
-            throw new IllegalStateException("datetime method is not yet supported. The query should have failed in JsonPathAnalyzer.");
-
-//            IrPathNode base = process(node.getBase());
-//            return new IrDatetimeMethod(base, /*parsed format*/, Optional.ofNullable(types.get(PathNodeRef.of(node))));
+            IrPathNode base = process(node.getBase());
+            return new IrDatetimeMethod(base, node.getFormat(), Optional.ofNullable(types.get(PathNodeRef.of(node))));
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonDateTimeTemplate.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonDateTimeTemplate.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.json;
+
+import io.trino.json.ir.TypedValue;
+import org.junit.jupiter.api.Test;
+
+import java.time.DateTimeException;
+
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.type.DateTimes.parseTimeWithTimeZone;
+import static io.trino.type.DateTimes.parseTimestamp;
+import static io.trino.type.DateTimes.parseTimestampWithTimeZone;
+import static io.trino.util.DateTimeUtils.parseDate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestJsonDateTimeTemplate
+{
+    @Test
+    public void testTypeInference()
+    {
+        assertThat(JsonDateTimeTemplate.parse("YYYY-MM-DD").getType()).isEqualTo(DATE);
+        assertThat(JsonDateTimeTemplate.parse("HH24:MI:SS.FF3TZH:TZM").getType()).isEqualTo(createTimeWithTimeZoneType(3));
+        assertThat(JsonDateTimeTemplate.parse("YYYY-MM-DD HH24:MI:SS.FF3").getType()).isEqualTo(createTimestampType(3));
+        assertThat(JsonDateTimeTemplate.parse("YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM").getType()).isEqualTo(createTimestampWithTimeZoneType(3));
+    }
+
+    @Test
+    public void testParseValue()
+    {
+        TypedValue date = JsonDateTimeTemplate.parse("YYYY-MM-DD").parseValue("2024-01-02");
+        assertThat(date).isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+
+        TypedValue timeWithTimeZone = JsonDateTimeTemplate.parse("HH24:MI:SS.FF3TZH:TZM").parseValue("12:34:56.789+05:30");
+        assertThat(timeWithTimeZone).isEqualTo(TypedValue.fromValueAsObject(createTimeWithTimeZoneType(3), parseTimeWithTimeZone(3, "12:34:56.789 +05:30")));
+
+        TypedValue timestamp = JsonDateTimeTemplate.parse("YYYY-MM-DD HH24:MI:SS.FF3").parseValue("2024-01-02 12:34:56.789");
+        assertThat(timestamp).isEqualTo(TypedValue.fromValueAsObject(createTimestampType(3), parseTimestamp(3, "2024-01-02 12:34:56.789")));
+
+        TypedValue timestampWithTimeZone = JsonDateTimeTemplate.parse("YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM").parseValue("2024-01-02 12:34:56.789 +05:30");
+        assertThat(timestampWithTimeZone).isEqualTo(TypedValue.fromValueAsObject(createTimestampWithTimeZoneType(3), parseTimestampWithTimeZone(3, "2024-01-02 12:34:56.789 +05:30")));
+    }
+
+    @Test
+    public void testNegativeSubHourOffset()
+    {
+        // Offsets like -00:30 round the signed hour to 0; the sign must be preserved
+        // independently of the hour magnitude.
+        TypedValue negativeHalfHour = JsonDateTimeTemplate.parse("HH24:MI:SS.FF3TZH:TZM").parseValue("12:34:56.789-00:30");
+        assertThat(negativeHalfHour).isEqualTo(TypedValue.fromValueAsObject(createTimeWithTimeZoneType(3), parseTimeWithTimeZone(3, "12:34:56.789 -00:30")));
+
+        TypedValue positiveHalfHour = JsonDateTimeTemplate.parse("HH24:MI:SS.FF3TZH:TZM").parseValue("12:34:56.789+00:30");
+        assertThat(positiveHalfHour).isEqualTo(TypedValue.fromValueAsObject(createTimeWithTimeZoneType(3), parseTimeWithTimeZone(3, "12:34:56.789 +00:30")));
+    }
+
+    @Test
+    public void testInvalidTemplates()
+    {
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("YYYYRR"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("datetime() format template cannot contain both year and rounded year fields");
+
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("HH24A.M."))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("datetime() format template with HH24 cannot contain HH, HH12, A.M. or P.M.");
+
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("TZM"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("datetime() format template with TZM requires TZH");
+    }
+
+    @Test
+    public void testQuotedLiteralTemplate()
+    {
+        // Double-quoted literal text in the template must match verbatim during parsing.
+        TypedValue timestamp = JsonDateTimeTemplate.parse("YYYY-MM-DD\"T\"HH24:MI:SS.FF3")
+                .parseValue("2024-01-02T12:34:56.789");
+        assertThat(timestamp).isEqualTo(TypedValue.fromValueAsObject(createTimestampType(3), parseTimestamp(3, "2024-01-02 12:34:56.789")));
+
+        // Mismatched literal text raises a diagnostic with position information.
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("YYYY-MM-DD\"T\"HH24")
+                .parseValue("2024-01-02X12:34:56"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected literal 'T'");
+    }
+
+    @Test
+    public void testFF10To12Precision()
+    {
+        // FF10..FF12 map to TIMESTAMP precisions above 9, matching Trino's max precision of 12.
+        assertThat(JsonDateTimeTemplate.parse("YYYY-MM-DD HH24:MI:SS.FF12").getType())
+                .isEqualTo(createTimestampType(12));
+
+        TypedValue ts = JsonDateTimeTemplate.parse("YYYY-MM-DD HH24:MI:SS.FF12")
+                .parseValue("2024-01-02 12:34:56.123456789012");
+        assertThat(ts).isEqualTo(TypedValue.fromValueAsObject(createTimestampType(12), parseTimestamp(12, "2024-01-02 12:34:56.123456789012")));
+    }
+
+    @Test
+    public void testAmPmCaseInsensitive()
+    {
+        // A.M. / P.M. comparisons use case-insensitive matching.
+        TypedValue lower = JsonDateTimeTemplate.parse("YYYY-MM-DD HH12:MI:SS a.m.")
+                .parseValue("2024-01-02 10:11:12 p.m.");
+        assertThat(lower).isEqualTo(TypedValue.fromValueAsObject(createTimestampType(0), parseTimestamp(0, "2024-01-02 22:11:12")));
+    }
+
+    @Test
+    public void testTemplateIsCanonicalized()
+    {
+        // Field tokens are matched case-insensitively, so templates that differ only in their
+        // case describe the same thing and must be indistinguishable to equals() and toString().
+        assertThat(JsonDateTimeTemplate.parse("yyyy-mm-dd").getTemplate()).isEqualTo("YYYY-MM-DD");
+        assertThat(JsonDateTimeTemplate.parse("yyyy-mm-dd")).isEqualTo(JsonDateTimeTemplate.parse("YYYY-MM-DD"));
+        assertThat(JsonDateTimeTemplate.parse("yyyy-mm-dd")).hasSameHashCodeAs(JsonDateTimeTemplate.parse("YYYY-MM-DD"));
+
+        assertThat(JsonDateTimeTemplate.parse("hh24:mi:ss.ff3 tzh:tzm").getTemplate()).isEqualTo("HH24:MI:SS.FF3 TZH:TZM");
+        assertThat(JsonDateTimeTemplate.parse("yyyy-mm-dd hh12:mi:ss a.m.").getTemplate()).isEqualTo("YYYY-MM-DD HH12:MI:SS A.M.");
+
+        // Literal text is matched case-sensitively, so it is preserved verbatim.
+        assertThat(JsonDateTimeTemplate.parse("yyyy\"t\"mm").getTemplate()).isEqualTo("YYYY\"t\"MM");
+        assertThat(JsonDateTimeTemplate.parse("yyyy\"t\"mm")).isNotEqualTo(JsonDateTimeTemplate.parse("yyyy\"T\"mm"));
+
+        // The canonical form parses back to itself.
+        JsonDateTimeTemplate canonical = JsonDateTimeTemplate.parse("yyyy\"t\"mm-dd");
+        assertThat(JsonDateTimeTemplate.parse(canonical.getTemplate())).isEqualTo(canonical);
+    }
+
+    @Test
+    public void testYearCompletion()
+    {
+        // Templates that specify only the low-order year digits take the remaining digits from a
+        // fixed reference year of 1970, so the result does not depend on the current date.
+        assertThat(JsonDateTimeTemplate.parse("Y-MM-DD").parseValue("4-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("1974-01-02")));
+        assertThat(JsonDateTimeTemplate.parse("YY-MM-DD").parseValue("24-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("1924-01-02")));
+        assertThat(JsonDateTimeTemplate.parse("YYY-MM-DD").parseValue("024-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("1024-01-02")));
+        assertThat(JsonDateTimeTemplate.parse("YYYY-MM-DD").parseValue("0024-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("0024-01-02")));
+
+        // RR rounds to the nearest century instead: with a reference year of 1970, values below 50
+        // belong to the next century and values from 50 up to the current one.
+        assertThat(JsonDateTimeTemplate.parse("RR-MM-DD").parseValue("24-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+        assertThat(JsonDateTimeTemplate.parse("RR-MM-DD").parseValue("74-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("1974-01-02")));
+
+        // RRRR is fully specified, so there is nothing to round.
+        assertThat(JsonDateTimeTemplate.parse("RRRR-MM-DD").parseValue("2024-01-02"))
+                .isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+    }
+
+    @Test
+    public void testEmptyTemplateRejected()
+    {
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+    }
+
+    @Test
+    public void testInvalidCharacterCarriesPosition()
+    {
+        // Invalid template characters include their position in the diagnostic.
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("YYYY@MM"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("position 4");
+    }
+
+    @Test
+    public void testSecondOfDayOutOfRange()
+    {
+        // SSSSS is bounds-checked at parse time so out-of-range values produce a clear error,
+        // rather than the decomposed (floorDiv/floorMod) values silently building an invalid time.
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("SSSSS").parseValue("99999"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("second-of-day value out of range")
+                .hasMessageContaining("99999");
+
+        // Boundaries are inclusive at 0 / 86399.
+        JsonDateTimeTemplate template = JsonDateTimeTemplate.parse("SSSSS");
+        template.parseValue("0");
+        template.parseValue("86399");
+        assertThatThrownBy(() -> template.parseValue("86400"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("second-of-day value out of range");
+    }
+
+    @Test
+    public void testHour12OutOfRange()
+    {
+        // HH12 is bounds-checked at parse time. `resolveHour` does `hour12 % 12`, so an
+        // out-of-range value (e.g. 13 A.M., 25 P.M., 0 A.M.) would otherwise fold into a
+        // valid-looking hour and never reach `parseTime`'s validator.
+        JsonDateTimeTemplate template = JsonDateTimeTemplate.parse("HH12:MI:SS A.M.");
+        template.parseValue("01:00:00 A.M.");
+        template.parseValue("12:00:00 P.M.");
+        assertThatThrownBy(() -> template.parseValue("00:00:00 A.M."))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hour-of-half-day value out of range [1, 12]: 0");
+        assertThatThrownBy(() -> template.parseValue("13:00:00 A.M."))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hour-of-half-day value out of range [1, 12]: 13");
+        assertThatThrownBy(() -> template.parseValue("25:00:00 P.M."))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("hour-of-half-day value out of range [1, 12]: 25");
+    }
+
+    @Test
+    public void testTimeZoneMinuteOutOfRange()
+    {
+        // TZM is bounds-checked at parse time. `resolveOffset` does `offsetMinute * 60`,
+        // so values like 99 carry into the hours (e.g. `+05:99` → `+06:39`) and would
+        // never raise an error for clearly-invalid input.
+        JsonDateTimeTemplate template = JsonDateTimeTemplate.parse("HH24:MI:SSTZH:TZM");
+        template.parseValue("12:34:56+05:30");
+        template.parseValue("12:34:56+05:59");
+        assertThatThrownBy(() -> template.parseValue("12:34:56+05:60"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("time-zone-minute value out of range [0, 59]: 60");
+        assertThatThrownBy(() -> template.parseValue("12:34:56+05:99"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("time-zone-minute value out of range [0, 59]: 99");
+    }
+
+    @Test
+    public void testMonthAndDayOutOfRange()
+    {
+        // Unlike the decomposed fields above, MM / DD / DDD are validated by java.time when the
+        // calendar date is assembled (LocalDate.of / LocalDate.ofYearDay), which rejects an
+        // impossible date outright rather than folding it into a valid-looking one.
+        JsonDateTimeTemplate date = JsonDateTimeTemplate.parse("YYYY-MM-DD");
+        date.parseValue("2024-01-01");
+        date.parseValue("2024-12-31");
+        assertThatThrownBy(() -> date.parseValue("2024-13-01"))
+                .isInstanceOf(DateTimeException.class);
+        assertThatThrownBy(() -> date.parseValue("2024-00-01"))
+                .isInstanceOf(DateTimeException.class);
+        assertThatThrownBy(() -> date.parseValue("2024-01-32"))
+                .isInstanceOf(DateTimeException.class);
+        // 2023 is not a leap year, so February has 28 days.
+        assertThatThrownBy(() -> date.parseValue("2023-02-29"))
+                .isInstanceOf(DateTimeException.class);
+
+        // Day of year is likewise validated against the (possibly leap) year.
+        JsonDateTimeTemplate dayOfYear = JsonDateTimeTemplate.parse("YYYY-DDD");
+        dayOfYear.parseValue("2024-366");
+        assertThatThrownBy(() -> dayOfYear.parseValue("2023-366"))
+                .isInstanceOf(DateTimeException.class);
+        assertThatThrownBy(() -> dayOfYear.parseValue("2024-000"))
+                .isInstanceOf(DateTimeException.class);
+        assertThatThrownBy(() -> dayOfYear.parseValue("2024-367"))
+                .isInstanceOf(DateTimeException.class);
+    }
+
+    @Test
+    public void testDelimiterAdjacentToQuotedLiteral()
+    {
+        // A delimiter next to a quoted literal is unambiguous (the delimiter is one character;
+        // the quoted text is verbatim) and must be accepted.
+        TypedValue timestamp = JsonDateTimeTemplate.parse("YYYY-\"Q\"MM-DD")
+                .parseValue("2024-Q01-02");
+        assertThat(timestamp).isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+
+        // Two adjacent DELIMITER characters remain rejected — that combination is ambiguous.
+        assertThatThrownBy(() -> JsonDateTimeTemplate.parse("YYYY--MM"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("consecutive delimiters");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
@@ -42,6 +42,7 @@ import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguratio
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.DateTimeException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -606,6 +607,68 @@ public class TestJsonPathEvaluator
                 path(true, new IrDatetimeMethod(literal(BIGINT, 1L), Optional.empty(), Optional.empty()))))
                 .isInstanceOf(PathEvaluationException.class)
                 .hasMessage("path evaluation failed: invalid item type. Expected: TEXT, actual: bigint");
+    }
+
+    @Test
+    public void testDatetimeMethodWithTemplate()
+    {
+        // With a template, the template determines the resulting type, and the value must match it
+        // exactly -- a shape that would be recognized without a template is not accepted.
+        assertThat(pathResult(
+                TextNode.valueOf("01/02/2024"),
+                path(true, datetimeMethod("MM/DD/YYYY"))))
+                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate("2024-01-02"))));
+
+        assertThat(pathResult(
+                TextNode.valueOf("2024-01-02 12:34:56.789"),
+                path(true, datetimeMethod("YYYY-MM-DD HH24:MI:SS.FF3"))))
+                .isEqualTo(singletonSequence(TypedValue.fromValueAsObject(createTimestampType(3), parseTimestamp(3, "2024-01-02 12:34:56.789"))));
+
+        // the template, not the value, fixes the precision of the resulting type
+        assertThat(pathResult(
+                TextNode.valueOf("12:34:56.789"),
+                path(true, datetimeMethod("HH24:MI:SS.FF6"))))
+                .isEqualTo(singletonSequence(new TypedValue(createTimeType(6), parseTime("12:34:56.789"))));
+
+        // a template that specifies only the low-order year digits completes the year
+        assertThat(pathResult(
+                TextNode.valueOf("24-01-02"),
+                path(true, datetimeMethod("RR-MM-DD"))))
+                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate("2024-01-02"))));
+
+        // multiple inputs -- array is automatically unwrapped in lax mode
+        assertThat(pathResult(
+                new ArrayNode(JsonNodeFactory.instance, ImmutableList.of(TextNode.valueOf("01/02/2024"), TextNode.valueOf("01/03/2024"))),
+                path(true, datetimeMethod("MM/DD/YYYY"))))
+                .isEqualTo(sequence(
+                        new TypedValue(DATE, (long) parseDate("2024-01-02")),
+                        new TypedValue(DATE, (long) parseDate("2024-01-03"))));
+
+        // the value does not match the template
+        assertThatThrownBy(() -> evaluate(
+                TextNode.valueOf("2024-01-02"),
+                path(true, datetimeMethod("MM/DD/YYYY"))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasRootCauseMessage("expected literal '/' at position 2");
+
+        // the value carries a field that the template does not accept
+        assertThatThrownBy(() -> evaluate(
+                TextNode.valueOf("13/02/2024"),
+                path(true, datetimeMethod("MM/DD/YYYY"))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasRootCauseInstanceOf(DateTimeException.class);
+
+        // non-text item is rejected before the template is applied
+        assertThatThrownBy(() -> evaluate(
+                IntNode.valueOf(0),
+                path(true, datetimeMethod("MM/DD/YYYY"))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasMessage("path evaluation failed: invalid item type. Expected: TEXT, actual: NUMBER");
+    }
+
+    private static IrDatetimeMethod datetimeMethod(String template)
+    {
+        return new IrDatetimeMethod(contextVariable(), Optional.of(JsonDateTimeTemplate.parse(template)), Optional.empty());
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ShortNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.json.ir.IrDatetimeMethod;
 import io.trino.json.ir.IrJsonPath;
 import io.trino.json.ir.IrPathNode;
 import io.trino.json.ir.IrPredicate;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.json.JsonEmptySequenceNode.EMPTY_SEQUENCE;
@@ -56,7 +58,10 @@ import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
@@ -105,6 +110,11 @@ import static io.trino.sql.planner.PathNodes.type;
 import static io.trino.sql.planner.PathNodes.wildcardArrayAccessor;
 import static io.trino.sql.planner.PathNodes.wildcardMemberAccessor;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.type.DateTimes.parseTime;
+import static io.trino.type.DateTimes.parseTimeWithTimeZone;
+import static io.trino.type.DateTimes.parseTimestamp;
+import static io.trino.type.DateTimes.parseTimestampWithTimeZone;
+import static io.trino.util.DateTimeUtils.parseDate;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -517,6 +527,85 @@ public class TestJsonPathEvaluator
                 path(true, ceiling(jsonVariable("null_parameter")))))
                 .isInstanceOf(PathEvaluationException.class)
                 .hasMessage("path evaluation failed: invalid item type. Expected: NUMBER, actual: NULL");
+    }
+
+    @Test
+    public void testDatetimeMethod()
+    {
+        // Without a template, the shape of the value determines the resulting type.
+        // text item: DATE shape
+        assertThat(pathResult(
+                TextNode.valueOf("2024-01-02"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate("2024-01-02"))));
+
+        // text item: TIME shape
+        assertThat(pathResult(
+                TextNode.valueOf("12:34:56.789"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(singletonSequence(new TypedValue(createTimeType(3), parseTime("12:34:56.789"))));
+
+        // text item: TIME WITH TIME ZONE shape
+        assertThat(pathResult(
+                TextNode.valueOf("12:34:56.789+05:30"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(singletonSequence(TypedValue.fromValueAsObject(createTimeWithTimeZoneType(3), parseTimeWithTimeZone(3, "12:34:56.789 +05:30"))));
+
+        // text item: TIMESTAMP shape
+        assertThat(pathResult(
+                TextNode.valueOf("2024-01-02 12:34:56.789"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(singletonSequence(TypedValue.fromValueAsObject(createTimestampType(3), parseTimestamp(3, "2024-01-02 12:34:56.789"))));
+
+        // text item: TIMESTAMP WITH TIME ZONE shape
+        assertThat(pathResult(
+                TextNode.valueOf("2024-01-02 12:34:56.789 +05:30"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(singletonSequence(TypedValue.fromValueAsObject(createTimestampWithTimeZoneType(3), parseTimestampWithTimeZone(3, "2024-01-02 12:34:56.789 +05:30"))));
+
+        // the precision of the resulting type follows the number of fractional digits in the value
+        assertThat(pathResult(
+                TextNode.valueOf("12:34:56"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(singletonSequence(new TypedValue(createTimeType(0), parseTime("12:34:56"))));
+
+        // multiple inputs -- array is automatically unwrapped in lax mode
+        assertThat(pathResult(
+                new ArrayNode(JsonNodeFactory.instance, ImmutableList.of(TextNode.valueOf("2024-01-02"), TextNode.valueOf("2024-01-03"))),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isEqualTo(sequence(
+                        new TypedValue(DATE, (long) parseDate("2024-01-02")),
+                        new TypedValue(DATE, (long) parseDate("2024-01-03"))));
+
+        // in strict mode the array is not unwrapped, so it is not a text item
+        assertThatThrownBy(() -> evaluate(
+                new ArrayNode(JsonNodeFactory.instance, ImmutableList.of(TextNode.valueOf("2024-01-02"))),
+                path(false, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasMessage("path evaluation failed: invalid item type. Expected: TEXT, actual: ARRAY");
+
+        // a value that does not match any of the recognized shapes fails as a path evaluation error
+        assertThatThrownBy(() -> evaluate(
+                TextNode.valueOf("not a datetime"),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasRootCauseMessage("Invalid TIMESTAMP 'not a datetime'");
+
+        // non-text JsonNode → itemTypeError
+        assertThatThrownBy(() -> evaluate(
+                IntNode.valueOf(0),
+                path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasMessage("path evaluation failed: invalid item type. Expected: TEXT, actual: NUMBER");
+
+        // non-text TypedValue → itemTypeError (not ClassCastException). The analyzer rejects
+        // statically-typed non-text sources, but defense in depth: if a non-text TypedValue
+        // somehow reaches the runtime, surface a clean item-type error.
+        assertThatThrownBy(() -> evaluate(
+                NullNode.instance,
+                path(true, new IrDatetimeMethod(literal(BIGINT, 1L), Optional.empty(), Optional.empty()))))
+                .isInstanceOf(PathEvaluationException.class)
+                .hasMessage("path evaluation failed: invalid item type. Expected: TEXT, actual: bigint");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
@@ -303,6 +303,19 @@ public class TestJsonValueFunction
                 "SELECT json_value('\"not a datetime\"', 'lax $.datetime()' RETURNING date DEFAULT DATE '1970-01-01' ON ERROR)"))
                 .matches("VALUES DATE '1970-01-01'");
 
+        // with a format template, the value must match the template
+        assertThat(assertions.query(
+                "SELECT json_value('\"01/02/2024\"', 'lax $.datetime(\"MM/DD/YYYY\")' RETURNING date)"))
+                .matches("VALUES DATE '2024-01-02'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('\"2024-01-02 12:34:56.789\"', 'lax $.datetime(\"YYYY-MM-DD HH24:MI:SS.FF3\")' RETURNING timestamp(3))"))
+                .matches("VALUES TIMESTAMP '2024-01-02 12:34:56.789'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('\"2024-01-02\"', 'lax $.datetime(\"MM/DD/YYYY\")' RETURNING date DEFAULT DATE '1970-01-01' ON ERROR)"))
+                .matches("VALUES DATE '1970-01-01'");
+
         // the actual value does not fit in the expected returned type. the error is handled accordingly to the ON ERROR clause
         assertThat(assertions.query(
                 "SELECT json_value('" + INPUT + "', 'lax 1000' RETURNING tinyint)"))

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
@@ -278,6 +278,31 @@ public class TestJsonValueFunction
                 "SELECT json_value('" + INPUT + "', 'lax $[1]' RETURNING char(10))"))
                 .matches("VALUES cast('b' AS char(10))");
 
+        assertThat(assertions.query(
+                "SELECT json_value('\"2024-01-02\"', 'lax $.datetime()' RETURNING date)"))
+                .matches("VALUES DATE '2024-01-02'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('\"12:34:56.789\"', 'lax $.datetime()' RETURNING time(3))"))
+                .matches("VALUES TIME '12:34:56.789'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('\"12:34:56.789+05:30\"', 'lax $.datetime()' RETURNING time(3) with time zone)"))
+                .matches("VALUES TIME '12:34:56.789+05:30'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('\"2024-01-02 12:34:56.789\"', 'lax $.datetime()' RETURNING timestamp(3))"))
+                .matches("VALUES TIMESTAMP '2024-01-02 12:34:56.789'");
+
+        assertThat(assertions.query(
+                "SELECT json_value('\"2024-01-02 12:34:56.789 UTC\"', 'lax $.datetime()' RETURNING timestamp(3) with time zone)"))
+                .matches("VALUES TIMESTAMP '2024-01-02 12:34:56.789 UTC'");
+
+        // a value that cannot be parsed as a datetime is a path evaluation error, so the ON ERROR clause applies
+        assertThat(assertions.query(
+                "SELECT json_value('\"not a datetime\"', 'lax $.datetime()' RETURNING date DEFAULT DATE '1970-01-01' ON ERROR)"))
+                .matches("VALUES DATE '1970-01-01'");
+
         // the actual value does not fit in the expected returned type. the error is handled accordingly to the ON ERROR clause
         assertThat(assertions.query(
                 "SELECT json_value('" + INPUT + "', 'lax 1000' RETURNING tinyint)"))

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonPath2016TypeSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonPath2016TypeSerialization.java
@@ -23,6 +23,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.JsonMapperProvider;
 import io.trino.block.BlockJsonSerde;
+import io.trino.json.JsonDateTimeTemplate;
 import io.trino.json.ir.IrAbsMethod;
 import io.trino.json.ir.IrArithmeticBinary;
 import io.trino.json.ir.IrArithmeticUnary;
@@ -130,9 +131,9 @@ public class TestJsonPath2016TypeSerialization
     @Test
     public void testMethods()
     {
+        assertJsonRoundTrip(new IrJsonPath(true, new IrDatetimeMethod(literal(BIGINT, 1L), Optional.of(JsonDateTimeTemplate.parse("HH24:MI:SS.FF3")), Optional.of(createTimeType(DEFAULT_PRECISION)))));
         assertJsonRoundTrip(new IrJsonPath(true, new IrAbsMethod(literal(DOUBLE, 1e0), Optional.of(DOUBLE))));
         assertJsonRoundTrip(new IrJsonPath(true, new IrCeilingMethod(literal(DOUBLE, 1e0), Optional.of(DOUBLE))));
-        assertJsonRoundTrip(new IrJsonPath(true, new IrDatetimeMethod(literal(BIGINT, 1L), Optional.of("some_time_format"), Optional.of(createTimeType(DEFAULT_PRECISION)))));
         assertJsonRoundTrip(new IrJsonPath(true, new IrDoubleMethod(literal(BIGINT, 1L), Optional.of(DOUBLE))));
         assertJsonRoundTrip(new IrJsonPath(true, new IrFloorMethod(literal(DOUBLE, 1e0), Optional.of(DOUBLE))));
         assertJsonRoundTrip(new IrJsonPath(true, new IrKeyValueMethod(JSON_NULL)));

--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -576,6 +576,47 @@ Without a format template, `datetime()` parses the value as the most specific of
 `DATE` / `TIME(p)` / `TIME(p) WITH TIME ZONE` / `TIMESTAMP(p)` /
 `TIMESTAMP(p) WITH TIME ZONE` based on the value's shape.
 
+The `datetime()` format template is a string of fields and literal text.
+Fields are case-insensitive and consume digits from the value; literal text
+must match the value verbatim.
+
+Supported fields:
+
+| Field            | Width | Description                                              |
+|------------------|-------|----------------------------------------------------------|
+| `YYYY` `YYY` `YY` `Y` | 4 / 3 / 2 / 1 | Year. Widths below 4 are prefixed with the leading digits of the reference year `1970` (e.g. `YY=24` → `1924`). |
+| `RRRR` `RR`      | 4 / 2 | Rounded year. With width 2, values 0–49 map to the current century, 50–99 to the previous century. |
+| `MM`             | 2     | Month, 1–12. |
+| `DD`             | 2     | Day of month, 1–31. |
+| `DDD`            | 3     | Day of year, 1–366. Mutually exclusive with `MM` / `DD`. |
+| `HH24`           | 2     | Hour of day, 0–23. Mutually exclusive with `HH` / `HH12` / `A.M.` / `P.M.`. |
+| `HH` `HH12`      | 2     | Hour of half-day, 1–12. Requires `A.M.` or `P.M.`. |
+| `A.M.` `P.M.`    | 4     | Half-day marker. Case-insensitive (both `a.m.` and `A.M.` are accepted). Requires `HH` or `HH12`. |
+| `MI`             | 2     | Minute, 0–59. |
+| `SS`             | 2     | Second, 0–59. |
+| `SSSSS`          | 5     | Second of day, 0–86399. Mutually exclusive with `HH` / `HH12` / `HH24` / `MI` / `SS` / `A.M.` / `P.M.`. |
+| `FF1`–`FF9`      | 1–9   | Fractional seconds, with the given digit width. |
+| `TZH`            | 3     | Time zone hour offset with sign, e.g. `+05` or `-08`. |
+| `TZM`            | 2     | Time zone minute offset, 0–59. Requires `TZH`. |
+
+Literal text is any of the single-character delimiters `-`, `.`, `/`, `,`,
+`'`, `;`, `:`, ` ` (space), or a double-quoted string (escape an embedded `"`
+as `""`). Two adjacent delimiters are rejected; a delimiter next to a quoted
+literal is fine.
+
+Examples:
+
+```text
+YYYY-MM-DD                          -> 2024-01-02
+YYYY-MM-DD"T"HH24:MI:SS.FF3         -> 2024-01-02T12:34:56.789
+HH12:MI:SS A.M.                     -> 09:30:00 P.M.
+YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM   -> 2024-01-02 12:34:56.789 +05:30
+```
+
+Trino additionally accepts `FF10`, `FF11`, and `FF12` to match Trino's maximum
+`TIME(p)` / `TIMESTAMP(p)` precision of 12 — these widths are a Trino
+extension and may not be portable across other SQL/JSON implementations.
+
 `like_regex()` accepts the standard SQL/XQuery flags (`i`, `m`, `s`, `x`).
 
 #### Limitations

--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -570,12 +570,11 @@ Let `<path>` return a sequence of three JSON arrays:
 <path>.size() --> 3, 4, 2
 ```
 
-### Limitations
-
-The SQL standard describes the `datetime()` JSON path item method. Trino does
-not support it.
-
 ### Trino-specific behavior
+
+Without a format template, `datetime()` parses the value as the most specific of
+`DATE` / `TIME(p)` / `TIME(p) WITH TIME ZONE` / `TIMESTAMP(p)` /
+`TIMESTAMP(p) WITH TIME ZONE` based on the value's shape.
 
 `like_regex()` accepts the standard SQL/XQuery flags (`i`, `m`, `s`, `x`).
 


### PR DESCRIPTION
## Summary

Implements the SQL:2023 §9.46 `datetime()` JSON path method, in both its bare and template-based forms. Three commits, separable but one user-visible feature:

1. **Bare `datetime()` method.** Replaces the trunk's "date method is not yet supported" stub with a real implementation. Detects shape (TIMESTAMP if value contains a space, TIME if it contains a colon, otherwise DATE), then dispatches to the matching parser once — no exception-driven fall-through.
2. **`equals` / `hashCode` on `TypedValue`.** Preparatory. `TypedValue` is a value object but previously relied on reference equality; structural equality is generally useful and is used by the template-roundtrip tests in the next commit.
3. **`datetime(<template>)` format templates.** A `JsonDateTimeTemplate` IR object holds the parsed template (segment list + inferred type + precision). `JsonDateTimeTemplateParser` lexes/validates the template at analysis time; `JsonDateTimeValueParser` applies it at runtime, constructing the underlying time/date representation directly without canonical-string roundtrips. The template language has no nesting or precedence, so the ANTLR grammar is lexer-only.

## SQL:2023 conformance

- Without a template: tries each shape exactly once (no exception-based dispatch); the most specific TIME/TIMESTAMP precision is inferred from the value's fractional digits.
- With a template: pattern is lexed and validated once at analysis time, applied at runtime.
- Failures raise `PathEvaluationException`, suppressed in lax mode per §9.46.

Supported template fields: `YYYY`/`YYY`/`YY`/`Y` (year, with low-width prefixing), `RRRR`/`RR` (rounded year), `MM` (month), `DD` (day), `DDD` (day of year), `HH24` (24-hour), `HH`/`HH12` + `A.M.`/`P.M.` (12-hour), `MI` (minute), `SS` (second), `SSSSS` (second of day, bounds-checked to [0, 86399]), `FF1`–`FF9` (standard fractional widths) plus `FF10`–`FF12` to match Trino's max `TIME(p)`/`TIMESTAMP(p)` precision of 12, `TZH`/`TZM` (time-zone hour/minute, bounds-checked). Literal text is either a single-character delimiter (`-`, `.`, `/`, `,`, `'`, `;`, `:`, space) or a double-quoted string (escape an embedded `"` as `""`).

Mutual exclusions (`YYYY` vs `RR`, `DDD` vs `MM`/`DD`, `HH24` vs `HH`/`A.M.`, `SSSSS` vs `HH`/`MI`/`SS`/…, `TZM` requires `TZH`) are enforced at analysis time. Out-of-range values for `HOUR12`, `TIME_ZONE_MINUTE`, and `SECOND_OF_DAY` — which would otherwise fold silently through downstream arithmetic — are bounds-checked at parse time with field-naming diagnostics.

## Test plan

- [x] `TestJsonDateTimeTemplate` covers type inference, value parsing across all 5 type shapes, quoted-literal templates, FF10–FF12 widths, case-insensitive A.M./P.M., adjacent-delimiter rejection, delimiter/quoted-literal interaction, and the HOUR12/SECOND_OF_DAY/TIME_ZONE_MINUTE bounds checks.
- [x] `TestJsonValueFunction` covers end-to-end `json_value(..., 'lax $.datetime()' RETURNING …)` for DATE and TIMESTAMP WITH TIME ZONE.
- [x] `TestJsonPath2016TypeSerialization` round-trips `IrDatetimeMethod` carrying a `JsonDateTimeTemplate`.
- [x] Each commit in the stack builds independently and passes the relevant tests.