### PR TITLE
Fix table credentials extraction to visit child plan nodes recursively

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -471,7 +471,7 @@ public final class SqlStage
         {
             TableWriterNode.MergeTarget target = node.getTarget();
             extract(builder, node, metadata.getTableCredentials(session, target.getHandle().catalogHandle(), target.getHandle().connectorHandle()));
-            return null;
+            return super.visitMergeWriter(node, context);
         }
 
         @Override
@@ -479,7 +479,7 @@ public final class SqlStage
         {
             TableWriterNode.TableExecuteTarget target = node.getTarget();
             extract(builder, node, metadata.getTableCredentials(session, target.getExecuteHandle().catalogHandle(), target.getExecuteHandle().connectorHandle()));
-            return null;
+            return super.visitTableExecute(node, context);
         }
 
         @Override
@@ -493,7 +493,7 @@ public final class SqlStage
                 case TableWriterNode.InsertTarget insertTarget -> extract(builder, node, metadata.getTableCredentials(session, insertTarget.getHandle().catalogHandle(), insertTarget.getHandle().connectorHandle()));
                 default -> throw new IllegalArgumentException("Unsupported table writer node: " + node.getClass().getSimpleName());
             }
-            return null;
+            return super.visitTableWriter(node, context);
         }
 
         @Override
@@ -501,7 +501,7 @@ public final class SqlStage
         {
             TableHandle table = node.getTable();
             extract(builder, node, metadata.getTableCredentials(session, table.catalogHandle(), table.connectorHandle()));
-            return null;
+            return super.visitTableScan(node, context);
         }
 
         @Override
@@ -509,7 +509,7 @@ public final class SqlStage
         {
             TableFunctionHandle handle = node.getHandle();
             extract(builder, node, metadata.getTableCredentials(session, handle.catalogHandle(), handle.functionHandle()));
-            return null;
+            return super.visitTableFunctionProcessor(node, context);
         }
 
         private static void extract(ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder, PlanNode node, Optional<ConnectorTableCredentials> credentials)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Maps.transformValues;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.maxPartitionsPerWriter;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileIoProperties;
@@ -137,6 +138,7 @@ public class IcebergPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
+        verify(tableCredentials.isPresent(), "tableCredentials is empty");
         IcebergTableExecuteHandle executeHandle = (IcebergTableExecuteHandle) tableExecuteHandle;
         return switch (executeHandle.procedureId()) {
             case OPTIMIZE -> {
@@ -178,6 +180,7 @@ public class IcebergPageSinkProvider
     @Override
     public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
+        verify(tableCredentials.isPresent(), "tableCredentials is empty");
         IcebergMergeTableHandle merge = (IcebergMergeTableHandle) mergeHandle;
         IcebergWritableTableHandle tableHandle = merge.getInsertTableHandle();
         Map<String, String> fileIoProperties = getFileIoProperties(tableCredentials);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -258,6 +258,7 @@ public class IcebergPageSourceProvider
             List<ColumnHandle> columns,
             DynamicFilter dynamicFilter)
     {
+        verify(connectorTableCredentials.isPresent(), "connectorTableCredentials is empty");
         if (connectorSplit instanceof FilesTableSplit filesTableSplit) {
             return new FilesTablePageSource(
                     typeManager,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_ORDINAL_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.DATA_CHANGE_TIMESTAMP_ID;
@@ -79,6 +80,7 @@ public class TableChangesFunctionProcessor
         requireNonNull(session, "session is null");
         requireNonNull(functionHandle, "functionHandle is null");
         requireNonNull(tableCredentials, "tableCredentials is null");
+        verify(tableCredentials.isPresent(), "tableCredentials is empty");
         requireNonNull(split, "split is null");
         requireNonNull(icebergPageSourceProvider, "icebergPageSourceProvider is null");
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -579,7 +579,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 getSession(icebergConfig),
                 split,
                 tableHandle.connectorHandle(),
-                Optional.empty(),
+                Optional.of(new IcebergTableCredentials(ImmutableMap.of())),
                 columns,
                 dynamicFilter);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The plan visitor in SqlStage was returning null in each visit method instead of delegating to super, so credentials were only extracted for the top-level plan node and its children were never traversed.

Add verify() assertions in Iceberg page source/sink providers and the table changes function processor to make it explicit that credentials are always expected to be present.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Issue discovered incidentally while adding a verify statement for the presence of the connector table credentials in Iceberg page source/sink providers

https://github.com/trinodb/trino/actions/runs/26531068397/job/78148387030?pr=29641
```
	Caused by: com.google.common.base.VerifyException: connectorTableCredentials must be present
		at com.google.common.base.Verify.verify(Verify.java:124)
		at io.trino.plugin.iceberg.IcebergPageSourceProvider.createPageSource(IcebergPageSourceProvider.java:261)
		at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:57)
		at io.trino.split.PageSourceManager$PageSourceProviderInstance.createPageSource(PageSourceManager.java:83)
		at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:271)
		at io.trino.operator.OutputValidatingSourceOperator.getOutput(OutputValidatingSourceOperator.java:70)
		at io.trino.operator.Driver.processInternal(Driver.java:403)
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Fix table credentials extraction to visit child plan nodes recursively. ({issue}`issuenumber`)
```
