### PR TITLE
Increase variant metadata size limit to 128MiB

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/spark/VariantUtil.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/spark/VariantUtil.java
@@ -120,11 +120,10 @@ public final class VariantUtil
     // The lower 4 bits of the first metadata byte contain the version.
     public static final byte VERSION_MASK = 0x0F;
 
-    public static final int U24_MAX = 0xFFFFFF;
     public static final int U32_SIZE = 4;
 
-    // Both variant value and variant metadata need to be no longer than 16MiB.
-    public static final int SIZE_LIMIT = U24_MAX + 1;
+    // Both variant value and variant metadata need to be no longer than 128MiB.
+    public static final int SIZE_LIMIT = 128 * 1024 * 1024;
 
     public static final int MAX_DECIMAL4_PRECISION = 9;
     public static final int MAX_DECIMAL8_PRECISION = 18;


### PR DESCRIPTION
## Description

Spark has increased the limit to 128MiB from 16MiB.

- Fixes #29423

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.