### PR TITLE
Fix preview Web UI output row rate units

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StageOperatorNode.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/flow/StageOperatorNode.tsx
@@ -113,7 +113,7 @@ export const StageOperatorNode = (props: IStageOperatorNodeProps) => {
     const rowInputRate = totalWallTime === 0 ? 0 : stats.inputPositions / (totalWallTime / 1000.0)
     const byteInputRate = totalWallTime === 0 ? 0 : (parseDataSize(stats.inputDataSize) || 0) / (totalWallTime / 1000.0)
 
-    const rowOutputRate = totalWallTime === 0 ? 0 : stats.outputPositions / totalWallTime
+    const rowOutputRate = totalWallTime === 0 ? 0 : stats.outputPositions / (totalWallTime / 1000.0)
     const byteOutputRate =
         totalWallTime === 0 ? 0 : (parseDataSize(stats.outputDataSize) || 0) / (totalWallTime / 1000.0)
 


### PR DESCRIPTION
## Summary
- fix the Preview Web UI output row rate calculation to use seconds instead of raw milliseconds

## Why
`StageOperatorNode` computes `totalWallTime` in milliseconds via `parseDuration(...)`.
The input row rate and byte rates convert that value to seconds, but the output row rate divided by the raw millisecond value while still being shown as `rows/s`.
That underreports the output row rate by 1000x.

## Impact
The Preview Web UI operator statistics modal now reports output row rates in the same units as the label and the adjacent rate calculations.

## Validation
- `npm run lint`
- `npm run build`
- `npm run prettier:check`

Fixes #29612
