### PR TITLE
Add OVERLAPS predicate

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -589,6 +589,7 @@ predicate[ParserRuleContext value]
     | IS NOT? truthValue=(TRUE | FALSE | UNKNOWN)                         #booleanTest
     | IS NOT? DISTINCT FROM right=valueExpression                         #distinctFrom
     | MATCH UNIQUE? matchType=(SIMPLE | PARTIAL | FULL)? '(' query ')'    #match
+    | OVERLAPS right=valueExpression                                      #overlaps
     ;
 
 valueExpression
@@ -1292,6 +1293,7 @@ OVER: 'OVER';
 OVERFLOW: 'OVERFLOW';
 OVERLAY: 'OVERLAY';
 PARTIAL: 'PARTIAL';
+OVERLAPS: 'OVERLAPS';
 PARTITION: 'PARTITION';
 PARTITIONS: 'PARTITIONS';
 PASSING: 'PASSING';

--- a/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
+++ b/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
@@ -221,6 +221,7 @@ public class TestSqlKeywords
                         "OVERFLOW",
                         "OVERLAY",
                         "PARTIAL",
+                        "OVERLAPS",
                         "PARTITION",
                         "PARTITIONS",
                         "PASSING",

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -145,6 +145,7 @@ import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.OrderBy;
+import io.trino.sql.tree.OverlapsPredicate;
 import io.trino.sql.tree.Overlay;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.Predicate;
@@ -962,6 +963,7 @@ public class ExpressionAnalyzer
                 case IsNullPredicate _ -> analyzeIsNull(node.getValue(), node, context);
                 case LikePredicate predicate -> analyzeLike(node.getValue(), predicate, node, context);
                 case MatchPredicate predicate -> analyzeMatchPredicate(node.getValue(), predicate, node, context);
+                case OverlapsPredicate predicate -> analyzeOverlaps(node.getValue(), predicate, node, context);
                 case QuantifiedComparisonPredicate predicate -> analyzeQuantifiedComparison(node.getValue(), predicate, node, context);
             };
         }
@@ -1116,6 +1118,7 @@ public class ExpressionAnalyzer
                         case IsNullPredicate _ -> analyzeIsNull(operand, whenClause, context);
                         case LikePredicate fragment -> analyzeLike(operand, fragment, whenClause, context);
                         case MatchPredicate fragment -> analyzeMatchPredicate(operand, fragment, whenClause, context);
+                        case OverlapsPredicate fragment -> analyzeOverlaps(operand, fragment, whenClause, context);
                         case QuantifiedComparisonPredicate fragment -> analyzeQuantifiedComparison(operand, fragment, whenClause, context);
                     }
                 }
@@ -2784,6 +2787,79 @@ public class ExpressionAnalyzer
             return setExpressionType(node, resultType);
         }
 
+        private Type analyzeOverlaps(Expression value, OverlapsPredicate predicate, Expression anchor, Context context)
+        {
+            RowType leftRow = validatePeriod(value, process(value, context));
+            RowType rightRow = validatePeriod(predicate.getRight(), process(predicate.getRight(), context));
+
+            Type leftStart = leftRow.getFields().get(0).getType();
+            Type leftEnd = leftRow.getFields().get(1).getType();
+            Type rightStart = rightRow.getFields().get(0).getType();
+            Type rightEnd = rightRow.getFields().get(1).getType();
+
+            Optional<Type> commonStart = typeCoercion.getCommonSuperType(leftStart, rightStart);
+            Optional<Type> commonEnd = typeCoercion.getCommonSuperType(leftEnd, rightEnd);
+            if (commonStart.isEmpty() || commonEnd.isEmpty()) {
+                throw semanticException(TYPE_MISMATCH, anchor, "Cannot apply OVERLAPS to %s and %s", leftRow, rightRow);
+            }
+
+            Type effectiveEnd;
+            if (isInterval(commonEnd.get())) {
+                try {
+                    effectiveEnd = plannerContext.getMetadata().resolveOperator(ADD, ImmutableList.of(commonStart.get(), commonEnd.get())).signature().getReturnType();
+                }
+                catch (TrinoException e) {
+                    throw semanticException(TYPE_MISMATCH, anchor, "Cannot apply OVERLAPS to %s and %s", leftRow, rightRow);
+                }
+            }
+            else {
+                effectiveEnd = commonEnd.get();
+            }
+            if (typeCoercion.getCommonSuperType(commonStart.get(), effectiveEnd).isEmpty()) {
+                throw semanticException(TYPE_MISMATCH, anchor, "Cannot apply OVERLAPS to %s and %s", leftRow, rightRow);
+            }
+
+            RowType commonRow = RowType.anonymous(ImmutableList.of(commonStart.get(), commonEnd.get()));
+            if (!leftRow.equals(commonRow)) {
+                addOrReplaceExpressionCoercion(value, commonRow);
+            }
+            if (!rightRow.equals(commonRow)) {
+                addOrReplaceExpressionCoercion(predicate.getRight(), commonRow);
+            }
+
+            return setExpressionType(anchor, BOOLEAN);
+        }
+
+        private RowType validatePeriod(Expression source, Type type)
+        {
+            if (!(type instanceof RowType row) || row.getFields().size() != 2) {
+                throw semanticException(TYPE_MISMATCH, source, "OVERLAPS operand must be a row of two elements (actual %s)", type);
+            }
+            Type start = row.getFields().get(0).getType();
+            Type end = row.getFields().get(1).getType();
+            if (!isDatetime(start)) {
+                throw semanticException(TYPE_MISMATCH, source, "OVERLAPS period start must be a datetime (actual %s)", start);
+            }
+            if (!isDatetime(end) && !isInterval(end)) {
+                throw semanticException(TYPE_MISMATCH, source, "OVERLAPS period end must be a datetime or interval (actual %s)", end);
+            }
+            return row;
+        }
+
+        private static boolean isDatetime(Type type)
+        {
+            return type instanceof DateType
+                    || type instanceof TimeType
+                    || type instanceof TimeWithTimeZoneType
+                    || type instanceof TimestampType
+                    || type instanceof TimestampWithTimeZoneType;
+        }
+
+        private static boolean isInterval(Type type)
+        {
+            return type == INTERVAL_DAY_TIME || type == INTERVAL_YEAR_MONTH;
+        }
+
         @Override
         protected Type visitCurrentCatalog(CurrentCatalog node, Context context)
         {
@@ -2962,15 +3038,9 @@ public class ExpressionAnalyzer
             return setExpressionType(node, BIGINT);
         }
 
-        private boolean isDateTimeType(Type type)
+        private static boolean isDateTimeType(Type type)
         {
-            return type.equals(DATE) ||
-                    type instanceof TimeType ||
-                    type instanceof TimeWithTimeZoneType ||
-                    type instanceof TimestampType ||
-                    type instanceof TimestampWithTimeZoneType ||
-                    type.equals(INTERVAL_DAY_TIME) ||
-                    type.equals(INTERVAL_YEAR_MONTH);
+            return isDatetime(type) || isInterval(type);
         }
 
         @Override
@@ -3667,7 +3737,7 @@ public class ExpressionAnalyzer
                     else if (isNumericType(parameterType) || parameterType.equals(BOOLEAN)) {
                         passedType = parameterType;
                     }
-                    else if (isDateTimeType(parameterType) && !parameterType.equals(INTERVAL_DAY_TIME) && !parameterType.equals(INTERVAL_YEAR_MONTH)) {
+                    else if (isDatetime(parameterType)) {
                         passedType = parameterType;
                     }
                     else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -110,6 +110,7 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.NullLiteral;
+import io.trino.sql.tree.OverlapsPredicate;
 import io.trino.sql.tree.Overlay;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.Predicate;
@@ -130,6 +131,7 @@ import io.trino.sql.tree.WhenClause.Partial;
 import io.trino.type.IntervalDayTimeType;
 import io.trino.type.IntervalYearMonthType;
 import io.trino.type.JsonPath2016Type;
+import io.trino.type.TypeCoercion;
 import io.trino.type.UnknownType;
 
 import java.util.ArrayList;
@@ -662,6 +664,7 @@ public class TranslationMap
             }
             case LikePredicate predicate -> translateLike(value, predicate);
             case MatchPredicate _ -> throw new IllegalStateException("MATCH predicate should have been planned by SubqueryPlanner");
+            case OverlapsPredicate predicate -> translateOverlaps(value, predicate);
             case QuantifiedComparisonPredicate _ -> throw new IllegalStateException("Quantified comparison should have been planned by SubqueryPlanner");
         };
     }
@@ -1141,6 +1144,109 @@ public class TranslationMap
                     .build();
             default -> throw new IllegalArgumentException("Unexpected type: " + valueType);
         };
+    }
+
+    private io.trino.sql.ir.Expression translateOverlaps(io.trino.sql.ir.Expression left, OverlapsPredicate predicate)
+    {
+        io.trino.sql.ir.Expression right = translateExpression(predicate.getRight());
+
+        RowType rowType = (RowType) left.type();
+        Type startType = rowType.getFields().get(0).getType();
+        Type secondType = rowType.getFields().get(1).getType();
+        boolean intervalEnd = secondType.equals(IntervalDayTimeType.INTERVAL_DAY_TIME) || secondType.equals(IntervalYearMonthType.INTERVAL_YEAR_MONTH);
+
+        Type endType = intervalEnd
+                ? plannerContext.getMetadata().resolveOperator(OperatorType.ADD, ImmutableList.of(startType, secondType)).signature().getReturnType()
+                : secondType;
+        Type comparisonType = startType.equals(endType)
+                ? startType
+                : new TypeCoercion(plannerContext.getTypeManager()::getType).getCommonSuperType(startType, endType).orElseThrow();
+
+        Symbol leftSymbol = new Symbol(rowType, "$overlaps_left");
+        Symbol rightSymbol = new Symbol(rowType, "$overlaps_right");
+        Endpoints period1 = endpoints(new Reference(rowType, leftSymbol.name()), intervalEnd, startType, secondType, endType, comparisonType);
+        Endpoints period2 = endpoints(new Reference(rowType, rightSymbol.name()), intervalEnd, startType, secondType, endType, comparisonType);
+
+        // Order each period's endpoints into a lower bound s and an upper bound t, binding each so the
+        // operands are evaluated once. The ordering is null-asymmetric: when one endpoint is null, s is
+        // the *known* endpoint and only t can be null — unlike least/greatest, which return null on any
+        // null argument. The overlap test below relies on that asymmetry to still yield a definite
+        // result when a single bound is null.
+        Symbol s1 = new Symbol(comparisonType, "$overlaps_s1");
+        Symbol t1 = new Symbol(comparisonType, "$overlaps_t1");
+        Symbol s2 = new Symbol(comparisonType, "$overlaps_s2");
+        Symbol t2 = new Symbol(comparisonType, "$overlaps_t2");
+
+        Reference rs1 = new Reference(comparisonType, s1.name());
+        Reference rt1 = new Reference(comparisonType, t1.name());
+        Reference rs2 = new Reference(comparisonType, s2.name());
+        Reference rt2 = new Reference(comparisonType, t2.name());
+
+        // Two periods overlap when they share at least one instant. This is the SQL specification's
+        // expansion, with (s1, t1) and (s2, t2) the ordered lower/upper bounds of the two periods; it
+        // is shaped to preserve the null handling described above, so a single null bound still yields
+        // a definite true/false rather than null:
+        //     (s1 > s2 AND NOT (s1 >= t2 AND t1 >= t2))
+        //  OR (s2 > s1 AND NOT (s2 >= t1 AND t2 >= t1))
+        //  OR (s1 = s2 AND (t1 <> t2 OR t1 = t2))
+        io.trino.sql.ir.Expression formula = new Logical(Logical.Operator.OR, ImmutableList.of(
+                new Logical(Logical.Operator.AND, ImmutableList.of(
+                        comparison(plannerContext.getMetadata(), GREATER_THAN, rs1, rs2),
+                        not(plannerContext.getMetadata(), new Logical(Logical.Operator.AND, ImmutableList.of(
+                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, rs1, rt2),
+                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, rt1, rt2)))))),
+                new Logical(Logical.Operator.AND, ImmutableList.of(
+                        comparison(plannerContext.getMetadata(), GREATER_THAN, rs2, rs1),
+                        not(plannerContext.getMetadata(), new Logical(Logical.Operator.AND, ImmutableList.of(
+                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, rs2, rt1),
+                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, rt2, rt1)))))),
+                new Logical(Logical.Operator.AND, ImmutableList.of(
+                        comparison(plannerContext.getMetadata(), EQUAL, rs1, rs2),
+                        new Logical(Logical.Operator.OR, ImmutableList.of(
+                                comparison(plannerContext.getMetadata(), NOT_EQUAL, rt1, rt2),
+                                comparison(plannerContext.getMetadata(), EQUAL, rt1, rt2)))))));
+
+        return new Let(leftSymbol, left,
+                new Let(rightSymbol, right,
+                        new Let(s1, lowerBound(period1),
+                                new Let(t1, upperBound(period1),
+                                        new Let(s2,
+                                                lowerBound(period2),
+                                                new Let(t2, upperBound(period2), formula))))));
+    }
+
+    // Lower bound s of a period: the smaller endpoint, or — when the start is null — the known end, so
+    // null is pushed onto the upper bound instead of swallowing both.
+    private io.trino.sql.ir.Expression lowerBound(Endpoints period)
+    {
+        return ifExpression(reversedOrNullStart(period), period.end(), period.start());
+    }
+
+    // Upper bound t of a period: the larger endpoint, or the null/start endpoint when swapped.
+    private io.trino.sql.ir.Expression upperBound(Endpoints period)
+    {
+        return ifExpression(reversedOrNullStart(period), period.start(), period.end());
+    }
+
+    private io.trino.sql.ir.Expression reversedOrNullStart(Endpoints period)
+    {
+        return new Logical(Logical.Operator.OR, ImmutableList.of(
+                new IsNull(period.start()),
+                comparison(plannerContext.getMetadata(), LESS_THAN, period.end(), period.start())));
+    }
+
+    private record Endpoints(io.trino.sql.ir.Expression start, io.trino.sql.ir.Expression end) {}
+
+    private Endpoints endpoints(io.trino.sql.ir.Expression row, boolean intervalEnd, Type startType, Type secondType, Type endType, Type comparisonType)
+    {
+        io.trino.sql.ir.Expression startRaw = new FieldReference(row, 0);
+        io.trino.sql.ir.Expression second = new FieldReference(row, 1);
+        io.trino.sql.ir.Expression endRaw = intervalEnd
+                ? new Call(plannerContext.getMetadata().resolveOperator(OperatorType.ADD, ImmutableList.of(startType, secondType)), ImmutableList.of(startRaw, second))
+                : second;
+        io.trino.sql.ir.Expression start = startType.equals(comparisonType) ? startRaw : new io.trino.sql.ir.Cast(startRaw, comparisonType);
+        io.trino.sql.ir.Expression end = endType.equals(comparisonType) ? endRaw : new io.trino.sql.ir.Cast(endRaw, comparisonType);
+        return new Endpoints(start, end);
     }
 
     private io.trino.sql.ir.Expression translate(Format node)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestOverlaps.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestOverlaps.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestOverlaps
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testDateRangesOverlapping()
+    {
+        // [Jan, Jun] and [May, Dec] share May–Jun.
+        assertThat(assertions.expression("(DATE '2020-01-01', DATE '2020-06-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("BOOLEAN 'true'");
+    }
+
+    @Test
+    public void testDateRangesDisjoint()
+    {
+        assertThat(assertions.expression("(DATE '2020-01-01', DATE '2020-03-01') OVERLAPS (DATE '2020-05-01', DATE '2020-07-01')"))
+                .matches("BOOLEAN 'false'");
+    }
+
+    @Test
+    public void testHalfOpenEndExclusive()
+    {
+        // SQL OVERLAPS uses half-open semantics: period 1's end equals period 2's start ⇒ no overlap.
+        assertThat(assertions.expression("(DATE '2020-01-01', DATE '2020-05-01') OVERLAPS (DATE '2020-05-01', DATE '2020-07-01')"))
+                .matches("BOOLEAN 'false'");
+    }
+
+    @Test
+    public void testSameStartsAlwaysOverlap()
+    {
+        // Per SQL spec, equal start points always overlap, even at a single instant.
+        assertThat(assertions.expression("(DATE '2020-05-01', DATE '2020-05-01') OVERLAPS (DATE '2020-05-01', DATE '2020-05-01')"))
+                .matches("BOOLEAN 'true'");
+        assertThat(assertions.expression("(DATE '2020-05-01', DATE '2020-05-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("BOOLEAN 'true'");
+    }
+
+    @Test
+    public void testReversedEndpoints()
+    {
+        // (end, start) is normalized to (start, end) before evaluation.
+        assertThat(assertions.expression("(DATE '2020-06-01', DATE '2020-01-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("BOOLEAN 'true'");
+    }
+
+    @Test
+    public void testIntervalEnd()
+    {
+        // The second column can be an interval; end is start + interval.
+        assertThat(assertions.expression("(DATE '2020-01-01', INTERVAL '5' MONTH) OVERLAPS (DATE '2020-05-01', INTERVAL '7' MONTH)"))
+                .matches("BOOLEAN 'true'");
+    }
+
+    @Test
+    public void testTimestampWithSubsecond()
+    {
+        assertThat(assertions.expression(
+                "(TIMESTAMP '2020-05-01 12:00:00.000', TIMESTAMP '2020-05-01 13:00:00.000') OVERLAPS " +
+                        "(TIMESTAMP '2020-05-01 12:30:00.000', TIMESTAMP '2020-05-01 14:00:00.000')"))
+                .matches("BOOLEAN 'true'");
+    }
+
+    @Test
+    public void testMixedPrecisionCoerces()
+    {
+        // TIMESTAMP(0) and TIMESTAMP(3) coerce to common TIMESTAMP(3) and compare.
+        assertThat(assertions.expression(
+                "(TIMESTAMP '2020-05-01 12:00:00', TIMESTAMP '2020-05-01 13:00:00') OVERLAPS " +
+                        "(TIMESTAMP '2020-05-01 12:30:00.123', TIMESTAMP '2020-05-01 14:00:00.456')"))
+                .matches("BOOLEAN 'true'");
+    }
+
+    @Test
+    public void testNullEndpoints()
+    {
+        // SQL §8.14 orders each period's endpoints null-asymmetrically: the known endpoint is the
+        // lower bound, so a single null endpoint does not collapse the period to all-unknown. When
+        // the known endpoint lies inside the other period the result is a definite TRUE.
+
+        // Null start, known end inside the other period.
+        assertThat(assertions.expression("(CAST(NULL AS DATE), DATE '2020-06-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("BOOLEAN 'true'");
+        // Null end, known start inside the other period.
+        assertThat(assertions.expression("(DATE '2020-06-01', CAST(NULL AS DATE)) OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("BOOLEAN 'true'");
+        // Null endpoint on the right operand, its known endpoint inside the left period.
+        assertThat(assertions.expression("(DATE '2020-06-01', DATE '2020-07-01') OVERLAPS (CAST(NULL AS DATE), DATE '2020-06-15')"))
+                .matches("BOOLEAN 'true'");
+        // A null interval end behaves like a null datetime end.
+        assertThat(assertions.expression("(DATE '2020-06-01', CAST(NULL AS INTERVAL YEAR TO MONTH)) OVERLAPS (DATE '2020-05-01', INTERVAL '7' MONTH)"))
+                .matches("BOOLEAN 'true'");
+
+        // Known endpoint outside the other period, the other endpoint null: indeterminate (the spec
+        // never yields a definite FALSE when an endpoint is null).
+        assertThat(assertions.expression("(DATE '2021-01-01', CAST(NULL AS DATE)) OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("CAST(NULL AS BOOLEAN)");
+        // A wholly null row yields unknown.
+        assertThat(assertions.expression("CAST(NULL AS ROW(DATE, DATE)) OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .matches("CAST(NULL AS BOOLEAN)");
+    }
+
+    @Test
+    public void testWrongRowDegreeRejected()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression(
+                "(DATE '2020-01-01', DATE '2020-06-01', DATE '2020-12-31') OVERLAPS (DATE '2020-05-01', DATE '2020-07-01')").evaluate())
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("OVERLAPS operand must be a row of two elements");
+    }
+
+    @Test
+    public void testWrongStartTypeRejected()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression(
+                "(1, 2) OVERLAPS (3, 4)").evaluate())
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("OVERLAPS period start must be a datetime");
+    }
+
+    @Test
+    public void testWrongEndTypeRejected()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression(
+                "(DATE '2020-01-01', VARCHAR 'not a date') OVERLAPS (DATE '2020-05-01', DATE '2020-07-01')").evaluate())
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("OVERLAPS period end must be a datetime or interval");
+    }
+
+    @Test
+    public void testIncompatibleShapesRejected()
+    {
+        // datetime-datetime vs datetime-interval cannot share a common row type.
+        assertTrinoExceptionThrownBy(() -> assertions.expression(
+                "(DATE '2020-01-01', DATE '2020-06-01') OVERLAPS (DATE '2020-05-01', INTERVAL '7' MONTH)").evaluate())
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("Cannot apply OVERLAPS");
+    }
+
+    @Test
+    public void testIncomparableEndpointsRejected()
+    {
+        // A period's start and end must be mutually comparable; DATE and TIME are not.
+        assertTrinoExceptionThrownBy(() -> assertions.expression(
+                "(DATE '2020-01-01', TIME '12:00:00') OVERLAPS (DATE '2020-05-01', TIME '13:00:00')").evaluate())
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessageContaining("Cannot apply OVERLAPS");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -88,6 +88,7 @@ import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.NumericParameter;
 import io.trino.sql.tree.OrderBy;
+import io.trino.sql.tree.OverlapsPredicate;
 import io.trino.sql.tree.Overlay;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.Predicated;
@@ -668,6 +669,12 @@ public final class ExpressionFormatter
             builder.append(' ').append(node.getType());
             builder.append(' ').append(process(node.getSubquery(), context));
             return builder.toString();
+        }
+
+        @Override
+        protected String visitOverlapsPredicate(OverlapsPredicate node, Void context)
+        {
+            return "OVERLAPS " + process(node.getRight(), context);
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -205,6 +205,7 @@ import io.trino.sql.tree.Offset;
 import io.trino.sql.tree.OneOrMoreQuantifier;
 import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.OrdinalityColumn;
+import io.trino.sql.tree.OverlapsPredicate;
 import io.trino.sql.tree.Overlay;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.ParameterDeclaration;
@@ -2344,6 +2345,14 @@ class AstBuilder
     public Node visitDistinctFrom(SqlBaseParser.DistinctFromContext context)
     {
         return new DistinctFromPredicate(getLocation(context), context.NOT() != null, (Expression) visit(context.right));
+    }
+
+    @Override
+    public Node visitOverlaps(SqlBaseParser.OverlapsContext context)
+    {
+        return new OverlapsPredicate(
+                getLocation(context.OVERLAPS()),
+                (Expression) visit(context.right));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -487,6 +487,11 @@ public abstract class AstVisitor<R, C>
         return visitPredicate(node, context);
     }
 
+    protected R visitOverlapsPredicate(OverlapsPredicate node, C context)
+    {
+        return visitPredicate(node, context);
+    }
+
     protected R visitQuantifiedComparisonPredicate(QuantifiedComparisonPredicate node, C context)
     {
         return visitPredicate(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -510,6 +510,13 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitOverlapsPredicate(OverlapsPredicate node, C context)
+    {
+        process(node.getRight(), context);
+        return null;
+    }
+
+    @Override
     protected Void visitQuantifiedComparisonPredicate(QuantifiedComparisonPredicate node, C context)
     {
         process(node.getSubquery(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -308,6 +308,10 @@ public final class ExpressionTreeRewriter<C>
                     Expression subquery = rewrite(predicate.getSubquery(), context.get());
                     yield subquery == predicate.getSubquery() ? predicate : new MatchPredicate(predicate.getLocation().orElseThrow(), predicate.isUnique(), predicate.getType(), subquery);
                 }
+                case OverlapsPredicate predicate -> {
+                    Expression right = rewrite(predicate.getRight(), context.get());
+                    yield right == predicate.getRight() ? predicate : new OverlapsPredicate(predicate.getLocation().orElseThrow(), right);
+                }
                 case QuantifiedComparisonPredicate predicate -> {
                     Expression subquery = rewrite(predicate.getSubquery(), context.get());
                     yield subquery == predicate.getSubquery() ? predicate : new QuantifiedComparisonPredicate(predicate.getLocation().orElseThrow(), predicate.getOperator(), predicate.getQuantifier(), subquery);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/OverlapsPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/OverlapsPredicate.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/// SQL spec `<overlaps predicate part 2> ::= OVERLAPS <row value predicand>`.
+public final class OverlapsPredicate
+        extends Predicate
+{
+    private final Expression right;
+
+    public OverlapsPredicate(NodeLocation location, Expression right)
+    {
+        super(location);
+        this.right = requireNonNull(right, "right is null");
+    }
+
+    public Expression getRight()
+    {
+        return right;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return List.of(right);
+    }
+
+    @Override
+    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitOverlapsPredicate(this, context);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        return o instanceof OverlapsPredicate that && right.equals(that.right);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(right);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "OVERLAPS " + right;
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Predicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Predicate.java
@@ -30,6 +30,7 @@ public abstract sealed class Predicate
                 IsNullPredicate,
                 LikePredicate,
                 MatchPredicate,
+                OverlapsPredicate,
                 QuantifiedComparisonPredicate
 {
     protected Predicate(NodeLocation location)

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -155,6 +155,7 @@ import io.trino.sql.tree.Offset;
 import io.trino.sql.tree.OneOrMoreQuantifier;
 import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.OrdinalityColumn;
+import io.trino.sql.tree.OverlapsPredicate;
 import io.trino.sql.tree.Overlay;
 import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.PathElement;
@@ -5586,6 +5587,27 @@ public class TestSqlParser
         assertStatement("SELECT TIMESTAMP '2012-10-31 01:00 UTC' AT LOCAL",
                 simpleQuery(selectList(
                         new AtLocal(new NodeLocation(1, 41), new GenericLiteral("TIMESTAMP", "2012-10-31 01:00 UTC")))));
+    }
+
+    @Test
+    public void testOverlaps()
+    {
+        GenericLiteral start1 = new GenericLiteral(location(1, 2), "DATE", "2020-01-01");
+        GenericLiteral end1 = new GenericLiteral(location(1, 21), "DATE", "2020-06-01");
+        GenericLiteral start2 = new GenericLiteral(location(1, 50), "DATE", "2020-05-01");
+        GenericLiteral end2 = new GenericLiteral(location(1, 69), "DATE", "2020-12-31");
+
+        assertThat(expression("(DATE '2020-01-01', DATE '2020-06-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31')"))
+                .isEqualTo(new Predicated(
+                        location(1, 40),
+                        new Row(location(1, 1), ImmutableList.of(
+                                new Row.Field(location(1, 2), Optional.empty(), start1),
+                                new Row.Field(location(1, 21), Optional.empty(), end1))),
+                        new OverlapsPredicate(
+                                location(1, 40),
+                                new Row(location(1, 49), ImmutableList.of(
+                                        new Row.Field(location(1, 50), Optional.empty(), start2),
+                                        new Row.Field(location(1, 69), Optional.empty(), end2))))));
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/datetime.md
+++ b/docs/src/main/sphinx/functions/datetime.md
@@ -39,6 +39,37 @@ SELECT timestamp '2012-10-31 01:00 UTC' AT LOCAL;
 -- 2012-10-30 18:00:00.000 America/Los_Angeles  (session zone)
 ```
 
+## OVERLAPS
+
+The `OVERLAPS` predicate tests whether two periods of time share any instant.
+Each operand is a row value of two elements:
+
+* The first element is the period's start point, a datetime value.
+* The second element is either the period's end point (a datetime value) or
+  the period's length (an interval value, in which case the end is computed
+  as `start + interval`).
+
+```
+SELECT (DATE '2020-01-01', DATE '2020-06-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31');
+-- true
+
+SELECT (DATE '2020-01-01', DATE '2020-03-01') OVERLAPS (DATE '2020-05-01', DATE '2020-07-01');
+-- false
+
+SELECT (DATE '2020-01-01', INTERVAL '5' MONTH) OVERLAPS (DATE '2020-05-01', INTERVAL '7' MONTH);
+-- true
+```
+
+If the start and end of an operand are given in reverse, they are normalized
+before evaluation. The half-open semantics mean that periods which touch only
+at a boundary (one period's end equal to the other's start) do not overlap;
+however, two periods that share the same start point always overlap.
+
+If one endpoint of a period is `NULL`, the period is treated as open-ended on
+that side: its known endpoint still anchors the comparison, so the result is
+`true` whenever that known endpoint falls inside the other period, and `NULL`
+(unknown) only when the open side leaves the outcome undetermined.
+
 ## Date and time functions
 
 :::{data} current_date

--- a/docs/src/main/sphinx/language/reserved.md
+++ b/docs/src/main/sphinx/language/reserved.md
@@ -73,6 +73,7 @@ be quoted (using double quotes) in order to be used as an identifier.
 | `OR`                | reserved | reserved |
 | `ORDER`             | reserved | reserved |
 | `OUTER`             | reserved | reserved |
+| `OVERLAPS`          | reserved | reserved |
 | `PREPARE`           | reserved | reserved |
 | `RECURSIVE`         | reserved |          |
 | `RIGHT`             | reserved | reserved |


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #29446** (extended CASE) → **#29809** (NEAREST subquery fix). This branch is stacked on extended-case via the `Add Let IR expression` commit (shared foundation with #29659, not separately PR'd). Review the `Add OVERLAPS predicate` commit at the top. Merge order: #29809 → #29446 → this.

## Summary

Adds the SQL `OVERLAPS` predicate, which tests whether two periods of time share any instant.

```sql
SELECT (DATE '2020-01-01', DATE '2020-06-01') OVERLAPS (DATE '2020-05-01', DATE '2020-12-31');
-- true
```

Each operand is a row value of degree two: `(start, end-or-interval)`, where the first column is a datetime and the second column is either a datetime or an interval (in which case the period end is `start + interval`).

**Stacks on top of #29446.** That PR's last two commits in this PR are the ones to review:

1. **Add Let IR expression** — new scalar `Let(name, value, body)` primitive in `io.trino.sql.ir`. Evaluates `value` once, binds the result to a symbol, and evaluates `body` in the extended scope. Wired through the IR visitors, optimizer, evaluator, bytecode compiler, formatter, `SqlRoutineHash`, and `SymbolsExtractor` (Let-bound symbols are local, not external dependencies).
2. **Add OVERLAPS predicate** — grammar, AST, analyzer, planner translation, docs, tests.

Once #29446 merges, this PR will rebase down to those two commits.

## Design

`OVERLAPS` lives in the grammar's `predicate` rule, sibling of `BETWEEN`, `LIKE`, etc. `OverlapsPredicate` extends the sealed `Predicate` introduced by #29446 (storing only the right-hand `Expression`); the left operand is supplied by the surrounding `Predicated` wrapper. The analyzer dispatches OVERLAPS from `visitPredicated`; the planner lowers via `translateOverlaps(value, predicate)` from `TranslationMap.translatePartial`.

The lowered IR binds each row operand to a fresh symbol via `Let`, so the operand is evaluated once even though the formula references each row's start and end:

```
Let($overlaps_left = <left row expr>,
  Let($overlaps_right = <right row expr>,
    (s1 = s2) OR (s1 < e2 AND s2 < e1)))
```

where `s = LEAST(start, end)` and `e = GREATEST(start, end)` for each period, with `end = start + interval` if the row is interval-shaped. Without `Let`, the lowering would build multiple `FieldReference` nodes against the same operand expression, evaluating the operand multiple times for non-deterministic or side-effecting operands.

The explicit `s1 = s2` disjunct matches the SQL spec's degenerate-instant rule (two periods sharing a starting moment overlap even if both are zero-length). The half-open `s1 < e2 AND s2 < e1` covers all other cases.

## Test plan

- [x] `TestSqlParser.testOverlaps` — parser shape against `Predicated(value, OverlapsPredicate(right))`.
- [x] New `TestOverlaps` query-level suite covering:
  - overlapping vs disjoint date periods
  - half-open boundary semantics
  - equal-start instants (the degenerate-overlap case)
  - reversed endpoints (normalization)
  - interval-form second field
  - timestamp precisions (single and mixed-precision coercion)
  - `NULL` propagation
  - analyzer rejection cases: wrong row degree, non-datetime start, non-datetime/interval end, incompatible row shapes
- [x] New `TestSymbolsExtractor` covering Let-bound symbols vs free symbols in the value expression.
- [x] New `TestExpressionFormatter.testLet`.
- [x] Regression sweep: `TestAnalyzer` (288/288 — one pre-existing skip), `TestExpressionInterpreter`, `TestExpressionCompiler`, `TestLogicalPlanner`, `TestEffectivePredicateExtractor`, `TestEqualityInference`.
