### PR TITLE
Add AT LOCAL operator

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -585,6 +585,7 @@ predicate[ParserRuleContext value]
 valueExpression
     : primaryExpression                                                                 #valueExpressionDefault
     | valueExpression AT timeZoneSpecifier                                              #atTimeZone
+    | valueExpression AT LOCAL                                                          #atLocal
     | operator=(MINUS | PLUS) valueExpression                                           #arithmeticUnary
     | left=valueExpression operator=(ASTERISK | SLASH | PERCENT) right=valueExpression  #arithmeticBinary
     | left=valueExpression operator=(PLUS | MINUS) right=valueExpression                #arithmeticBinary

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -25,6 +25,7 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.Cast;
@@ -234,6 +235,12 @@ class AggregationAnalyzer
 
         @Override
         protected Boolean visitAtTimeZone(AtTimeZone node, Void context)
+        {
+            return process(node.getValue(), context);
+        }
+
+        @Override
+        protected Boolean visitAtLocal(AtLocal node, Void context)
         {
             return process(node.getValue(), context);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -73,6 +73,7 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
@@ -2353,6 +2354,20 @@ public class ExpressionAnalyzer
             else if (valueType instanceof TimestampType timestampType) {
                 resultType = createTimestampWithTimeZoneType(timestampType.getPrecision());
             }
+
+            return setExpressionType(node, resultType);
+        }
+
+        @Override
+        protected Type visitAtLocal(AtLocal node, Context context)
+        {
+            Type valueType = process(node.getValue(), context);
+            Type resultType = switch (valueType) {
+                case TimeType type -> createTimeWithTimeZoneType(type.getPrecision());
+                case TimestampType type -> createTimestampWithTimeZoneType(type.getPrecision());
+                case TimeWithTimeZoneType _, TimestampWithTimeZoneType _ -> valueType;
+                default -> throw semanticException(TYPE_MISMATCH, node.getValue(), "Type of value must be a time or timestamp with or without time zone (actual %s)", valueType);
+            };
 
             return setExpressionType(node, resultType);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -2344,16 +2344,12 @@ public class ExpressionAnalyzer
         {
             Type valueType = process(node.getValue(), context);
             process(node.getTimeZone(), context);
-            if (!(valueType instanceof TimeWithTimeZoneType) && !(valueType instanceof TimestampWithTimeZoneType) && !(valueType instanceof TimeType) && !(valueType instanceof TimestampType)) {
-                throw semanticException(TYPE_MISMATCH, node.getValue(), "Type of value must be a time or timestamp with or without time zone (actual %s)", valueType);
-            }
-            Type resultType = valueType;
-            if (valueType instanceof TimeType timeType) {
-                resultType = createTimeWithTimeZoneType(timeType.getPrecision());
-            }
-            else if (valueType instanceof TimestampType timestampType) {
-                resultType = createTimestampWithTimeZoneType(timestampType.getPrecision());
-            }
+            Type resultType = switch (valueType) {
+                case TimeType type -> createTimeWithTimeZoneType(type.getPrecision());
+                case TimestampType type -> createTimestampWithTimeZoneType(type.getPrecision());
+                case TimeWithTimeZoneType _, TimestampWithTimeZoneType _ -> valueType;
+                default -> throw semanticException(TYPE_MISMATCH, node.getValue(), "Type of value must be a time or timestamp with or without time zone (actual %s)", valueType);
+            };
 
             return setExpressionType(node, resultType);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -59,6 +59,7 @@ import io.trino.sql.ir.WhenClause;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
+import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
@@ -144,6 +145,7 @@ import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
@@ -337,6 +339,7 @@ public class TranslationMap
                 case LocalTimestamp expression -> translate(expression);
                 case Extract expression -> translate(expression);
                 case AtTimeZone expression -> translate(expression);
+                case AtLocal expression -> translate(expression);
                 case Format expression -> translate(expression);
                 case TryExpression expression -> translate(expression);
                 case LikePredicate expression -> translate(expression);
@@ -903,12 +906,26 @@ public class TranslationMap
 
     private io.trino.sql.ir.Expression translate(AtTimeZone node)
     {
-        Type valueType = analysis.getType(node.getValue());
-        io.trino.sql.ir.Expression value = translateExpression(node.getValue());
+        return atTimeZone(
+                analysis.getType(node.getValue()),
+                translateExpression(node.getValue()),
+                analysis.getType(node.getTimeZone()),
+                translateExpression(node.getTimeZone()));
+    }
 
-        Type timeZoneType = analysis.getType(node.getTimeZone());
-        io.trino.sql.ir.Expression timeZone = translateExpression(node.getTimeZone());
+    private io.trino.sql.ir.Expression translate(AtLocal node)
+    {
+        String zoneId = session.getTimeZoneKey().getId();
+        Type timeZoneType = createVarcharType(zoneId.length());
+        return atTimeZone(
+                analysis.getType(node.getValue()),
+                translateExpression(node.getValue()),
+                timeZoneType,
+                new Constant(timeZoneType, utf8Slice(zoneId)));
+    }
 
+    private io.trino.sql.ir.Expression atTimeZone(Type valueType, io.trino.sql.ir.Expression value, Type timeZoneType, io.trino.sql.ir.Expression timeZone)
+    {
         return switch (valueType) {
             case TimeType type -> BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                     .setName("$at_timezone")

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestAtLocal.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestAtLocal.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamptz;
+
+import io.trino.Session;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestAtLocal
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        Session session = testSessionBuilder()
+                .setTimeZoneKey(getTimeZoneKey("America/Los_Angeles"))
+                .build();
+        assertions = new QueryAssertions(session);
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testTimestampWithTimeZone()
+    {
+        assertThat(assertions.expression("TIMESTAMP '2020-05-01 12:34:56 +07:09' AT LOCAL"))
+                .matches("TIMESTAMP '2020-04-30 22:25:56 America/Los_Angeles'");
+        assertThat(assertions.expression("TIMESTAMP '2020-05-01 12:34:56.123 +07:09' AT LOCAL"))
+                .matches("TIMESTAMP '2020-04-30 22:25:56.123 America/Los_Angeles'");
+        assertThat(assertions.expression("TIMESTAMP '2020-05-01 12:34:56.123456789 +07:09' AT LOCAL"))
+                .matches("TIMESTAMP '2020-04-30 22:25:56.123456789 America/Los_Angeles'");
+    }
+
+    @Test
+    public void testTimestamp()
+    {
+        // Timestamp without time zone is treated as being in the session time zone, so AT LOCAL is the identity.
+        assertThat(assertions.expression("TIMESTAMP '2020-05-01 12:34:56' AT LOCAL"))
+                .matches("TIMESTAMP '2020-05-01 12:34:56 America/Los_Angeles'");
+    }
+
+    @Test
+    public void testTime()
+    {
+        // Session zone is America/Los_Angeles (-07:00 in May; PDT). A naive TIME
+        // is interpreted in the session zone, so AT LOCAL attaches the session offset.
+        assertThat(assertions.expression("TIME '12:34:56' AT LOCAL"))
+                .matches("TIME '12:34:56-07:00'");
+    }
+
+    @Test
+    public void testTimeWithTimeZone()
+    {
+        // Re-anchor TIME from +07:09 to session offset -07:00.
+        assertThat(assertions.expression("TIME '12:34:56+07:09' AT LOCAL"))
+                .matches("TIME '22:25:56-07:00'");
+    }
+
+    @Test
+    public void testFollowsSessionTimeZone()
+    {
+        // Same instant rendered in Pacific/Apia (+13:00 in May 2020).
+        Session pacific = testSessionBuilder().setTimeZoneKey(getTimeZoneKey("Pacific/Apia")).build();
+        try (QueryAssertions pacificAssertions = new QueryAssertions(pacific)) {
+            assertThat(pacificAssertions.expression("TIMESTAMP '2020-05-01 12:34:56 +07:09' AT LOCAL"))
+                    .matches("TIMESTAMP '2020-05-01 18:25:56 Pacific/Apia'");
+        }
+    }
+
+    @Test
+    public void testEquivalentToAtTimeZoneWithSessionZone()
+    {
+        // AT LOCAL is sugar for AT TIME ZONE <session zone>
+        assertThat(assertions.expression("TIMESTAMP '2020-05-01 12:34:56 +07:09' AT LOCAL"))
+                .matches("TIMESTAMP '2020-05-01 12:34:56 +07:09' AT TIME ZONE 'America/Los_Angeles'");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -21,6 +21,7 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
@@ -189,6 +190,12 @@ public final class ExpressionFormatter
             return process(node.getValue(), context) +
                     " AT TIME ZONE " +
                     process(node.getTimeZone(), context);
+        }
+
+        @Override
+        protected String visitAtLocal(AtLocal node, Void context)
+        {
+            return process(node.getValue(), context) + " AT LOCAL";
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -33,6 +33,7 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AssignmentStatement;
+import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
@@ -2478,6 +2479,14 @@ class AstBuilder
                 getLocation(context.AT()),
                 (Expression) visit(context.valueExpression()),
                 (Expression) visit(context.timeZoneSpecifier()));
+    }
+
+    @Override
+    public Node visitAtLocal(SqlBaseParser.AtLocalContext context)
+    {
+        return new AtLocal(
+                getLocation(context.AT()),
+                (Expression) visit(context.valueExpression()));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -917,6 +917,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitAtLocal(AtLocal node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitGroupBy(GroupBy node, C context)
     {
         return visitNode(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AtLocal.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AtLocal.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class AtLocal
+        extends Expression
+{
+    private final Expression value;
+
+    public AtLocal(NodeLocation location, Expression value)
+    {
+        super(location);
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    public Expression getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitAtLocal(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of(value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        AtLocal other = (AtLocal) obj;
+        return Objects.equals(value, other.value);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -69,6 +69,14 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitAtLocal(AtLocal node, C context)
+    {
+        process(node.getValue(), context);
+
+        return null;
+    }
+
+    @Override
     protected Void visitArray(Array node, C context)
     {
         for (Expression expression : node.getValues()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -215,6 +215,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteAtLocal(AtLocal node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteCurrentCatalog(CurrentCatalog node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -179,6 +179,25 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
+        protected Expression visitAtLocal(AtLocal node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteAtLocal(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            Expression value = rewrite(node.getValue(), context.get());
+
+            if (value != node.getValue()) {
+                return new AtLocal(node.getLocation().orElseThrow(), value);
+            }
+
+            return node;
+        }
+
+        @Override
         protected Expression visitSubscriptExpression(SubscriptExpression node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -25,6 +25,7 @@ import io.trino.sql.tree.Analyze;
 import io.trino.sql.tree.AnchorPattern;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.Array;
+import io.trino.sql.tree.AtLocal;
 import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
@@ -5365,6 +5366,14 @@ public class TestSqlParser
         assertStatement("SELECT TIMESTAMP '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles'",
                 simpleQuery(selectList(
                         new AtTimeZone(new GenericLiteral("TIMESTAMP", "2012-10-31 01:00 UTC"), new StringLiteral("America/Los_Angeles")))));
+    }
+
+    @Test
+    public void testAtLocal()
+    {
+        assertStatement("SELECT TIMESTAMP '2012-10-31 01:00 UTC' AT LOCAL",
+                simpleQuery(selectList(
+                        new AtLocal(new NodeLocation(1, 41), new GenericLiteral("TIMESTAMP", "2012-10-31 01:00 UTC")))));
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/datetime.md
+++ b/docs/src/main/sphinx/functions/datetime.md
@@ -32,6 +32,13 @@ SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles';
 -- 2012-10-30 18:00:00.000 America/Los_Angeles
 ```
 
+The `AT LOCAL` operator renders a datetime in the current session time zone:
+
+```
+SELECT timestamp '2012-10-31 01:00 UTC' AT LOCAL;
+-- 2012-10-30 18:00:00.000 America/Los_Angeles  (session zone)
+```
+
 ## Date and time functions
 
 :::{data} current_date


### PR DESCRIPTION
## Summary

The `AT LOCAL` operator renders a datetime value at the current session time zone. It's equivalent to `AT TIME ZONE <session zone>` but avoids having to spell out the session zone at the call site.

```sql
SELECT TIMESTAMP '2012-10-31 01:00 UTC' AT LOCAL;
-- 2012-10-30 18:00:00.000 America/Los_Angeles  (session zone)
```

## Design

`AT LOCAL` is sugar over `AT TIME ZONE`. The grammar adds a new sibling production for `AT LOCAL`; the AST preserves the call-site shape; the planner — not the parser — substitutes the session zone at translation time.

Internally, both `translate(AtTimeZone)` and `translate(AtLocal)` delegate to a shared `atTimeZone(valueType, value, timeZoneType, timeZone)` helper that dispatches the four datetime-input cases (`TIME`, `TIME WITH TIME ZONE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`). `AT LOCAL` materializes the session zone as a `VARCHAR` constant; `AT TIME ZONE` passes through the analyzed timezone expression.

## Test plan

- [x] `TestSqlParser.testAtLocal` covering the parser shape.
- [x] New `TestAtLocal` query-level suite covering TIMESTAMP, TIMESTAMP WITH TIME ZONE, TIME, TIME WITH TIME ZONE, session-zone-follow (`Pacific/Apia`), and direct equivalence to `AT TIME ZONE <session zone>`.
- [x] Existing `TestAtTimeZone`, `TestTimestampWithTimeZone`, `TestTimeWithTimeZone`, `TestExpressionInterpreter`, `TestExpressionCompiler` pass unchanged.