### PR TITLE
  Fix iceberg metadata cache reading partial content with stale length

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystemCache.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystemCache.java
@@ -18,6 +18,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.Weigher;
 import com.google.inject.Inject;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.cache.EvictableCacheBuilder;
@@ -180,8 +181,20 @@ public final class MemoryFileSystemCache
         if (fileSize > maxContentLengthBytes) {
             return Optional.empty();
         }
-        try (TrinoInput trinoInput = delegate.newInput()) {
-            return Optional.of(trinoInput.readTail(toIntExact(fileSize)));
+        // Read from the start of the file, capped at maxContentLengthBytes + 1.
+        // The declared file length is treated as a hint only: callers may pass a
+        // stale (smaller) length (see https://github.com/trinodb/trino/issues/25702).
+        // Reading the tail in that case would miss bytes at the beginning of the
+        // file (e.g., Avro magic bytes). Reading from position 0 preserves file
+        // headers regardless of how accurate the declared length is. The +1 detects
+        // files whose actual size exceeds the max content length, in which case we
+        // skip caching.
+        try (TrinoInputStream stream = delegate.newStream()) {
+            byte[] buffer = stream.readNBytes(maxContentLengthBytes + 1);
+            if (buffer.length > maxContentLengthBytes) {
+                return Optional.empty();
+            }
+            return Optional.of(Slices.wrappedBuffer(buffer));
         }
     }
 

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystemAccessOperations.java
@@ -82,7 +82,7 @@ public class TestCacheFileSystemAccessOperations
         assertReadOperations(location, content,
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(location, "InputFile.length"))
-                        .add(new FileOperation(location, "InputFile.newInput"))
+                        .add(new FileOperation(location, "InputFile.newStream"))
                         .add(new FileOperation(location, "InputFile.lastModified"))
                         .build());
         assertReadOperations(location, content,
@@ -97,7 +97,7 @@ public class TestCacheFileSystemAccessOperations
         assertReadOperations(location, modifiedContent,
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(location, "InputFile.length"))
-                        .add(new FileOperation(location, "InputFile.newInput"))
+                        .add(new FileOperation(location, "InputFile.newStream"))
                         .add(new FileOperation(location, "InputFile.lastModified"))
                         .build());
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMemoryCacheFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMemoryCacheFileOperations.java
@@ -81,12 +81,12 @@ public class TestIcebergMemoryCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .addCopies(new CacheOperation("Input.readTail", DATA), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", DATA), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheInput", DATA), 2)
                         .add(new CacheOperation("FileSystemCache.cacheStream", METADATA_JSON))
                         .add(new CacheOperation("FileSystemCache.cacheLength", SNAPSHOT))
                         .add(new CacheOperation("FileSystemCache.cacheStream", SNAPSHOT))
-                        .addCopies(new CacheOperation("Input.readTail", MANIFEST), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", MANIFEST), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", MANIFEST), 2)
                         .build());
 
@@ -107,12 +107,12 @@ public class TestIcebergMemoryCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .addCopies(new CacheOperation("Input.readTail", DATA), 3)
+                        .addCopies(new CacheOperation("InputFile.newStream", DATA), 3)
                         .addCopies(new CacheOperation("FileSystemCache.cacheInput", DATA), 5)
                         .add(new CacheOperation("FileSystemCache.cacheStream", METADATA_JSON))
                         .add(new CacheOperation("FileSystemCache.cacheLength", SNAPSHOT))
                         .add(new CacheOperation("FileSystemCache.cacheStream", SNAPSHOT))
-                        .addCopies(new CacheOperation("Input.readTail", MANIFEST), 3)
+                        .addCopies(new CacheOperation("InputFile.newStream", MANIFEST), 3)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", MANIFEST), 5)
                         .build());
 
@@ -135,14 +135,14 @@ public class TestIcebergMemoryCacheFileOperations
                 "SELECT * FROM test_select_with_filter WHERE col_name = 1",
                 ImmutableMultiset.<CacheOperation>builder()
                         .add(new CacheOperation("FileSystemCache.cacheStream", METADATA_JSON))
-                        .add(new CacheOperation("Input.readTail", METADATA_JSON))
+                        .add(new CacheOperation("InputFile.newStream", METADATA_JSON))
                         .add(new CacheOperation("InputFile.length", METADATA_JSON))
                         .add(new CacheOperation("FileSystemCache.cacheStream", SNAPSHOT))
                         .add(new CacheOperation("FileSystemCache.cacheLength", SNAPSHOT))
                         .add(new CacheOperation("FileSystemCache.cacheStream", MANIFEST))
-                        .add(new CacheOperation("Input.readTail", MANIFEST))
+                        .add(new CacheOperation("InputFile.newStream", MANIFEST))
                         .add(new CacheOperation("FileSystemCache.cacheInput", DATA))
-                        .add(new CacheOperation("Input.readTail", DATA))
+                        .add(new CacheOperation("InputFile.newStream", DATA))
                         .build());
 
         assertFileSystemAccesses(
@@ -164,14 +164,14 @@ public class TestIcebergMemoryCacheFileOperations
 
         assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .addCopies(new CacheOperation("Input.readTail", METADATA_JSON), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", METADATA_JSON), 2)
                         .addCopies(new CacheOperation("InputFile.length", METADATA_JSON), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", METADATA_JSON), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", SNAPSHOT), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheLength", SNAPSHOT), 2)
-                        .addCopies(new CacheOperation("Input.readTail", MANIFEST), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", MANIFEST), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheStream", MANIFEST), 4)
-                        .addCopies(new CacheOperation("Input.readTail", DATA), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", DATA), 2)
                         .addCopies(new CacheOperation("FileSystemCache.cacheInput", DATA), 2)
                         .build());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestCachedManifestStaleLength.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestCachedManifestStaleLength.java
@@ -25,11 +25,11 @@ import io.trino.filesystem.cache.DefaultCacheKeyProvider;
 import io.trino.filesystem.memory.MemoryFileSystem;
 import io.trino.filesystem.memory.MemoryFileSystemCache;
 import io.trino.filesystem.memory.MemoryFileSystemCacheConfig;
-import org.apache.avro.InvalidAvroMagicException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.file.FileReader;
 import org.apache.avro.file.SeekableByteArrayInput;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
@@ -43,24 +43,23 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.HOURS;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCachedManifestStaleLength
 {
     @Test
-    public void testStaleDeclaredLengthCausesAvroMagicFailure()
+    public void testStaleDeclaredLengthPreservesAvroFileHeader()
             throws IOException
     {
-        // Reproduces https://github.com/trinodb/trino/issues/25702.
+        // Regression test for https://github.com/trinodb/trino/issues/25702.
         //
         // In production an iceberg manifest list may record a manifest file's
         // length from before the file was rewritten with a larger version,
         // leaving the recorded length smaller than the actual on-storage size.
-        // When a reader opens the file with that stale length,
-        // MemoryFileSystemCache.load calls readTail(staleLength) and caches only
-        // the last staleLength bytes — the cached content begins with bytes from
-        // the middle of the file, not the Avro magic header. Avro's
-        // DataFileReader then throws InvalidAvroMagicException.
+        // When a reader opens the file with that stale length the cache must
+        // still load the full file from position 0, otherwise the Avro magic
+        // header would be missing from the cached content and the reader would
+        // throw InvalidAvroMagicException.
 
         MemoryFileSystem delegate = new MemoryFileSystem();
         MemoryFileSystemCache cache = new MemoryFileSystemCache(new MemoryFileSystemCacheConfig()
@@ -70,38 +69,32 @@ public class TestCachedManifestStaleLength
 
         Location location = Location.of("memory:///stale-length-%s".formatted(UUID.randomUUID()));
 
-        // The file exists on storage in its original (smaller) form.
         byte[] originalContent = "small".getBytes(UTF_8);
         fileSystem.newOutputFile(location).createOrOverwrite(originalContent);
 
-        // The file is rewritten with a larger, valid Avro data file.
         Schema schema = SchemaBuilder.record("Test").namespace("test").fields().requiredString("value").endRecord();
         byte[] avroContent = writeAvroFile(schema, "hello world");
         fileSystem.newOutputFile(location).createOrOverwrite(avroContent);
 
-        // A reader opens the file using the STALE (original, smaller) length.
         TrinoInputFile inputFile = fileSystem.newInputFile(location, originalContent.length);
 
-        // Trigger cache load via readTail(staleLength); the cached entry contains
-        // only the last staleLength bytes of the Avro file, missing the magic
-        // header at the beginning.
+        // Trigger cache load via the stale (smaller) length. The cache must load
+        // the full file from position 0 rather than only the tail.
         try (TrinoInput input = inputFile.newInput()) {
             input.readTail(originalContent.length);
         }
 
-        // Read the cached content and feed it to Avro's DataFileReader, mirroring
-        // what iceberg does when reading a manifest. The magic check fails because
-        // the cache returned the tail of the file, not the start.
         byte[] cachedBytes;
         try (TrinoInputStream stream = inputFile.newStream()) {
             cachedBytes = stream.readAllBytes();
         }
 
-        assertThatThrownBy(() -> DataFileReader.openReader(
+        try (FileReader<GenericRecord> reader = DataFileReader.openReader(
                 new SeekableByteArrayInput(cachedBytes),
-                new GenericDatumReader<GenericRecord>()))
-                .isInstanceOf(InvalidAvroMagicException.class)
-                .hasMessage("Not an Avro data file");
+                new GenericDatumReader<>())) {
+            assertThat(reader.hasNext()).isTrue();
+            assertThat(reader.next().get("value")).hasToString("hello world");
+        }
     }
 
     private static byte[] writeAvroFile(Schema schema, String value)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestCachedManifestStaleLength.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestCachedManifestStaleLength.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.cache;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import io.trino.filesystem.memory.MemoryFileSystemCache;
+import io.trino.filesystem.memory.MemoryFileSystemCacheConfig;
+import org.apache.avro.InvalidAvroMagicException;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestCachedManifestStaleLength
+{
+    @Test
+    public void testStaleDeclaredLengthCausesAvroMagicFailure()
+            throws IOException
+    {
+        // Reproduces https://github.com/trinodb/trino/issues/25702.
+        //
+        // In production an iceberg manifest list may record a manifest file's
+        // length from before the file was rewritten with a larger version,
+        // leaving the recorded length smaller than the actual on-storage size.
+        // When a reader opens the file with that stale length,
+        // MemoryFileSystemCache.load calls readTail(staleLength) and caches only
+        // the last staleLength bytes — the cached content begins with bytes from
+        // the middle of the file, not the Avro magic header. Avro's
+        // DataFileReader then throws InvalidAvroMagicException.
+
+        MemoryFileSystem delegate = new MemoryFileSystem();
+        MemoryFileSystemCache cache = new MemoryFileSystemCache(new MemoryFileSystemCacheConfig()
+                .setMaxContentLength(DataSize.ofBytes(2L * 1024 * 1024))
+                .setCacheTtl(new Duration(8, HOURS)));
+        TrinoFileSystem fileSystem = new CacheFileSystem(delegate, cache, new DefaultCacheKeyProvider());
+
+        Location location = Location.of("memory:///stale-length-%s".formatted(UUID.randomUUID()));
+
+        // The file exists on storage in its original (smaller) form.
+        byte[] originalContent = "small".getBytes(UTF_8);
+        fileSystem.newOutputFile(location).createOrOverwrite(originalContent);
+
+        // The file is rewritten with a larger, valid Avro data file.
+        Schema schema = SchemaBuilder.record("Test").namespace("test").fields().requiredString("value").endRecord();
+        byte[] avroContent = writeAvroFile(schema, "hello world");
+        fileSystem.newOutputFile(location).createOrOverwrite(avroContent);
+
+        // A reader opens the file using the STALE (original, smaller) length.
+        TrinoInputFile inputFile = fileSystem.newInputFile(location, originalContent.length);
+
+        // Trigger cache load via readTail(staleLength); the cached entry contains
+        // only the last staleLength bytes of the Avro file, missing the magic
+        // header at the beginning.
+        try (TrinoInput input = inputFile.newInput()) {
+            input.readTail(originalContent.length);
+        }
+
+        // Read the cached content and feed it to Avro's DataFileReader, mirroring
+        // what iceberg does when reading a manifest. The magic check fails because
+        // the cache returned the tail of the file, not the start.
+        byte[] cachedBytes;
+        try (TrinoInputStream stream = inputFile.newStream()) {
+            cachedBytes = stream.readAllBytes();
+        }
+
+        assertThatThrownBy(() -> DataFileReader.openReader(
+                new SeekableByteArrayInput(cachedBytes),
+                new GenericDatumReader<GenericRecord>()))
+                .isInstanceOf(InvalidAvroMagicException.class)
+                .hasMessage("Not an Avro data file");
+    }
+
+    private static byte[] writeAvroFile(Schema schema, String value)
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(schema))) {
+            writer.create(schema, baos);
+            GenericRecord record = new GenericData.Record(schema);
+            record.put("value", value);
+            writer.append(record);
+        }
+        return baos.toByteArray();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes #25702 

Fix `MemoryFileSystemCache` returning partial file content when a caller
opens an input file via `newInputFile(location, length)` with a declared
length smaller than the actual on-storage size. The previous
implementation used `readTail(declaredLength)`, which cached only the
tail of the file and dropped bytes at the beginning. In iceberg this
surfaced as `org.apache.avro.InvalidAvroMagicException: Not an Avro
data file` when a manifest was opened through a stale-length cache
entry, because the cached content no longer started with the Avro
magic header.

The first commit adds a focused reproduction test in trino-iceberg that
exercises the full Avro read path through the cache and asserts the
production-symptom `InvalidAvroMagicException`. The second commit
applies the fix and flips the test to assert the Avro record is read
back successfully.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
*   Fix iceberg metadata cache reading partial content with stale length ({issue}`25702`)
```
