### PR TITLE
Apply backoff when Hive metastore connection fails

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
@@ -103,6 +103,7 @@ public class StaticTokenAwareMetastoreClientFactory
             }
             catch (TException e) {
                 lastException = e;
+                backoff.fail();
             }
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestStaticTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestStaticTokenAwareMetastoreClientFactory.java
@@ -19,9 +19,12 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.TestingTicker;
 import io.trino.hive.thrift.metastore.Table;
 import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.Test;
 
 import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -183,6 +186,27 @@ public class TestStaticTokenAwareMetastoreClientFactory
         assertEqualHiveClient(metastoreClient3, DEFAULT_CLIENT);
     }
 
+    @Test
+    public void testBackoffAppliedOnConnectionFailure()
+            throws TException
+    {
+        ConnectionCountingThriftMetastoreClientFactory clientFactory = new ConnectionCountingThriftMetastoreClientFactory(
+                ImmutableMap.of(DEFAULT_URI, Optional.empty(), FALLBACK_URI, Optional.of(FALLBACK_CLIENT)));
+        StaticMetastoreConfig config = new StaticMetastoreConfig().setMetastoreUris(ImmutableList.of(DEFAULT_URI, FALLBACK_URI));
+        StaticTokenAwareMetastoreClientFactory metastoreClientFactory = new StaticTokenAwareMetastoreClientFactory(
+                config, new ThriftMetastoreAuthenticationConfig(), clientFactory, new TestingTicker());
+
+        assertEqualHiveClient(metastoreClientFactory.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        assertThat(clientFactory.connectionAttempts()).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(
+                URI.create(DEFAULT_URI), 1,
+                URI.create(FALLBACK_URI), 1));
+        clientFactory.resetConnectionAttempts();
+        assertEqualHiveClient(metastoreClientFactory.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        // The previous connection failure on DEFAULT_URI is not attempted first again on the second call
+        assertThat(clientFactory.connectionAttempts()).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(
+                URI.create(FALLBACK_URI), 1));
+    }
+
     private static void assertGetTableException(ThriftMetastoreClient client)
     {
         assertThatThrownBy(() -> client.getTable("foo", "bar"))
@@ -229,5 +253,35 @@ public class TestStaticTokenAwareMetastoreClientFactory
             expected = ((FailureAwareThriftMetastoreClient) expected).getDelegate();
         }
         assertThat(actual).isEqualTo(expected);
+    }
+
+    private static class ConnectionCountingThriftMetastoreClientFactory
+            implements ThriftMetastoreClientFactory
+    {
+        private final ThriftMetastoreClientFactory delegate;
+        private final Map<URI, Integer> attempts = new HashMap<>();
+
+        public ConnectionCountingThriftMetastoreClientFactory(Map<String, Optional<ThriftMetastoreClient>> clients)
+        {
+            this.delegate = new MockThriftMetastoreClientFactory(clients);
+        }
+
+        @Override
+        public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
+                throws TTransportException
+        {
+            attempts.merge(uri, 1, Integer::sum);
+            return delegate.create(uri, delegationToken);
+        }
+
+        public void resetConnectionAttempts()
+        {
+            attempts.clear();
+        }
+
+        public Map<URI, Integer> connectionAttempts()
+        {
+            return ImmutableMap.copyOf(attempts);
+        }
     }
 }


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`StaticTokenAwareMetastoreClientFactory.createMetastoreClient()` applies back-off only for failures on an already-connected metastore client. A failure to establish the connection is caught but never calls backoff.fail(), so the unreachable metastore is never de-prioritised and is retried first on every call — a redundant connection attempt to a metastore known to be down on each client creation.

This calls `backoff.fail()` on connection failure as well, so a failing metastore is backed off and subsequent calls prefer a healthy one. Adds a test asserting the failing metastore is contacted only once across two client creations.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #29653.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: