### PR TITLE
Remove hadoop-apache, hive-apache from Iceberg

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -656,18 +656,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.trino.hadoop</groupId>
-            <artifactId>hadoop-apache</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino.hive</groupId>
-            <artifactId>hive-apache</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.trino.tpch</groupId>
             <artifactId>tpch</artifactId>
             <scope>test</scope>
@@ -773,6 +761,26 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <configuration>
+                        <rules>
+                            <bannedDependencies>
+                                <!-- HadoopTables depends on hadoop-apache -->
+                                <searchTransitive>false</searchTransitive>
+                                <excludes combine.children="append">
+                                    <exclude>io.trino.hadoop:hadoop-apache</exclude>
+                                </excludes>
+                            </bannedDependencies>
+                            <bannedDependencies>
+                                <excludes combine.children="append">
+                                    <exclude>io.trino.hive:hive-apache</exclude>
+                                </excludes>
+                            </bannedDependencies>
+                        </rules>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -51,7 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TestFileBasedConflictDetection
 {
-    private static final HadoopTables HADOOP_TABLES = new HadoopTables(new Configuration(false));
+    private static final HadoopTables HADOOP_TABLES = new HadoopTables();
     private static final String COLUMN_1_NAME = "col1";
     private static final ColumnIdentity COLUMN_1_IDENTITY = new ColumnIdentity(1, COLUMN_1_NAME, PRIMITIVE, ImmutableList.of());
     private static final IcebergColumnHandle COLUMN_1_HANDLE = IcebergColumnHandle.optional(COLUMN_1_IDENTITY).columnType(INTEGER).build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
@@ -26,7 +26,6 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -503,7 +502,7 @@ public class TestIcebergRegisterTableProcedure
         // create hadoop table
         String hadoopTableName = "hadoop_table_" + randomNameSuffix();
         String hadoopTableLocation = metastoreDir.getPath() + "/" + hadoopTableName;
-        HadoopTables hadoopTables = new HadoopTables(new Configuration(false));
+        HadoopTables hadoopTables = new HadoopTables();
         Schema schema = new Schema(ImmutableList.of(
                 Types.NestedField.optional(1, "id", Types.IntegerType.get()),
                 Types.NestedField.optional(2, "name", Types.StringType.get())));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV3.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV3.java
@@ -30,7 +30,6 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -87,7 +86,7 @@ public class TestIcebergV3
         extends AbstractTestQueryFramework
 {
     private static final List<String> ALL_FILE_FORMATS = List.of("PARQUET", "ORC", "AVRO");
-    private static final HadoopTables HADOOP_TABLES = new HadoopTables(new Configuration(false));
+    private static final HadoopTables HADOOP_TABLES = new HadoopTables();
 
     private HiveMetastore metastore;
     private TrinoFileSystemFactory fileSystemFactory;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
@@ -21,7 +21,6 @@ import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
@@ -101,7 +100,7 @@ public abstract class BaseIcebergJdbcCatalogConnectorSmokeTest
                         .put(PROPERTY_PREFIX + "schema-version", SchemaVersion.V1.toString())
                         .put(WAREHOUSE_LOCATION, warehouseLocation.getAbsolutePath())
                         .buildOrThrow(),
-                new Configuration(false));
+                null);
         return IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
@@ -26,7 +26,6 @@ import io.trino.plugin.iceberg.containers.NessieContainer;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.tpch.TpchTable;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -97,7 +96,7 @@ public class TestIcebergNessieCatalogConnectorSmokeTest
                         .put(URI, nessieContainer.getRestApiUri())
                         .put(WAREHOUSE_LOCATION, tempDir.toString())
                         .buildOrThrow(),
-                new Configuration(false));
+                null);
 
         return IcebergQueryRunner.builder()
                 .setBaseDataDir(Optional.of(tempDir))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest.java
@@ -15,27 +15,16 @@ package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.ServerFeature;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.node.NodeInfo;
-import io.trino.hdfs.DynamicHdfsConfiguration;
-import io.trino.hdfs.HdfsConfig;
-import io.trino.hdfs.HdfsConfiguration;
-import io.trino.hdfs.HdfsConfigurationInitializer;
-import io.trino.hdfs.HdfsContext;
-import io.trino.hdfs.HdfsEnvironment;
-import io.trino.hdfs.authentication.NoHdfsAuthentication;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
-import io.trino.spi.connector.ConnectorSession;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.TestingConnectorSession;
 import io.trino.testing.sql.TestTable;
 import io.trino.tpch.TpchTable;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
@@ -116,14 +105,7 @@ abstract class AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
         properties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation);
         properties.putAll(backendCatalogFileIoProperties());
 
-        ConnectorSession connectorSession = TestingConnectorSession.builder().build();
-        HdfsConfig hdfsConfig = new HdfsConfig();
-        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
-        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
-        HdfsContext context = new HdfsContext(connectorSession);
-
         JdbcCatalog catalog = new JdbcCatalog();
-        catalog.setConf(hdfsEnvironment.getConfiguration(context, new Path(warehouseLocation)));
         catalog.initialize("backend_jdbc", properties.buildOrThrow());
         return catalog;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/RestCatalogTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/RestCatalogTestUtils.java
@@ -14,16 +14,6 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import io.trino.hdfs.DynamicHdfsConfiguration;
-import io.trino.hdfs.HdfsConfig;
-import io.trino.hdfs.HdfsConfiguration;
-import io.trino.hdfs.HdfsConfigurationInitializer;
-import io.trino.hdfs.HdfsContext;
-import io.trino.hdfs.HdfsEnvironment;
-import io.trino.hdfs.authentication.NoHdfsAuthentication;
-import io.trino.spi.connector.ConnectorSession;
-import io.trino.testing.TestingConnectorSession;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
@@ -46,14 +36,7 @@ public final class RestCatalogTestUtils
         properties.put(JdbcCatalog.PROPERTY_PREFIX + "schema-version", "V1");
         properties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation.resolve("iceberg_data").toFile().getAbsolutePath());
 
-        ConnectorSession connectorSession = TestingConnectorSession.builder().build();
-        HdfsConfig hdfsConfig = new HdfsConfig();
-        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
-        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
-        HdfsContext context = new HdfsContext(connectorSession);
-
         JdbcCatalog catalog = new JdbcCatalog();
-        catalog.setConf(hdfsEnvironment.getConfiguration(context, new org.apache.hadoop.fs.Path(warehouseLocation.toAbsolutePath().toString())));
         catalog.initialize("backend_jdbc", properties.buildOrThrow());
 
         return catalog;


### PR DESCRIPTION
## Description

Remove hadoop-apache, hive-apache from Iceberg. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
