### PR TITLE
Add support in Iceberg REST catalog for prefixed path storage credentials - no apache/iceberg library changes

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -845,9 +845,9 @@
                                 <exclude>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
-                                <exclude>**/TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.java</exclude>
+                                <exclude>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</exclude>
-                                <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.java</exclude>
+                                <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
                                 <exclude>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</exclude>
@@ -916,9 +916,9 @@
                                 <include>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
-                                <include>**/TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.java</include>
+                                <include>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</include>
-                                <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.java</include>
+                                <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergSnowflakeCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestTrinoSnowflakeCatalog.java</include>

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -846,6 +846,7 @@
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</exclude>
+                                <exclude>**/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
@@ -917,6 +918,7 @@
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</include>
+                                <include>**/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileSystemFactory.java
@@ -20,5 +20,17 @@ import java.util.Map;
 
 public interface IcebergFileSystemFactory
 {
+    /**
+     * Creates a file system using raw FileIO properties, as delivered directly by the Iceberg catalog.
+     */
     TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties);
+
+    /**
+     * Creates a file system from typed table credentials, which carry both the global FileIO properties
+     * and any prefixed storage credentials vended by the catalog.
+     */
+    default TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
+    {
+        return create(identity, tableCredentials.fileIoProperties());
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1472,7 +1472,7 @@ public class IcebergMetadata
         try {
             // S3 Tables internally assigns a unique location for each table
             if (!isS3Tables(location.toString())) {
-                TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), transaction.table().io().properties());
+                TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(transaction.table().io()));
                 if (!replace && fileSystem.listFiles(location).hasNext()) {
                     throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, format("" +
                             "Cannot create a table on a non-empty location: %s, set 'iceberg.unique-table-location=true' in your Iceberg catalog properties " +
@@ -2381,7 +2381,7 @@ public class IcebergMetadata
         }
 
         Instant expiration = session.getStart().minusMillis(retention.toMillis());
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(table.io()));
         return removeOrphanFiles(
                 table,
                 fileSystem,
@@ -2395,7 +2395,7 @@ public class IcebergMetadata
     {
         IcebergAddFilesHandle addFilesHandle = (IcebergAddFilesHandle) executeHandle.procedureHandle();
         Table table = catalog.loadTable(session, executeHandle.schemaTableName());
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(table.io()));
         long addedDataFiles = addFiles(
                 session,
                 fileSystem,
@@ -2412,7 +2412,7 @@ public class IcebergMetadata
     {
         IcebergAddFilesFromTableHandle addFilesHandle = (IcebergAddFilesFromTableHandle) executeHandle.procedureHandle();
         Table table = catalog.loadTable(session, executeHandle.schemaTableName());
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), table.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(table.io()));
         long addedDataFiles = addFilesFromTable(
                 session,
                 fileSystem,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -49,7 +49,6 @@ import java.util.Optional;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Maps.transformValues;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.maxPartitionsPerWriter;
-import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static java.util.Objects.requireNonNull;
 
@@ -93,7 +92,7 @@ public class IcebergPageSinkProvider
     {
         verify(tableCredentials.isPresent(), "tableCredentials must be present");
         IcebergWritableTableHandle tableHandle = (IcebergWritableTableHandle) outputTableHandle;
-        return createPageSink(session, tableHandle, getFileIoProperties(tableCredentials));
+        return createPageSink(session, tableHandle, tableCredentials.map(IcebergTableCredentials.class::cast).get());
     }
 
     @Override
@@ -101,16 +100,16 @@ public class IcebergPageSinkProvider
     {
         verify(tableCredentials.isPresent(), "tableCredentials must be present");
         IcebergWritableTableHandle tableHandle = (IcebergWritableTableHandle) insertTableHandle;
-        return createPageSink(session, tableHandle, getFileIoProperties(tableCredentials));
+        return createPageSink(session, tableHandle, tableCredentials.map(IcebergTableCredentials.class::cast).get());
     }
 
-    private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, Map<String, String> fileIoProperties)
+    private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, IcebergTableCredentials tableCredentials)
     {
         Schema schema = SchemaParser.fromJson(tableHandle.schemaAsJson());
-        return createPageSink(session, tableHandle, schema, fileIoProperties);
+        return createPageSink(session, tableHandle, schema, tableCredentials);
     }
 
-    private IcebergPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, Schema schema, Map<String, String> fileIoProperties)
+    private IcebergPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle, Schema schema, IcebergTableCredentials tableCredentials)
     {
         String partitionSpecJson = tableHandle.partitionsSpecsAsJson().get(tableHandle.partitionSpecId());
         PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, partitionSpecJson);
@@ -121,7 +120,7 @@ public class IcebergPageSinkProvider
                 locationProvider,
                 fileWriterFactory,
                 pageIndexerFactory,
-                fileSystemFactory.create(session.getIdentity(), fileIoProperties),
+                fileSystemFactory.create(session.getIdentity(), tableCredentials),
                 tableHandle.partitionColumns(),
                 jsonCodec,
                 session,
@@ -157,7 +156,7 @@ public class IcebergPageSinkProvider
                         locationProvider,
                         fileWriterFactory,
                         pageIndexerFactory,
-                        fileSystemFactory.create(session.getIdentity(), getFileIoProperties(tableCredentials)),
+                        fileSystemFactory.create(session.getIdentity(), tableCredentials.map(IcebergTableCredentials.class::cast).get()),
                         optimizeHandle.partitionColumns(),
                         jsonCodec,
                         session,
@@ -185,7 +184,6 @@ public class IcebergPageSinkProvider
         verify(tableCredentials.isPresent(), "tableCredentials is empty");
         IcebergMergeTableHandle merge = (IcebergMergeTableHandle) mergeHandle;
         IcebergWritableTableHandle tableHandle = merge.getInsertTableHandle();
-        Map<String, String> fileIoProperties = getFileIoProperties(tableCredentials);
         LocationProvider locationProvider = getLocationProvider(tableHandle.name(), tableHandle.outputPath(), tableHandle.storageProperties());
         Schema schema = SchemaParser.fromJson(tableHandle.schemaAsJson());
         Map<Integer, PartitionSpec> partitionsSpecs = transformValues(tableHandle.partitionsSpecsAsJson(), json -> PartitionSpecParser.fromJson(schema, json));
@@ -202,13 +200,14 @@ public class IcebergPageSinkProvider
         else {
             outputSchema = SchemaParser.fromJson(tableHandle.schemaAsJson());
         }
-        ConnectorPageSink pageSink = createPageSink(session, tableHandle, outputSchema, fileIoProperties);
+        IcebergTableCredentials icebergTableCredentials = tableCredentials.map(IcebergTableCredentials.class::cast).get();
+        ConnectorPageSink pageSink = createPageSink(session, tableHandle, outputSchema, icebergTableCredentials);
 
         return new IcebergMergeSink(
                 formatVersion,
                 locationProvider,
                 fileWriterFactory,
-                fileSystemFactory.create(session.getIdentity(), fileIoProperties),
+                fileSystemFactory.create(session.getIdentity(), icebergTableCredentials),
                 jsonCodec,
                 session,
                 tableHandle.fileFormat(),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -183,7 +183,6 @@ import static io.trino.plugin.iceberg.IcebergSplitSource.partitionMatchesPredica
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
-import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionValues;
 import static io.trino.plugin.iceberg.IcebergUtil.schemaFromHandles;
@@ -264,10 +263,11 @@ public class IcebergPageSourceProvider
             DynamicFilter dynamicFilter)
     {
         verify(connectorTableCredentials.isPresent(), "connectorTableCredentials is empty");
+        IcebergTableCredentials icebergTableCredentials = connectorTableCredentials.map(IcebergTableCredentials.class::cast).get();
         if (connectorSplit instanceof FilesTableSplit filesTableSplit) {
             return new FilesTablePageSource(
                     typeManager,
-                    fileSystemFactory.create(session.getIdentity(), getFileIoProperties(connectorTableCredentials)),
+                    fileSystemFactory.create(session.getIdentity(), icebergTableCredentials),
                     fileIoFactory,
                     columns.stream().map(SystemColumnHandle.class::cast).map(SystemColumnHandle::columnName).collect(toImmutableList()),
                     filesTableSplit);
@@ -301,7 +301,7 @@ public class IcebergPageSourceProvider
                 split.fileSize(),
                 split.fileRecordCount(),
                 split.fileFormat(),
-                getFileIoProperties(connectorTableCredentials),
+                icebergTableCredentials,
                 split.dataSequenceNumber(),
                 split.fileFirstRowId(),
                 tableHandle.getNameMappingJson().map(NameMappingParser::fromJson));
@@ -323,7 +323,7 @@ public class IcebergPageSourceProvider
             long fileSize,
             long fileRecordCount,
             IcebergFileFormat fileFormat,
-            Map<String, String> fileIoProperties,
+            IcebergTableCredentials tableCredentials,
             OptionalLong dataSequenceNumber,
             OptionalLong fileFirstRowId,
             Optional<NameMapping> nameMapping)
@@ -341,7 +341,7 @@ public class IcebergPageSourceProvider
 
         // exit early when only reading partition keys from a simple split
         String partition = partitionSpec.partitionToPath(partitionData);
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), fileIoProperties);
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), tableCredentials);
         TrinoInputFile inputFile = isUseFileSizeFromMetadata(session)
                 ? fileSystem.newInputFile(Location.of(path), fileSize)
                 : fileSystem.newInputFile(Location.of(path));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -139,7 +139,7 @@ public class IcebergSplitSource
     private final IcebergFileSystemFactory fileSystemFactory;
     private final ConnectorSession session;
     private final IcebergTableHandle tableHandle;
-    private final Map<String, String> fileIoProperties;
+    private final IcebergTableCredentials tableCredentials;
     private final Scan<?, FileScanTask, CombinedScanTask> tableScan;
     private final OptionalLong maxScannedFileSizeInBytes;
     private final Map<Integer, Type.PrimitiveType> fieldIdToType;
@@ -209,7 +209,7 @@ public class IcebergSplitSource
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.session = requireNonNull(session, "session is null");
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
-        this.fileIoProperties = requireNonNull(icebergTable.io().properties(), "fileIoProperties is null");
+        this.tableCredentials = IcebergTableCredentials.forFileIO(icebergTable.io());
         this.tableScan = requireNonNull(tableScan, "tableScan is null");
         this.maxScannedFileSizeInBytes = maxScannedFileSize.isPresent() ? OptionalLong.of(maxScannedFileSize.orElseThrow().toBytes()) : OptionalLong.empty();
         this.fieldIdToType = primitiveFieldTypes(tableScan.schema());
@@ -457,7 +457,7 @@ public class IcebergSplitSource
         }
         Domain fullFileModifiedTimeDomain = fileModifiedTimeDomain.intersect(getFileModifiedTimeDomain(dynamicFilterPredicate));
         if (!fullFileModifiedTimeDomain.isAll()) {
-            long fileModifiedTime = getModificationTime(fileScanTask.file().location(), fileSystemFactory.create(session.getIdentity(), fileIoProperties));
+            long fileModifiedTime = getModificationTime(fileScanTask.file().location(), fileSystemFactory.create(session.getIdentity(), tableCredentials));
             if (!fullFileModifiedTimeDomain.includesNullableValue(packDateTimeWithZone(fileModifiedTime, UTC_KEY))) {
                 return true;
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStorageCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStorageCredentials.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record IcebergStorageCredentials(String prefix, Map<String, String> config)
+{
+    public IcebergStorageCredentials
+    {
+        requireNonNull(prefix, "prefix is null");
+        config = ImmutableMap.copyOf(config);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentials.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentials.java
@@ -13,22 +13,35 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 
+import java.util.List;
 import java.util.Map;
 
-public record IcebergTableCredentials(Map<String, String> fileIoProperties)
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public record IcebergTableCredentials(Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentials)
         implements ConnectorTableCredentials
 {
     public IcebergTableCredentials
     {
         fileIoProperties = ImmutableMap.copyOf(fileIoProperties);
+        storageCredentials = ImmutableList.copyOf(storageCredentials);
     }
 
     public static IcebergTableCredentials forFileIO(FileIO io)
     {
-        return new IcebergTableCredentials(io.properties());
+        if (io instanceof SupportsStorageCredentials storageCredentials) {
+            return new IcebergTableCredentials(
+                    io.properties(),
+                    storageCredentials.credentials().stream()
+                            .map(credential -> new IcebergStorageCredentials(credential.prefix(), credential.config()))
+                            .collect(toImmutableList()));
+        }
+        return new IcebergTableCredentials(io.properties(), ImmutableList.of());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentialsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableCredentialsProvider.java
@@ -37,7 +37,7 @@ public class IcebergTableCredentialsProvider
     public Optional<ConnectorTableCredentials> getTableCredentials(ConnectorSession session, SchemaTableName schemaTableName)
     {
         return Optional.of(tableCredentials.computeIfAbsent(schemaTableName, key ->
-                new IcebergTableCredentials(catalog.loadTable(session, key).io().properties())));
+                IcebergTableCredentials.forFileIO(catalog.loadTable(session, key).io())));
     }
 
     public void putTableCredentials(SchemaTableName schemaTableName, IcebergTableCredentials credentials)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -39,7 +39,6 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.InvocationConvention;
@@ -1385,13 +1384,5 @@ public final class IcebergUtil
         catch (NotFoundException | UncheckedIOException e) {
             throw new TrinoException(ICEBERG_INVALID_METADATA, "Error accessing manifest file for table %s".formatted(icebergTable.name()), e);
         }
-    }
-
-    public static Map<String, String> getFileIoProperties(Optional<ConnectorTableCredentials> tableCredentials)
-    {
-        if (tableCredentials.isPresent()) {
-            return ((IcebergTableCredentials) tableCredentials.get()).fileIoProperties();
-        }
-        return ImmutableMap.of();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystem.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
@@ -21,15 +22,16 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
@@ -37,11 +39,18 @@ import static java.util.stream.Collectors.groupingBy;
 public class IcebergRestCatalogFileSystem
         implements TrinoFileSystem
 {
-    private final Function<Location, TrinoFileSystem> loader;
+    protected List<IcebergStorageCredentials> storageCredentials = ImmutableList.of();
+    private final IcebergRestCatalogFileSystemLoader loader;
 
-    public IcebergRestCatalogFileSystem(Function<Location, TrinoFileSystem> loader)
+    public IcebergRestCatalogFileSystem(IcebergRestCatalogFileSystemLoader loader)
     {
         this.loader = requireNonNull(loader, "loader is null");
+    }
+
+    public void setCredentials(List<IcebergStorageCredentials> storageCredentials)
+    {
+        this.storageCredentials = ImmutableList.copyOf(storageCredentials);
+        loader.setStorageCredentials(storageCredentials);
     }
 
     @Override
@@ -103,11 +112,23 @@ public class IcebergRestCatalogFileSystem
     public void deleteFiles(Collection<Location> locations)
             throws IOException
     {
-        Map<String, List<Location>> byScheme = locations.stream()
-                .collect(groupingBy(location -> location.scheme().orElseThrow()));
-        for (List<Location> group : byScheme.values()) {
+        // Group by the longest matching storage-credential prefix first so each group is served
+        // by a single credential set. Locations that match no prefix fall back to grouping by
+        // scheme, which is safe because all such locations share the root fileIoProperties.
+        Map<String, List<Location>> groups = locations.stream()
+                .collect(groupingBy(this::locationPrefix));
+        for (List<Location> group : groups.values()) {
             fileSystem(group.getFirst()).deleteFiles(group);
         }
+    }
+
+    private String locationPrefix(Location location)
+    {
+        return storageCredentials.stream()
+                .filter(credential -> location.toString().startsWith(credential.prefix()))
+                .max(Comparator.comparingInt(credential -> credential.prefix().length()))
+                .map(IcebergStorageCredentials::prefix)
+                .orElseGet(() -> location.scheme().orElseThrow());
     }
 
     @Override
@@ -189,6 +210,6 @@ public class IcebergRestCatalogFileSystem
 
     private TrinoFileSystem fileSystem(Location location)
     {
-        return loader.apply(location);
+        return loader.create(location);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -13,18 +13,24 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.cache.EvictableCacheBuilder;
+import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -56,65 +62,137 @@ public class IcebergRestCatalogFileSystemFactory
         this.catalogProperties = ImmutableMap.copyOf(catalogPropertiesProvider.catalogProperties());
     }
 
+    @VisibleForTesting
+    void flushVendedCredentialsCache()
+    {
+        vendedCredentialsProvidersCache.invalidateAll();
+    }
+
+    // Used by ioBuilder function in the RESTSessionCatalog
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
         if (vendedCredentialsEnabled) {
-            CachedVendedCredentialsProviders cached = uncheckedCacheGet(
-                    vendedCredentialsProvidersCache,
-                    createVendedCredentialsCacheKey(identity, fileIoProperties),
-                    () -> createVendedCredentialsProviders(fileIoProperties));
+            return new IcebergRestCatalogFileSystem(new IcebergRestCatalogFileSystemLoader()
+            {
+                @Override
+                public TrinoFileSystem create(Location location)
+                {
+                    if (location.scheme().isEmpty()) {
+                        throw new IllegalArgumentException("Location scheme is empty: " + location);
+                    }
+                    CachedVendedCredentialsProviders cached = uncheckedCacheGet(
+                            vendedCredentialsProvidersCache,
+                            createVendedCredentialsCacheKey(identity, fileIoProperties, this.storageCredentials),
+                            () -> createVendedCredentialsProviders(fileIoProperties, this.storageCredentials));
 
-            if (cached.s3VendedCredentialsProvider().isPresent() || cached.gcsVendedCredentialsProvider().isPresent() || cached.azureVendedCredentialsProvider().isPresent()) {
-                return new IcebergRestCatalogFileSystem(
-                        location -> {
-                            if (location.scheme().isEmpty()) {
-                                throw new IllegalArgumentException("Location scheme is empty: " + location);
-                            }
-                            // Derive the vended credentials to load from the location scheme
-                            Optional<VendedCredentials> vendedCredentials = switch (location.scheme().get()) {
-                                case "s3", "s3a", "s3n" -> cached.s3VendedCredentialsProvider().map(S3VendedCredentialsProvider::getCredentials);
-                                case "gs" -> cached.gcsVendedCredentialsProvider().map(GcsVendedCredentialsProvider::getCredentials);
-                                case "abfs", "abfss", "wasb", "wasbs" -> cached.azureVendedCredentialsProvider().map(AzureVendedCredentialsProvider::getCredentials);
-                                default -> throw new IllegalArgumentException("Unsupported location scheme for vended credentials: " + location);
-                            };
-                            if (vendedCredentials.isEmpty()) {
-                                throw new IllegalStateException("Failed to initialize the vended credentials from the provided fileIoProperties");
-                            }
-
-                            ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
-                                    .withGroups(identity.getGroups())
-                                    .withPrincipal(identity.getPrincipal())
-                                    .withEnabledSystemRoles(identity.getEnabledSystemRoles())
-                                    .withConnectorRole(identity.getConnectorRole())
-                                    .withExtraCredentials(ImmutableMap.<String, String>builder()
-                                            .putAll(cached.extraCredentials())
-                                            .putAll(ImmutableMap.copyOf(vendedCredentials.map(VendedCredentials::toExtraCredentials).orElse(ImmutableMap.of())))
-                                            .buildOrThrow())
-                                    .build();
-
-                            return fileSystemFactory.create(identityWithExtraCredentials);
-                        });
-            }
+                    return getTrinoFileSystem(location, identity, cached);
+                }
+            });
         }
         return fileSystemFactory.create(identity);
     }
 
-    private static VendedCredentialsCacheKey createVendedCredentialsCacheKey(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
     {
-        Optional<S3VendedCredentials> s3VendedCredentials = createVendedCredentialsIfPresent(
+        if (vendedCredentialsEnabled) {
+            return new IcebergRestCatalogFileSystem(new IcebergRestCatalogFileSystemLoader()
+            {
+                @Override
+                public TrinoFileSystem create(Location location)
+                {
+                    if (location.scheme().isEmpty()) {
+                        throw new IllegalArgumentException("Location scheme is empty: " + location);
+                    }
+                    CachedVendedCredentialsProviders cached = uncheckedCacheGet(
+                            vendedCredentialsProvidersCache,
+                            createVendedCredentialsCacheKey(identity, tableCredentials.fileIoProperties(), tableCredentials.storageCredentials()),
+                            () -> createVendedCredentialsProviders(tableCredentials.fileIoProperties(), tableCredentials.storageCredentials()));
+
+                    return getTrinoFileSystem(location, identity, cached);
+                }
+            });
+        }
+        return fileSystemFactory.create(identity);
+    }
+
+    private TrinoFileSystem getTrinoFileSystem(Location location, ConnectorIdentity identity, CachedVendedCredentialsProviders cached)
+    {
+        // Derive the vended credentials to load from the location scheme
+        Optional<VendedCredentials> vendedCredentials = switch (location.scheme().get()) {
+            case "s3", "s3a", "s3n" -> findVendedCredentialsForLocation(cached.s3VendedCredentialsProviders(), location);
+            case "gs" -> findVendedCredentialsForLocation(cached.gcsVendedCredentialsProviders(), location);
+            case "abfs", "abfss", "wasb", "wasbs" -> cached.azureVendedCredentialsProvider().map(AzureVendedCredentialsProvider::getCredentials);
+            default -> throw new IllegalArgumentException("Unsupported location scheme for vended credentials: " + location);
+        };
+        if (vendedCredentials.isEmpty()) {
+            throw new IllegalStateException("Failed to initialize the vended credentials from the provided fileIoProperties");
+        }
+
+        ConnectorIdentity identityWithExtraCredentials = ConnectorIdentity.forUser(identity.getUser())
+                .withGroups(identity.getGroups())
+                .withPrincipal(identity.getPrincipal())
+                .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                .withConnectorRole(identity.getConnectorRole())
+                .withExtraCredentials(ImmutableMap.<String, String>builder()
+                        .putAll(cached.extraCredentials())
+                        .putAll(ImmutableMap.copyOf(vendedCredentials.map(VendedCredentials::toExtraCredentials).orElse(ImmutableMap.of())))
+                        .buildOrThrow())
+                .build();
+
+        return fileSystemFactory.create(identityWithExtraCredentials);
+    }
+
+    private static VendedCredentialsCacheKey createVendedCredentialsCacheKey(ConnectorIdentity identity, Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentials)
+    {
+        return new VendedCredentialsCacheKey(
+                identity.getUser(),
+                createS3VendedCredentials(fileIoProperties, storageCredentials),
+                createGcsVendedCredentials(fileIoProperties, storageCredentials),
+                createAzureVendedCredentials(fileIoProperties));
+    }
+
+    private static Map<String, S3VendedCredentials> createS3VendedCredentials(Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentialsList)
+    {
+        ImmutableMap.Builder<String, S3VendedCredentials> builder = ImmutableMap.builder();
+        // Root-prefix entries built from fileIoProperties — act as catch-all fallback, matching any S3 path
+        createVendedCredentialsIfPresent(
                 fileIoProperties,
                 () -> S3VendedCredentialsProvider.createVendedCredentials(fileIoProperties),
                 S3FileIOProperties.ACCESS_KEY_ID,
                 S3FileIOProperties.SECRET_ACCESS_KEY,
-                S3FileIOProperties.SESSION_TOKEN);
-        Optional<GcsVendedCredentials> gcsVendedCredentials = createVendedCredentialsIfPresent(
+                S3FileIOProperties.SESSION_TOKEN)
+                .ifPresent(vendedCredentials -> builder.put("s3", vendedCredentials));
+
+        for (IcebergStorageCredentials storageCredentials : storageCredentialsList) {
+            if (isS3Prefix(storageCredentials.prefix())) {
+                builder.put(
+                        storageCredentials.prefix(),
+                        S3VendedCredentialsProvider.createVendedCredentials(mergeConfigs(fileIoProperties, storageCredentials.config())));
+            }
+        }
+        return builder.buildKeepingLast();
+    }
+
+    private static Map<String, GcsVendedCredentials> createGcsVendedCredentials(Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentialsList)
+    {
+        ImmutableMap.Builder<String, GcsVendedCredentials> builder = ImmutableMap.builder();
+        // Root-prefix entries built from fileIoProperties — act as catch-all fallback, matching any GCS path
+        createVendedCredentialsIfPresent(
                 fileIoProperties,
                 () -> GcsVendedCredentialsProvider.createVendedCredentials(fileIoProperties),
-                GCPProperties.GCS_OAUTH2_TOKEN);
-        Optional<AzureVendedCredentials> azureVendedCredentials = createAzureVendedCredentials(fileIoProperties);
+                GCPProperties.GCS_OAUTH2_TOKEN)
+                .ifPresent(vendedCredentials -> builder.put("gs", vendedCredentials));
 
-        return new VendedCredentialsCacheKey(identity.getUser(), s3VendedCredentials, gcsVendedCredentials, azureVendedCredentials);
+        for (IcebergStorageCredentials storageCredentials : storageCredentialsList) {
+            if (isGcsPrefix(storageCredentials.prefix())) {
+                builder.put(
+                        storageCredentials.prefix(),
+                        GcsVendedCredentialsProvider.createVendedCredentials(mergeConfigs(fileIoProperties, storageCredentials.config())));
+            }
+        }
+        return builder.buildKeepingLast();
     }
 
     private static <T> Optional<T> createVendedCredentialsIfPresent(
@@ -140,60 +218,77 @@ public class IcebergRestCatalogFileSystemFactory
         return Optional.empty();
     }
 
-    private CachedVendedCredentialsProviders createVendedCredentialsProviders(Map<String, String> fileIoProperties)
+    private CachedVendedCredentialsProviders createVendedCredentialsProviders(Map<String, String> fileIoProperties, List<IcebergStorageCredentials> storageCredentialsList)
     {
-        Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+        ImmutableMap.Builder<String, S3VendedCredentialsProvider> s3ProvidersBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, GcsVendedCredentialsProvider> gcsProvidersBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
+
+        // Root-prefix providers built from fileIoProperties — act as catch-all fallback, matching any S3/GCS path
+        createVendedCredentialsProviderIfPresent(
                 fileIoProperties,
                 () -> new S3VendedCredentialsProvider(catalogProperties, fileIoProperties),
                 S3FileIOProperties.ACCESS_KEY_ID,
                 S3FileIOProperties.SECRET_ACCESS_KEY,
-                S3FileIOProperties.SESSION_TOKEN);
-        Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider = createVendedCredentialsProviderIfPresent(
+                S3FileIOProperties.SESSION_TOKEN)
+                .ifPresent(vendedCredentialsProvider -> s3ProvidersBuilder.put("s3", vendedCredentialsProvider));
+        createVendedCredentialsProviderIfPresent(
                 fileIoProperties,
                 () -> new GcsVendedCredentialsProvider(catalogProperties, fileIoProperties),
-                GCPProperties.GCS_OAUTH2_TOKEN);
-        Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
-
-        ImmutableMap.Builder<String, String> extraCredentialsBuilder = ImmutableMap.builder();
-        // handle GCS
+                GCPProperties.GCS_OAUTH2_TOKEN)
+                .ifPresent(vendedCredentialsProvider -> gcsProvidersBuilder.put("gs", vendedCredentialsProvider));
         if (fileIoProperties.containsKey(GCPProperties.GCS_OAUTH2_TOKEN)) {
             addOptionalProperty(extraCredentialsBuilder, fileIoProperties, GCPProperties.GCS_PROJECT_ID, EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY);
         }
 
+        // Per-prefix providers built from merged config (storage credential config overrides fileIoProperties)
+        for (IcebergStorageCredentials storageCredentials : storageCredentialsList) {
+            String credentialPrefix = storageCredentials.prefix();
+            if (isS3Prefix(credentialPrefix)) {
+                s3ProvidersBuilder.put(credentialPrefix, new S3VendedCredentialsProvider(catalogProperties, mergeConfigs(fileIoProperties, storageCredentials.config())));
+            }
+            else if (isGcsPrefix(credentialPrefix)) {
+                gcsProvidersBuilder.put(credentialPrefix, new GcsVendedCredentialsProvider(catalogProperties, mergeConfigs(fileIoProperties, storageCredentials.config())));
+            }
+        }
+
+        // Azure does not make use of SupportsStorageCredentials mechanism; always from fileIoProperties
+        Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider = createAzureVendedCredentialsProvider(fileIoProperties);
+
         return new CachedVendedCredentialsProviders(
-                s3VendedCredentialsProvider,
-                gcsVendedCredentialsProvider,
+                s3ProvidersBuilder.buildKeepingLast(),
+                gcsProvidersBuilder.buildKeepingLast(),
                 azureVendedCredentialsProvider,
                 extraCredentialsBuilder.buildOrThrow());
     }
 
     private record VendedCredentialsCacheKey(
             String user,
-            Optional<S3VendedCredentials> s3VendedCredentials,
-            Optional<GcsVendedCredentials> gcsVendedCredentials,
+            Map<String, S3VendedCredentials> s3VendedCredentials,
+            Map<String, GcsVendedCredentials> gcsVendedCredentials,
             Optional<AzureVendedCredentials> azureVendedCredentials)
     {
         public VendedCredentialsCacheKey
         {
             requireNonNull(user, "user is null");
-            requireNonNull(s3VendedCredentials, "s3VendedCredentials is null");
-            requireNonNull(gcsVendedCredentials, "gcsVendedCredentials is null");
+            s3VendedCredentials = ImmutableMap.copyOf(s3VendedCredentials);
+            gcsVendedCredentials = ImmutableMap.copyOf(gcsVendedCredentials);
             requireNonNull(azureVendedCredentials, "azureVendedCredentials is null");
         }
     }
 
     private record CachedVendedCredentialsProviders(
-            Optional<S3VendedCredentialsProvider> s3VendedCredentialsProvider,
-            Optional<GcsVendedCredentialsProvider> gcsVendedCredentialsProvider,
+            Map<String, S3VendedCredentialsProvider> s3VendedCredentialsProviders,
+            Map<String, GcsVendedCredentialsProvider> gcsVendedCredentialsProviders,
             Optional<AzureVendedCredentialsProvider> azureVendedCredentialsProvider,
             Map<String, String> extraCredentials)
     {
         public CachedVendedCredentialsProviders
         {
-            requireNonNull(s3VendedCredentialsProvider, "s3VendedCredentialsProvider is null");
-            requireNonNull(gcsVendedCredentialsProvider, "gcsVendedCredentialsProvider is null");
+            s3VendedCredentialsProviders = ImmutableMap.copyOf(s3VendedCredentialsProviders);
+            gcsVendedCredentialsProviders = ImmutableMap.copyOf(gcsVendedCredentialsProviders);
             requireNonNull(azureVendedCredentialsProvider, "azureVendedCredentialsProvider is null");
-            requireNonNull(extraCredentials, "extraCredentials is null");
+            extraCredentials = ImmutableMap.copyOf(extraCredentials);
         }
     }
 
@@ -230,5 +325,31 @@ public class IcebergRestCatalogFileSystemFactory
         if (value != null) {
             builder.put(extraCredentialKey, value);
         }
+    }
+
+    private static <V extends VendedCredentials, P extends VendedCredentialsProvider<V>> Optional<VendedCredentials> findVendedCredentialsForLocation(Map<String, P> providers, Location location)
+    {
+        return providers.entrySet().stream()
+                .filter(e -> location.toString().startsWith(e.getKey()))
+                .max(Comparator.comparingInt(e -> e.getKey().length()))
+                .map(e -> e.getValue().getCredentials());
+    }
+
+    private static boolean isS3Prefix(String prefix)
+    {
+        return prefix.startsWith("s3://") || prefix.startsWith("s3a://") || prefix.startsWith("s3n://");
+    }
+
+    private static boolean isGcsPrefix(String prefix)
+    {
+        return prefix.startsWith("gs://");
+    }
+
+    private static Map<String, String> mergeConfigs(Map<String, String> base, Map<String, String> override)
+    {
+        return ImmutableMap.<String, String>builder()
+                .putAll(base)
+                .putAll(override)
+                .buildKeepingLast();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemLoader.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemLoader.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
+
+import java.util.List;
+
+public abstract class IcebergRestCatalogFileSystemLoader
+{
+    protected List<IcebergStorageCredentials> storageCredentials = ImmutableList.of();
+
+    public abstract TrinoFileSystem create(Location location);
+
+    void setStorageCredentials(List<IcebergStorageCredentials> storageCredentials)
+    {
+        this.storageCredentials = ImmutableList.copyOf(storageCredentials);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -29,6 +29,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.metastore.TableInfo;
 import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.plugin.iceberg.IcebergUtil;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.Security;
@@ -518,7 +519,7 @@ public class TrinoRestCatalog
             // So log the exception and continue with deleting the table location
             log.warn(e, "Failed to delete table data referenced by metadata");
         }
-        deleteTableDirectory(fileSystemFactory.create(session.getIdentity(), table.io().properties()), schemaTableName, table.location());
+        deleteTableDirectory(fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(table.io())), schemaTableName, table.location());
     }
 
     private static void deleteTableDirectory(TrinoFileSystem fileSystem, SchemaTableName schemaTableName, String tableLocation)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
@@ -25,6 +25,7 @@ import io.trino.plugin.base.util.Closables;
 import io.trino.plugin.iceberg.IcebergColumnHandle;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergPageSourceProviderFactory;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.plugin.iceberg.IcebergTableHandle;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
@@ -119,7 +120,7 @@ public class DefaultDeletionVectorWriter
         ExistingDeletes existingDeletes = getExistingDeletesByMetadataOnly(icebergTable, snapshotId, deletionVectorBuilders.keySet());
 
         // merge existing deletion vectors into the new ones
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), icebergTable.io().properties());
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), IcebergTableCredentials.forFileIO(icebergTable.io()));
         existingDeletes.deletionVectors().forEach((dataFilePath, deleteFile) -> {
             try (TrinoInput input = fileSystem.newInputFile(Location.of(deleteFile.location()), deleteFile.fileSizeInBytes()).newInput()) {
                 Slice data = input.readFully(deleteFile.contentOffset(), toIntExact(deleteFile.contentSizeInBytes()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
@@ -14,11 +14,14 @@
 package io.trino.plugin.iceberg.fileio;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
+import io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogFileSystem;
 import io.trino.spi.TrinoException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -27,7 +30,9 @@ import org.apache.iceberg.ManifestListFile;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsBulkOperations;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -46,7 +51,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 public class ForwardingFileIo
-        implements SupportsBulkOperations
+        implements SupportsBulkOperations, SupportsStorageCredentials
 {
     private static final int DELETE_BATCH_SIZE = 1000;
     private static final int BATCH_DELETE_PATHS_MESSAGE_LIMIT = 5;
@@ -55,6 +60,8 @@ public class ForwardingFileIo
     private final Map<String, String> properties;
     private final boolean useFileSizeFromMetadata;
     private final ExecutorService deleteExecutor;
+
+    private List<StorageCredential> credentials = ImmutableList.of();
 
     @VisibleForTesting
     public ForwardingFileIo(TrinoFileSystem fileSystem, boolean useFileSizeFromMetadata)
@@ -68,6 +75,23 @@ public class ForwardingFileIo
         this.deleteExecutor = requireNonNull(deleteExecutor, "executorService is null");
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
         this.useFileSizeFromMetadata = useFileSizeFromMetadata;
+    }
+
+    @Override
+    public void setCredentials(List<StorageCredential> credentials)
+    {
+        this.credentials = ImmutableList.copyOf(credentials);
+        if (fileSystem instanceof IcebergRestCatalogFileSystem icebergRestCatalogFileSystem) {
+            icebergRestCatalogFileSystem.setCredentials(credentials.stream()
+                    .map(credential -> new IcebergStorageCredentials(credential.prefix(), credential.config()))
+                    .collect(toImmutableList()));
+        }
+    }
+
+    @Override
+    public List<StorageCredential> credentials()
+    {
+        return ImmutableList.copyOf(credentials);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.functions.tablechanges;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.iceberg.IcebergColumnHandle;
 import io.trino.plugin.iceberg.IcebergPageSourceProvider;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.plugin.iceberg.PartitionData;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -44,7 +45,6 @@ import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_ORDINAL_ID
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TIMESTAMP_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TYPE_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_VERSION_ID;
-import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
 import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
 import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.produced;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
@@ -133,7 +133,7 @@ public class TableChangesFunctionProcessor
                 split.fileSize(),
                 split.fileRecordCount(),
                 split.fileFormat(),
-                getFileIoProperties(tableCredentials),
+                tableCredentials.map(IcebergTableCredentials.class::cast).get(),
                 OptionalLong.empty(),
                 OptionalLong.empty(),
                 functionHandle.nameMappingJson().map(NameMappingParser::fromJson));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -581,7 +581,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 getSession(icebergConfig),
                 split,
                 tableHandle.connectorHandle(),
-                Optional.of(new IcebergTableCredentials(ImmutableMap.of())),
+                Optional.of(new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of())),
                 columns,
                 dynamicFilter);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
@@ -161,7 +161,7 @@ class TestIcebergPageSourceProvider
                 dataInputFile.length(),
                 3, // fileRecordCount
                 PARQUET,
-                ImmutableMap.of(),
+                new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of()),
                 OptionalLong.of(0), // dataSequenceNumber
                 OptionalLong.empty(),
                 Optional.empty())) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefresh.java
@@ -45,7 +45,7 @@ import static io.trino.tpch.TpchTable.REGION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Execution(ExecutionMode.SAME_THREAD)
-abstract class AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+abstract class AbstractTestIcebergRestCatalogVendedCredentialsRefresh
         extends AbstractTestQueryFramework
 {
     private static final List<TpchTable<?>> REQUIRED_TPCH_TABLES = ImmutableList.of(REGION);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefresh.java
@@ -20,6 +20,8 @@ import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.ServerFeature;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.node.NodeInfo;
+import io.trino.plugin.iceberg.IcebergConnector;
+import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
@@ -41,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.tpch.TpchTable.REGION;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -123,15 +126,24 @@ abstract class AbstractTestIcebergRestCatalogVendedCredentialsRefresh
         try (TestTable testTable = newTrinoTable("test_ctas", "AS SELECT * FROM region")) {
             // Intentionally set the expiration time to be in the near future to test credential refresh logic
             sessionTokenExpirationTime.set(Instant.now().plusSeconds(60));
+            icebergRestCatalogFileSystemFactory(getQueryRunner()).flushVendedCredentialsCache();
             int refreshCount = servlet.getVendedCredentialsRefreshCount();
             assertQuery("SELECT * FROM " + testTable.getName(), "SELECT * FROM region");
             assertThat(servlet.getVendedCredentialsRefreshCount()).isGreaterThan(refreshCount);
 
             // Providing a session token that expires only in one hour should not trigger token refresh
             sessionTokenExpirationTime.set(Instant.now().plus(1, ChronoUnit.HOURS));
+            icebergRestCatalogFileSystemFactory(getQueryRunner()).flushVendedCredentialsCache();
             refreshCount = servlet.getVendedCredentialsRefreshCount();
             assertQuery("SELECT * FROM " + testTable.getName(), "SELECT * FROM region");
             assertThat(servlet.getVendedCredentialsRefreshCount()).isEqualTo(refreshCount);
         }
+    }
+
+    private static IcebergRestCatalogFileSystemFactory icebergRestCatalogFileSystemFactory(QueryRunner queryRunner)
+    {
+        return (IcebergRestCatalogFileSystemFactory) ((IcebergConnector) queryRunner.getCoordinator().getConnector(ICEBERG_CATALOG))
+                .getInjector()
+                .getInstance(IcebergFileSystemFactory.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java
@@ -44,10 +44,10 @@ import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
 
-final class TestIcebergAzureRestCatalogVendedCredentialsRefreshTest
-        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+final class TestIcebergAzureRestCatalogVendedCredentialsRefresh
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
 {
-    private static final Logger LOG = Logger.get(TestIcebergAzureRestCatalogVendedCredentialsRefreshTest.class);
+    private static final Logger LOG = Logger.get(TestIcebergAzureRestCatalogVendedCredentialsRefresh.class);
 
     private final String container = requiredNonEmptySystemProperty("testing.azure-abfs-container");
     private final String account = requiredNonEmptySystemProperty("testing.azure-abfs-account");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.gcs.GcsFileSystemConfig;
+import io.trino.filesystem.gcs.GcsFileSystemFactory;
+import io.trino.filesystem.gcs.GcsServiceAccountAuth;
+import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
+import io.trino.filesystem.gcs.GcsStorageFactory;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.gcp.gcs.GCSFileIO;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+
+final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
+{
+    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogStorageCredentialsRefresh.class);
+
+    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
+    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+
+    private String oauthToken;
+    private long tokenExpiresAtMs;
+    private String gcpProjectId;
+    private TrinoFileSystem fileSystem;
+
+    @BeforeAll
+    public void initFileSystem()
+            throws Exception
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        GcsFileSystemConfig config = new GcsFileSystemConfig();
+        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
+        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+    }
+
+    @AfterAll
+    public void removeTestData()
+    {
+        if (fileSystem == null) {
+            return;
+        }
+        try {
+            fileSystem.deleteDirectory(Location.of(warehouseLocation));
+        }
+        catch (IOException e) {
+            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
+            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+        }
+    }
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+            throws Exception
+    {
+        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
+        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
+                .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        AccessToken accessToken = credentials.refreshAccessToken();
+        oauthToken = accessToken.getTokenValue();
+        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
+
+        JsonMapper mapper = new JsonMapper();
+        JsonNode jsonKey = mapper.readTree(gcpCredentials);
+        gcpProjectId = jsonKey.get("project_id").asText();
+
+        return "gs://%s/gcs-storage-creds-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, GCSFileIO.class.getName())
+                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        RESTCatalogAdapter adapter = new RESTCatalogAdapter(backendCatalog)
+        {
+            @Override
+            protected <T extends RESTResponse> T execute(
+                    HTTPRequest request,
+                    Class<T> responseType,
+                    Consumer<ErrorResponse> errorHandler,
+                    Consumer<Map<String, String>> responseHeaders)
+            {
+                T response = super.execute(request, responseType, errorHandler, responseHeaders);
+                if (response instanceof LoadTableResponse loadTableResponse) {
+                    String host = request.headers().entries("host").stream()
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("Host header not found in request"))
+                            .value();
+                    String restServerUri = "http://" + host;
+                    return responseType.cast(LoadTableResponse.builder()
+                            .withTableMetadata(loadTableResponse.tableMetadata())
+                            // Credentials are returned as storage credentials in the credentials list, not as flat config
+                            .addCredential(ImmutableCredential.builder()
+                                    .prefix("gs://" + gcpStorageBucket + "/")
+                                    .putAllConfig(ImmutableMap.<String, String>builder()
+                                            .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                                            .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, "true")
+                                            .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                                            .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(sessionTokenExpirationTime.get().toEpochMilli()))
+                                            .buildOrThrow())
+                                    .build())
+                            .build());
+                }
+                return response;
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "gs://" + gcpStorageBucket + "/";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                return ImmutableMap.<String, String>builder()
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
+                        .put(GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
+                        .buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.gcs.enabled", "true")
+                .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .buildOrThrow();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
@@ -43,10 +43,10 @@ import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
-final class TestIcebergGcsRestCatalogVendedCredentialsRefreshTest
-        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
 {
-    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogVendedCredentialsRefreshTest.class);
+    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogVendedCredentialsRefresh.class);
 
     private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
     private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogFileSystemFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import io.trino.filesystem.FileIterator;
@@ -23,6 +24,8 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
+import io.trino.plugin.iceberg.IcebergStorageCredentials;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.security.ConnectorIdentity;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
@@ -32,7 +35,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -46,6 +51,7 @@ import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACC
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class TestIcebergRestCatalogFileSystemFactory
 {
@@ -152,19 +158,13 @@ final class TestIcebergRestCatalogFileSystemFactory
     @Test
     void testNoVendedCredentialsInProperties()
     {
-        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
-        TrinoFileSystemFactory delegate = identity -> {
-            capturedIdentity.set(identity);
-            return new MockTrinoFileSystem();
-        };
-
-        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+        IcebergRestCatalogFileSystemFactory factory = createFactory(_ -> new MockTrinoFileSystem(), true);
 
         ConnectorIdentity originalIdentity = ConnectorIdentity.ofUser("test");
-        factory.create(originalIdentity, ImmutableMap.of());
+        TrinoFileSystem fileSystem = factory.create(originalIdentity, ImmutableMap.of());
 
-        ConnectorIdentity identity = capturedIdentity.get();
-        assertThat(identity).isSameAs(originalIdentity);
+        assertThatThrownBy(() -> fileSystem.newInputFile(Location.of("s3://bucket/path/file")))
+                .hasMessage("Failed to initialize the vended credentials from the provided fileIoProperties");
     }
 
     @Test
@@ -254,6 +254,282 @@ final class TestIcebergRestCatalogFileSystemFactory
         ConnectorIdentity identity = capturedIdentity.get();
         assertThat(identity).isNotNull();
         assertThat(identity.getExtraCredentials()).isEmpty();
+    }
+
+    @Test
+    void testS3StorageCredentialsSinglePrefix()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials storageCredential = new IcebergStorageCredentials(
+                "s3://bucket-a/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-a",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-a",
+                        S3FileIOProperties.SESSION_TOKEN, "token-a"));
+
+        IcebergRestCatalogFileSystem fileSystem = (IcebergRestCatalogFileSystem) factory.create(ConnectorIdentity.ofUser("test"), ImmutableMap.of());
+        fileSystem.setCredentials(ImmutableList.of(storageCredential));
+
+        fileSystem.newInputFile(Location.of("s3://bucket-a/path/file"));
+
+        assertS3ExtraCredentials(capturedIdentity.get(), "key-a", "secret-a", "token-a");
+    }
+
+    @Test
+    void testS3StorageCredentialsSinglePrefixIcebergTableCredentials()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials storageCredential = new IcebergStorageCredentials(
+                "s3://bucket-a/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-a",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-a",
+                        S3FileIOProperties.SESSION_TOKEN, "token-a"));
+
+        TrinoFileSystem fileSystem = factory.create(ConnectorIdentity.ofUser("test"), new IcebergTableCredentials(ImmutableMap.of(), ImmutableList.of(storageCredential)));
+
+        fileSystem.newInputFile(Location.of("s3://bucket-a/path/file"));
+
+        assertS3ExtraCredentials(capturedIdentity.get(), "key-a", "secret-a", "token-a");
+    }
+
+    @Test
+    void testS3StorageCredentialsMultiplePrefixes()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentityA = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityB = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityRoot = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            switch (identity.getExtraCredentials().getOrDefault(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "")) {
+                case "key-a" -> capturedIdentityA.set(identity);
+                case "key-b" -> capturedIdentityB.set(identity);
+                default -> capturedIdentityRoot.set(identity);
+            }
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "key-root",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "secret-root",
+                S3FileIOProperties.SESSION_TOKEN, "token-root");
+        IcebergStorageCredentials credentialA = new IcebergStorageCredentials(
+                "s3://bucket-a/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-a",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-a",
+                        S3FileIOProperties.SESSION_TOKEN, "token-a"));
+        IcebergStorageCredentials credentialB = new IcebergStorageCredentials(
+                "s3://bucket-b/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-b",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-b",
+                        S3FileIOProperties.SESSION_TOKEN, "token-b"));
+
+        IcebergRestCatalogFileSystem fileSystem = (IcebergRestCatalogFileSystem) factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        fileSystem.setCredentials(ImmutableList.of(credentialA, credentialB));
+
+        fileSystem.newInputFile(Location.of("s3://bucket-a/path/file"));
+        assertS3ExtraCredentials(capturedIdentityA.get(), "key-a", "secret-a", "token-a");
+
+        fileSystem.newInputFile(Location.of("s3://bucket-b/data/file"));
+        assertS3ExtraCredentials(capturedIdentityB.get(), "key-b", "secret-b", "token-b");
+
+        // bucket-c has no per-prefix credential — falls back to the root credential from fileIoProperties
+        fileSystem.newInputFile(Location.of("s3://bucket-c/other/file"));
+        assertS3ExtraCredentials(capturedIdentityRoot.get(), "key-root", "secret-root", "token-root");
+    }
+
+    @Test
+    void testS3StorageCredentialsMultiplePrefixesDeleteFiles()
+            throws IOException
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentityA = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityB = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityRoot = new AtomicReference<>();
+        List<Collection<Location>> deletedFilesCollections = new ArrayList<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            switch (identity.getExtraCredentials().getOrDefault(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, "")) {
+                case "key-a" -> capturedIdentityA.set(identity);
+                case "key-b" -> capturedIdentityB.set(identity);
+                default -> capturedIdentityRoot.set(identity);
+            }
+            return new MockTrinoFileSystem()
+            {
+                @Override
+                public void deleteFiles(Collection<Location> locations)
+                {
+                    deletedFilesCollections.add(locations);
+                }
+            };
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        Map<String, String> fileIoProperties = ImmutableMap.of(
+                S3FileIOProperties.ACCESS_KEY_ID, "key-root",
+                S3FileIOProperties.SECRET_ACCESS_KEY, "secret-root",
+                S3FileIOProperties.SESSION_TOKEN, "token-root");
+        IcebergStorageCredentials credentialA = new IcebergStorageCredentials(
+                "s3://bucket-a/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-a",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-a",
+                        S3FileIOProperties.SESSION_TOKEN, "token-a"));
+        IcebergStorageCredentials credentialB = new IcebergStorageCredentials(
+                "s3://bucket-b/",
+                ImmutableMap.of(
+                        S3FileIOProperties.ACCESS_KEY_ID, "key-b",
+                        S3FileIOProperties.SECRET_ACCESS_KEY, "secret-b",
+                        S3FileIOProperties.SESSION_TOKEN, "token-b"));
+
+        IcebergRestCatalogFileSystem fileSystem = (IcebergRestCatalogFileSystem) factory.create(ConnectorIdentity.ofUser("test"), fileIoProperties);
+        fileSystem.setCredentials(ImmutableList.of(credentialA, credentialB));
+
+        // Only storage credentials prefix paths
+        fileSystem.deleteFiles(ImmutableList.of(
+                Location.of("s3://bucket-a/path/file1"),
+                Location.of("s3://bucket-a/path/file2"),
+                Location.of("s3://bucket-a/path/dir3/file3")));
+        assertS3ExtraCredentials(capturedIdentityA.get(), "key-a", "secret-a", "token-a");
+        assertThat(capturedIdentityB.get()).isNull();
+        assertThat(capturedIdentityRoot.get()).isNull();
+        assertThat(deletedFilesCollections).containsExactly(ImmutableList.of(
+                Location.of("s3://bucket-a/path/file1"),
+                Location.of("s3://bucket-a/path/file2"),
+                Location.of("s3://bucket-a/path/dir3/file3")));
+
+        capturedIdentityRoot.set(null);
+        capturedIdentityA.set(null);
+        capturedIdentityB.set(null);
+        deletedFilesCollections.clear();
+
+        // Only root paths
+        fileSystem.deleteFiles(ImmutableList.of(
+                Location.of("s3://bucket-root/path/file1"),
+                Location.of("s3://bucket-root/path/file2"),
+                Location.of("s3://bucket-root/path/dir3/file3")));
+        assertS3ExtraCredentials(capturedIdentityRoot.get(), "key-root", "secret-root", "token-root");
+        assertThat(capturedIdentityA.get()).isNull();
+        assertThat(capturedIdentityB.get()).isNull();
+        assertThat(deletedFilesCollections).containsExactly(ImmutableList.of(
+                Location.of("s3://bucket-root/path/file1"),
+                Location.of("s3://bucket-root/path/file2"),
+                Location.of("s3://bucket-root/path/dir3/file3")));
+
+        capturedIdentityRoot.set(null);
+        capturedIdentityA.set(null);
+        capturedIdentityB.set(null);
+        deletedFilesCollections.clear();
+
+        // Both root and prefixed paths
+        fileSystem.deleteFiles(ImmutableList.of(
+                Location.of("s3://bucket-a/path/file1"),
+                Location.of("s3://bucket-root/path/file1"),
+                Location.of("s3://bucket-a/path/dir2/file2"),
+                Location.of("s3://bucket-root/path/file2"),
+                Location.of("s3://bucket-b/some/path/file5"),
+                Location.of("s3://bucket-c/path/dir3/file3")));
+        assertS3ExtraCredentials(capturedIdentityRoot.get(), "key-root", "secret-root", "token-root");
+        assertS3ExtraCredentials(capturedIdentityA.get(), "key-a", "secret-a", "token-a");
+        assertS3ExtraCredentials(capturedIdentityB.get(), "key-b", "secret-b", "token-b");
+        assertThat(deletedFilesCollections).containsExactlyInAnyOrder(
+                ImmutableList.of(
+                        Location.of("s3://bucket-root/path/file1"),
+                        Location.of("s3://bucket-root/path/file2"),
+                        Location.of("s3://bucket-c/path/dir3/file3")),
+                ImmutableList.of(
+                        Location.of("s3://bucket-a/path/file1"),
+                        Location.of("s3://bucket-a/path/dir2/file2")),
+                ImmutableList.of(
+                        Location.of("s3://bucket-b/some/path/file5")));
+    }
+
+    @Test
+    void testGcsStorageCredentialsSinglePrefix()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentity = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            capturedIdentity.set(identity);
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials storageCredentials = new IcebergStorageCredentials(
+                "gs://gcs-bucket/",
+                ImmutableMap.of(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.token-for-gcs-bucket"));
+
+        IcebergRestCatalogFileSystem fileSystem = (IcebergRestCatalogFileSystem) factory.create(ConnectorIdentity.ofUser("test"), ImmutableMap.of());
+        fileSystem.setCredentials(ImmutableList.of(storageCredentials));
+        fileSystem.newInputFile(Location.of("gs://gcs-bucket/path/file"));
+
+        assertGcsExtraCredentials(capturedIdentity.get(), "ya29.token-for-gcs-bucket");
+    }
+
+    @Test
+    void testGcsStorageCredentialsMultiplePrefixes()
+    {
+        AtomicReference<ConnectorIdentity> capturedIdentityA = new AtomicReference<>();
+        AtomicReference<ConnectorIdentity> capturedIdentityB = new AtomicReference<>();
+        TrinoFileSystemFactory delegate = identity -> {
+            if (identity.getExtraCredentials().getOrDefault(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "").equals("ya29.token-a")) {
+                capturedIdentityA.set(identity);
+            }
+            else {
+                capturedIdentityB.set(identity);
+            }
+            return new MockTrinoFileSystem();
+        };
+
+        IcebergRestCatalogFileSystemFactory factory = createFactory(delegate, true);
+
+        IcebergStorageCredentials credentialA = new IcebergStorageCredentials(
+                "gs://bucket-a/",
+                ImmutableMap.of(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.token-a"));
+        IcebergStorageCredentials credentialB = new IcebergStorageCredentials(
+                "gs://bucket-b/",
+                ImmutableMap.of(GCPProperties.GCS_OAUTH2_TOKEN, "ya29.token-b"));
+
+        IcebergRestCatalogFileSystem fileSystem = (IcebergRestCatalogFileSystem) factory.create(ConnectorIdentity.ofUser("test"), ImmutableMap.of());
+        fileSystem.setCredentials(ImmutableList.of(credentialA, credentialB));
+
+        fileSystem.newInputFile(Location.of("gs://bucket-a/path/file"));
+        assertGcsExtraCredentials(capturedIdentityA.get(), "ya29.token-a");
+
+        fileSystem.newInputFile(Location.of("gs://bucket-b/data/file"));
+        assertGcsExtraCredentials(capturedIdentityB.get(), "ya29.token-b");
+    }
+
+    private static void assertGcsExtraCredentials(ConnectorIdentity identity, String oautToken)
+    {
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials()).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, oautToken));
+    }
+
+    private static void assertS3ExtraCredentials(ConnectorIdentity identity, String accessKey, String secretKey, String sessionToken)
+    {
+        assertThat(identity).isNotNull();
+        assertThat(identity.getExtraCredentials())
+                .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(
+                        EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY, accessKey,
+                        EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY, secretKey,
+                        EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY, sessionToken));
     }
 
     private static IcebergRestCatalogFileSystemFactory createFactory(TrinoFileSystemFactory delegate, boolean vendedCredentialsEnabled)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogStorageCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogStorageCredentialsRefresh.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.containers.Minio;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
+
+final class TestIcebergS3RestCatalogStorageCredentialsRefresh
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
+{
+    private final String bucketName = "test-iceberg-storage-creds-rest-" + randomNameSuffix();
+    private Minio minio;
+
+    @Override
+    protected String setupStorageAndGetWarehouseLocation()
+    {
+        minio = closeAfterClass(Minio.builder().build());
+        minio.start();
+        minio.createBucket(bucketName);
+        return "s3://%s/default/".formatted(bucketName);
+    }
+
+    @Override
+    protected Map<String, String> backendCatalogFileIoProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(FILE_IO_IMPL, S3FileIO.class.getName())
+                .put(S3FileIOProperties.PATH_STYLE_ACCESS, "true")
+                .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                .put(S3FileIOProperties.ACCESS_KEY_ID, MINIO_ROOT_USER)
+                .put(S3FileIOProperties.SECRET_ACCESS_KEY, MINIO_ROOT_PASSWORD)
+                .put(S3FileIOProperties.ENDPOINT, minio.getMinioAddress())
+                .buildOrThrow();
+    }
+
+    @Override
+    protected VendedCredentialsRestCatalogServlet createServlet(Catalog backendCatalog)
+    {
+        RESTCatalogAdapter adapter = new RESTCatalogAdapter(backendCatalog)
+        {
+            @Override
+            protected <T extends RESTResponse> T execute(
+                    HTTPRequest request,
+                    Class<T> responseType,
+                    Consumer<ErrorResponse> errorHandler,
+                    Consumer<Map<String, String>> responseHeaders)
+            {
+                T response = super.execute(request, responseType, errorHandler, responseHeaders);
+                if (response instanceof LoadTableResponse loadTableResponse) {
+                    String host = request.headers().entries("host").stream()
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("Host header not found in request"))
+                            .value();
+                    String restServerUri = "http://" + host;
+                    Credentials sessionCredentials = getSessionCredentials();
+                    return responseType.cast(LoadTableResponse.builder()
+                            .withTableMetadata(loadTableResponse.tableMetadata())
+                            // Credentials are returned as storage credentials in the credentials list, not as flat config
+                            .addCredential(ImmutableCredential.builder()
+                                    .prefix("s3://" + bucketName + "/")
+                                    .putAllConfig(ImmutableMap.<String, String>builder()
+                                            .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                                            .put(S3FileIOProperties.ACCESS_KEY_ID, sessionCredentials.accessKeyId())
+                                            .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
+                                            .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
+                                            .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
+                                            .put(AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
+                                            .put(S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS, Long.toString(sessionTokenExpirationTime.get().toEpochMilli()))
+                                            .buildOrThrow())
+                                    .build())
+                            .build());
+                }
+                return response;
+            }
+        };
+        return new VendedCredentialsRestCatalogServlet(adapter)
+        {
+            @Override
+            public String getPrefix()
+            {
+                return "s3://" + bucketName + "/";
+            }
+
+            @Override
+            public Map<String, String> getCredentialsConfig()
+            {
+                Credentials sessionCredentials = getSessionCredentials();
+                return ImmutableMap.<String, String>builder()
+                        .put(AwsClientProperties.CLIENT_REGION, MINIO_REGION)
+                        .put(S3FileIOProperties.ACCESS_KEY_ID, sessionCredentials.accessKeyId())
+                        .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
+                        .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
+                        .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
+                        .put(S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS, Long.toString(sessionCredentials.expiration().toEpochMilli()))
+                        .buildOrThrow();
+            }
+        };
+    }
+
+    @Override
+    protected Map<String, String> catalogFileSystemProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fs.s3.enabled", "true")
+                .put("s3.region", MINIO_REGION)
+                .put("s3.endpoint", minio.getMinioAddress())
+                .put("s3.path-style-access", "true")
+                .buildOrThrow();
+    }
+
+    public Credentials getSessionCredentials()
+    {
+        AwsCredentials rootCredentials = AwsBasicCredentials.create(MINIO_ROOT_USER, MINIO_ROOT_PASSWORD);
+        try (StsClient stsClient = StsClient.builder()
+                .endpointOverride(URI.create(minio.getMinioAddress()))
+                .credentialsProvider(StaticCredentialsProvider.create(rootCredentials))
+                .region(Region.of(MINIO_REGION))
+                .build()) {
+            AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(AssumeRoleRequest.builder().build());
+            return assumeRoleResponse.credentials();
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogVendedCredentialsRefresh.java
@@ -83,7 +83,7 @@ final class TestIcebergS3RestCatalogVendedCredentialsRefresh
                         .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
                         .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
                         .put(AwsClientProperties.REFRESH_CREDENTIALS_ENDPOINT, restServerUri + "/credentials")
-                        .put("s3.session-token-expires-at-ms", Long.toString(sessionTokenExpirationTime.get().toEpochMilli()));
+                        .put(S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS, Long.toString(sessionTokenExpirationTime.get().toEpochMilli()));
                 return builder.buildOrThrow();
             }
         };
@@ -105,7 +105,7 @@ final class TestIcebergS3RestCatalogVendedCredentialsRefresh
                         .put(S3FileIOProperties.SECRET_ACCESS_KEY, sessionCredentials.secretAccessKey())
                         .put(S3FileIOProperties.SESSION_TOKEN, sessionCredentials.sessionToken())
                         .put(AwsClientProperties.REFRESH_CREDENTIALS_ENABLED, "true")
-                        .put("s3.session-token-expires-at-ms", Long.toString(sessionCredentials.expiration().toEpochMilli()));
+                        .put(S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS, Long.toString(sessionCredentials.expiration().toEpochMilli()));
                 return builder.buildOrThrow();
             }
         };

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergS3RestCatalogVendedCredentialsRefresh.java
@@ -38,8 +38,8 @@ import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
 import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
-final class TestIcebergS3RestCatalogVendedCredentialsRefreshTest
-        extends AbstractTestIcebergRestCatalogVendedCredentialsRefreshTest
+final class TestIcebergS3RestCatalogVendedCredentialsRefresh
+        extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
 {
     private final String bucketName = "test-iceberg-refresh-vending-credentials-rest-" + randomNameSuffix();
     private Minio minio;


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
 
The Iceberg REST catalog can vend per-path-prefix credential sets via
SupportsStorageCredentials when loading a table. ForwardingFileIo now
implements this interface so RESTSessionCatalog can inject prefix-keyed
credentials; IcebergTableCredentials.forFileIO() surfaces them alongside
fileIoProperties for all callers in the query path (PageSource, PageSink,
SplitSource, metadata operations).

IcebergRestCatalogFileSystemFactory builds one vended-credential provider
per prefix (storage credential config merged over root fileIoProperties,
matching S3FileIO/GCSFileIO behavior), plus a root catch-all for paths
without a specific prefix. Longest-prefix matching routes each file access
to the right credential set. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Alternative to https://github.com/trinodb/trino/pull/29590 which relies on the changes performed already on https://github.com/apache/iceberg/pull/15752

The current approach avoids making changes in `apache/iceberg` as described in the PR https://github.com/apache/iceberg/pull/16536

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support in Iceberg REST catalog for prefixed path storage credentials. ({issue}`issuenumber`)
```
