### PR TITLE
Skip writing empty puffin file during OPTIMIZE when no statistics exist

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2141,10 +2141,10 @@ public class IcebergMetadata
         commitUpdate(rewriteFiles, session, "optimize");
 
         long newSnapshotId = icebergTable.currentSnapshot().snapshotId();
-        StatisticsFile newStatsFile = tableStatisticsWriter.rewriteStatisticsFile(session, icebergTable, newSnapshotId);
-        transaction.updateStatistics()
-                .setStatistics(newStatsFile)
-                .commit();
+        tableStatisticsWriter.rewriteStatisticsFile(session, icebergTable, newSnapshotId).ifPresent(newStatsFile ->
+                transaction.updateStatistics()
+                        .setStatistics(newStatsFile)
+                        .commit());
 
         commitTransaction(transaction, "optimize");
         transaction = null;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsWriter.java
@@ -110,15 +110,25 @@ public class TableStatisticsWriter
         return writeStatisticsFile(session, table, fileIO, snapshotId, ndvSketches);
     }
 
-    public StatisticsFile rewriteStatisticsFile(ConnectorSession session, Table table, long snapshotId)
+    public Optional<StatisticsFile> rewriteStatisticsFile(ConnectorSession session, Table table, long snapshotId)
     {
+        Optional<StatisticsFile> latestStatisticsFile = getLatestStatisticsFile(table, snapshotId);
+        if (latestStatisticsFile.isEmpty() || latestStatisticsFile.get().blobMetadata().isEmpty()) {
+            return Optional.empty();
+        }
         TableOperations operations = ((HasTableOperations) table).operations();
         FileIO fileIO = operations.io();
         // This will rewrite old statistics file as ndvSketches map is empty
-        return writeStatisticsFile(session, table, fileIO, snapshotId, Map.of());
+        return Optional.of(writeStatisticsFile(session, table, fileIO, snapshotId, Map.of(), latestStatisticsFile));
     }
 
-    private GenericStatisticsFile writeStatisticsFile(ConnectorSession session, Table table, FileIO fileIO, long snapshotId, Map<Integer, CompactThetaSketch> ndvSketches)
+    private StatisticsFile writeStatisticsFile(ConnectorSession session, Table table, FileIO fileIO, long snapshotId, Map<Integer, CompactThetaSketch> ndvSketches)
+    {
+        Optional<StatisticsFile> latestStatisticsFile = getLatestStatisticsFile(table, snapshotId);
+        return writeStatisticsFile(session, table, fileIO, snapshotId, ndvSketches, latestStatisticsFile);
+    }
+
+    private StatisticsFile writeStatisticsFile(ConnectorSession session, Table table, FileIO fileIO, long snapshotId, Map<Integer, CompactThetaSketch> ndvSketches, Optional<StatisticsFile> latestStatisticsFile)
     {
         Snapshot snapshot = table.snapshot(snapshotId);
         long snapshotSequenceNumber = snapshot.sequenceNumber();
@@ -148,7 +158,7 @@ public class TableStatisticsWriter
             try (PuffinWriter writer = Puffin.write(outputFile)
                     .createdBy("Trino version " + trinoVersion)
                     .build()) {
-                getLatestStatisticsFile(table, snapshotId)
+                latestStatisticsFile
                         .ifPresent(previousStatisticsFile -> copyRetainedStatistics(fileIO, previousStatisticsFile, validFieldIds, ndvSketches.keySet(), writer));
 
                 ndvSketches.entrySet().stream()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
@@ -13,12 +13,22 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.math.IntMath;
 import io.trino.Session;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.metastore.HiveMetastore;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.GenericStatisticsFile;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.puffin.Puffin;
+import org.apache.iceberg.puffin.PuffinWriter;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,6 +40,9 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.COLLECT_EXTENDED_STATISTICS_ON_WRITE;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.EXPIRE_SNAPSHOTS_MIN_RETENTION;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergTestUtils.loadTable;
 import static io.trino.testing.DataProviders.cartesianProduct;
 import static io.trino.testing.DataProviders.trueFalse;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.EXECUTE_TABLE_PROCEDURE;
@@ -44,6 +57,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestIcebergStatistics
         extends AbstractTestQueryFramework
 {
+    private HiveMetastore metastore;
+    private TrinoFileSystemFactory fileSystemFactory;
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -51,6 +67,13 @@ public class TestIcebergStatistics
         return IcebergQueryRunner.builder()
                 .setInitialTables(NATION)
                 .build();
+    }
+
+    @BeforeAll
+    public void setUp()
+    {
+        metastore = getHiveMetastore(getQueryRunner());
+        fileSystemFactory = getFileSystemFactory(getQueryRunner());
     }
 
     @ParameterizedTest
@@ -1149,6 +1172,66 @@ public class TestIcebergStatistics
     }
 
     @Test
+    public void testOptimizeWithoutPreexistingStatistics()
+    {
+        String tableName = "test_optimize_no_stats_" + randomNameSuffix();
+        Session writeSession = withStatsOnWrite(getSession(), false);
+
+        assertUpdate(writeSession, "CREATE TABLE " + tableName + " (key integer)");
+        assertUpdate(writeSession, "INSERT INTO " + tableName + " VALUES 1, 2, 3", 3);
+        // Delete forces OPTIMIZE to actually rewrite the file (a lone file with no deletions is skipped)
+        assertUpdate(writeSession, "DELETE FROM " + tableName + " WHERE key = 1", 1);
+
+        // OPTIMIZE with no prior ANALYZE — must not write a statistics file
+        assertUpdate("ALTER TABLE " + tableName + " EXECUTE optimize");
+
+        assertThat(loadIcebergTable(tableName).statisticsFiles()).isEmpty();
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testOptimizeWithEmptyPreexistingStatistics()
+            throws Exception
+    {
+        String tableName = "test_optimize_empty_stats_" + randomNameSuffix();
+        Session writeSession = withStatsOnWrite(getSession(), false);
+
+        assertUpdate(writeSession, "CREATE TABLE " + tableName + " (key integer)");
+        assertUpdate(writeSession, "INSERT INTO " + tableName + " VALUES 1, 2, 3", 3);
+        // Delete forces OPTIMIZE to actually rewrite the file (a lone file with no deletions is skipped)
+        assertUpdate(writeSession, "DELETE FROM " + tableName + " WHERE key = 1", 1);
+
+        // Register an empty statistics file (no blobs) for the current snapshot by writing a real Puffin file.
+        // Iceberg silently discards GenericStatisticsFile registrations with empty blob lists if no physical file exists.
+        BaseTable icebergTable = loadIcebergTable(tableName);
+        long snapshotId = icebergTable.currentSnapshot().snapshotId();
+        TableOperations ops = icebergTable.operations();
+        String statsPath = ops.metadataFileLocation("empty-stats-" + randomNameSuffix() + ".stats");
+        try (PuffinWriter writer = Puffin.write(ops.io().newOutputFile(statsPath)).build()) {
+            writer.finish();
+            StatisticsFile emptyStatsFile = new GenericStatisticsFile(snapshotId, statsPath, writer.fileSize(), writer.footerSize(), ImmutableList.of());
+            icebergTable.updateStatistics()
+                    .setStatistics(emptyStatsFile)
+                    .commit();
+        }
+        icebergTable.refresh();
+
+        List<StatisticsFile> statisticsFiles = icebergTable.statisticsFiles();
+        assertThat(statisticsFiles).hasSize(1);
+
+        // OPTIMIZE with an empty pre-existing statistics file — must not write a new statistics file
+        assertUpdate("ALTER TABLE " + tableName + " EXECUTE optimize");
+
+        icebergTable.refresh();
+        assertThat(icebergTable.statisticsFiles())
+                .hasSize(1)
+                .containsExactlyInAnyOrderElementsOf(statisticsFiles);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testStatsAfterDeletingAllRows()
     {
         String tableName = "test_stats_after_deleting_all_rows_";
@@ -1204,5 +1287,10 @@ public class TestIcebergStatistics
         return Session.builder(session)
                 .setCatalogSessionProperty(catalog, COLLECT_EXTENDED_STATISTICS_ON_WRITE, Boolean.toString(enabled))
                 .build();
+    }
+
+    private BaseTable loadIcebergTable(String tableName)
+    {
+        return loadTable(tableName, metastore, fileSystemFactory, "iceberg", "tpch");
     }
 }


### PR DESCRIPTION
## Description
This is a minor optimization to avoid writing and committing empty puffin stats files unnecessarily.

## Additional context and related issues
Puffin files hold the NDV (number of distinct values) statistics. Since optimize does not change data, the current statistics get rewritten here....but if there are no existing stats, we're writing an empty puffin file when we could just skip doing that entirely.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.