### PR TITLE
Improve Iceberg 1.11 REST catalog compatibility 

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroPageSource.java
@@ -78,7 +78,7 @@ public class IcebergAvroPageSource
             List<Type> columnTypes,
             boolean appendRowNumberColumn,
             OptionalLong fileFirstRowId,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             AggregatedMemoryContext memoryUsage)
     {
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
@@ -94,7 +94,8 @@ public class IcebergAvroPageSource
         Map<Integer, Object> idToConstant = new HashMap<>();
         if (fileFirstRowId.isPresent()) {
             idToConstant.put(ROW_ID.fieldId(), fileFirstRowId.getAsLong());
-            idToConstant.put(LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), dataSequenceNumber);
+            idToConstant.put(LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), dataSequenceNumber.orElseThrow(() ->
+                    new IllegalArgumentException("dataSequenceNumber is required when fileFirstRowId is present")));
         }
 
         // Metadata row-lineage columns are not part of table schema JSON, but can be physically present in v3 files.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -319,7 +319,7 @@ public class IcebergPageSourceProvider
             long fileRecordCount,
             IcebergFileFormat fileFormat,
             Map<String, String> fileIoProperties,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             OptionalLong fileFirstRowId,
             Optional<NameMapping> nameMapping)
     {
@@ -543,7 +543,7 @@ public class IcebergPageSourceProvider
                 Optional.empty(),
                 "",
                 ImmutableMap.of(),
-                0,
+                OptionalLong.empty(),
                 OptionalLong.empty())
                 .pageSource();
     }
@@ -563,7 +563,7 @@ public class IcebergPageSourceProvider
             Optional<NameMapping> nameMapping,
             String partition,
             Map<Integer, Optional<String>> partitionKeys,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             OptionalLong fileFirstRowId)
     {
         return switch (fileFormat) {
@@ -684,7 +684,7 @@ public class IcebergPageSourceProvider
             Optional<NameMapping> nameMapping,
             String partition,
             Map<Integer, Optional<String>> partitionKeys,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             OptionalLong fileFirstRowId)
     {
         OrcDataSource orcDataSource = null;
@@ -775,7 +775,8 @@ public class IcebergPageSourceProvider
                         transforms.transform(new RowIdTransform(fileFirstRowId.getAsLong(), -1));
                     }
                     else if (column.isLastUpdatedSequenceNumberColumn()) {
-                        transforms.constantValue(nativeValueToBlock(column.getType(), dataSequenceNumber));
+                        transforms.constantValue(nativeValueToBlock(column.getType(), dataSequenceNumber.orElseThrow(() ->
+                                new TrinoException(ICEBERG_BAD_DATA, "Cannot read $last_updated_sequence_number metadata column: Iceberg manifest is missing dataSequenceNumber"))));
                     }
                     else {
                         Object initialDefault = getInitialDefault(tableSchema, column.getBaseColumnIdentity().getId());
@@ -803,7 +804,8 @@ public class IcebergPageSourceProvider
                         transforms.transform(new RowIdTransform(fileFirstRowId.getAsLong(), ordinal));
                     }
                     else if (column.isLastUpdatedSequenceNumberColumn()) {
-                        transforms.transform(new DataSequenceNumberTransform(dataSequenceNumber, ordinal));
+                        transforms.transform(new DataSequenceNumberTransform(dataSequenceNumber.orElseThrow(() ->
+                                new TrinoException(ICEBERG_BAD_DATA, "Cannot read $last_updated_sequence_number metadata column: Iceberg manifest is missing dataSequenceNumber")), ordinal));
                     }
                     else if (column.isBaseColumn()) {
                         transforms.column(ordinal);
@@ -1006,7 +1008,7 @@ public class IcebergPageSourceProvider
             Optional<NameMapping> nameMapping,
             String partition,
             Map<Integer, Optional<String>> partitionKeys,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             OptionalLong fileFirstRowId)
     {
         AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
@@ -1099,7 +1101,8 @@ public class IcebergPageSourceProvider
                         transforms.transform(new RowIdTransform(fileFirstRowId.getAsLong(), -1));
                     }
                     else if (column.isLastUpdatedSequenceNumberColumn()) {
-                        transforms.constantValue(nativeValueToBlock(column.getType(), dataSequenceNumber));
+                        transforms.constantValue(nativeValueToBlock(column.getType(), dataSequenceNumber.orElseThrow(() ->
+                                new TrinoException(ICEBERG_BAD_DATA, "Cannot read $last_updated_sequence_number metadata column: Iceberg manifest is missing dataSequenceNumber"))));
                     }
                     else {
                         Object initialDefault = getInitialDefault(tableSchema, column.getBaseColumn().getId());
@@ -1134,7 +1137,8 @@ public class IcebergPageSourceProvider
                         transforms.transform(new RowIdTransform(fileFirstRowId.getAsLong(), ordinal));
                     }
                     else if (column.isLastUpdatedSequenceNumberColumn()) {
-                        transforms.transform(new DataSequenceNumberTransform(dataSequenceNumber, ordinal));
+                        transforms.transform(new DataSequenceNumberTransform(dataSequenceNumber.orElseThrow(() ->
+                                new TrinoException(ICEBERG_BAD_DATA, "Cannot read $last_updated_sequence_number metadata column: Iceberg manifest is missing dataSequenceNumber")), ordinal));
                     }
                     else if (column.isBaseColumn()) {
                         transforms.column(ordinal);
@@ -1260,7 +1264,7 @@ public class IcebergPageSourceProvider
             String partition,
             List<IcebergColumnHandle> columns,
             Map<Integer, Optional<String>> partitionKeys,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             OptionalLong fileFirstRowId)
     {
         InputFile file = new ForwardingInputFile(inputFile);
@@ -1335,7 +1339,8 @@ public class IcebergPageSourceProvider
                         transforms.transform(new RowIdTransform(fileFirstRowId.getAsLong(), -1));
                     }
                     else if (column.isLastUpdatedSequenceNumberColumn()) {
-                        transforms.constantValue(nativeValueToBlock(column.getType(), dataSequenceNumber));
+                        transforms.constantValue(nativeValueToBlock(column.getType(), dataSequenceNumber.orElseThrow(() ->
+                                new TrinoException(ICEBERG_BAD_DATA, "Cannot read $last_updated_sequence_number metadata column: Iceberg manifest is missing dataSequenceNumber"))));
                     }
                     else {
                         Object initialDefault = getInitialDefault(fileSchema, column.getBaseColumn().getId());
@@ -1359,7 +1364,8 @@ public class IcebergPageSourceProvider
                         transforms.transform(new RowIdTransform(fileFirstRowId.getAsLong(), ordinal));
                     }
                     else if (column.isLastUpdatedSequenceNumberColumn()) {
-                        transforms.transform(new DataSequenceNumberTransform(dataSequenceNumber, ordinal));
+                        transforms.transform(new DataSequenceNumberTransform(dataSequenceNumber.orElseThrow(() ->
+                                new TrinoException(ICEBERG_BAD_DATA, "Cannot read $last_updated_sequence_number metadata column: Iceberg manifest is missing dataSequenceNumber")), ordinal));
                     }
                     else if (column.isBaseColumn()) {
                         transforms.column(ordinal);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -48,7 +48,7 @@ public record IcebergSplit(
         @JsonProperty("splitWeight") SplitWeight splitWeight,
         @JsonProperty("fileStatisticsDomain") TupleDomain<IcebergColumnHandle> fileStatisticsDomain,
         @JsonProperty("affinityKey") Optional<String> affinityKey,
-        @JsonProperty("dataSequenceNumber") long dataSequenceNumber,
+        @JsonProperty("dataSequenceNumber") OptionalLong dataSequenceNumber,
         @JsonProperty("fileFirstRowId") OptionalLong fileFirstRowId)
         implements ConnectorSplit
 {
@@ -63,6 +63,7 @@ public record IcebergSplit(
         requireNonNull(splitWeight, "splitWeight is null");
         requireNonNull(fileStatisticsDomain, "fileStatisticsDomain is null");
         requireNonNull(affinityKey, "affinityKey is null");
+        requireNonNull(dataSequenceNumber, "dataSequenceNumber is null");
         requireNonNull(fileFirstRowId, "fileFirstRowId is null");
     }
 
@@ -89,7 +90,7 @@ public record IcebergSplit(
                 + estimatedSizeOf(deletes, DeleteFile::retainedSizeInBytes)
                 + splitWeight.getRetainedSizeInBytes()
                 + fileStatisticsDomain.getRetainedSizeInBytes(IcebergColumnHandle::getRetainedSizeInBytes)
-                + SIZE_OF_LONG // dataSequenceNumber
+                + (dataSequenceNumber.isPresent() ? SIZE_OF_LONG : 0)
                 + sizeOf(affinityKey, SizeOf::estimatedSizeOf)
                 + (fileFirstRowId.isPresent() ? SIZE_OF_LONG : 0);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -40,14 +40,13 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.metrics.InMemoryMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getDynamicFilteringWaitTimeout;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
 import static io.trino.spi.connector.FixedSplitSource.emptySplitSource;
@@ -153,15 +152,14 @@ public class IcebergSplitManager
         }
 
         Schema schema = schemaFor(icebergTable, table.getSnapshotId().getAsLong());
-        List<String> names = table.getProjectedColumns().stream()
-                .map(column -> schema.findField(column.getId()))
-                .filter(Objects::nonNull) // Newly added column may not be found in current snapshot schema until new files are added
-                .map(Types.NestedField::name)
-                .collect(toImmutableList());
+        Set<Integer> projectedIds = table.getProjectedColumns().stream()
+                .map(IcebergColumnHandle::getId)
+                .filter(id -> schema.findField(id) != null) // Newly added column may not be found in current snapshot schema until new files are added
+                .collect(toImmutableSet());
 
         return icebergTable.newScan()
                 .useSnapshot(table.getSnapshotId().getAsLong())
-                .project(schema.select(names)) // Using Scan.project method because Scan.select throws an exception for nested variant
+                .project(TypeUtil.select(schema, projectedIds)) // Using Scan.project method because Scan.select throws an exception for nested variant
                 .planWith(executor)
                 .metricsReporter(metricsReporter);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -749,7 +749,7 @@ public class IcebergSplitSource
                 SplitWeight.fromProportion(clamp(getSplitWeight(task), minimumAssignedSplitWeight, 1.0)),
                 taskWithDomain.fileStatisticsDomain(),
                 affinityKey,
-                task.file().dataSequenceNumber(),
+                task.file().dataSequenceNumber() == null ? OptionalLong.empty() : OptionalLong.of(task.file().dataSequenceNumber()),
                 task.file().firstRowId() == null ? OptionalLong.empty() : OptionalLong.of(task.file().firstRowId()));
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteManager.java
@@ -55,7 +55,7 @@ public class DeleteManager
 
     public Optional<RowPredicate> getDeletePredicate(
             String dataFilePath,
-            long dataSequenceNumber,
+            OptionalLong dataSequenceNumber,
             List<DeleteFile> deleteFiles,
             List<IcebergColumnHandle> readColumns,
             Schema tableSchema,
@@ -112,9 +112,17 @@ public class DeleteManager
                     };
                 });
 
-        Optional<RowPredicate> equalityDeletes = createEqualityDeleteFilter(equalityDeleteFiles, tableSchema, deletePageSourceProvider).stream()
-                .map(filter -> filter.createPredicate(readColumns, dataSequenceNumber))
-                .reduce(RowPredicate::and);
+        Optional<RowPredicate> equalityDeletes;
+        if (equalityDeleteFiles.isEmpty()) {
+            equalityDeletes = Optional.empty();
+        }
+        else {
+            long splitDataSequenceNumber = dataSequenceNumber.orElseThrow(() ->
+                    new TrinoException(ICEBERG_BAD_DATA, "Cannot apply equality deletes: Iceberg manifest is missing dataSequenceNumber for " + dataFilePath));
+            equalityDeletes = createEqualityDeleteFilter(equalityDeleteFiles, tableSchema, deletePageSourceProvider).stream()
+                    .map(filter -> filter.createPredicate(readColumns, splitDataSequenceNumber))
+                    .reduce(RowPredicate::and);
+        }
 
         if (positionDeletes.isPresent() && equalityDeletes.isPresent()) {
             return Optional.of(positionDeletes.get().and(equalityDeletes.get()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -134,7 +134,7 @@ public class TableChangesFunctionProcessor
                 split.fileRecordCount(),
                 split.fileFormat(),
                 getFileIoProperties(tableCredentials),
-                0,
+                OptionalLong.empty(),
                 OptionalLong.empty(),
                 functionHandle.nameMappingJson().map(NameMappingParser::fromJson));
         this.delegateColumnMap = delegateColumnMap;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -152,7 +152,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                     SplitWeight.standard(),
                     TupleDomain.all(),
                     Optional.empty(),
-                    0,
+                    OptionalLong.empty(),
                     OptionalLong.empty());
 
             String tablePath = inputFile.location().fileName();
@@ -213,7 +213,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                     SplitWeight.standard(),
                     TupleDomain.withColumnDomains(ImmutableMap.of(keyColumnHandle, Domain.singleValue(INTEGER, (long) keyColumnValue))),
                     Optional.empty(),
-                    0,
+                    OptionalLong.empty(),
                     OptionalLong.empty());
 
             tableHandle = new TableHandle(
@@ -324,7 +324,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                     SplitWeight.standard(),
                     TupleDomain.all(),
                     Optional.empty(),
-                    0,
+                    OptionalLong.empty(),
                     OptionalLong.empty());
 
             String tablePath = inputFile.location().fileName();
@@ -474,7 +474,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                     SplitWeight.standard(),
                     TupleDomain.all(),
                     Optional.empty(),
-                    0,
+                    OptionalLong.empty(),
                     OptionalLong.empty());
 
             String tablePath = inputFile.location().fileName();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
@@ -143,7 +143,7 @@ class TestIcebergPageSourceProvider
                 3, // fileRecordCount
                 PARQUET,
                 ImmutableMap.of(),
-                0L, // dataSequenceNumber
+                OptionalLong.of(0), // dataSequenceNumber
                 OptionalLong.empty(),
                 Optional.empty())) {
             // Memory should still be 0 before reading any pages (lazy loading)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

There are a couple quirks that Iceberg REST catalogs introduce after 1.11 that we currently do not handle in our Iceberg connector. This PR addresses:
1. Null data sequence numbers, which can appear in 1.11 FileScanTasks
2. Inconsistencies when handling names of nested structs

Neither change should affect behavior, but both make the connector more resilient.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
