### PR TITLE
Skip table location filesystem check when catalog generates table location

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1471,8 +1471,7 @@ public class IcebergMetadata
         }
         Location location = Location.of(transaction.table().location());
         try {
-            // S3 Tables internally assigns a unique location for each table
-            if (!isS3Tables(location.toString())) {
+            if (!skipEmptyLocationCheck(tableLocation, location)) {
                 TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(transaction.table().io()));
                 if (!replace && fileSystem.listFiles(location).hasNext()) {
                     throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, format("" +
@@ -4458,5 +4457,11 @@ public class IcebergMetadata
         if (formatVersion < 3 && defaultValuePresent) {
             throw new TrinoException(NOT_SUPPORTED, "Default column values are not supported for Iceberg table format version < 3");
         }
+    }
+
+    private static boolean skipEmptyLocationCheck(String targetLocation, Location finalLocation)
+    {
+        return targetLocation == null || // True iff the namespace location is null, in which case the catalog internally assigns a unique location
+                isS3Tables(finalLocation.toString()); // S3 Tables internally assigns a unique location for each table too
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogGeneratingTableLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogGeneratingTableLocation.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestIcebergTrinoRestCatalogGeneratingTableLocation
+        extends AbstractTestQueryFramework
+{
+    private static final String SCHEMA = "test_no_namespace_location";
+
+    @TempDir
+    private static Path warehouseLocation;
+    private JdbcCatalog backend;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        // Backend that never returns a location property for its namespaces, so
+        // TrinoRestCatalog.defaultTableLocation returns null and CREATE TABLE goes
+        // through the non-staged create path (tableBuilder.create().newTransaction()).
+        backend = closeAfterClass(backendCatalogWithoutNamespaceLocation(warehouseLocation));
+
+        DelegatingRestSessionCatalog delegatingCatalog = DelegatingRestSessionCatalog.builder()
+                .delegate(backend)
+                .build();
+        TestingHttpServer testServer = delegatingCatalog.testServer();
+        testServer.start();
+        closeAfterClass(testServer::stop);
+
+        backend.createNamespace(Namespace.of(SCHEMA), ImmutableMap.of());
+
+        return IcebergQueryRunner.builder(SCHEMA)
+                .setIcebergProperties(ImmutableMap.<String, String>builder()
+                        .put("iceberg.catalog.type", "rest")
+                        .put("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
+                        .put("fs.hadoop.enabled", "true")
+                        .buildOrThrow())
+                .disableSchemaInitializer()
+                .build();
+    }
+
+    @Test
+    void testCreateTable()
+    {
+        // Iceberg writes the initial metadata files to the table location before
+        // IcebergMetadata.beginCreateTable checks whether the location is empty, which used
+        // to cause a spurious "Cannot create a table on a non-empty location" error.
+        try (TestTable table = newTrinoTable("test_table_", "(col INTEGER)")) {
+            assertThat(backend.loadTable(TableIdentifier.of(SCHEMA, table.getName())).location())
+                    .isEqualTo(warehouseLocation.resolve(SCHEMA, table.getName()).toString());
+            assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+        }
+    }
+
+    /**
+     * Creates a backend catalog backed by a file:// URI warehouse whose namespace metadata
+     * never includes a {@code location} property (such REST catalogs are technically allowed).
+     */
+    private static JdbcCatalog backendCatalogWithoutNamespaceLocation(Path warehouseLocation)
+            throws IOException
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put(CatalogProperties.URI, "jdbc:h2:file:" + Files.createTempFile(null, null).toAbsolutePath())
+                .put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation.toFile().getAbsolutePath())
+                .put(JdbcCatalog.PROPERTY_PREFIX + "username", "user")
+                .put(JdbcCatalog.PROPERTY_PREFIX + "password", "password")
+                .put(JdbcCatalog.PROPERTY_PREFIX + "schema-version", "V1")
+                .buildOrThrow();
+        JdbcCatalog backend = new JdbcCatalog()
+        {
+            @Override
+            public Map<String, String> loadNamespaceMetadata(Namespace namespace)
+            {
+                Map<String, String> metadata = new HashMap<>(super.loadNamespaceMetadata(namespace));
+                metadata.remove("location");
+                return ImmutableMap.copyOf(metadata);
+            }
+        };
+        backend.initialize("backend_jdbc", properties);
+        return backend;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This should fix #26742 - previously during `CREATE TABLE`, catalogs that don't return a namespace `location` are first treated as S3-tables (non staged create), but then a filesystem check of 'no existing files' is still done (which fails since the creation has finalised and the catalog has stored metadata there).

This is a follow-up to #26744 which attempted the same solution, but seems to be going stale. Since I would like to prioritize this getting fixed, opening a separate PR that I can more actively contribute to.

## Additional context and related issues
See #26742 for a more detailed explanation of the cause of the problem.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: