### PR TITLE
Throw on incompatible BETWEEN type validation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -2537,11 +2537,11 @@ public class ExpressionAnalyzer
                     .flatMap(type -> typeCoercion.getCommonSuperType(type, maxType));
 
             if (commonType.isEmpty()) {
-                semanticException(TYPE_MISMATCH, node, "Cannot check if %s is BETWEEN %s and %s", valueType, minType, maxType);
+                throw semanticException(TYPE_MISMATCH, node, "Cannot check if %s is BETWEEN %s and %s", valueType, minType, maxType);
             }
 
             if (!commonType.get().isOrderable()) {
-                semanticException(TYPE_MISMATCH, node, "Cannot check if %s is BETWEEN %s and %s", valueType, minType, maxType);
+                throw semanticException(TYPE_MISMATCH, node, "Cannot check if %s is BETWEEN %s and %s", valueType, minType, maxType);
             }
 
             if (!valueType.equals(commonType.get())) {


### PR DESCRIPTION
## Summary

`analyzeBetween` constructed a `semanticException(TYPE_MISMATCH, …)` for incompatible or non-orderable BETWEEN operand types but never threw it. Execution fell through to `commonType.get()`, which then either NPE'd on the empty Optional or silently accepted a non-orderable type. Two-line fix: add the missing `throw`.

## Test plan

- [x] `TestAnalyzer` (288/288, 1 pre-existing skip).