### PR TITLE
Move engine-only query tests

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -222,13 +222,6 @@ public class TestCassandraConnectorTest
     }
 
     @Test
-    @Override // Override because some tests (e.g. testKeyspaceNameAmbiguity) cause table listing failure
-    public void testShowInformationSchemaTables()
-    {
-        executeExclusively(super::testShowInformationSchemaTables);
-    }
-
-    @Test
     @Override // Override because some tests (e.g. testKeyspaceNameAmbiguity, testNativeQueryCaseSensitivity) cause column listing failure
     public void testSelectInformationSchemaColumns()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -75,6 +75,7 @@ import static io.trino.sql.tree.ExplainType.Type.LOGICAL;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertContains;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.QueryTemplate.parameter;
 import static io.trino.tests.QueryTemplate.queryTemplate;
 import static io.trino.tpch.TpchTable.CUSTOMER;
@@ -5596,6 +5597,77 @@ public abstract class AbstractTestEngineOnlyQueries
     }
 
     @Test
+    public void testShowSchemasLike()
+    {
+        MaterializedResult result = computeActual(format("SHOW SCHEMAS LIKE '%s'", getSession().getSchema().get()));
+        assertThat(result.getOnlyColumnAsSet()).isEqualTo(ImmutableSet.of(getSession().getSchema().get()));
+    }
+
+    @Test
+    public void testShowSchemasFrom()
+    {
+        MaterializedResult result = computeActual(format("SHOW SCHEMAS FROM %s", getSession().getCatalog().get()));
+        assertThat(result.getOnlyColumnAsSet()).contains("information_schema");
+    }
+
+    @Test
+    public void testShowTablesLike()
+    {
+        assertThat(computeActual("SHOW TABLES LIKE 'or%'").getOnlyColumnAsSet())
+                .contains("orders")
+                .allMatch(tableName -> ((String) tableName).startsWith("or"));
+    }
+
+    @Test
+    public void testShowInformationSchemaTables()
+    {
+        assertThat(computeActual("SHOW TABLES FROM information_schema").getOnlyColumnAsSet())
+                .isEqualTo(Set.of("applicable_roles", "columns", "enabled_roles", "roles", "schemata", "table_privileges", "tables", "views"));
+    }
+
+    @Test
+    public void testShowCreateInformationSchema()
+    {
+        assertThat(query("SHOW CREATE SCHEMA information_schema"))
+                .skippingTypesCheck()
+                .matches(format("VALUES 'CREATE SCHEMA %s.information_schema'", getSession().getCatalog().orElseThrow()));
+    }
+
+    @Test
+    public void testShowCreateInformationSchemaTable()
+    {
+        assertQueryFails("SHOW CREATE VIEW information_schema.schemata", "line 1:1: Relation '\\w+.information_schema.schemata' is a table, not a view");
+        assertQueryFails("SHOW CREATE MATERIALIZED VIEW information_schema.schemata", "line 1:1: Relation '\\w+.information_schema.schemata' is a table, not a materialized view");
+
+        assertThat((String) computeScalar("SHOW CREATE TABLE information_schema.schemata"))
+                .isEqualTo("CREATE TABLE " + getSession().getCatalog().orElseThrow() + ".information_schema.schemata (\n" +
+                        "   catalog_name varchar,\n" +
+                        "   schema_name varchar\n" +
+                        ")");
+    }
+
+    @Test
+    public void testSymbolAliasing()
+    {
+        String tableName = "memory.default.test_symbol_aliasing_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 foo_1, 2 foo_2_4", 1);
+            assertQuery("SELECT foo_1, foo_2_4 FROM " + tableName, "SELECT 1, 2");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testDropTableIfExists()
+    {
+        assertThat(getQueryRunner().tableExists(getSession(), "test_drop_if_exists")).isFalse();
+        assertUpdate("DROP TABLE IF EXISTS test_drop_if_exists");
+        assertThat(getQueryRunner().tableExists(getSession(), "test_drop_if_exists")).isFalse();
+    }
+
+    @Test
     public void testCast()
     {
         assertQuery("SELECT CAST('1' AS BIGINT)");
@@ -5758,6 +5830,12 @@ public abstract class AbstractTestEngineOnlyQueries
                         "   UNION ALL " +
                         "   SELECT shipdate ds, orderkey FROM lineitem) a " +
                         "JOIN orders o ON (a.orderkey = o.orderkey)");
+    }
+
+    @Test
+    public void testUnionAllAboveBroadcastJoin()
+    {
+        assertQuery("SELECT COUNT(*) FROM region r JOIN (SELECT nationkey FROM nation UNION ALL SELECT nationkey as key FROM nation) n ON r.regionkey = n.nationkey", "VALUES 10");
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -254,20 +254,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testShowSchemasFrom()
-    {
-        MaterializedResult result = computeActual(format("SHOW SCHEMAS FROM %s", getSession().getCatalog().get()));
-        assertThat(result.getOnlyColumnAsSet()).contains(getSession().getSchema().get(), INFORMATION_SCHEMA);
-    }
-
-    @Test
-    public void testShowSchemasLike()
-    {
-        MaterializedResult result = computeActual(format("SHOW SCHEMAS LIKE '%s'", getSession().getSchema().get()));
-        assertThat(result.getOnlyColumnAsSet()).isEqualTo(ImmutableSet.of(getSession().getSchema().get()));
-    }
-
-    @Test
     public void testShowTables()
     {
         Set<String> expectedTables = REQUIRED_TPCH_TABLES.stream()
@@ -276,14 +262,6 @@ public abstract class AbstractTestQueries
 
         MaterializedResult result = computeActual("SHOW TABLES");
         assertThat(result.getOnlyColumnAsSet()).containsAll(expectedTables);
-    }
-
-    @Test
-    public void testShowTablesLike()
-    {
-        assertThat(computeActual("SHOW TABLES LIKE 'or%'").getOnlyColumnAsSet())
-                .contains("orders")
-                .allMatch(tableName -> ((String) tableName).startsWith("or"));
     }
 
     @Test
@@ -459,11 +437,5 @@ public abstract class AbstractTestQueries
     {
         assertQuery("SELECT * FROM (SELECT count(*) FROM orders) WHERE 0=1");
         assertQuery("SELECT * FROM (SELECT count(*) FROM orders) WHERE null");
-    }
-
-    @Test
-    public void testUnionAllAboveBroadcastJoin()
-    {
-        assertQuery("SELECT COUNT(*) FROM region r JOIN (SELECT nationkey FROM nation UNION ALL SELECT nationkey as key FROM nation) n ON r.regionkey = n.nationkey", "VALUES 10");
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -526,19 +526,6 @@ public abstract class BaseConnectorSmokeTest
         assertUpdate("DROP SCHEMA " + schemaName);
     }
 
-    /**
-     * This seemingly duplicate test of {@link BaseConnectorTest#testShowInformationSchemaTables()}
-     * is used in the context of this class in order to be able to test
-     * against a wider range of connector configurations.
-     */
-    @Test
-    public void testShowInformationSchemaTables()
-    {
-        assertThat(query("SHOW TABLES FROM information_schema"))
-                .skippingTypesCheck()
-                .containsAll("VALUES 'applicable_roles', 'columns', 'enabled_roles', 'roles', 'schemata', 'table_privileges', 'tables', 'views'");
-    }
-
     @Test
     public void testSelectInformationSchemaTables()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -981,14 +981,6 @@ public abstract class BaseConnectorTest
     }
 
     @Test
-    public void testShowInformationSchemaTables()
-    {
-        assertThat(query("SHOW TABLES FROM information_schema"))
-                .skippingTypesCheck()
-                .containsAll("VALUES 'applicable_roles', 'columns', 'enabled_roles', 'roles', 'schemata', 'table_privileges', 'tables', 'views'");
-    }
-
-    @Test
     public void testView()
     {
         if (!hasBehavior(SUPPORTS_CREATE_VIEW)) {
@@ -2564,27 +2556,6 @@ public abstract class BaseConnectorTest
                 ('orders', 'shippriority'),
                 ('orders', 'comment')
                 """;
-    }
-
-    @Test
-    public void testShowCreateInformationSchema()
-    {
-        assertThat(query("SHOW CREATE SCHEMA information_schema"))
-                .skippingTypesCheck()
-                .matches(format("VALUES 'CREATE SCHEMA %s.information_schema'", getSession().getCatalog().orElseThrow()));
-    }
-
-    @Test
-    public void testShowCreateInformationSchemaTable()
-    {
-        assertQueryFails("SHOW CREATE VIEW information_schema.schemata", "line 1:1: Relation '\\w+.information_schema.schemata' is a table, not a view");
-        assertQueryFails("SHOW CREATE MATERIALIZED VIEW information_schema.schemata", "line 1:1: Relation '\\w+.information_schema.schemata' is a table, not a materialized view");
-
-        assertThat((String) computeScalar("SHOW CREATE TABLE information_schema.schemata"))
-                .isEqualTo("CREATE TABLE " + getSession().getCatalog().orElseThrow() + ".information_schema.schemata (\n" +
-                        "   catalog_name varchar,\n" +
-                        "   schema_name varchar\n" +
-                        ")");
     }
 
     @Test
@@ -6018,14 +5989,6 @@ public abstract class BaseConnectorTest
     }
 
     @Test
-    public void testDropTableIfExists()
-    {
-        assertThat(getQueryRunner().tableExists(getSession(), "test_drop_if_exists")).isFalse();
-        assertUpdate("DROP TABLE IF EXISTS test_drop_if_exists");
-        assertThat(getQueryRunner().tableExists(getSession(), "test_drop_if_exists")).isFalse();
-    }
-
-    @Test
     public void testTruncateTable()
     {
         if (!hasBehavior(SUPPORTS_TRUNCATE)) {
@@ -6106,18 +6069,6 @@ public abstract class BaseConnectorTest
     {
         MaterializedResult result = computeActual("SHOW SCHEMAS FROM tpch");
         assertThat(result.getOnlyColumnAsSet().containsAll(ImmutableSet.of(INFORMATION_SCHEMA, "tiny", "sf1"))).isTrue();
-    }
-
-    // TODO move to to engine-only
-    @Test
-    public void testSymbolAliasing()
-    {
-        skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
-
-        String tableName = "test_symbol_aliasing" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 foo_1, 2 foo_2_4", 1);
-        assertQuery("SELECT foo_1, foo_2_4 FROM " + tableName, "SELECT 1, 2");
-        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test


### PR DESCRIPTION
Reduce redundant connector test coverage by running engine-only query behavior in the engine-only suite.